### PR TITLE
Verbose Field Note export

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -182,6 +182,8 @@
   <string name="err_parse_lon">c:geo konnte den Längengrad nicht verarbeiten.</string>
   <string name="err_parse_bear">c:geo konnte die Richtung nicht verarbeiten.</string>
   <string name="err_parse_dist">c:geo konnte die Entfernung nicht verarbeiten.</string>
+  
+  <string name="err_fieldnotes_export_failed">Exportieren der Field Notes fehlgeschlagen.</string>
 
   <string name="warn_save_nothing">Es gibt nichts zum speichern.</string>
   <string name="warn_no_cache_coord">Es gibt hier keinen Cache mit Koordinaten.</string>
@@ -205,6 +207,8 @@
   <string name="info_log_saved">Log erfolgreich gespeichert.</string>
   <string name="info_log_cleared">Log wurde geleert.</string>
   <string name="info_log_type_changed">Logtyp wurde verändert!</string>
+  
+  <string name="info_fieldnotes_exported_to">Field Notes exportiert nach</string>
 
   <!-- location service -->
   <string name="loc_last">Letzte Position</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -187,6 +187,8 @@
   <string name="err_parse_lon">Sorry, c:geo can\'t parse longitude.</string>
   <string name="err_parse_bear">Sorry, c:geo can\'t parse bearing.</string>
   <string name="err_parse_dist">Sorry, c:geo can\'t parse distance.</string>
+  
+  <string name="err_fieldnotes_export_failed">Export of Field Notes failed.</string>
 
   <string name="warn_save_nothing">There is nothing to be saved.</string>
   <string name="warn_no_cache_coord">There is no cache with coordinates.</string>
@@ -210,6 +212,8 @@
   <string name="info_log_saved">c:geo successfully saved log.</string>
   <string name="info_log_cleared">Log was cleared.</string>
   <string name="info_log_type_changed">Type of log has been changed!</string>
+  
+  <string name="info_fieldnotes_exported_to">Field Notes exported to</string>
 
   <!-- location service -->
   <string name="loc_last">Last known</string>

--- a/src/cgeo/geocaching/cgeocaches.java
+++ b/src/cgeo/geocaching/cgeocaches.java
@@ -452,6 +452,14 @@ public class cgeocaches extends ListActivity {
                 cacheList.get(msg.what).statusChecked = false;
                 waitDialog.setProgress(detailProgress);
             }
+            if (-2 == msg.what)
+            {
+                warning.showToast(res.getString(R.string.info_fieldnotes_exported_to) + ": " + msg.obj.toString());
+            }
+            if (-3 == msg.what)
+            {
+                warning.showToast(res.getString(R.string.err_fieldnotes_export_failed));
+            }
             else
             {
                 if (adapter != null)
@@ -2208,9 +2216,12 @@ public class cgeocaches extends ListActivity {
                     os = new FileOutputStream(exportFile);
                     fw = new OutputStreamWriter(os, "ISO-8859-1"); // TODO: gc.com doesn't support UTF-8
                     fw.write(fieldNoteBuffer.toString());
+                    
+                    Message.obtain(handler, -2, exportFile).sendToTarget();
                 }
                 catch (IOException e) {
                     Log.e(cgSettings.tag, "cgeocaches.geocachesExportFieldNotes: " + e.toString());
+                    handler.sendEmptyMessage(-3);
                 }
                 finally
                 {


### PR DESCRIPTION
Add verbose field-notes-export (error-message in case of failure, else path to exported field-notes-file). Some people asked on Facebook, what the Field-Note-export does or where they can find the exported files. This is a try to make it a bit more verbose.
