### PR TITLE
Asynchronous uploading/reseting coords

### DIFF
--- a/main/res/layout/reset_cache_coords_dialog.xml
+++ b/main/res/layout/reset_cache_coords_dialog.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="3dip" >
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/waypoint_reset_cache_coords_info" />
+
+    <CheckBox
+        android:id="@+id/local"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/waypoint_localy_reset_cache_coords" />
+
+    <CheckBox
+        android:id="@+id/upload"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="false"
+        android:visibility="gone"
+        android:text="@string/waypoint_reset_cache_coords_on_website" />
+
+    <Button
+        android:id="@+id/reset"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="3dip"
+        android:text="@string/waypoint_reset" />
+
+</LinearLayout>

--- a/main/res/layout/waypoint_new.xml
+++ b/main/res/layout/waypoint_new.xml
@@ -51,44 +51,79 @@
                 android:hint="@string/waypoint_bearing"
                 android:inputType="numberDecimal" />
 
-	        <LinearLayout
-	            android:layout_width="fill_parent"
-    	        android:layout_height="wrap_content"
-            	android:orientation="horizontal" >
-            
-	            <EditText
-                	android:id="@+id/distance"
-                	style="@style/edittext_full"
-                	android:hint="@string/waypoint_distance"
-                	android:inputType="numberDecimal"
-                	android:layout_width="0dip"
-                	android:layout_weight="1" />
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" >
 
-	            <Spinner 
-                	android:id="@+id/distanceUnit"
-                	android:layout_width="wrap_content"
-					android:layout_height="wrap_content"
-					android:entries="@array/distance_units" />
-        	</LinearLayout>
+                <EditText
+                    android:id="@+id/distance"
+                    style="@style/edittext_full"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:hint="@string/waypoint_distance"
+                    android:inputType="numberDecimal" />
 
-	        <AutoCompleteTextView
+                <Spinner
+                    android:id="@+id/distanceUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:entries="@array/distance_units" />
+            </LinearLayout>
+
+            <AutoCompleteTextView
                 android:id="@+id/name"
                 style="@style/edittext_full"
                 android:hint="@string/waypoint_name" />
-            
-            <Spinner 
+
+            <Spinner
                 android:id="@+id/type"
                 android:layout_width="fill_parent"
-				android:layout_height="wrap_content" />
+                android:layout_height="wrap_content" />
 
             <EditText
                 android:id="@+id/note"
                 style="@style/edittext_full"
                 android:layout_height="wrap_content"
-                android:inputType="textMultiLine|textCapSentences"
                 android:hint="@string/waypoint_note"
+                android:inputType="textMultiLine|textCapSentences"
                 android:minLines="5"
                 android:singleLine="false" />
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" >
+
+                <CheckBox
+                    android:id="@+id/setAsCacheCoordsCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+                <TextView
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/waypoint_set_as_cache_coords"
+                    android:textColor="?text_color" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" >
+
+                <CheckBox
+                    android:id="@+id/uploadCoordsToWebsiteCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/waypoint_modify_on_website"
+                    android:textColor="?text_color" />
+            </LinearLayout>
 
             <Button
                 android:id="@+id/add_waypoint"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -53,6 +53,7 @@
   <string name="wp_pkg">Parking Area</string>
   <string name="wp_trailhead">Trailhead</string>
   <string name="wp_waypoint">Reference Point</string>
+  <string name="wp_original">Original Coordinates</string>
 
   <!-- logs -->
   <string name="log_found">Found it</string>
@@ -570,6 +571,8 @@
   <string name="cache_menu_visit_offline">Log Visit offline</string>
   <string name="cache_menu_spoilers">Spoiler images</string>
   <string name="cache_menu_around">Caches around</string>
+  <string name="cache_menu_set_as_cache_coords">Set as cache coords</string>
+  <string name="cache_menu_upload_wpt_to_gc_com">Set as cache coords and upload waypoint to Geocaching.com</string>
   <string name="cache_menu_event">Add to calendar</string>
   <string name="cache_menu_details">Details</string>
   <string name="cache_menu_share">Share cache</string>
@@ -673,6 +676,21 @@
   <string name="waypoint_save">Save</string>
   <string name="waypoint_loading">Loading waypoint…</string>
   <string name="waypoint_unknown_coordinates">Coordinates unknown</string>
