### PR TITLE
Fix #1099 - Don't display offline store message

### DIFF
--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -802,7 +802,6 @@ public class cgBase {
                 return null;
             }
             // save full detailed caches
-            sendLoadProgressDetail(handler, R.string.cache_dialog_offline_save_message);
             cache.setListId(StoredList.TEMPORARY_LIST_ID);
             cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
         }


### PR DESCRIPTION
Don't display the store message here because we are only storing it into cache and don't want to confuse the user.
Fixes #1099
