### PR TITLE
Use a cancellable handler when loading, storing and refreshing caches

### DIFF
--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.activity;
 
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.os.Message;
 
 /**
  * progress dialog wrapper for easier management of resources
@@ -17,9 +18,12 @@ public class Progress {
         dialog = null;
     }
 
-    public synchronized void show(Context context, String title, String message, boolean indeterminate, boolean cancelable) {
+    public synchronized void show(final Context context, final String title, final String message, final boolean indeterminate, final Message cancelMessage) {
         if (dialog == null) {
-            dialog = ProgressDialog.show(context, title, message, indeterminate, cancelable);
+            dialog = ProgressDialog.show(context, title, message, indeterminate, cancelMessage != null);
+            if (cancelMessage != null) {
+                dialog.setCancelMessage(cancelMessage);
+            }
         }
     }
 

--- a/main/src/cgeo/geocaching/cgeopopup.java
+++ b/main/src/cgeo/geocaching/cgeopopup.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.apps.cache.navi.NavigationAppFactory;
 import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.utils.CancellableHandler;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -53,10 +54,10 @@ public class cgeopopup extends AbstractActivity {
             }
         }
     };
-    private Handler storeCacheHandler = new Handler() {
+    private CancellableHandler storeCacheHandler = new CancellableHandler() {
 
         @Override
-        public void handleMessage(Message msg) {
+        public void handleRegularMessage(Message msg) {
             try {
                 if (storeDialog != null) {
                     storeDialog.dismiss();
@@ -566,10 +567,10 @@ public class cgeopopup extends AbstractActivity {
 
     private class storeCacheThread extends Thread {
 
-        private Handler handler = null;
+        final private CancellableHandler handler;
 
-        public storeCacheThread(Handler handlerIn) {
-            handler = handlerIn;
+        public storeCacheThread(final CancellableHandler handler) {
+            this.handler = handler;
         }
 
         @Override

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -4,8 +4,7 @@ import cgeo.geocaching.cgBase;
 import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgSearch;
 import cgeo.geocaching.cgeoapplication;
-
-import android.os.Handler;
+import cgeo.geocaching.utils.CancellableHandler;
 
 public abstract class AbstractConnector implements IConnector {
 
@@ -45,7 +44,7 @@ public abstract class AbstractConnector implements IConnector {
     }
 
     @Override
-    public cgSearch searchByGeocode(cgBase base, String geocode, String guid, cgeoapplication app, cgSearch search, int reason, Handler handler) {
+    public cgSearch searchByGeocode(cgBase base, String geocode, String guid, cgeoapplication app, cgSearch search, int reason, CancellableHandler handler) {
         return null;
     }
 

--- a/main/src/cgeo/geocaching/connector/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/GCConnector.java
@@ -8,11 +8,11 @@ import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgCacheWrap;
 import cgeo.geocaching.cgSearch;
 import cgeo.geocaching.cgeoapplication;
+import cgeo.geocaching.utils.CancellableHandler;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import android.os.Handler;
 import android.util.Log;
 
 import java.util.ArrayList;
@@ -67,7 +67,7 @@ public class GCConnector extends AbstractConnector implements IConnector {
     }
 
     @Override
-    public cgSearch searchByGeocode(final cgBase base, String geocode, final String guid, final cgeoapplication app, final cgSearch search, final int reason, final Handler handler) {
+    public cgSearch searchByGeocode(final cgBase base, String geocode, final String guid, final cgeoapplication app, final cgSearch search, final int reason, final CancellableHandler handler) {
         final Parameters params = new Parameters("decrypt", "y");
         if (StringUtils.isNotBlank(geocode)) {
             params.put("wp", geocode);

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -4,8 +4,7 @@ import cgeo.geocaching.cgBase;
 import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgSearch;
 import cgeo.geocaching.cgeoapplication;
-
-import android.os.Handler;
+import cgeo.geocaching.utils.CancellableHandler;
 
 public interface IConnector {
     /**
@@ -76,5 +75,5 @@ public interface IConnector {
      */
     public boolean supportsCachesAround();
 
-    public cgSearch searchByGeocode(final cgBase base, final String geocode, final String guid, final cgeoapplication app, final cgSearch search, final int reason, final Handler handler);
+    public cgSearch searchByGeocode(final cgBase base, final String geocode, final String guid, final cgeoapplication app, final cgSearch search, final int reason, final CancellableHandler handler);
 }

