### PR TITLE
Fix #1226 - Make trackable icon large enough to fill the height of the text view

### DIFF
--- a/main/src/cgeo/geocaching/cgeotrackable.java
+++ b/main/src/cgeo/geocaching/cgeotrackable.java
@@ -589,7 +589,8 @@ public class cgeotrackable extends AbstractActivity {
         public void handleMessage(Message message) {
             BitmapDrawable image = (BitmapDrawable) message.obj;
             if (image != null && view != null) {
-                view.setCompoundDrawablesWithIntrinsicBounds(image, null, null, null);
+                image.setBounds(0, 0, view.getHeight(), view.getHeight());
+                view.setCompoundDrawables(image, null, null, null);
             }
         }
     }


### PR DESCRIPTION
I am not sure if it is better to call `getHeight()` twice or store the value temporarily.

Thanks to @SammysHP for the hint.

Fixes #1226
