### PR TITLE
navigation static maps only if map exists

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.Progress;
 import cgeo.geocaching.apps.cache.GeneralAppsFactory;
 import cgeo.geocaching.apps.cache.navi.NavigationAppFactory;
+import cgeo.geocaching.apps.cache.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.GCParser;
@@ -521,7 +522,11 @@ public class CacheDetailActivity extends AbstractActivity {
             menu.add(0, MENU_DEFAULT_NAVIGATION, 0, NavigationAppFactory.getDefaultNavigationApplication(this).getName()).setIcon(R.drawable.ic_menu_compass); // default navigation tool
 
             final SubMenu subMenu = menu.addSubMenu(1, 0, 0, res.getString(R.string.cache_menu_navigate)).setIcon(R.drawable.ic_menu_mapmode);
-            NavigationAppFactory.addMenuItems(subMenu, this);
+            List<NavigationAppsEnum> filter = new ArrayList<NavigationAppsEnum>(1);
+            if (!StaticMapsProvider.doesExistStaticMapForCache(cache.getGeocode())) {
+                filter.add(NavigationAppsEnum.STATIC_MAP);
+            }
+            NavigationAppFactory.addMenuItems(subMenu, this, filter);
             GeneralAppsFactory.addMenuItems(subMenu, this, cache);
 
             menu.add(1, MENU_CALENDAR, 0, res.getString(R.string.cache_menu_event)).setIcon(R.drawable.ic_menu_agenda); // add event to calendar

--- a/main/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
@@ -4,10 +4,10 @@ import cgeo.geocaching.IGeoData;
 import cgeo.geocaching.R;
 import cgeo.geocaching.Settings;
 import cgeo.geocaching.StaticMapsProvider;
-import cgeo.geocaching.apps.AbstractAppFactory;
 import cgeo.geocaching.cgCache;
 import cgeo.geocaching.cgWaypoint;
 import cgeo.geocaching.cgeoapplication;
+import cgeo.geocaching.apps.AbstractAppFactory;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.utils.Log;
 
@@ -196,30 +196,32 @@ public final class NavigationAppFactory extends AbstractAppFactory {
      * @param menu
      * @param activity
      */
-    public static void addMenuItems(final Menu menu, final Activity activity) {
-        addMenuItems(menu, activity, true, false);
+    public static void addMenuItems(final Menu menu, final Activity activity, List<NavigationAppsEnum> filter) {
+        addMenuItems(menu, activity, false, filter);
     }
 
     /**
      * Adds the installed navigation tools to the given menu.
      * Use {@link #onMenuItemSelected(MenuItem, IGeoData, Activity, cgCache, cgWaypoint, Geopoint)} on
      * selection event to start the selected navigation tool.
-     *
+     * 
      * <b>Only use this way if
      * {@link #showNavigationMenu(IGeoData, Activity, cgCache, cgWaypoint, Geopoint, boolean, boolean)} is
      * not suitable for the given usecase.</b>
-     *
+     * 
      * @param menu
      * @param activity
-     * @param showInternalMap
      * @param showDefaultNavigation
+     * @param filter
+     *            Remove this items from the menu
      */
-    public static void addMenuItems(final Menu menu, final Activity activity,
-            final boolean showInternalMap, final boolean showDefaultNavigation) {
+    public static void addMenuItems(final Menu menu, final Activity activity, final boolean showDefaultNavigation, List<NavigationAppsEnum> filter) {
         final int defaultNavigationTool = Settings.getDefaultNavigationTool();
         for (NavigationAppsEnum navApp : getInstalledNavigationApps(activity)) {
-            if ((showInternalMap || !(navApp.app instanceof InternalMap)) &&
-                    (showDefaultNavigation || defaultNavigationTool != navApp.id)) {
+            if (filter.contains(navApp)) {
+                continue;
+            }
+            if (showDefaultNavigation || defaultNavigationTool != navApp.id) {
                 menu.add(0, MENU_ITEM_OFFSET + navApp.id, 0, navApp.app.getName());
             }
         }

--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -1497,15 +1497,15 @@ public class cgCache implements ICache, IWaypoint {
                 return;
             }
 
-            // store map previews
-            StaticMapsProvider.downloadMaps(cache, activity);
+            cache.setListId(listId);
+            cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
 
             if (CancellableHandler.isCancelled(handler)) {
                 return;
             }
 
-            cache.setListId(listId);
-            cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
+            // store map previews
+            StaticMapsProvider.downloadMaps(cache, activity);
 
             if (handler != null) {
                 handler.sendMessage(Message.obtain());

--- a/main/src/cgeo/geocaching/cgeowaypoint.java
+++ b/main/src/cgeo/geocaching/cgeowaypoint.java
@@ -2,6 +2,7 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.apps.cache.navi.NavigationAppFactory;
+import cgeo.geocaching.apps.cache.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.utils.IObserver;
@@ -26,7 +27,9 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 public class cgeowaypoint extends AbstractActivity implements IObserver<IGeoData> {
 
@@ -336,7 +339,11 @@ public class cgeowaypoint extends AbstractActivity implements IObserver<IGeoData
             ContextMenuInfo menuInfo) {
         if (navigationPossible()) {
             menu.setHeaderTitle(res.getString(R.string.cache_menu_navigate));
-            NavigationAppFactory.addMenuItems(menu, this);
+            List<NavigationAppsEnum> filter = new ArrayList<NavigationAppsEnum>(1);
+            if (!StaticMapsProvider.doesExistStaticMapForWaypoint(waypoint.getGeocode(), waypoint.getId())) {
+                filter.add(NavigationAppsEnum.STATIC_MAP);
+            }
+            NavigationAppFactory.addMenuItems(menu, this, filter);
         }
     }
 


### PR DESCRIPTION
Now for cache navigation menu there is only a Static Maps item if a static map exists for cache.
Original waypoints now also have static maps. Had to move storage of static maps behind the
storage of waypoints because the waypointId is given there and needed for storage file.
