### PR TITLE
Adding a link to gc-mail function for myself in contributors

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -919,7 +919,7 @@
     · <a href="http://www.jaytech.cz/">Jan Žatecký</a> (graphic)\n
     · <a href="http://joachim-wilke.de/">JoWi24</a> (code)\n
     · <a href="http://github.com/koem">Karsten Priegnitz</a> (code, artwork computation)\n
-    · Lineflyer (tester)\n
+    · <a href="http://www.geocaching.com/email/?guid=d11a3e3d-7db0-4d43-87f2-7893238844a6">Lineflyer</a> (tester)\n
     · Ludovic Valente (localization FR)\n
     · MichielK (code, loc. NL)\n
     · mucek4 (code, open source project leader)\n


### PR DESCRIPTION
I hope this is OK for you. 
Up to now its without link.
