### PR TITLE
Don't reset distance in popups to "--" when updating U/I elements

### DIFF
--- a/main/src/cgeo/geocaching/AbstractPopupActivity.java
+++ b/main/src/cgeo/geocaching/AbstractPopupActivity.java
@@ -276,7 +276,9 @@ public abstract class AbstractPopupActivity extends AbstractActivity {
         details.addCacheState(cache);
 
         // distance
-        details.add(R.string.cache_distance, "--");
+        // if there is already a distance in cacheDistance, use it instead of resetting to default.
+        // this prevents displaying "--" while waiting for a new position update (See bug #1468)
+        details.add(R.string.cache_distance, cacheDistance != null ? cacheDistance.getText().toString() : "--");
         cacheDistance = details.getValueView();
 
         details.addDifficulty(cache);


### PR DESCRIPTION
This is a fix to additional occurrences of problem discussed in #1468.
Current code resets distance to "--" every time interface is updated (such as screen rotated, cache refreshed or stored [after merging pull request 1507]).

Instead of deleting and adding back the geoObserver each time, its easier just to reuse data that we already have.
