### PR TITLE
Fix check for calendar add-on installed

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -796,7 +796,7 @@ public class CacheDetailActivity extends AbstractActivity {
 
     private void addToCalendarWithIntent() {
 
-        final boolean calendarAddOnAvailable = cgBase.isIntentAvailable(this, ICalendar.INTENT);
+        final boolean calendarAddOnAvailable = cgBase.isIntentAvailable(this, ICalendar.INTENT, Uri.parse(ICalendar.URI_SCHEME + "://" + ICalendar.URI_HOST));
 
         if (calendarAddOnAvailable) {
             final Parameters params = new Parameters(

--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -2841,8 +2841,33 @@ public class cgBase {
      *         responded to, false otherwise.
      */
     public static boolean isIntentAvailable(Context context, String action) {
+        return isIntentAvailable(context, action, null);
+    }
+
+    /**
+     * Indicates whether the specified action can be used as an intent. This
+     * method queries the package manager for installed packages that can
+     * respond to an intent with the specified action. If no suitable package is
+     * found, this method returns false.
+     *
+     * @param context
+     *            The application's environment.
+     * @param action
+     *            The Intent action to check for availability.
+     * @param uri
+     *            The Intent URI to check for availability.
+     *
+     * @return True if an Intent with the specified action can be sent and
+     *         responded to, false otherwise.
+     */
+    public static boolean isIntentAvailable(Context context, String action, Uri uri) {
         final PackageManager packageManager = context.getPackageManager();
-        final Intent intent = new Intent(action);
+        final Intent intent;
+        if (uri == null) {
+            intent = new Intent(action);
+        } else {
+            intent = new Intent(action, uri);
+        }
         List<ResolveInfo> list = packageManager.queryIntentActivities(intent,
                 PackageManager.MATCH_DEFAULT_ONLY);
         return list.size() > 0;


### PR DESCRIPTION
The calendar add-on AndroidManifest.xml includes a filter for data type. 
Therefore, to successfully check it if is installed, the Intent must have data type as well.

From http://developer.android.com/guide/topics/intents/intents-filters.html
"An Intent object that contains a URI but no data type passes the test only if its URI matches a URI in the filter and the filter likewise does not specify a type."

Addresses problem discussed in #1166 (but doesn't fix #1166).
