### PR TITLE
Fix #965: Basic table formatting and note to user

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -485,6 +485,7 @@
   <string name="cache_personal_note">Personal note</string>
   <string name="cache_description">Description</string>
   <string name="cache_description_long">Long Description</string>
+  <string name="cache_description_table_note">Description contains table formatting which may need to be viewed at geocaching.com to be seen correctly.</string>
   <string name="cache_watchlist">Watchlist</string>
   <string name="cache_watchlist_on">This cache is on your watchlist.</string>
   <string name="cache_watchlist_not_on">This cache is not on your watchlist.</string>

--- a/main/src/cgeo/geocaching/utils/UnknownTagsHandler.java
+++ b/main/src/cgeo/geocaching/utils/UnknownTagsHandler.java
@@ -11,11 +11,18 @@ public class UnknownTagsHandler implements TagHandler {
 
     private static final int UNDEFINED_POSITION = -1;
     int strikePos = UNDEFINED_POSITION;
+    private boolean tableDetected = false;
 
     public void handleTag(boolean opening, String tag, Editable output,
             XMLReader xmlReader) {
         if (tag.equalsIgnoreCase("strike") || tag.equals("s")) {
             handleStrike(opening, output);
+        } else if (tag.equalsIgnoreCase("table")) {
+            handleTable();
+        } else if (tag.equalsIgnoreCase("td")) {
+            handleTd(opening, output);
+        } else if (tag.equalsIgnoreCase("tr")) {
+            handleTr(opening, output);
         }
     }
 
@@ -30,4 +37,27 @@ public class UnknownTagsHandler implements TagHandler {
             }
         }
     }
+
+    public boolean isTableDetected() {
+        return tableDetected;
+    }
+
+    private void handleTable() {
+        tableDetected = true;
+    }
+
+    private static void handleTd(boolean opening, Editable output) {
+        // insert space for each table column
+        if (opening) {
+            output.insert(output.length(), " ");
+        }
+    }
+
+    private static void handleTr(boolean opening, Editable output) {
+        // insert new line for each table row
+        if (opening) {
+            output.insert(output.length(), "\n");
+        }
+    }
+
 }


### PR DESCRIPTION
Add a note to the description if it contains HTML tables since we don't format them correctly.
Add rudimentary formatting for <td> and <tr> HTML tags.

Fixes #965.
