### PR TITLE
Generate date and time according to system-wide settings

### DIFF
--- a/src/cgeo/geocaching/cgBase.java
+++ b/src/cgeo/geocaching/cgBase.java
@@ -19,7 +19,6 @@ import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -61,6 +60,7 @@ import android.os.Handler;
 import android.os.Message;
 import android.text.Html;
 import android.text.Spannable;
+import android.text.format.DateUtils;
 import android.text.style.StrikethroughSpan;
 import android.util.Log;
 import android.view.Display;
@@ -88,9 +88,6 @@ public class cgBase {
 	public static SimpleDateFormat dateTbIn2 = new SimpleDateFormat("EEEEE, MMMMM dd, yyyy", Locale.ENGLISH); // Saturday, March 28, 2009
 	public static SimpleDateFormat dateSqlIn = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"); // 2010-07-25 14:44:01
 	public static SimpleDateFormat dateGPXIn = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"); // 2010-04-20T07:00:00Z
-	public static DateFormat dateOut = DateFormat.getDateInstance(DateFormat.LONG, Locale.getDefault());
-	public static DateFormat timeOut = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault());
-	public static DateFormat dateOutShort = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault());
 	private Resources res = null;
 	private HashMap<String, String> cookies = new HashMap<String, String>();
 	private static final String passMatch = "[/\\?&]*[Pp]ass(word)?=[^&^#^$]+";
@@ -5513,5 +5510,54 @@ public class cgBase {
 		}
 
 		return elv;
+	}
+
+	/**
+	 * Generate a time string according to system-wide settings (locale, 12/24 hour)
+	 * such as "13:24".
+	 *
+	 * @param context a context
+	 * @param date milliseconds since the epoch
+	 * @return the formatted string
+	 */
+	public String formatTime(long date) {
+		return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_TIME);
+	}
+
+	/**
+	 * Generate a date string according to system-wide settings (locale, date format)
+	 * such as "20 December" or "20 December 2010". The year will only be included when necessary.
+	 *
+	 * @param context a context
+	 * @param date milliseconds since the epoch
+	 * @return the formatted string
+	 */
+	public String formatDate(long date) {
+		return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE);
+	}
+
+	/**
+	 * Generate a date string according to system-wide settings (locale, date format)
+	 * such as "20 December 2010". The year will always be included, making it suitable
+	 * to generate long-lived log entries.
+	 *
+	 * @param context a context
+	 * @param date milliseconds since the epoch
+	 * @return the formatted string
+	 */
+	public String formatFullDate(long date) {
+		return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_YEAR);
+	}
+
+	/**
+	 * Generate a numeric date string according to system-wide settings (locale, date format)
+	 * such as "10/20/2010".
+	 *
+	 * @param context a context
+	 * @param date milliseconds since the epoch
+	 * @return the formatted string
+	 */
+	public String formatShortDate(long date) {
+		return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_NUMERIC_DATE);
 	}
 }

