### PR TITLE
fix offline cache + not stored images

### DIFF
--- a/src/cgeo/geocaching/cgeoimages.java
+++ b/src/cgeo/geocaching/cgeoimages.java
@@ -73,6 +73,9 @@ public class cgeoimages extends Activity {
 
 					if (app.isOffline(geocode, null) == true) {
 						offline = 1;
+						if ((img_type == LOG_IMAGE) && (settings.storelogimages == false)) { 
+							offline = 0;
+						}						
 					} else {
 						offline = 0;
 					}


### PR DESCRIPTION
fix: if logimages are not stored for offline use they will now be loaded in a offline stored cache.
