### PR TITLE
Refactor to address issue #361

### DIFF
--- a/src/cgeo/geocaching/LogTemplateProvider.java
+++ b/src/cgeo/geocaching/LogTemplateProvider.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,7 +85,7 @@ public class LogTemplateProvider {
 				@Override
 				String getValue(final cgBase base) {
 					String findCount = "";
-					final HashMap<String, String> params = new HashMap<String, String>();
+					final Map<String, String> params = new HashMap<String, String>();
 					final String page = base.request(false, "www.geocaching.com", "/email/", "GET", params, false, false, false).getData();
 					int current = parseFindCount(page);
 

--- a/src/cgeo/geocaching/activity/ActivityMixin.java
+++ b/src/cgeo/geocaching/activity/ActivityMixin.java
@@ -2,7 +2,7 @@ package cgeo.geocaching.activity;
 
 import gnu.android.app.appmanualclient.AppManualReaderClient;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -133,7 +133,7 @@ public final class ActivityMixin {
 		if (settings.isLogin()) {
 			if (settings.getLogOffline()) {
 				SubMenu logMenu = menu.addSubMenu(1, IAbstractActivity.MENU_LOG_VISIT_OFFLINE, 0, res.getString(R.string.cache_menu_visit_offline)).setIcon(MENU_ICON_LOG_VISIT);
-				ArrayList<Integer> logTypes = cache.getPossibleLogTypes(settings);
+				List<Integer> logTypes = cache.getPossibleLogTypes(settings);
 				for (Integer logType : logTypes) {
 					String label = cgBase.logTypes2.get(logType);
 					logMenu.add(1, IAbstractActivity.MENU_LOG_VISIT_OFFLINE + logType, 0, label);

--- a/src/cgeo/geocaching/apps/cache/navi/LocusApp.java
+++ b/src/cgeo/geocaching/apps/cache/navi/LocusApp.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.apps.cache.navi;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -35,7 +36,7 @@ class LocusApp extends AbstractLocusApp implements NavigationApp {
 		}
 		try {
 			if (isInstalled(activity)) {
-				final ArrayList<cgWaypoint> waypoints = new ArrayList<cgWaypoint>();
+				final List<cgWaypoint> waypoints = new ArrayList<cgWaypoint>();
 				// get only waypoints with coordinates
 				if (cache != null && cache.waypoints != null
 						&& cache.waypoints.isEmpty() == false) {

--- a/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
+++ b/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.apps.cache.navi;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -46,7 +46,7 @@ public final class NavigationAppFactory extends AbstractAppFactory {
 	public static boolean onMenuItemSelected(final MenuItem item,
 			final cgGeo geo, Activity activity, Resources res,
 			cgCache cache,
-			Long searchId, cgWaypoint waypoint, ArrayList<Double> destination) {
+			Long searchId, cgWaypoint waypoint, List<Double> destination) {
 		NavigationApp app = (NavigationApp) getAppFromMenuItem(item, apps);
 		if (app != null) {
 			Double latitude = null;

--- a/src/cgeo/geocaching/apps/cachelist/CacheListAppFactory.java
+++ b/src/cgeo/geocaching/apps/cachelist/CacheListAppFactory.java
@@ -38,7 +38,7 @@ public final class CacheListAppFactory extends AbstractAppFactory {
 	 */
 	public static MenuItem addMenuItems(Menu menu,
 			Activity activity, Resources res) {
-		ArrayList<CacheListApp> activeApps = new ArrayList<CacheListApp>();
+		List<CacheListApp> activeApps = new ArrayList<CacheListApp>();
 		for (CacheListApp app : getMultiPointNavigationApps(res)) {
 			if (app.isInstalled(activity)) {
 				activeApps.add(app);

--- a/src/cgeo/geocaching/apps/cachelist/LocusCacheListApp.java
+++ b/src/cgeo/geocaching/apps/cachelist/LocusCacheListApp.java
@@ -31,7 +31,7 @@ class LocusCacheListApp extends AbstractLocusApp implements CacheListApp {
 		}
 
 		try {
-			final ArrayList<cgCache> cacheListCoord = new ArrayList<cgCache>();
+			final List<cgCache> cacheListCoord = new ArrayList<cgCache>();
 			for (cgCache cache : cacheList) {
 				if (cache.latitude != null && cache.longitude != null) {
 					cacheListCoord.add(cache);

--- a/src/cgeo/geocaching/cgBase.java
+++ b/src/cgeo/geocaching/cgBase.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -125,18 +126,18 @@ public class cgBase {
 	private final static Pattern PATTERN_TRACKABLE_Distance = Pattern.compile("<h4[^>]*\\W*Tracking History \\(([0-9\\.,]+(km|mi))[^\\)]*\\)", Pattern.CASE_INSENSITIVE);
 	private final static Pattern PATTERN_TRACKABLE_Log = Pattern.compile("<tr class=\"Data.+?src=\"/images/icons/([^\\.]+)\\.gif[^>]+>&nbsp;([^<]+)</td>.+?guid.+?>([^<]+)</a>.+?(?:guid=([^\"]+)\">([^<]+)</a>.+?)?<td colspan=\"4\">(.+?)(?:<ul.+?ul>)?\\s*</td>\\s*</tr>", Pattern.CASE_INSENSITIVE);
 
-	public static HashMap<String, String> cacheTypes = new HashMap<String, String>();
-	public static HashMap<String, String> cacheTypesInv = new HashMap<String, String>();
-	public static HashMap<String, String> cacheIDs = new HashMap<String, String>();
-	public static HashMap<String, String> cacheIDsChoices = new HashMap<String, String>();
-	public static HashMap<String, String> waypointTypes = new HashMap<String, String>();
-	public static HashMap<String, Integer> logTypes = new HashMap<String, Integer>();
-	public static HashMap<String, Integer> logTypes0 = new HashMap<String, Integer>();
-	public static HashMap<Integer, String> logTypes1 = new HashMap<Integer, String>();
-	public static HashMap<Integer, String> logTypes2 = new HashMap<Integer, String>();
-	public static HashMap<Integer, String> logTypesTrackable = new HashMap<Integer, String>();
-	public static HashMap<Integer, String> logTypesTrackableAction = new HashMap<Integer, String>();
-	public static HashMap<Integer, String> errorRetrieve = new HashMap<Integer, String>();
+	public static Map<String, String> cacheTypes = new HashMap<String, String>();
+	public static Map<String, String> cacheTypesInv = new HashMap<String, String>();
+	public static Map<String, String> cacheIDs = new HashMap<String, String>();
+	public static Map<String, String> cacheIDsChoices = new HashMap<String, String>();
+	public static Map<String, String> waypointTypes = new HashMap<String, String>();
+	public static Map<String, Integer> logTypes = new HashMap<String, Integer>();
+	public static Map<String, Integer> logTypes0 = new HashMap<String, Integer>();
+	public static Map<Integer, String> logTypes1 = new HashMap<Integer, String>();
+	public static Map<Integer, String> logTypes2 = new HashMap<Integer, String>();
+	public static Map<Integer, String> logTypesTrackable = new HashMap<Integer, String>();
+	public static Map<Integer, String> logTypesTrackableAction = new HashMap<Integer, String>();
+	public static Map<Integer, String> errorRetrieve = new HashMap<Integer, String>();
 	public static final Map<String, SimpleDateFormat> gcCustomDateFormats;
 	static {
 	    final String[] formats = new String[] {
@@ -149,7 +150,7 @@ public class cgBase {
 	            "dd/MM/yyyy"
 	        };
 
-	    HashMap<String, SimpleDateFormat> map = new HashMap<String, SimpleDateFormat>();
+	    Map<String, SimpleDateFormat> map = new HashMap<String, SimpleDateFormat>();
 
 	    for (String format : formats)
 	    {
@@ -162,7 +163,7 @@ public class cgBase {
 	public final static SimpleDateFormat dateTbIn2 = new SimpleDateFormat("EEEEE, MMMMM dd, yyyy", Locale.ENGLISH); // Saturday, March 28, 2009
 	public final static SimpleDateFormat dateSqlIn = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"); // 2010-07-25 14:44:01
 	private Resources res = null;
-	private HashMap<String, String> cookies = new HashMap<String, String>();
+	private Map<String, String> cookies = new HashMap<String, String>();
 	private static final String passMatch = "[/\\?&]*[Pp]ass(word)?=[^&^#^$]+";
 	private static final Pattern patternLoggedIn = Pattern.compile("<span class=\"Success\">You are logged in as[^<]*<strong[^>]*>([^<]+)</strong>[^<]*</span>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 	private static final Pattern patternLogged2In = Pattern.compile("<strong>\\W*Hello,[^<]*<a[^>]+>([^<]+)</a>[^<]*</strong>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
@@ -179,8 +180,8 @@ public class cgBase {
 	public String version = null;
 	private String idBrowser = "Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.86 Safari/533.4";
 	Context context = null;
-	final private static HashMap<String, Integer> gcIcons = new HashMap<String, Integer>();
-	final private static HashMap<String, Integer> wpIcons = new HashMap<String, Integer>();
+	final private static Map<String, Integer> gcIcons = new HashMap<String, Integer>();
+	final private static Map<String, Integer> wpIcons = new HashMap<String, Integer>();
 
 	public static final int LOG_FOUND_IT = 2;
 	public static final int LOG_DIDNT_FIND_IT = 3;
@@ -463,7 +464,7 @@ public class cgBase {
 	/**
 	 * put viewstates into request parameters
 	 */
-	private static void setViewstates(String[] viewstates, HashMap<String, String> params) {
+	private static void setViewstates(String[] viewstates, Map<String, String> params) {
 		if (ArrayUtils.isEmpty(viewstates))
 			return;
 		params.put("__VIEWSTATE", viewstates[0]);
@@ -478,7 +479,7 @@ public class cgBase {
 	 * transfers the viewstates variables from a page (response) to parameters
 	 * (next request)
 	 */
-	public static void transferViewstates(String page, HashMap<String, String> params) {
+	public static void transferViewstates(String page, Map<String, String> params) {
 		setViewstates(getViewstates(page), params);
 	}
 
@@ -499,7 +500,7 @@ public class cgBase {
 
 		String[] viewstates = null;
 
-		final HashMap<String, String> loginStart = settings.getLogin();
+		final Map<String, String> loginStart = settings.getLogin();
 
 		if (loginStart == null) {
 			return -3; // no login information stored
@@ -527,8 +528,8 @@ public class cgBase {
 			return -2; // no loginpage
 		}
 
-		final HashMap<String, String> login = settings.getLogin();
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> login = settings.getLogin();
+		final Map<String, String> params = new HashMap<String, String>();
 
 		if (login == null || StringUtils.isEmpty(login.get("username")) || StringUtils.isEmpty(login.get("password"))) {
 			Log.e(cgSettings.tag, "cgeoBase.login: No login information stored");
@@ -606,7 +607,7 @@ public class cgBase {
 	public String switchToEnglish(String[] viewstates) {
 		final String host = "www.geocaching.com";
 		final String path = "/default.aspx";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 
 		setViewstates(viewstates, params);
 		params.put("__EVENTTARGET", "ctl00$uxLocaleList$uxLocaleList$ctl00$uxLocaleItem"); // switch to english
@@ -622,8 +623,8 @@ public class cgBase {
 		}
 
 		final cgCacheWrap caches = new cgCacheWrap();
-		final ArrayList<String> cids = new ArrayList<String>();
-		final ArrayList<String> guids = new ArrayList<String>();
+		final List<String> cids = new ArrayList<String>();
+		final List<String> guids = new ArrayList<String>();
 		String recaptchaChallenge = null;
 		String recaptchaText = null;
 
@@ -977,7 +978,7 @@ public class cgBase {
 			Log.i(cgSettings.tag, "Trying to get ratings for " + cids.size() + " caches");
 
 			try {
-				final HashMap<String, cgRating> ratings = getRating(guids, null);
+				final Map<String, cgRating> ratings = getRating(guids, null);
 
 				if (CollectionUtils.isNotEmpty(ratings)) {
 					// save found cache coordinates
@@ -1329,7 +1330,7 @@ public class cgBase {
 			if (matcherLatLon.find() && matcherLatLon.groupCount() > 0) {
 				cache.latlon = getMatch(matcherLatLon.group(2)); // first is <b>
 
-				HashMap<String, Object> tmp = cgBase.parseLatlon(cache.latlon);
+				Map<String, Object> tmp = cgBase.parseLatlon(cache.latlon);
 				if (tmp.size() > 0) {
 					cache.latitude = (Double) tmp.get("latitude");
 					cache.longitude = (Double) tmp.get("longitude");
@@ -1721,7 +1722,7 @@ public class cgBase {
 						if (matcherWpLatLon.find() && matcherWpLatLon.groupCount() > 1) {
 							waypoint.latlon = Html.fromHtml(matcherWpLatLon.group(2)).toString();
 
-							final HashMap<String, Object> tmp = cgBase.parseLatlon(waypoint.latlon);
+							final Map<String, Object> tmp = cgBase.parseLatlon(waypoint.latlon);
 							if (tmp.size() > 0) {
 								waypoint.latitude = (Double) tmp.get("latitude");
 								waypoint.longitude = (Double) tmp.get("longitude");
@@ -1882,8 +1883,8 @@ public class cgBase {
 	}
 
 	public cgRating getRating(String guid, String geocode) {
-		ArrayList<String> guids = null;
-		ArrayList<String> geocodes = null;
+		List<String> guids = null;
+		List<String> geocodes = null;
 
 		if (StringUtils.isNotBlank(guid)) {
 			guids = new ArrayList<String>();
@@ -1895,7 +1896,7 @@ public class cgBase {
 			return null;
 		}
 
-		final HashMap<String, cgRating> ratings = getRating(guids, geocodes);
+		final Map<String, cgRating> ratings = getRating(guids, geocodes);
 		if(ratings != null){
 			for (Entry<String, cgRating> entry : ratings.entrySet()) {
 				return entry.getValue();
@@ -1905,17 +1906,17 @@ public class cgBase {
 		return null;
 	}
 
-	public HashMap<String, cgRating> getRating(ArrayList<String> guids, ArrayList<String> geocodes) {
+	public Map<String, cgRating> getRating(List<String> guids, List<String> geocodes) {
 		if (guids == null && geocodes == null) {
 			return null;
 		}
 
-		final HashMap<String, cgRating> ratings = new HashMap<String, cgRating>();
+		final Map<String, cgRating> ratings = new HashMap<String, cgRating>();
 
 		try {
-			final HashMap<String, String> params = new HashMap<String, String>();
+			final Map<String, String> params = new HashMap<String, String>();
 			if (settings.isLogin()) {
-				final HashMap<String, String> login = settings.getGCvoteLogin();
+				final Map<String, String> login = settings.getGCvoteLogin();
 				if (login != null) {
 					params.put("userName", login.get("username"));
 					params.put("password", login.get("password"));
@@ -2261,12 +2262,12 @@ public class cgBase {
 		return trackable;
 	}
 
-	public static ArrayList<Integer> parseTypes(String page) {
+	public static List<Integer> parseTypes(String page) {
 		if (StringUtils.isEmpty(page)) {
 			return null;
 		}
 
-		final ArrayList<Integer> types = new ArrayList<Integer>();
+		final List<Integer> types = new ArrayList<Integer>();
 
 		final Pattern typeBoxPattern = Pattern.compile("<select name=\"ctl00\\$ContentBody\\$LogBookPanel1\\$ddLogType\" id=\"ctl00_ContentBody_LogBookPanel1_ddLogType\"[^>]*>"
 				+ "(([^<]*<option[^>]*>[^<]+</option>)+)[^<]*</select>", Pattern.CASE_INSENSITIVE);
@@ -2295,12 +2296,12 @@ public class cgBase {
 		return types;
 	}
 
-	public static ArrayList<cgTrackableLog> parseTrackableLog(String page) {
+	public static List<cgTrackableLog> parseTrackableLog(String page) {
 		if (StringUtils.isEmpty(page)) {
 			return null;
 		}
 
-		final ArrayList<cgTrackableLog> trackables = new ArrayList<cgTrackableLog>();
+		final List<cgTrackableLog> trackables = new ArrayList<cgTrackableLog>();
 
 		int startPos = -1;
 		int endPos = -1;
@@ -2487,7 +2488,7 @@ public class cgBase {
 		return result;
 	}
 
-	public static HashMap<String, Double> getRadialDistance(Double latitude, Double longitude, Double bearing, Double distance) {
+	public static Map<String, Double> getRadialDistance(Double latitude, Double longitude, Double bearing, Double distance) {
 		final Double rlat1 = latitude * deg2rad;
 		final Double rlon1 = longitude * deg2rad;
 		final Double rbearing = bearing * deg2rad;
@@ -2496,7 +2497,7 @@ public class cgBase {
 		final Double rlat = Math.asin(Math.sin(rlat1) * Math.cos(rdistance) + Math.cos(rlat1) * Math.sin(rdistance) * Math.cos(rbearing));
 		final Double rlon = rlon1 + Math.atan2(Math.sin(rbearing) * Math.sin(rdistance) * Math.cos(rlat1), Math.cos(rdistance) - Math.sin(rlat1) * Math.sin(rlat));
 
-		HashMap<String, Double> result = new HashMap<String, Double>();
+		Map<String, Double> result = new HashMap<String, Double>();
 		result.put("latitude", rlat * rad2deg);
 		result.put("longitude", rlon * rad2deg);
 
@@ -2564,8 +2565,8 @@ public class cgBase {
 		}
 	}
 
-	public static HashMap<String, Object> parseLatlon(String latlon) {
-		final HashMap<String, Object> result = new HashMap<String, Object>();
+	public static Map<String, Object> parseLatlon(String latlon) {
+		final Map<String, Object> result = new HashMap<String, Object>();
 		final Pattern patternLatlon = Pattern.compile("([NS])[^\\d]*(\\d+)[^°]*° (\\d+)\\.(\\d+) ([WE])[^\\d]*(\\d+)[^°]*° (\\d+)\\.(\\d+)", Pattern.CASE_INSENSITIVE);
 		final Matcher matcherLatlon = patternLatlon.matcher(latlon);
 
@@ -2625,8 +2626,8 @@ public class cgBase {
 		return formatLatitude(latitude, degrees) + " | " + formatLongitude(longitude, degrees);
 	}
 
-	public static HashMap<String, Object> parseCoordinate(String coord, String latlon) {
-		final HashMap<String, Object> coords = new HashMap<String, Object>();
+	public static Map<String, Object> parseCoordinate(String coord, String latlon) {
+		final Map<String, Object> coords = new HashMap<String, Object>();
 
 		final Pattern patternA = Pattern.compile("^([NSWE])[^\\d]*(\\d+)°? +(\\d+)([\\.|,](\\d+))?$", Pattern.CASE_INSENSITIVE);
 		final Pattern patternB = Pattern.compile("^([NSWE])[^\\d]*(\\d+)([\\.|,](\\d+))?$", Pattern.CASE_INSENSITIVE);
@@ -2776,7 +2777,7 @@ public class cgBase {
 			path = url;
 		}
 
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		setViewstates(viewstates, params);
 		params.put("__EVENTTARGET", "ctl00$ContentBody$pgrBottom$ctl08");
 		params.put("__EVENTARGUMENT", "");
@@ -2810,7 +2811,7 @@ public class cgBase {
 		app.setError(searchId, caches.error);
 		app.setViewstates(searchId, caches.viewstates);
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
+		final List<cgCache> cacheList = new ArrayList<cgCache>();
 		for (cgCache cache : caches.cacheList) {
 			app.addGeocode(searchId, cache.geocode);
 			cacheList.add(cache);
@@ -2821,7 +2822,7 @@ public class cgBase {
 		return searchId;
 	}
 
-	public Long searchByGeocode(HashMap<String, String> parameters, int reason, boolean forceReload) {
+	public Long searchByGeocode(Map<String, String> parameters, int reason, boolean forceReload) {
 		final cgSearch search = new cgSearch();
 		String geocode = parameters.get("geocode");
 		String guid = parameters.get("guid");
@@ -2836,7 +2837,7 @@ public class cgBase {
 				geocode = app.getGeocode(guid);
 			}
 
-			ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
+			List<cgCache> cacheList = new ArrayList<cgCache>();
 			cacheList.add(app.getCacheByGeocode(geocode, true, true, true, true, true, true));
 			search.addGeocode(geocode);
 
@@ -2851,7 +2852,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/seek/cache_details.aspx";
 		final String method = "GET";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		if (StringUtils.isNotBlank(geocode)) {
 			params.put("wp", geocode);
 		} else if (StringUtils.isNotBlank(guid)) {
@@ -2871,7 +2872,7 @@ public class cgBase {
 					geocode = app.getGeocode(guid);
 				}
 
-				final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
+				final List<cgCache> cacheList = new ArrayList<cgCache>();
 				cacheList.add(app.getCacheByGeocode(geocode));
 				search.addGeocode(geocode);
 				search.error = null;
@@ -2908,22 +2909,7 @@ public class cgBase {
 			return null;
 		}
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
-		if (caches != null) {
-			if (StringUtils.isNotBlank(caches.error)) {
-				search.error = caches.error;
-			}
-			if (StringUtils.isNotBlank(caches.url)) {
-				search.url = caches.url;
-			}
-			search.viewstates = caches.viewstates;
-			search.totalCnt = caches.totalCnt;
-
-			for (cgCache cache : caches.cacheList) {
-				search.addGeocode(cache.geocode);
-				cacheList.add(cache);
-			}
-		}
+		List<cgCache> cacheList = processSearchResults(search, caches, 0, 0,  null);
 
 		app.addSearch(search, cacheList, true, reason);
 
@@ -2933,7 +2919,7 @@ public class cgBase {
 		return search.getCurrentId();
 	}
 
-	public Long searchByOffline(HashMap<String, Object> parameters) {
+	public Long searchByOffline(Map<String, Object> parameters) {
 		if (app == null) {
 			Log.e(cgSettings.tag, "cgeoBase.searchByOffline: No application found");
 			return null;
@@ -2963,7 +2949,7 @@ public class cgBase {
 		return search.getCurrentId();
 	}
 
-	public Long searchByHistory(HashMap<String, Object> parameters) {
+	public Long searchByHistory(Map<String, Object> parameters) {
 		if (app == null) {
 			Log.e(cgSettings.tag, "cgeoBase.searchByHistory: No application found");
 			return null;
@@ -2981,7 +2967,7 @@ public class cgBase {
 		return search.getCurrentId();
 	}
 
-	public Long searchByCoords(cgSearchThread thread, HashMap<String, String> parameters, int reason, boolean showCaptcha) {
+	public Long searchByCoords(cgSearchThread thread, Map<String, String> parameters, int reason, boolean showCaptcha) {
 		final cgSearch search = new cgSearch();
 		final String latitude = parameters.get("latitude");
 		final String longitude = parameters.get("longitude");
@@ -3005,7 +2991,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/seek/nearest.aspx";
 		final String method = "GET";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		if (cacheType != null && cacheIDs.containsKey(cacheType)) {
 			params.put("tx", cacheIDs.get(cacheType));
 		} else {
@@ -3032,31 +3018,14 @@ public class cgBase {
 			return null;
 		}
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
-		if (caches != null) {
-			if (StringUtils.isNotBlank(caches.error)) {
-				search.error = caches.error;
-			}
-			if (StringUtils.isNotBlank(caches.url)) {
-				search.url = caches.url;
-			}
-			search.viewstates = caches.viewstates;
-			search.totalCnt = caches.totalCnt;
-
-			for (cgCache cache : caches.cacheList) {
-				if (settings.excludeDisabled == 0 || (settings.excludeDisabled == 1 && cache.disabled == false)) {
-					search.addGeocode(cache.geocode);
-					cacheList.add(cache);
-				}
-			}
-		}
+		List<cgCache> cacheList = processSearchResults(search, caches, settings.excludeDisabled, 0,  null);
 
 		app.addSearch(search, cacheList, true, reason);
 
 		return search.getCurrentId();
 	}
 
-	public Long searchByKeyword(cgSearchThread thread, HashMap<String, String> parameters, int reason, boolean showCaptcha) {
+	public Long searchByKeyword(cgSearchThread thread, Map<String, String> parameters, int reason, boolean showCaptcha) {
 		final cgSearch search = new cgSearch();
 		final String keyword = parameters.get("keyword");
 		cgCacheWrap caches = new cgCacheWrap();
@@ -3074,7 +3043,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/seek/nearest.aspx";
 		final String method = "GET";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		if (cacheType != null && cacheIDs.containsKey(cacheType)) {
 			params.put("tx", cacheIDs.get(cacheType));
 		} else {
@@ -3100,31 +3069,14 @@ public class cgBase {
 			return null;
 		}
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
-		if (caches != null) {
-			if (StringUtils.isNotBlank(caches.error)) {
-				search.error = caches.error;
-			}
-			if (StringUtils.isNotBlank(caches.url)) {
-				search.url = caches.url;
-			}
-			search.viewstates = caches.viewstates;
-			search.totalCnt = caches.totalCnt;
-
-			for (cgCache cache : caches.cacheList) {
-				if (settings.excludeDisabled == 0 || (settings.excludeDisabled == 1 && cache.disabled == false)) {
-					search.addGeocode(cache.geocode);
-					cacheList.add(cache);
-				}
-			}
-		}
+		List<cgCache> cacheList = processSearchResults(search, caches, settings.excludeDisabled, 0,  null);
 
 		app.addSearch(search, cacheList, true, reason);
 
 		return search.getCurrentId();
 	}
 
-	public Long searchByUsername(cgSearchThread thread, HashMap<String, String> parameters, int reason, boolean showCaptcha) {
+	public Long searchByUsername(cgSearchThread thread, Map<String, String> parameters, int reason, boolean showCaptcha) {
 		final cgSearch search = new cgSearch();
 		final String userName = parameters.get("username");
 		cgCacheWrap caches = new cgCacheWrap();
@@ -3142,7 +3094,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/seek/nearest.aspx";
 		final String method = "GET";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		if (cacheType != null && cacheIDs.containsKey(cacheType)) {
 			params.put("tx", cacheIDs.get(cacheType));
 		} else {
@@ -3174,31 +3126,14 @@ public class cgBase {
 			return null;
 		}
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
-		if (caches != null) {
-			if (StringUtils.isNotBlank(caches.error)) {
-				search.error = caches.error;
-			}
-			if (StringUtils.isNotBlank(caches.url)) {
-				search.url = caches.url;
-			}
-			search.viewstates = caches.viewstates;
-			search.totalCnt = caches.totalCnt;
-
-			for (cgCache cache : caches.cacheList) {
-				if (settings.excludeDisabled == 0 || (settings.excludeDisabled == 1 && cache.disabled == false)) {
-					search.addGeocode(cache.geocode);
-					cacheList.add(cache);
-				}
-			}
-		}
+		List<cgCache> cacheList = processSearchResults(search, caches, settings.excludeDisabled, 0,  null);
 
 		app.addSearch(search, cacheList, true, reason);
 
 		return search.getCurrentId();
 	}
 
-	public Long searchByOwner(cgSearchThread thread, HashMap<String, String> parameters, int reason, boolean showCaptcha) {
+	public Long searchByOwner(cgSearchThread thread, Map<String, String> parameters, int reason, boolean showCaptcha) {
 		final cgSearch search = new cgSearch();
 		final String userName = parameters.get("username");
 		cgCacheWrap caches = new cgCacheWrap();
@@ -3216,7 +3151,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/seek/nearest.aspx";
 		final String method = "GET";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		if (cacheType != null && cacheIDs.containsKey(cacheType)) {
 			params.put("tx", cacheIDs.get(cacheType));
 		} else {
@@ -3242,31 +3177,14 @@ public class cgBase {
 			return null;
 		}
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
-		if (caches != null) {
-			if (StringUtils.isNotBlank(caches.error)) {
-				search.error = caches.error;
-			}
-			if (StringUtils.isNotBlank(caches.url)) {
-				search.url = caches.url;
-			}
-			search.viewstates = caches.viewstates;
-			search.totalCnt = caches.totalCnt;
-
-			for (cgCache cache : caches.cacheList) {
-				if (settings.excludeDisabled == 0 || (settings.excludeDisabled == 1 && cache.disabled == false)) {
-					search.addGeocode(cache.geocode);
-					cacheList.add(cache);
-				}
-			}
-		}
+		List<cgCache> cacheList = processSearchResults(search, caches, settings.excludeDisabled, 0,  null);
 
 		app.addSearch(search, cacheList, true, reason);
 
 		return search.getCurrentId();
 	}
 
-	public Long searchByViewport(HashMap<String, String> parameters, int reason) {
+	public Long searchByViewport(Map<String, String> parameters, int reason) {
 		final cgSearch search = new cgSearch();
 		final String latMin = parameters.get("latitude-min");
 		final String latMax = parameters.get("latitude-max");
@@ -3311,37 +3229,15 @@ public class cgBase {
 			return null;
 		}
 
-		final ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
-		if (caches != null) {
-			if (StringUtils.isNotBlank(caches.error)) {
-				search.error = caches.error;
-			}
-			if (StringUtils.isNotBlank(caches.url)) {
-				search.url = caches.url;
-			}
-			search.viewstates = caches.viewstates;
-			search.totalCnt = caches.totalCnt;
-
-			if (CollectionUtils.isNotEmpty(caches.cacheList)) {
-				for (cgCache cache : caches.cacheList) {
-					if ((settings.excludeDisabled == 0 || (settings.excludeDisabled == 1 && cache.disabled == false))
-							&& (settings.excludeMine == 0 || (settings.excludeMine == 1 && cache.own == false))
-							&& (settings.excludeMine == 0 || (settings.excludeMine == 1 && cache.found == false))
-							&& (settings.cacheType == null || (settings.cacheType.equals(cache.type)))) {
-						search.addGeocode(cache.geocode);
-						cacheList.add(cache);
-					}
-				}
-			}
-		}
+		List<cgCache> cacheList = processSearchResults(search, caches, settings.excludeDisabled, settings.excludeMine, settings.cacheType);
 
 		app.addSearch(search, cacheList, true, reason);
 
 		return search.getCurrentId();
 	}
 
-	public ArrayList<cgUser> getGeocachersInViewport(String username, Double latMin, Double latMax, Double lonMin, Double lonMax) {
-		final ArrayList<cgUser> users = new ArrayList<cgUser>();
+	public List<cgUser> getGeocachersInViewport(String username, Double latMin, Double latMax, Double lonMin, Double lonMax) {
+		final List<cgUser> users = new ArrayList<cgUser>();
 
 		if (username == null) {
 			return users;
@@ -3353,7 +3249,7 @@ public class cgBase {
 		final String host = "api.go4cache.com";
 		final String path = "/get.php";
 		final String method = "POST";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 
 		params.put("u", username);
 		params.put("ltm", String.format((Locale) null, "%.6f", latMin));
@@ -3404,7 +3300,34 @@ public class cgBase {
 		return users;
 	}
 
-	public cgTrackable searchTrackable(HashMap<String, String> parameters) {
+	 	public List<cgCache> processSearchResults(cgSearch search, cgCacheWrap caches, int excludeDisabled, int excludeMine, String cacheType) {
+		 		List<cgCache> cacheList = new ArrayList<cgCache>();
+		  		if (caches != null) {
+		 			if (StringUtils.isNotBlank(caches.error)) {
+		  				search.error = caches.error;
+		  			}
+		 			if (StringUtils.isNotBlank(caches.url)) {
+		  				search.url = caches.url;
+		  			}
+		  			search.viewstates = caches.viewstates;
+		  			search.totalCnt = caches.totalCnt;
+		  
+		 			if (CollectionUtils.isNotEmpty(caches.cacheList)) {
+		  				for (cgCache cache : caches.cacheList) {
+		 					if ((excludeDisabled == 0 || (excludeDisabled == 1 && cache.disabled == false))
+		 							&& (excludeMine == 0 || (excludeMine == 1 && cache.own == false))
+		 							&& (excludeMine == 0 || (excludeMine == 1 && cache.found == false))
+		 							&& (cacheType == null || (cacheType.equals(cache.type)))) {
+		  						search.addGeocode(cache.geocode);
+		  						cacheList.add(cache);
+		  					}
+		  				}
+		 			}
+		  		}
+		  		return cacheList;
+	 	}
+	
+	public cgTrackable searchTrackable(Map<String, String> parameters) {
 		final String geocode = parameters.get("geocode");
 		final String guid = parameters.get("guid");
 		final String id = parameters.get("id");
@@ -3418,7 +3341,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/track/details.aspx";
 		final String method = "GET";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		if (StringUtils.isNotBlank(geocode)) {
 			params.put("tracker", geocode);
 		} else if (StringUtils.isNotBlank(guid)) {
@@ -3444,7 +3367,7 @@ public class cgBase {
 	}
 
 	public int postLog(cgeoapplication app, String geocode, String cacheid, String[] viewstates,
-			int logType, int year, int month, int day, String log, ArrayList<cgTrackableLog> trackables) {
+			int logType, int year, int month, int day, String log, List<cgTrackableLog> trackables) {
 		if (ArrayUtils.isEmpty(viewstates)) {
 			Log.e(cgSettings.tag, "cgeoBase.postLog: No viewstate given");
 			return 1000;
@@ -3488,7 +3411,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/seek/log.aspx?ID=" + cacheid;
 		final String method = "POST";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 
 		setViewstates(viewstates, params);
 		params.put("__EVENTTARGET", "");
@@ -3630,7 +3553,7 @@ public class cgBase {
 		final String host = "www.geocaching.com";
 		final String path = "/track/log.aspx?wid=" + tbid;
 		final String method = "POST";
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 
 		setViewstates(viewstates, params);
 		params.put("__EVENTTARGET", "");
@@ -3725,7 +3648,7 @@ public class cgBase {
 		}
 
 		// removing cache from list needs approval by hitting "Yes" button
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		transferViewstates(page, params);
 		params.put("__EVENTTARGET", "");
 		params.put("__EVENTARGUMENT", "");
@@ -3805,7 +3728,7 @@ public class cgBase {
 		}
 
 		try {
-			HashMap<String, String> parameters = new HashMap<String, String>();
+			Map<String, String> parameters = new HashMap<String, String>();
 
 			parameters.put("status", status);
 			if (latitude != null && longitude != null) {
@@ -3936,7 +3859,7 @@ public class cgBase {
 		return encoded;
 	}
 
-	public String prepareParameters(HashMap<String, String> params, boolean my, boolean addF) {
+	public String prepareParameters(Map<String, String> params, boolean my, boolean addF) {
 		String paramsDone = null;
 
 		if (my != true && settings.excludeMine > 0) {
@@ -3952,7 +3875,7 @@ public class cgBase {
 
 		if (params != null) {
 			Set<Map.Entry<String, String>> entrySet = params.entrySet();
-			ArrayList<String> paramsEncoded = new ArrayList<String>();
+			List<String> paramsEncoded = new ArrayList<String>();
 
 			for(Map.Entry<String, String> entry : entrySet)
 			{
@@ -3977,13 +3900,13 @@ public class cgBase {
 		return paramsDone;
 	}
 
-	public String[] requestViewstates(boolean secure, String host, String path, String method, HashMap<String, String> params, boolean xContentType, boolean my) {
+	public String[] requestViewstates(boolean secure, String host, String path, String method, Map<String, String> params, boolean xContentType, boolean my) {
 		final cgResponse response = request(secure, host, path, method, params, xContentType, my, false);
 
 		return getViewstates(response.getData());
 	}
 
-	public String requestLogged(boolean secure, String host, String path, String method, HashMap<String, String> params, boolean xContentType, boolean my, boolean addF) {
+	public String requestLogged(boolean secure, String host, String path, String method, Map<String, String> params, boolean xContentType, boolean my, boolean addF) {
 		cgResponse response = request(secure, host, path, method, params, xContentType, my, addF);
 		String data = response.getData();
 
@@ -4000,14 +3923,14 @@ public class cgBase {
 		return data;
 	}
 
-	public cgResponse request(boolean secure, String host, String path, String method, HashMap<String, String> params, boolean xContentType, boolean my, boolean addF) {
+	public cgResponse request(boolean secure, String host, String path, String method, Map<String, String> params, boolean xContentType, boolean my, boolean addF) {
 		// prepare parameters
 		final String paramsDone = prepareParameters(params, my, addF);
 
 		return request(secure, host, path, method, paramsDone, 0, xContentType);
 	}
 
-	public cgResponse request(boolean secure, String host, String path, String method, HashMap<String, String> params, int requestId, boolean xContentType, boolean my, boolean addF) {
+	public cgResponse request(boolean secure, String host, String path, String method, Map<String, String> params, int requestId, boolean xContentType, boolean my, boolean addF) {
 		// prepare parameters
 		final String paramsDone = prepareParameters(params, my, addF);
 
@@ -4231,7 +4154,7 @@ public class cgBase {
 
 		if (cookies != null) {
 			final Set<Map.Entry<String, String>> entrySet = cookies.entrySet();
-			final ArrayList<String> cookiesEncoded = new ArrayList<String>();
+			final List<String> cookiesEncoded = new ArrayList<String>();
 
 			for(Map.Entry<String, String> entry : entrySet){
 				cookiesEncoded.add(entry.getKey() + "=" + entry.getValue());
@@ -4247,7 +4170,7 @@ public class cgBase {
 
 			if (CollectionUtils.isNotEmpty(prefsValues)) {
 				final Set<? extends Map.Entry<String, ?>> entrySet = prefsValues.entrySet();
-				final ArrayList<String> cookiesEncoded = new ArrayList<String>();
+				final List<String> cookiesEncoded = new ArrayList<String>();
 
 				for(Map.Entry<String, ?> entry : entrySet){
 					String key = entry.getKey();
@@ -4653,13 +4576,13 @@ public class cgBase {
 			if (cache != null) {
 				// only reload the cache, if it was already stored or has not all details (by checking the description)
 				if (cache.reason > 0 || StringUtils.isBlank(cache.description)) {
-					final HashMap<String, String> params = new HashMap<String, String>();
+					final Map<String, String> params = new HashMap<String, String>();
 					params.put("geocode", cache.geocode);
 					final Long searchId = searchByGeocode(params, listId, false);
 					cache = app.getCache(searchId);
 				}
 			} else if (StringUtils.isNotBlank(geocode)) {
-				final HashMap<String, String> params = new HashMap<String, String>();
+				final Map<String, String> params = new HashMap<String, String>();
 				params.put("geocode", geocode);
 				final Long searchId = searchByGeocode(params, listId, false);
 				cache = app.getCache(searchId);

--- a/src/cgeo/geocaching/cgCache.java
+++ b/src/cgeo/geocaching/cgCache.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,12 +72,12 @@ public class cgCache implements ICache {
 	public Float myVote = null;
 	public int inventoryItems = 0;
 	public boolean onWatchlist = false;
-	public ArrayList<String> attributes = null;
-	public ArrayList<cgWaypoint> waypoints = null;
-	public ArrayList<cgImage> spoilers = null;
-	public ArrayList<cgLog> logs = null;
-	public ArrayList<cgTrackable> inventory = null;
-	public HashMap<Integer, Integer> logCounts = new HashMap<Integer, Integer>();
+	public List<String> attributes = null;
+	public List<cgWaypoint> waypoints = null;
+	public List<cgImage> spoilers = null;
+	public List<cgLog> logs = null;
+	public List<cgTrackable> inventory = null;
+	public Map<Integer, Integer> logCounts = new HashMap<Integer, Integer>();
 	public boolean logOffline = false;
 	// temporary values
 	public boolean statusChecked = false;
@@ -327,9 +329,9 @@ public class cgCache implements ICache {
 		}
 	}
 
-	public ArrayList<Integer> getPossibleLogTypes(cgSettings settings) {
+	public List<Integer> getPossibleLogTypes(cgSettings settings) {
 		boolean isOwner = owner != null && owner.equalsIgnoreCase(settings.getUsername());
-		ArrayList<Integer> types = new ArrayList<Integer>();
+		List<Integer> types = new ArrayList<Integer>();
 		if ("event".equals(type) || "mega".equals(type) || "cito".equals(type) || "lostfound".equals(type)) {
 			types.add(cgBase.LOG_WILL_ATTEND);
 			types.add(cgBase.LOG_NOTE);

--- a/src/cgeo/geocaching/cgCacheListAdapter.java
+++ b/src/cgeo/geocaching/cgCacheListAdapter.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -58,9 +59,9 @@ public class cgCacheListAdapter extends ArrayAdapter<cgCache> {
 	private boolean sort = true;
 	private int checked = 0;
 	private boolean selectMode = false;
-	private static HashMap<String, Drawable> gcIconDrawables = new HashMap<String, Drawable>();
-	private ArrayList<cgCompassMini> compasses = new ArrayList<cgCompassMini>();
-	private ArrayList<cgDistanceView> distances = new ArrayList<cgDistanceView>();
+	private static Map<String, Drawable> gcIconDrawables = new HashMap<String, Drawable>();
+	private List<cgCompassMini> compasses = new ArrayList<cgCompassMini>();
+	private List<cgDistanceView> distances = new ArrayList<cgDistanceView>();
 	private int[] ratingBcgs = new int[3];
 	private float pixelDensity = 1f;
 	private static final int SWIPE_MIN_DISTANCE = 60;

--- a/src/cgeo/geocaching/cgCacheWrap.java
+++ b/src/cgeo/geocaching/cgCacheWrap.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * List of caches
@@ -10,5 +11,5 @@ public class cgCacheWrap {
 	public String url = "";
 	public String[] viewstates = null;
 	public int totalCnt = 0;
-	public ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
+	public List<cgCache> cacheList = new ArrayList<cgCache>();
 }

--- a/src/cgeo/geocaching/cgData.java
+++ b/src/cgeo/geocaching/cgData.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -828,7 +829,7 @@ public class cgData {
 		init();
 
 		Cursor cursor = null;
-		ArrayList<String> thereA = new ArrayList<String>();
+		List<String> thereA = new ArrayList<String>();
 
 		try {
 			cursor = databaseRO.query(
@@ -1287,7 +1288,7 @@ public class cgData {
 		return false;
 	}
 
-	public boolean saveAttributes(String geocode, ArrayList<String> attributes) {
+	public boolean saveAttributes(String geocode, List<String> attributes) {
 		init();
 
 		if (StringUtils.isBlank(geocode) || attributes == null) {
@@ -1354,7 +1355,7 @@ public class cgData {
 		return success;
 	}
 
-	public boolean saveWaypoints(String geocode, ArrayList<cgWaypoint> waypoints, boolean drop) {
+	public boolean saveWaypoints(String geocode,List <cgWaypoint> waypoints, boolean drop) {
 		init();
 
 		if (StringUtils.isBlank(geocode) || waypoints == null) {
@@ -1461,7 +1462,7 @@ public class cgData {
 		return false;
 	}
 
-	public boolean saveSpoilers(String geocode, ArrayList<cgImage> spoilers) {
+	public boolean saveSpoilers(String geocode, List<cgImage> spoilers) {
 		init();
 
 		if (StringUtils.isBlank(geocode) || spoilers == null) {
@@ -1493,11 +1494,11 @@ public class cgData {
 		return true;
 	}
 
-	public boolean saveLogs(String geocode, ArrayList<cgLog> logs) {
+	public boolean saveLogs(String geocode, List<cgLog> logs) {
 		return saveLogs(geocode, logs, true);
 	}
 
-	public boolean saveLogs(String geocode, ArrayList<cgLog> logs, boolean drop) {
+	public boolean saveLogs(String geocode, List<cgLog> logs, boolean drop) {
 		init();
 
 		if (StringUtils.isBlank(geocode) || logs == null) {
@@ -1547,11 +1548,11 @@ public class cgData {
 		return true;
 	}
 
-	public boolean saveLogCount(String geocode, HashMap<Integer, Integer> logCounts) {
+	public boolean saveLogCount(String geocode, Map<Integer, Integer> logCounts) {
 		return saveLogCount(geocode, logCounts, true);
 	}
 
-	public boolean saveLogCount(String geocode, HashMap<Integer, Integer> logCounts, boolean drop) {
+	public boolean saveLogCount(String geocode, Map<Integer, Integer> logCounts, boolean drop) {
 		init();
 
 		if (StringUtils.isBlank(geocode) || CollectionUtils.isEmpty(logCounts)) {
@@ -1584,7 +1585,7 @@ public class cgData {
 		return true;
 	}
 
-	public boolean saveInventory(String geocode, ArrayList<cgTrackable> trackables) {
+	public boolean saveInventory(String geocode, List<cgTrackable> trackables) {
 		init();
 
 		if (trackables == null) {
@@ -1630,12 +1631,12 @@ public class cgData {
 		return true;
 	}
 
-	public ArrayList<Object> getBounds(Object[] geocodes) {
+	public List<Object> getBounds(Object[] geocodes) {
 		init();
 
 		Cursor cursor = null;
 
-		final ArrayList<Object> viewport = new ArrayList<Object>();
+		final List<Object> viewport = new ArrayList<Object>();
 
 		try {
 			final StringBuilder where = new StringBuilder();
@@ -1713,7 +1714,7 @@ public class cgData {
 			guids = null;
 		}
 
-		ArrayList<cgCache> caches = loadCaches(geocodes, guids, null, null, null, null, loadA, loadW, loadS, loadL, loadI, loadO);
+		List<cgCache> caches = loadCaches(geocodes, guids, null, null, null, null, loadA, loadW, loadS, loadL, loadI, loadO);
 		if (caches != null && caches.isEmpty() == false) {
 			return caches.get(0);
 		}
@@ -1721,11 +1722,11 @@ public class cgData {
 		return null;
 	}
 
-	public ArrayList<cgCache> loadCaches(Object[] geocodes, Object[] guids) {
+	public List<cgCache> loadCaches(Object[] geocodes, Object[] guids) {
 		return loadCaches(geocodes, guids, null, null, null, null, false, true, false, false, false, false);
 	}
 
-	public ArrayList<cgCache> loadCaches(Object[] geocodes, Object[] guids, boolean lite) {
+	public List<cgCache> loadCaches(Object[] geocodes, Object[] guids, boolean lite) {
 		if (lite) {
 			return loadCaches(geocodes, guids, null, null, null, null, false, true, false, false, false, false);
 		} else {
@@ -1733,12 +1734,12 @@ public class cgData {
 		}
 	}
 
-	public ArrayList<cgCache> loadCaches(Object[] geocodes, Object[] guids, Long centerLat, Long centerLon, Long spanLat, Long spanLon, boolean loadA, boolean loadW, boolean loadS, boolean loadL, boolean loadI, boolean loadO) {
+	public List<cgCache> loadCaches(Object[] geocodes, Object[] guids, Long centerLat, Long centerLon, Long spanLat, Long spanLon, boolean loadA, boolean loadW, boolean loadS, boolean loadL, boolean loadI, boolean loadO) {
 		init();
 
 		StringBuilder where = new StringBuilder();
 		Cursor cursor = null;
-		ArrayList<cgCache> caches = new ArrayList<cgCache>();
+		List<cgCache> caches = new ArrayList<cgCache>();
 
 		try {
 			if (geocodes != null && geocodes.length > 0) {
@@ -1904,7 +1905,7 @@ public class cgData {
 						cache.onWatchlist = cursor.getLong(cursor.getColumnIndex("onWatchlist")) == 1L;
 
 						if (loadA) {
-							ArrayList<String> attributes = loadAttributes(cache.geocode);
+							List<String> attributes = loadAttributes(cache.geocode);
 							if (attributes != null && attributes.isEmpty() == false) {
 								if (cache.attributes == null)
 									cache.attributes = new ArrayList<String>();
@@ -1915,7 +1916,7 @@ public class cgData {
 						}
 
 						if (loadW) {
-							ArrayList<cgWaypoint> waypoints = loadWaypoints(cache.geocode);
+							List<cgWaypoint> waypoints = loadWaypoints(cache.geocode);
 							if (waypoints != null && waypoints.isEmpty() == false) {
 								if (cache.waypoints == null)
 									cache.waypoints = new ArrayList<cgWaypoint>();
@@ -1926,7 +1927,7 @@ public class cgData {
 						}
 
 						if (loadS) {
-							ArrayList<cgImage> spoilers = loadSpoilers(cache.geocode);
+							List<cgImage> spoilers = loadSpoilers(cache.geocode);
 							if (spoilers != null && spoilers.isEmpty() == false) {
 								if (cache.spoilers == null)
 									cache.spoilers = new ArrayList<cgImage>();
@@ -1937,7 +1938,7 @@ public class cgData {
 						}
 
 						if (loadL) {
-							ArrayList<cgLog> logs = loadLogs(cache.geocode);
+							List<cgLog> logs = loadLogs(cache.geocode);
 							if (logs != null && logs.isEmpty() == false) {
 								if (cache.logs == null)
 									cache.logs = new ArrayList<cgLog>();
@@ -1945,7 +1946,7 @@ public class cgData {
 									cache.logs.clear();
 								cache.logs.addAll(logs);
 							}
-							HashMap<Integer, Integer> logCounts = loadLogCounts(cache.geocode);
+							Map<Integer, Integer> logCounts = loadLogCounts(cache.geocode);
 							if (logCounts != null && logCounts.isEmpty() == false) {
 								cache.logCounts.clear();
 								cache.logCounts.putAll(logCounts);
@@ -1953,7 +1954,7 @@ public class cgData {
 						}
 
 						if (loadI) {
-							ArrayList<cgTrackable> inventory = loadInventory(cache.geocode);
+							List<cgTrackable> inventory = loadInventory(cache.geocode);
 							if (inventory != null && inventory.isEmpty() == false) {
 								if (cache.inventory == null)
 									cache.inventory = new ArrayList<cgTrackable>();
@@ -1988,7 +1989,7 @@ public class cgData {
 		return caches;
 	}
 
-	public ArrayList<String> loadAttributes(String geocode) {
+	public List<String> loadAttributes(String geocode) {
 		if (StringUtils.isBlank(geocode)) {
 			return null;
 		}
@@ -2054,14 +2055,14 @@ public class cgData {
 		return waypoint;
 	}
 
-	public ArrayList<cgWaypoint> loadWaypoints(String geocode) {
+	public List<cgWaypoint> loadWaypoints(String geocode) {
 		if (StringUtils.isBlank(geocode)) {
 			return null;
 		}
 
 		init();
 
-		ArrayList<cgWaypoint> waypoints = new ArrayList<cgWaypoint>();
+		List<cgWaypoint> waypoints = new ArrayList<cgWaypoint>();
 
 		Cursor cursor = databaseRO.query(
 				dbTableWaypoints,
@@ -2119,14 +2120,14 @@ public class cgData {
 		return waypoint;
 	}
 
-	public ArrayList<cgImage> loadSpoilers(String geocode) {
+	public List<cgImage> loadSpoilers(String geocode) {
 		if (StringUtils.isBlank(geocode)) {
 			return null;
 		}
 
 		init();
 
-		ArrayList<cgImage> spoilers = new ArrayList<cgImage>();
+		List<cgImage> spoilers = new ArrayList<cgImage>();
 
 		Cursor cursor = databaseRO.query(
 				dbTableSpoilers,
@@ -2214,14 +2215,14 @@ public class cgData {
 		return success;
 	}
 
-	public ArrayList<cgLog> loadLogs(String geocode) {
+	public List<cgLog> loadLogs(String geocode) {
 		if (StringUtils.isBlank(geocode)) {
 			return null;
 		}
 
 		init();
 
-		ArrayList<cgLog> logs = new ArrayList<cgLog>();
+		List<cgLog> logs = new ArrayList<cgLog>();
 
 		Cursor cursor = databaseRO.query(
 				dbTableLogs,
@@ -2257,14 +2258,14 @@ public class cgData {
 		return logs;
 	}
 
-	public HashMap<Integer, Integer> loadLogCounts(String geocode) {
+	public Map<Integer, Integer> loadLogCounts(String geocode) {
 		if (StringUtils.isBlank(geocode)) {
 			return null;
 		}
 
 		init();
 
-		HashMap<Integer, Integer> logCounts = new HashMap<Integer, Integer>();
+		Map<Integer, Integer> logCounts = new HashMap<Integer, Integer>();
 
 		Cursor cursor = databaseRO.query(
 				dbTableLogCount,
@@ -2294,10 +2295,10 @@ public class cgData {
 		return logCounts;
 	}
 
-	public ArrayList<cgImage> loadLogImages(int log_id) {
+	public List<cgImage> loadLogImages(int log_id) {
 		init();
 
-		ArrayList<cgImage> logImgList = new ArrayList<cgImage>();
+		List<cgImage> logImgList = new ArrayList<cgImage>();
 
 		Cursor cursor = databaseRO.query(
 				dbTableLogImages,
@@ -2327,14 +2328,14 @@ public class cgData {
 		return logImgList;
 	}
 
-	public ArrayList<cgTrackable> loadInventory(String geocode) {
+	public List<cgTrackable> loadInventory(String geocode) {
 		if (StringUtils.isBlank(geocode)) {
 			return null;
 		}
 
 		init();
 
-		ArrayList<cgTrackable> trackables = new ArrayList<cgTrackable>();
+		List<cgTrackable> trackables = new ArrayList<cgTrackable>();
 
 		Cursor cursor = databaseRO.query(
 				dbTableTrackables,
@@ -2467,14 +2468,14 @@ public class cgData {
 		return count;
 	}
 
-	public ArrayList<String> loadBatchOfStoredGeocodes(boolean detailedOnly, Double latitude, Double longitude, String cachetype, int list) {
+	public List<String> loadBatchOfStoredGeocodes(boolean detailedOnly, Double latitude, Double longitude, String cachetype, int list) {
 		init();
 
 		if (list < 1) {
 			list = 1;
 		}
 
-		ArrayList<String> geocodes = new ArrayList<String>();
+		List<String> geocodes = new ArrayList<String>();
 
 		StringBuilder specifySql = new StringBuilder();
 
@@ -2523,10 +2524,10 @@ public class cgData {
 		return geocodes;
 	}
 
-	public ArrayList<String> loadBatchOfHistoricGeocodes(boolean detailedOnly, String cachetype) {
+	public List<String> loadBatchOfHistoricGeocodes(boolean detailedOnly, String cachetype) {
 		init();
 
-		ArrayList<String> geocodes = new ArrayList<String>();
+		List<String> geocodes = new ArrayList<String>();
 
 		StringBuilder specifySql = new StringBuilder();
 		specifySql.append("visiteddate > 0");
@@ -2572,22 +2573,22 @@ public class cgData {
 		return geocodes;
 	}
 
-	public ArrayList<String> getCachedInViewport(Long centerLat, Long centerLon, Long spanLat, Long spanLon, String cachetype) {
+	public List<String> getCachedInViewport(Long centerLat, Long centerLon, Long spanLat, Long spanLon, String cachetype) {
 		return getInViewport(false, centerLat, centerLon, spanLat, spanLon, cachetype);
 	}
 
-	public ArrayList<String> getStoredInViewport(Long centerLat, Long centerLon, Long spanLat, Long spanLon, String cachetype) {
+	public List<String> getStoredInViewport(Long centerLat, Long centerLon, Long spanLat, Long spanLon, String cachetype) {
 		return getInViewport(true, centerLat, centerLon, spanLat, spanLon, cachetype);
 	}
 
-	public ArrayList<String> getInViewport(boolean stored, Long centerLat, Long centerLon, Long spanLat, Long spanLon, String cachetype) {
+	public List<String> getInViewport(boolean stored, Long centerLat, Long centerLon, Long spanLat, Long spanLon, String cachetype) {
 		if (centerLat == null || centerLon == null || spanLat == null || spanLon == null) {
 			return null;
 		}
 
 		init();
 
-		ArrayList<String> geocodes = new ArrayList<String>();
+		List<String> geocodes = new ArrayList<String>();
 
 		// viewport limitation
 		double latMin = (centerLat / 1e6) - ((spanLat / 1e6) / 2) - ((spanLat / 1e6) / 4);
@@ -2661,10 +2662,10 @@ public class cgData {
 		return geocodes;
 	}
 
-	public ArrayList<String> getOfflineAll(String cachetype) {
+	public List<String> getOfflineAll(String cachetype) {
 		init();
 
-		ArrayList<String> geocodes = new ArrayList<String>();
+		List<String> geocodes = new ArrayList<String>();
 
 		StringBuilder where = new StringBuilder();
 
@@ -2782,7 +2783,7 @@ public class cgData {
 		Log.d(cgSettings.tag, "Database clean: started");
 
 		Cursor cursor = null;
-		ArrayList<String> geocodes = new ArrayList<String>();
+		List<String> geocodes = new ArrayList<String>();
 
 		try {
 			if (more) {
@@ -2854,7 +2855,7 @@ public class cgData {
 	public void dropStored(int listId) {
 		init();
 
-		ArrayList<String> geocodes = new ArrayList<String>();
+		List<String> geocodes = new ArrayList<String>();
 
 		try {
 			Cursor cursor = databaseRO.query(
@@ -3033,10 +3034,10 @@ public class cgData {
         }
     }
 
-	public ArrayList<cgList> getLists(Resources res) {
+	public List<cgList> getLists(Resources res) {
 		init();
 
-		ArrayList<cgList> lists = new ArrayList<cgList>();
+		List<cgList> lists = new ArrayList<cgList>();
 
 		lists.add(new cgList(true, 1, res.getString(R.string.list_inbox)));
 		// lists.add(new cgList(true, 2, res.getString(R.string.list_wpt)));

--- a/src/cgeo/geocaching/cgGeo.java
+++ b/src/cgeo/geocaching/cgGeo.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -396,7 +397,7 @@ public class cgGeo {
 
 				final String username = settings.getUsername();
 				if (username != null) {
-					final HashMap<String, String> params = new HashMap<String, String>();
+					final Map<String, String> params = new HashMap<String, String>();
 					final String latStr = String.format((Locale) null, "%.6f", latitudeNow);
 					final String lonStr = String.format((Locale) null, "%.6f", longitudeNow);
 					params.put("u", username);

--- a/src/cgeo/geocaching/cgLog.java
+++ b/src/cgeo/geocaching/cgLog.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class cgLog {
 	public int id = 0;
@@ -9,7 +9,7 @@ public class cgLog {
 	public String log = "";
 	public long date = 0;
 	public int found = -1;
-	public ArrayList<cgImage> logImages = null;
+	public List<cgImage> logImages = null;
 	public String cacheName = ""; // used for trackables
 	public String cacheGuid = ""; // used for trackables
 }

--- a/src/cgeo/geocaching/cgOAuth.java
+++ b/src/cgeo/geocaching/cgOAuth.java
@@ -3,10 +3,11 @@ package cgeo.geocaching;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class cgOAuth {
-	public static String signOAuth(String host, String path, String method, boolean https, HashMap<String, String> params, String token, String tokenSecret) {
+	public static String signOAuth(String host, String path, String method, boolean https, Map<String, String> params, String token, String tokenSecret) {
 		String paramsDone = "";
 		if (method.equalsIgnoreCase("GET") == false && method.equalsIgnoreCase("POST") == false) {
 			method = "POST";
@@ -32,7 +33,7 @@ public class cgOAuth {
 		params.keySet().toArray(keys);
 		Arrays.sort(keys);
 
-		ArrayList<String> paramsEncoded = new ArrayList<String>();
+		List<String> paramsEncoded = new ArrayList<String>();
 		for (String key : keys) {
 			String value = params.get(key);
 			paramsEncoded.add(key + "=" + cgBase.urlencode_rfc3986(value));

--- a/src/cgeo/geocaching/cgSearch.java
+++ b/src/cgeo/geocaching/cgSearch.java
@@ -1,10 +1,11 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class cgSearch {
 	private Long id = null;
-	private ArrayList<String> geocodes = new ArrayList<String>();
+	private List<String> geocodes = new ArrayList<String>();
 
 	public int errorRetrieve = 0;
 	public String error = null;
@@ -20,7 +21,7 @@ public class cgSearch {
 		return id;
 	}
 
-	public ArrayList<String> getGeocodes() {
+	public List<String> getGeocodes() {
 		return geocodes;
 	}
 

--- a/src/cgeo/geocaching/cgSelectMapfile.java
+++ b/src/cgeo/geocaching/cgSelectMapfile.java
@@ -1,13 +1,12 @@
 package cgeo.geocaching;
 
 import java.io.File;
-import java.util.ArrayList;
-
-import cgeo.geocaching.files.FileList;
+import java.util.List;
 
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Environment;
+import cgeo.geocaching.files.FileList;
 
 public class cgSelectMapfile extends FileList<cgMapfileListAdapter> {
 
@@ -35,7 +34,7 @@ public class cgSelectMapfile extends FileList<cgMapfileListAdapter> {
 	}
 
 	@Override
-	protected cgMapfileListAdapter getAdapter(ArrayList<File> files) {
+	protected cgMapfileListAdapter getAdapter(List<File> files) {
 		return new cgMapfileListAdapter(this, files);
 	}
 

--- a/src/cgeo/geocaching/cgSettings.java
+++ b/src/cgeo/geocaching/cgSettings.java
@@ -281,8 +281,8 @@ public class cgSettings {
 		}
 	}
 
-	public HashMap<String, String> getLogin() {
-		final HashMap<String, String> login = new HashMap<String, String>();
+	public Map<String, String> getLogin() {
+		final Map<String, String> login = new HashMap<String, String>();
 
 		if (username == null || password == null) {
 			final String preUsername = prefs.getString(KEY_USERNAME, null);
@@ -371,8 +371,8 @@ public class cgSettings {
 		});
 	}
 
-	public HashMap<String, String> getGCvoteLogin() {
-		final HashMap<String, String> login = new HashMap<String, String>();
+	public Map<String, String> getGCvoteLogin() {
+		final Map<String, String> login = new HashMap<String, String>();
 
 		if (username == null || password == null) {
 			final String preUsername = prefs.getString(KEY_USERNAME, null);

--- a/src/cgeo/geocaching/cgTrackable.java
+++ b/src/cgeo/geocaching/cgTrackable.java
@@ -1,8 +1,10 @@
 package cgeo.geocaching;
 
-import android.text.Spannable;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+
+import android.text.Spannable;
 
 public class cgTrackable {
 	static public int SPOTTED_UNSET = 0;
@@ -31,5 +33,5 @@ public class cgTrackable {
 	public String goal = null;
 	public String details = null;
 	public String image = null;
-	public ArrayList<cgLog> logs = new ArrayList<cgLog>();
+	public List<cgLog> logs = new ArrayList<cgLog>();
 }

--- a/src/cgeo/geocaching/cgWaypoint.java
+++ b/src/cgeo/geocaching/cgWaypoint.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -68,8 +68,8 @@ public class cgWaypoint {
 		}
 	}
 
-	public static void mergeWayPoints(ArrayList<cgWaypoint> newPoints,
-			ArrayList<cgWaypoint> oldPoints) {
+	public static void mergeWayPoints(List<cgWaypoint> newPoints,
+			List<cgWaypoint> oldPoints) {
 		// copy user modified details of the waypoints
 		if (newPoints != null && oldPoints != null) {
 			for (cgWaypoint old : oldPoints) {

--- a/src/cgeo/geocaching/cgeo.java
+++ b/src/cgeo/geocaching/cgeo.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
@@ -312,7 +313,7 @@ public class cgeo extends AbstractActivity {
 
 		// context menu for offline button
 		if (v.getId() == R.id.search_offline) {
-			ArrayList<cgList> cacheLists = app.getLists();
+			List<cgList> cacheLists = app.getLists();
 			int listCount = cacheLists.size();
 			menu.setHeaderTitle(res.getString(R.string.list_title));
 			for (int i = 0; i < listCount; i++) {
@@ -332,11 +333,11 @@ public class cgeo extends AbstractActivity {
 		menu.add(1, 3, 0, res.getString(R.string.mystery));
 
 		// then add all other cache types sorted alphabetically
-		HashMap<String, String> allTypes = new HashMap<String, String>(cgBase.cacheTypesInv);
+		Map<String, String> allTypes = new HashMap<String, String>(cgBase.cacheTypesInv);
 		allTypes.remove("traditional");
 		allTypes.remove("multi");
 		allTypes.remove("mystery");
-		ArrayList<String> sorted = new ArrayList<String>(allTypes.values());
+		List<String> sorted = new ArrayList<String>(allTypes.values());
 		Collections.sort(sorted);
 		for (String choice : sorted) {
 			menu.add(1, menu.size(), 0, choice);

--- a/src/cgeo/geocaching/cgeoaddresses.java
+++ b/src/cgeo/geocaching/cgeoaddresses.java
@@ -19,7 +19,7 @@ import android.widget.LinearLayout;
 import cgeo.geocaching.activity.AbstractActivity;
 
 public class cgeoaddresses extends AbstractActivity {
-	private final ArrayList<Address> addresses = new ArrayList<Address>();
+	private final List<Address> addresses = new ArrayList<Address>();
 	private String keyword = null;
 	private LayoutInflater inflater = null;
 	private LinearLayout addList = null;

--- a/src/cgeo/geocaching/cgeoadvsearch.java
+++ b/src/cgeo/geocaching/cgeoadvsearch.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -251,8 +251,8 @@ public class cgeoadvsearch extends AbstractActivity {
 			latView.setText(cgBase.formatLatitude(geo.latitudeNow, true));
 			lonView.setText(cgBase.formatLongitude(geo.longitudeNow, true));
 		} else {
-			HashMap<String, Object> latParsed = cgBase.parseCoordinate(latText, "lat");
-			HashMap<String, Object> lonParsed = cgBase.parseCoordinate(lonText, "lat");
+			Map<String, Object> latParsed = cgBase.parseCoordinate(latText, "lat");
+			Map<String, Object> lonParsed = cgBase.parseCoordinate(lonText, "lat");
 
 			if (latParsed == null || latParsed.get("coordinate") == null || latParsed.get("string") == null) {
 				showToast(res.getString(R.string.err_parse_lat));

--- a/src/cgeo/geocaching/cgeoapplication.java
+++ b/src/cgeo/geocaching/cgeoapplication.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -24,8 +25,8 @@ public class cgeoapplication extends Application {
 	private boolean geoInUse = false;
 	private cgDirection dir = null;
 	private boolean dirInUse = false;
-	final private HashMap<Long, cgSearch> searches = new HashMap<Long, cgSearch>(); // information about searches
-	final private HashMap<String, cgCache> cachesCache = new HashMap<String, cgCache>(); // caching caches into memory
+	final private Map<Long, cgSearch> searches = new HashMap<Long, cgSearch>(); // information about searches
+	final private Map<String, cgCache> cachesCache = new HashMap<String, cgCache>(); // caching caches into memory
 	public boolean firstRun = true; // c:geo is just launched
 	public boolean warnedLanguage = false; // user was warned about different language settings on geocaching.com
 	private boolean databaseCleaned = false; // database was cleaned
@@ -303,7 +304,7 @@ public class cgeoapplication extends Application {
 		}
 
 		int count = 0;
-		ArrayList<String> geocodes = searches.get(searchId).getGeocodes();
+		List<String> geocodes = searches.get(searchId).getGeocodes();
 		if (geocodes != null) {
 			for (String geocode : geocodes) {
 				if (isOffline(geocode, null) == false) {
@@ -389,7 +390,7 @@ public class cgeoapplication extends Application {
 		return storage.loadWaypoint(id);
 	}
 
-	public ArrayList<Object> getBounds(String geocode) {
+	public List<Object> getBounds(String geocode) {
 		if (geocode == null) {
 			return null;
 		}
@@ -400,7 +401,7 @@ public class cgeoapplication extends Application {
 		return getBounds(geocodeList);
 	}
 
-	public ArrayList<Object> getBounds(Long searchId) {
+	public List<Object> getBounds(Long searchId) {
 		if (searchId == null || searches.containsKey(searchId) == false) {
 			return null;
 		}
@@ -410,12 +411,12 @@ public class cgeoapplication extends Application {
 		}
 
 		final cgSearch search = searches.get(searchId);
-		final ArrayList<String> geocodeList = search.getGeocodes();
+		final List<String> geocodeList = search.getGeocodes();
 
 		return getBounds(geocodeList);
 	}
 
-	public ArrayList<Object> getBounds(List<String> geocodes) {
+	public List<Object> getBounds(List<String> geocodes) {
 		if (geocodes == null || geocodes.isEmpty()) {
 			return null;
 		}
@@ -433,28 +434,28 @@ public class cgeoapplication extends Application {
 		}
 
 		cgSearch search = searches.get(searchId);
-		ArrayList<String> geocodeList = search.getGeocodes();
+		List<String> geocodeList = search.getGeocodes();
 
 		return getCacheByGeocode(geocodeList.get(0), true, true, true, true, true, true);
 	}
 
-	public ArrayList<cgCache> getCaches(Long searchId) {
+	public List<cgCache> getCaches(Long searchId) {
 		return getCaches(searchId, null, null, null, null, false, true, false, false, false, true);
 	}
 
-	public ArrayList<cgCache> getCaches(Long searchId, boolean loadA, boolean loadW, boolean loadS, boolean loadL, boolean loadI, boolean loadO) {
+	public List<cgCache> getCaches(Long searchId, boolean loadA, boolean loadW, boolean loadS, boolean loadL, boolean loadI, boolean loadO) {
 		return getCaches(searchId, null, null, null, null, loadA, loadW, loadS, loadL, loadI, loadO);
 	}
 
-	public ArrayList<cgCache> getCaches(Long searchId, Long centerLat, Long centerLon, Long spanLat, Long spanLon) {
+	public List<cgCache> getCaches(Long searchId, Long centerLat, Long centerLon, Long spanLat, Long spanLon) {
 		return getCaches(searchId, centerLat, centerLon, spanLat, spanLon, false, true, false, false, false, true);
 	}
 
-	public ArrayList<cgCache> getCaches(Long searchId, Long centerLat, Long centerLon, Long spanLat, Long spanLon, boolean loadA, boolean loadW, boolean loadS, boolean loadL, boolean loadI, boolean loadO) {
+	public List<cgCache> getCaches(Long searchId, Long centerLat, Long centerLon, Long spanLat, Long spanLon, boolean loadA, boolean loadW, boolean loadS, boolean loadL, boolean loadI, boolean loadO) {
 		if (searchId == null || searches.containsKey(searchId) == false) {
-			ArrayList<cgCache> cachesOut = new ArrayList<cgCache>();
+			List<cgCache> cachesOut = new ArrayList<cgCache>();
 
-			final ArrayList<cgCache> cachesPre = storage.loadCaches(null , null, centerLat, centerLon, spanLat, spanLon, loadA, loadW, loadS, loadL, loadI, loadO);
+			final List<cgCache> cachesPre = storage.loadCaches(null , null, centerLat, centerLon, spanLat, spanLon, loadA, loadW, loadS, loadL, loadI, loadO);
 
 			if (cachesPre != null) {
 				cachesOut.addAll(cachesPre);
@@ -463,16 +464,16 @@ public class cgeoapplication extends Application {
 			return cachesOut;
 		}
 
-		ArrayList<cgCache> cachesOut = new ArrayList<cgCache>();
+		List<cgCache> cachesOut = new ArrayList<cgCache>();
 
 		cgSearch search = searches.get(searchId);
-		ArrayList<String> geocodeList = search.getGeocodes();
+		List<String> geocodeList = search.getGeocodes();
 
 		if (storage == null) {
 			storage = new cgData(this);
 		}
 
-		final ArrayList<cgCache> cachesPre = storage.loadCaches(geocodeList.toArray(), null, centerLat, centerLon, spanLat, spanLon, loadA, loadW, loadS, loadL, loadI, loadO);
+		final List<cgCache> cachesPre = storage.loadCaches(geocodeList.toArray(), null, centerLat, centerLon, spanLat, spanLon, loadA, loadW, loadS, loadL, loadI, loadO);
 		if (cachesPre != null) {
 			cachesOut.addAll(cachesPre);
 		}
@@ -486,7 +487,7 @@ public class cgeoapplication extends Application {
 		}
 		cgSearch search = new cgSearch();
 
-		ArrayList<String> geocodes = storage.loadBatchOfStoredGeocodes(detailedOnly, latitude, longitude, cachetype, list);
+		List<String> geocodes = storage.loadBatchOfStoredGeocodes(detailedOnly, latitude, longitude, cachetype, list);
 		if (geocodes != null && geocodes.isEmpty() == false) {
 			for (String gccode : geocodes) {
 				search.addGeocode(gccode);
@@ -511,7 +512,7 @@ public class cgeoapplication extends Application {
 		}
 		cgSearch search = new cgSearch();
 
-		ArrayList<String> geocodes = storage.loadBatchOfHistoricGeocodes(detailedOnly, cachetype);
+		List<String> geocodes = storage.loadBatchOfHistoricGeocodes(detailedOnly, cachetype);
 		if (geocodes != null && geocodes.isEmpty() == false) {
 			for (String gccode : geocodes) {
 				search.addGeocode(gccode);
@@ -528,7 +529,7 @@ public class cgeoapplication extends Application {
 		}
 		cgSearch search = new cgSearch();
 
-		ArrayList<String> geocodes = storage.getCachedInViewport(centerLat, centerLon, spanLat, spanLon, cachetype);
+		List<String> geocodes = storage.getCachedInViewport(centerLat, centerLon, spanLat, spanLon, cachetype);
 		if (geocodes != null && geocodes.isEmpty() == false) {
 			for (String gccode : geocodes) {
 				search.addGeocode(gccode);
@@ -545,7 +546,7 @@ public class cgeoapplication extends Application {
 		}
 		cgSearch search = new cgSearch();
 
-		ArrayList<String> geocodes = storage.getStoredInViewport(centerLat, centerLon, spanLat, spanLon, cachetype);
+		List<String> geocodes = storage.getStoredInViewport(centerLat, centerLon, spanLat, spanLon, cachetype);
 		if (geocodes != null && geocodes.isEmpty() == false) {
 			for (String gccode : geocodes) {
 				search.addGeocode(gccode);
@@ -562,7 +563,7 @@ public class cgeoapplication extends Application {
 		}
 		cgSearch search = new cgSearch();
 
-		ArrayList<String> geocodes = storage.getOfflineAll(cachetype);
+		List<String> geocodes = storage.getOfflineAll(cachetype);
 		if (geocodes != null && geocodes.isEmpty() == false) {
 			for (String gccode : geocodes) {
 				search.addGeocode(gccode);
@@ -626,7 +627,7 @@ public class cgeoapplication extends Application {
 		return storage.saveSearchedDestination(destination);
 	}
 
-	public boolean saveWaypoints(String geocode, ArrayList<cgWaypoint> waypoints, boolean drop) {
+	public boolean saveWaypoints(String geocode, List<cgWaypoint> waypoints, boolean drop) {
 		if (storage == null) {
 			storage = new cgData(this);
 		}
@@ -652,7 +653,7 @@ public class cgeoapplication extends Application {
 			storage = new cgData(this);
 		}
 
-		final ArrayList<cgTrackable> list = new ArrayList<cgTrackable>();
+		final List<cgTrackable> list = new ArrayList<cgTrackable>();
 		list.add(trackable);
 
 		return storage.saveInventory("---", list);
@@ -666,7 +667,7 @@ public class cgeoapplication extends Application {
 		this.searches.get(searchId).addGeocode(geocode);
 	}
 
-	public Long addSearch(Long searchId, ArrayList<cgCache> cacheList, Boolean newItem, int reason) {
+	public Long addSearch(Long searchId, List<cgCache> cacheList, Boolean newItem, int reason) {
 		if (this.searches.containsKey(searchId) == false) {
 			return null;
 		}
@@ -676,7 +677,7 @@ public class cgeoapplication extends Application {
 		return addSearch(search, cacheList, newItem, reason);
 	}
 
-	public Long addSearch(final cgSearch search, final ArrayList<cgCache> cacheList, final boolean newItem, final int reason) {
+	public Long addSearch(final cgSearch search, final List<cgCache> cacheList, final boolean newItem, final int reason) {
 		if (CollectionUtils.isEmpty(cacheList)) {
 			return null;
 		}
@@ -746,15 +747,15 @@ public class cgeoapplication extends Application {
 		storage.dropStored(listId);
 	}
 
-	public ArrayList<cgTrackable> loadInventory(String geocode) {
+	public List<cgTrackable> loadInventory(String geocode) {
 		return storage.loadInventory(geocode);
 	}
 
-	public HashMap<Integer,Integer> loadLogCounts(String geocode) {
+	public Map<Integer,Integer> loadLogCounts(String geocode) {
 		return storage.loadLogCounts(geocode);
 	}
 
-	public ArrayList<cgImage> loadSpoilers(String geocode) {
+	public List<cgImage> loadSpoilers(String geocode) {
 		return storage.loadSpoilers(geocode);
 	}
 
@@ -781,7 +782,7 @@ public class cgeoapplication extends Application {
 			return false;
 		}
 
-		ArrayList<cgLog> list = new ArrayList<cgLog>();
+		List<cgLog> list = new ArrayList<cgLog>();
 		list.add(log);
 
 		return storage.saveLogs(geocode, list, false);
@@ -820,7 +821,7 @@ public class cgeoapplication extends Application {
         storage.clearVisitDate(geocode);
     }
 
-	public ArrayList<cgList> getLists() {
+	public List<cgList> getLists() {
 		return storage.getLists(getResources());
 	}
 

--- a/src/cgeo/geocaching/cgeoauth.java
+++ b/src/cgeo/geocaching/cgeoauth.java
@@ -9,6 +9,7 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -204,7 +205,7 @@ public class cgeoauth extends AbstractActivity {
 						prefsEdit.commit();
 
 						try {
-							final HashMap<String, String> paramsPre = new HashMap<String, String>();
+							final Map<String, String> paramsPre = new HashMap<String, String>();
 							paramsPre.put("oauth_callback", "oob");
 
 							final String paramsBrowser = cgOAuth.signOAuth(host, pathAuthorize, "GET", true, paramsPre, OAtoken, OAtokenSecret);
@@ -242,7 +243,7 @@ public class cgeoauth extends AbstractActivity {
 		String lineOne = null;
 
 		try {
-			final HashMap<String, String> paramsPre = new HashMap<String, String>();
+			final Map<String, String> paramsPre = new HashMap<String, String>();
 			paramsPre.put("oauth_verifier", pinEntry.getText().toString());
 
 			int code = -1;

--- a/src/cgeo/geocaching/cgeocaches.java
+++ b/src/cgeo/geocaching/cgeocaches.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -143,7 +144,7 @@ public class cgeocaches extends AbstractListActivity {
 	private String address = null;
 	private String username = null;
 	private Long searchId = null;
-	private ArrayList<cgCache> cacheList = new ArrayList<cgCache>();
+	private List<cgCache> cacheList = new ArrayList<cgCache>();
 	private cgCacheListAdapter adapter = null;
 	private LayoutInflater inflater = null;
 	private View listFooter = null;
@@ -164,7 +165,7 @@ public class cgeocaches extends AbstractListActivity {
 	private geocachesExportFieldNotes threadF = null;
 	private geocachesRemoveFromHistory threadH = null;
 	private int listId = 0;
-	private ArrayList<cgList> lists = null;
+	private List<cgList> lists = null;
 	private String selectedFilter = null;
 	private GeocodeComparator gcComparator = new GeocodeComparator();
 	private Handler loadCachesHandler = new Handler() {
@@ -176,7 +177,7 @@ public class cgeocaches extends AbstractListActivity {
 					setTitle(title + " [" + app.getCount(searchId) + "]");
 					cacheList.clear();
 
-					final ArrayList<cgCache> cacheListTmp = app.getCaches(searchId);
+					final List<cgCache> cacheListTmp = app.getCaches(searchId);
 					if (CollectionUtils.isNotEmpty(cacheListTmp)) {
 						cacheList.addAll(cacheListTmp);
 						cacheListTmp.clear();
@@ -274,7 +275,7 @@ public class cgeocaches extends AbstractListActivity {
 					setTitle(title + " [" + app.getCount(searchId) + "]");
 					cacheList.clear();
 
-					final ArrayList<cgCache> cacheListTmp = app.getCaches(searchId);
+					final List<cgCache> cacheListTmp = app.getCaches(searchId);
 					if (CollectionUtils.isNotEmpty(cacheListTmp)) {
 						cacheList.addAll(cacheListTmp);
 						cacheListTmp.clear();
@@ -363,7 +364,7 @@ public class cgeocaches extends AbstractListActivity {
 				}
 			} else {
 				if (cacheList != null && searchId != null) {
-					final ArrayList<cgCache> cacheListTmp = app.getCaches(searchId);
+					final List<cgCache> cacheListTmp = app.getCaches(searchId);
 					if (CollectionUtils.isNotEmpty(cacheListTmp)) {
 						cacheList.clear();
 						cacheList.addAll(cacheListTmp);
@@ -424,7 +425,7 @@ public class cgeocaches extends AbstractListActivity {
 
 				cacheList.clear();
 
-				final ArrayList<cgCache> cacheListTmp = app.getCaches(searchId);
+				final List<cgCache> cacheListTmp = app.getCaches(searchId);
 				if (CollectionUtils.isNotEmpty(cacheListTmp)) {
 					cacheList.addAll(cacheListTmp);
 					cacheListTmp.clear();
@@ -452,7 +453,7 @@ public class cgeocaches extends AbstractListActivity {
 
 			cacheList.clear();
 
-			final ArrayList<cgCache> cacheListTmp = app.getCaches(searchId);
+			final List<cgCache> cacheListTmp = app.getCaches(searchId);
 			if (CollectionUtils.isNotEmpty(cacheListTmp)) {
 				cacheList.addAll(cacheListTmp);
 				cacheListTmp.clear();
@@ -744,7 +745,7 @@ public class cgeocaches extends AbstractListActivity {
 		subMenuSort.setHeaderTitle(res.getString(R.string.caches_sort_title));
 
 		// sort the context menu labels alphabetically for easier reading
-		HashMap<String, Integer> comparators = new HashMap<String, Integer>();
+		Map<String, Integer> comparators = new HashMap<String, Integer>();
 		comparators.put(res.getString(R.string.caches_sort_distance), MENU_SORT_DISTANCE);
 		comparators.put(res.getString(R.string.caches_sort_difficulty), MENU_SORT_DIFFICULTY);
 		comparators.put(res.getString(R.string.caches_sort_terrain), MENU_SORT_TERRAIN);
@@ -759,7 +760,7 @@ public class cgeocaches extends AbstractListActivity {
 		comparators.put(res.getString(R.string.caches_sort_finds), MENU_SORT_FINDS);
 		comparators.put(res.getString(R.string.caches_sort_state), MENU_SORT_STATE);
 
-		ArrayList<String> sortedLabels = new ArrayList<String>(comparators.keySet());
+		List<String> sortedLabels = new ArrayList<String>(comparators.keySet());
 		Collections.sort(sortedLabels);
 		for (String label : sortedLabels) {
 			Integer id = comparators.get(label);
@@ -1108,7 +1109,7 @@ public class cgeocaches extends AbstractListActivity {
 			}
 			if (cache.reason >= 1) {
 				menu.add(0, MENU_DROP_CACHE, 0, res.getString(R.string.cache_offline_drop));
-				ArrayList<cgList> cacheLists = app.getLists();
+				List<cgList> cacheLists = app.getLists();
 				int listCount = cacheLists.size();
 				if (listCount > 1) {
 					SubMenu submenu = menu.addSubMenu(0, MENU_MOVE_TO_LIST, 0, res.getString(R.string.cache_menu_move_list));
@@ -1122,7 +1123,7 @@ public class cgeocaches extends AbstractListActivity {
 	}
 
 	private void createFakeContextMenuMoveToList(ContextMenu menu) {
-		ArrayList<cgList> cacheLists = app.getLists();
+		List<cgList> cacheLists = app.getLists();
 		int listCount = cacheLists.size();
 		menu.setHeaderTitle(res.getString(R.string.cache_menu_move_list));
 		for (int i = 0; i < listCount; i++) {
@@ -1251,7 +1252,7 @@ public class cgeocaches extends AbstractListActivity {
 		} else if (id >= MENU_MOVE_SELECTED_OR_ALL_TO_LIST && id < MENU_MOVE_SELECTED_OR_ALL_TO_LIST + 100) {
 			int newListId = id - MENU_MOVE_SELECTED_OR_ALL_TO_LIST;
 			boolean moveAll = adapter.getChecked() == 0;
-			final ArrayList<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
+			final List<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
 			for (cgCache c : cacheListTemp) {
 				if (moveAll || c.statusChecked) {
 					app.moveToList(c.geocode, newListId);
@@ -1270,7 +1271,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		if (cache != null) {
 			// create a searchId for a single cache (as if in details view)
-			HashMap<String, String> params = new HashMap<String, String>();
+			Map<String, String> params = new HashMap<String, String>();
 			params.put("geocode", cache.geocode);
 			Long singleSearchId = base.searchByGeocode(params, 0, false);
 
@@ -1754,7 +1755,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, Object> params = new HashMap<String, Object>();
+			Map<String, Object> params = new HashMap<String, Object>();
 			if (latitude != null && longitude != null) {
 				params.put("latitude", latitude);
 				params.put("longitude", longitude);
@@ -1778,7 +1779,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, Object> params = new HashMap<String, Object>();
+			Map<String, Object> params = new HashMap<String, Object>();
 			if (latitude != null && longitude != null) {
 				params.put("cachetype", settings.cacheType);
 			}
@@ -1830,7 +1831,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, String> params = new HashMap<String, String>();
+			Map<String, String> params = new HashMap<String, String>();
 			params.put("latitude", String.format((Locale) null, "%.6f", latitude));
 			params.put("longitude", String.format((Locale) null, "%.6f", longitude));
 			params.put("cachetype", cachetype);
@@ -1864,7 +1865,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, String> params = new HashMap<String, String>();
+			Map<String, String> params = new HashMap<String, String>();
 			params.put("keyword", keyword);
 			params.put("cachetype", cachetype);
 
@@ -1897,7 +1898,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, String> params = new HashMap<String, String>();
+			Map<String, String> params = new HashMap<String, String>();
 			params.put("username", username);
 			params.put("cachetype", cachetype);
 
@@ -1930,7 +1931,7 @@ public class cgeocaches extends AbstractListActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, String> params = new HashMap<String, String>();
+			Map<String, String> params = new HashMap<String, String>();
 			params.put("username", username);
 			params.put("cachetype", cachetype);
 
@@ -1972,7 +1973,7 @@ public class cgeocaches extends AbstractListActivity {
 				geo = app.removeGeo();
 			}
 
-			final ArrayList<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
+			final List<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
 			for (cgCache cache : cacheListTemp) {
 				if (checked > 0 && cache.statusChecked == false) {
 					handler.sendEmptyMessage(0);
@@ -2146,7 +2147,7 @@ public class cgeocaches extends AbstractListActivity {
 				geo = app.removeGeo();
 			}
 
-			final ArrayList<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
+			final List<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
 			for (cgCache cache : cacheListTemp) {
 				if (checked > 0 && cache.statusChecked == false) {
 					continue;
@@ -2251,7 +2252,7 @@ public class cgeocaches extends AbstractListActivity {
             // We need our own HashMap because cgBase.LogTypes1 will give us localized and maybe
             // different strings than gc.com expects in the field note
             // We only need such logtypes that are possible to log via c:geo
-            HashMap<Integer, String> logTypes = new HashMap<Integer, String>();
+            Map<Integer, String> logTypes = new HashMap<Integer, String>();
             logTypes.put(cgBase.LOG_FOUND_IT, "Found it");
             logTypes.put(cgBase.LOG_DIDNT_FIND_IT, "Didn't find it");
             logTypes.put(cgBase.LOG_NOTE, "Write Note");
@@ -2374,7 +2375,7 @@ public class cgeocaches extends AbstractListActivity {
 			return;
 		}
 
-		final ArrayList<CharSequence> listsTitle = new ArrayList<CharSequence>();
+		final List<CharSequence> listsTitle = new ArrayList<CharSequence>();
 		for (cgList list : lists) {
 			listsTitle.add(list.title);
 		}
@@ -2438,7 +2439,7 @@ public class cgeocaches extends AbstractListActivity {
 		public void run() {
 			int checked = adapter.getChecked();
 			if (checked > 0) {
-				final ArrayList<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
+				final List<cgCache> cacheListTemp = new ArrayList<cgCache>(cacheList);
 				for (cgCache cache : cacheListTemp) {
 					if (cache.statusChecked) {
 						app.moveToList(cache.geocode, listId);

--- a/src/cgeo/geocaching/cgeocoords.java
+++ b/src/cgeo/geocaching/cgeocoords.java
@@ -1,7 +1,8 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -467,8 +468,8 @@ public class cgeocoords extends Dialog {
 			if (currentFormat == coordInputFormatEnum.Plain) {
 				if (eLat.length() > 0 && eLon.length() > 0) {
 					// latitude & longitude
-					HashMap<String, Object> latParsed = cgBase.parseCoordinate(eLat.getText().toString(), "lat");
-					HashMap<String, Object> lonParsed = cgBase.parseCoordinate(eLon.getText().toString(), "lon");
+					Map<String, Object> latParsed = cgBase.parseCoordinate(eLat.getText().toString(), "lat");
+					Map<String, Object> lonParsed = cgBase.parseCoordinate(eLon.getText().toString(), "lon");
 
 					if (latParsed == null || latParsed.get("coordinate") == null || latParsed.get("string") == null) {
 						context.showToast(context.getResources().getString(R.string.err_parse_lat));
@@ -492,7 +493,7 @@ public class cgeocoords extends Dialog {
 					longitude = geo.longitudeNow;
 				}
 			}
-			ArrayList<Double> co = new ArrayList<Double>();
+			List<Double> co = new ArrayList<Double>();
 			co.add(latitude);
 			co.add(longitude);
 			cuListener.update(co);
@@ -505,7 +506,7 @@ public class cgeocoords extends Dialog {
 	}
 
 	public interface CoordinateUpdate {
-		public void update(ArrayList<Double> coords);
+		public void update(List<Double> coords);
 	}
 
 }

--- a/src/cgeo/geocaching/cgeodetail.java
+++ b/src/cgeo/geocaching/cgeodetail.java
@@ -6,7 +6,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
@@ -92,7 +94,7 @@ public class cgeodetail extends AbstractActivity {
 	private ProgressDialog dropDialog = null;
 	private ProgressDialog watchlistDialog = null; // progress dialog for watchlist add/remove
 	private Thread watchlistThread = null; // thread for watchlist add/remove
-	private HashMap<Integer, String> calendars = new HashMap<Integer, String>();
+	private Map<Integer, String> calendars = new HashMap<Integer, String>();
 
 	private ViewGroup attributeIconsLayout; // layout for attribute icons
 	private ViewGroup attributeDescriptionsLayout; // layout for attribute descriptions
@@ -991,7 +993,7 @@ public class cgeodetail extends AbstractActivity {
 				LinearLayout waypointView;
 
 				// sort waypoints: PP, Sx, FI, OWN
-				ArrayList<cgWaypoint> sortedWaypoints = new ArrayList<cgWaypoint>(cache.waypoints);
+				List<cgWaypoint> sortedWaypoints = new ArrayList<cgWaypoint>(cache.waypoints);
 				Collections.sort(sortedWaypoints, new Comparator<cgWaypoint>() {
 
 					@Override
@@ -1137,7 +1139,7 @@ public class cgeodetail extends AbstractActivity {
 			buff.append(": ");
 
 			// sort the log counts by type id ascending. that way the FOUND, DNF log types are the first and most visible ones
-			ArrayList<Entry<Integer, Integer>> sortedLogCounts = new ArrayList<Entry<Integer,Integer>>();
+			List<Entry<Integer, Integer>> sortedLogCounts = new ArrayList<Entry<Integer,Integer>>();
 			sortedLogCounts.addAll(cache.logCounts.entrySet());
 			Collections.sort(sortedLogCounts, new Comparator<Entry<Integer, Integer>>() {
 
@@ -1303,7 +1305,7 @@ public class cgeodetail extends AbstractActivity {
 
 		@Override
 		public void run() {
-			HashMap<String, String> params = new HashMap<String, String>();
+			Map<String, String> params = new HashMap<String, String>();
 			if (StringUtils.isNotBlank(geocode)) {
 				params.put("geocode", geocode);
 			} else if (StringUtils.isNotBlank(guid)) {
@@ -1379,9 +1381,9 @@ public class cgeodetail extends AbstractActivity {
 		}
 	}
 
-	public ArrayList<cgCoord> getCoordinates() {
+	public List<cgCoord> getCoordinates() {
 		cgCoord coords = null;
-		ArrayList<cgCoord> coordinates = new ArrayList<cgCoord>();
+		List<cgCoord> coordinates = new ArrayList<cgCoord>();
 
 		try {
 			// cache
@@ -1749,7 +1751,7 @@ public class cgeodetail extends AbstractActivity {
 		public void run() {
 			app.removeCacheFromCache(geocode);
 
-			final HashMap<String, String> params = new HashMap<String, String>();
+			final Map<String, String> params = new HashMap<String, String>();
 			params.put("geocode", cache.geocode);
 			searchId = base.searchByGeocode(params, 0, true);
 

--- a/src/cgeo/geocaching/cgeogpxes.java
+++ b/src/cgeo/geocaching/cgeogpxes.java
@@ -1,7 +1,7 @@
 package cgeo.geocaching;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.List;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
@@ -57,7 +57,7 @@ public class cgeogpxes extends FileList<cgGPXListAdapter> {
 	};
 
 	@Override
-	protected cgGPXListAdapter getAdapter(ArrayList<File> files) {
+	protected cgGPXListAdapter getAdapter(List<File> files) {
 		return new cgGPXListAdapter(this, getSettings(), files);
 	}
 

--- a/src/cgeo/geocaching/cgeoimages.java
+++ b/src/cgeo/geocaching/cgeoimages.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -32,7 +33,7 @@ public class cgeoimages extends AbstractActivity {
 	public static final int SPOILER_IMAGE = 2;
 
 	private int img_type;
-	private ArrayList<cgImage> images = new ArrayList<cgImage>();
+	private List<cgImage> images = new ArrayList<cgImage>();
 	private String geocode = null;
 	private String title = null;
 	private String url = null;

--- a/src/cgeo/geocaching/cgeonavigate.java
+++ b/src/cgeo/geocaching/cgeonavigate.java
@@ -2,7 +2,9 @@ package cgeo.geocaching;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -24,7 +26,7 @@ import cgeo.geocaching.activity.AbstractActivity;
 
 public class cgeonavigate extends AbstractActivity {
 
-	public static ArrayList<cgCoord> coordinates = new ArrayList<cgCoord>();
+	public static List<cgCoord> coordinates = new ArrayList<cgCoord>();
 	private PowerManager pm = null;
 	private cgGeo geo = null;
 	private cgDirection dir = null;
@@ -326,8 +328,8 @@ public class cgeonavigate extends AbstractActivity {
 		updateDistanceInfo();
 	}
 
-	public HashMap<String, Double> getCoordinatesNow() {
-		HashMap<String, Double> coordsNow = new HashMap<String, Double>();
+	public Map<String, Double> getCoordinatesNow() {
+		Map<String, Double> coordsNow = new HashMap<String, Double>();
 		if (geo != null) {
 			coordsNow.put("latitude", geo.latitudeNow);
 			coordsNow.put("longitude", geo.longitudeNow);

--- a/src/cgeo/geocaching/cgeopoint.java
+++ b/src/cgeo/geocaching/cgeopoint.java
@@ -1,8 +1,8 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -292,7 +292,7 @@ public class cgeopoint extends AbstractActivity {
 		super.onPrepareOptionsMenu(menu);
 
 		try {
-			ArrayList<Double> coords = getDestination();
+			List<Double> coords = getDestination();
 
 			if (coords != null && coords.get(0) != null && coords.get(1) != null) {
 				menu.findItem(0).setVisible(true);
@@ -316,7 +316,7 @@ public class cgeopoint extends AbstractActivity {
 	public boolean onOptionsItemSelected(MenuItem item) {
 		final int menuItem = item.getItemId();
 
-		ArrayList<Double> coords = getDestination();
+		List<Double> coords = getDestination();
 
 		if(coords != null && !coords.isEmpty())
 		{
@@ -338,7 +338,8 @@ public class cgeopoint extends AbstractActivity {
 		return NavigationAppFactory.onMenuItemSelected(item, geo, this, res, null, null, null, coords);
 	}
 
-	private void addToHistory(ArrayList<Double> coords) {
+	private void addToHistory(List
+			<Double> coords) {
 		// Add locations to history
 		cgDestination loc = new cgDestination();
 		loc.setLatitude(coords.get(0));
@@ -415,7 +416,7 @@ public class cgeopoint extends AbstractActivity {
 	}
 
 	private void cachesAround() {
-		ArrayList<Double> coords = getDestination();
+		List<Double> coords = getDestination();
 
 		if (coords == null || coords.get(0) == null || coords.get(1) == null) {
 			showToast(res.getString(R.string.err_location_unknown));
@@ -475,8 +476,8 @@ public class cgeopoint extends AbstractActivity {
 		}
 	}
 
-	private ArrayList<Double> getDestination() {
-		ArrayList<Double> coords = new ArrayList<Double>();
+	private List<Double> getDestination() {
+		List<Double> coords = new ArrayList<Double>();
 		Double latitude = null;
 		Double longitude = null;
 
@@ -493,8 +494,8 @@ public class cgeopoint extends AbstractActivity {
 
 		if (StringUtils.isNotBlank(latText) && StringUtils.isNotBlank(lonText)) {
 			// latitude & longitude
-			HashMap<String, Object> latParsed = cgBase.parseCoordinate(latText, "lat");
-			HashMap<String, Object> lonParsed = cgBase.parseCoordinate(lonText, "lon");
+			Map<String, Object> latParsed = cgBase.parseCoordinate(latText, "lat");
+			Map<String, Object> lonParsed = cgBase.parseCoordinate(lonText, "lon");
 
 			if (latParsed == null || latParsed.get("coordinate") == null || latParsed.get("string") == null) {
 				showToast(res.getString(R.string.err_parse_lat));
@@ -575,7 +576,7 @@ public class cgeopoint extends AbstractActivity {
 			Double latParsed = null;
 			Double lonParsed = null;
 
-			HashMap<String, Double> coordsDst = cgBase.getRadialDistance(latitude, longitude, bearing, distance);
+			Map<String, Double> coordsDst = cgBase.getRadialDistance(latitude, longitude, bearing, distance);
 
 			latParsed = coordsDst.get("latitude");
 			lonParsed = coordsDst.get("longitude");

--- a/src/cgeo/geocaching/cgeosmaps.java
+++ b/src/cgeo/geocaching/cgeosmaps.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.app.ProgressDialog;
 import android.graphics.Bitmap;
@@ -17,7 +18,7 @@ import cgeo.geocaching.utils.CollectionUtils;
 
 public class cgeosmaps extends AbstractActivity {
 
-	private ArrayList<Bitmap> maps = new ArrayList<Bitmap>();
+	private List<Bitmap> maps = new ArrayList<Bitmap>();
 	private String geocode = null;
 	private LayoutInflater inflater = null;
 	private ProgressDialog waitDialog = null;

--- a/src/cgeo/geocaching/cgeotouch.java
+++ b/src/cgeo/geocaching/cgeotouch.java
@@ -3,6 +3,8 @@ package cgeo.geocaching;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -27,7 +29,7 @@ import android.widget.TextView;
 
 public class cgeotouch extends cgLogForm {
 	private cgTrackable trackable = null;
-	private ArrayList<Integer> types = new ArrayList<Integer>();
+	private List<Integer> types = new ArrayList<Integer>();
 	private ProgressDialog waitDialog = null;
 	private String guid = null;
 	private String geocode = null;
@@ -361,7 +363,7 @@ public class cgeotouch extends cgLogForm {
 
 		@Override
 		public void run() {
-			final HashMap<String, String> params = new HashMap<String, String>();
+			final Map<String, String> params = new HashMap<String, String>();
 
 			showProgressHandler.sendEmptyMessage(0);
 			gettingViewstate = true;
@@ -379,7 +381,7 @@ public class cgeotouch extends cgLogForm {
 
 				viewstates = cgBase.getViewstates(page);
 
-				final ArrayList<Integer> typesPre = cgBase.parseTypes(page);
+				final List<Integer> typesPre = cgBase.parseTypes(page);
 				if (typesPre.size() > 0) {
 					types.clear();
 					types.addAll(typesPre);

--- a/src/cgeo/geocaching/cgeotrackable.java
+++ b/src/cgeo/geocaching/cgeotrackable.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -486,7 +487,7 @@ public class cgeotrackable extends AbstractActivity {
 	}
 
 	public void loadTrackableFn(String geocode, String guid, String id) {
-		HashMap<String, String> params = new HashMap<String, String>();
+		Map<String, String> params = new HashMap<String, String>();
 		if (StringUtils.isNotBlank(geocode)) {
 			params.put("geocode", geocode);
 		} else if (StringUtils.isNotBlank(guid)) {

--- a/src/cgeo/geocaching/cgeotrackables.java
+++ b/src/cgeo/geocaching/cgeotrackables.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.app.ProgressDialog;
 import android.content.Intent;
@@ -16,7 +17,7 @@ import android.widget.LinearLayout;
 import cgeo.geocaching.activity.AbstractActivity;
 
 public class cgeotrackables extends AbstractActivity {
-	private ArrayList<cgTrackable> trackables = new ArrayList<cgTrackable>();
+	private List<cgTrackable> trackables = new ArrayList<cgTrackable>();
 	private String geocode = null;
 	private LayoutInflater inflater = null;
 	private LinearLayout addList = null;

--- a/src/cgeo/geocaching/cgeovisit.java
+++ b/src/cgeo/geocaching/cgeovisit.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -42,7 +44,7 @@ public class cgeovisit extends cgLogForm {
 	
 	private LayoutInflater inflater = null;
 	private cgCache cache = null;
-	private ArrayList<Integer> types = new ArrayList<Integer>();
+	private List<Integer> types = new ArrayList<Integer>();
 	private ProgressDialog waitDialog = null;
 	private String cacheid = null;
 	private String geocode = null;
@@ -50,7 +52,7 @@ public class cgeovisit extends cgLogForm {
 	private boolean alreadyFound = false;
 	private String[] viewstates = null;
 	private Boolean gettingViewstate = true;
-	private ArrayList<cgTrackableLog> trackables = null;
+	private List<cgTrackableLog> trackables = null;
 	private Calendar date = Calendar.getInstance();
 	private int typeSelected = 1;
 	private int attempts = 0;
@@ -366,12 +368,12 @@ public class cgeovisit extends cgLogForm {
 			return false;
 		}
 
-		final HashMap<String, String> login = settings.getGCvoteLogin();
+		final Map<String, String> login = settings.getGCvoteLogin();
 		if (login == null) {
 			return false;
 		}
 
-		final HashMap<String, String> params = new HashMap<String, String>();
+		final Map<String, String> params = new HashMap<String, String>();
 		params.put("userName", login.get("username"));
 		params.put("password", login.get("password"));
 		params.put("cacheId", guid);
@@ -701,7 +703,7 @@ public class cgeovisit extends cgLogForm {
 
 		@Override
 		public void run() {
-			final HashMap<String, String> params = new HashMap<String, String>();
+			final Map<String, String> params = new HashMap<String, String>();
 
 			showProgressHandler.sendEmptyMessage(0);
 			gettingViewstate = true;
@@ -720,7 +722,7 @@ public class cgeovisit extends cgLogForm {
 				viewstates = cgBase.getViewstates(page);
 				trackables = cgBase.parseTrackableLog(page);
 
-				final ArrayList<Integer> typesPre = cgBase.parseTypes(page);
+				final List<Integer> typesPre = cgBase.parseTypes(page);
 				if (CollectionUtils.isNotEmpty(typesPre)) {
 					types.clear();
 					types.addAll(typesPre);

--- a/src/cgeo/geocaching/cgeowaypointadd.java
+++ b/src/cgeo/geocaching/cgeowaypointadd.java
@@ -1,7 +1,8 @@
 package cgeo.geocaching;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -121,7 +122,7 @@ public class cgeowaypointadd extends AbstractActivity {
 		Button addWaypoint = (Button) findViewById(R.id.add_waypoint);
 		addWaypoint.setOnClickListener(new coordsListener());
 
-		ArrayList<String> wayPointNames = new ArrayList<String>(cgBase.waypointTypes.values());
+		List<String> wayPointNames = new ArrayList<String>(cgBase.waypointTypes.values());
 		AutoCompleteTextView textView = (AutoCompleteTextView) findViewById(R.id.name);
 		ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line, wayPointNames);
 		textView.setAdapter(adapter);
@@ -222,7 +223,7 @@ public class cgeowaypointadd extends AbstractActivity {
 			coordsDialog.setCancelable(true);
 			coordsDialog.setOnCoordinateUpdate(new cgeocoords.CoordinateUpdate() {
 				@Override
-				public void update(ArrayList<Double> coords) {
+				public void update(List<Double> coords) {
 					((Button) findViewById(R.id.buttonLatitude)).setText(cgBase.formatLatitude(coords.get(0), true));
 					((Button) findViewById(R.id.buttonLongitude)).setText(cgBase.formatLongitude(coords.get(1), true));
 					if (waypoint != null) {
@@ -238,7 +239,7 @@ public class cgeowaypointadd extends AbstractActivity {
 	private class coordsListener implements View.OnClickListener {
 
 		public void onClick(View arg0) {
-			ArrayList<Double> coords = new ArrayList<Double>();
+			List<Double> coords = new ArrayList<Double>();
 			Double latitude = null;
 			Double longitude = null;
 
@@ -255,8 +256,8 @@ public class cgeowaypointadd extends AbstractActivity {
 
 			if (StringUtils.isNotBlank(latText) && StringUtils.isNotBlank(lonText)) {
 				// latitude & longitude
-				HashMap<String, Object> latParsed = cgBase.parseCoordinate(latText, "lat");
-				HashMap<String, Object> lonParsed = cgBase.parseCoordinate(lonText, "lon");
+				Map<String, Object> latParsed = cgBase.parseCoordinate(latText, "lat");
+				Map<String, Object> lonParsed = cgBase.parseCoordinate(lonText, "lon");
 
 				if (latParsed == null || latParsed.get("coordinate") == null || latParsed.get("string") == null) {
 					showToast(res.getString(R.string.err_parse_lat));
@@ -337,7 +338,7 @@ public class cgeowaypointadd extends AbstractActivity {
 				Double latParsed = null;
 				Double lonParsed = null;
 
-				HashMap<String, Double> coordsDst = cgBase.getRadialDistance(latitude, longitude, bearing, distance);
+				Map<String, Double> coordsDst = cgBase.getRadialDistance(latitude, longitude, bearing, distance);
 
 				latParsed = coordsDst.get("latitude");
 				lonParsed = coordsDst.get("longitude");

--- a/src/cgeo/geocaching/files/FileList.java
+++ b/src/cgeo/geocaching/files/FileList.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.files;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -19,7 +20,7 @@ import cgeo.geocaching.activity.AbstractListActivity;
 
 public abstract class FileList<T extends ArrayAdapter<File>> extends AbstractListActivity {
 
-	private ArrayList<File> files = new ArrayList<File>();
+	private List<File> files = new ArrayList<File>();
 	private T adapter = null;
 	private ProgressDialog waitDialog = null;
 	private loadFiles searchingThread = null;
@@ -115,7 +116,7 @@ public abstract class FileList<T extends ArrayAdapter<File>> extends AbstractLis
 		getSettings().load();
 	}
 
-	protected abstract T getAdapter(ArrayList<File> files);
+	protected abstract T getAdapter(List<File> files);
 
 	private void setAdapter() {
 		if (adapter == null) {
@@ -142,7 +143,7 @@ public abstract class FileList<T extends ArrayAdapter<File>> extends AbstractLis
 
 		@Override
 		public void run() {
-			ArrayList<File> list = new ArrayList<File>();
+			List<File> list = new ArrayList<File>();
 
 			try {
 				if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
@@ -180,7 +181,7 @@ public abstract class FileList<T extends ArrayAdapter<File>> extends AbstractLis
 		}
 	}
 
-	private void listDir(ArrayList<File> result, File directory) {
+	private void listDir(List<File> result, File directory) {
 		if (directory == null || !directory.isDirectory() || !directory.canRead()) {
 			return;
 		}

--- a/src/cgeo/geocaching/files/LocParser.java
+++ b/src/cgeo/geocaching/files/LocParser.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.files;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,7 +37,7 @@ public final class LocParser extends FileParser {
 
 	public static void parseLoc(final cgCacheWrap caches,
 			final String fileContent) {
-		final HashMap<String, cgCoord> cidCoords = parseCoordinates(fileContent);
+		final Map<String, cgCoord> cidCoords = parseCoordinates(fileContent);
 
 		// save found cache coordinates
 		for (cgCache cache : caches.cacheList) {
@@ -60,9 +61,9 @@ public final class LocParser extends FileParser {
 		}
 	}
 
-	private static HashMap<String, cgCoord> parseCoordinates(
+	private static Map<String, cgCoord> parseCoordinates(
 			final String fileContent) {
-		final HashMap<String, cgCoord> coords = new HashMap<String, cgCoord>();
+		final Map<String, cgCoord> coords = new HashMap<String, cgCoord>();
 		if (StringUtils.isBlank(fileContent)) {
 			return coords;
 		}
@@ -73,7 +74,7 @@ public final class LocParser extends FileParser {
 		// parse coordinates
 		for (String pointString : points) {
 			final cgCoord pointCoord = new cgCoord();
-			HashMap<String, Object> tmp = null;
+			Map<String, Object> tmp = null;
 
 			final Matcher matcherGeocode = patternGeocode.matcher(pointString);
 			if (matcherGeocode.find()) {
@@ -149,7 +150,7 @@ public final class LocParser extends FileParser {
 		long searchId = 0L;
 
 		try {
-			HashMap<String, cgCoord> coords = parseCoordinates(readFile(file).toString());
+			Map<String, cgCoord> coords = parseCoordinates(readFile(file).toString());
 			final cgCacheWrap caches = new cgCacheWrap();
 			for (Entry<String, cgCoord> entry : coords.entrySet()) {
 				cgCoord coord = entry.getValue();

--- a/src/cgeo/geocaching/mapcommon/cgMapMyOverlay.java
+++ b/src/cgeo/geocaching/mapcommon/cgMapMyOverlay.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.mapcommon;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import android.app.Activity;
 import android.graphics.Bitmap;
@@ -8,9 +9,9 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Paint;
+import android.graphics.Paint.Style;
 import android.graphics.PaintFlagsDrawFilter;
 import android.graphics.Point;
-import android.graphics.Paint.Style;
 import android.location.Location;
 import cgeo.geocaching.R;
 import cgeo.geocaching.cgBase;
@@ -38,7 +39,7 @@ public class cgMapMyOverlay implements OverlayBase {
 	private PaintFlagsDrawFilter setfil = null;
 	private PaintFlagsDrawFilter remfil = null;
 	private Location historyRecent = null;
-	private ArrayList<Location> history = new ArrayList<Location>();
+	private List<Location> history = new ArrayList<Location>();
 	private Point historyPointN = new Point();
 	private Point historyPointP = new Point();
 	private Activity activity;

--- a/src/cgeo/geocaching/mapcommon/cgMapOverlay.java
+++ b/src/cgeo/geocaching/mapcommon/cgMapOverlay.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.mapcommon;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -35,7 +36,7 @@ import cgeo.geocaching.mapinterfaces.OverlayBase;
 
 public class cgMapOverlay extends ItemizedOverlayBase implements OverlayBase {
 
-	private ArrayList<CacheOverlayItemImpl> items = new ArrayList<CacheOverlayItemImpl>();
+	private List<CacheOverlayItemImpl> items = new ArrayList<CacheOverlayItemImpl>();
 	private Context context = null;
 	private Boolean fromDetail = false;
 	private boolean displayCircles = false;
@@ -61,13 +62,13 @@ public class cgMapOverlay extends ItemizedOverlayBase implements OverlayBase {
 	}
 	
 	public void updateItems(CacheOverlayItemImpl item) {
-		ArrayList<CacheOverlayItemImpl> itemsPre = new ArrayList<CacheOverlayItemImpl>();
+		List<CacheOverlayItemImpl> itemsPre = new ArrayList<CacheOverlayItemImpl>();
 		itemsPre.add(item);
 
 		updateItems(itemsPre);
 	}
 
-	public void updateItems(ArrayList<CacheOverlayItemImpl> itemsPre) {
+	public void updateItems(List<CacheOverlayItemImpl> itemsPre) {
 		if (itemsPre == null) {
 			return;
 		}

--- a/src/cgeo/geocaching/mapcommon/cgUsersOverlay.java
+++ b/src/cgeo/geocaching/mapcommon/cgUsersOverlay.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.mapcommon;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -25,7 +26,7 @@ import cgeo.geocaching.mapinterfaces.UserOverlayItemImpl;
 
 public class cgUsersOverlay extends ItemizedOverlayBase implements OverlayBase {
 
-	private ArrayList<UserOverlayItemImpl> items = new ArrayList<UserOverlayItemImpl>();
+	private List<UserOverlayItemImpl> items = new ArrayList<UserOverlayItemImpl>();
 	private Context context = null;
 	private final Pattern patternGeocode = Pattern.compile("^(GC[A-Z0-9]+)(\\: ?(.+))?$", Pattern.CASE_INSENSITIVE);
 
@@ -37,13 +38,13 @@ public class cgUsersOverlay extends ItemizedOverlayBase implements OverlayBase {
 	}
 
 	protected void updateItems(UserOverlayItemImpl item) {
-		ArrayList<UserOverlayItemImpl> itemsPre = new ArrayList<UserOverlayItemImpl>();
+		List<UserOverlayItemImpl> itemsPre = new ArrayList<UserOverlayItemImpl>();
 		itemsPre.add(item);
 
 		updateItems(itemsPre);
 	}
 
-	public void updateItems(ArrayList<UserOverlayItemImpl> itemsPre) {
+	public void updateItems(List<UserOverlayItemImpl> itemsPre) {
 		if (itemsPre == null) {
 			return;
 		}

--- a/src/cgeo/geocaching/mapcommon/cgeomap.java
+++ b/src/cgeo/geocaching/mapcommon/cgeomap.java
@@ -2,7 +2,9 @@ package cgeo.geocaching.mapcommon;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
@@ -113,10 +115,10 @@ public class cgeomap extends MapBase {
 	private cgMapMyOverlay overlayMyLoc = null;
 	// data for overlays
 	private int cachesCnt = 0;
-	private HashMap<Integer, Drawable> iconsCache = new HashMap<Integer, Drawable>();
-	private ArrayList<cgCache> caches = new ArrayList<cgCache>();
-	private ArrayList<cgUser> users = new ArrayList<cgUser>();
-	private ArrayList<cgCoord> coordinates = new ArrayList<cgCoord>();
+	private Map<Integer, Drawable> iconsCache = new HashMap<Integer, Drawable>();
+	private List<cgCache> caches = new ArrayList<cgCache>();
+	private List<cgUser> users = new ArrayList<cgUser>();
+	private List<cgCoord> coordinates = new ArrayList<cgCoord>();
 	// storing for offline
 	private ProgressDialog waitDialog = null;
 	private int detailTotal = 0;
@@ -559,9 +561,9 @@ public class cgeomap extends MapBase {
 			searchIdIntent = null;
 		} else if (id == MENU_STORE_CACHES) {
 			if (live && !isLoading() && caches != null && !caches.isEmpty()) {
-				final ArrayList<String> geocodes = new ArrayList<String>();
+				final List<String> geocodes = new ArrayList<String>();
 
-				ArrayList<cgCache> cachesProtected = new ArrayList<cgCache>(caches);
+				List<cgCache> cachesProtected = new ArrayList<cgCache>(caches);
 				try {
 					if (CollectionUtils.isNotEmpty(cachesProtected)) {
 						final GeoPointImpl mapCenter = mapView.getMapViewCenter();
@@ -1189,7 +1191,7 @@ public class cgeomap extends MapBase {
 					return;
 				}
 
-				HashMap<String, String> params = new HashMap<String, String>();
+				Map<String, String> params = new HashMap<String, String>();
 				params.put("usertoken", token);
 				params.put("latitude-min", String.format((Locale) null, "%.6f", latMin));
 				params.put("latitude-max", String.format((Locale) null, "%.6f", latMax));
@@ -1251,8 +1253,8 @@ public class cgeomap extends MapBase {
 				}
 
 				// display caches
-				final ArrayList<cgCache> cachesProtected = new ArrayList<cgCache>(caches);
-				final ArrayList<CacheOverlayItemImpl> items = new ArrayList<CacheOverlayItemImpl>();
+				final List<cgCache> cachesProtected = new ArrayList<cgCache>(caches);
+				final List<CacheOverlayItemImpl> items = new ArrayList<CacheOverlayItemImpl>();
 
 				if (cachesProtected != null && !cachesProtected.isEmpty()) {
 					int icon = 0;
@@ -1406,9 +1408,9 @@ public class cgeomap extends MapBase {
 	// display users of Go 4 Cache
 	private class DisplayUsersThread extends DoThread {
 
-		private ArrayList<cgUser> users = null;
+		private List<cgUser> users = null;
 
-		public DisplayUsersThread(ArrayList<cgUser> usersIn, long centerLatIn, long centerLonIn, long spanLatIn, long spanLonIn) {
+		public DisplayUsersThread(List<cgUser> usersIn, long centerLatIn, long centerLonIn, long spanLatIn, long spanLonIn) {
 			super(centerLatIn, centerLonIn, spanLatIn, spanLonIn);
 
 			users = usersIn;
@@ -1425,7 +1427,7 @@ public class cgeomap extends MapBase {
 				}
 
 				// display users
-				ArrayList<UserOverlayItemImpl> items = new ArrayList<UserOverlayItemImpl>();
+				List<UserOverlayItemImpl> items = new ArrayList<UserOverlayItemImpl>();
 
 				int counter = 0;
 				UserOverlayItemImpl item = null;
@@ -1543,11 +1545,11 @@ public class cgeomap extends MapBase {
 	private class LoadDetails extends Thread {
 
 		private Handler handler = null;
-		private ArrayList<String> geocodes = null;
+		private List<String> geocodes = null;
 		private volatile boolean stop = false;
 		private long last = 0L;
 
-		public LoadDetails(Handler handlerIn, ArrayList<String> geocodesIn) {
+		public LoadDetails(Handler handlerIn, List<String> geocodesIn) {
 			handler = handlerIn;
 			geocodes = geocodesIn;
 		}
@@ -1648,7 +1650,7 @@ public class cgeomap extends MapBase {
 			alreadyCentered = true;
 		} else if (!centered && (geocodeCenter != null || searchIdIntent != null)) {
 			try {
-				ArrayList<Object> viewport = null;
+				List<Object> viewport = null;
 
 				if (geocodeCenter != null) {
 					viewport = app.getBounds(geocodeCenter);


### PR DESCRIPTION
While refactoring the code i noticed that we are using instance types for holding Lists and  Maps and for method parameters

```
ArrayList<String> geocodes = new ArrayList();
public Long searchByGeocode(HashMap<String, String> parameters, int reason, boolean forceReload)
```

when we should be using generic types - methods should not care that its a HashMap just that its a Map so I have changed the instance types to generic types e.g.

```
List<String> geocodes = new ArrayList();
public Long searchByGeocode(Map<String, String> parameters, int reason, boolean forceReload)
```

Also I noticed most of the search methods were all doing a similar thing when dealing with the results so I have put that code in a separate method  that is called from all the rest rather than having the code duplicated
