### PR TITLE
Change of URLs used to 'Open in Browser'

### DIFF
--- a/main/src/cgeo/geocaching/cgTrackable.java
+++ b/main/src/cgeo/geocaching/cgTrackable.java
@@ -48,7 +48,7 @@ public class cgTrackable implements ILogable {
                 return null;
             }
         }
-        return "http://coord.info/" + geocode.toUpperCase();
+        return "http://www.geocaching.com/track/details.aspx?tracker=" + geocode.toUpperCase();
     }
 
     public String getGuid() {

--- a/main/src/cgeo/geocaching/cgWaypoint.java
+++ b/main/src/cgeo/geocaching/cgWaypoint.java
@@ -156,7 +156,7 @@ public class cgWaypoint implements IWaypoint, Comparable<cgWaypoint> {
     }
 
     public String getUrl() {
-        return "http://coord.info/" + geocode.toUpperCase();
+        return "http://www.geocaching.com/seek/cache_details.aspx?wp=" + geocode.toUpperCase();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -45,7 +45,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     public String getCacheUrl(cgCache cache) {
         // it would also be possible to use "http://www.geocaching.com/seek/cache_details.aspx?wp=" + cache.getGeocode();
-        return "http://coord.info/" + cache.getGeocode();
+        return "http://www.geocaching.com/seek/cache_details.aspx?wp=" + cache.getGeocode();
     }
 
     @Override


### PR DESCRIPTION
When surfing on the gc.com pages I sometimes select cgeo and sometimes browser to view TB/GC.
Íf you select to view a TB or GC using "Open in Browser" (from cgeo) then you'll get two dialogs to select which application to use for it. With this change there will only be one.
You can of course select the default application (cgeo or browser) for the urls, but then it will be impossible to open TB/GC in browser. 
