### PR TITLE
Ambigious translation fixed

### DIFF
--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -599,6 +599,7 @@
   <string name="trackable_origin">Původ</string>
   <string name="trackable_unknown">Neznámý</string>
   <string name="trackable_released">Vypuštění</string>
+  <string name="trackable_distance">Nacestoval</string>
   <string name="trackable_touch">Dotyk</string>
 
   <!-- navigation -->


### PR DESCRIPTION
Fixed ambigious translation of discovered log name. Previous was a bit confusing because it is in czech similar to found it.
