### PR TITLE
Fix for null coords to allow "Store for offline"

### DIFF
--- a/main/src/cgeo/geocaching/geopoint/Viewport.java
+++ b/main/src/cgeo/geocaching/geopoint/Viewport.java
@@ -71,7 +71,8 @@ public class Viewport {
      */
     public boolean contains(final ICoordinates point) {
         final Geopoint coords = point.getCoords();
-        return coords.getLongitudeE6() >= bottomLeft.getLongitudeE6()
+        return coords != null
+                && coords.getLongitudeE6() >= bottomLeft.getLongitudeE6()
                 && coords.getLongitudeE6() <= topRight.getLongitudeE6()
                 && coords.getLatitudeE6() >= bottomLeft.getLatitudeE6()
                 && coords.getLatitudeE6() <= topRight.getLatitudeE6();
@@ -120,7 +121,7 @@ public class Viewport {
 
     /**
      * Return a viewport that contains the current viewport as well as another point.
-     * 
+     *
      * @param point
      *            the point we want in the viewport
      * @return either the same or an expanded viewport


### PR DESCRIPTION
Some caches are not loaded with coords and this makes the method Viewport.contains throw a nullpointer exception leading to the menu item "Store for offline" in the map view to stay inactive.

The cause of the coords not being loaded has to be resolved elsewhere but this fix will allow loading for the majority of caches in the view.

Even if this fix does not solve the cause it still ensure that the method functions correct (by assuming that a cache with no coords is not contained in the viewport.
