### PR TITLE
Stronger use of CacheCache -> Performance boost

### DIFF
--- a/main/src/cgeo/geocaching/CacheCache.java
+++ b/main/src/cgeo/geocaching/CacheCache.java
@@ -3,9 +3,6 @@ package cgeo.geocaching;
 import cgeo.geocaching.cgData.StorageLocation;
 import cgeo.geocaching.utils.LeastRecentlyUsedCache;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Cache for Caches. Every cache is stored in memory while c:geo is active to
  * speed up the app and to minimize network request - which are slow.
@@ -72,23 +69,6 @@ public class CacheCache {
         }
 
         return null;
-    }
-
-    /**
-     * @param geocode
-     *            Geocode of the cache to retrieve from the cache
-     * @return cache if found, null else
-     */
-    public List<cgCache> getCachesFromCache(final List<String> geocodes) {
-        if (geocodes == null || geocodes.isEmpty()) {
-            return null;
-        }
-
-        ArrayList<cgCache> caches = new ArrayList<cgCache>();
-        for (String geocode : geocodes) {
-            caches.add(getCacheFromCache(geocode));
-        }
-        return caches;
     }
 
 }

--- a/main/src/cgeo/geocaching/VisitCacheActivity.java
+++ b/main/src/cgeo/geocaching/VisitCacheActivity.java
@@ -711,11 +711,6 @@ public class VisitCacheActivity extends AbstractActivity implements DateDialog.D
                     }
                 }
 
-                if (cache != null) {
-                    cgeoapplication.putCacheInCache(cache);
-                } else {
-                    cgeoapplication.removeCacheFromCache(geocode);
-                }
             }
 
             if (status == StatusCode.NO_ERROR) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1289,8 +1289,6 @@ public class CGeoMap extends AbstractMap implements OnDragListener, ViewFactory 
                     return;
                 }
 
-                //TODO Portree Only overwrite if we got some. Otherwise maybe error icon
-                //TODO Merge not to show locally found caches
                 caches = app.getCaches(search, centerLat, centerLon, spanLat, spanLon);
 
                 if (stop) {


### PR DESCRIPTION
Analysing #949 i found out that most of the time (~98%) is spent for the sequence cgData.loadCache() + cgData.storeCache() for each cache retrieved by the search (by viewport).

This search returns only rudimentary informations about each cache. Information that is not worth to be saved in the database BUT must be stored there because of the architecture of c:geo (intents use the geocode and not a cache object e.g.).

Instead of really storing and loading each minimalistic cache into and from the database (what is very, veeery, vvvvvvvvveeeeeeerrrrrrrrryyyyyyy slow) i tried to use more often the CacheCache - with success. The in-memory-db cache is now controlled fully by cgData. The advantages are:
- less DB operations
- better overall performance
- smaller DB. Only fully detailed caches are stored now.

Please have a look at the changes in cgeoapplication and cgData. These changes could be merged into the market release to solve #949.
As further steps i will move CacheCache into an inner class of cgData and will have a look at ParseResult (if it is still needed).
