### PR TITLE
usage of WaypointType instead of strings

### DIFF
--- a/main/src/cgeo/geocaching/StaticMapsProvider.java
+++ b/main/src/cgeo/geocaching/StaticMapsProvider.java
@@ -80,7 +80,7 @@ public class StaticMapsProvider {
                 waypoints.append("&markers=icon%3A");
                 waypoints.append(MARKERS_URL);
                 waypoints.append("marker_waypoint_");
-                waypoints.append(waypoint.typee != null ? waypoint.typee.id : null);
+                waypoints.append(waypoint.type != null ? waypoint.type.id : null);
                 waypoints.append(".png%7C");
                 waypoints.append(String.format((Locale) null, "%.6f", waypoint.coords.getLatitude()));
                 waypoints.append(',');

--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -148,7 +148,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 PointGeocachingDataWaypoint wp = new PointGeocachingDataWaypoint();
                 wp.code = waypoint.geocode;
                 wp.name = waypoint.name;
-                String locusWpId = toLocusId(waypoint.typee);
+                String locusWpId = toLocusId(waypoint.type);
                 if (locusWpId != null) {
                     wp.type = locusWpId;
                 }

--- a/main/src/cgeo/geocaching/apps/cache/navi/InternalMap.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/InternalMap.java
@@ -37,7 +37,7 @@ class InternalMap extends AbstractInternalMap implements
         if (waypoint != null) {
             mapIntent.putExtra("latitude", waypoint.coords.getLatitude());
             mapIntent.putExtra("longitude", waypoint.coords.getLongitude());
-            mapIntent.putExtra("wpttype", waypoint.typee.id);
+            mapIntent.putExtra("wpttype", waypoint.type != null ? waypoint.type.id : null);
         } else if (coords != null) {
             mapIntent.putExtra("latitude", coords.getLatitude());
             mapIntent.putExtra("longitude", coords.getLongitude());

--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -135,7 +135,7 @@ public class cgBase {
     public final static Map<String, String> cacheTypesInv = new HashMap<String, String>();
     public final static Map<String, String> cacheIDsChoices = new HashMap<String, String>();
     public final static Map<CacheSize, String> cacheSizesInv = new HashMap<CacheSize, String>();
-    public final static Map<WaypointType, String> waypointTypees = new HashMap<WaypointType, String>();
+    public final static Map<WaypointType, String> waypointTypes = new HashMap<WaypointType, String>();
     public final static Map<String, Integer> logTypes = new HashMap<String, Integer>();
     public final static Map<String, Integer> logTypes0 = new HashMap<String, Integer>();
     public final static Map<Integer, String> logTypes1 = new HashMap<Integer, String>();
@@ -240,7 +240,7 @@ public class cgBase {
         // waypoint types
         for (WaypointType wt : WaypointType.values()) {
             if (wt != WaypointType.OWN) {
-                waypointTypees.put(wt, res.getString(wt.stringId));
+                waypointTypes.put(wt, res.getString(wt.stringId));
             }
         }
 
@@ -1420,7 +1420,7 @@ public class cgBase {
                     try {
                         final Matcher matcherWpType = patternWpType.matcher(wp[3]);
                         if (matcherWpType.find() && matcherWpType.groupCount() > 0) {
-                            waypoint.typee = WaypointType.FIND_BY_ID.get(matcherWpType.group(1).trim());
+                            waypoint.type = WaypointType.FIND_BY_ID.get(matcherWpType.group(1).trim());
                         }
                     } catch (Exception e) {
                         // failed to parse type

--- a/main/src/cgeo/geocaching/cgCoord.java
+++ b/main/src/cgeo/geocaching/cgCoord.java
@@ -8,7 +8,7 @@ public class cgCoord {
     public Integer id = null;
     public String geocode = "";
     public String type = "cache";
-    public String typeeSpec = "traditional";
+    public String typeSpec = "traditional";
     public String name = "";
     public boolean found = false;
     public boolean disabled = false;
@@ -27,7 +27,7 @@ public class cgCoord {
         coords = cache.coords;
         name = cache.name;
         type = "cache";
-        typeeSpec = cache.type;
+        typeSpec = cache.type;
         difficulty = cache.difficulty;
         terrain = cache.terrain;
         size = cache.size;
@@ -41,6 +41,6 @@ public class cgCoord {
         coords = waypoint.coords;
         name = waypoint.name;
         type = "waypoint";
-        typeeSpec = waypoint.typee.id;
+        typeSpec = waypoint.type != null ? waypoint.type.id : null;
     }
 }

--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -1409,7 +1409,7 @@ public class cgData {
                     values.clear();
                     values.put("geocode", geocode);
                     values.put("updated", timeStamp);
-                    values.put("type", oneWaypoint.typee != null ? oneWaypoint.typee.id : null);
+                    values.put("type", oneWaypoint.type != null ? oneWaypoint.type.id : null);
                     values.put("prefix", oneWaypoint.getPrefix());
                     values.put("lookup", oneWaypoint.lookup);
                     values.put("name", oneWaypoint.name);
@@ -1495,7 +1495,7 @@ public class cgData {
             ContentValues values = new ContentValues();
             values.put("geocode", geocode);
             values.put("updated", System.currentTimeMillis());
-            values.put("type", waypoint.typee != null ? waypoint.typee.id : null);
+            values.put("type", waypoint.type != null ? waypoint.type.id : null);
             values.put("prefix", waypoint.getPrefix());
             values.put("lookup", waypoint.lookup);
             values.put("name", waypoint.name);
@@ -2203,7 +2203,7 @@ public class cgData {
 
         waypoint.id = cursor.getInt(cursor.getColumnIndex("_id"));
         waypoint.geocode = cursor.getString(cursor.getColumnIndex("geocode"));
-        waypoint.typee = WaypointType.FIND_BY_ID.get(cursor.getString(cursor.getColumnIndex("type")));
+        waypoint.type = WaypointType.FIND_BY_ID.get(cursor.getString(cursor.getColumnIndex("type")));
         waypoint.setPrefix(cursor.getString(cursor.getColumnIndex("prefix")));
         waypoint.lookup = cursor.getString(cursor.getColumnIndex("lookup"));
         waypoint.name = cursor.getString(cursor.getColumnIndex("name"));

--- a/main/src/cgeo/geocaching/cgWaypoint.java
+++ b/main/src/cgeo/geocaching/cgWaypoint.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class cgWaypoint implements Comparable<cgWaypoint> {
     public Integer id = 0;
     public String geocode = "geocode";
-    public WaypointType typee = WaypointType.WAYPOINT;
+    public WaypointType type = WaypointType.WAYPOINT;
     private String prefix = "";
     public String lookup = "";
     public String name = "";
@@ -23,7 +23,7 @@ public class cgWaypoint implements Comparable<cgWaypoint> {
     private Integer cachedOrder = null;
 
     public void setIcon(Resources res, cgBase base, TextView nameView) {
-        nameView.setCompoundDrawablesWithIntrinsicBounds(res.getDrawable(typee.drawableId), null, null, null);
+        nameView.setCompoundDrawablesWithIntrinsicBounds(res.getDrawable(type.drawableId), null, null, null);
     }
 
     public void merge(final cgWaypoint old) {
@@ -78,7 +78,7 @@ public class cgWaypoint implements Comparable<cgWaypoint> {
     }
 
     public boolean isUserDefined() {
-        return typee == WaypointType.OWN;
+        return type == WaypointType.OWN;
     }
 
     private int computeOrder() {

--- a/main/src/cgeo/geocaching/cgeodetail.java
+++ b/main/src/cgeo/geocaching/cgeodetail.java
@@ -1021,7 +1021,7 @@ public class cgeodetail extends AbstractActivity {
                     waypointView = (LinearLayout) inflater.inflate(R.layout.waypoint_item, null);
                     final TextView identification = (TextView) waypointView.findViewById(R.id.identification);
 
-                    ((TextView) waypointView.findViewById(R.id.type)).setText(cgBase.waypointTypees.get(wpt.typee));
+                    ((TextView) waypointView.findViewById(R.id.type)).setText(cgBase.waypointTypes.get(wpt.type));
                     if (!wpt.getPrefix().equalsIgnoreCase("OWN")) {
                         identification.setText(wpt.getPrefix().trim() + "/" + wpt.lookup.trim());
                     } else {

--- a/main/src/cgeo/geocaching/cgeowaypointadd.java
+++ b/main/src/cgeo/geocaching/cgeowaypointadd.java
@@ -54,7 +54,7 @@ public class cgeowaypointadd extends AbstractActivity {
                     id = -1;
                 } else {
                     geocode = waypoint.geocode;
-                    type = waypoint.typee;
+                    type = waypoint.type;
                     prefix = waypoint.getPrefix();
                     lookup = waypoint.lookup;
 
@@ -127,7 +127,7 @@ public class cgeowaypointadd extends AbstractActivity {
         Button addWaypoint = (Button) findViewById(R.id.add_waypoint);
         addWaypoint.setOnClickListener(new coordsListener());
 
-        List<String> wayPointNames = new ArrayList<String>(cgBase.waypointTypees.values());
+        List<String> wayPointNames = new ArrayList<String>(cgBase.waypointTypes.values());
         AutoCompleteTextView textView = (AutoCompleteTextView) findViewById(R.id.name);
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line, wayPointNames);
         textView.setAdapter(adapter);
@@ -329,7 +329,7 @@ public class cgeowaypointadd extends AbstractActivity {
             final String note = ((EditText) findViewById(R.id.note)).getText().toString().trim();
 
             final cgWaypoint waypoint = new cgWaypoint();
-            waypoint.typee = type;
+            waypoint.type = type;
             waypoint.geocode = geocode;
             waypoint.setPrefix(prefix);
             waypoint.lookup = lookup;

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -305,7 +305,7 @@ public abstract class GPXParser extends FileParser {
                     if (cacheForWaypoint != null) {
                         final cgWaypoint waypoint = new cgWaypoint();
                         waypoint.id = -1;
-                        waypoint.typee = convertWaypointSym2Type(sym);
+                        waypoint.type = convertWaypointSym2Type(sym);
                         waypoint.geocode = cacheGeocodeForWaypoint;
                         waypoint.setPrefix(cache.name.substring(0, 2));
                         waypoint.lookup = "---";

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -90,7 +90,7 @@ public class CGeoMap extends AbstractMap implements OnDragListener, ViewFactory 
     private String searchIdIntent = null;
     private String geocodeIntent = null;
     private Geopoint coordsIntent = null;
-    private WaypointType waypointTypeeIntent = null;
+    private WaypointType waypointTypeIntent = null;
     private int[] mapStateIntent = null;
     // status data
     private UUID searchId = null;
@@ -328,7 +328,7 @@ public class CGeoMap extends AbstractMap implements OnDragListener, ViewFactory 
             final double latitudeIntent = extras.getDouble("latitude");
             final double longitudeIntent = extras.getDouble("longitude");
             coordsIntent = new Geopoint(latitudeIntent, longitudeIntent);
-            waypointTypeeIntent = WaypointType.FIND_BY_ID.get(extras.getString("wpttype"));
+            waypointTypeIntent = WaypointType.FIND_BY_ID.get(extras.getString("wpttype"));
             mapStateIntent = extras.getIntArray("mapstate");
 
             if ("".equals(searchIdIntent)) {
@@ -677,7 +677,7 @@ public class CGeoMap extends AbstractMap implements OnDragListener, ViewFactory 
                     mapIntent.putExtra("latitude", coordsIntent.getLatitude());
                     mapIntent.putExtra("longitude", coordsIntent.getLongitude());
                 }
-                mapIntent.putExtra("wpttype", waypointTypeeIntent.id);
+                mapIntent.putExtra("wpttype", waypointTypeIntent != null ? waypointTypeIntent.id : null);
                 int[] mapState = new int[4];
                 GeoPointImpl mapCenter = mapView.getMapViewCenter();
                 mapState[0] = mapCenter.getLatitudeE6();
@@ -1307,7 +1307,7 @@ public class CGeoMap extends AbstractMap implements OnDragListener, ViewFactory 
                                     continue;
                                 }
 
-                                items.add(getWaypointItem(new cgCoord(oneWaypoint), oneWaypoint.typee));
+                                items.add(getWaypointItem(new cgCoord(oneWaypoint), oneWaypoint.type));
                             }
                         }
                         items.add(getCacheItem(new cgCoord(cacheOne), cacheOne.type, cacheOne.own, cacheOne.found, cacheOne.disabled));
@@ -1529,7 +1529,7 @@ public class CGeoMap extends AbstractMap implements OnDragListener, ViewFactory 
                 coordinates.add(coord);
                 CachesOverlayItemImpl item = Settings.getMapFactory().getCachesOverlayItem(coord, null);
 
-                final int icon = waypointTypeeIntent.markerId;
+                final int icon = waypointTypeIntent != null ? waypointTypeIntent.markerId : null;
                 Drawable pin = null;
                 if (iconsCache.containsKey(icon)) {
                     pin = iconsCache.get(icon);

--- a/main/src/cgeo/geocaching/maps/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/CachesOverlay.java
@@ -276,8 +276,8 @@ public class CachesOverlay extends AbstractItemizedOverlay implements GeneralOve
                 dialog.setTitle("cache");
 
                 String cacheType;
-                if (cgBase.cacheTypesInv.containsKey(coordinate.typeeSpec)) {
-                    cacheType = cgBase.cacheTypesInv.get(coordinate.typeeSpec);
+                if (cgBase.cacheTypesInv.containsKey(coordinate.typeSpec)) {
+                    cacheType = cgBase.cacheTypesInv.get(coordinate.typeSpec);
                 } else {
                     cacheType = cgBase.cacheTypesInv.get("mystery");
                 }
@@ -315,9 +315,9 @@ public class CachesOverlay extends AbstractItemizedOverlay implements GeneralOve
             } else {
                 dialog.setTitle("waypoint");
 
-                String waypointL10N = cgBase.waypointTypees.get(coordinate.typeeSpec);
+                String waypointL10N = cgBase.waypointTypes.get(WaypointType.FIND_BY_ID.get(coordinate.typeSpec));
                 if (waypointL10N == null) {
-                    waypointL10N = cgBase.waypointTypees.get(WaypointType.WAYPOINT);
+                    waypointL10N = cgBase.waypointTypes.get(WaypointType.WAYPOINT);
                 }
 
                 dialog.setMessage(Html.fromHtml(item.getTitle()) + "\n\ntype: " + waypointL10N);

--- a/tests/src/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src/cgeo/geocaching/files/GPXParserTest.java
@@ -159,7 +159,7 @@ public class GPXParserTest extends InstrumentationTestCase {
         assertEquals("---", wp.lookup);
         assertEquals("Parkplatz", wp.name);
         assertEquals("Kostenfreies Parken (je nach Parkreihe Parkscheibe erforderlich)", wp.note);
-        assertEquals(WaypointType.PKG, wp.typee);
+        assertEquals(WaypointType.PKG, wp.type);
         assertEquals(49.317517, wp.coords.getLatitude(), 0.000001);
         assertEquals(8.545083, wp.coords.getLongitude(), 0.000001);
 
@@ -169,7 +169,7 @@ public class GPXParserTest extends InstrumentationTestCase {
         assertEquals("---", wp.lookup);
         assertEquals("Station 1", wp.name);
         assertEquals("Ein zweiter Wegpunkt, der nicht wirklich existiert sondern nur zum Testen gedacht ist.", wp.note);
-        assertEquals(WaypointType.STAGE, wp.typee);
+        assertEquals(WaypointType.STAGE, wp.type);
         assertEquals(49.317500, wp.coords.getLatitude(), 0.000001);
         assertEquals(8.545100, wp.coords.getLongitude(), 0.000001);
     }


### PR DESCRIPTION
finally I did have some time to code again...

I eliminated the use of strings for waypoint types were possible.

In cgCoord I had to use strings because the type can be either a cache type or a waypoint type. I think it is not worth giving this class any efford, because in my opinion we should get rid of it anyway. Maybe by having a non-abstract base classe for Cache and Waypoint?

next I'll eliminate the cache type strings...
