### PR TITLE
Updated send2cgeo.user.js to adapt the map changes done by Groundspeak o...

### DIFF
--- a/send2cgeo/send2cgeo.user.js
+++ b/send2cgeo/send2cgeo.user.js
@@ -3,7 +3,7 @@
 // @namespace      http://send2.cgeo.org/
 // @description    Add Send to c:geo button to geocaching.com
 // @include        http://www.geocaching.com/seek/cache_details*
-// @include        http://www.geocaching.com/map/default*
+// @include        http://www.geocaching.com/map/*
 // @version        0.25
 // ==/UserScript==
 


### PR DESCRIPTION
...n 2012-02-14.

Hello,
I've changed the greasemonkey script to adapt the changes in the map. On my Chrome installation the send2cgeo button is back again and works.
I have not tested it on Firefox.
