### PR TITLE
Changelog - for code discussion only - *** don't merge ***

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-		android:versionName="09.10.2011"
+		android:versionName="15.10.2011"
 		android:versionCode="20111009"
 		package="cgeo.geocaching"
 		name="c:geo"

--- a/main/res/layout/about.xml
+++ b/main/res/layout/about.xml
@@ -186,20 +186,6 @@
 			<RelativeLayout style="@style/separator_horizontal_layout" >
 				<View style="@style/separator_horizontal" />
 				<TextView style="@style/separator_horizontal_headline"
-						android:text="@string/about_changelog" />
-			</RelativeLayout>
-			<TextView
-					android:layout_width="wrap_content"
-					android:layout_height="wrap_content"
-					android:layout_margin="7dip"
-					android:layout_gravity="left"
-					android:paddingLeft="3dip"
-					android:textSize="12dip"
-					android:textColor="?text_color"
-					android:text="@string/changelog" />
-			<RelativeLayout style="@style/separator_horizontal_layout" >
-				<View style="@style/separator_horizontal" />
-				<TextView style="@style/separator_horizontal_headline"
 						android:text="@string/about_contributors" />
 			</RelativeLayout>
 			<TextView android:id="@+id/contributors"

--- a/main/res/raw/changelog.txt
+++ b/main/res/raw/changelog.txt
@@ -1,0 +1,126 @@
+<html>
+  <head>
+    <style type='text/css'>
+      a            { color:#a0a0e0 }
+      div.title    { 
+          color:#C0F0C0; 
+          font-size:1.2em; 
+          font-weight:bold; 
+          margin-top:1em; 
+          margin-bottom:0.5em; 
+          text-align:center }
+      div.subtitle { 
+          color:#C0C0F0; 
+          font-size:0.6em; 
+          margin-bottom:1em; 
+          text-align:center }
+      div.freetext { color:#F0F0F0 }
+      div.list     { 
+          color:#C0C0C0;
+          font-size:0.8em }
+    </style>
+  </head>
+  <body>
+$ new release
+  % new release
+  _ This also is in this version:
+    * <b>new:</b> cleanup the cgeo private cache directory when caches are removed from database
+    * <b>new:</b> display user avatar when checking login/password from geocaching.com
+
+$ 09.10.2011
+  % 09.10.2011
+    * <b>fix:</b> small bugs due to GC.com change
+    
+$ 06.10.2011
+  % 06.10.2011
+    * <b>new:</b> import waypoint files from pocket query
+    * <b>new:</b> automatically filter out counter images from cache description
+    * <b>new:</b> show all the images belonging to a log entry at once
+    * <b>new:</b> make it possible to display intermediate waypoints on live map
+    * <b>new:</b> better progress information when importing GPX files
+    * <b>new:</b> better progress information during backup/restore of database
+    * <b>new:</b> better French, German, Hungarian, and Slovak translations
+    * <b>new:</b> better icon for caches needing maintenance
+    * <b>fix:</b> work again on all devices, it was broken on some Android 1.6 models
+    * <b>fix:</b> correctly display target on map when using any coordinates mode
+    * <b>fix:</b> forwarding of OC caches used wrong URL
+    * <b>fix:</b> better performance when parsing cache description
+    * <b>fix:</b> performance improvements when importing waypoints
+    * <b>fix:</b> reclaim bitmap memory earlier to prevent memory exhaustion
+    * <b>fix:</b> cleaner location names (no more HTML) in cache descriptions
+    * <b>fix:</b> load descriptions from database only when needed (lower memory consumption)
+    * <b>fix:</b> one of the coordinates entry mode was using the wrong coordinate when reediting
+    * <b>fix:</b> latitude and longitude are now localized
+    * <b>fix:</b> remove redundant fields in the database to reduce used space
+    * <b>fix:</b> various bug fixes and internal enhancements
+    
+$ 24.09.2011
+  % 24.09.2011
+    * <b>new:</b> import of LOC files
+    * <b>new:</b> search for geo code supports OpenCaching.ORG.UK/.PL/.US
+    * <b>new:</b> restore settings after reinstallation (Android 2.3+)
+    * <b>new:</b> save the log locally when leaving the log activity
+    * <b>new:</b> insert signature after the cursor when logging
+    * <b>fix:</b> various bug fixes
+    
+$ 18.09.2011
+  % 18.09.2011
+    * <b>fix:</b> Android 3+ compatibility
+    
+$ 17.09.2011
+  % 17.09.2011
+    * <b>fix:</b> more small fixes
+    
+$ 16.09.2011
+  % 16.09.2011
+    * <b>fix:</b> many small fixed due to GC.com changes
+    
+$ 15.09.2011
+  % 15.09.2011
+    * <b>new:</b> sort by state, sort by find count
+    * <b>new:</b> experimental support for .gpx from opencaching.com
+    * <b>new:</b> scan QR code to open cache description (Barcode Scanner from Market)
+    * <b>new:</b> context menu on stored caches button (main screen)
+    * <b>new:</b> compass immediately shows the right direction
+    * <b>new:</b> active filters are shown in list mode
+    * <b>fix:</b> performance of GPX import
+    * <b>fix:</b> performance of deleting caches from list
+    * <b>fix:</b> performance of web traffic
+    * <b>fix:</b> return to list after GPX import
+    * <b>fix:</b> fill signature when logging offline
+    * <b>fix:</b> show strikethrough in caches
+    * <b>fix:</b> no more empty map previews
+    * <b>fix:</b> send2c:geo authorization
+    
+$ 26.08.2011
+  % 26.08.2011
+    * <b>new:</b> street view
+    * <b>new:</b> attribute icons
+    * <b>new:</b> experimental support for .gpx from opencaching.de
+    * <b>fix:</b> log-dates
+    * <b>fix:</b> coordinates input
+    * <b>fix:</b> nearby list performance update
+    
+$ 22.08.2011
+  % 22.08.2011
+    * <b>fix:</b> due to GC.com changes c:geo hangs in displaying cache detail
+    
+$ 20.08.2011
+  % 20.08.2011
+    * <b>fix:</b> Additional adaption to GC.com changes
+    
+$ 19.08.2011
+  % 19.08.2011
+    * <b>new:</b> Numeric entry for coordinates
+    * <b>fix:</b> adaption to GC.com changes
+    
+$ 15.08.2011
+  % 15.08.2011
+    * <b>new:</b> OpenStreetMap support
+    * <b>new:</b> Send to c:geo from web
+    * <b>new:</b> Export field notes
+    * <b>new:</b> Clear history
+    * <b>fix:</b> A lot of bugs
+$ END_OF_CHANGE_LOG
+  </body>
+</html>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -246,6 +246,11 @@
   <string name="any_button">Any destination</string>
   <string name="unknown_scan">Didn\'t find geo code in scan result.</string>
 
+  <!-- changelog -->
+  <string name="changelog_full_title">Change Log</string>
+  <string name="changelog_title">What\'s New</string>
+  <string name="changelog_ok_button">OK</string>
+      
   <!-- caches -->
   <string name="caches_no_cache">There is no cache</string>
   <string name="caches_more_caches">Not enough? Get more caches!</string>
@@ -917,94 +922,4 @@
     · <a href="http://commons.apache.org/">The Apache Commons Project</a>\n
     · <a href="http://androidicons.com/">Android Icons</a> (<a href="https://creativecommons.org/licenses/by/3.0/">CC-BY 3.0</a>)\n
   </string>
-
-  <!-- changelog -->
-  <string name="changelog">\n
-    <b>New release</b>\n
-    · new: cleanup the cgeo private cache directory when caches are removed from database\n
-    · new: display user avatar when checking login/password from geocaching.com\n
-    \n\n
-    <b>09.10.2011</b>\n
-    · fix: small bugs due to GC.com change\n
-    \n\n
-    <b>06.10.2011</b>\n
-    · new: import waypoint files from pocket query\n
-    · new: automatically filter out counter images from cache description\n
-    · new: show all the images belonging to a log entry at once\n
-    · new: make it possible to display intermediate waypoints on live map\n
-    · new: better progress information when importing GPX files\n
-    · new: better progress information during backup/restore of database\n
-    · new: better French, German, Hungarian, and Slovak translations\n
-    · new: better icon for caches needing maintenance\n
-    · fix: work again on all devices, it was broken on some Android 1.6 models\n
-    · fix: correctly display target on map when using any coordinates mode\n
-    · fix: forwarding of OC caches used wrong URL\n
-    · fix: better performance when parsing cache description\n
-    · fix: performance improvements when importing waypoints\n
-    · fix: reclaim bitmap memory earlier to prevent memory exhaustion\n
-    · fix: cleaner location names (no more HTML) in cache descriptions\n
-    · fix: load descriptions from database only when needed (lower memory consumption)\n
-    · fix: one of the coordinates entry mode was using the wrong coordinate when reediting\n
-    · fix: latitude and longitude are now localized\n
-    · fix: remove redundant fields in the database to reduce used space\n
-    · fix: various bug fixes and internal enhancements\n
-    \n\n
-    <b>24.09.2011</b>\n
-    · new: import of LOC files\n
-    · new: search for geo code supports OpenCaching.ORG.UK/.PL/.US\n
-    · new: restore settings after reinstallation (Android 2.3+)\n
-    · new: save the log locally when leaving the log activity\n
-    · new: insert signature after the cursor when logging\n
-    · fix: various bug fixes\n
-    \n\n
-    <b>18.09.2011</b>\n
-    · fix: Android 3+ compatibility\n
-    \n\n
-    <b>17.09.2011</b>\n
-    · fix: more small fixes\n
-    \n\n
-    <b>16.09.2011</b>\n
-    · fix: many small fixed due to GC.com changes\n
-    \n\n
-    <b>15.09.2011</b>\n
-    · new: sort by state, sort by find count\n
-    · new: experimental support for .gpx from opencaching.com\n
-    · new: scan QR code to open cache description (Barcode Scanner from Market)\n
-    · new: context menu on stored caches button (main screen)\n
-    · new: compass immediately shows the right direction\n
-    · new: active filters are shown in list mode\n
-    · fix: performance of GPX import\n
-    · fix: performance of deleting caches from list\n
-    · fix: performance of web traffic\n
-    · fix: return to list after GPX import\n
-    · fix: fill signature when logging offline\n
-    · fix: show strikethrough in caches\n
-    · fix: no more empty map previews\n
-    · fix: send2c:geo authorization\n
-    \n\n
-    <b>26.08.2011</b>\n
-    · new: street view\n
-    · new: attribute icons\n
-    · new: experimental support for .gpx from opencaching.de\n
-    · fix: log-dates\n
-    · fix: coordinates input\n
-    · fix: nearby list performance update\n
-    \n\n
-    <b>22.08.2011</b>\n
-    · fix: due to GC.com changes c:geo hangs in displaying cache detail\n
-    \n\n
-    <b>20.08.2011</b>\n
-    · fix: Additional adaption to GC.com changes\n
-    \n\n
-    <b>19.08.2011</b>\n
-    · new: Numeric entry for coordinates\n
-    · fix: adaption to GC.com changes\n
-    \n\n
-    <b>15.08.2011</b>\n
-    · new: OpenStreetMap support\n
-    · new: Send to c:geo from web\n
-    · new: Export field notes\n
-    · new: Clear history\n
-    · fix: A lot of bugs\n
-    \n</string>
 </resources>

--- a/main/src/cgeo/geocaching/cgeo.java
+++ b/main/src/cgeo/geocaching/cgeo.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.maps.CGeoMap;
+import cgeo.geocaching.utils.ChangeLog;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -152,6 +153,13 @@ public class cgeo extends AbstractActivity {
         super.onCreate(savedInstanceState);
 
         context = this;
+
+        ChangeLog cl = new ChangeLog(this);
+        // if (cl.firstRun()) {
+            // use this to only show what's new: cl.getLogDialog().show();
+            cl.getFullLogDialog().show();
+        // }
+
         app.setAction(null);
 
         app.cleanGeo();

--- a/main/src/cgeo/geocaching/utils/ChangeLog.java
+++ b/main/src/cgeo/geocaching/utils/ChangeLog.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (C) 2011, Karsten Priegnitz
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in the source code
+ * of all copies.
+ *
+ * @author: Karsten Priegnitz
+ * @see: http://code.google.com/p/android-change-log/
+ */
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.webkit.WebView;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class ChangeLog {
+
+    private final Context context;
+    private String lastVersion, thisVersion;
+
+    // this is the key for storing the version name in SharedPreferences
+    private static final String VERSION_KEY = "PREFS_VERSION_KEY";
+
+    /**
+     * Constructor
+     *
+     * Retrieves the version names and stores the new version name in
+     * SharedPreferences
+     */
+    public ChangeLog(Context context) {
+        this.context = context;
+
+        SharedPreferences sp = PreferenceManager
+        		.getDefaultSharedPreferences(context);
+
+        // get version numbers
+        this.lastVersion = sp.getString(VERSION_KEY, "");
+        Log.d(TAG, "lastVersion: " + lastVersion);
+        try {
+			this.thisVersion = context.getPackageManager().getPackageInfo(
+					context.getPackageName(), 0).versionName;
+		} catch (NameNotFoundException e) {
+			this.thisVersion = "?";
+			Log.e(TAG, "could not get version name from manifest!");
+			e.printStackTrace();
+		}
+        Log.d(TAG, "appVersion: " + this.thisVersion);
+
+        // save new version number to preferences
+        SharedPreferences.Editor editor = sp.edit();
+        editor.putString(VERSION_KEY, this.thisVersion);
+        editor.commit();
+    }
+
+    /**
+     * @return  The version name of the last installation of this app (as
+     *          described in the former manifest). This will be the same as
+     *          returned by <code>getThisVersion()</code> the second time
+     *          this version of the app is launched (more precisely: the
+     *          second time ChangeLog is instantiated).
+     * @see AndroidManifest.xml#android:versionName
+     */
+    public String getLastVersion() {
+    	return  this.lastVersion;
+    }
+
+    /**
+     * @return  The version name of this app as described in the manifest.
+     * @see AndroidManifest.xml#android:versionName
+     */
+    public String getThisVersion() {
+    	return  this.thisVersion;
+    }
+
+    /**
+     * @return  <code>true</code> if this version of your app is started the
+     *          first time
+     */
+    public boolean firstRun() {
+        return  ! this.lastVersion.equals(this.thisVersion);
+    }
+
+    /**
+     * @return  <code>true</code> if your app is started the first time ever.
+     *          Also <code>true</code> if your app was deinstalled and
+     *          installed again.
+     */
+    public boolean firstRunEver() {
+        return  "".equals(this.lastVersion);
+    }
+
+    /**
+     * @return  an AlertDialog displaying the changes since the previous
+     *          installed version of your app (what's new).
+     */
+    public AlertDialog getLogDialog() {
+        return  this.getDialog(false);
+    }
+
+    /**
+     * @return  an AlertDialog with a full change log displayed
+     */
+    public AlertDialog getFullLogDialog() {
+        return  this.getDialog(true);
+    }
+
+    private AlertDialog getDialog(boolean full) {
+
+        WebView wv = new WebView(this.context);
+        wv.setBackgroundColor(0); // transparent
+        // wv.getSettings().setDefaultTextEncodingName("utf-8");
+        wv.loadDataWithBaseURL(null, this.getLog(full), "text/html", "UTF-8",
+        		null);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this.context);
+        builder.setTitle(context.getResources().getString(
+                full
+                    ? R.string.changelog_full_title
+                    : R.string.changelog_title))
+                .setView(wv)
+                .setCancelable(false)
+                .setPositiveButton(
+                        context.getResources().getString(
+                                R.string.changelog_ok_button),
+                        new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.cancel();
+                    }
+                });
+        return  builder.create();
+    }
+
+    /**
+     * @return  HTML displaying the changes since the previous
+     *          installed version of your app (what's new)
+     */
+    public String getLog() {
+        return  this.getLog(false);
+    }
+
+    /**
+     * @return  HTML which displays full change log
+     */
+    public String getFullLog() {
+        return  this.getLog(true);
+    }
+
+    /** modes for HTML-Lists (bullet, numbered) */
+    private enum Listmode {
+        NONE,
+        ORDERED,
+        UNORDERED,
+    };
+    private Listmode listMode = Listmode.NONE;
+    private StringBuffer sb = null;
+    private static final String EOCL = "END_OF_CHANGE_LOG";
+
+    private String getLog(boolean full) {
+        // read changelog.txt file
+    	sb = new StringBuffer();
+    	try {
+            InputStream ins = context.getResources().openRawResource(
+                    R.raw.changelog);
+            BufferedReader br = new BufferedReader(new InputStreamReader(ins));
+
+            String line = null;
+            boolean advanceToEOVS = false; // true = ignore further version sections
+            while (( line = br.readLine()) != null){
+                line = line.trim();
+                if (line.startsWith("$")) {
+                    // begin of a version section
+                    this.closeList();
+                    String version = line.substring(1).trim();
+                    // stop output?
+                    if (! full) {
+                        if (this.lastVersion.equals(version))
+                            advanceToEOVS = true;
+                        else if (version.equals(EOCL))
+                            advanceToEOVS = false;
+                     }
+                } else if (! advanceToEOVS) {
+                    if (line.startsWith("%")) {
+                        // line contains version title
+                        this.closeList();
+                        sb.append("<div class='title'>"
+                                + line.substring(1).trim() + "</div>\n");
+                    } else if (line.startsWith("_")) {
+                        // line contains version title
+                        this.closeList();
+                        sb.append("<div class='subtitle'>"
+                                + line.substring(1).trim() + "</div>\n");
+                    } else if (line.startsWith("!")) {
+                        // line contains free text
+                        this.closeList();
+                        sb.append("<div class='freetext'>"
+                                + line.substring(1).trim() + "</div>\n");
+                    } else if (line.startsWith("#")) {
+                        // line contains numbered list item
+                        this.openList(Listmode.ORDERED);
+                        sb.append("<li>"
+                                + line.substring(1).trim() + "</li>\n");
+                    } else if (line.startsWith("*")) {
+                        // line contains bullet list item
+                        this.openList(Listmode.UNORDERED);
+                        sb.append("<li>"
+                                + line.substring(1).trim() + "</li>\n");
+                    } else {
+                        // no special character: just use line as is
+                        this.closeList();
+                        sb.append(line + "\n");
+                    }
+                }
+            }
+            this.closeList();
+            br.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return  sb.toString();
+    }
+
+    private void openList(Listmode listMode) {
+        if (this.listMode != listMode) {
+            closeList();
+            if (listMode == Listmode.ORDERED) {
+                sb.append("<div class='list'><ol>\n");
+            } else if (listMode == Listmode.UNORDERED) {
+                sb.append("<div class='list'><ul>\n");
+            }
+            this.listMode = listMode;
+        }
+    }
+    private void closeList() {
+        if (this.listMode == Listmode.ORDERED) {
+            sb.append("</ol></div>\n");
+        } else if (this.listMode == Listmode.UNORDERED) {
+            sb.append("</ul></div>\n");
+        }
+        this.listMode = Listmode.NONE;
+    }
+
+    private static final String TAG = "ChangeLog";
+
+    /**
+     * manually set the last version name - for testing purposes only
+     * @param lastVersion
+     */
+    void setLastVersion(String lastVersion) {
+    	this.lastVersion = lastVersion;
+    }
+}


### PR DESCRIPTION
I added my ChangeLog class from http://code.google.com/p/android-change-log
- this pull request is for others to see what impact this has on c:geo source tree
- missing: additional button in menu to open full change log
- markup used in changelog.txt:
  - % begins a line of a version section title.
  - _ begins a line of a version section subtitle.
  - ! begins a line of free text.
  - # begins a line within a numbered list.
  - \* begins a line within a bullet list.
- screenshot of full changelog: https://picasaweb.google.com/104330171804341345351/DropBox?authkey=Gv1sRgCPnQ-pCs2rGlmwE#5665277498092641586

Q: is there another way to discuss code "snippets" like these than opening a full pull request??
