### PR TITLE
Fix #1862 - Only append offline log table when loading offline logs 

### DIFF
--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -1472,7 +1472,9 @@ public class cgData {
         for (int i = 0; i < CACHE_COLUMNS.length; i++) {
             query.append(i > 0 ? ", " : "").append(dbTableCaches).append('.').append(CACHE_COLUMNS[i]).append(' ');
         }
-        query.append(',').append(dbTableLogsOffline).append(".log");
+        if (loadFlags.contains(LoadFlag.LOAD_OFFLINE_LOG)) {
+            query.append(',').append(dbTableLogsOffline).append(".log");
+        }
 
         query.append(" FROM ").append(dbTableCaches);
         if (loadFlags.contains(LoadFlag.LOAD_OFFLINE_LOG)) {


### PR DESCRIPTION
The check is done correctly a few lines down, but it is needed here as well.

Fixes #1862
