### PR TITLE
Add additional progress message when loading caches

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -517,6 +517,7 @@
   <string name="cache_dialog_loading_details_status_waypoints">Processing waypoints</string>
   <string name="cache_dialog_loading_details_status_gcvote">Loading GCVote</string>
   <string name="cache_dialog_loading_details_status_elevation">Loading elevation data</string>
+  <string name="cache_dialog_loading_details_status_cache">Caching Data</string>
   <string name="cache_dialog_loading_details_status_render">Render view</string>
   <string name="cache_dialog_offline_save_title">Offline</string>
   <string name="cache_dialog_offline_save_message">Saving cache for offline use…</string>

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -316,11 +316,14 @@ public abstract class GCParser {
             if (CancellableHandler.isCancelled(handler)) {
                 return null;
             }
-            // update progress message so user knows we're still working. Otherwise it will remain on whatever was set
-            // in getExtraOnlineInfo (which could be logs, gcvote, or elevation)
-            CancellableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_render);
+
             // save full detailed caches
+            CancellableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_cache);
             cgeoapplication.getInstance().saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
+
+            // update progress message so user knows we're still working. This is more of a place holder than
+            // actual indication of what the program is doing
+            CancellableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_render);
         }
         return searchResult;
     }


### PR DESCRIPTION
This is done so that "Render View" isn't shown for such a long time, since that isn't what is actually happening.
This is in preparations for making Refresh from popup show the progress statements (in that case, there should be no view rendered at all, but the statement will still show since it is a catch all).
