### PR TITLE
Ensure zoom doesn't exceed max zoom when changing map sources

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -750,6 +750,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
             mapRestart();
         } else if (mapView != null) {
             mapView.setMapSource();
+            mapController = mapView.getMapController();
         }
 
         return restartRequired;

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -184,6 +184,13 @@ public class MapsforgeMapView extends MapView implements MapViewImpl {
         }
 
         MapGenerator mapGenerator = MapGeneratorFactory.createMapGenerator(newMapType);
+
+        // When swapping map sources, make sure we aren't exceeding max zoom. See bug #1535
+        final int maxZoom = mapGenerator.getZoomLevelMax();
+        if (getMapPosition().getZoomLevel() > maxZoom) {
+            getController().setZoom(maxZoom);
+        }
+
         setMapGenerator(mapGenerator);
         if (!mapGenerator.requiresInternetConnection()) {
             setMapFile(new File(Settings.getMapFile()));


### PR DESCRIPTION
When map source is set, make sure the current zoom does not exceed max zoom.
Also, in CGeoMap, we need to get the new controller as it has the max zoom set inside (which could have changed)

Fixes #1535
