### PR TITLE
Fix date format

### DIFF
--- a/src/cgeo/geocaching/cgBase.java
+++ b/src/cgeo/geocaching/cgBase.java
@@ -5094,6 +5094,18 @@ public class cgBase {
 	}
 
 	/**
+	 * Generate a numeric date and time string according to system-wide settings (locale,
+	 * date format) such as "7 sept. à 12:35".
+	 *
+	 * @param context a Context
+	 * @param date milliseconds since the epoch
+	 * @return the formatted string
+	 */
+	public static String formatShortDateTime(Context context, long date) {
+		return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME | DateUtils.FORMAT_ABBREV_ALL);
+	}
+
+	/**
 	 * TODO This method is only needed until the settings are a singleton
 	 * @return
 	 */

--- a/src/cgeo/geocaching/cgeopoint.java
+++ b/src/cgeo/geocaching/cgeopoint.java
@@ -14,7 +14,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.text.format.DateFormat;
 import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
@@ -66,9 +65,7 @@ public class cgeopoint extends AbstractActivity {
 
 			longitude.setText(lonString);
 			latitude.setText(latString);
-			CharSequence dateString = DateFormat.format("dd/MM/yy kk:mm",
-					loc.getDate());
-			date.setText(dateString);
+			date.setText(cgBase.formatShortDateTime(getContext(), loc.getDate()));
 
 			return convertView;
 		}


### PR DESCRIPTION
This uses a short string instead of a non-localized version in coordinates history (see #7).