--- a/src/cgeo/geocaching/cgCacheListAdapter.java
+++ b/src/cgeo/geocaching/cgCacheListAdapter.java
@@ -584,9 +584,9 @@ public class cgCacheListAdapter extends ArrayAdapter<cgCache> {
 
 		StringBuilder cacheInfo = new StringBuilder();
 		if (historic == true && cache.visitedDate != null) {
-			cacheInfo.append(cgBase.timeOut.format(cache.visitedDate));
+			cacheInfo.append(base.formatTime(cache.visitedDate));
 			cacheInfo.append("; ");
-			cacheInfo.append(cgBase.dateOut.format(cache.visitedDate));
+			cacheInfo.append(base.formatDate(cache.visitedDate));
 		} else {
 			if (cache.geocode != null && cache.geocode.length() > 0) {
 				cacheInfo.append(cache.geocode);

--- a/src/cgeo/geocaching/cgeodetail.java
+++ b/src/cgeo/geocaching/cgeodetail.java
@@ -766,7 +766,7 @@ public class cgeodetail extends AbstractActivity {
 				} else {
 					itemName.setText(res.getString(R.string.cache_hidden));
 				}
-				itemValue.setText(cgBase.dateOut.format(cache.hidden));
+				itemValue.setText(base.formatFullDate(cache.hidden.getTime()));
 				detailsList.addView(itemLayout);
 			}
 
@@ -1136,8 +1136,7 @@ public class cgeodetail extends AbstractActivity {
 				rowView = (RelativeLayout) inflater.inflate(R.layout.log_item, null);
 
 				if (log.date > 0) {
-					final Date logDate = new Date(log.date);
-					((TextView) rowView.findViewById(R.id.added)).setText(cgBase.dateOutShort.format(logDate));
+					((TextView) rowView.findViewById(R.id.added)).setText(base.formatShortDate(log.date));
 				}
 
 				if (cgBase.logTypes1.containsKey(log.type) == true) {

--- a/src/cgeo/geocaching/cgeoinit.java
+++ b/src/cgeo/geocaching/cgeoinit.java
@@ -442,7 +442,7 @@ public class cgeoinit extends AbstractActivity {
 		TextView lastBackup = (TextView) findViewById(R.id.backup_last);
 		File lastBackupFile = cgeoapplication.isRestoreFile();
 		if (lastBackupFile != null) {
-			lastBackup.setText(res.getString(R.string.init_backup_last) + " " + cgBase.timeOut.format(lastBackupFile.lastModified()) + ", " + cgBase.dateOut.format(lastBackupFile.lastModified()));
+			lastBackup.setText(res.getString(R.string.init_backup_last) + " " + base.formatTime(lastBackupFile.lastModified()) + ", " + base.formatDate(lastBackupFile.lastModified()));
 		} else {
 			lastBackup.setText(res.getString(R.string.init_backup_last_no));
 		}

--- a/src/cgeo/geocaching/cgeotouch.java
+++ b/src/cgeo/geocaching/cgeotouch.java
@@ -2,7 +2,6 @@ package cgeo.geocaching;
 
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 
 import android.app.Dialog;
@@ -198,8 +197,10 @@ public class cgeotouch extends cgLogForm {
 		if ((id >= 0x1 && id <= 0x7)) {
 			text = (EditText) findViewById(R.id.log);
 			textContent = text.getText().toString();
-			dateString = cgBase.dateOut.format(new Date());
-			timeString = cgBase.timeOut.format(new Date());
+
+			final long now = System.currentTimeMillis();
+			dateString = base.formatDate(now);
+			timeString = base.formatTime(now);
 
 			if ((id & 0x4) == 0x4) {
 				addText += dateString;
@@ -277,7 +278,7 @@ public class cgeotouch extends cgLogForm {
 		});
 
 		Button dateButton = (Button)findViewById(R.id.date);
-		dateButton.setText(cgBase.dateOutShort.format(date.getTime()));
+		dateButton.setText(base.formatShortDate(date.getTime().getTime()));
 		dateButton.setOnClickListener(new cgeotouchDateListener());
 
         if (tweetBox == null) tweetBox = (LinearLayout)findViewById(R.id.tweet_box);
@@ -303,7 +304,7 @@ public class cgeotouch extends cgLogForm {
 		date = dateIn;
 
 		final Button dateButton = (Button)findViewById(R.id.date);
-		dateButton.setText(cgBase.dateOutShort.format(date.getTime()));
+		dateButton.setText(base.formatShortDate(date.getTime().getTime()));
 	}
 
 	public void setType(int type) {

--- a/src/cgeo/geocaching/cgeotrackable.java
+++ b/src/cgeo/geocaching/cgeotrackable.java
@@ -2,7 +2,6 @@ package cgeo.geocaching;
 
 import java.net.URLEncoder;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 
 import android.app.ProgressDialog;
@@ -207,7 +206,7 @@ public class cgeotrackable extends AbstractActivity {
 					itemValue = (TextView) itemLayout.findViewById(R.id.value);
 
 					itemName.setText(res.getString(R.string.trackable_released));
-					itemValue.setText(cgBase.dateOut.format(trackable.released));
+					itemValue.setText(base.formatDate(trackable.released.getTime()));
 					detailsList.addView(itemLayout);
 				}
 
@@ -526,8 +525,7 @@ public class cgeotrackable extends AbstractActivity {
 				rowView = (RelativeLayout) inflater.inflate(R.layout.trackable_logitem, null);
 
 				if (log.date > 0) {
-					final Date logDate = new Date(log.date);
-					((TextView) rowView.findViewById(R.id.added)).setText(cgBase.dateOutShort.format(logDate));
+					((TextView) rowView.findViewById(R.id.added)).setText(base.formatShortDate(log.date));
 				}
 
 

--- a/src/cgeo/geocaching/cgeovisit.java
+++ b/src/cgeo/geocaching/cgeovisit.java
@@ -364,16 +364,16 @@ public class cgeovisit extends cgLogForm {
 	}
 
 	public void addSignature(int id) {
+		final long now = System.currentTimeMillis();
+		final String dateString = base.formatFullDate(now);
+		final String timeString = base.formatTime(now);
 		EditText text = null;
 		String textContent = null;
-		String dateString = null;
-		String timeString = null;
 		StringBuilder addText = new StringBuilder();
 
 		text = (EditText) findViewById(R.id.log);
 		textContent = text.getText().toString();
-		dateString = cgBase.dateOut.format(new Date());
-		timeString = cgBase.timeOut.format(new Date());
+
 
 		if ((id & LOG_DATE) == LOG_DATE) {
 			addText.append(dateString);
@@ -603,7 +603,7 @@ public class cgeovisit extends cgLogForm {
 		});
 
 		Button dateButton = (Button) findViewById(R.id.date);
-		dateButton.setText(cgBase.dateOutShort.format(date.getTime()));
+		dateButton.setText(base.formatShortDate(date.getTime().getTime()));
 		dateButton.setOnClickListener(new cgeovisitDateListener());
 
 		EditText logView = (EditText) findViewById(R.id.log);
@@ -651,7 +651,7 @@ public class cgeovisit extends cgLogForm {
 		date = dateIn;
 
 		final Button dateButton = (Button) findViewById(R.id.date);
-		dateButton.setText(cgBase.dateOutShort.format(date.getTime()));
+		dateButton.setText(base.formatShortDate(date.getTime().getTime()));
 	}
 
 	public void setType(int type) {
@@ -756,7 +756,7 @@ public class cgeovisit extends cgLogForm {
 			setType(typeSelected);
 
 			Button dateButton = (Button) findViewById(R.id.date);
-			dateButton.setText(cgBase.dateOutShort.format(date.getTime()));
+			dateButton.setText(base.formatShortDate(date.getTime().getTime()));
 			dateButton.setOnClickListener(new cgeovisitDateListener());
 
 			EditText logView = (EditText) findViewById(R.id.log);


### PR DESCRIPTION
This set of commits tries to use the best date and time representation while respecting system-wide settings (locale, date format, 12/24 hour). This would fix #136.
