### PR TITLE
support import of PQs that include PQ name in download zip file name

### DIFF
--- a/main/src/cgeo/geocaching/cgeogpxes.java
+++ b/main/src/cgeo/geocaching/cgeogpxes.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class cgeogpxes extends FileList<cgGPXListAdapter> {
     private static final String EXTRAS_LIST_ID = "list";
 
-    private static final Pattern gpxZipFilePattern = Pattern.compile("\\d+\\.zip", Pattern.CASE_INSENSITIVE);
+    private static final Pattern gpxZipFilePattern = Pattern.compile("\\d{7,}(_.+)?\\.zip", Pattern.CASE_INSENSITIVE);
 
     public cgeogpxes() {
         super(new String[] { "gpx", "loc", "zip" });

--- a/tests/src/cgeo/geocaching/cgeogpxesTest.java
+++ b/tests/src/cgeo/geocaching/cgeogpxesTest.java
@@ -17,6 +17,11 @@ public class cgeogpxesTest extends ActivityInstrumentationTestCase2<cgeogpxes> {
         assertTrue(importGpxActivity.filenameBelongsToList("1234567.LOC"));
         assertTrue(importGpxActivity.filenameBelongsToList("1234567.zip"));
         assertTrue(importGpxActivity.filenameBelongsToList("1234567.ZIP"));
+        assertTrue(importGpxActivity.filenameBelongsToList("12345678.zip"));
+        assertTrue(importGpxActivity.filenameBelongsToList("1234567_query.zip"));
+        assertTrue(importGpxActivity.filenameBelongsToList("12345678_query.zip"));
+        assertTrue(importGpxActivity.filenameBelongsToList("12345678_my_query_1.zip"));
+        assertTrue(importGpxActivity.filenameBelongsToList("12345678_my query.zip"));
 
         assertFalse(importGpxActivity.filenameBelongsToList("1234567.gpy"));
         assertFalse(importGpxActivity.filenameBelongsToList("1234567.agpx"));
@@ -26,6 +31,9 @@ public class cgeogpxesTest extends ActivityInstrumentationTestCase2<cgeogpxes> {
         assertFalse(importGpxActivity.filenameBelongsToList("test.zip"));
         assertFalse(importGpxActivity.filenameBelongsToList("zip"));
         assertFalse(importGpxActivity.filenameBelongsToList(".zip"));
+        assertFalse(importGpxActivity.filenameBelongsToList("123456.zip"));
+        assertFalse(importGpxActivity.filenameBelongsToList("1234567query.zip"));
+        assertFalse(importGpxActivity.filenameBelongsToList("1234567_.zip"));
 
         assertFalse(importGpxActivity.filenameBelongsToList("1234567-wpts.gpx"));
     }

--- a/tests/src/cgeo/geocaching/files/GPXImporterTest.java
+++ b/tests/src/cgeo/geocaching/files/GPXImporterTest.java
@@ -30,6 +30,7 @@ public class GPXImporterTest extends AbstractResourceInstrumentationTestCase {
         assertEquals("1234567-wpts.gpx", GPXImporter.getWaypointsFileNameForGpxFileName("1234567.GPX"));
         assertEquals("gpx.gpx-wpts.gpx", GPXImporter.getWaypointsFileNameForGpxFileName("gpx.gpx.gpx"));
         assertEquals("/mnt/sdcard/-wpts.gpx", GPXImporter.getWaypointsFileNameForGpxFileName("/mnt/sdcard/.gpx"));
+        assertEquals("1234567_query-wpts.gpx", GPXImporter.getWaypointsFileNameForGpxFileName("1234567_query.gpx"));
         assertNull(GPXImporter.getWaypointsFileNameForGpxFileName("123.gpy"));
         assertNull(GPXImporter.getWaypointsFileNameForGpxFileName("gpx"));
         assertNull(GPXImporter.getWaypointsFileNameForGpxFileName(".gpx"));
@@ -44,6 +45,7 @@ public class GPXImporterTest extends AbstractResourceInstrumentationTestCase {
         assertEquals("1234567.gpx", GPXImporter.getGpxFileNameForZipFileName("1234567.ZIP"));
         assertEquals("zip.zip.gpx", GPXImporter.getGpxFileNameForZipFileName("zip.zip.zip"));
         assertEquals("/mnt/sdcard/.gpx", GPXImporter.getGpxFileNameForZipFileName("/mnt/sdcard/.zip"));
+        assertEquals("1234567_query.gpx", GPXImporter.getGpxFileNameForZipFileName("1234567_query.zip"));
         assertNull(GPXImporter.getGpxFileNameForZipFileName("123.zap"));
         assertNull(GPXImporter.getGpxFileNameForZipFileName("zip"));
         assertNull(GPXImporter.getGpxFileNameForZipFileName(".zip"));


### PR DESCRIPTION
zip name format: 1234567_query.zip
contains:
- 1234567_query.gpx
- 1234567_query-wpts.gpx

PQ number has at least 7 digits.
