### PR TITLE
Added onPress and onSelected backgrounds to the actionbar buttons

### DIFF
--- a/res/drawable/actionbar_button.xml
+++ b/res/drawable/actionbar_button.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:drawable="@drawable/actionbar_button_pressed"
+		android:state_focused="true" android:state_pressed="true" />
+	<item android:drawable="@drawable/actionbar_button_pressed"
+		android:state_focused="false" android:state_pressed="true" />
+	<item android:drawable="@drawable/actionbar_button_selected"
+		android:state_focused="true" />
+	<item android:drawable="@android:color/transparent"
+		android:state_focused="false" android:state_pressed="false" />
+</selector>

--- a/res/drawable/actionbar_button_pressed.xml
+++ b/res/drawable/actionbar_button_pressed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+		android:shape="rectangle">
+	<solid
+			android:color="#44FFFFFF" />
+</shape>

--- a/res/drawable/actionbar_button_selected.xml
+++ b/res/drawable/actionbar_button_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+		android:shape="rectangle">
+	<solid
+			android:color="#22FFFFFF" />
+</shape>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -47,7 +47,9 @@
 		<item name="android:padding">4dip</item>
 		<item name="android:gravity">center</item>
 		<item name="android:scaleType">center</item>
+		<item name="android:focusable">true</item>
 		<item name="android:src">@drawable/actionbar_cgeo</item>
+		<item name="android:background">@drawable/actionbar_button</item>
 	</style>
 
 	<style name="action_bar_action">
@@ -56,7 +58,9 @@
 		<item name="android:padding">2dip</item>
 		<item name="android:gravity">center</item>
 		<item name="android:scaleType">center</item>
+		<item name="android:focusable">true</item>
 		<item name="android:src">@drawable/actionbar_home</item>
+		<item name="android:background">@drawable/actionbar_button</item>
 	</style>
 
 	<style name="action_bar_separator">


### PR DESCRIPTION
Made it so that the action buttons change their background then pressed or selected.
I followed the same colours as used for the normal buttons in the dark theme, since the action bar is always dark.

I also added focusable=true to the buttons, so that they can be selected using the arrow buttons.

This is my first contribution and I have close to no experience with Git, so please let me know if I'm doing something wrong.
