### PR TITLE
Fix #1101 - Add list for distance units

### DIFF
--- a/main/res/layout/point_controls.xml
+++ b/main/res/layout/point_controls.xml
@@ -60,7 +60,8 @@
         <Spinner
             android:id="@+id/distanceUnit"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+			android:entries="@array/distance_units" />
     </LinearLayout>
 
     <RelativeLayout style="@style/separator_horizontal_layout" >

--- a/main/res/layout/waypoint_new.xml
+++ b/main/res/layout/waypoint_new.xml
@@ -67,7 +67,8 @@
 	            <Spinner 
                 	android:id="@+id/distanceUnit"
                 	android:layout_width="wrap_content"
-					android:layout_height="wrap_content" />
+					android:layout_height="wrap_content"
+					android:entries="@array/distance_units" />
         	</LinearLayout>
 
 	        <AutoCompleteTextView

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -664,6 +664,20 @@
   </string-array>
   <string name="waypoint_coordinate_formats_plain">Plain</string>
 
+  <!-- distance units -->
+  <string-array name="distance_units">
+    <item>@string/unit_m</item>
+    <item>@string/unit_km</item>
+    <item>@string/unit_ft</item>
+    <item>@string/unit_yd</item>
+    <item>@string/unit_mi</item>
+  </string-array>
+  <string name="unit_m">m</string>
+  <string name="unit_km">km</string>
+  <string name="unit_ft">ft</string>
+  <string name="unit_yd">yd</string>
+  <string name="unit_mi">mi</string>
+  
   <!-- visit -->
   <string name="visit_tweet">Post this find to Twitter</string>
 

--- a/main/src/cgeo/geocaching/cgeopoint.java
+++ b/main/src/cgeo/geocaching/cgeopoint.java
@@ -101,7 +101,6 @@ public class cgeopoint extends AbstractActivity {
     private int contextMenuItemPosition;
 
     String distanceUnit = "";
-    private static final String[] distanceUnits = { "m", "km", "ft", "yd", "mi" };
 
     public cgeopoint() {
         super("c:geo-navigate-any");
@@ -286,16 +285,14 @@ public class cgeopoint extends AbstractActivity {
 
         Spinner distanceUnitSelector = (Spinner) findViewById(R.id.distanceUnit);
 
-        ArrayAdapter<String> unitAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, distanceUnits);
-        unitAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        distanceUnitSelector.setAdapter(unitAdapter);
-
-        if (Settings.isUseMetricUnits()) {
-            distanceUnitSelector.setSelection(0); // m
-            distanceUnit = cgeopoint.distanceUnits[0];
-        } else {
-            distanceUnitSelector.setSelection(2); // ft
-            distanceUnit = cgeopoint.distanceUnits[2];
+        if (StringUtils.isBlank(distanceUnit)) {
+            if (Settings.isUseMetricUnits()) {
+                distanceUnitSelector.setSelection(0); // m
+                distanceUnit = res.getStringArray(R.array.distance_units)[0];
+            } else {
+                distanceUnitSelector.setSelection(2); // ft
+                distanceUnit = res.getStringArray(R.array.distance_units)[2];
+            }
         }
 
         distanceUnitSelector.setOnItemSelectedListener(new changeDistanceUnit(this));
@@ -333,7 +330,7 @@ public class cgeopoint extends AbstractActivity {
         @Override
         public void onItemSelected(AdapterView<?> arg0, View arg1, int arg2,
                 long arg3) {
-            unitView.distanceUnit = cgeopoint.distanceUnits[arg2];
+            unitView.distanceUnit = (String) arg0.getItemAtPosition(arg2);
         }
 
         @Override

--- a/main/src/cgeo/geocaching/cgeowaypointadd.java
+++ b/main/src/cgeo/geocaching/cgeowaypointadd.java
@@ -44,8 +44,6 @@ public class cgeowaypointadd extends AbstractActivity {
     private boolean own = true;
     ArrayList<WaypointType> wpTypes = null;
     String distanceUnit = "";
-    private static final String[] distanceUnits = { "m", "km", "ft", "yd", "mi" };
-
 
     /**
      * number of waypoints that the corresponding cache has until now
@@ -228,16 +226,14 @@ public class cgeowaypointadd extends AbstractActivity {
 
         Spinner distanceUnitSelector = (Spinner) findViewById(R.id.distanceUnit);
 
-        ArrayAdapter<String> unitAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, distanceUnits);
-        unitAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        distanceUnitSelector.setAdapter(unitAdapter);
-
-        if (Settings.isUseMetricUnits()) {
-            distanceUnitSelector.setSelection(0); // m
-            distanceUnit = cgeowaypointadd.distanceUnits[0];
-        } else {
-            distanceUnitSelector.setSelection(2); // ft
-            distanceUnit = cgeowaypointadd.distanceUnits[2];
+        if (StringUtils.isBlank(distanceUnit)) {
+            if (Settings.isUseMetricUnits()) {
+                distanceUnitSelector.setSelection(0); // m
+                distanceUnit = res.getStringArray(R.array.distance_units)[0];
+            } else {
+                distanceUnitSelector.setSelection(2); // ft
+                distanceUnit = res.getStringArray(R.array.distance_units)[2];
+            }
         }
 
         distanceUnitSelector.setOnItemSelectedListener(new changeDistanceUnit(this));
@@ -340,7 +336,7 @@ public class cgeowaypointadd extends AbstractActivity {
         @Override
         public void onItemSelected(AdapterView<?> arg0, View arg1, int arg2,
                 long arg3) {
-            unitView.distanceUnit = cgeowaypointadd.distanceUnits[arg2];
+            unitView.distanceUnit = (String) arg0.getItemAtPosition(arg2);
         }
 
         @Override


### PR DESCRIPTION
This adds a drop down list (spinner) to allow user to set unit for distance on all screens with bearing/distance options. List defaults based on if user is using metric units or not.

(I apologize for reformatting point_controls.xml, but it was very difficult to read. The changes I made to it are the same as the ones I made to waypoint_new.xml)
