### PR TITLE
Fixes issue #1511 endless loop downloading static maps on demand

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -146,6 +146,7 @@
   <string name="err_detail_cache_find_next">c:geo konnte die nächsten Caches nicht finden.</string>
   <string name="err_detail_cache_forgot">c:geo hat vergessen, welcher Cache aufgerufen werden sollte.</string>
   <string name="err_detail_cache_forgot_visit">c:geo hat vergessen, welcher Cache besucht werden sollte.</string>
+  <string name="err_detail_google_maps_limit_reached">c:geo kann die statischen Karten nicht herunterladen. Google Maps Limit könnte erreicht sein.</string>
   <string name="err_detail_no_spoiler">c:geo hat kein Hinweisbild für diesen Cache gefunden.</string>
   <string name="err_detail_no_map_static">c:geo hat keine statische Karte für diesen Cache gefunden.</string>
   <string name="err_detail_not_load_map_static">c:geo konnte die statische Karte nicht laden.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -146,6 +146,7 @@
   <string name="err_detail_cache_find_next">c:geo can\'t find next geocaches.</string>
   <string name="err_detail_cache_forgot">c:geo forgot which geocache you want.</string>
   <string name="err_detail_cache_forgot_visit">c:geo forgot which cache you visited.</string>
+  <string name="err_detail_google_maps_limit_reached">c:geo failed to download static maps. Maybe google maps limit is reached.</string>
   <string name="err_detail_no_spoiler">c:geo found no spoiler images for this cache.</string>
   <string name="err_detail_no_map_static">c:geo found no static maps for this cache.</string>
   <string name="err_detail_not_load_map_static">c:geo failed to load static maps.</string>

--- a/main/src/cgeo/geocaching/StaticMapsActivity.java
+++ b/main/src/cgeo/geocaching/StaticMapsActivity.java
@@ -42,13 +42,16 @@ public class StaticMapsActivity extends AbstractActivity {
             try {
                 if (CollectionUtils.isEmpty(maps)) {
                     if (download) {
-                        downloadStaticMaps();
-                        startActivity(StaticMapsActivity.this.getIntent());
-                        finish();
+                        final boolean succeeded = downloadStaticMaps();
+                        if (succeeded) {
+                            startActivity(StaticMapsActivity.this.getIntent());
+                        } else {
+                            showToast(res.getString(R.string.err_detail_google_maps_limit_reached));
+                        }
                     } else {
                         showToast(res.getString(R.string.err_detail_not_load_map_static));
-                        finish();
                     }
+                    finish();
                 } else {
                     showStaticMaps();
                 }
@@ -188,19 +191,20 @@ public class StaticMapsActivity extends AbstractActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    private void downloadStaticMaps() {
+    private boolean downloadStaticMaps() {
         final cgCache cache = app.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
         if (waypoint_id == null) {
             showToast(res.getString(R.string.info_storing_static_maps));
             StaticMapsProvider.storeCacheStaticMap(cache, this, true);
-        } else {
-            final cgWaypoint waypoint = cache.getWaypointById(waypoint_id);
-            if (waypoint != null) {
-                showToast(res.getString(R.string.info_storing_static_maps));
-                StaticMapsProvider.storeWaypointStaticMap(cache, this, waypoint, true);
-            } else {
-                showToast(res.getString(R.string.err_detail_not_load_map_static));
-            }
+            return StaticMapsProvider.doesExistStaticMapForCache(geocode);
         }
+        final cgWaypoint waypoint = cache.getWaypointById(waypoint_id);
+        if (waypoint != null) {
+            showToast(res.getString(R.string.info_storing_static_maps));
+            StaticMapsProvider.storeWaypointStaticMap(cache, this, waypoint, true);
+            return StaticMapsProvider.doesExistStaticMapForWaypoint(geocode, waypoint_id);
+        }
+        showToast(res.getString(R.string.err_detail_not_load_map_static));
+        return false;
     }
 }


### PR DESCRIPTION
This fixes an endless loop in StaticMapsActivity if "download static maps" is chosen from navigation menu and google maps limit is already reached.

Now I check if files exist and give user feedback, finishing the activity.
