### PR TITLE
Refactoring (Bugfix, unneeded variable-assignments, duplicate code)

### DIFF
--- a/src/cgeo/geocaching/cgeoapplication.java
+++ b/src/cgeo/geocaching/cgeoapplication.java
@@ -89,11 +89,7 @@ public class cgeoapplication extends Application {
 	}
 
 	public boolean storageStatus() {
-		if (storage.status() == false) {
-			return false;
-		}
-
-		return true;
+		return storage.status();
 	}
 
 	public cgGeo startGeo(Context context, cgUpdateLoc geoUpdate, cgBase base, cgSettings settings, int time, int distance) {


### PR DESCRIPTION
This commit contains a couple of changes:
[Bug] SQLiteStatement wasn't closed
[Best practice] Use whereArgs to set query-variable (1)
[Performance] Removed unnecessary method calls (2)
[Performance / clean code] Unnecessary null-assignment of variable (3)
[Clean code] Remove duplicate code (move duplicate code to one method)

All changes are low impact...

(1) example:
Use
`databaseRW.update(dbTableCaches, values, "geocode = ?", new String[] {geocode});`
Instead of
`databaseRW.update(dbTableCaches, values, "geocode = \"" + geocode + "\"", null);`
(reads better and escapes special characters in variable-string, so no sql-injection (you never know...))

(2) example:
A lot of _init()_ calls were placed before a argument-check. By moving the _init()_ call after the argument-check, you potentially prevent an unnecessary _init()_ call.

(3) example:
Weird code-pattern - Init a variable with null and immediately after that, assign the variable --> removed the null-init.
Changed:

```
Cursor cursor = null;
cursor = databaseRO.query(
```

to:

```
Cursor cursor = databaseRO.query(
```
