### PR TITLE
fixes #1512 : deletes all static maps for waypoints of a cache on refresh

### DIFF
--- a/main/src/cgeo/geocaching/StaticMapsProvider.java
+++ b/main/src/cgeo/geocaching/StaticMapsProvider.java
@@ -88,6 +88,8 @@ public class StaticMapsProvider {
 
         // download static map for current waypoints
         if (Settings.isStoreOfflineWpMaps() && CollectionUtils.isNotEmpty(cache.getWaypoints())) {
+            // remove all waypoint static map files due to origin cache waypoint id changed on saveCache
+            LocalStorage.deleteFilesWithPrefix(cache.getGeocode(), "map_wp");
             for (cgWaypoint waypoint : cache.getWaypoints()) {
                 storeWaypointStaticMap(cache.getGeocode(), edge, waypoint, false);
             }
@@ -181,7 +183,7 @@ public class StaticMapsProvider {
         return MARKERS_URL + "marker_waypoint_" + type + ".png";
     }
 
-    public static void removeWpStaticMaps(int wp_id, String geocode) {
+    public static void removeWpStaticMaps(int wp_id, final String geocode) {
         for (int level = 1; level <= 5; level++) {
             try {
                 if (wp_id > 0) {

--- a/main/src/cgeo/geocaching/files/LocalStorage.java
+++ b/main/src/cgeo/geocaching/files/LocalStorage.java
@@ -15,6 +15,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -320,4 +321,48 @@ public class LocalStorage {
         return path.delete();
     }
 
+    /**
+     * Deletes all files from directory geocode with the given prefix.
+     *
+     * @param geocode
+     *            The geocode identifying the cache directory
+     * @param prefix
+     *            The filename prefix
+     */
+    public static void deleteFilesWithPrefix(final String geocode, final String prefix) {
+        final File[] filesToDelete = getFilesWithPrefix(geocode, prefix);
+        for (final File file : filesToDelete) {
+            try {
+                if (!file.delete()) {
+                    Log.w("LocalStorage.deleteFilesPrefix: Can't delete file " + file.getName());
+                }
+            } catch (Exception e) {
+                Log.e("LocalStorage.deleteFilesPrefix: " + e.toString());
+            }
+        }
+    }
+
+    /**
+     * Get an array of all files of the geocode directory starting with
+     * the given filenamePrefix.
+     *
+     * @param geocode
+     *            The geocode identifying the cache data directory
+     * @param filenamePrefix
+     *            The prefix of the files
+     * @return File[] the array of files starting with filenamePrefix in geocode directory
+     */
+    public static File[] getFilesWithPrefix(final String geocode, final String filenamePrefix) {
+        final FilenameFilter filter = new FilenameFilter() {
+            public boolean accept(File dir, String filename) {
+                if (filename.startsWith(filenamePrefix)) {
+                    return true;
+                }
+                return false;
+            }
+        };
+        final File gcDir = LocalStorage.getStorageDir(geocode);
+        final File[] found = gcDir.listFiles(filter);
+        return found;
+    }
 }


### PR DESCRIPTION
Added remove waypoint static map files on download of the whole cache static maps.
This removes also waypoint static maps not referenced any more cleaning up diretories.

The refactoring issues mentions in #1512 have been put into 2 other issues.
