### PR TITLE
Fix OSM offline zoom issues - #1485

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -50,7 +50,7 @@ public class MapsforgeMapView extends MapView implements MapViewImpl {
     @Override
     public void draw(Canvas canvas) {
         try {
-            if (getMapZoomLevel() >= 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
+            if (getMapZoomLevel() > 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
                 getController().setZoom(22);
             }
 
@@ -171,7 +171,7 @@ public class MapsforgeMapView extends MapView implements MapViewImpl {
 
     @Override
     public int getMapZoomLevel() {
-        return getMapPosition().getZoomLevel() + 1;
+        return getMapPosition().getZoomLevel();
     }
 
     @Override


### PR DESCRIPTION
Don't overstate map zoom level (by adding the +1).
Don't reset zoom to 22 if it already is 22 (remove the = check).

Would appreciate review by @rsudev

Fixes #1485
