### PR TITLE
Fix #828: do not use an extra thread to update the data

### DIFF
--- a/main/src/cgeo/geocaching/utils/PeriodicHandler.java
+++ b/main/src/cgeo/geocaching/utils/PeriodicHandler.java
@@ -1,0 +1,74 @@
+package cgeo.geocaching.utils;
+
+import android.os.Handler;
+import android.os.Message;
+
+/**
+ * A PeriodicHandler class helps with the implementation of a periodic
+ * action embedded in a thread with a looper such as the UI thread.
+ * The act() method will be called periodically. The clock may drift
+ * as the implementation does not target real-time actions.
+ *
+ * The handler will be interrupted if the device goes to sleep.
+ *
+ */
+abstract public class PeriodicHandler extends Handler {
+
+    final static private int START = 0;
+    final static private int STOP = 1;
+    final static private int ACT = 2;
+
+    final private long period;
+
+    /**
+     * Create a new PeriodicHandler object.
+     *
+     * @param period
+     *            The period in milliseconds.
+     */
+    public PeriodicHandler(final long period) {
+        this.period = period;
+    }
+
+    /**
+     * Subclasses of PeriodicHandler must implement this method.
+     */
+    abstract public void act();
+
+    @Override
+    public void handleMessage(final Message msg) {
+        switch (msg.what) {
+            case START:
+                removeMessages(ACT);
+                sendEmptyMessage(ACT);
+                break;
+            case STOP:
+                removeMessages(ACT);
+                break;
+            case ACT:
+                sendEmptyMessageDelayed(ACT, period);
+                act();
+        }
+    }
+
+    /**
+     * Start the periodic handler.
+     *
+     * Restarting a handler that is already started will only
+     * reset its clock.
+     */
+    public void start() {
+        sendEmptyMessage(START);
+    }
+
+    /**
+     * Stop the periodic handler.
+     *
+     * If this method is called from the looper thread, this call is
+     * guaranteed to be synchronous.
+     */
+    public void stop() {
+        sendMessageAtFrontOfQueue(obtainMessage(STOP));
+    }
+
+}


### PR DESCRIPTION
There is no need to create an extra thread just to signal a handler.
The handler can signal itself periodically by using delayed messages.
