### PR TITLE
Remove incorrect labeling of distance unit as meter in waypoint creation

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -622,7 +622,7 @@
   <string name="waypoint_custom">Benutzerdefiniert</string>
   <string name="waypoint_my_coordinates">Meine Koordinaten</string>
   <string name="waypoint_bearing">Richtung in °</string>
-  <string name="waypoint_distance">Entfernung in m</string>
+  <string name="waypoint_distance">Entfernung</string>
   <string name="waypoint_name">Name</string>
   <string name="waypoint_edit">Bearbeiten</string>
   <string name="waypoint_delete">Löschen</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -622,7 +622,7 @@
   <string name="waypoint_custom">Custom</string>
   <string name="waypoint_my_coordinates">Coordinate attuali</string>
   <string name="waypoint_bearing">Angolo in gradi</string>
-  <string name="waypoint_distance">Distanza in metri</string>
+  <string name="waypoint_distance">Distanza</string>
   <string name="waypoint_name">Nome</string>
   <string name="waypoint_edit">Modifica</string>
   <string name="waypoint_delete">Elimina</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -616,7 +616,7 @@
   <string name="waypoint_custom">Egen</string>
   <string name="waypoint_my_coordinates">Mina koordinater</string>
   <string name="waypoint_bearing">Riktning (°)</string>
-  <string name="waypoint_distance">Avstånd (meter)</string>
+  <string name="waypoint_distance">Avstånd</string>
   <string name="waypoint_name">Namn</string>
   <string name="waypoint_edit">Redigera</string>
   <string name="waypoint_delete">Ta bort</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -636,7 +636,7 @@
   <string name="waypoint_custom">Custom</string>
   <string name="waypoint_my_coordinates">My coordinates</string>
   <string name="waypoint_bearing">Bearing in °</string>
-  <string name="waypoint_distance">Distance in m</string>
+  <string name="waypoint_distance">Distance</string>
   <string name="waypoint_name">Name</string>
   <string name="waypoint_edit">Edit</string>
   <string name="waypoint_delete">Delete</string>


### PR DESCRIPTION
The unit used depends on the user's settings (use Metric or not).
This change will match with #1101 once it is implemented.
