### PR TITLE
fixes finalDefined vanishing on refresh

### DIFF
--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -327,6 +327,9 @@ public class cgCache implements ICache, IWaypoint {
         if (zoomlevel == -1) {
             zoomlevel = other.zoomlevel;
         }
+        if (!finalDefined) {
+            finalDefined = other.finalDefined;
+        }
 
         boolean isEqual = isEqualTo(other);
 


### PR DESCRIPTION
This is a fix for the finalDefined flag in the cache list after refreshing the cache from GC.com

The cgCache instance loaded from GC.com is detailed, so the call:

```
 gcLoadedCache.gatherMissingFrom(storedCache)
```

will never merge the finalDefined flag because this is only done on not detailed caches.
I added some merge code to the end.
