### PR TITLE
Fix #1021 finish() when the dialog is done

### DIFF
--- a/cgeo-calendar/src/cgeo/calendar/CalendarActivity.java
+++ b/cgeo-calendar/src/cgeo/calendar/CalendarActivity.java
@@ -57,7 +57,6 @@ public final class CalendarActivity extends Activity {
             finish();
             return;
         }
-        finish();
     }
 
     private String getParameter(final String paramKey) {


### PR DESCRIPTION
Don't call finish() in onCreate, but make sure it is called when the dialog is complete (either a calendar is selected or user goes back)
