### PR TITLE
fixes #1725: no static maps apps as default nav app

### DIFF
--- a/main/src/cgeo/geocaching/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/SettingsActivity.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.utils.LogTemplateProvider;
 import cgeo.geocaching.utils.LogTemplateProvider.LogTemplate;
 
 import ch.boye.httpclientandroidlib.HttpResponse;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -594,7 +595,7 @@ public class SettingsActivity extends AbstractActivity {
 
         // Default navigation tool settings
         Spinner defaultNavigationToolSelector = (Spinner) findViewById(R.id.default_navigation_tool);
-        final List<NavigationAppsEnum> apps = NavigationAppFactory.getInstalledNavigationApps();
+        final List<NavigationAppsEnum> apps = NavigationAppFactory.getInstalledDefaultNavigationApps();
         ArrayAdapter<NavigationAppsEnum> naviAdapter = new ArrayAdapter<NavigationAppsEnum>(this, android.R.layout.simple_spinner_item, apps) {
             @Override
             public View getView(int position, View convertView, ViewGroup parent) {

--- a/main/src/cgeo/geocaching/apps/AbstractApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractApp.java
@@ -47,6 +47,11 @@ public abstract class AbstractApp implements App {
     }
 
     @Override
+    public boolean isDefaultNavigationApp() {
+        return true;
+    }
+
+    @Override
     public String getName() {
         return name;
     }

--- a/main/src/cgeo/geocaching/apps/App.java
+++ b/main/src/cgeo/geocaching/apps/App.java
@@ -5,6 +5,8 @@ import cgeo.geocaching.cgCache;
 public interface App {
     public boolean isInstalled();
 
+    public boolean isDefaultNavigationApp();
+
     public String getName();
 
     int getId();

--- a/main/src/cgeo/geocaching/apps/cache/navi/AbstractStaticMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/AbstractStaticMapsApp.java
@@ -24,6 +24,11 @@ abstract class AbstractStaticMapsApp extends AbstractApp implements CacheNavigat
         return true;
     }
 
+    @Override
+    public boolean isDefaultNavigationApp() {
+        return false;
+    }
+
     protected static boolean hasStaticMap(cgCache cache) {
         String geocode = cache.getGeocode();
         if (StringUtils.isNotEmpty(geocode) && cgeoapplication.getInstance().isOffline(geocode, null)) {

--- a/main/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
@@ -178,6 +178,21 @@ public final class NavigationAppFactory extends AbstractAppFactory {
     }
 
     /**
+     * Returns all installed navigation apps for default navigation.
+     * 
+     * @return
+     */
+    public static List<NavigationAppsEnum> getInstalledDefaultNavigationApps() {
+        final List<NavigationAppsEnum> installedNavigationApps = new ArrayList<NavigationAppsEnum>();
+        for (NavigationAppsEnum appEnum : NavigationAppsEnum.values()) {
+            if (appEnum.app.isInstalled() && appEnum.app.isDefaultNavigationApp()) {
+                installedNavigationApps.add(appEnum);
+            }
+        }
+        return installedNavigationApps;
+    }
+
+    /**
      * This offset is used to build unique menu ids to avoid collisions of ids in menus
      */
     private static final int MENU_ITEM_OFFSET = 12345;


### PR DESCRIPTION
A new approach after some suggestions of samuel. StaticMaps nav apps are not shown on settings choice for default nav apps.

I added the method isDefaultNavigationApp() to App and the default implementation in AbstractApp with default=true. AbstratStaticMapsApp overwrites the method returning false.

Tested and working.