+  <string name="waypoint_set_as_cache_coords">Set as cache coordinates</string>
+  <string name="waypoint_reset_cache_coords">Reset cache coordinates</string>
+  <string name="waypoint_reset_cache_coords_on_website">Reset cache coordinates on website</string>
+  <string name="waypoint_coordinates_has_been_reset_on_website">Cache coordinates has been reset on website.</string>
+  <string name="waypoint_coordinates_being_reset_on_website">Cache coordinates being reset on website.</string>
+  <string name="waypoint_reset_cache_coords_info">Reset possibilities</string>
+  <string name="waypoint_reset">Reset</string>
+  <string name="waypoint_localy_reset_cache_coords">Reset coordinates locally</string>
+  <string name="waypoint_modify_on_website">Modify coordinates on website</string>
+  <string name="waypoint_coordinates_couldnt_be_modified_on_website">Cache coordinates couldn\'t be set on website.</string>
+  <string name="waypoint_coordinates_upload_error">Error occurred during uploading coordinates to website.</string>
+  <string name="waypoint_coordinates_uploading_to_website">Uploading %s to website.</string>
+  <string name="waypoint_coordinates_reseting_on_website">Reseting to original coordinates on website.</string>
+  <string name="waypoint_coordinates_has_been_modified_on_website">Cache coordinates has been modified on website to: %s.</string>
+  <string name="waypoint_coordinates_has_been_set_as_cache_coordinates">Cache coordinates has been localy modified to: %s.</string>
   <string name="waypoint_done">Done</string>
   <string name="waypoint_duplicate">Duplicate</string>
   <string name="waypoint_copy_of">Copy of</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -12,6 +12,7 @@ import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.LogType;
+import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.geopoint.GeopointFormatter;
 import cgeo.geocaching.geopoint.Units;
 import cgeo.geocaching.network.HtmlImage;
