### PR TITLE
Disable maps position tracking on double-tap zoom-in

### DIFF
--- a/src/cgeo/geocaching/googlemaps/googleMapView.java
+++ b/src/cgeo/geocaching/googlemaps/googleMapView.java
@@ -175,6 +175,9 @@ public class googleMapView extends MapView implements MapViewImpl {
 		@Override
 		public boolean onDoubleTap(MotionEvent e) {
 			getController().zoomInFixing((int) e.getX(), (int) e.getY());
+			if (onDragListener != null) {
+				onDragListener.onDrag();
+			}
 			return true;
 		}
 

--- a/src/cgeo/geocaching/mapsforge/mfMapView.java
+++ b/src/cgeo/geocaching/mapsforge/mfMapView.java
@@ -225,6 +225,14 @@ public class mfMapView extends MapView implements MapViewImpl {
 
 	private class GestureListener extends SimpleOnGestureListener {
 		@Override
+		public boolean onDoubleTap(MotionEvent e) {
+			if (onDragListener != null) {
+				onDragListener.onDrag();
+			}
+			return true;
+		}
+
+		@Override
 		public boolean onScroll(MotionEvent e1, MotionEvent e2,
 				float distanceX, float distanceY) {
 			if (onDragListener != null) {


### PR DESCRIPTION
Mimics the behaviour of the Android Google Maps app.
