### PR TITLE
workaround #1973 - load cache fully if logs are missing

### DIFF
--- a/main/src/cgeo/geocaching/VisitCacheActivity.java
+++ b/main/src/cgeo/geocaching/VisitCacheActivity.java
@@ -680,6 +680,14 @@ public class VisitCacheActivity extends AbstractLoggingActivity implements DateD
             if (status == StatusCode.NO_ERROR) {
                 final LogEntry logNow = new LogEntry(date, typeSelected, log);
 
+                // Workaround for #1973
+                if (cache.getLogs() == null || cache.getLogs().size() == 0) {
+                    cgCache loadCache = app.loadCache(geocode, LoadFlags.LOAD_ALL_DB_ONLY);
+                    if (loadCache != null) {
+                        cache = loadCache;
+                    }
+                }
+
                 cache.prependLog(logNow);
 
                 if (typeSelected == LogType.FOUND_IT) {
@@ -687,9 +695,7 @@ public class VisitCacheActivity extends AbstractLoggingActivity implements DateD
                 }
 
                 app.updateCache(cache);
-            }
 
-            if (status == StatusCode.NO_ERROR) {
                 app.clearLogOffline(geocode);
             }
 

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -807,6 +807,7 @@ public abstract class GCParser {
             return null;
         }
 
+        // TODO This seems to store the fresh loaded cache in CacheCache although it is in DB
         final SearchResult searchResult = parseSearch(fullUri, page, showCaptcha);
         if (searchResult == null || CollectionUtils.isEmpty(searchResult.getGeocodes())) {
             Log.e("GCParser.searchByAny: No cache parsed");

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1226,6 +1226,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
 
                 } while (count < 2);
 
+                // TODO searchResult is already loaded through searchByViewport!
                 if (searchResult != null) {
                     Set<cgCache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);
                     // to update the caches they have to be removed first


### PR DESCRIPTION
In my opinion this is the best workaround to solve the missing log entries.
This loads the cache from DB if the log entries are missing.

For not stored caches there will maybe log entries still missing, but in my opinion
this is OK.
