### PR TITLE
fixes #1557: renaming methods to better fit the underlying code

### DIFF
--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -404,7 +404,7 @@ public class EditWaypointActivity extends AbstractActivity implements IObserver<
             waypoint.setId(id);
 
             cgCache cache = app.loadCache(geocode, LoadFlags.LOAD_WAYPOINTS);
-            if (null != cache && cache.addWaypoint(waypoint, true)) {
+            if (null != cache && cache.addOrChangeWaypoint(waypoint, true)) {
                 app.saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
                 StaticMapsProvider.removeWpStaticMaps(id, geocode);
                 if (Settings.isStoreOfflineWpMaps()) {

--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -1108,7 +1108,7 @@ public class cgCache implements ICache, IWaypoint {
      *            called while loading or building a cache
      * @return <code>true</code> if waypoint successfully added to waypoint database
      */
-    public boolean addWaypoint(final cgWaypoint waypoint, boolean saveToDatabase) {
+    public boolean addOrChangeWaypoint(final cgWaypoint waypoint, boolean saveToDatabase) {
         if (null == waypoints) {
             waypoints = new ArrayList<cgWaypoint>();
         }
@@ -1130,7 +1130,7 @@ public class cgCache implements ICache, IWaypoint {
             resetFinalDefined();
         }
 
-        return saveToDatabase && cgeoapplication.getInstance().saveOwnWaypoint(waypoint.getId(), geocode, waypoint);
+        return saveToDatabase && cgeoapplication.getInstance().saveWaypoint(waypoint.getId(), geocode, waypoint);
     }
 
     public boolean hasWaypoints() {
@@ -1182,7 +1182,7 @@ public class cgCache implements ICache, IWaypoint {
         copy.setUserDefined();
         copy.setName(cgeoapplication.getInstance().getString(R.string.waypoint_copy_of) + " " + copy.getName());
         waypoints.add(index + 1, copy);
-        return cgeoapplication.getInstance().saveOwnWaypoint(-1, geocode, copy);
+        return cgeoapplication.getInstance().saveWaypoint(-1, geocode, copy);
     }
 
     /**
@@ -1285,7 +1285,7 @@ public class cgCache implements ICache, IWaypoint {
                         final String name = cgeoapplication.getInstance().getString(R.string.cache_personal_note) + " " + count;
                         final cgWaypoint waypoint = new cgWaypoint(name, WaypointType.WAYPOINT, false);
                         waypoint.setCoords(point);
-                        addWaypoint(waypoint, false);
+                        addOrChangeWaypoint(waypoint, false);
                         count++;
                     }
                 } catch (Geopoint.ParseException e) {

--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -1028,7 +1028,7 @@ public class cgData {
 
         try {
             saveAttributesWithoutTransaction(cache);
-            saveWaypointsWithoutTransaction(cache);
+            saveOriginalWaypointsWithoutTransaction(cache);
             saveSpoilersWithoutTransaction(cache);
             saveLogsWithoutTransaction(cache.getGeocode(), cache.getLogs());
             saveLogCountsWithoutTransaction(cache);
@@ -1103,7 +1103,7 @@ public class cgData {
         databaseRW.beginTransaction();
 
         try {
-            saveWaypointsWithoutTransaction(cache);
+            saveOriginalWaypointsWithoutTransaction(cache);
             databaseRW.setTransactionSuccessful();
             result = true;
         } catch (Exception e) {
@@ -1114,7 +1114,7 @@ public class cgData {
         return result;
     }
 
-    private void saveWaypointsWithoutTransaction(final cgCache cache) {
+    private void saveOriginalWaypointsWithoutTransaction(final cgCache cache) {
         String geocode = cache.getGeocode();
         databaseRW.delete(dbTableWaypoints, "geocode = ? and type <> ? and own = 0", new String[] { geocode, "own" });
 
@@ -1177,7 +1177,7 @@ public class cgData {
         return new Geopoint(cursor.getDouble(indexLat), cursor.getDouble(indexLon));
     }
 
-    public boolean saveOwnWaypoint(int id, String geocode, cgWaypoint waypoint) {
+    public boolean saveWaypoint(int id, String geocode, cgWaypoint waypoint) {
         if ((StringUtils.isBlank(geocode) && id <= 0) || waypoint == null) {
             return false;
         }

--- a/main/src/cgeo/geocaching/cgeoapplication.java
+++ b/main/src/cgeo/geocaching/cgeoapplication.java
@@ -292,8 +292,8 @@ public class cgeoapplication extends Application {
         return storage.saveWaypoints(cache);
     }
 
-    public boolean saveOwnWaypoint(int id, String geocode, cgWaypoint waypoint) {
-        if (storage.saveOwnWaypoint(id, geocode, waypoint)) {
+    public boolean saveWaypoint(int id, String geocode, cgWaypoint waypoint) {
+        if (storage.saveWaypoint(id, geocode, waypoint)) {
             this.removeCache(geocode, EnumSet.of(RemoveFlag.REMOVE_CACHE));
             return true;
         }

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -618,7 +618,7 @@ public abstract class GCParser {
             if (null != originalCoords) {
                 final cgWaypoint waypoint = new cgWaypoint(cgeoapplication.getInstance().getString(R.string.cache_coordinates_original), WaypointType.WAYPOINT, false);
                 waypoint.setCoords(new Geopoint(originalCoords));
-                cache.addWaypoint(waypoint, false);
+                cache.addOrChangeWaypoint(waypoint, false);
                 cache.setUserModifiedCoords(true);
             }
         } catch (Geopoint.GeopointException e) {
@@ -688,7 +688,7 @@ public abstract class GCParser {
                     // waypoint note
                     waypoint.setNote(BaseUtils.getMatch(wp[3], GCConstants.PATTERN_WPNOTE, waypoint.getNote()));
 
-                    cache.addWaypoint(waypoint, false);
+                    cache.addOrChangeWaypoint(waypoint, false);
                 }
             }
         }


### PR DESCRIPTION
Renamed some methods to better fit the code.
- storeWaypointWithoutTransaction is deleting and storing only original waypoints, renamed to storeOriginalWaypointsWithoutTransaction
- storeOwnWaypoint is renamed to storeWaypoint because it stores own and original waypoints
- addWaypoint is renamed to addOrChangeWaypoint because a waypoint without id is added and a waypoint with id is changed/updated
