### PR TITLE
Crash with NPE when the handset is offline

### DIFF
--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -271,7 +271,9 @@ public class cgeocaches extends AbstractListActivity {
 
     private void replaceCacheListFromSearch() {
         cacheList.clear();
-        cacheList.addAll(search.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB));
+        if (search!=null) {
+            cacheList.addAll(search.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB));
+        }
     }
 
     protected void updateTitle() {


### PR DESCRIPTION
The variable 'search' can be null if the app is offline and the user e.g. calls "nearby caches" from the main screen.

One may consider rewriting this to have searchByAny to never return null, but an empty SearchResult

cgeo.geocaching.connector.gc.GCParser#searchByAny can return null
so does cgeo.geocaching.connector.gc.GCParser#searchByKeyword

09-12 11:32:54.195: ERROR/cgeo(2493): Failure 1/5 (java.net.UnknownHostException: Unable to resolve host "www.geocaching.com": No address associated with hostname) (3 ms) - retrying GET https://www.geocaching.com/login/default.aspx
09-12 11:32:54.195: ERROR/cgeo(2493): Failure 2/5 (java.net.UnknownHostException: Unable to resolve host "www.geocaching.com": No address associated with hostname) (1 ms) - retrying GET https://www.geocaching.com/login/default.aspx
09-12 11:32:54.205: ERROR/cgeo(2493): Failure 3/5 (java.net.UnknownHostException: Unable to resolve host "www.geocaching.com": No address associated with hostname) (1 ms) - retrying GET https://www.geocaching.com/login/default.aspx
09-12 11:32:54.205: ERROR/cgeo(2493): Failure 4/5 (java.net.UnknownHostException: Unable to resolve host "www.geocaching.com": No address associated with hostname) (0 ms) - retrying GET https://www.geocaching.com/login/default.aspx
09-12 11:32:54.205: ERROR/cgeo(2493): Failure 5/5 (0 ms) GET https://www.geocaching.com/login/default.aspx
09-12 11:32:54.205: ERROR/cgeo(2493): Login.login: Failed to retrieve login page (1st)
09-12 11:32:54.205: WARN/cgeo(2493): Working as guest.
09-12 11:32:54.205: ERROR/cgeo(2493): GCParser.searchByAny: No data from server
09-12 11:32:54.205: WARN/dalvikvm(2493): threadid=20: thread exiting with uncaught exception (group=0x4139b300)
09-12 11:32:54.205: ERROR/AndroidRuntime(2493): FATAL EXCEPTION: Thread-5272
        java.lang.NullPointerException
        at cgeo.geocaching.cgeocaches.replaceCacheListFromSearch(cgeocaches.java:275)
        at cgeo.geocaching.cgeocaches.access$1500(cgeocaches.java:67)
        at cgeo.geocaching.cgeocaches$LoadByCoordsThread.runSearch(cgeocaches.java:1316)
        at cgeo.geocaching.connector.gc.AbstractSearchThread.run(AbstractSearchThread.java:59)