--- a/main/src/cgeo/geocaching/connector/opencaching/ApiOpenCachingConnector.java
+++ b/main/src/cgeo/geocaching/connector/opencaching/ApiOpenCachingConnector.java
@@ -7,9 +7,8 @@ import cgeo.geocaching.cgCacheWrap;
 import cgeo.geocaching.cgSearch;
 import cgeo.geocaching.cgeoapplication;
 import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.utils.CancellableHandler;
 import cgeo.geocaching.utils.CryptUtils;
-
-import android.os.Handler;
 
 import java.util.List;
 
@@ -38,7 +37,7 @@ public class ApiOpenCachingConnector extends OpenCachingConnector implements ICo
     }
 
     @Override
-    public cgSearch searchByGeocode(final cgBase base, final String geocode, final String guid, final cgeoapplication app, final cgSearch search, final int reason, final Handler handler) {
+    public cgSearch searchByGeocode(final cgBase base, final String geocode, final String guid, final cgeoapplication app, final cgSearch search, final int reason, final CancellableHandler handler) {
         final cgCache cache = OkapiClient.getCache(geocode);
         if (cache == null) {
             return null;

--- a/main/src/cgeo/geocaching/utils/CancellableHandler.java
+++ b/main/src/cgeo/geocaching/utils/CancellableHandler.java
@@ -1,0 +1,112 @@
+package cgeo.geocaching.utils;
+
+import android.os.Handler;
+import android.os.Message;
+
+/**
+ * Handler with a cancel policy. Once cancelled, the handler will not handle
+ * any more cancel or regular message.
+ */
+public abstract class CancellableHandler extends Handler {
+
+    private boolean cancelled = false;
+
+    private static class CancelHolder {
+        final Object payload;
+
+        CancelHolder(final Object payload) {
+            this.payload = payload;
+        }
+    }
+
+    @Override
+    final public void handleMessage(final Message message) {
+        if (cancelled) {
+            return;
+        }
+
+        if (message.obj instanceof CancelHolder) {
+            cancelled = true;
+            handleCancel(((CancelHolder) message.obj).payload);
+        } else {
+            handleRegularMessage(message);
+        }
+    }
+
+    /**
+     * Handle a non-cancel message.<br>
+     * Subclasses must implement this to handle messages.
+     *
+     * @param message
+     *            the message to handle
+     */
+    abstract protected void handleRegularMessage(final Message message);
+
+    /**
+     * Handle a cancel message.
+     *
+     * @param extra
+     *            the additional payload given by the canceller
+     */
+    protected void handleCancel(final Object extra) {
+    }
+
+    /**
+     * Get a cancel message that can later be sent to this handler to cancel it.
+     *
+     * @return a cancel message
+     */
+    public Message cancelMessage() {
+        return cancelMessage(null);
+    }
+
+    /**
+     * Get a cancel message with an additional parameter that can later be sent to
+     * this handler to cancel it.
+     *
+     * @param extra
+     *            the extra parameter to give to the cancel handler
+     * @return a cancel message
+     */
+    public Message cancelMessage(final Object extra) {
+        return this.obtainMessage(0, new CancelHolder(extra));
+    }
+
+    /**
+     * Cancel the current handler. This can be called from any thread.
+     */
+    public void cancel() {
+        cancel(null);
+    }
+
+    /**
+     * Cancel the current handler. This can be called from any thread.
+     *
+     * @param extra
+     *            the extra parameter to give to the cancel handler
+     */
+    public void cancel(final Object extra) {
+        cancelMessage(extra).sendToTarget();
+    }
+
+    /**
+     * Check if the current handler has been cancelled.
+     *
+     * @return true if the handler has been cancelled
+     */
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Check if a handler has been cancelled.
+     *
+     * @param handler
+     *            a handler, or null
+     * @return true if the handler is not null and has been cancelled
+     */
+    public static boolean isCancelled(final CancellableHandler handler) {
+        return handler != null && handler.isCancelled();
+    }
+
+}

--- a/tests/src/cgeo/geocaching/activity/ProgressTest.java
+++ b/tests/src/cgeo/geocaching/activity/ProgressTest.java
@@ -14,7 +14,7 @@ public class ProgressTest extends ActivityInstrumentationTestCase2<cgeo> {
 
         assertFalse(progress.isShowing()); // nothing shown initially
 
-        progress.show(getActivity(), "Title", "Message", true, false);
+        progress.show(getActivity(), "Title", "Message", true, null);
         assertTrue(progress.isShowing());
 
         progress.setMessage("Test");


### PR DESCRIPTION
This is a fix for #685. I've used it with success yesterday, but if someone else could test it/review it before I merge, it would be better.
