### PR TITLE
Add quick access to default navigation to waypoints in waypoint list in cache details view

### DIFF
--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -5,27 +5,43 @@
     android:orientation="vertical"
     android:paddingTop="9dp" >
 
-    <TextView
-        android:id="@+id/name"
+    <RelativeLayout
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:textColor="?text_color"
-        android:textSize="18dp" />
-
-    <TextView
-        android:id="@+id/info"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="left"
-        android:layout_marginLeft="12dp"
-        android:ellipsize="marquee"
-        android:lines="1"
-        android:scrollHorizontally="true"
-        android:singleLine="true"
-        android:textColor="?text_color_headline"
-        android:textSize="14dp"
-        android:visibility="gone" />
-
+        android:layout_height="fill_parent"
+        android:orientation="horizontal">
+		<LinearLayout
+	        android:layout_width="fill_parent"
+	        android:layout_height="wrap_content"
+	        android:layout_alignParentLeft="true"
+	        android:orientation="vertical">
+		    <TextView
+		        android:id="@+id/name"
+		        android:layout_width="fill_parent"
+		        android:layout_height="wrap_content"
+		        android:textColor="?text_color"
+		        android:textSize="18dp" />
+		    <TextView
+		        android:id="@+id/info"
+		        android:layout_width="fill_parent"
+		        android:layout_height="wrap_content"
+		        android:layout_gravity="left"
+		        android:layout_marginLeft="12dp"
+		        android:ellipsize="marquee"
+		        android:lines="1"
+		        android:scrollHorizontally="true"
+		        android:singleLine="true"
+		        android:textColor="?text_color_headline"
+		        android:textSize="14dp"
+		        android:visibility="gone" />
+	    </LinearLayout>
+		<ImageView style="@style/action_bar_action"
+		 		android:id="@+id/wpDefaultNavigation"
+				android:src="@drawable/actionbar_compass"
+				android:layout_gravity="right"
+				android:layout_alignParentRight="true"
+				android:clickable="true"
+				android:longClickable="true" />
+    </RelativeLayout>
     <TextView
         android:id="@+id/coordinates"
         android:layout_width="fill_parent"

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2407,7 +2407,7 @@ public class CacheDetailActivity extends AbstractActivity {
                 List<cgWaypoint> sortedWaypoints = new ArrayList<cgWaypoint>(cache.getWaypoints());
                 Collections.sort(sortedWaypoints);
 
-                for (cgWaypoint wpt : sortedWaypoints) {
+                for (final cgWaypoint wpt : sortedWaypoints) {
                     waypointView = (LinearLayout) getLayoutInflater().inflate(R.layout.waypoint_item, null);
 
                     // coordinates
@@ -2460,6 +2460,21 @@ public class CacheDetailActivity extends AbstractActivity {
                             noteView.setText(wpt.getNote());
                         }
                     }
+
+                    View wpNavView = waypointView.findViewById(R.id.wpDefaultNavigation);
+                    wpNavView.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            NavigationAppFactory.startDefaultNavigationApplication(geolocation, CacheDetailActivity.this, null, wpt, null);
+                        }
+                    });
+                    wpNavView.setOnLongClickListener(new View.OnLongClickListener() {
+                        @Override
+                        public boolean onLongClick(View v) {
+                            NavigationAppFactory.startDefaultNavigationApplication2(geolocation, CacheDetailActivity.this, null, wpt, null);
+                            return true;
+                        }
+                    });
 
                     registerForContextMenu(waypointView);
                     waypointView.setOnClickListener(new WaypointInfoClickListener());


### PR DESCRIPTION
Actually i missed quick access to default navigation for waypoints. As the click event is already in use for the listed waypoints you always have to open the menu. Also the second preferred navigation tool is not supported from the menu.

This change adds the navigation icon at the right border of the waypoints inside the waypoint list. The icon starts the first default navigation tool on click and the second preferred navigation tool on long click. It's the same behaviour as already used for default navigation for the cache.

From my point of view it is simple to understand, will improve the caching experience a lot and is only a small layout change to add access to already approved functions.
