### PR TITLE
Fix #1010 - Make sure we are taking action on correct cache from the context menu

### DIFF
--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -1277,7 +1277,7 @@ public class cgeocaches extends AbstractListActivity {
      */
     private cgCache getCacheFromAdapter(final AdapterContextMenuInfo adapterInfo) {
         final cgCache cache = adapter.getItem(adapterInfo.position);
-        if (cache.getGeocode().compareToIgnoreCase(contextMenuGeocode) == 0) {
+        if (cache.getGeocode().equalsIgnoreCase(contextMenuGeocode)) {
             return cache;
         }
 

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -129,7 +129,7 @@ public class CacheListAdapter extends ArrayAdapter<cgCache> {
 
     public cgCache findCacheByGeocode(String geocode) {
         for (int i = 0; i < getCount(); i++) {
-            if (getItem(i).getGeocode().compareToIgnoreCase(geocode) == 0) {
+            if (getItem(i).getGeocode().equalsIgnoreCase(geocode)) {
                 return getItem(i);
             }
         }


### PR DESCRIPTION
I don't see a way to keep track of the geocode in the context menu, so I added a variable to keep track.
It is set when the context menu is created. When the cache is looked up, a quick check is done to make sure the stored geocode matches the one just looked up.
If they don't match (the list has reordered in the background) then a full search of the adapter is done to find the correct cache. As this should be a rare occurrence, it isn't much of a performance penalty.

It isn't pretty, but it does solve the bug until someone has time to find a better way.
