### PR TITLE
Deactivate debug info in release mode

### DIFF
--- a/main/res/layout/init.xml
+++ b/main/res/layout/init.xml
@@ -870,44 +870,50 @@
 					android:linksClickable="true"
 					android:text="@string/init_backup_note" />
 <!-- ** -->
-			<RelativeLayout style="@style/separator_horizontal_layout" >
-				<View style="@style/separator_horizontal" />
-				<TextView
-				    style="@style/separator_horizontal_headline"
-					android:text="@string/init_debug_title" />
-			</RelativeLayout>
-			<TextView
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_marginLeft="10dip"
-				android:layout_marginRight="10dip"
-				android:layout_marginBottom="5dip"
-				android:layout_gravity="left"
-				android:padding="3dip"
-				android:textSize="14dip"
-				android:textColor="?text_color"
-				android:textColorLink="?text_color_link"
-				android:linksClickable="true"
-				android:text="@string/init_debug_note" />
 			<LinearLayout
-				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:orientation="horizontal" >
-				<CheckBox android:id="@+id/debug"
-					android:layout_width="wrap_content"
-					android:layout_height="wrap_content"
-					android:layout_gravity="left"
-					android:padding="1px"
-					android:gravity="center" />
+					android:id="@+id/debug_section"
+					android:layout_width="fill_parent"
+					android:layout_height="fill_parent"
+					android:orientation="vertical">
+				<RelativeLayout style="@style/separator_horizontal_layout" >
+					<View style="@style/separator_horizontal" />
+					<TextView
+					    style="@style/separator_horizontal_headline"
+						android:text="@string/init_debug_title" />
+				</RelativeLayout>
 				<TextView
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
-					android:layout_gravity="center_vertical"
-					android:gravity="left"
-					android:paddingRight="3dip"
+					android:layout_marginLeft="10dip"
+					android:layout_marginRight="10dip"
+					android:layout_marginBottom="5dip"
+					android:layout_gravity="left"
+					android:padding="3dip"
 					android:textSize="14dip"
 					android:textColor="?text_color"
-					android:text="@string/init_debug" />
+					android:textColorLink="?text_color_link"
+					android:linksClickable="true"
+					android:text="@string/init_debug_note" />
+				<LinearLayout
+					android:layout_width="fill_parent"
+					android:layout_height="wrap_content"
+					android:orientation="horizontal" >
+					<CheckBox android:id="@+id/debug"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_gravity="left"
+						android:padding="1px"
+						android:gravity="center" />
+					<TextView
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_gravity="center_vertical"
+						android:gravity="left"
+						android:paddingRight="3dip"
+						android:textSize="14dip"
+						android:textColor="?text_color"
+						android:text="@string/init_debug" />
+				</LinearLayout>
 			</LinearLayout>
 		</LinearLayout>
 	</ScrollView>

--- a/main/src/cgeo/geocaching/cgeoinit.java
+++ b/main/src/cgeo/geocaching/cgeoinit.java
@@ -670,16 +670,21 @@ public class cgeoinit extends AbstractActivity {
         refreshBackupLabel();
 
         // Debug settings
-        final CheckBox debugButton = (CheckBox) findViewById(R.id.debug);
-        debugButton.setChecked(Settings.isDebug());
-        debugButton.setOnClickListener(new View.OnClickListener() {
+        if (BuildConfig.DEBUG) {
+            final CheckBox debugButton = (CheckBox) findViewById(R.id.debug);
+            debugButton.setChecked(Settings.isDebug());
+            debugButton.setOnClickListener(new View.OnClickListener() {
 
-            @Override
-            public void onClick(View v) {
-                Settings.setDebug(!Settings.isDebug());
-                debugButton.setChecked(Settings.isDebug());
-            }
-        });
+                @Override
+                public void onClick(View v) {
+                    Settings.setDebug(!Settings.isDebug());
+                    debugButton.setChecked(Settings.isDebug());
+                }
+            });
+        } else {
+            final ViewGroup debugSection = (ViewGroup) findViewById(R.id.debug_section);
+            debugSection.removeAllViews();
+        }
     }
 
     private void initMapfileEdittext(boolean setFocus) {

--- a/main/src/cgeo/geocaching/utils/Log.java
+++ b/main/src/cgeo/geocaching/utils/Log.java
@@ -1,41 +1,48 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.BuildConfig;
 import cgeo.geocaching.Settings;
 
 final public class Log {
 
+    // A warning may be issued when DEBUG is false
+    @SuppressWarnings("unused")
+    private static boolean debugEnabled() {
+        return BuildConfig.DEBUG && Settings.isDebug();
+    }
+
     public static void v(final String tag, final String msg) {
-        if (Settings.isDebug()) {
+        if (debugEnabled()) {
             android.util.Log.v(tag, msg);
         }
     }
 
     public static void v(final String tag, final String msg, final Throwable t) {
-        if (Settings.isDebug()) {
+        if (debugEnabled()) {
             android.util.Log.v(tag, msg, t);
         }
     }
 
     public static void d(final String tag, final String msg) {
-        if (Settings.isDebug()) {
+        if (debugEnabled()) {
             android.util.Log.d(tag, msg);
         }
     }
 
     public static void d(final String tag, final String msg, final Throwable t) {
-        if (Settings.isDebug()) {
+        if (debugEnabled()) {
             android.util.Log.d(tag, msg, t);
         }
     }
 
     public static void i(final String tag, final String msg) {
-        if (Settings.isDebug()) {
+        if (debugEnabled()) {
             android.util.Log.i(tag, msg);
         }
     }
 
     public static void i(final String tag, final String msg, final Throwable t) {
-        if (Settings.isDebug()) {
+        if (debugEnabled()) {
             android.util.Log.i(tag, msg, t);
         }
     }


### PR DESCRIPTION
See issue #1301 for a discussion about this.

Do not merge while we do not have the infrastructure to generate two versions:
- one with debugging information
- one without debugging information

so that we can ask a user to replace the version they're using (without debugging information) with a version with debugging information.

Also, we should decide whether nightly builds get debug information or not (RC should probably not).
