### PR TITLE
fixes #2170 - removed setting progress devider to 1024

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -374,7 +374,6 @@ public class GPXImporter {
 
                 case IMPORT_STEP_READ_FILE:
                 case IMPORT_STEP_READ_WPT_FILE:
-                    progress.setProgressDivider(1024);
                     progress.setMessage(res.getString(msg.arg1));
                     progress.setMaxProgressAndReset(msg.arg2);
                     break;


### PR DESCRIPTION
I don't get it on release branch, sorry.

Removed the line to set progress devider to 1024. This is not needed anymore and caused a NaN in static maps import.
