### PR TITLE
Change logging tag from "c:geo" to "cgeo"

### DIFF
--- a/src/cgeo/geocaching/cgSettings.java
+++ b/src/cgeo/geocaching/cgSettings.java
@@ -155,7 +155,7 @@ public class cgSettings {
     public boolean signatureAutoinsert = false;
 
 	// usable values
-	public static final String tag = "c:geo";
+	public static final String tag = "cgeo";
 
 	/** Name of the preferences file */
 	public static final String preferences = "cgeo.pref";


### PR DESCRIPTION
`logcat` uses ":" to separate the tag from the priority when filtering messages. Using "cgeo"` as a tag lets one do:

``` shell
% adb logcat cgeo "*:s"
```

to display only c:geo-related logging information.

The older tag didn't let one use this as "c:geo" is parsed as tag "c" with priority "geo" ("c:geo:*" does not work either).
