### PR TITLE
cacheChangeNotificationHandler must be set each time cache is created

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -635,11 +635,6 @@ public class CacheDetailActivity extends AbstractActivity {
 
                 // Data loaded, we're ready to show it!
                 notifyDataSetChanged();
-                // cache isn't available until after notifyDataSetChanged is called
-                if (cache != null) {
-                    cache.setChangeNotificationHandler(cacheChangeNotificationHandler);
-                }
-
             }
         }
 
@@ -669,6 +664,9 @@ public class CacheDetailActivity extends AbstractActivity {
             finish();
             return;
         }
+
+        // allow cache to notify CacheDetailActivity when it changes so it can be reloaded
+        cache.setChangeNotificationHandler(cacheChangeNotificationHandler);
 
         // notify all creators that the data has changed
         for (PageViewCreator creator : viewCreators.values()) {


### PR DESCRIPTION
`notifyDataSetChanged` gets a new `cache` which sets the change handler back to null. The change handler must be set when the cache object is created.

This fixes the following bug:
- Open a cache from map or list
- Move to page other than Details (such as description)
- Offline log the cache
- Go back to map or list. Cache doesn't update to show the offline log. 

This is because `notifyDataSetChanged` was called at some point and the change handler that was set when cache was loaded is gone.
