### PR TITLE
Fix #966 - Load display string for error

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -244,7 +244,7 @@
   <string name="caches_nearby_button">Nearby</string>
   <string name="advanced_search_button">Search</string>
   <string name="stored_caches_button">Stored</string>
-  <string name="any_button">Navigate to...</string>
+  <string name="any_button">Any destination</string>
   <string name="unknown_scan">Didn\'t find any geocode in the scan result.</string>
 
   <!-- caches -->


### PR DESCRIPTION
Add call to getErrorString so we show the actual display text for the error.
Fixes #966
