### PR TITLE
Fix #1007, TB logging not possible after gc.com site update

### DIFF
--- a/main/src/cgeo/geocaching/GCConstants.java
+++ b/main/src/cgeo/geocaching/GCConstants.java
@@ -66,7 +66,7 @@ public final class GCConstants {
     /**
      * Patterns for parsing trackables
      */
-    public final static Pattern PATTERN_TRACKABLE_ID = Pattern.compile("<a id=\"ctl00_ContentBody_LogLink\" title=\"[^\"]*\" href=\".*log\\.aspx\\?wid=([a-z0-9\\-]+)\"[^>]*>[^<]*</a>");
+    public final static Pattern PATTERN_TRACKABLE_ID = Pattern.compile("<a id=\"ctl00_ContentBody_lnkPrint\" title=\"[^\"]*\" href=\".*sheet\\.aspx\\?guid=([a-z0-9\\-]+)\"[^>]*>[^<]*</a>");
     public final static Pattern PATTERN_TRACKABLE_GEOCODE = Pattern.compile("<span id=\"ctl00_ContentBody_BugDetails_BugTBNum\" String=\"[^\"]*\">Use[^<]*<strong>(TB[0-9A-Z]+)[^<]*</strong> to reference this item.[^<]*</span>");
     public final static Pattern PATTERN_TRACKABLE_NAME = Pattern.compile("<h2[^>]*>(?:[^<]*<img[^>]*>)?[^<]*<span id=\"ctl00_ContentBody_lbHeading\">([^<]+)</span>[^<]*</h2>");
     /** Two groups ! */


### PR DESCRIPTION
Changed parsing to use print link for getting the gui
Please review the regex change, I am happy to apply this to release afterwards
