### PR TITLE
Use more portable single equals in if

### DIFF
--- a/main/project/localization/findmissingtranslations.sh
+++ b/main/project/localization/findmissingtranslations.sh
@@ -37,7 +37,7 @@ elif [ "$1" != "all" -a ! -f ../../res/values-$1/strings.xml ]; then
     usage
 fi
 
-if [ "$1" == "all" ]; then
+if [ "$1" = "all" ]; then
     langs=$alllangs
 else
     langs=$1


### PR DESCRIPTION
Single equals follows POSIX. In Ubuntu default /bin/sh is Dash, which
warns about double equals:
$ ./findmissingtranslations.sh sk
[: 44: sk: unexpected operator
