### PR TITLE
fix #1204: keep screen on during GPX-import 

### DIFF
--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.os.Message;
+import android.view.WindowManager;
 
 /**
  * progress dialog wrapper for easier management of resources
@@ -41,6 +42,7 @@ public class Progress {
             } else {
                 dialog.setCancelable(false);
             }
+            dialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             dialog.show();
         }
     }


### PR DESCRIPTION
This fixes the screen-off for all GPX/LOC file imports (also import from browser downloads and email). It
is achieved by keeping screen on for all progress dialogs using Progress class.

It does not fix 'Import from Web' because cgeocaches uses own ProgressDialogs instead of the Progress class.
I could try to replace ProgressDialog by Progress but want to hear your opinion first.
