### PR TITLE
fix #1699 - when unknown attribute was present: FC in export (string not...

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -826,6 +826,9 @@
   <string name="export_fieldnotes_creating">Creating Field Notes…</string>
   <string name="export_gpx">GPX</string>
   
+  <!--  attribute unknown -->
+  <string name="attribute_unknown_yes">Unknown attribute present</string>
+  <string name="attribute_unknown_no">Unknown attribute not present</string>
   <!--  attributes (permissions -> allowed, not allowed) -->
   <string name="attribute_dogs_yes">Dogs allowed</string>
   <string name="attribute_dogs_no">Dogs not allowed</string>

--- a/main/src/cgeo/geocaching/enumerations/CacheAttribute.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheAttribute.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 
 public enum CacheAttribute {
-    UNKNOWN(0, "", R.drawable.attribute__strikethru, 0, 0),
+    UNKNOWN(0, "unknown", R.drawable.attribute__strikethru, R.string.attribute_unknown_yes, R.string.attribute_unknown_no),
     DOGS(1, "dogs", R.drawable.attribute_dogs, R.string.attribute_dogs_yes, R.string.attribute_dogs_no),
     FEE(2, "fee", R.drawable.attribute_fee, R.string.attribute_fee_yes, R.string.attribute_fee_no),
     RAPPELLING(3, "rappelling", R.drawable.attribute_rappelling, R.string.attribute_rappelling_yes, R.string.attribute_rappelling_no),


### PR DESCRIPTION
... found)

This adds two strings for identifiing unknown attribute, so export will not fail.
