### PR TITLE
Fix #963 - Add extra friend logs to the end of the list instead of the front

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -554,7 +554,7 @@ public class CacheDetailActivity extends AbstractActivity {
                 }
 
                 if (SearchResult.getError(search) != null) {
-                    showToast(res.getString(R.string.err_dwld_details_failed_reason) + " " + SearchResult.getError(search).getErrorString(res) + ".");
+                    showToast(res.getString(R.string.err_dwld_details_failed_reason) + " " + SearchResult.getError(search) + ".");
 
                     finish();
                     return;


### PR DESCRIPTION
Friend logs that were not already in the list of logs were being added to the front with use of position variable. Removing it adds the friend logs to the end.

If friend logs were found, but not already in the list, it is because they are older, so it is correct to add them to the end of the list.

Fixes #963
