### PR TITLE
make google maps api optional so that cgeo runs on x86 emulator

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 			android:label="@string/app_name"
 			android:icon="@drawable/cgeo"
 			android:backupAgent="cgeo.geocaching.backup.CentralBackupAgent" >
-		<uses-library android:name="com.google.android.maps" />
+		<uses-library android:name="com.google.android.maps" android:required="false" />
 		<meta-data
 			android:name="android.app.default_searchable"
 			android:value=".cgeoadvsearch" />

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -20,7 +20,14 @@ public class MapProviderFactory {
     private SortedMap<Integer, String> mapSources;
 
     private MapProviderFactory() {
-        mapProviders = new MapProvider[] { new GoogleMapProvider(GOOGLEMAP_BASEID), new MapsforgeMapProvider(MFMAP_BASEID) };
+        // add GoogleMapProvider only if google api is available in order to support x86 android emulator
+        try {
+            Class.forName("com.google.android.maps.MapActivity");
+            mapProviders = new MapProvider[] { new GoogleMapProvider(GOOGLEMAP_BASEID), new MapsforgeMapProvider(MFMAP_BASEID) };
+        } catch (ClassNotFoundException e) {
+            mapProviders = new MapProvider[] { new MapsforgeMapProvider(MFMAP_BASEID) };
+        }
+
         mapSources = new TreeMap<Integer, String>();
         for (MapProvider mp : mapProviders) {
             mapSources.putAll(mp.getMapSources());


### PR DESCRIPTION
- x86 system images in virtualization mode allows much faster dev cycles (since SDK r17)
- GoogleMapProvider is added only if google map api is detected at run time
