### PR TITLE
Use Google backup agent to backup preferences

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -22,11 +22,15 @@
 			android:name=".cgeoapplication"
 			android:theme="@style/cgeo"
 			android:label="@string/app_name"
-			android:icon="@drawable/cgeo" >
+			android:icon="@drawable/cgeo"
+			android:backupAgent="cgeo.geocaching.backup.CentralBackupAgent" >
 		<uses-library android:name="com.google.android.maps" />
 		<meta-data
 			android:name="android.app.default_searchable"
 			android:value=".cgeoadvsearch" />
+		<meta-data
+			android:name="com.google.android.backup.api_key"
+			android:value="AEdPqrEAAAAIsvD_aUSDMwWOf9NkwwxZ4kJJI_AG2EaxjSu2jw" />
 		<activity
 			android:name=".cgeo"
 			android:label="@string/app_name"

--- a/main/proguard.cfg
+++ b/main/proguard.cfg
@@ -44,3 +44,5 @@
     public <init>(android.content.Context, android.util.AttributeSet, int);
     public void set*(...);
 }
+
+-keep public class cgeo.geocaching.backup.CentralBackupAgent

--- a/main/src/cgeo/geocaching/backup/CentralBackupAgent.java
+++ b/main/src/cgeo/geocaching/backup/CentralBackupAgent.java
@@ -1,0 +1,18 @@
+package cgeo.geocaching.backup;
+
+import cgeo.geocaching.cgSettings;
+
+import android.app.backup.BackupAgentHelper;
+import android.app.backup.SharedPreferencesBackupHelper;
+
+public class CentralBackupAgent extends BackupAgentHelper {
+
+    static final String PREFS_BACKUP_KEY = "prefs";
+
+    @Override
+    public void onCreate() {
+        SharedPreferencesBackupHelper helper = new SharedPreferencesBackupHelper(this, cgSettings.preferences);
+        addHelper(PREFS_BACKUP_KEY, helper);
+    }
+
+}

--- a/main/src/cgeo/geocaching/cgeoinit.java
+++ b/main/src/cgeo/geocaching/cgeoinit.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import cgeo.geocaching.LogTemplateProvider.LogTemplate;
 import cgeo.geocaching.cgSettings.mapSourceEnum;
 import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.compatibility.Compatibility;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -139,6 +140,7 @@ public class cgeoinit extends AbstractActivity {
     @Override
     public void onStop() {
         saveValues();
+        Compatibility.dataChanged(getPackageName());
         super.onStop();
     }
 

--- a/main/src/cgeo/geocaching/compatibility/AndroidLevel8.java
+++ b/main/src/cgeo/geocaching/compatibility/AndroidLevel8.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.compatibility;
 
 import android.app.Activity;
+import android.app.backup.BackupManager;
 import android.view.Display;
 
 public class AndroidLevel8 {
@@ -10,4 +11,7 @@ public class AndroidLevel8 {
         return display.getRotation();
     }
 
+    public void dataChanged(final String name) {
+        BackupManager.dataChanged(name);
+    }
 }

--- a/main/src/cgeo/geocaching/compatibility/Compatibility.java
+++ b/main/src/cgeo/geocaching/compatibility/Compatibility.java
@@ -43,4 +43,10 @@ public final class Compatibility {
         return Uri.parse(isLevel8 ? "content://com.android.calendar/events" : "content://calendar/events");
     }
 
+    public static void dataChanged(final String name) {
+        if (isLevel8) {
+            level8.dataChanged(name);
+        }
+    }
+
 }


### PR DESCRIPTION
This lets Google backup the settings automatically. If c:geo is uninstalled then reinstalled, or if the user gets a new device, the settings will be restored when c:geo is installed.

See http://developer.android.com/guide/topics/data/backup.html

This will do nothing if the SDK API < 8.
