### PR TITLE
Fixes #1037, New live-map reliability check

### DIFF
--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -737,7 +737,8 @@ public class cgBase {
             final JSONObject extra = dataJSON.getJSONObject("cs");
             if (extra != null && extra.length() > 0) {
                 int count = extra.getInt("count");
-                // check login status (presumably meaning of the 'li' member
+                // currently unused: 'pm', true for premium members
+                // check login status
                 boolean li = extra.getBoolean("li");
                 if (!li) {
                     parseResult.error = StatusCode.NOT_LOGGED_IN;


### PR DESCRIPTION
Here I use solely the newly discovered 'li' property to detect the invalidation of the live-map token.
Next steps would be to re-login instead of marking the coordinates as unreliable.
Please take a good look onto it!
