### PR TITLE
Solved force close in SimpleDirChooser

### DIFF
--- a/main/res/layout/init.xml
+++ b/main/res/layout/init.xml
@@ -726,6 +726,9 @@
             <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dip"
+                    android:layout_marginRight="10dip"
+                    android:layout_marginBottom="5dip"
                     android:layout_gravity="center_vertical"
                     android:gravity="left"
                     android:padding="3dip"

--- a/main/src/cgeo/geocaching/files/SimpleDirChooser.java
+++ b/main/src/cgeo/geocaching/files/SimpleDirChooser.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.files;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 
+import org.apache.commons.lang3.StringUtils;
+
 import android.app.ListActivity;
 import android.content.Context;
 import android.content.Intent;
@@ -43,7 +45,7 @@ public class SimpleDirChooser extends ListActivity {
         super.onCreate(savedInstanceState);
         final Bundle extras = getIntent().getExtras();
         String startDir = extras.getString(START_DIR);
-        if (startDir == null) {
+        if (StringUtils.isBlank(startDir)) {
             startDir = Environment.getExternalStorageDirectory().getPath();
         } else {
             startDir = startDir.substring(0, startDir.lastIndexOf(File.separatorChar));


### PR DESCRIPTION
If no path is entered and SimpleDirChooser is opened then it will crash
due to IndexOfOfBoundsExcep. This happened to me when trying to use
map themes the first time ever today.
