### PR TITLE
Fix #1235 - Support adding events to calendar in Android version 4 

### DIFF
--- a/cgeo-calendar/src/cgeo/calendar/Compatibility.java
+++ b/cgeo-calendar/src/cgeo/calendar/Compatibility.java
@@ -7,12 +7,17 @@ public final class Compatibility {
 
     private final static int sdkVersion = Integer.parseInt(Build.VERSION.SDK);
     private final static boolean isLevel8 = sdkVersion >= 8;
+    private final static boolean isLevel14 = sdkVersion >= 14;
 
     public static Uri getCalendarProviderURI() {
         return Uri.parse(isLevel8 ? "content://com.android.calendar/calendars" : "content://calendar/calendars");
     }
 
-    public static Uri getCalenderEventsProviderURI() {
+    public static Uri getCalendarEventsProviderURI() {
         return Uri.parse(isLevel8 ? "content://com.android.calendar/events" : "content://calendar/events");
+    }
+
+    public static boolean isLevel14() {
+        return isLevel14;
     }
 }


### PR DESCRIPTION
Used new functionality from API 14 to pass an Intent to add an event to the calendar. I'm not certain if this will only work for built in calendar app or all of them.
This opens a new window in calendar to add the event. Handling it the same way as versions prior to 4 would require changing `targetSdkVersion` to 14 so that we can use new functions.

The changes to existing code are:
- move common code to new functions
- don't perform lots of action inside (!= null) blocks, but return if it is null
- don't call `close()` on a cursor from managedQuery per Android documentation

Fixes #1235
