### PR TITLE
fixes #1257 - next try, only setting for default import dir

### DIFF
--- a/main/res/layout/init.xml
+++ b/main/res/layout/init.xml
@@ -709,6 +709,42 @@
 			<RelativeLayout style="@style/separator_horizontal_layout" >
 				<View style="@style/separator_horizontal" />
 				<TextView style="@style/separator_horizontal_headline"
+						android:text="@string/init_gpx_importdir" />
+			</RelativeLayout>
+			<TextView
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_marginLeft="10dip"
+					android:layout_marginRight="10dip"
+					android:layout_marginBottom="5dip"
+					android:layout_gravity="left"
+					android:padding="3dip"
+					android:textSize="14dip"
+					android:textColor="?text_color"
+					android:textColorLink="?text_color_link"
+					android:linksClickable="true"
+					android:autoLink="web"
+					android:text="@string/init_gpx_importdir_description" />
+			<LinearLayout
+					android:id="@+id/init_gpx_import_group"
+					android:layout_width="fill_parent"
+					android:layout_height="wrap_content"
+					android:orientation="horizontal" >
+				<Button style="@style/button_full"
+						android:id="@+id/select_gpx_importdir"
+						android:text="@string/init_select_gpx_importdir"
+						android:layout_width="wrap_content" />
+				<EditText style="@style/edittext_full"
+						android:id="@+id/gpx_importdir"
+						android:singleLine="true"
+						android:lines="1"
+						android:scrollHorizontally="true"
+						android:inputType="textNoSuggestions" />
+			</LinearLayout>
+<!-- ** -->
+			<RelativeLayout style="@style/separator_horizontal_layout" >
+				<View style="@style/separator_horizontal" />
+				<TextView style="@style/separator_horizontal_headline"
 						android:text="@string/init_altitude" />
 			</RelativeLayout>
 			<EditText style="@style/edittext_full"

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -424,9 +424,13 @@
   <string name="init_mapsource_select">Kartenquelle wählen</string>
   <string name="init_select_mapfile">…</string>
   <string name="init_select_gpx_exportdir">…</string>
+  <string name="init_select_gpx_importdir">…</string>
   <string name="init_gpx_exportdir">Verzeichnis für GPX Exporte</string>
+  <string name="init_gpx_importdir">Verzeichnis für GPX Importe</string>
   <string name="init_gpx_exportdir_description">Hier kann das Verzeichnis für GPX-Exporte gewählt werden.</string>
+  <string name="init_gpx_importdir_description">Hier kann das Verzeichnis für GPX-Importe gewählt werden.</string>
   <string name="init_gpx_exportdir_select">Wähle Verzeichnis für GPX Exporte</string>
+  <string name="init_gpx_importdir_select">Wähle Verzeichnis für GPX Importe</string>
   <string name="init_maptrail">Zeige Spur auf Karte</string>
   <string name="init_share_after_export">Weiterleiten nach dem Export</string>
   <string name="init_trackautovisit">Trackables automatisch auf \"besuchen\" setzen</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -425,9 +425,13 @@
   <string name="init_mapsource_select">Select Map Source</string>
   <string name="init_select_mapfile">…</string>
   <string name="init_select_gpx_exportdir">…</string>
+  <string name="init_select_gpx_importdir">…</string>
   <string name="init_gpx_exportdir">GPX Export Directory</string>
+  <string name="init_gpx_importdir">GPX Import Directory</string>
   <string name="init_gpx_exportdir_description">Here you can select the directory for GPX exports.</string>
+  <string name="init_gpx_importdir_description">Here you can select the directory for GPX imports.</string>
   <string name="init_gpx_exportdir_select">Select GPX Export Directory</string>
+  <string name="init_gpx_importdir_select">Select GPX Import Directory</string>
   <string name="init_maptrail">Show trail on Map</string>
   <string name="init_share_after_export">Open share menu after GPX export</string>
   <string name="init_trackautovisit">Set trackables to \"Visited\" as a default</string>

--- a/main/src/cgeo/geocaching/Settings.java
+++ b/main/src/cgeo/geocaching/Settings.java
@@ -22,6 +22,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Environment;
 import android.preference.PreferenceManager;
 
 import java.util.Locale;
