### PR TITLE
Friend logs

### DIFF
--- a/main/res/layout/init.xml
+++ b/main/res/layout/init.xml
@@ -279,6 +279,28 @@
 							android:textColor="?text_color"
 							android:text="@string/init_elevationwanted" />
 					</LinearLayout>
+					<LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" >
+                    <CheckBox
+                        android:id="@+id/friendlogswanted"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentLeft="true"
+                        android:layout_gravity="left"
+                        android:gravity="center"
+                        android:padding="1px" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:gravity="left"
+                        android:paddingRight="3dip"
+                        android:text="@string/init_friendlogswanted"
+                        android:textColor="?text_color"
+                        android:textSize="14dip" />
+                	</LinearLayout>
                     <LinearLayout
                         android:layout_width="fill_parent"
                         android:layout_height="wrap_content"

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -367,6 +367,7 @@
   <string name="init_details">Cache Details</string>
   <string name="init_ratingwanted">Lade Cache-Bewertung von GCvote.com</string>
   <string name="init_elevationwanted">Lade Höhe des Caches</string>
+  <string name="init_friendlogswanted">Lade Logbuch (Freunde)</string>
   <string name="init_openlastdetailspage">Öffne Details mit zuletzt genutzter Seite</string>
   <string name="init_autoload">Ausführliche Beschreibung automatisch laden</string>
   <string name="init_other">Weitere Optionen</string>
@@ -474,6 +475,7 @@
   <string name="cache_waypoints_add">Wegpunkt hinzufügen</string>
   <string name="cache_hint">Hinweis</string>
   <string name="cache_logs">Logbuch</string>
+  <string name="cache_logsfriends">Logbuch (Freunde)</string>
   <string name="cache_dialog_loading_details">Lade Cache-Details…</string>
   <string name="cache_dialog_loading_details_status_loadpage">Lade Seite</string>
   <string name="cache_dialog_loading_details_status_details">Verarbeite Details</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -367,6 +367,7 @@
   <string name="init_details">Cache details</string>
   <string name="init_ratingwanted">Load cache rating from GCvote.com</string>
   <string name="init_elevationwanted">Load cache elevation data</string>
+  <string name="init_friendlogswanted">Load logbook (friends)</string>
   <string name="init_openlastdetailspage">Open details with last used page</string>
   <string name="init_autoload">Auto-loading long description</string>
   <string name="init_other">Other options</string>
@@ -487,6 +488,7 @@
   <string name="cache_waypoints_add">Add waypoint</string>
   <string name="cache_hint">Hint</string>
   <string name="cache_logs">Logbook</string>
+  <string name="cache_logsfriends">Logbook (Friends)</string>
   <string name="cache_dialog_loading_details">Loading cache details…</string>
   <string name="cache_dialog_loading_details_status_loadpage">Loading page</string>
   <string name="cache_dialog_loading_details_status_details">Processing details</string>
@@ -947,6 +949,7 @@
   <!-- changelog -->
   <string name="changelog">\n
     <b>next release</b>\n
