### PR TITLE
EventDateComparator class to fix sorting error from #982

### DIFF
--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -20,6 +20,7 @@ import cgeo.geocaching.maps.CGeoMap;
 import cgeo.geocaching.sorting.CacheComparator;
 import cgeo.geocaching.sorting.DateComparator;
 import cgeo.geocaching.sorting.DifficultyComparator;
+import cgeo.geocaching.sorting.EventDateComparator;
 import cgeo.geocaching.sorting.FindsComparator;
 import cgeo.geocaching.sorting.GeocodeComparator;
 import cgeo.geocaching.sorting.InventoryComparator;
@@ -2630,12 +2631,12 @@ public class cgeocaches extends AbstractListActivity {
                 }
             }
             if (eventsOnly) {
-                adapter.setComparator(new DateComparator());
+                adapter.setComparator(new EventDateComparator());
             }
             else if (type == CacheListType.HISTORY) {
                 adapter.setComparator(new VisitComparator());
             }
-            else if (adapter.getCacheComparator() != null && adapter.getCacheComparator() instanceof DateComparator) {
+            else if (adapter.getCacheComparator() != null && adapter.getCacheComparator() instanceof EventDateComparator) {
                 adapter.setComparator(null);
             }
         }

--- a/main/src/cgeo/geocaching/sorting/EventDateComparator.java
+++ b/main/src/cgeo/geocaching/sorting/EventDateComparator.java
@@ -1,0 +1,23 @@
+package cgeo.geocaching.sorting;
+
+import cgeo.geocaching.cgCache;
+
+
+/**
+ * Compares caches by date. Used only for event caches.
+ *
+ * @author campbeb
+ *
+ */
+public class EventDateComparator extends DateComparator {
+
+    @Override
+    protected boolean canCompare(cgCache cache1, cgCache cache2) {
+        return super.canCompare(cache1, cache2);
+    }
+
+    @Override
+    protected int compareCaches(cgCache cache1, cgCache cache2) {
+        return super.compareCaches(cache1, cache2);
+    }
+}


### PR DESCRIPTION
New EventDateComparator class used for list of only event caches. Fixes #982
