### PR TITLE
Fix #982: Maintain lists sorted after viewing a cache

### DIFF
--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -2634,9 +2634,6 @@ public class cgeocaches extends AbstractListActivity {
             else if (type == CacheListType.HISTORY) {
                 adapter.setComparator(new VisitComparator());
             }
-            else {
-                adapter.setComparator(null);
-            }
         }
     }
 


### PR DESCRIPTION
Don't set comparator to null as this reverts all lists back to distance sort

Fixes #982
