### PR TITLE
Remove useless intent filters for in-application activities

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -49,9 +49,6 @@
 			<intent-filter>
 				<action android:name="android.intent.action.SEARCH"/>
 			</intent-filter>
-			<intent-filter>
-				<action android:name="cgeo.geocaching.CGEOADVSEARCH"/>
-			</intent-filter>
 			<meta-data
 				android:name="android.app.searchable"
 				android:resource="@xml/searchable" />


### PR DESCRIPTION
As stated in the Android documentation, "an explicit intent is always delivered to its target, no matter what it contains; the filter is not consulted".

There are no advantage in letting those filters in, as the name described in the filter is never used.

I open this pull request in case I overlooked something here.
