### PR TITLE
Fix for Issue #1331

### DIFF
--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -70,6 +70,7 @@ public class Progress {
             dialog.setMax(modMax);
             dialog.setProgress(0);
         }
+        this.progress = 0;
     }
 
     public synchronized void setProgress(final int progress) {

--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -399,10 +399,10 @@ public class GPXImporter {
                     break;
 
                 case IMPORT_STEP_STORE_CACHES:
-                    showProgressAfterCancel = true;
                     progress.setProgressDivider(1);
                     progress.setMessage(res.getString(msg.arg1));
                     progress.setMaxProgressAndReset(msg.arg2);
+                    showProgressAfterCancel = true;
                     break;
 
                 case IMPORT_STEP_STORE_STATIC_MAPS:


### PR DESCRIPTION
StaticMapsImport finishes normal on cancel to report the count.
I forgot to skip the following sendMessage (finished) that shows the second message.

Solution was to return a boolean from importStaticMaps showing if it finished or
was canceled.

A second issue was that skipping Waypoint file also was showing number of caches
although none was imported. That was because I didn't reset the internal progress
of Progress dialog on setMaxAndReset(int).

Both solved.
