### PR TITLE
Solves original waypoints had no static maps

### DIFF
--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -1497,15 +1497,14 @@ public class cgCache implements ICache, IWaypoint {
                 return;
             }
 
-            // store map previews
-            StaticMapsProvider.downloadMaps(cache);
+            cache.setListId(listId);
+            cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
 
             if (CancellableHandler.isCancelled(handler)) {
                 return;
             }
 
-            cache.setListId(listId);
-            cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
+            StaticMapsProvider.downloadMaps(cache);
 
             if (handler != null) {
                 handler.sendMessage(Message.obtain());


### PR DESCRIPTION
Solves that original waypoints downloaded got no static maps because of missing waypoint id.
