### PR TITLE
Search for maps on all storages

### DIFF
--- a/main/src/cgeo/geocaching/cgSelectMapfile.java
+++ b/main/src/cgeo/geocaching/cgSelectMapfile.java
@@ -6,9 +6,9 @@ import cgeo.geocaching.ui.MapfileListAdapter;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Environment;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 public class cgSelectMapfile extends FileList<MapfileListAdapter> {
@@ -41,13 +41,14 @@ public class cgSelectMapfile extends FileList<MapfileListAdapter> {
     }
 
     @Override
-    protected File[] getBaseFolders() {
-        final File base = Environment.getExternalStorageDirectory();
-        return new File[] {
-                new File(base, "mfmaps"),
-                new File(new File(base, "Locus"), "mapsVector"),
-                new File(base, LocalStorage.cache)
-        };
+    protected List<File> getBaseFolders() {
+        List<File> folders = new ArrayList<File>();
+        for (File dir : getStorages()) {
+            folders.add(new File(dir, "mfmaps"));
+            folders.add(new File(new File(dir, "Locus"), "mapsVector"));
+            folders.add(new File(dir, LocalStorage.cache));
+        }
+        return folders;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/cgeogpxes.java
+++ b/main/src/cgeo/geocaching/cgeogpxes.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 public class cgeogpxes extends FileList<GPXListAdapter> {
@@ -30,9 +31,8 @@ public class cgeogpxes extends FileList<GPXListAdapter> {
     }
 
     @Override
-    protected File[] getBaseFolders() {
-        String gpxImportDir = Settings.getGpxImportDir();
-        return new File[] { new File(gpxImportDir) };
+    protected List<File> getBaseFolders() {
+        return Collections.singletonList(new File(Settings.getGpxImportDir()));
     }
 
     @Override


### PR DESCRIPTION
Many devices are mounting /mnt/sdcard to internal flash memory. This memory is then
referred to as the ExternalStorage. These devices may still have the possibility to
insert an SDcard and that memory is hard to access. This modification will search all
mounted memory that is available for the user for map files.
The advantage with this fix is that maps can be placed at the storage with most available space.
