### PR TITLE
Fix for #209

### DIFF
--- a/src/cgeo/geocaching/googlemaps/googleOverlay.java
+++ b/src/cgeo/geocaching/googlemaps/googleOverlay.java
@@ -1,8 +1,5 @@
 package cgeo.geocaching.googlemaps;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 import android.graphics.Canvas;
 import cgeo.geocaching.mapinterfaces.MapViewImpl;
 import cgeo.geocaching.mapinterfaces.OverlayBase;
@@ -12,27 +9,18 @@ import com.google.android.maps.MapView;
 import com.google.android.maps.Overlay;
 
 public class googleOverlay extends Overlay implements OverlayImpl {
-    private static Lock lock = new ReentrantLock();
 
-    public static void lock() {
-        lock.lock();
-    }
+	private OverlayBase overlayBase;
+	
+	public googleOverlay(OverlayBase overlayBaseIn) {
+		overlayBase = overlayBaseIn;
+	}
+	
+	@Override
+	public void draw(Canvas canvas, MapView mapView, boolean shadow) {
+		super.draw(canvas, mapView, shadow);
+		
+		overlayBase.draw(canvas, (MapViewImpl) mapView, shadow);
+	}
 
-    public static void unlock() {
-        lock.unlock();
-    }
-
-    private OverlayBase overlayBase;
-
-    public googleOverlay(OverlayBase overlayBaseIn) {
-        overlayBase = overlayBaseIn;
-    }
-
-    @Override
-    public void draw(Canvas canvas, MapView mapView, boolean shadow) {
-        super.draw(canvas, mapView, shadow);
-        lock();
-        overlayBase.draw(canvas, (MapViewImpl) mapView, shadow);
-        unlock();
-    }
 }

--- a/src/cgeo/geocaching/mapcommon/cgMapOverlay.java
+++ b/src/cgeo/geocaching/mapcommon/cgMapOverlay.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.mapcommon;
 
 import java.util.ArrayList;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -23,7 +25,6 @@ import cgeo.geocaching.cgeodetail;
 import cgeo.geocaching.cgeonavigate;
 import cgeo.geocaching.cgeopopup;
 import cgeo.geocaching.cgeowaypoint;
-import cgeo.geocaching.googlemaps.googleOverlay;
 import cgeo.geocaching.mapinterfaces.CacheOverlayItemImpl;
 import cgeo.geocaching.mapinterfaces.GeoPointImpl;
 import cgeo.geocaching.mapinterfaces.ItemizedOverlayImpl;
@@ -46,6 +47,7 @@ public class cgMapOverlay extends ItemizedOverlayBase implements OverlayBase {
 	private PaintFlagsDrawFilter remfil = null;
 	private cgSettings settings;
 	private MapFactory mapFactory = null;
+    static private Lock lock = new ReentrantLock();
 
 	public cgMapOverlay(cgSettings settingsIn, ItemizedOverlayImpl ovlImpl, Context contextIn, Boolean fromDetailIn) {
 		super(ovlImpl);
@@ -75,11 +77,11 @@ public class cgMapOverlay extends ItemizedOverlayBase implements OverlayBase {
 			item.setMarker(boundCenterBottom(item.getMarker(0)));
 		}
 
-		googleOverlay.lock();
+		lock.lock();
         items = new ArrayList<CacheOverlayItemImpl>(itemsPre);
 		setLastFocusedItemIndex(-1); // to reset tap during data change
 		populate();
-        googleOverlay.unlock();
+        lock.unlock();
 	}
 
 	public boolean getCircles() {
@@ -92,10 +94,10 @@ public class cgMapOverlay extends ItemizedOverlayBase implements OverlayBase {
 
 	@Override
 	public void draw(Canvas canvas, MapViewImpl mapView, boolean shadow) {
-
+        lock.lock();
 		drawInternal(canvas, mapView.getMapProjection());
-
 		super.draw(canvas, mapView, false);
+        lock.unlock();
 	}
 
 	@Override


### PR DESCRIPTION
I tried different other things mentioned in several discussion groups about google maps - but finally gave up...
This approach here is probably not very elegant but at least it should work;
by stopping all draw() calls while changing the overlay list, ArrayIndexOutOfBoundsExceptions should no longer occur.
