### PR TITLE
Fix offline zoom issue and document zoom level differences

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -916,7 +916,9 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                     if (mapView != null) {
                         // get current viewport
                         final Viewport viewportNow = mapView.getViewport();
-                        int zoomNow = mapView.getMapZoomLevel();
+                        // Since zoomNow is used only for local comparison purposes,
+                        // it is ok to use the Google Maps compatible zoom level of OSM Maps
+                        final int zoomNow = mapView.getMapZoomLevel();
 
                         // check if map moved or zoomed
                         //TODO Portree Use Rectangle inside with bigger search window. That will stop reloading on every move

--- a/main/src/cgeo/geocaching/maps/google/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/GoogleMapView.java
@@ -56,7 +56,7 @@ public class GoogleMapView extends MapView implements MapViewImpl {
     @Override
     public void draw(Canvas canvas) {
         try {
-            if (getMapZoomLevel() >= 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
+            if (getMapZoomLevel() > 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
                 getController().setZoom(22);
             }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapController.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapController.java
@@ -26,13 +26,15 @@ public class MapsforgeMapController implements MapControllerImpl {
         mapController.setCenter((GeoPoint) geoPoint);
     }
 
+    /**
+     * Set the map zoom level to mapzoom-1 or maxZoomLevel, whichever is least
+     * mapzoom-1 is used to be compatible with Google Maps zoom levels
+     */
     @Override
     public void setZoom(int mapzoom) {
-        int mfzoom = mapzoom - 1;
-        if (mfzoom > maxZoomLevel) {
-            mfzoom = maxZoomLevel;
-        }
-        mapController.setZoom(mfzoom);
+        // Google Maps and OSM Maps use different zoom levels for the same view.
+        // All OSM Maps zoom levels are offset by 1 so they match Google Maps.
+        mapController.setZoom(Math.min(mapzoom - 1, maxZoomLevel));
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -51,7 +51,9 @@ public class MapsforgeMapView extends MapView implements MapViewImpl {
     @Override
     public void draw(Canvas canvas) {
         try {
-            if (getMapZoomLevel() >= 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
+            // Google Maps and OSM Maps use different zoom levels for the same view.
+            // Here we don't want the Google Maps compatible zoom level, but the actual one.
+            if (getActualMapZoomLevel() > 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
                 getController().setZoom(22);
             }
 
@@ -170,9 +172,25 @@ public class MapsforgeMapView extends MapView implements MapViewImpl {
         // Nothing to do here
     }
 
+    /**
+     * Get the map zoom level which is compatible with Google Maps.
+     *
+     * @return the current map zoom level +1
+     */
     @Override
     public int getMapZoomLevel() {
+        // Google Maps and OSM Maps use different zoom levels for the same view.
+        // All OSM Maps zoom levels are offset by 1 so they match Google Maps.
         return getMapPosition().getZoomLevel() + 1;
+    }
+
+    /**
+     * Get the actual map zoom level
+     * 
+     * @return the current map zoom level with no adjustments
+     */
+    private int getActualMapZoomLevel() {
+        return getMapPosition().getZoomLevel();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/mapsforge/v024/MapsforgeMapController.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v024/MapsforgeMapController.java
@@ -26,13 +26,15 @@ public class MapsforgeMapController implements MapControllerImpl {
         mapController.setCenter((GeoPoint) geoPoint);
     }
 
+    /**
+     * Set the map zoom level to mapzoom-1 or maxZoomLevel, whichever is least
+     * mapzoom-1 is used to be compatible with Google Maps zoom levels
+     */
     @Override
     public void setZoom(int mapzoom) {
-        int mfzoom = mapzoom - 1;
-        if (mfzoom > maxZoomLevel) {
-            mfzoom = maxZoomLevel;
-        }
-        mapController.setZoom(mfzoom);
+        // Google Maps and OSM Maps use different zoom levels for the same view.
+        // All OSM Maps zoom levels are offset by 1 so they match Google Maps.
+        mapController.setZoom(Math.min(mapzoom - 1, maxZoomLevel));
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/mapsforge/v024/MapsforgeMapView024.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v024/MapsforgeMapView024.java
@@ -46,7 +46,9 @@ public class MapsforgeMapView024 extends MapView implements MapViewImpl {
     @Override
     public void draw(Canvas canvas) {
         try {
-            if (getMapZoomLevel() >= 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
+            // Google Maps and OSM Maps use different zoom levels for the same view.
+            // Here we don't want the Google Maps compatible zoom level, but the actual one.
+            if (getActualMapZoomLevel() > 22) { // to avoid too close zoom level (mostly on Samsung Galaxy S series)
                 getController().setZoom(22);
             }
 
@@ -165,9 +167,25 @@ public class MapsforgeMapView024 extends MapView implements MapViewImpl {
         // Nothing to do here
     }
 
+    /**
+     * Get the map zoom level which is compatible with Google Maps.
+     * 
+     * @return the current map zoom level +1
+     */
     @Override
     public int getMapZoomLevel() {
+        // Google Maps and OSM Maps use different zoom levels for the same view.
+        // All OSM Maps zoom levels are offset by 1 so they match Google Maps.
         return getZoomLevel() + 1;
+    }
+
+    /**
+     * Get the actual map zoom level
+     *
+     * @return the current map zoom level with no adjustments
+     */
+    private int getActualMapZoomLevel() {
+        return getZoomLevel();
     }
 
     @Override


### PR DESCRIPTION
Google Maps and OSM Maps use different zoom levels for the same
view ranges. This is better documented. Additionally, this change
fixes zooming out causing zoom in.

Fixes #1485.
