### PR TITLE
fix finalDefined flag vanishing on list item refresh

### DIFF
--- a/main/src/cgeo/geocaching/cgCache.java
+++ b/main/src/cgeo/geocaching/cgCache.java
@@ -294,12 +294,12 @@ public class cgCache implements ICache, IWaypoint {
             attributes.set(other.attributes);
         }
         if (waypoints.isEmpty()) {
-            waypoints.set(other.waypoints);
+            this.setWaypoints(other.waypoints.asList(), false);
         }
         else {
             ArrayList<cgWaypoint> newPoints = new ArrayList<cgWaypoint>(waypoints.asList());
-            cgWaypoint.mergeWayPoints(newPoints, other.getWaypoints(), false);
-            waypoints.set(newPoints);
+            cgWaypoint.mergeWayPoints(newPoints, other.waypoints.asList(), false);
+            this.setWaypoints(newPoints, false);
         }
         if (spoilers == null) {
             spoilers = other.spoilers;


### PR DESCRIPTION
As discussed with @Bananeweizen in a previous commit:

I changed  calls to waypoints.add in cgCache.gatherMissingFrom to calls of setWaypoints which internally sets finalDefined.

@Lineflyer

The problem is reproducable:
- take a mystery
- add a user defined final waypoint in c:geo
- go to list view
- mark mystery for refresh
- call menu/refresh

-> finalDefined overlay is gone

I will not merge my own changes before someone tells me to do.
