### PR TITLE
new: cancel GPX import with back button

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -564,8 +564,8 @@
   <string name="gpx_import_error_parser">Dateiformat nicht ok</string>
   <string name="gpx_import_error_unexpected">Unerwarteter Fehler</string>
   <string name="gpx_import_confirm">Soll die GPX-Datei importiert werden?</string>
-  <string name="gpx_import_loading">Lade Caches von GPS-Datei</string>
-      
+  <string name="gpx_import_canceled">Der GPX-Import wurde abgebrochen</string>      
+
   <!-- map file select -->
   <string name="map_file_select_title">Wähle eine Kartendatei</string>
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -35,7 +35,7 @@
   <string name="ape">Project ape cache</string>
   <string name="gchq">Groundspeak hq</string>
   <string name="gps">GPS cache exhibit</string>
-  <string name="unknown">Unknown cache</string>
+  <string name="unknown">Unknown type</string>
 
   <!-- cache sizes -->
   <string name="cache_size_micro">micro</string>
@@ -579,6 +579,7 @@
   <string name="gpx_import_error_parser">File format not ok</string>
   <string name="gpx_import_error_unexpected">Unexpected error</string>
   <string name="gpx_import_confirm">Do you want to import the GPX file into c:geo?</string>
+  <string name="gpx_import_canceled">GPX import was canceled</string>      
 
   <!-- map file select -->
   <string name="map_file_select_title">Select map file</string>

