### PR TITLE
fix #986: mention standard GPX directory in progress dialog

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -566,6 +566,7 @@
 
   <!-- file list base -->
   <string name="file_searching_in">Suche nach Dateien\nin</string>
+  <string name="file_searching_sdcard_in">Keine Dateien in Standardverzeichnissen gefunden:\n%1$s\n\nDurchsuche komplette SD-Karte:\n</string>
   <string name="file_list_no_files">c:geo hat keine passenden Dateien gefunden.</string>
   <string name="file_searching">Suche nach passenden Dateien</string>
   <string name="file_title_searching">Suche</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -580,6 +580,7 @@
       
   <!-- file list base -->
   <string name="file_searching_in">Searching for files\nin</string>
+  <string name="file_searching_sdcard_in">No files found in default folders:\n%1$s\n\nSearching whole SD card for files:\n</string>
   <string name="file_list_no_files">c:geo found no appropriate files.</string>
   <string name="file_searching">Searching for matching files</string>
   <string name="file_title_searching">Searching</string>


### PR DESCRIPTION
If no files were found in the standard folders (getBaseFolders), a message is shown that the whole SD card needs to be searched.

Works for all FileList dialogs,
