### PR TITLE
fixes #1808 - removed alertDialog.cancel() on positive / negativ button

### DIFF
--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -1243,14 +1243,14 @@ public class cgeocaches extends AbstractListActivity {
                 if (removeListAfterwards) {
                     removeList(false);
                 }
-                dialog.cancel();
+                //dialog.cancel();
             }
         });
         dialog.setNegativeButton(getString(android.R.string.no), new DialogInterface.OnClickListener() {
 
             @Override
             public void onClick(DialogInterface dialog, int id) {
-                dialog.cancel();
+                //dialog.cancel();
             }
         });
 


### PR DESCRIPTION
AlertDialog should never call cancel() in onClick() of negative or positive button because they cancel by default. setCancelable(true) is also not necessary because this is the default behaviour.

I guess the second cancel() leads to forced close if the device is fast enough...

@Lineflyer
If this is merged you can check.

If this solves the #1808 fully we will have to look through the whole code. I have seen other cancel() calls on other AlertDialogs ... this might also cause forced close.
