### PR TITLE
DO NOT MERGE: Fix: when having wpt treshold 0, waypoints are displayed on map from cache detail

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1074,7 +1074,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                     }
                 }
                 countVisibleCaches();
-                if (cachesCnt < Settings.getWayPointsThreshold())
+                if (cachesCnt < Settings.getWayPointsThreshold() || geocodeIntent != null || searchIntent != null)
                 {
                     waypoints.clear();
                     if (searchIntent == null && geocodeIntent == null) {


### PR DESCRIPTION
this fix is not correct now (it adds another bug)
