### PR TITLE
Display user avatar

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -1,14 +1,15 @@
 package cgeo.geocaching.activity;
 
+import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgBase;
 import cgeo.geocaching.cgCache;
-import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgeoapplication;
 
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.View;
@@ -58,8 +59,12 @@ public abstract class AbstractActivity extends Activity implements IAbstractActi
         ActivityMixin.showShortToast(this, text);
     }
 
-    public final void helpDialog(String title, String message) {
-        ActivityMixin.helpDialog(this, title, message);
+    public final void helpDialog(final String title, final String message) {
+        ActivityMixin.helpDialog(this, title, message, null);
+    }
+
+    public final void helpDialog(final String title, final String message, final Drawable icon) {
+        ActivityMixin.helpDialog(this, title, message, icon);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/activity/AbstractListActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractListActivity.java
@@ -1,14 +1,15 @@
 package cgeo.geocaching.activity;
 
+import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgBase;
 import cgeo.geocaching.cgCache;
-import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgeoapplication;
 
 import android.app.ListActivity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.View;
@@ -55,8 +56,12 @@ public abstract class AbstractListActivity extends ListActivity implements
         ActivityMixin.showShortToast(this, text);
     }
 
-    public final void helpDialog(String title, String message) {
-        ActivityMixin.helpDialog(this, title, message);
+    public final void helpDialog(final String title, final String message) {
+        ActivityMixin.helpDialog(this, title, message, null);
+    }
+
+    public final void helpDialog(final String title, final String message, final Drawable icon) {
+        ActivityMixin.helpDialog(this, title, message, icon);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/cgeo/geocaching/activity/ActivityMixin.java
@@ -1,9 +1,9 @@
 package cgeo.geocaching.activity;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgBase;
 import cgeo.geocaching.cgCache;
-import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgeo;
 
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +14,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.SubMenu;
@@ -102,20 +103,20 @@ public final class ActivityMixin {
         }
     }
 
-    public static final void helpDialog(final Activity activity, final String title, final String message) {
+    public static final void helpDialog(final Activity activity, final String title, final String message, final Drawable icon) {
         if (StringUtils.isBlank(message)) {
             return;
         }
 
-        AlertDialog.Builder dialog = new AlertDialog.Builder(activity);
-        dialog.setTitle(title);
-        dialog.setMessage(message);
-        dialog.setCancelable(true);
+        AlertDialog.Builder dialog = new AlertDialog.Builder(activity).setTitle(title).setMessage(message).setCancelable(true);
         dialog.setNeutralButton("Ok", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
                 dialog.cancel();
             }
         });
+        if (icon != null) {
+            dialog.setIcon(icon);
+        }
 
         AlertDialog alert = dialog.create();
         alert.show();

--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -43,6 +43,7 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Message;
@@ -100,6 +101,8 @@ public class cgBase {
     private final static Pattern patternInventory = Pattern.compile("<span id=\"ctl00_ContentBody_uxTravelBugList_uxInventoryLabel\">\\W*Inventory[^<]*</span>[^<]*</h3>[^<]*<div class=\"WidgetBody\">([^<]*<ul>(([^<]*<li>[^<]*<a href=\"[^\"]+\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>[^<]+<\\/span>[^<]*<\\/a>[^<]*<\\/li>)+)[^<]*<\\/ul>)?", Pattern.CASE_INSENSITIVE);
     private final static Pattern patternInventoryInside = Pattern.compile("[^<]*<li>[^<]*<a href=\"[a-z0-9\\-\\_\\.\\?\\/\\:\\@]*\\/track\\/details\\.aspx\\?guid=([0-9a-z\\-]+)[^\"]*\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>([^<]+)<\\/span>[^<]*<\\/a>[^<]*<\\/li>", Pattern.CASE_INSENSITIVE);
     private final static Pattern patternOnWatchlist = Pattern.compile("<img\\s*src=\"\\/images\\/stockholm\\/16x16\\/icon_stop_watchlist.gif\"", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern patternAvatarImg = Pattern.compile("<img src=\"(http://img.geocaching.com/user/avatar/[0-9a-f-]+\\.jpg)\"[^>]*\\salt=\"Avatar\"");
 
     private final static Pattern PATTERN_TRACKABLE_TrackableId = Pattern.compile("<a id=\"ctl00_ContentBody_LogLink\" title=\"[^\"]*\" href=\".*log\\.aspx\\?wid=([a-z0-9\\-]+)\"[^>]*>[^<]*</a>", Pattern.CASE_INSENSITIVE);
     private final static Pattern PATTERN_TRACKABLE_Geocode = Pattern.compile("<span id=\"ctl00_ContentBody_BugDetails_BugTBNum\" String=\"[^\"]*\">Use[^<]*<strong>(TB[0-9a-z]+)[^<]*</strong> to reference this item.[^<]*</span>", Pattern.CASE_INSENSITIVE);
@@ -1680,6 +1683,23 @@ public class cgBase {
         {
             Settings.setGcCustomDate(matcher.group(1));
         }
+    }
+
+    public static BitmapDrawable downloadAvatar(final Context context) {
+        try {
+            final String profile = replaceWhitespace(getResponseData(request("http://www.geocaching.com/my/", null, false)));
+            final Matcher matcher = patternAvatarImg.matcher(profile);
+            if (matcher.find()) {
+                final String avatarURL = matcher.group(1);
+                final cgHtmlImg imgGetter = new cgHtmlImg(context, "", false, 0, false, false);
+                return imgGetter.getDrawable(avatarURL);
+            }
+            // No match? There may be no avatar set by user.
+            Log.d(Settings.tag, "No avatar set for user");
+        } catch (Exception e) {
+            Log.w(Settings.tag, "Error when retrieving user avatar", e);
+        }
+        return null;
     }
 
     public cgTrackable parseTrackable(String page) {

--- a/main/src/cgeo/geocaching/cgeoinit.java
+++ b/main/src/cgeo/geocaching/cgeoinit.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpResponse;
 import android.app.ProgressDialog;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -50,12 +51,13 @@ public class cgeoinit extends AbstractActivity {
                     loginDialog.dismiss();
                 }
 
-                final StatusCode error = (StatusCode) msg.obj;
-                if (error == null || error == StatusCode.NO_ERROR) {
-                    helpDialog(res.getString(R.string.init_login_popup), res.getString(R.string.init_login_popup_ok));
+                if (msg.obj == null || (msg.obj instanceof Drawable)) {
+                    helpDialog(res.getString(R.string.init_login_popup), res.getString(R.string.init_login_popup_ok),
+                            (Drawable) msg.obj);
                 } else {
                     helpDialog(res.getString(R.string.init_login_popup),
-                            res.getString(R.string.init_login_popup_failed_reason) + " " + error.getErrorString(res) + ".");
+                            res.getString(R.string.init_login_popup_failed_reason) + " " +
+                                    ((StatusCode) msg.obj).getErrorString(res) + ".");
                 }
             } catch (Exception e) {
                 showToast(res.getString(R.string.err_login_failed));
@@ -687,11 +689,10 @@ public class cgeoinit extends AbstractActivity {
                 @Override
                 public void run() {
                     final StatusCode loginResult = cgBase.login();
-                    if (loginResult == StatusCode.NO_ERROR)
-                    {
+                    if (loginResult == StatusCode.NO_ERROR) {
                         cgBase.detectGcCustomDate();
                     }
-                    logInHandler.sendMessage(logInHandler.obtainMessage(0, loginResult));
+                    logInHandler.obtainMessage(0, cgBase.downloadAvatar(cgeoinit.this)).sendToTarget();
                 }
             }).start();
         }


### PR DESCRIPTION
This patch adds the GC.com user avatar to the display dialog confirming that the user credentials at GC.com are correct. This way, the user may be more confident that the credentials have indeed been recognized.

The penalty to get this feature are:
- one extra HTTP request when the user clicks "check credentials & get date format" in the parameters string
- one extra HTTP request to get the avatar if the first step determines that the user has indeed set one in their profile

I encourage you to try it (if you have set an avatar at GC.com). I find it very reassuring for a very small (delay+traffic) price.
