### PR TITLE
Fix #946: Comparator must allow for objects to be equal

### DIFF
--- a/main/src/cgeo/geocaching/sorting/DistanceComparator.java
+++ b/main/src/cgeo/geocaching/sorting/DistanceComparator.java
@@ -30,6 +30,9 @@ public class DistanceComparator extends AbstractCacheComparator {
 
     @Override
     protected int compareCaches(final cgCache cache1, final cgCache cache2) {
+        if (cache1.getCoords() == null && cache2.getCoords() == null) {
+            return 0;
+        }
         if (cache1.getCoords() == null) {
             return 1;
         }


### PR DESCRIPTION
See #946: If cache1 and cache2 are archived then coords will be null. This means that distance between them is "equal". Current code doesn't allow for equal which is why it violates the contract. The sorting algorithm gets confused because it is getting arbitrary answers.
