### PR TITLE
Fixes #1990 Changed saving of Map-Mode

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -350,12 +350,10 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
     public void onSaveInstanceState(final Bundle outState) {
         outState.putInt(BUNDLE_MAP_SOURCE, currentSourceId);
         outState.putIntArray(BUNDLE_MAP_STATE, currentMapState());
-        if (isLiveMode())
-        {
+        if (isLiveMode()) {
             outState.putString(BUNDLE_MAP_MODE, mapMode.name());
         }
-        else
-        {
+        else {
             outState.putString(BUNDLE_MAP_MODE, null);
         }
     }


### PR DESCRIPTION
- Live map starts in last LiveMapMode, persists on exit
- Other maps always start in non-live mode, switch possible,
  CurrentMapMode not persisted

Closes #1990
