### PR TITLE
Prevent a NPE if cache and waypoint are null.

### DIFF
--- a/main/src/cgeo/geocaching/apps/cache/navi/AbstractStaticMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/AbstractStaticMapsApp.java
@@ -30,6 +30,8 @@ abstract class AbstractStaticMapsApp extends AbstractApp implements CacheNavigat
     }
 
     protected static boolean hasStaticMap(cgWaypoint waypoint) {
+        if (waypoint==null)
+            return false;
         String geocode = waypoint.getGeocode();
         int id = waypoint.getId();
         if (StringUtils.isNotEmpty(geocode) && cgeoapplication.getInstance().isOffline(geocode, null)) {
@@ -40,11 +42,12 @@ abstract class AbstractStaticMapsApp extends AbstractApp implements CacheNavigat
 
     protected static boolean invokeStaticMaps(final Activity activity, final cgCache cache, final cgWaypoint waypoint, final boolean download) {
         final ILogable logable = cache != null && cache.getListId() != 0 ? cache : waypoint;
-        final String geocode = StringUtils.upperCase(logable.getGeocode());
-        if (geocode == null) {
+        // If the cache is not stored for offline, cache seems to be null and waypoint may be null too
+        if (logable==null || logable.getGeocode()==null ) {
             ActivityMixin.showToast(activity, getString(R.string.err_detail_no_map_static));
             return true;
         }
+        final String geocode = StringUtils.upperCase(logable.getGeocode());
 
         StaticMapsActivity.startActivity(activity, geocode, download, waypoint);
         return true;


### PR DESCRIPTION
If a cache is shown e.g. from the "caches close by" functionality and then click on "Save static map", c:geo crashes with a NPE

09-09 22:29:34.032: ERROR/AndroidRuntime(8503): FATAL EXCEPTION: main
        java.lang.NullPointerException
        at cgeo.geocaching.apps.cache.navi.AbstractStaticMapsApp.invokeStaticMaps(AbstractStaticMapsApp.java:51)
        at cgeo.geocaching.apps.cache.navi.DownloadStaticMapsApp.navigate(DownloadStaticMapsApp.java:27)
        at cgeo.geocaching.apps.cache.navi.NavigationAppFactory$1.onClick(NavigationAppFactory.java:149)
        at com.android.internal.app.AlertController$AlertParams$3.onItemClick(AlertController.java:924)
        at android.widget.AdapterView.performItemClick(AdapterView.java:298)
        at android.widget.AbsListView.performItemClick(AbsListView.java:1086)
        at android.widget.AbsListView$PerformClick.run(AbsListView.java:2855)

Looking at the code, this can happen when cache and waypoint are null and thus the loggable. This patch should fix this.
