### PR TITLE
Improvement of english texts

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -472,7 +472,7 @@
   <string name="cache_attributes">Attributes</string>
   <string name="cache_attributes_no_icons">(refresh cache to show attribute icons)</string>
   <string name="cache_inventory">Inventory</string>
-  <string name="cache_log_offline">Offline oLg</string>
+  <string name="cache_log_offline">Offline Log</string>
   <string name="cache_log_images_loading">Loading Log images …</string>
   <string name="cache_log_images_title">Log images</string>
   <string name="cache_log_image_default_title">Photo</string>


### PR DESCRIPTION
Advised by a native speaker I did some corrections and improvements to the strings-file.

The changes are:
- Inserting missing determiners in longer sentences ( #215 )
- Minor typo-corrections
- Checked capitalisation (in case prompt is used as headline or for some special "Proper Nouns")
- Aligned prompts with gc.com website (assuming that they now what is correct)
- Changed some help-texts and settings-switches as they were hard to understand or had a different meaning before.

Comments are welcome as I might also have made some mistakes in it.
