### PR TITLE
Fix for ArrayIndexOutOfBoundsException (google maps view)

### DIFF
--- a/src/cgeo/geocaching/googlemaps/googleOverlay.java
+++ b/src/cgeo/geocaching/googlemaps/googleOverlay.java
@@ -1,5 +1,8 @@
 package cgeo.geocaching.googlemaps;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 import android.graphics.Canvas;
 import cgeo.geocaching.mapinterfaces.MapViewImpl;
 import cgeo.geocaching.mapinterfaces.OverlayBase;
@@ -10,6 +13,16 @@ import com.google.android.maps.Overlay;
 
 public class googleOverlay extends Overlay implements OverlayImpl {
 
+    private static Lock lock = new ReentrantLock();
+
+    public static void lock() {
+        lock.lock();
+    }
+
+    public static void unlock() {
+        lock.unlock();
+    }
+
 	private OverlayBase overlayBase;
 	
 	public googleOverlay(OverlayBase overlayBaseIn) {
@@ -18,9 +31,10 @@ public class googleOverlay extends Overlay implements OverlayImpl {
 	
 	@Override
 	public void draw(Canvas canvas, MapView mapView, boolean shadow) {
+	    lock();
 		super.draw(canvas, mapView, shadow);
-		
 		overlayBase.draw(canvas, (MapViewImpl) mapView, shadow);
+		unlock();
 	}
 
 }

--- a/src/cgeo/geocaching/mapcommon/cgMapOverlay.java
+++ b/src/cgeo/geocaching/mapcommon/cgMapOverlay.java
@@ -23,6 +23,7 @@ import cgeo.geocaching.cgeodetail;
 import cgeo.geocaching.cgeonavigate;
 import cgeo.geocaching.cgeopopup;
 import cgeo.geocaching.cgeowaypoint;
+import cgeo.geocaching.googlemaps.googleOverlay;
 import cgeo.geocaching.mapinterfaces.CacheOverlayItemImpl;
 import cgeo.geocaching.mapinterfaces.GeoPointImpl;
 import cgeo.geocaching.mapinterfaces.ItemizedOverlayImpl;
@@ -73,11 +74,12 @@ public class cgMapOverlay extends ItemizedOverlayBase implements OverlayBase {
 		for (CacheOverlayItemImpl item : itemsPre) {
 			item.setMarker(boundCenterBottom(item.getMarker(0)));
 		}
-
+		
+		googleOverlay.lock();
 		items = new ArrayList<CacheOverlayItemImpl>(itemsPre);
-
 		setLastFocusedItemIndex(-1); // to reset tap during data change
 		populate();
+        googleOverlay.unlock();
 	}
 
 	public boolean getCircles() {


### PR DESCRIPTION
avoid ArrayIndexOutOvBoundException (#209) caused by concurrent access to the cache overlay item list from c:geo logic and google maps view.
