### PR TITLE
Fixes #933: Don't need to restart c-geo when GPS changes from disabled to enabled

### DIFF
--- a/main/src/cgeo/geocaching/cgGeo.java
+++ b/main/src/cgeo/geocaching/cgGeo.java
@@ -81,9 +81,7 @@ public class cgGeo {
 
         @Override
         public void onProviderDisabled(String provider) {
-            if (provider.equals(locationProvider)) {
-                geoManager.removeUpdates(this);
-            }
+            // nothing
         }
 
         @Override


### PR DESCRIPTION
Calling `removeUpdates` when a provider is disabled prevents us from getting any further updates for that provider (including when it becomes enabled again).
It is ok to continue waiting for updates for a provider that is disabled. c-geo already does this if GPS is disabled when the app is launched.

Cleanup (calling `removeUpdates`) is still taken care of in `closeGeo()`