--- a/main/src/cgeo/geocaching/GPXImportActivity.java
+++ b/main/src/cgeo/geocaching/GPXImportActivity.java
@@ -23,7 +23,7 @@ public class GPXImportActivity extends AbstractActivity {
                 .setCancelable(false)
                 .setPositiveButton(getString(android.R.string.yes), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        (new GPXImporter(cgList.STANDARD_LIST_ID)).importGPX(GPXImportActivity.this, getIntent().getData(), getContentResolver());
+                        (new GPXImporter(GPXImportActivity.this, cgList.STANDARD_LIST_ID)).importGPX(getIntent().getData(), getContentResolver());
                     }
                 })
                 .setNegativeButton(getString(android.R.string.no), new DialogInterface.OnClickListener() {

--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -27,6 +27,22 @@ public class Progress {
         }
     }
 
+    public synchronized void show(final Context context, final String title, final String message, final int style, final Message cancelMessage) {
+        if (dialog == null) {
+            dialog = new ProgressDialog(context);
+            dialog.setTitle(title);
+            dialog.setMessage(message);
+            dialog.setProgressStyle(style);
+            if (cancelMessage != null) {
+                dialog.setCancelable(true);
+                dialog.setCancelMessage(cancelMessage);
+            } else {
+                dialog.setCancelable(false);
+            }
+            dialog.show();
+        }
+    }
+
     public synchronized void setMessage(final String message) {
         if (dialog != null && dialog.isShowing()) {
             dialog.setMessage(message);
@@ -37,4 +53,16 @@ public class Progress {
         return dialog != null && dialog.isShowing();
     }
 
+    public synchronized void setMaxProgressAndReset(final int max) {
+        if (dialog != null && dialog.isShowing()) {
+            dialog.setMax(max);
+            dialog.setProgress(0);
+        }
+    }
+
+    public synchronized void setProgress(final int progress) {
+        if (dialog != null && dialog.isShowing()) {
+            dialog.setProgress(progress);
+        }
+    }
 }

--- a/main/src/cgeo/geocaching/cgGPXListAdapter.java
+++ b/main/src/cgeo/geocaching/cgGPXListAdapter.java
@@ -70,7 +70,7 @@ public class cgGPXListAdapter extends ArrayAdapter<File> {
         // tap on item
         @Override
         public void onClick(View view) {
-            (new GPXImporter(parent.getListId())).importGPX(parent, file);
+            (new GPXImporter(parent, parent.getListId())).importGPX(file);
         }
     }
 }

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -13,12 +13,12 @@ import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.geopoint.Geopoint;
+import cgeo.geocaching.utils.CancellableHandler;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import android.os.Handler;
 import android.sax.Element;
 import android.sax.EndElementListener;
 import android.sax.EndTextElementListener;
@@ -235,7 +235,7 @@ public abstract class GPXParser extends FileParser {
         return formatSimple.parse(input);
     }
 
-    public Collection<cgCache> parse(final InputStream stream, final Handler progressHandler) throws IOException, ParserException {
+    public Collection<cgCache> parse(final InputStream stream, final CancellableHandler progressHandler) throws IOException, ParserException {
         final RootElement root = new RootElement(namespace, "gpx");
         final Element waypoint = root.getChild(namespace, "wpt");
 

--- a/main/src/cgeo/geocaching/files/LocParser.java
+++ b/main/src/cgeo/geocaching/files/LocParser.java
@@ -7,10 +7,10 @@ import cgeo.geocaching.cgCoord;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.geopoint.GeopointParser;
+import cgeo.geocaching.utils.CancellableHandler;
 
 import org.apache.commons.lang3.StringUtils;
 
-import android.os.Handler;
 import android.util.Log;
 
 import java.io.IOException;
@@ -145,7 +145,7 @@ public final class LocParser extends FileParser {
     }
 
     @Override
-    public Collection<cgCache> parse(InputStream stream, Handler progressHandler) throws IOException, ParserException {
+    public Collection<cgCache> parse(InputStream stream, CancellableHandler progressHandler) throws IOException, ParserException {
         // TODO: progress reporting happens during reading stream only, not during parsing
         String streamContent = readStream(stream, progressHandler).toString();
         final Map<String, cgCoord> coords = parseCoordinates(streamContent);

--- a/main/src/cgeo/geocaching/utils/CancellableHandler.java
+++ b/main/src/cgeo/geocaching/utils/CancellableHandler.java
@@ -9,7 +9,7 @@ import android.os.Message;
  */
 public abstract class CancellableHandler extends Handler {
 
-    private boolean cancelled = false;
+    private volatile boolean cancelled = false;
 
     private static class CancelHolder {
         final Object payload;

--- a/tests/src/cgeo/geocaching/files/GPXImporterTest.java
+++ b/tests/src/cgeo/geocaching/files/GPXImporterTest.java
@@ -4,8 +4,8 @@ import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgSearch;
 import cgeo.geocaching.cgeoapplication;
 import cgeo.geocaching.test.R;
+import cgeo.geocaching.utils.CancellableHandler;
 
-import android.os.Handler;
 import android.os.Message;
 import android.test.InstrumentationTestCase;
 
@@ -118,6 +118,20 @@ public class GPXImporterTest extends InstrumentationTestCase {
         assertEquals(GPXImporter.IMPORT_STEP_FINISHED_WITH_ERROR, importStepHandler.messages.get(1).what);
     }
 
+    public void testImportGpxCancel() throws IOException {
+        File gc31j2h = new File(tempDir, "gc31j2h.gpx");
+        copyResourceToFile(R.raw.gc31j2h, gc31j2h);
+
+        progressHandler.cancel();
+        GPXImporter.ImportGpxFileThread importThread = new GPXImporter.ImportGpxFileThread(gc31j2h, listId, importStepHandler, progressHandler);
+        importThread.run();
+        importStepHandler.waitForCompletion();
+
+        assertEquals(2, importStepHandler.messages.size());
+        assertEquals(GPXImporter.IMPORT_STEP_READ_FILE, importStepHandler.messages.get(0).what);
+        assertEquals(GPXImporter.IMPORT_STEP_CANCELED, importStepHandler.messages.get(1).what);
+    }
+
     private void copyResourceToFile(int resourceId, File file) throws IOException {
         final InputStream is = getInstrumentation().getContext().getResources().openRawResource(resourceId);
         final FileOutputStream os = new FileOutputStream(file);
@@ -134,12 +148,12 @@ public class GPXImporterTest extends InstrumentationTestCase {
         }
     }
 
-    static class TestHandler extends Handler {
+    static class TestHandler extends CancellableHandler {
         private final List<Message> messages = new ArrayList<Message>();
         private long lastMessage = System.currentTimeMillis();
 
         @Override
-        public synchronized void handleMessage(Message msg) {
+        public synchronized void handleRegularMessage(Message msg) {
             final Message msg1 = new Message();
             msg1.copyFrom(msg);
             messages.add(msg1);

--- a/tests/src/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src/cgeo/geocaching/files/GPXParserTest.java
@@ -11,7 +11,6 @@ import cgeo.geocaching.geopoint.GeopointFormatter;
 import cgeo.geocaching.test.R;
 
 import android.content.res.Resources;
-import android.os.Handler;
 import android.test.InstrumentationTestCase;
 
 import java.io.IOException;
@@ -190,7 +189,7 @@ public class GPXParserTest extends InstrumentationTestCase {
             final Resources res = getInstrumentation().getContext().getResources();
             final InputStream instream = res.openRawResource(resourceId);
             try {
-                caches = parser.parse(instream, new Handler());
+                caches = parser.parse(instream, null);
                 assertNotNull(caches);
             } finally {
                 instream.close();

--- a/tests/src/cgeo/geocaching/files/LocParserTest.java
+++ b/tests/src/cgeo/geocaching/files/LocParserTest.java
@@ -6,7 +6,6 @@ import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.test.R;
 
 import android.content.res.Resources;
-import android.os.Handler;
 import android.test.InstrumentationTestCase;
 
 import java.io.IOException;
@@ -22,7 +21,7 @@ public class LocParserTest extends InstrumentationTestCase {
         final Resources res = getInstrumentation().getContext().getResources();
         final InputStream instream = res.openRawResource(resourceId);
         try {
-            caches = parser.parse(instream, new Handler());
+            caches = parser.parse(instream, null);
             assertNotNull(caches);
             assertTrue(caches.size() > 0);
         } finally {


### PR DESCRIPTION
- use CancellableHandler for progress reporting so that import can be canceled
- some cleanups: deprecation warnings in test and string resources for gpx import
