### PR TITLE
Fix for issue #1147: Improved pattern and usage

### DIFF
--- a/main/src/cgeo/geocaching/GCConstants.java
+++ b/main/src/cgeo/geocaching/GCConstants.java
@@ -56,8 +56,8 @@ public final class GCConstants {
     // Info box top-right
     public static final Pattern PATTERN_LOGIN_NAME = Pattern.compile("\"SignedInProfileLink\">([^<]+)</a>");
     public static final Pattern PATTERN_MEMBER_STATUS = Pattern.compile("<span id=\"ctl00_litPMLevel\" style=\"display: block;\">([^<]+)</span>");
-    /** Use replaceAll("[,\\.]","") on the resulting string before converting to an int */
-    public static final Pattern PATTERN_CACHES_FOUND = Pattern.compile("title=\"Caches Found\"[\\s\\w=\"/\\.]*/>\\s*([\\d,\\.]+)");
+    /** Use replaceAll("[,.]","") on the resulting string before converting to an int */
+    public static final Pattern PATTERN_CACHES_FOUND = Pattern.compile("title=\"Caches Found\"[\\s\\w=\"/.]*/>\\s*([\\d,.]+)");
     public static final Pattern PATTERN_AVATAR_IMAGE_PROFILE_PAGE = Pattern.compile("<img src=\"(http://img.geocaching.com/user/avatar/[0-9a-f-]+\\.jpg)\"[^>]*\\salt=\"Avatar\"");
     public static final Pattern PATTERN_LOGIN_NAME_LOGIN_PAGE = Pattern.compile("<span class=\"Success\">You are logged in as[^<]*<strong[^>]*>([^<]+)</strong>[^<]*</span>");
     public static final Pattern PATTERN_CUSTOMDATE = Pattern.compile("<option selected=\"selected\" value=\"([ /Mdy-]+)\">");

--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -364,7 +364,7 @@ public class cgBase {
         if (isActualLoginStatus()) {
             setActualUserName(BaseUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME, true, "???"));
             setActualMemberStatus(BaseUtils.getMatch(page, GCConstants.PATTERN_MEMBER_STATUS, true, "???"));
-            setActualCachesFound(Integer.parseInt(BaseUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "0").replaceAll("[,\\.]", "")));
+            setActualCachesFound(Integer.parseInt(BaseUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "0").replaceAll("[,.]", "")));
             return true;
         }
 
@@ -1416,7 +1416,7 @@ public class cgBase {
 
             Settings.setMemberStatus(BaseUtils.getMatch(profile, GCConstants.PATTERN_MEMBER_STATUS, true, null));
 
-            setActualCachesFound(Integer.parseInt(BaseUtils.getMatch(profile, GCConstants.PATTERN_CACHES_FOUND, true, "-1").replaceAll("[,\\.]", "")));
+            setActualCachesFound(Integer.parseInt(BaseUtils.getMatch(profile, GCConstants.PATTERN_CACHES_FOUND, true, "-1").replaceAll("[,.]", "")));
 
             final String avatarURL = BaseUtils.getMatch(profile, GCConstants.PATTERN_AVATAR_IMAGE_PROFILE_PAGE, false, null);
             if (null != avatarURL) {

--- a/main/src/cgeo/geocaching/utils/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/utils/LogTemplateProvider.java
@@ -127,6 +127,6 @@ public class LogTemplateProvider {
             return -1;
         }
 
-        return Integer.parseInt(BaseUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "-1").replaceAll("[,\\.]", ""));
+        return Integer.parseInt(BaseUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "-1").replaceAll("[,.]", ""));
     }
 }

--- a/tests/src/cgeo/geocaching/GCConstantsTest.java
+++ b/tests/src/cgeo/geocaching/GCConstantsTest.java
@@ -29,6 +29,6 @@ public class GCConstantsTest extends AndroidTestCase {
     }
 
     private static void assertCacheCount(final int count, final String html) {
-        assertEquals(count, Integer.parseInt(BaseUtils.getMatch(html, GCConstants.PATTERN_CACHES_FOUND, true, "0").replaceAll("[,\\.]", "")));
+        assertEquals(count, Integer.parseInt(BaseUtils.getMatch(html, GCConstants.PATTERN_CACHES_FOUND, true, "0").replaceAll("[,.]", "")));
     }
 }

--- a/tests/src/cgeo/geocaching/cgBaseTest.java
+++ b/tests/src/cgeo/geocaching/cgBaseTest.java
@@ -22,7 +22,7 @@ public class cgBaseTest extends AndroidTestCase {
         assertEquals("blafoo", BaseUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME, true, "???"));
         // TODO blafoo reactivate
         // assertEquals("Premium Member", BaseUtils.getMatch(page, GCConstants.PATTERN_MEMBER_STATUS, true, "???"));
-        int cachesFound = Integer.parseInt(BaseUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "0").replaceAll("[,\\.]", ""));
+        int cachesFound = Integer.parseInt(BaseUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "0").replaceAll("[,.]", ""));
         assertTrue(cachesFound >= 491);
     }
 


### PR DESCRIPTION
- Replaced 'old' cache found parsing by usage of cache found pattern.
- Improved pattern to respect the `.` as thousands separator too. 

I don't know if depending on the users locale the dot as separator will occure at gc.com. But it was also removed in the 'old' parsing method from `LogTemplateProvider.java`. And from now on we can handle this correct too.