@@ -95,6 +96,7 @@ public final class Settings {
     private static final String KEY_LAST_TRACKABLE_ACTION = "trackableaction";
     private static final String KEY_SHARE_AFTER_EXPORT = "shareafterexport";
     private static final String KEY_GPX_EXPORT_DIR = "gpxExportDir";
+    private static final String KEY_GPX_IMPORT_DIR = "gpxImportDir";
 
     private final static int unitsMetric = 1;
 
@@ -1152,7 +1154,7 @@ public final class Settings {
     }
 
     public static String getGpxExportDir() {
-        return sharedPrefs.getString(KEY_GPX_EXPORT_DIR, "/sdcard/gpx");
+        return sharedPrefs.getString(KEY_GPX_EXPORT_DIR, Environment.getExternalStorageDirectory().getPath() + "/gpx");
     }
 
     public static void setGpxExportDir(final String gpxExportDir) {
@@ -1160,6 +1162,19 @@ public final class Settings {
             @Override
             public void edit(Editor edit) {
                 edit.putString(KEY_GPX_EXPORT_DIR, gpxExportDir);
+            }
+        });
+    }
+
+    public static String getGpxImportDir() {
+        return sharedPrefs.getString(KEY_GPX_IMPORT_DIR, Environment.getExternalStorageDirectory().getPath() + "/gpx");
+    }
+
+    public static void setGpxImportDir(final String gpxImportDir) {
+        editSharedSettings(new PrefRunnable() {
+            @Override
+            public void edit(Editor edit) {
+                edit.putString(KEY_GPX_IMPORT_DIR, gpxImportDir);
             }
         });
     }

--- a/main/src/cgeo/geocaching/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/SettingsActivity.java
@@ -57,6 +57,7 @@ public class SettingsActivity extends AbstractActivity {
 
     private final static int SELECT_MAPFILE_REQUEST = 1;
     private final static int SELECT_GPXDIR_REQUEST = 2;
+    private final static int SELECT_IMPGPXDIR_REQUEST = 3;
 
 
     private ProgressDialog loginDialog = null;
@@ -573,6 +574,20 @@ public class SettingsActivity extends AbstractActivity {
             }
         });
 
+        // GPX Import directory
+        final EditText gpxImportDir = (EditText) findViewById(R.id.gpx_importdir);
+        gpxImportDir.setText(Settings.getGpxImportDir());
+        Button selectGpxImportDir = (Button) findViewById(R.id.select_gpx_importdir);
+        selectGpxImportDir.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                Intent dirChooser = new Intent(SettingsActivity.this, SimpleDirChooser.class);
+                dirChooser.putExtra(SimpleDirChooser.START_DIR, Settings.getGpxImportDir());
+                startActivityForResult(dirChooser, SELECT_IMPGPXDIR_REQUEST);
+            }
+        });
+
         // Display trail on map
         final CheckBox trailButton = (CheckBox) findViewById(R.id.trail);
         trailButton.setChecked(Settings.isMapTrail());
@@ -924,6 +939,16 @@ public class SettingsActivity extends AbstractActivity {
             EditText gpxExportDir = (EditText) findViewById(R.id.gpx_exportdir);
             gpxExportDir.setText(Settings.getGpxExportDir());
             gpxExportDir.requestFocus();
+        }
+        if (requestCode == SELECT_IMPGPXDIR_REQUEST) {
+            if (resultCode == RESULT_OK) {
+                if (data.hasExtra("chosenDir")) {
+                    Settings.setGpxImportDir(data.getStringExtra("chosenDir"));
+                }
+            }
+            EditText gpxImportDir = (EditText) findViewById(R.id.gpx_importdir);
+            gpxImportDir.setText(Settings.getGpxExportDir());
+            gpxImportDir.requestFocus();
         }
     }
 

--- a/main/src/cgeo/geocaching/cgeogpxes.java
+++ b/main/src/cgeo/geocaching/cgeogpxes.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Environment;
 
 import java.io.File;
 import java.util.List;
@@ -32,7 +31,8 @@ public class cgeogpxes extends FileList<GPXListAdapter> {
 
     @Override
     protected File[] getBaseFolders() {
-        return new File[] { new File(Environment.getExternalStorageDirectory(), "gpx") };
+        String gpxImportDir = Settings.getGpxImportDir();
+        return new File[] { new File(gpxImportDir) };
     }
 
     @Override


### PR DESCRIPTION
This is a pull request for setting gpx import dir through settings **without** a choice dialog to choose between forced scan or scan default dir only.

@Bananeweizen
Please choose the pull request of your desire and just close the other one.
