### PR TITLE
Fix text by requiring the current year to be present in output

### DIFF
--- a/tests/src/cgeo/geocaching/LogTemplateProviderTest.java
+++ b/tests/src/cgeo/geocaching/LogTemplateProviderTest.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching;
 
+import java.util.Calendar;
+
 import junit.framework.TestCase;
 
 public class LogTemplateProviderTest extends TestCase {
@@ -7,7 +9,10 @@ public class LogTemplateProviderTest extends TestCase {
     public static void testApplyTemplates() {
         final String noTemplates = " no templates ";
         assertEquals(noTemplates, LogTemplateProvider.applyTemplates(noTemplates, true));
-        assertTrue(LogTemplateProvider.applyTemplates("[DATE]", true).contains("."));
+
+        // This test can occasionally fail if the current year changes right after the next line.
+        final String currentYear = Integer.toString(Calendar.YEAR);
+        assertTrue(LogTemplateProvider.applyTemplates("[DATE]", true).contains(currentYear));
     }
 
 }


### PR DESCRIPTION
I am not sure why a dot was expected in the expansion of [DATE]. With a French locale, the date is expanded into "2 décembre 2011".

The test checks the presence of the year in the output, but I wonder whether the date could be expanded as "2/12/11" (with a short year) or not.

Merge if you feel it is probably ok :)
