### PR TITLE
Fixe for Issue #1270

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -583,8 +583,8 @@
   <string name="gpx_import_loading_waypoints">Lade Wegpunkte aus GPX-Datei</string>
   <string name="gpx_import_store_static_maps">Schreibe statische Karten</string>
   <string name="gpx_import_storing">Schreibe Caches in Datenbank</string>
-  <string name="gpx_import_caches_imported">Caches importiert.</string>
-  <string name="gpx_import_caches_imported_maps_skipped">Caches importiert, Download statischer Karten abgebrochen.</string>
+  <string name="gpx_import_caches_imported">Caches importiert</string>
+  <string name="gpx_import_static_maps_skipped">Download statischer Karten abgebrochen</string>
   <string name="gpx_import_title">Importiere GPX-Datei</string>
   <string name="gpx_import_title_reading_file">Lese Datei</string>
   <string name="gpx_import_title_static_maps">Speichern statischer Karten</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -598,7 +598,7 @@
   <string name="gpx_import_store_static_maps">Storing static maps</string>
   <string name="gpx_import_storing">Writing caches to database</string>
   <string name="gpx_import_caches_imported">caches imported</string>
-  <string name="gpx_import_caches_imported_maps_skipped">caches imported, download of static maps aborted.</string>
+  <string name="gpx_import_static_maps_skipped">Download of static maps aborted</string>
   <string name="gpx_import_title_static_maps">Store static maps</string>
   <string name="gpx_import_title_reading_file">Reading file</string>
   <string name="gpx_import_title">Import GPX</string>
@@ -609,7 +609,7 @@
   <string name="gpx_import_error_unexpected">Unexpected error</string>
   <string name="gpx_import_confirm">Do you want to import the GPX file into c:geo?</string>
   <string name="gpx_import_canceled">GPX import was canceled</string>
-
+  
   <!-- map file select -->
   <string name="map_file_select_title">Select map file</string>
 

--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -12,6 +12,7 @@ import android.view.WindowManager;
 public class Progress {
 
     private ProgressDialog dialog;
+    private int progress = 0;
 
     public synchronized void dismiss() {
         if (dialog != null && dialog.isShowing()) {
@@ -25,6 +26,7 @@ public class Progress {
             dialog = ProgressDialog.show(context, title, message, indeterminate, cancelMessage != null);
             dialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             dialog.setProgress(0);
+            this.progress = 0;
             if (cancelMessage != null) {
                 dialog.setCancelMessage(cancelMessage);
             }
@@ -35,6 +37,7 @@ public class Progress {
         if (dialog == null) {
             dialog = new ProgressDialog(context);
             dialog.setProgress(0);
+            this.progress = 0;
             dialog.setTitle(title);
             dialog.setMessage(message);
             dialog.setProgressStyle(style);
@@ -71,5 +74,13 @@ public class Progress {
         if (dialog != null && dialog.isShowing()) {
             dialog.setProgress(progress);
         }
+        this.progress = progress;
+    }
+
+    public synchronized int getProgress() {
+        if (dialog != null) {
+            dialog.getProgress();
+        }
+        return this.progress;
     }
 }

--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -379,6 +379,7 @@ public class GPXImporter {
     final private Handler importStepHandler = new Handler() {
         @Override
         public void handleMessage(Message msg) {
+            StringBuffer buffer = null;
             switch (msg.what) {
                 case IMPORT_STEP_START:
                     Message cancelMessage = importStepHandler.obtainMessage(IMPORT_STEP_CANCEL);
@@ -394,14 +395,16 @@ public class GPXImporter {
 
                 case IMPORT_STEP_STORE_STATIC_MAPS:
                     progress.dismiss();
-                    Message skipMessage = importStepHandler.obtainMessage(IMPORT_STEP_STATIC_MAPS_SKIPPED);
+                    Message skipMessage = importStepHandler.obtainMessage(IMPORT_STEP_STATIC_MAPS_SKIPPED, msg.arg2, 0);
                     progress.show((Context) fromActivity, res.getString(R.string.gpx_import_title_static_maps), res.getString(R.string.gpx_import_store_static_maps), ProgressDialog.STYLE_HORIZONTAL, skipMessage);
                     progress.setMaxProgressAndReset(msg.arg2);
                     break;
 
                 case IMPORT_STEP_STATIC_MAPS_SKIPPED:
                     progress.dismiss();
-                    fromActivity.helpDialog(res.getString(R.string.gpx_import_title_caches_imported), msg.arg1 + " " + res.getString(R.string.gpx_import_caches_imported_maps_skipped));
+                    buffer = new StringBuffer(20);
+                    buffer.append(res.getString(R.string.gpx_import_static_maps_skipped)).append(", ").append(msg.arg1).append(" ").append(res.getString(R.string.gpx_import_caches_imported));
+                    fromActivity.helpDialog(res.getString(R.string.gpx_import_title_caches_imported), buffer.toString());
                     importFinished();
                     break;
 
@@ -423,7 +426,9 @@ public class GPXImporter {
                     break;
 
                 case IMPORT_STEP_CANCELED:
-                    fromActivity.showShortToast(res.getString(R.string.gpx_import_canceled));
+                    buffer = new StringBuffer(20);
+                    buffer.append(res.getString(R.string.gpx_import_canceled)).append(", ").append(progress.getProgress()).append(" ").append(res.getString(R.string.gpx_import_caches_imported));
+                    fromActivity.showShortToast(buffer.toString());
                     importFinished();
                     break;
 


### PR DESCRIPTION
This fixes the following on GPXImporter:
- cancel import of GPX-caches now shows number of caches imported
- cancel import of GPX-caches static maps now shows number of caches
- Progress now shows a cancel button if cancelMessage is given
- Progress now provides progress count after dialog is dismissed

The cancel button on Progress dialog will now show up every time a
cancelMessage is given. This is a better behaviour than cancel by
the back button.