+    · new: additional page in the details view for logs from friends\n
     · new: horizontal scrollable pages for cache details\n
     · new: click on cache coordinates to change format\n
     · new: show own rating in cache details\n

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -617,8 +617,11 @@ public class CacheDetailActivity extends AbstractActivity {
         pageOrder.add(Page.WAYPOINTS);
         pageOrder.add(Page.DETAILS);
         pageOrder.add(Page.DESCRIPTION);
-        if (CollectionUtils.isNotEmpty(cache.getLogs())) {
+        if (CollectionUtils.isNotEmpty(cache.getLogs(true))) {
             pageOrder.add(Page.LOGS);
+        }
+        if (CollectionUtils.isNotEmpty(cache.getLogs(false))) {
+            pageOrder.add(Page.LOGSFRIENDS);
         }
         if (CollectionUtils.isNotEmpty(cache.getInventory())) {
             pageOrder.add(Page.INVENTORY);
@@ -983,7 +986,11 @@ public class CacheDetailActivity extends AbstractActivity {
                         break;
 
                     case LOGS:
-                        creator = new LogsViewCreator();
+                        creator = new LogsViewCreator(true);
+                        break;
+
+                    case LOGSFRIENDS:
+                        creator = new LogsViewCreator(false);
                         break;
 
                     case WAYPOINTS:
@@ -1051,6 +1058,7 @@ public class CacheDetailActivity extends AbstractActivity {
         DETAILS(R.string.detail),
         DESCRIPTION(R.string.cache_description),
         LOGS(R.string.cache_logs),
+        LOGSFRIENDS(R.string.cache_logsfriends),
         WAYPOINTS(R.string.cache_waypoints),
         INVENTORY(R.string.cache_inventory);
 
@@ -1997,6 +2005,12 @@ public class CacheDetailActivity extends AbstractActivity {
 
     private class LogsViewCreator implements PageViewCreator {
         ScrollView view;
+        boolean allLogs;
+
+        LogsViewCreator(boolean allLogs) {
+            super();
+            this.allLogs = allLogs;
+        }
 
         @Override
         public void notifyDataSetChanged() {
@@ -2072,8 +2086,8 @@ public class CacheDetailActivity extends AbstractActivity {
                 // cache logs
                 RelativeLayout rowView;
 
-                if (cache != null && cache.getLogs() != null) {
-                    for (cgLog log : cache.getLogs()) {
+                if (cache != null && cache.getLogs(allLogs) != null) {
+                    for (cgLog log : cache.getLogs(allLogs)) {
                         rowView = (RelativeLayout) getLayoutInflater().inflate(R.layout.cacheview_logs_item, null);
 
                         if (log.date > 0) {

--- a/main/src/cgeo/geocaching/Settings.java
+++ b/main/src/cgeo/geocaching/Settings.java
@@ -49,6 +49,7 @@ public final class Settings {
     private static final String KEY_LOAD_DESCRIPTION = "autoloaddesc";
     private static final String KEY_RATING_WANTED = "ratingwanted";
     private static final String KEY_ELEVATION_WANTED = "elevationwanted";
+    private static final String KEY_FRIENDLOGS_WANTED = "friendlogswanted";
     private static final String KEY_USE_ENGLISH = "useenglish";
     private static final String KEY_AS_BROWSER = "asbrowser";
     private static final String KEY_USE_COMPASS = "usecompass";
@@ -574,6 +575,20 @@ public final class Settings {
             @Override
             public void edit(Editor edit) {
                 edit.putBoolean(KEY_ELEVATION_WANTED, elevationWanted);
+            }
+        });
+    }
+
+    public static boolean isFriendLogsWanted() {
+        return sharedPrefs.getBoolean(KEY_FRIENDLOGS_WANTED, true);
+    }
+
+    public static void setFriendLogsWanted(final boolean friendLogsWanted) {
+        editSharedSettings(new PrefRunnable() {
+
+            @Override
+            public void edit(Editor edit) {
+                edit.putBoolean(KEY_FRIENDLOGS_WANTED, friendLogsWanted);
             }
         });
     }

--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -779,9 +779,31 @@ public class cgCache implements ICache {
     }
 
     public List<cgLog> getLogs() {
-        return logs;
+        return getLogs(true);
     }
 
+    /**
+     * @param allLogs
+     *            true for all logs, false for friend logs only
+     * @return the logs with all entries or just the entries of the friends
+     */
+    public List<cgLog> getLogs(boolean allLogs) {
+        if (allLogs) {
+            return logs;
+        }
+        ArrayList<cgLog> friendLogs = new ArrayList<cgLog>();
+        for (cgLog log : logs) {
+            if (log.friend) {
+                friendLogs.add(log);
+            }
+        }
+        return friendLogs;
+    }
+
+    /**
+     * @param logs
+     *            the log entries
+     */
     public void setLogs(List<cgLog> logs) {
         this.logs = logs;
     }

--- a/main/src/cgeo/geocaching/cgLog.java
+++ b/main/src/cgeo/geocaching/cgLog.java
@@ -9,7 +9,32 @@ public class cgLog {
     public String log = "";
     public long date = 0;
     public int found = -1;
+    /** Friend's logentry */
+    public boolean friend = false;
     public List<cgImage> logImages = null;
     public String cacheName = ""; // used for trackables
     public String cacheGuid = ""; // used for trackables
+
+    @Override
+    public int hashCode() {
+        return (int) date * type * author.hashCode() * log.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final cgLog otherLog = (cgLog) obj;
+        return date == otherLog.date &&
+                type == otherLog.type &&
+                author.compareTo(otherLog.author) == 0 &&
+                log.compareTo(otherLog.log) == 0 ? true : false;
+    }
 }

--- a/main/src/cgeo/geocaching/cgeoadvsearch.java
+++ b/main/src/cgeo/geocaching/cgeoadvsearch.java
@@ -24,7 +24,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class cgeoadvsearch extends AbstractActivity {

--- a/main/src/cgeo/geocaching/cgeoinit.java
+++ b/main/src/cgeo/geocaching/cgeoinit.java
@@ -345,6 +345,16 @@ public class cgeoinit extends AbstractActivity {
             }
         });
 
+        final CheckBox friendLogsWantedButton = (CheckBox) findViewById(R.id.friendlogswanted);
+        friendLogsWantedButton.setChecked(Settings.isFriendLogsWanted());
+        friendLogsWantedButton.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                Settings.setFriendLogsWanted(friendLogsWantedButton.isChecked());
+            }
+        });
+
         final CheckBox openLastDetailsPageButton = (CheckBox) findViewById(R.id.openlastdetailspage);
         openLastDetailsPageButton.setChecked(Settings.isOpenLastDetailsPage());
         openLastDetailsPageButton.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Everybody of us knows the following situation: 
you are on a cache tour and get a problem with a specific cache. If it's not a simple 1/1 tradi telephone support is appreciate - who of your friends have already done this cache ? 
For a better cache experience i enhanced the details view with a new page "Logbook (Friends)" to help the user to find his (or her) friends which already found the cache using a feature from GC.com that is available since two (?) updates. GC.com offers three tabs for the logbook: all logs, personal logs and friend logs. The information from the last tab is displayed on the new tab.

This feature requires a DB update. If there are no concerns i will merge the PR at the weekend.
