### PR TITLE
Fix #1019 by correcting the index for substring calls.

### DIFF
--- a/cgeo-calendar/src/cgeo/calendar/CalendarActivity.java
+++ b/cgeo-calendar/src/cgeo/calendar/CalendarActivity.java
@@ -153,7 +153,7 @@ public final class CalendarActivity extends Activity {
                 String text = spanned.toString();
                 final ImageSpan[] spans = spanned.getSpans(0, spanned.length(), ImageSpan.class);
                 for (int i = spans.length - 1; i >= 0; i--) {
-                    text = text.substring(0, spanned.getSpanStart(spans[i]) - 1) + text.substring(spanned.getSpanEnd(spans[i]) + 1);
+                    text = text.substring(0, spanned.getSpanStart(spans[i])) + text.substring(spanned.getSpanEnd(spans[i]));
                 }
                 if (text.length() > 0) {
                     description.append("\n\n");


### PR DESCRIPTION
The calls to substring should not be adjusted (-1 or +1).
I tested and this code works for short descriptions matching following patterns:
`<image>`
`<image>Text`
`Text<image>Text`
`Text<image>Text<image>Text`
