### PR TITLE
fixes #2129 - log details user caches corrected

### DIFF
--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -415,7 +415,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Žádná keš</item>
     <item quantity="one">Jedna keš</item>
-    <item quantity="other">keší</item>
+    <item quantity="other">%1$d keší</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Obnovit</string>

--- a/main/res/values-da/strings.xml
+++ b/main/res/values-da/strings.xml
@@ -171,7 +171,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Ingen cache</item>
     <item quantity="one">En cache</item>
-    <item quantity="other">Cacher</item>
+    <item quantity="other">%1$d Cacher</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Genindlæs</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -491,7 +491,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Kein Cache</item>
     <item quantity="one">Ein Cache</item>
-    <item quantity="other">Caches</item>
+    <item quantity="other">%1$d Caches</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Aktualisieren</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -408,7 +408,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Sin escondites</item>
     <item quantity="one">Un escondite</item>
-    <item quantity="other">Escondites</item>
+    <item quantity="other">%1$d Escondites</item>
   </plurals>
   <string name="cache_offline">Desconectado</string>
   <string name="cache_offline_refresh">Actualizar</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -477,7 +477,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">aucune cache</item>
     <item quantity="one">une cache</item>
-    <item quantity="other">caches</item>
+    <item quantity="other">%1$d caches</item>
   </plurals>
   <string name="cache_offline">Hors ligne</string>
   <string name="cache_offline_refresh">Recharger</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -418,7 +418,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Nincs megtalálás</item>
     <item quantity="one">Megtalálás</item>
-    <item quantity="other">Megtalálások</item>
+    <item quantity="other">%1$d Megtalálások</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Frissítés</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -482,7 +482,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Nessun cache</item>
     <item quantity="one">Un cache</item>
-    <item quantity="other">Cache</item>
+    <item quantity="other">%1$d Cache</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Aggiorna</string>

--- a/main/res/values-ja/strings.xml
+++ b/main/res/values-ja/strings.xml
@@ -498,7 +498,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">キャッシュがありません</item>
     <item quantity="one">1つのキャッシュ</item>
-    <item quantity="other">個のキャッシュ</item>
+    <item quantity="other">%1$d 個のキャッシュ</item>
   </plurals>
   <string name="cache_offline">オフライン</string>
   <string name="cache_offline_refresh">更新</string>

--- a/main/res/values-nb/strings.xml
+++ b/main/res/values-nb/strings.xml
@@ -252,7 +252,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Ingen cacher</item>
     <item quantity="one">Én cache</item>
-    <item quantity="other">Cacher</item>
+    <item quantity="other">%1$d Cacher</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Oppdater</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -457,7 +457,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Geen cache</item>
     <item quantity="one">Een cache</item>
-    <item quantity="other">Caches</item>
+    <item quantity="other">%1$d Caches</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Verversen</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -404,7 +404,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Nie ma skrzynek</item>
     <item quantity="one">Jedna skrzynka</item>
-    <item quantity="other">Skrzynki</item>
+    <item quantity="other">%1$d Skrzynki</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Odśwież</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -450,7 +450,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Nenhuma cache</item>
     <item quantity="one">Uma cache</item>
-    <item quantity="other">Caches</item>
+    <item quantity="other">%1$d Caches</item>
   </plurals>
   <string name="cache_offline">Arquivo</string>
   <string name="cache_offline_refresh">Actualizar</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -486,7 +486,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">žiadna skrýša</item>
     <item quantity="one">jedna skrýša</item>
-    <item quantity="other">skrýš</item>
+    <item quantity="other">%1$d skrýš</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Obnoviť</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -493,7 +493,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">Ingen cache</item>
     <item quantity="one">En cache</item>
-    <item quantity="other">cacher</item>
+    <item quantity="other">%1$d cacher</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Uppdatera</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -501,7 +501,7 @@
   <plurals name="cache_counts">
     <item quantity="zero">No cache</item>
     <item quantity="one">One cache</item>
-    <item quantity="other">Caches</item>
+    <item quantity="other">%1$d Caches</item>
   </plurals>
   <string name="cache_offline">Offline</string>
   <string name="cache_offline_refresh">Refresh</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2235,7 +2235,7 @@ public class CacheDetailActivity extends AbstractActivity {
                     if (log.found == -1) {
                         holder.count.setVisibility(View.GONE);
                     } else  {
-                        holder.count.setText(log.found + " " + res.getQuantityText(R.plurals.cache_counts,log.found));
+                        holder.count.setText(res.getQuantityString(R.plurals.cache_counts, log.found, log.found));
                     }
 
                     // logtext, avoid parsing HTML if not necessary


### PR DESCRIPTION
At CacheDetailsActivity - LogDatailsView the number of user caches is now a parameter in cache_count string, not concatenated in source code anymore.
