### PR TITLE
StaticMaps for waypoints default now off

### DIFF
--- a/main/src/cgeo/geocaching/Settings.java
+++ b/main/src/cgeo/geocaching/Settings.java
@@ -539,7 +539,7 @@ public final class Settings {
     }
 
     public static boolean isStoreOfflineWpMaps() {
-        return 0 != sharedPrefs.getInt(KEY_USE_OFFLINEWPMAPS, 1);
+        return 0 != sharedPrefs.getInt(KEY_USE_OFFLINEWPMAPS, 0);
     }
 
     public static void setStoreOfflineWpMaps(final boolean offlineMaps) {


### PR DESCRIPTION
Just switched default for waypoints static maps to 0 (OFF) in Settings.
