### PR TITLE
Fix #1196 and other waypoint refactoring

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.RemoveFlag;
+import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.LogType;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.geopoint.GeopointFormatter;
@@ -503,11 +504,13 @@ public class CacheDetailActivity extends AbstractActivity {
                 break;
             case CONTEXT_MENU_WAYPOINT_DUPLICATE:
                 if (cache.duplicateWaypoint(index)) {
+                    app.saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
                     notifyDataSetChanged();
                 }
                 break;
             case CONTEXT_MENU_WAYPOINT_DELETE:
                 if (cache.deleteWaypoint(index)) {
+                    app.saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
                     notifyDataSetChanged();
                 }
                 break;

--- a/main/src/cgeo/geocaching/cgBase.java
+++ b/main/src/cgeo/geocaching/cgBase.java
@@ -28,7 +28,6 @@ import cgeo.geocaching.utils.BaseUtils;
 import cgeo.geocaching.utils.CancellableHandler;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -977,7 +976,7 @@ public class cgBase {
                 // res is null during the unit tests
                 final cgWaypoint waypoint = new cgWaypoint(res != null ? res.getString(R.string.cache_coordinates_original) : "res = null", WaypointType.WAYPOINT, false);
                 waypoint.setCoords(new Geopoint(originalCoords));
-                cache.addWaypoint(waypoint);
+                cache.addWaypoint(waypoint, false);
                 cache.setUserModifiedCoords(true);
             }
         } catch (Geopoint.GeopointException e) {
@@ -1048,7 +1047,7 @@ public class cgBase {
                     // waypoint note
                     waypoint.setNote(BaseUtils.getMatch(wp[3], GCConstants.PATTERN_WPNOTE, waypoint.getNote()));
 
-                    cache.addWaypoint(waypoint);
+                    cache.addWaypoint(waypoint, false);
                 }
             }
         }

--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -1960,7 +1960,7 @@ public class cgData {
                         if (loadFlags.contains(LoadFlag.LOAD_WAYPOINTS)) {
                             final List<cgWaypoint> waypoints = loadWaypoints(cache.getGeocode());
                             if (CollectionUtils.isNotEmpty(waypoints)) {
-                                cache.setWaypoints(waypoints);
+                                cache.setWaypoints(waypoints, false);
                             }
                         }
 

--- a/main/src/cgeo/geocaching/cgeowaypoint.java
+++ b/main/src/cgeo/geocaching/cgeowaypoint.java
@@ -2,7 +2,8 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.apps.cache.navi.NavigationAppFactory;
-import cgeo.geocaching.enumerations.LoadFlags.RemoveFlag;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -319,12 +320,12 @@ public class cgeowaypoint extends AbstractActivity {
     private class deleteWaypointListener implements View.OnClickListener {
 
         public void onClick(View arg0) {
-            if (app.deleteWaypoint(id)) {
-                String geocode = waypoint.getGeocode();
+            String geocode = waypoint.getGeocode();
+            cgCache cache = app.loadCache(geocode, LoadFlags.LOAD_WAYPOINTS);
+            if (null != cache && cache.deleteWaypoint(waypoint)) {
+                app.saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
+
                 StaticMapsProvider.removeWpStaticMaps(id, geocode);
-                if (!StringUtils.isEmpty(geocode)) {
-                    app.removeCache(geocode, EnumSet.of(RemoveFlag.REMOVE_CACHE));
-                }
 
                 finish();
                 return;

--- a/main/src/cgeo/geocaching/cgeowaypointadd.java
+++ b/main/src/cgeo/geocaching/cgeowaypointadd.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.geopoint.DistanceParser;
 import cgeo.geocaching.geopoint.Geopoint;
@@ -27,6 +28,7 @@ import android.widget.EditText;
 import android.widget.Spinner;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 public class cgeowaypointadd extends AbstractActivity {
@@ -419,10 +421,12 @@ public class cgeowaypointadd extends AbstractActivity {
             waypoint.setNote(note);
             waypoint.setId(id);
 
-            if (app.saveOwnWaypoint(id, geocode, waypoint)) {
+            cgCache cache = app.loadCache(geocode, LoadFlags.LOAD_WAYPOINTS);
+            if (null != cache && cache.addWaypoint(waypoint, true)) {
+                app.saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
                 StaticMapsProvider.removeWpStaticMaps(id, geocode);
                 if (Settings.isStoreOfflineWpMaps()) {
-                    StaticMapsProvider.storeWaypointStaticMap(app.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB), cgeowaypointadd.this, waypoint, false);
+                    StaticMapsProvider.storeWaypointStaticMap(cache, cgeowaypointadd.this, waypoint, false);
                 }
                 finish();
                 return;

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -320,7 +320,7 @@ public abstract class GPXParser extends FileParser {
                         mergedWayPoints.addAll(cacheForWaypoint.getWaypoints());
 
                         cgWaypoint.mergeWayPoints(mergedWayPoints, Collections.singletonList(waypoint), true);
-                        cacheForWaypoint.setWaypoints(mergedWayPoints);
+                        cacheForWaypoint.setWaypoints(mergedWayPoints, false);
                         result.put(cacheGeocodeForWaypoint, cacheForWaypoint);
                         showProgressMessage(progressHandler, progressStream.getProgress());
                     }

--- a/tests/src/cgeo/geocaching/cgBaseTest.java
+++ b/tests/src/cgeo/geocaching/cgBaseTest.java
@@ -134,7 +134,7 @@ public class cgBaseTest extends AndroidTestCase {
 
     private static void assertWaypointsFromNote(final cgCache cache, Geopoint[] expected, String note) {
         cache.setPersonalNote(note);
-        cache.setWaypoints(new ArrayList<cgWaypoint>());
+        cache.setWaypoints(new ArrayList<cgWaypoint>(), false);
         cache.parseWaypointsFromNote();
         assertEquals(expected.length, cache.getWaypoints().size());
         for (int i = 0; i < expected.length; i++) {


### PR DESCRIPTION
Refactor so all waypoint operations are done through the Cache object.
Check for editing a waypoint when adding.
Save cache after waypoint operations so finalDefined is set correctly.

Fixes #1196
