### PR TITLE
Fix #1164 - Change label for unknown cache size - Unknown instead of Unknown Error

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">Other</string>
   <string name="cache_size_virtual">Kein Behälter</string>
   <string name="cache_size_notchosen">Nicht gewählt</string>
-
+  <string name="cache_size_unknown">Unbekannt</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Final</string>
   <string name="wp_stage">Station eines Multi-Cache</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -42,7 +42,8 @@
   <string name="cache_size_other">otro</string>
   <string name="cache_size_virtual">virtual</string>
   <string name="cache_size_notchosen">no elegido</string>
-
+  <string name="cache_size_unknown">desconocido</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Ubicación final</string>
   <string name="wp_stage">Etapa de multi escondite</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">autre</string>
   <string name="cache_size_virtual">virtuelle</string>
   <string name="cache_size_notchosen">non renseignée</string>
-
+  <string name="cache_size_unknown">inconnu</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Étape finale</string>
   <string name="wp_stage">Étape</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -44,7 +44,8 @@
   <string name="cache_size_other">egyéb</string>
   <string name="cache_size_virtual">virtuális</string>
   <string name="cache_size_notchosen">nincs megadva</string>
-
+  <string name="cache_size_unknown">ismeretlen</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Végső helyszín</string>
   <string name="wp_stage">Multi-láda állomása</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">altro</string>
   <string name="cache_size_virtual">virtual</string>
   <string name="cache_size_notchosen">non selezionata</string>
-
+  <string name="cache_size_unknown">sconosciuto</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Destinazione finale</string>
   <string name="wp_stage">Step intermedio multi-cache</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">other</string>
   <string name="cache_size_virtual">virtual</string>
   <string name="cache_size_notchosen">not chosen</string>
-
+  <string name="cache_size_unknown">Onbekend</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Eindbestemming</string>
   <string name="wp_stage">Multi-cache punt</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -42,7 +42,8 @@
   <string name="cache_size_other">inna</string>
   <string name="cache_size_virtual">wirtualna</string>
   <string name="cache_size_notchosen">nie wybrana</string>
-
+  <string name="cache_size_unknown">nieznany</string>
+    
   <!-- waypoints -->
   <string name="wp_final">Finał</string>
   <string name="wp_stage">Etap do skrzynki</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">Outra</string>
   <string name="cache_size_virtual">Virtual</string>
   <string name="cache_size_notchosen">Não especificado</string>
-
+  <string name="cache_size_unknown">Desconhecido</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Localização final</string>
   <string name="wp_stage">Estado da multi-cache</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">iná</string>
   <string name="cache_size_virtual">virtuálna</string>
   <string name="cache_size_notchosen">nezvolené</string>
-
+  <string name="cache_size_unknown">neznámy</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Cieľ</string>
   <string name="wp_stage">Časť multi-skrýše</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -45,7 +45,8 @@
   <string name="cache_size_other">other</string>
   <string name="cache_size_virtual">virtual</string>
   <string name="cache_size_notchosen">not chosen</string>
-
+  <string name="cache_size_unknown">Okänd</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Slutlig plats</string>
   <string name="wp_stage">Delsteg för multi-cache</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -46,7 +46,8 @@
   <string name="cache_size_other">Other</string>
   <string name="cache_size_virtual">Virtual</string>
   <string name="cache_size_notchosen">Not chosen</string>
-
+  <string name="cache_size_unknown">Unknown</string>
+  
   <!-- waypoints -->
   <string name="wp_final">Final Location</string>
   <string name="wp_stage">Stage of a Multicache</string>

--- a/main/src/cgeo/geocaching/enumerations/CacheSize.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheSize.java
@@ -20,7 +20,7 @@ public enum CacheSize {
     VIRTUAL("virtual", 0, R.string.cache_size_virtual),
     NOT_CHOSEN("not chosen", 0, R.string.cache_size_notchosen),
     OTHER("other", 0, R.string.cache_size_other),
-    UNKNOWN("unknown", 0, R.string.err_unknown); // CacheSize not init. yet
+    UNKNOWN("unknown", 0, R.string.cache_size_unknown); // CacheSize not init. yet
 
     public final String id;
     public final int comparable;


### PR DESCRIPTION
This is a quick change to try and not confuse the user by showing option of "Unknown Error"
As Unknown isn't an actual size option, it may be better to refactor the code so it doesn't show at all.

The translations come from the string `trackable_unknown`

Fixes #1164