@@ -38,7 +39,9 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import android.R.color;
+import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -80,6 +83,9 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -122,6 +128,7 @@ public class CacheDetailActivity extends AbstractActivity {
     private static final int CONTEXT_MENU_WAYPOINT_NAVIGATE = 1238;
     private static final int CONTEXT_MENU_WAYPOINT_CACHES_AROUND = 1239;
     private static final int CONTEXT_MENU_WAYPOINT_DEFAULT_NAVIGATION = 1240;
+    private static final int CONTEXT_MENU_WAYPOINT_RESET_ORIGINAL_CACHE_COORDINATES = 1241;
 
     private cgCache cache;
     private final Progress progress = new Progress();
@@ -428,10 +435,14 @@ public class CacheDetailActivity extends AbstractActivity {
                                 final cgWaypoint waypoint = sortedWaypoints.get(i);
                                 final int index = cache.getWaypoints().indexOf(waypoint);
                                 menu.setHeaderTitle(res.getString(R.string.waypoint));
-                                menu.add(CONTEXT_MENU_WAYPOINT_EDIT, index, 0, R.string.waypoint_edit);
-                                menu.add(CONTEXT_MENU_WAYPOINT_DUPLICATE, index, 0, R.string.waypoint_duplicate);
+                                if (waypoint.getWaypointType().equals(WaypointType.ORIGINAL)) {
+                                    menu.add(CONTEXT_MENU_WAYPOINT_RESET_ORIGINAL_CACHE_COORDINATES, index, 0, R.string.waypoint_reset_cache_coords);
+                                } else {
+                                    menu.add(CONTEXT_MENU_WAYPOINT_EDIT, index, 0, R.string.waypoint_edit);
+                                    menu.add(CONTEXT_MENU_WAYPOINT_DUPLICATE, index, 0, R.string.waypoint_duplicate);
+                                }
                                 contextMenuWPIndex = index;
-                                if (waypoint.isUserDefined()) {
+                                if (waypoint.isUserDefined() && !waypoint.getWaypointType().equals(WaypointType.ORIGINAL)) {
                                     menu.add(CONTEXT_MENU_WAYPOINT_DELETE, index, 0, R.string.waypoint_delete);
                                 }
                                 if (waypoint.getCoords() != null) {
@@ -541,6 +552,11 @@ public class CacheDetailActivity extends AbstractActivity {
                 }
             }
                 break;
+            case CONTEXT_MENU_WAYPOINT_RESET_ORIGINAL_CACHE_COORDINATES: {
+                new ResetCacheCoordinatesDialog(cache, cache.getWaypoint(index), this).show();
+            }
+                break;
+
             default:
                 return onOptionsItemSelected(item);
         }
@@ -578,7 +594,7 @@ public class CacheDetailActivity extends AbstractActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         final int menuItem = item.getItemId();
 
-        switch(menuItem) {
+        switch (menuItem) {
             case 0:
                 // no menu selected, but a new sub menu shown
                 return false;
@@ -1389,22 +1405,22 @@ public class CacheDetailActivity extends AbstractActivity {
             if (cache.getCoords() != null) {
                 TextView valueView = details.add(R.string.cache_coordinates, cache.getCoords().toString());
                 valueView.setOnClickListener(new View.OnClickListener() {
-                            private int position = 0;
-                            private GeopointFormatter.Format[] availableFormats = new GeopointFormatter.Format[] {
-                                    GeopointFormatter.Format.LAT_LON_DECMINUTE,
-                                    GeopointFormatter.Format.LAT_LON_DECSECOND,
-                                    GeopointFormatter.Format.LAT_LON_DECDEGREE
-                            };
+                    private int position = 0;
+                    private GeopointFormatter.Format[] availableFormats = new GeopointFormatter.Format[] {
+                            GeopointFormatter.Format.LAT_LON_DECMINUTE,
+                            GeopointFormatter.Format.LAT_LON_DECSECOND,
+                            GeopointFormatter.Format.LAT_LON_DECDEGREE
+                    };
 
-                            // rotate coordinate formats on click
-                            @Override
-                            public void onClick(View view) {
-                                position = (position + 1) % availableFormats.length;
+                    // rotate coordinate formats on click
+                    @Override
+                    public void onClick(View view) {
+                        position = (position + 1) % availableFormats.length;
 
-                                final TextView valueView = (TextView) view.findViewById(R.id.value);
-                                valueView.setText(cache.getCoords().format(availableFormats[position]));
-                            }
-                        });
+                        final TextView valueView = (TextView) view.findViewById(R.id.value);
+                        valueView.setText(cache.getCoords().format(availableFormats[position]));
+                    }
+                });
                 registerForContextMenu(valueView);
             }
 
@@ -2428,5 +2444,118 @@ public class CacheDetailActivity extends AbstractActivity {
         cacheIntent.putExtra("guid", guid);
         cacheIntent.putExtra("name", cacheName);
         context.startActivity(cacheIntent);
+    }
+
+    /**
+     * A dialog to allow the user to select reseting coordinates local/remote/both.
+     */
+    private class ResetCacheCoordinatesDialog extends AlertDialog implements OnCheckedChangeListener {
+
+        final CheckBox uploadOption;
+        final CheckBox resetLocalyOption;
+
+        public ResetCacheCoordinatesDialog(final cgCache cache, final cgWaypoint wpt, final Activity activity) {
+            super(activity);
+
+            View layout = activity.getLayoutInflater().inflate(R.layout.reset_cache_coords_dialog, null);
+            setView(layout);
+
+            uploadOption = (CheckBox) layout.findViewById(R.id.upload);
+            resetLocalyOption = (CheckBox) layout.findViewById(R.id.local);
+
+            if (ConnectorFactory.getConnector(cache).supportsOwnCoordinates()) {
+                uploadOption.setChecked(true);
+                uploadOption.setVisibility(View.VISIBLE);
+            }
+
+            uploadOption.setOnCheckedChangeListener(this);
+            resetLocalyOption.setOnCheckedChangeListener(this);
+
+            ((Button) layout.findViewById(R.id.reset)).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    dismiss();
+                    final ProgressDialog p = ProgressDialog.show(CacheDetailActivity.this, res.getString(R.string.cache), res.getString(R.string.waypoint_reset), true);
+                    Handler h = new Handler() {
+                        @Override
+                        public void handleMessage(Message msg) {
+                            p.dismiss();
+                            notifyDataSetChanged();
+                        }
+                    };
+                    new ResetCoordsThread(cache, h, wpt, resetLocalyOption.isChecked(), uploadOption.isChecked(), p).start();
+                }
+            });
+        }
+
+        @Override
+        public void onCheckedChanged(CompoundButton arg0, boolean arg1) {
+            ((Button) findViewById(R.id.reset)).setEnabled(
+                    (uploadOption.isChecked() || resetLocalyOption.isChecked()));
+        }
+    }
+
+    private class ResetCoordsThread extends Thread {
+
+        private final cgCache cache;
+        private final Handler handler;
+        private final boolean local;
+        private final boolean remote;
+        private final cgWaypoint wpt;
+        private ProgressDialog progress;
+
+        public ResetCoordsThread(cgCache cache, Handler handler, final cgWaypoint wpt, boolean local, boolean remote, final ProgressDialog progress) {
+            this.cache = cache;
+            this.handler = handler;
+            this.local = local;
+            this.remote = remote;
+            this.wpt = wpt;
+            this.progress = progress;
+        }
+
+        @Override
+        public void run() {
+
+            if (local) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        progress.setMessage(res.getString(R.string.waypoint_reset_cache_coords));
+                    }
+                });
+                cache.setCoords(wpt.getCoords());
+                cache.setUserModifiedCoords(false);
+                cache.deleteWaypointForce(wpt);
+                cgeoapplication.getInstance().updateCache(cache);
+            }
+
+            IConnector con = ConnectorFactory.getConnector(cache);
+            if (remote && con.supportsOwnCoordinates()) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        progress.setMessage(res.getString(R.string.waypoint_coordinates_being_reset_on_website));
+                    }
+                });
+
+                final boolean result = con.deleteModifiedCoordinates(cache);
+
+                runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        if (result) {
+                            showToast(getString(R.string.waypoint_coordinates_has_been_reset_on_website));
+                        } else {
+                            showToast(getString(R.string.waypoint_coordinates_upload_error));
+                        }
+                        handler.sendMessage(Message.obtain());
+                        notifyDataSetChanged();
+                    }
+
+                });
+
+            }
+        }
     }
 }

