### PR TITLE
Remember the last trackable logging action to use as default next time

### DIFF
--- a/main/src/cgeo/geocaching/Settings.java
+++ b/main/src/cgeo/geocaching/Settings.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.connector.gc.Login;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LiveMapStrategy.Strategy;
+import cgeo.geocaching.enumerations.LogType;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.maps.MapProviderFactory;
 import cgeo.geocaching.maps.interfaces.MapProvider;
@@ -89,6 +90,7 @@ public final class Settings {
     private static final String KEY_LIVE_MAP_HINT_SHOW_COUNT = "livemaphintshowcount";
     private static final String KEY_SETTINGS_VERSION = "settingsversion";
     private static final String KEY_DB_ON_SDCARD = "dbonsdcard";
+    private static final String KEY_LAST_TRACKABLE_ACTION = "trackableaction";
 
     private final static int unitsMetric = 1;
 
@@ -1140,6 +1142,20 @@ public final class Settings {
             @Override
             public void edit(Editor edit) {
                 edit.putBoolean(KEY_DB_ON_SDCARD, dbOnSDCard);
+            }
+        });
+    }
+
+    public static int getTrackableAction() {
+        return sharedPrefs.getInt(KEY_LAST_TRACKABLE_ACTION, LogType.RETRIEVED_IT.id);
+    }
+
+    public static void setTrackableAction(final int trackableAction) {
+        editSharedSettings(new PrefRunnable() {
+
+            @Override
+            public void edit(Editor edit) {
+                edit.putInt(KEY_LAST_TRACKABLE_ACTION, trackableAction);
             }
         });
     }

--- a/main/src/cgeo/geocaching/cgeotouch.java
+++ b/main/src/cgeo/geocaching/cgeotouch.java
@@ -270,10 +270,7 @@ public class cgeotouch extends AbstractActivity implements DateDialog.DateDialog
         logTypes.add(LogType.NOTE);
         logTypes.add(LogType.DISCOVERED_IT);
 
-        if (LogType.UNKNOWN == typeSelected) {
-            typeSelected = LogType.RETRIEVED_IT;
-        }
-        setType(typeSelected);
+        setType(LogType.getById(Settings.getTrackableAction()));
 
         Button typeButton = (Button) findViewById(R.id.type);
         registerForContextMenu(typeButton);
@@ -349,6 +346,8 @@ public class cgeotouch extends AbstractActivity implements DateDialog.DateDialog
             if (!gettingViewstate) {
                 waitDialog = ProgressDialog.show(cgeotouch.this, null, res.getString(R.string.log_saving), true);
                 waitDialog.setCancelable(true);
+
+                Settings.setTrackableAction(typeSelected.id);
 
                 String tracking = ((EditText) findViewById(R.id.tracking)).getText().toString();
                 String log = ((EditText) findViewById(R.id.log)).getText().toString();


### PR DESCRIPTION
This pull request adds a settings to keep track of the last logging action taken from trackable screen.

Fixes #1566

(Note: I intend to do some refactoring in cgeotouches to clean up a lot of the code and rename it to VisitTrackableActivity)
