### PR TITLE
fixes #2170 - We don't need progress devider anymore

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -374,7 +374,6 @@ public class GPXImporter {
 
                 case IMPORT_STEP_READ_FILE:
                 case IMPORT_STEP_READ_WPT_FILE:
-                    progress.setProgressDivider(1024);
                     progress.setMessage(res.getString(msg.arg1));
                     progress.setMaxProgressAndReset(msg.arg2);
                     break;


### PR DESCRIPTION
I had introduced a progressDevider to shorten bytes on file import progress.
This was set to 1024. A step between file import and cache storing set it back
to 1 but it was removed.

Having @Bananeweizen fix that only the percentage is shown there is no need
to use the progress devider anymore. Removing to set it to 1024 fixed the issue.
