### PR TITLE
Add method to refresh cache and some cleanup

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.apps.cache.navi.NavigationAppFactory;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.enumerations.LoadFlags;
-import cgeo.geocaching.enumerations.LoadFlags.RemoveFlag;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.LogType;
 import cgeo.geocaching.enumerations.WaypointType;
@@ -1587,14 +1586,12 @@ public class CacheDetailActivity extends AbstractActivity {
                     storeThread = null;
 
                     try {
-                        cache = search.getFirstCacheFromResult(LoadFlags.LOAD_ALL_DB_ONLY); // reload cache details
+                        CacheDetailActivity.this.notifyDataSetChanged(); // reload cache details
                     } catch (Exception e) {
                         showToast(res.getString(R.string.err_store_failed));
 
                         Log.e(Settings.tag, "CacheDetailActivity.storeCacheHandler: " + e.toString());
                     }
-
-                    CacheDetailActivity.this.notifyDataSetChanged();
                 }
             }
 
@@ -1614,14 +1611,12 @@ public class CacheDetailActivity extends AbstractActivity {
                     refreshThread = null;
 
                     try {
-                        cache = search.getFirstCacheFromResult(LoadFlags.LOAD_ALL_DB_ONLY); // reload cache details
+                        CacheDetailActivity.this.notifyDataSetChanged(); // reload cache details
                     } catch (Exception e) {
                         showToast(res.getString(R.string.err_refresh_failed));
 
                         Log.e(Settings.tag, "CacheDetailActivity.refreshCacheHandler: " + e.toString());
                     }
-
-                    CacheDetailActivity.this.notifyDataSetChanged();
                 }
             }
 
@@ -1701,8 +1696,7 @@ public class CacheDetailActivity extends AbstractActivity {
 
             @Override
             public void run() {
-                app.removeCache(cache.getGeocode(), EnumSet.of(RemoveFlag.REMOVE_CACHE));
-                search = cgBase.searchByGeocode(cache.getGeocode(), null, 0, true, handler);
+                cgBase.refreshCache(CacheDetailActivity.this, cache.getGeocode(), cache.getListId(), handler);
 
                 handler.sendEmptyMessage(0);
             }

--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -1420,7 +1420,7 @@ public class cgCache implements ICache {
 
     public void store(Activity activity, CancellableHandler handler) {
         final int listId = Math.max(getListId(), StoredList.STANDARD_LIST_ID);
-        cgBase.storeCache(activity, this, null, listId, handler);
+        cgBase.storeCache(activity, this, null, listId, false, handler);
     }
 
     public int getZoomlevel() {

--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -1853,7 +1853,7 @@ public class cgeocaches extends AbstractListActivity {
                     }
 
                     detailProgress++;
-                    cgBase.storeCache(cgeocaches.this, cache, null, listIdLD, null);
+                    cgBase.refreshCache(cgeocaches.this, cache.getGeocode(), listIdLD, null);
 
                     handler.sendEmptyMessage(cacheList.indexOf(cache));
 
@@ -1916,7 +1916,7 @@ public class cgeocaches extends AbstractListActivity {
                         handler.sendMessage(handler.obtainMessage(1, GCcode));
                         yield();
 
-                        cgBase.storeCache(cgeocaches.this, null, GCcode, listIdLFW, null);
+                        cgBase.storeCache(cgeocaches.this, null, GCcode, listIdLFW, false, null);
 
                         handler.sendMessage(handler.obtainMessage(2, GCcode));
                         yield();

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1492,7 +1492,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                             break;
                         }
 
-                        cgBase.storeCache(activity, null, geocode, StoredList.STANDARD_LIST_ID, handler);
+                        cgBase.storeCache(activity, null, geocode, StoredList.STANDARD_LIST_ID, false, handler);
                     }
                 } catch (Exception e) {
                     Log.e(Settings.tag, "cgeocaches.LoadDetails.run: " + e.toString());

--- a/main/src/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/cgeo/geocaching/network/HtmlImage.java
@@ -74,6 +74,18 @@ public class HtmlImage implements Html.ImageGetter {
 
         Bitmap imagePre = null;
 
+        // if image is just being stored, check if online version is newer than stored version
+        if (onlySave) {
+            // returns 0 if file does not exists
+            final long localDate = LocalStorage.getStorageFile(geocode, url, true, false).lastModified();
+            // returns 0 if website does not support last modified date or error occurs
+            final long onlineDate = Network.requestLastModifiedDate(makeAbsoluteURL(url));
+            // image was stored since it was last changed online, so no need to download again
+            if (localDate > onlineDate) {
+                return null;
+            }
+        }
+
         // Load image from cache
         if (!onlySave) {
             imagePre = loadImageFromStorage(url);

--- a/main/src/cgeo/geocaching/network/Network.java
+++ b/main/src/cgeo/geocaching/network/Network.java
@@ -42,6 +42,9 @@ import android.util.Log;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
@@ -361,4 +364,23 @@ public abstract class Network {
 
         return encoded;
     }
+
+    /**
+     * Returns the value of the response header field <code>last-modified</code> or 0 if this value is not set.
+     * 
+     * @param url
+     *            to retrieve last modified date of
+     * @return the value of the <cod>last-modified</code> header field.
+     */
+    public static long requestLastModifiedDate(String url) {
+        try {
+            return ((HttpURLConnection) new URL(url).openConnection()).getLastModified();
+        } catch (MalformedURLException e) {
+            Log.e(Settings.tag, "Failed to get last modified date for: " + url + " " + e);
+        } catch (IOException e) {
+            Log.e(Settings.tag, "Failed to get last modified date for: " + url + " " + e);
+        }
+        return 0;
+    }
+
 }


### PR DESCRIPTION
- Function added to cgBase for `refreshCache`
- Added check in HTMLImage to prevent downloading an image if it hasn't been updated since last time it was downloaded (speeds up refreshes)
- When refresh or store in CacheDetailActivity, don't call `search.getFirstCacheFromResult` as it will be called in `notifyDataSetChanged`

Fixes #1064 and #1321.
Might help with #1315 and #1320, but requires more testing to determine.