--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -276,9 +276,17 @@ public class cgCache implements ICache, IWaypoint {
         if (logCounts.size() == 0) {
             logCounts = other.logCounts;
         }
-        if (!userModifiedCoords) {
-            userModifiedCoords = other.userModifiedCoords;
+
+        // if cache has ORIGINAL type waypoint ... it is considered that it has modified coordinates, otherwise not
+        userModifiedCoords = false;
+        if (waypoints != null) {
+            for (cgWaypoint wpt : waypoints) {
+                if (wpt.getWaypointType() == WaypointType.ORIGINAL) {
+                    userModifiedCoords = true;
+                }
+            }
         }
+
         if (!reliableLatLon) {
             reliableLatLon = other.reliableLatLon;
         }
@@ -298,7 +306,8 @@ public class cgCache implements ICache, IWaypoint {
     /**
      * Compare two caches quickly. For map and list fields only the references are compared !
      *
-     * @param other the other cache to compare this one to
+     * @param other
+     *            the other cache to compare this one to
      * @return true if both caches have the same content
      */
     private boolean isEqualTo(final cgCache other) {
@@ -496,6 +505,10 @@ public class cgCache implements ICache, IWaypoint {
         return getConnector().supportsLogging();
     }
 
+    public boolean supportsOwnCoordinates() {
+        return getConnector().supportsOwnCoordinates();
+    }
+
     @Override
     public float getDifficulty() {
         return difficulty;
@@ -657,7 +670,6 @@ public class cgCache implements ICache, IWaypoint {
     public void setFavorite(boolean favourite) {
         this.favorite = favourite;
     }
-
 
     @Override
     public boolean isWatchlist() {
@@ -1164,13 +1176,14 @@ public class cgCache implements ICache, IWaypoint {
     }
 
     public void setUserModifiedCoords(boolean coordsChanged) {
-        this.userModifiedCoords = coordsChanged;
+        userModifiedCoords = coordsChanged;
     }
 
     /**
      * Duplicate a waypoint.
      *
-     * @param index the waypoint to duplicate
+     * @param index
+     *            the waypoint to duplicate
      * @return <code>true</code> if the waypoint was duplicated, <code>false</code> otherwise (invalid index)
      */
     public boolean duplicateWaypoint(final int index) {
@@ -1211,6 +1224,20 @@ public class cgCache implements ICache, IWaypoint {
     }
 
     /**
+     * deletes any waypoint
+     *
+     * @param waypoint
+     */
+
+    public void deleteWaypointForce(cgWaypoint waypoint) {
+        final int index = getWaypointIndex(waypoint);
+        waypoints.remove(index);
+        cgeoapplication.getInstance().deleteWaypoint(waypoint.getId());
+        cgeoapplication.getInstance().removeCache(geocode, EnumSet.of(RemoveFlag.REMOVE_CACHE));
+        resetFinalDefined();
+    }
+
+    /**
      * delete a user defined waypoint
      *
      * @param waypoint
@@ -1246,7 +1273,8 @@ public class cgCache implements ICache, IWaypoint {
     /**
      * Retrieve a given waypoint.
      *
-     * @param index the index of the waypoint
+     * @param index
+     *            the index of the waypoint
      * @return waypoint or <code>null</code> if index is out of range
      */
     public cgWaypoint getWaypoint(final int index) {
@@ -1256,7 +1284,8 @@ public class cgCache implements ICache, IWaypoint {
     /**
      * Lookup a waypoint by its id.
      *
-     * @param id the id of the waypoint to look for
+     * @param id
+     *            the id of the waypoint to look for
      * @return waypoint or <code>null</code>
      */
     public cgWaypoint getWaypointById(final int id) {

--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -74,7 +74,7 @@ public class cgData {
     private static int[] cacheColumnIndex;
     private CacheCache cacheCache = new CacheCache();
     private SQLiteDatabase database = null;
-    private static final int dbVersion = 64;
+    private static final int dbVersion = 65;
     public static final int customListIdOffset = 10;
     private static final String dbName = "data";
     private static final String dbTableCaches = "cg_caches";
@@ -659,6 +659,15 @@ public class cgData {
                             db.execSQL("update " + dbTableCaches + " set reason=1 where reason=2");
                         } catch (Exception e) {
                             Log.e("Failed to upgrade to ver. 64", e);
+                        }
+                    }
+
+                    if (oldVersion < 65) {
+                        try {
+                            // Set all waypoints where name is Original coordinates to type ORIGINAL
+                            db.execSQL("update " + dbTableWaypoints + " set type='original', own=0 where name='Original Coordinates'");
+                        } catch (Exception e) {
+                            Log.e("Failed to upgrade to ver. 65:" + e.toString());
                         }
                     }
                 }

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector;
 
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.cgCache;
+import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.geopoint.Viewport;
 
 public abstract class AbstractConnector implements IConnector {
@@ -14,6 +15,31 @@ public abstract class AbstractConnector implements IConnector {
     @Override
     public boolean supportsWatchList() {
         return false;
+    }
+
+    @Override
+    public boolean supportsOwnCoordinates() {
+        return false;
+    }
+
+    /**
+     * Uploading modified coordinates to website
+     * 
+     * @param cache
+     * @param wpt
+     * @return success
+     */
+    @Override
+    public boolean uploadModifiedCoordinates(cgCache cache, Geopoint wpt) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@link IConnector}
+     */
+    @Override
+    public boolean deleteModifiedCoordinates(cgCache cache) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector;
 
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.cgCache;
+import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.geopoint.Viewport;
 
 public interface IConnector {
@@ -103,5 +104,29 @@ public interface IConnector {
      * @return
      */
     public String[] getTokens();
+
+    /**
+     * enable/disable uploading modified coordinates to website
+     *
+     * @return true, when uploading is possible
+     */
+    public boolean supportsOwnCoordinates();
+
+    /**
+     * Uploading modified coordinates to website
+     *
+     * @param cache
+     * @param wpt
+     * @return success
+     */
+    public boolean uploadModifiedCoordinates(cgCache cache, Geopoint wpt);
+
+    /**
+     * Reseting of modified coordinates on website to details
+     *
+     * @param cache
+     * @return success
+     */
+    public boolean deleteModifiedCoordinates(cgCache cache);
 
 }

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -49,6 +49,11 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    public boolean supportsOwnCoordinates() {
+        return true;
+    }
+
+    @Override
     public boolean supportsWatchList() {
         return true;
     }
@@ -155,6 +160,24 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
             cgeoapplication.getInstance().updateCache(cache);
         }
         return removed;
+    }
+
+    @Override
+    public boolean uploadModifiedCoordinates(cgCache cache, Geopoint wpt) {
+        final boolean uploaded = GCParser.uploadModifiedCoordinates(cache, wpt);
+        if (uploaded) {
+            cgeoapplication.getInstance().updateCache(cache);
+        }
+        return uploaded;
+    }
+
+    @Override
+    public boolean deleteModifiedCoordinates(cgCache cache) {
+        final boolean deleted = GCParser.deleteModifiedCoordinates(cache);
+        if (deleted) {
+            cgeoapplication.getInstance().updateCache(cache);
+        }
+        return deleted;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -19,7 +19,8 @@ public enum WaypointType {
     PUZZLE("puzzle", R.string.wp_puzzle, R.drawable.waypoint_puzzle),
     STAGE("stage", R.string.wp_stage, R.drawable.waypoint_stage),
     TRAILHEAD("trailhead", R.string.wp_trailhead, R.drawable.waypoint_trailhead),
-    WAYPOINT("waypoint", R.string.wp_waypoint, R.drawable.waypoint_waypoint);
+    WAYPOINT("waypoint", R.string.wp_waypoint, R.drawable.waypoint_waypoint),
+    ORIGINAL("original", R.string.wp_original, R.drawable.waypoint_waypoint);
 
     public final String id;
     public final int stringId;
@@ -36,13 +37,13 @@ public enum WaypointType {
      * non public so that <code>null</code> handling can be handled centrally in the enum type itself
      */
     private static final Map<String, WaypointType> FIND_BY_ID;
-    public static final Set<WaypointType> ALL_TYPES_EXCEPT_OWN = new HashSet<WaypointType>();
+    public static final Set<WaypointType> ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL = new HashSet<WaypointType>();
     static {
         final HashMap<String, WaypointType> mapping = new HashMap<String, WaypointType>();
         for (WaypointType wt : values()) {
             mapping.put(wt.id, wt);
-            if (wt != WaypointType.OWN) {
-                ALL_TYPES_EXCEPT_OWN.add(wt);
+            if (wt != WaypointType.OWN && wt != WaypointType.ORIGINAL) {
+                ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL.add(wt);
             }
         }
         FIND_BY_ID = Collections.unmodifiableMap(mapping);
@@ -66,7 +67,6 @@ public enum WaypointType {
     public final String getL10n() {
         return cgeoapplication.getInstance().getBaseContext().getResources().getString(stringId);
     }
-
 
     @Override
     public final String toString() {

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -796,7 +796,7 @@ public abstract class GPXParser extends FileParser {
             return WaypointType.FINAL;
         }
         // this is not fully correct, but lets also look for localized waypoint types
-        for (WaypointType waypointType : WaypointType.ALL_TYPES_EXCEPT_OWN) {
+        for (WaypointType waypointType : WaypointType.ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL) {
             final String localized = waypointType.getL10n();
             if (StringUtils.isNotEmpty(localized)) {
                 if (localized.equalsIgnoreCase(sym)) {

--- a/main/src/cgeo/geocaching/network/Network.java
+++ b/main/src/cgeo/geocaching/network/Network.java
@@ -21,6 +21,7 @@ import ch.boye.httpclientandroidlib.client.methods.HttpGet;
 import ch.boye.httpclientandroidlib.client.methods.HttpPost;
 import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
 import ch.boye.httpclientandroidlib.client.params.ClientPNames;
+import ch.boye.httpclientandroidlib.entity.StringEntity;
 import ch.boye.httpclientandroidlib.entity.mime.MultipartEntity;
 import ch.boye.httpclientandroidlib.entity.mime.content.FileBody;
 import ch.boye.httpclientandroidlib.entity.mime.content.StringBody;
@@ -32,6 +33,7 @@ import ch.boye.httpclientandroidlib.params.CoreProtocolPNames;
 import ch.boye.httpclientandroidlib.params.HttpParams;
 import ch.boye.httpclientandroidlib.protocol.HttpContext;
 import ch.boye.httpclientandroidlib.util.EntityUtils;
+
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -145,6 +147,28 @@ public abstract class Network {
      */
     public static HttpResponse postRequest(final String uri, final Parameters params, final Parameters headers) {
         return request("POST", uri, params, headers, null);
+    }
+
+    /**
+     *  POST HTTP request with Json POST DATA
+     *
+     * @param uri the URI to request
+     * @param json the json object to add to the POST request
+     * @return the HTTP response, or null in case of an encoding error params
+     */
+    public static HttpResponse postJsonRequest(final String uri, final JSONObject json) {
+        HttpPost request;
+        request = new HttpPost(uri);
+        request.addHeader("Content-Type", "application/json; charset=utf-8");
+        if (json != null) {
+            try {
+                request.setEntity(new StringEntity(json.toString()));
+            } catch (UnsupportedEncodingException e) {
+                Log.e("postJsonRequest:JSON Entity: UnsupportedEncodingException");
+                return null;
+            }
+        }
+        return doRepeatedRequests(request);
     }
 
     /**

--- a/main/src/cgeo/geocaching/ui/Formatter.java
+++ b/main/src/cgeo/geocaching/ui/Formatter.java
@@ -153,7 +153,7 @@ public abstract class Formatter {
 
     public static String formatWaypointInfo(cgWaypoint waypoint) {
         final List<String> infos = new ArrayList<String>(3);
-        if (WaypointType.ALL_TYPES_EXCEPT_OWN.contains(waypoint.getWaypointType())) {
+        if (WaypointType.ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL.contains(waypoint.getWaypointType())) {
             infos.add(waypoint.getWaypointType().getL10n());
         }
         if (cgWaypoint.PREFIX_OWN.equalsIgnoreCase(waypoint.getPrefix())) {

--- a/tests/src/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/tests/src/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -125,6 +125,25 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
                 "Station3: N51 21.444 / E07 02.600\r\nStation4: N51 21.789 / E07 02.800\r\nStation5: N51 21.667 / E07 02.800\r\nStation6: N51 21.444 / E07 02.706\r\nStation7: N51 21.321 / E07 02.700\r\nStation8: N51 21.123 / E07 02.477\r\nStation9: N51 21.734 / E07 02.500\r\nStation10: N51 21.733 / E07 02.378\r\nFinal: N51 21.544 / E07 02.566");
     }
 
+    @MediumTest
+    public static void testEditModifiedCoordinates() {
+        cgCache cache = new cgCache();
+        cache.setGeocode("GC2ZN4G");
+        // upload coordinates
+        GCParser.editModifiedCoordinates(cache, new Geopoint("N51 21.544", "E07 02.566"));
+        cache.drop(null);
+        String page = GCParser.requestHtmlPage(cache.getGeocode(), null, "n", "0");
+        cgCache cache2 = GCParser.parseCacheFromText(page, null).getFirstCacheFromResult(LoadFlags.LOAD_CACHE_ONLY);
+        assertTrue(cache2.hasUserModifiedCoords());
+        assertEquals(new Geopoint("N51 21.544", "E07 02.566"), cache2.getCoords());
+        // delete coordinates
+        GCParser.deleteModifiedCoordinates(cache2);
+        cache2.drop(null);
+        String page2 = GCParser.requestHtmlPage(cache.getGeocode(), null, "n", "0");
+        cgCache cache3 = GCParser.parseCacheFromText(page2, null).getFirstCacheFromResult(LoadFlags.LOAD_CACHE_ONLY);
+        assertFalse(cache3.hasUserModifiedCoords());
+    }
+
     private static void assertWaypointsFromNote(final cgCache cache, Geopoint[] expected, String note) {
         cache.setPersonalNote(note);
         cache.setWaypoints(new ArrayList<cgWaypoint>(), false);


### PR DESCRIPTION
Hi, I've implemented uploading of cache coordinates to GC.com (using connector interface, so possibly for other sites, but as i know OC doesn't support it). Could sb review my code, test and comment it ?

Added functionality:
- In waypoint edit/create dialog there are two checkboxes ... 
  - first is for setting coordinates of this wp as cache coordinates,
  - second uploads coordinates to website (it's shown only when connector supports this)
- In waypoint context menu there is new option (Reset cache coordinates), its only in context menu of waypoint with original coordinates (new type, updated in connector too).
  - This option opens dialog with two chechboxes, first is used to reset cache coordinates from original waypoint locally in c:geo, second checkbox performs reset on website.

All operations with network are executed in async task, so it doesn't block UI thread.
