### PR TITLE
Fix #1011 Don't try to load more caches for stored lists

### DIFF
--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -192,8 +192,7 @@ public class cgeocaches extends AbstractListActivity {
                     setMoreCaches(false);
                 } else {
                     final int count = SearchResult.getTotal(search);
-                    final String url = SearchResult.getUrl(search);
-                    setMoreCaches(StringUtils.isNotBlank(url) && count > 0 && cacheList != null && cacheList.size() < count && cacheList.size() < MAX_LIST_ITEMS);
+                    setMoreCaches(type != CacheListType.OFFLINE && count > 0 && cacheList != null && cacheList.size() < count && cacheList.size() < MAX_LIST_ITEMS);
                 }
 
                 if (cacheList != null && SearchResult.getError(search) == StatusCode.UNAPPROVED_LICENSE) {
@@ -284,8 +283,7 @@ public class cgeocaches extends AbstractListActivity {
                     setMoreCaches(false);
                 } else {
                     final int count = SearchResult.getTotal(search);
-                    final String url = SearchResult.getUrl(search);
-                    setMoreCaches(StringUtils.isNotBlank(url) && count > 0 && cacheList != null && cacheList.size() < count && cacheList.size() < MAX_LIST_ITEMS);
+                    setMoreCaches(type != CacheListType.OFFLINE && count > 0 && cacheList != null && cacheList.size() < count && cacheList.size() < MAX_LIST_ITEMS);
                 }
 
                 if (SearchResult.getError(search) != null) {
@@ -1390,8 +1388,7 @@ public class cgeocaches extends AbstractListActivity {
 
         if (CollectionUtils.isNotEmpty(cacheList)) {
             final int count = SearchResult.getTotal(search);
-            final String url = SearchResult.getUrl(search);
-            setMoreCaches(StringUtils.isNotBlank(url) && count > 0 && cacheList.size() < count && cacheList.size() < MAX_LIST_ITEMS);
+            setMoreCaches(type != CacheListType.OFFLINE && count > 0 && cacheList.size() < count && cacheList.size() < MAX_LIST_ITEMS);
         }
 
         setTitle(title);


### PR DESCRIPTION
If URL in the search result is blank, then we are looking at stored caches and don't want to try to load more.

I feel like this is a bit of a hack, but I don't see another way of verifying whether we have a list of stored caches or are looking online.

Fixes #1011.
