### PR TITLE
Modifications for exporting caches to Locus (#1282)

### DIFF
--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -210,6 +210,7 @@
   <string name="caches_refresh_selected">aktualizovat vybrané</string>
   <string name="caches_refresh_all">aktualizovat vše</string>
   <string name="caches_map_locus">Locus</string>
+  <string name="caches_map_locus_export">Exportovat do Locusu</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Opište text z obrázků. Je to důležité pro stažení souřadnic keší.</string>
   <string name="caches_recaptcha_hint">Text z obrázku</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -302,6 +302,7 @@
   <string name="caches_move_selected">Move selected</string>
   <string name="caches_move_all">Move all</string>
   <string name="caches_map_locus">Locus</string>
+  <string name="caches_map_locus_export">Export to Locus</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Please, write text from image. It\'s important to download coordinates of caches. It\'s optional and can be switched off in Settings.</string>
   <string name="caches_recaptcha_hint">Text from image</string>

--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -37,6 +37,10 @@ public abstract class AbstractLocusApp extends AbstractApp {
         super(getString(R.string.caches_map_locus), INTENT);
     }
 
+    protected AbstractLocusApp(final String text, final String intent) {
+        super(text, intent);
+    }
+
     @Override
     public boolean isInstalled(Context context) {
         return LocusUtils.isLocusAvailable(context);
@@ -52,7 +56,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
      * @param activity
      * @author koem
      */
-    protected static boolean showInLocus(final List<? extends Object> objectsToShow, final boolean withCacheWaypoints,
+    protected static boolean showInLocus(final List<? extends Object> objectsToShow, final boolean withCacheWaypoints, final boolean export,
             final Activity activity) {
         if (objectsToShow == null || objectsToShow.isEmpty()) {
             return false;
@@ -78,13 +82,13 @@ public abstract class AbstractLocusApp extends AbstractApp {
         }
 
         if (pd.getPoints().size() <= 1000) {
-            DisplayData.sendData(activity, pd, false);
+            DisplayData.sendData(activity, pd, export);
         } else {
             final ArrayList<PointsData> data = new ArrayList<PointsData>();
             data.add(pd);
             DisplayData.sendDataCursor(activity, data,
                     "content://" + LocusDataStorageProvider.class.getCanonicalName().toLowerCase(),
-                    false);
+                    export);
         }
 
         return true;

--- a/main/src/cgeo/geocaching/apps/cache/navi/LocusApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/LocusApp.java
@@ -34,7 +34,7 @@ class LocusApp extends AbstractLocusApp implements NavigationApp {
             points.add(waypoint);
         }
 
-        return showInLocus(points, true, activity);
+        return showInLocus(points, true, false, activity);
     }
 
 }

--- a/main/src/cgeo/geocaching/apps/cachelist/CacheListAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/cachelist/CacheListAppFactory.java
@@ -27,7 +27,8 @@ public final class CacheListAppFactory extends AbstractAppFactory {
         if (ArrayUtils.isEmpty(apps)) {
             apps = new CacheListApp[] {
                     new InternalCacheListMap(),
-                    new LocusCacheListApp() };
+                    new LocusCacheListApp(false),
+                    new LocusCacheListApp(true) };
         }
         return apps;
     }

--- a/main/src/cgeo/geocaching/apps/cachelist/LocusCacheListApp.java
+++ b/main/src/cgeo/geocaching/apps/cachelist/LocusCacheListApp.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.apps.cachelist;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgGeo;
@@ -8,10 +9,18 @@ import cgeo.geocaching.apps.AbstractLocusApp;
 import org.apache.commons.collections.CollectionUtils;
 
 import android.app.Activity;
+import android.content.Intent;
 
 import java.util.List;
 
 class LocusCacheListApp extends AbstractLocusApp implements CacheListApp {
+
+    private boolean export;
+
+    public LocusCacheListApp(boolean export) {
+        super(getString(export ? R.string.caches_map_locus_export : R.string.caches_map_locus), Intent.ACTION_VIEW);
+        this.export = export;
+    }
 
     /**
      * show caches in Locus
@@ -25,7 +34,7 @@ class LocusCacheListApp extends AbstractLocusApp implements CacheListApp {
             return false;
         }
 
-        showInLocus(cacheList, false, activity);
+        showInLocus(cacheList, false, export, activity);
 
         return true;
     }


### PR DESCRIPTION
This adds new option _Export to Locus_ to _Stored-Show On Map_ menu.
_Export to Locus_ works completely same as existing _Locus_ option but after opening Locus it asks about saving caches to its database (as I described in #1282).
