### PR TITLE
DO NOT MERGE: Terminating of previous map activity when opening another one instance. ...

### DIFF
--- a/main/src/cgeo/geocaching/cgeoapplication.java
+++ b/main/src/cgeo/geocaching/cgeoapplication.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.LogType;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.geopoint.Viewport;
+import cgeo.geocaching.maps.CGeoMap;
 import cgeo.geocaching.network.StatusUpdater;
 import cgeo.geocaching.utils.IObserver;
 import cgeo.geocaching.utils.Log;
@@ -45,6 +46,18 @@ public class cgeoapplication extends Application {
     private boolean liveMapHintShown = false; // livemap hint has been shown
     final private StatusUpdater statusUpdater = new StatusUpdater();
     private static cgeoapplication instance = null;
+
+    private CGeoMap lastMapActivity;
+
+    public void setLastMapActivity(CGeoMap lastMapActivity) {
+        this.lastMapActivity = lastMapActivity;
+    }
+
+    public void terminateMapActivity() {
+        if (lastMapActivity != null) {
+            lastMapActivity.getActivity().finish();
+        }
+    }
 
     public cgeoapplication() {
         instance = this;

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -370,6 +370,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
         res = this.getResources();
         activity = this.getActivity();
         app = (cgeoapplication) activity.getApplication();
+        app.terminateMapActivity();
 
         int countBubbleCnt = app.getAllStoredCachesCount(true, CacheType.ALL);
         caches = new LeastRecentlyUsedSet<cgCache>(MAX_CACHES + countBubbleCnt);
@@ -539,6 +540,8 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
         if (mapView != null) {
             mapView.destroyDrawingCache();
         }
+
+        cgeoapplication.getInstance().setLastMapActivity(this);
 
         super.onPause();
     }


### PR DESCRIPTION
...This prevents OOM errors when opening cache from live map and then in detail opening map for waypoints.

Please comment this aproach, I think that this is the only way using c:geo on low memory phones (and if we merge this, we could switch live map everywhere).
