### PR TITLE
Fix #1430: Watchlist state toggling not recorded

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1634,7 +1634,11 @@ public class CacheDetailActivity extends AbstractActivity {
 
             @Override
             public void run() {
-                handler.sendEmptyMessage(GCConnector.addToWatchlist(cache));
+                final int result = GCConnector.addToWatchlist(cache);
+                if (-1 != result) {
+                    app.saveCache(cache, cache.getListId() != StoredList.TEMPORARY_LIST_ID ? LoadFlags.SAVE_ALL : EnumSet.of(SaveFlag.SAVE_CACHE));
+                }
+                handler.sendEmptyMessage(result);
             }
         }
 
@@ -1648,7 +1652,11 @@ public class CacheDetailActivity extends AbstractActivity {
 
             @Override
             public void run() {
-                handler.sendEmptyMessage(GCConnector.removeFromWatchlist(cache));
+                final int result = GCConnector.removeFromWatchlist(cache);
+                if (-1 != result) {
+                    app.saveCache(cache, cache.getListId() != StoredList.TEMPORARY_LIST_ID ? LoadFlags.SAVE_ALL : EnumSet.of(SaveFlag.SAVE_CACHE));
+                }
+                handler.sendEmptyMessage(result);
             }
         }
 


### PR DESCRIPTION
This adds a call to store the cache in the cache/database. Not really nice, but it works.
