### PR TITLE
fixes #2170 - removed setting progress devider to 1024

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -374,7 +374,6 @@ public class GPXImporter {
 
                 case IMPORT_STEP_READ_FILE:
                 case IMPORT_STEP_READ_WPT_FILE:
-                    progress.setProgressDivider(1024);
                     progress.setMessage(res.getString(msg.arg1));
                     progress.setMaxProgressAndReset(msg.arg2);
                     break;


### PR DESCRIPTION
With the help of rsudev on IRC, thanks.

I introduced a progress devider to shorten file import bytes. This was set to 1024 and back to 1 in a step that is now removed. Because we only show percentage we don't need progress devider any more. This is a one line fix.
