### PR TITLE
Permit to enable live map in every map

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -598,10 +598,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
             item = menu.findItem(MENU_MAP_LIVE); // live map
             if (mapMode == MapMode.LIVE_ONLINE) {
                 item.setTitle(res.getString(R.string.map_live_disable));
-            } else if (mapMode == MapMode.LIVE_OFFLINE) {
-                item.setTitle(res.getString(R.string.map_live_enable));
             } else {
-                item.setEnabled(false);
                 item.setTitle(res.getString(R.string.map_live_enable));
             }
 


### PR DESCRIPTION
This partialy solves issue #1768. At best we have to implement context menu to address list, which could search 20 caches around that address(actual behavior) or open live map centered at that point.
