### PR TITLE
Fix #1314 - Store OC caches to database on load and mark as detailed

### DIFF
--- a/main/src/cgeo/geocaching/connector/opencaching/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/opencaching/OkapiClient.java
@@ -4,10 +4,12 @@ import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgImage;
 import cgeo.geocaching.cgLog;
+import cgeo.geocaching.cgeoapplication;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.LogType;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.geopoint.GeopointFormatter;
@@ -28,6 +30,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
@@ -75,13 +78,7 @@ final public class OkapiClient {
             return null;
         }
 
-        final cgCache cache = parseCache(data);
-
-        long time = new Date().getTime();
-        cache.setUpdated(time);
-        cache.setDetailedUpdate(time);
-
-        return cache;
+        return parseCache(data);
     }
 
     public static List<cgCache> getCachesAround(final Geopoint center, IConnector connector) {
@@ -177,6 +174,12 @@ final public class OkapiClient {
             cache.setLogs(parseLogs(response.getJSONArray(CACHE_LATEST_LOGS)));
             cache.setHidden(parseDate(response.getString(CACHE_HIDDEN)));
 
+            cache.setUpdated(System.currentTimeMillis());
+            cache.setDetailedUpdate(cache.getUpdated());
+            cache.setDetailed(true);
+
+            // save full detailed caches
+            cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
         } catch (JSONException e) {
             Log.e(Settings.tag, "OkapiClient.parseCache", e);
         }

--- a/tests/src/cgeo/geocaching/connector/opencaching/OkapiClientTest.java
+++ b/tests/src/cgeo/geocaching/connector/opencaching/OkapiClientTest.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.connector.opencaching;
 
 import cgeo.geocaching.cgCache;
+import cgeo.geocaching.cgeoapplication;
+import cgeo.geocaching.enumerations.LoadFlags;
 
 import android.test.AndroidTestCase;
 
@@ -12,6 +14,14 @@ public class OkapiClientTest extends AndroidTestCase {
         assertNotNull(cache);
         assertEquals(geoCode, cache.getGeocode());
         assertEquals("Oshkosh Municipal Tank", cache.getName());
+        assertTrue(cache.isDetailed());
+
+        // cache should be stored to DB (to listID 0) when loaded above
+        cache = cgeoapplication.getInstance().loadCache(geoCode, LoadFlags.LOAD_ALL_DB_ONLY);
+        assertNotNull(cache);
+        assertEquals(geoCode, cache.getGeocode());
+        assertEquals("Oshkosh Municipal Tank", cache.getName());
+        assertTrue(cache.isDetailed());
     }
 
 }


### PR DESCRIPTION
Search was failing because when CacheDetailActivity loads a cache for display, it uses `LOAD_DB_ONLY` and the OkapiClient.parseCache did not save to database (under listID 0) which is done in cgBase.parseCache.

Cache was unable to be properly stored because it wasn't marked as detailed when it was being parsed.

Fixes #1314
