### PR TITLE
GH-1528 mark owned caches in the list with a yellow strip.

### DIFF
--- a/main/res/drawable/mark_yellow.xml
+++ b/main/res/drawable/mark_yellow.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+		android:shape="rectangle">
+	<solid
+			android:color="#FFE800" />
+</shape>

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -386,6 +386,9 @@ public class CacheListAdapter extends ArrayAdapter<cgCache> {
         } else if (cache.isLogOffline()) {
             holder.logStatusMark.setImageResource(R.drawable.mark_orange);
             holder.logStatusMark.setVisibility(View.VISIBLE);
+        } else if (cache.isOwn()) {
+            holder.logStatusMark.setImageResource(R.drawable.mark_yellow);
+            holder.logStatusMark.setVisibility(View.VISIBLE);
         } else {
             holder.logStatusMark.setVisibility(View.GONE);
         }


### PR DESCRIPTION
Address GH-1528 ( and GH-1805 and GH-2042) and mark owned caches with a yellow stripe in the list view.
