### PR TITLE
Use image hash code instead of view ID to reference log images

### DIFF
--- a/main/src/cgeo/geocaching/cgeoimages.java
+++ b/main/src/cgeo/geocaching/cgeoimages.java
@@ -128,6 +128,7 @@ public class cgeoimages extends AbstractActivity {
 
                 view.addView(image_view);
 
+                image_view.setId(image.hashCode());
                 images.put(image_view.getId(), img);
             }
 


### PR DESCRIPTION
The images were being stored with a key of R.id, but since we reuse the the view, every image had the same id.
Using the hash code of the image as the key allows us to find the correct image.

Fixes #1614.
