### PR TITLE
DO NOT MERGE - Prototype of opencaching integration with oc11xml api

### DIFF
--- a/main/res/layout/init.xml
+++ b/main/res/layout/init.xml
@@ -60,6 +60,47 @@
 			<RelativeLayout style="@style/separator_horizontal_layout" >
 				<View style="@style/separator_horizontal" />
 				<TextView style="@style/separator_horizontal_headline"
+						android:text="@string/init_oc" />
+			</RelativeLayout>
+			<LinearLayout
+					android:layout_width="fill_parent"
+					android:layout_height="wrap_content"
+					android:layout_margin="3dip"
+					android:orientation="horizontal"
+					android:padding="3dip" >
+				<CheckBox android:id="@+id/oc_option"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_gravity="left"
+						android:padding="1dip"
+						android:gravity="center" />
+				<TextView
+						android:layout_width="fill_parent"
+						android:layout_height="wrap_content"
+						android:layout_gravity="center_vertical"
+						android:gravity="left"
+						android:paddingRight="3dip"
+						android:textSize="14sp"
+						android:textColor="?text_color"
+						android:text="@string/init_oc_activate" />
+			</LinearLayout>
+			<TextView
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_marginLeft="10dip"
+				android:layout_marginRight="10dip"
+				android:layout_marginBottom="5dip"
+				android:padding="3dip"
+				android:textSize="14sp"
+				android:textColor="?text_color"
+				android:text="@string/init_oc_username_description" />
+			<EditText style="@style/edittext_full"
+				android:id="@+id/oc_username"
+				android:hint="@string/init_oc_username" />
+<!-- ** -->
+			<RelativeLayout style="@style/separator_horizontal_layout" >
+				<View style="@style/separator_horizontal" />
+				<TextView style="@style/separator_horizontal_headline"
 						android:text="@string/init_gcvote" />
 			</RelativeLayout>
 			<EditText style="@style/edittext_full"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -339,6 +339,10 @@
 
   <!-- init -->
   <string name="init_geocaching">Geocaching.com</string>
+  <string name="init_oc">opencaching.de</string>
+  <string name="init_oc_activate">Activate opencaching.de on live-map and in searches</string>
+  <string name="init_oc_username_description">Enter your opencaching.de user name in order to allow marking your finds.</string>
+  <string name="init_oc_username">Enter your user name</string>
   <string name="init_gcvote">GCvote.com</string>
   <string name="init_twitter">Twitter</string>
   <string name="init_username">Username</string>

--- a/main/src/cgeo/geocaching/Settings.java
+++ b/main/src/cgeo/geocaching/Settings.java
@@ -109,6 +109,8 @@ public final class Settings {
     private static final String KEY_PLAIN_LOGS = "plainLogs";
     private static final String KEY_NATIVE_UA = "nativeUa";
     private static final String KEY_MAP_DIRECTORY = "mapDirectory";
+    private static final String KEY_CONNECTOR_OC = "connectorOC";
+    private static final String KEY_CONNECTOR_OC_USER = "connectorOCUser";
 
     private final static int unitsMetric = 1;
 
@@ -300,6 +302,50 @@ public final class Settings {
                     edit.remove(KEY_MEMBER_STATUS);
                 } else {
                     edit.putString(KEY_MEMBER_STATUS, memberStatus);
+                }
+            }
+        });
+    }
+
+    public static boolean isOCConnectorActive() {
+        String ocConnectorSetting = sharedPrefs.getString(KEY_CONNECTOR_OC, null);
+        if (StringUtils.isBlank(ocConnectorSetting)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean setOCConnectorActive(final boolean isActive) {
+        return editSharedSettings(new PrefRunnable() {
+
+            @Override
+            public void edit(Editor edit) {
+                if (isActive) {
+                    edit.putString(KEY_CONNECTOR_OC, "Active");
+                } else {
+                    edit.putString(KEY_CONNECTOR_OC, StringUtils.EMPTY);
+                }
+            }
+        });
+    }
+
+    public static String getOCConnectorUserName() {
+        String ocConnectorUser = sharedPrefs.getString(KEY_CONNECTOR_OC_USER, null);
+        if (StringUtils.isBlank(ocConnectorUser)) {
+            return StringUtils.EMPTY;
+        }
+        return ocConnectorUser;
+    }
+
+    public static boolean setOCConnectorUserName(final String userName) {
+        return editSharedSettings(new PrefRunnable() {
+
+            @Override
+            public void edit(Editor edit) {
+                if (StringUtils.isBlank(userName)) {
+                    edit.remove(KEY_CONNECTOR_OC_USER);
+                } else {
+                    edit.putString(KEY_CONNECTOR_OC_USER, userName);
                 }
             }
         });

--- a/main/src/cgeo/geocaching/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/SettingsActivity.java
@@ -242,6 +242,21 @@ public class SettingsActivity extends AbstractActivity {
             }
         });
 
+        // opencaching.de settings
+        final CheckBox ocCheck = (CheckBox) findViewById(R.id.oc_option);
+        ocCheck.setChecked(Settings.isOCConnectorActive());
+        ocCheck.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                Settings.setOCConnectorActive(ocCheck.isChecked());
+            }
+        });
+        EditText ocUserEdit = (EditText) findViewById(R.id.oc_username);
+        if (ocUserEdit.getText().length() == 0) {
+            ocUserEdit.setText(Settings.getOCConnectorUserName());
+        }
+
         // gcvote settings
         final ImmutablePair<String, String> gcvoteLogin = Settings.getGCvoteLogin();
         if (null != gcvoteLogin && null != gcvoteLogin.right) {
@@ -813,6 +828,7 @@ public class SettingsActivity extends AbstractActivity {
         String signatureNew = ((EditText) findViewById(R.id.signature)).getText().toString();
         String mapDirectoryNew = StringUtils.trimToEmpty(((EditText) findViewById(R.id.map_directory)).getText().toString());
         String themesDirectoryNew = StringUtils.trimToEmpty(((EditText) findViewById(R.id.themefolder)).getText().toString());
+        String ocUserName = StringUtils.trimToEmpty(((EditText) findViewById(R.id.oc_username)).getText().toString());
 
         String altitudeNew = StringUtils.trimToNull(((EditText) findViewById(R.id.altitude)).getText().toString());
         int altitudeNewInt = parseNumber(altitudeNew, 0);
@@ -826,6 +842,7 @@ public class SettingsActivity extends AbstractActivity {
         final boolean status4 = Settings.setAltCorrection(altitudeNewInt);
         final boolean status5 = Settings.setMapFileDirectory(mapDirectoryNew);
         final boolean status6 = Settings.setCustomRenderThemeBaseFolder(themesDirectoryNew);
+        final boolean status7 = Settings.setOCConnectorUserName(ocUserName);
         Settings.setShowWaypointsThreshold(waypointThreshold);
 
         String importNew = StringUtils.trimToEmpty(((EditText) findViewById(R.id.gpx_importdir)).getText().toString());
@@ -833,7 +850,7 @@ public class SettingsActivity extends AbstractActivity {
         Settings.setGpxImportDir(importNew);
         Settings.setGpxExportDir(exportNew);
 
-        return status1 && status2 && status3 && status4 && status5 && status6;
+        return status1 && status2 && status3 && status4 && status5 && status6 && status7;
     }
 
     /**

--- a/main/src/cgeo/geocaching/cgeocaches.java
+++ b/main/src/cgeo/geocaching/cgeocaches.java
@@ -7,6 +7,8 @@ import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.activity.Progress;
 import cgeo.geocaching.apps.cache.navi.NavigationAppFactory;
 import cgeo.geocaching.apps.cachelist.CacheListAppFactory;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.gc.AbstractSearchThread;
 import cgeo.geocaching.connector.gc.GCParser;
 import cgeo.geocaching.connector.gc.SearchHandler;
@@ -1345,6 +1347,12 @@ public class cgeocaches extends AbstractListActivity implements FilteredActivity
         @Override
         public void runSearch() {
             search = GCParser.searchByCoords(coords, Settings.getCacheType(), Settings.isShowCaptcha());
+            if (Settings.isOCConnectorActive()) {
+                SearchResult temp = ((ISearchByCenter) ConnectorFactory.getConnector("OCXXX")).searchByCenter(coords);
+                if (temp != null) {
+                    search.addGeocodes(temp.getGeocodes());
+                }
+            }
             replaceCacheListFromSearch();
         }
     }

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -1,8 +1,6 @@
 package cgeo.geocaching.connector;
 
-import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.cgCache;
-import cgeo.geocaching.geopoint.Viewport;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,11 +34,6 @@ public abstract class AbstractConnector implements IConnector {
     @Override
     public boolean supportsUserActions() {
         return false;
-    }
-
-    @Override
-    public SearchResult searchByViewport(Viewport viewport, String tokens[]) {
-        return null;
     }
 
     protected static boolean isNumericId(final String string) {

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -2,10 +2,13 @@ package cgeo.geocaching.connector;
 
 import cgeo.geocaching.ICache;
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.Settings;
 import cgeo.geocaching.cgTrackable;
+import cgeo.geocaching.connector.capability.ISearchByViewPort;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.oc.OCApiConnector;
 import cgeo.geocaching.connector.oc.OCConnector;
+import cgeo.geocaching.connector.oc.OCXMLApiConnector;
 import cgeo.geocaching.connector.ox.OXConnector;
 import cgeo.geocaching.geopoint.Viewport;
 
@@ -15,13 +18,13 @@ public final class ConnectorFactory {
     private static final UnknownConnector UNKNOWN_CONNECTOR = new UnknownConnector();
     private static final IConnector[] connectors = new IConnector[] {
             GCConnector.getInstance(),
-            new OCConnector("OpenCaching.DE", "www.opencaching.de", "OC"),
+            new OCXMLApiConnector("OpenCaching.DE", "www.opencaching.de", "OC"),
             new OCConnector("OpenCaching.CZ", "www.opencaching.cz", "OZ"),
             new OCApiConnector("OpenCaching.CO.UK", "www.opencaching.org.uk", "OK", "arU4okouc4GEjMniE2fq"),
             new OCConnector("OpenCaching.ES", "www.opencachingspain.es", "OC"),
             new OCConnector("OpenCaching.IT", "www.opencaching.it", "OC"),
             new OCConnector("OpenCaching.JP", "www.opencaching.jp", "OJ"),
-            new OCConnector("OpenCaching.NO/SE", "www.opencaching.no", "OS"),
+            new OCConnector("OpenCaching.NO/SE", "www.opencaching.se", "OS"),
             new OCApiConnector("OpenCaching.NL", "www.opencaching.nl", "OB", "PdzU8jzIlcfMADXaYN8j"),
             new OCApiConnector("OpenCaching.PL", "www.opencaching.pl", "OP", "GkxM47WkUkLQXXsZ9qSh"),
             new OCApiConnector("OpenCaching.US", "www.opencaching.us", "OU", "pTsYAYSXFcfcRQnYE6uA"),
@@ -74,11 +77,24 @@ public final class ConnectorFactory {
         return StringUtils.isBlank(geocode) || !Character.isLetterOrDigit(geocode.charAt(0));
     }
 
-    /** @see IConnector#searchByViewport */
+    /** @see ISearchByViewPort#searchByViewport */
     public static SearchResult searchByViewport(final Viewport viewport, final String[] tokens) {
         // We have only connector capable of doing a 'searchByViewport()'
         // If there is a second connector the information has to be collected from all collectors
-        return GCConnector.getInstance().searchByViewport(viewport, tokens);
+        SearchResult result = new SearchResult();
+        ISearchByViewPort vpconn = GCConnector.getInstance();
+        SearchResult temp = vpconn.searchByViewport(viewport, tokens);
+        if (temp != null) {
+            result.addGeocodes(temp.getGeocodes());
+        }
+        if (Settings.isOCConnectorActive()) {
+            vpconn = (ISearchByViewPort) ConnectorFactory.getConnector("OCXXX");
+            temp = vpconn.searchByViewport(viewport, tokens);
+            if (temp != null) {
+                result.addGeocodes(temp.getGeocodes());
+            }
+        }
+        return result;
     }
 
     public static String getGeocodeFromURL(final String url) {

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -1,8 +1,6 @@
 package cgeo.geocaching.connector;
 
-import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.cgCache;
-import cgeo.geocaching.geopoint.Viewport;
 
 public interface IConnector {
     /**
@@ -37,7 +35,7 @@ public interface IConnector {
 
     /**
      * enable/disable favorite points controls in cache details
-     *
+     * 
      * @return
      */
     public boolean supportsFavoritePoints();
@@ -70,15 +68,6 @@ public interface IConnector {
      * @return
      */
     public boolean supportsUserActions();
-
-    /**
-     * Search caches by viewport.
-     *
-     * @param viewport
-     * @param tokens
-     * @return
-     */
-    public SearchResult searchByViewport(final Viewport viewport, final String[] tokens);
 
     /**
      * return true if this is a ZIP file containing a GPX file

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.cgData;
 import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
+import cgeo.geocaching.connector.capability.ISearchByViewPort;
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.geopoint.Viewport;
@@ -18,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Pattern;
 
-public class GCConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter {
+public class GCConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter, ISearchByViewPort {
 
     private static final String HTTP_COORD_INFO = "http://coord.info/";
     private static GCConnector instance;

--- a/main/src/cgeo/geocaching/connector/oc/OC11XMLParser.java
+++ b/main/src/cgeo/geocaching/connector/oc/OC11XMLParser.java
@@ -1,0 +1,539 @@
+package cgeo.geocaching.connector.oc;
+
+import cgeo.geocaching.LogEntry;
+import cgeo.geocaching.Settings;
+import cgeo.geocaching.cgCache;
+import cgeo.geocaching.cgWaypoint;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.LogType;
+import cgeo.geocaching.geopoint.Geopoint;
+import cgeo.geocaching.utils.Log;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+import android.sax.Element;
+import android.sax.EndElementListener;
+import android.sax.EndTextElementListener;
+import android.sax.RootElement;
+import android.sax.StartElementListener;
+import android.util.Xml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+public class OC11XMLParser {
+
+    private static class CacheLog {
+        public String cacheId;
+        public LogEntry logEntry;
+    }
+
+    private static class CacheDescription {
+        public String cacheId;
+        public String shortDesc;
+        public String desc;
+        public String hint;
+    }
+
+    private static Date parseFullDate(final String date) {
+        final SimpleDateFormat ISO8601DATEFORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+        ISO8601DATEFORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+        final String strippedDate = date.replaceAll("\\+0([0-9]){1}\\:00", "+0$100");
+        try {
+            return ISO8601DATEFORMAT.parse(strippedDate);
+        } catch (ParseException e) {
+            Log.e("OC11XMLParser.parseFullDate", e);
+        }
+        return null;
+    }
+
+    private static Date parseDayDate(final String date) {
+        final SimpleDateFormat ISO8601DATEFORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        ISO8601DATEFORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+        final String strippedDate = date.replaceAll("\\+0([0-9]){1}\\:00", "+0$100");
+        try {
+            return ISO8601DATEFORMAT.parse(strippedDate);
+        } catch (ParseException e) {
+            Log.e("OC11XMLParser.parseDayDate", e);
+        }
+        return null;
+    }
+
+    private static CacheSize getCacheSize(final String sizeId) {
+        int size = Integer.parseInt(sizeId);
+
+        switch (size) {
+            case 1:
+                return CacheSize.OTHER;
+            case 2:
+                return CacheSize.MICRO;
+            case 3:
+                return CacheSize.SMALL;
+            case 4:
+                return CacheSize.REGULAR;
+            case 5:
+            case 6:
+                return CacheSize.LARGE;
+            case 8:
+                return CacheSize.VIRTUAL;
+            default:
+                break;
+        }
+        return CacheSize.NOT_CHOSEN;
+    }
+
+    private static CacheType getCacheType(final String typeId) {
+        int type = Integer.parseInt(typeId);
+        switch (type) {
+            case 1: // Other/unbekannter Cachetyp
+                return CacheType.UNKNOWN;
+            case 2: // Trad./normaler Cache
+                return CacheType.TRADITIONAL;
+            case 3: // Multi/Multicache
+                return CacheType.MULTI;
+            case 4: // Virt./virtueller Cache
+                return CacheType.VIRTUAL;
+            case 5: // ICam./Webcam-Cache
+                return CacheType.WEBCAM;
+            case 6: // Event/Event-Cache
+                return CacheType.EVENT;
+            case 7: // Quiz/Rätselcache
+                return CacheType.MYSTERY;
+            case 8: // Math/Mathe-/Physikcache
+                return CacheType.MYSTERY;
+            case 9: // Moving/beweglicher Cache
+                return CacheType.UNKNOWN;
+            case 10: // Driv./Drive-In
+                return CacheType.TRADITIONAL;
+        }
+        return CacheType.UNKNOWN;
+    }
+
+    private static LogType getLogType(final int typeId) {
+        switch (typeId) {
+            case 1:
+                return LogType.FOUND_IT;
+            case 2:
+                return LogType.DIDNT_FIND_IT;
+            case 3:
+                return LogType.NOTE;
+            case 7:
+                return LogType.ATTENDED;
+            case 8:
+                return LogType.WILL_ATTEND;
+        }
+        return LogType.UNKNOWN;
+    }
+
+    private static void setCacheStatus(final int statusId, final cgCache cache) {
+
+        cache.setArchived(true);
+        cache.setDisabled(false);
+
+        switch (statusId) {
+            case 1:
+                cache.setArchived(false);
+                cache.setDisabled(false);
+                break;
+            case 2:
+                cache.setArchived(false);
+                cache.setDisabled(true);
+                break;
+        }
+    }
+
+    private static void resetCache(final ArrayList<cgCache> cacheHolder) {
+        final cgCache cache = new cgCache();
+        cache.setReliableLatLon(true);
+        cache.setAttributes(Collections.<String> emptyList());
+        cache.setWaypoints(Collections.<cgWaypoint> emptyList(), false);
+        cache.setLogs(Collections.<LogEntry> emptyList());
+        cache.setDescription(StringUtils.EMPTY);
+        cacheHolder.clear();
+        cacheHolder.add(cache);
+    }
+
+    private static void resetLog(final ArrayList<CacheLog> logHolder) {
+        if (logHolder.size() == 0) {
+            logHolder.add(new CacheLog());
+        }
+        CacheLog log = logHolder.get(0);
+        log.cacheId = StringUtils.EMPTY;
+        log.logEntry = new LogEntry("", 0, LogType.UNKNOWN, "");
+    }
+
+    private static void resetDesc(final ArrayList<CacheDescription> descHolder) {
+        if (descHolder.size() == 0) {
+            descHolder.add(new CacheDescription());
+        }
+        final CacheDescription desc = descHolder.get(0);
+        desc.cacheId = StringUtils.EMPTY;
+        desc.shortDesc = StringUtils.EMPTY;
+        desc.desc = StringUtils.EMPTY;
+        desc.hint = StringUtils.EMPTY;
+    }
+
+    public static Collection<cgCache> parseCaches(final InputStream stream) throws IOException {
+
+        final Map<String, cgCache> caches = new HashMap<String, cgCache>();
+
+        final ArrayList<cgCache> cacheHolder = new ArrayList<cgCache>();
+        final ArrayList<CacheLog> logHolder = new ArrayList<CacheLog>();
+        final ArrayList<CacheDescription> descHolder = new ArrayList<CacheDescription>();
+
+        final RootElement root = new RootElement("oc11xml");
+        final Element cacheNode = root.getChild("cache");
+
+        // root
+        root.setEndElementListener(new EndElementListener() {
+
+            @Override
+            public void end() {
+                cgCache[] parsedCaches = caches.values().toArray(new cgCache[] {});
+                for (cgCache cache : parsedCaches) {
+                    if (StringUtils.isEmpty(cache.getGeocode())
+                            || cache.getCoords() == null
+                            || cache.isArchived()) {
+
+                        // remove incomplete caches
+                        caches.remove(cache.getCacheId());
+                    }
+                }
+            }
+
+        });
+
+        // cache
+        cacheNode.setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attributes) {
+                resetCache(cacheHolder);
+            }
+
+        });
+
+        cacheNode.setEndElementListener(new EndElementListener() {
+
+            @Override
+            public void end() {
+                cgCache cache = cacheHolder.get(0);
+                if (StringUtils.isNotBlank(cache.getGeocode())
+                        && cache.getCoords() != null) {
+                    caches.put(cache.getCacheId(), cache);
+                }
+            }
+        });
+
+        // cache.id
+        cacheNode.getChild("id").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                cacheHolder.get(0).setCacheId(body);
+            }
+        });
+
+        // cache.longitude
+        cacheNode.getChild("longitude").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                Geopoint coords = cacheHolder.get(0).getCoords();
+                if (coords == null) {
+                    coords = new Geopoint(0, 0);
+                }
+                String longitude = body.trim();
+                if (StringUtils.isNotBlank(longitude)) {
+                    coords = new Geopoint(coords.getLatitude(), Double.valueOf(longitude));
+                    cacheHolder.get(0).setCoords(coords);
+                }
+            }
+        });
+
+        // cache.latitude
+        cacheNode.getChild("latitude").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                Geopoint coords = cacheHolder.get(0).getCoords();
+                if (coords == null) {
+                    coords = new Geopoint(0, 0);
+                }
+                String latitude = body.trim();
+                if (StringUtils.isNotBlank(latitude)) {
+                    coords = new Geopoint(Double.valueOf(latitude), coords.getLongitude());
+                    cacheHolder.get(0).setCoords(coords);
+                }
+            }
+        });
+
+        // cache.name
+        cacheNode.getChild("name").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                cacheHolder.get(0).setName(content);
+            }
+        });
+
+        // cache.waypoints[oc]
+        cacheNode.getChild("waypoints").setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attrs) {
+                if (attrs.getIndex("oc") > -1) {
+                    cacheHolder.get(0).setGeocode(attrs.getValue("oc"));
+                }
+                if (attrs.getIndex("gccom") > -1) {
+                    String gccode = attrs.getValue("gccom");
+                    if (!StringUtils.isBlank(gccode)) {
+                        cacheHolder.get(0).setDescription(String.format("Listed on geocaching com: <a href=\"http://coord.info/%s\">%s</a><br /><br />", gccode, gccode));
+                    }
+                }
+            }
+        });
+
+        // cache.type[id]
+        cacheNode.getChild("type").setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attrs) {
+                if (attrs.getIndex("id") > -1) {
+                    final String typeId = attrs.getValue("id");
+                    cacheHolder.get(0).setType(getCacheType(typeId));
+                }
+            }
+        });
+
+        // cache.status[id]
+        cacheNode.getChild("status").setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attrs) {
+                if (attrs.getIndex("id") > -1) {
+                    final int statusId = Integer.parseInt(attrs.getValue("id"));
+                    setCacheStatus(statusId, cacheHolder.get(0));
+                }
+            }
+        });
+
+        // cache.size[id]
+        cacheNode.getChild("size").setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attrs) {
+                if (attrs.getIndex("id") > -1) {
+                    final String typeId = attrs.getValue("id");
+                    cacheHolder.get(0).setSize(getCacheSize(typeId));
+                }
+            }
+        });
+
+        // cache.difficulty
+        cacheNode.getChild("difficulty").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                cacheHolder.get(0).setDifficulty(Float.valueOf(content));
+            }
+        });
+
+        // cache.terrain
+        cacheNode.getChild("terrain").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                cacheHolder.get(0).setTerrain(Float.valueOf(content));
+            }
+        });
+
+        // cache.terrain
+        cacheNode.getChild("datehidden").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                cacheHolder.get(0).setHidden(parseFullDate(content));
+            }
+        });
+
+        // cache.attributes.attribute
+        cacheNode.getChild("attributes").getChild("attribute").setEndTextElementListener(new EndTextElementListener() {
+            @Override
+            public void end(String body) {
+                if (StringUtils.isNotBlank(body)) {
+                    cacheHolder.get(0).getAttributes().add(body.trim());
+                }
+            }
+        });
+
+        // cachedesc
+        final Element cacheDesc = root.getChild("cachedesc");
+
+        cacheDesc.setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attributes) {
+                resetDesc(descHolder);
+            }
+        });
+
+        cacheDesc.setEndElementListener(new EndElementListener() {
+
+            @Override
+            public void end() {
+                final CacheDescription desc = descHolder.get(0);
+                final cgCache cache = caches.get(desc.cacheId);
+                if (cache != null) {
+                    cache.setShortdesc(desc.shortDesc);
+                    cache.setDescription(cache.getDescription() + desc.desc);
+                    cache.setHint(desc.hint);
+                }
+            }
+        });
+
+        // cachedesc.cacheid
+        cacheDesc.getChild("cacheid").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                descHolder.get(0).cacheId = body;
+            }
+        });
+
+        // cachedesc.desc
+        cacheDesc.getChild("shortdesc").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                descHolder.get(0).shortDesc = content;
+            }
+        });
+
+        // cachedesc.desc
+        cacheDesc.getChild("desc").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                descHolder.get(0).desc = content;
+            }
+        });
+
+        // cachedesc.hint
+        cacheDesc.getChild("hint").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                final String content = body.trim();
+                descHolder.get(0).hint = content;
+            }
+        });
+
+        // cachelog
+        final Element cacheLog = root.getChild("cachelog");
+
+        cacheLog.setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attrs) {
+                resetLog(logHolder);
+            }
+        });
+
+        cacheLog.setEndElementListener(new EndElementListener() {
+
+            @Override
+            public void end() {
+                final CacheLog log = logHolder.get(0);
+                final cgCache cache = caches.get(log.cacheId);
+                if (cache != null && log.logEntry.type != LogType.UNKNOWN) {
+                    cache.getLogs().prepend(log.logEntry);
+                    if (log.logEntry.type == LogType.FOUND_IT
+                            && StringUtils.equals(log.logEntry.author, Settings.getOCConnectorUserName())) {
+                        cache.setFound(true);
+                        cache.setVisitedDate(log.logEntry.date);
+                    }
+                }
+            }
+        });
+
+        // cachelog.cacheid
+        cacheLog.getChild("cacheid").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                logHolder.get(0).cacheId = body;
+            }
+        });
+
+        // cachelog.date
+        cacheLog.getChild("date").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String body) {
+                try {
+                    logHolder.get(0).logEntry.date = parseDayDate(body).getTime();
+                } catch (Exception e) {
+                    Log.w("Failed to parse log date: " + e.toString());
+                }
+            }
+        });
+
+        // cachelog.logtype
+        cacheLog.getChild("logtype").setStartElementListener(new StartElementListener() {
+
+            @Override
+            public void start(Attributes attrs) {
+                if (attrs.getIndex("id") > -1) {
+                    final int typeId = Integer.parseInt(attrs.getValue("id"));
+                    logHolder.get(0).logEntry.type = getLogType(typeId);
+                }
+            }
+        });
+
+        // cachelog.userid
+        cacheLog.getChild("userid").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String finderName) {
+                logHolder.get(0).logEntry.author = finderName;
+            }
+        });
+
+        // cachelog.text
+        cacheLog.getChild("text").setEndTextElementListener(new EndTextElementListener() {
+
+            @Override
+            public void end(String logText) {
+                logHolder.get(0).logEntry.log = logText;
+            }
+        });
+
+        try {
+            Xml.parse(stream, Xml.Encoding.UTF_8, root.getContentHandler());
+            return caches.values();
+        } catch (SAXException e) {
+            Log.e("Cannot parse .gpx file as oc11xml: could not parse XML - " + e.toString());
+            return null;
+        }
+    }
+}

--- a/main/src/cgeo/geocaching/connector/oc/OCXMLApiConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCXMLApiConnector.java
@@ -1,0 +1,39 @@
+package cgeo.geocaching.connector.oc;
+
+import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.cgCache;
+import cgeo.geocaching.connector.capability.ISearchByCenter;
+import cgeo.geocaching.connector.capability.ISearchByGeocode;
+import cgeo.geocaching.connector.capability.ISearchByViewPort;
+import cgeo.geocaching.geopoint.Geopoint;
+import cgeo.geocaching.geopoint.Viewport;
+import cgeo.geocaching.utils.CancellableHandler;
+
+public class OCXMLApiConnector extends OCConnector implements ISearchByGeocode, ISearchByCenter, ISearchByViewPort {
+
+    public OCXMLApiConnector(String name, String host, String prefix) {
+        super(name, host, prefix);
+    }
+
+    @Override
+    public SearchResult searchByGeocode(String geocode, String guid, CancellableHandler handler) {
+        final cgCache cache = OCXMLClient.getCache(geocode);
+        if (cache == null) {
+            return null;
+        }
+        return new SearchResult(cache);
+    }
+
+    @Override
+    public SearchResult searchByCenter(Geopoint center) {
+        return new SearchResult(OCXMLClient.getCachesAround(center, 5.0));
+    }
+
+    @Override
+    public SearchResult searchByViewport(Viewport viewport, String[] tokens) {
+        Geopoint center = viewport.getCenter();
+        double distance = center.distanceTo(viewport.bottomLeft) * 1.15;
+        return new SearchResult(OCXMLClient.getCachesAround(center, distance));
+    }
+
+}

--- a/main/src/cgeo/geocaching/connector/oc/OCXMLClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCXMLClient.java
@@ -1,0 +1,108 @@
+package cgeo.geocaching.connector.oc;
+
+import cgeo.geocaching.cgCache;
+import cgeo.geocaching.cgData;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.geopoint.Geopoint;
+import cgeo.geocaching.geopoint.GeopointFormatter;
+import cgeo.geocaching.network.Network;
+import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.utils.Log;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
+
+public class OCXMLClient {
+
+    private static final String SERVICE_CACHE = "/xml/ocxml11.php";
+
+    // Url for single cache requests
+    // http://www.opencaching.de/xml/ocxml11.php?modifiedsince=20060320000000&user=0&cache=1&cachedesc=1&cachelog=1&picture=1&removedobject=0&session=0&doctype=0&charset=utf-8&wp=OCC9BE
+
+    public static cgCache getCache(final String geoCode) {
+        try {
+            final Parameters params = new Parameters("modifiedsince", "20060320000000",
+                    "user", "0", "cache", "1", "cachedesc", "1",
+                    "cachelog", "1", "picture", "0", "removedobject", "0",
+                    "session", "0", "doctype", "0", "charset", "utf-8", "zip", "gzip");
+            params.put("wp", geoCode);
+            final InputStream data = request(ConnectorFactory.getConnector(geoCode), SERVICE_CACHE, params);
+
+            if (data == null) {
+                return null;
+            }
+
+            Collection<cgCache> caches = OC11XMLParser.parseCaches(new GZIPInputStream(data));
+            if (caches.iterator().hasNext()) {
+                cgCache cache = caches.iterator().next();
+                cache.setDetailed(true);
+                cgData.saveCache(cache, LoadFlags.SAVE_ALL);
+                return cache;
+            }
+            return null;
+        } catch (IOException e) {
+            Log.e("Error parsing cache '" + geoCode + "': " + e.toString());
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Collection<cgCache> getCachesAround(final Geopoint center, final double distance) {
+        try {
+            final Parameters params = new Parameters("modifiedsince", "20060320000000",
+                    "user", "0", "cache", "1", "cachedesc", "0",
+                    "cachelog", "0", "picture", "0", "removedobject", "0",
+                    "session", "0", "doctype", "0", "charset", "utf-8", "zip", "gzip");
+            params.put("lat", GeopointFormatter.format(GeopointFormatter.Format.LAT_DECDEGREE_RAW, center));
+            params.put("lon", GeopointFormatter.format(GeopointFormatter.Format.LON_DECDEGREE_RAW, center));
+            params.put("distance", String.format(Locale.US, "%f", distance));
+            final InputStream data = request(ConnectorFactory.getConnector("OCXXX"), SERVICE_CACHE, params);
+
+            if (data == null) {
+                return CollectionUtils.EMPTY_COLLECTION;
+            }
+
+            return OC11XMLParser.parseCaches(new GZIPInputStream(data));
+        } catch (IOException e) {
+            Log.e("Error parsing nearby search result: " + e.toString());
+            return CollectionUtils.EMPTY_COLLECTION;
+        }
+    }
+
+    private static InputStream request(final IConnector connector, final String service, final Parameters params) {
+        if (connector == null) {
+            return null;
+        }
+        if (!(connector instanceof OCXMLApiConnector)) {
+            return null;
+        }
+
+        final String host = connector.getHost();
+        if (StringUtils.isBlank(host)) {
+            return null;
+        }
+
+        final String uri = "http://" + host + service;
+        HttpResponse resp = Network.getRequest(uri, params);
+        if (resp != null) {
+            try {
+                return resp.getEntity().getContent();
+            } catch (IllegalStateException e) {
+                // fall through and return null
+            } catch (IOException e) {
+                // fall through and return null
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Here is my first go at implementing a connection to opencaching.de. As they do not have OKAPI, the only offering besides scraping is the so-called OC11xml-Api (see http://www.opencaching.de/doc/xml/).

There are several issues with this Api that make it not so well suited for us. It is aimed at time-stamp based server sync, not at personalised queries for single users. So you cannot log in and don't get personalized information (like found status), but you can retrieve different levels of detail.

Following is implemented (in a rough fashion):
- nearby search on oc.de as well. As this is not incremental as gc.com, I take everything from a 5km radius
- oc.de caches on live map
- detailed caches download. here found status is detected through logs
- you can switch it on and off in settings and supply a username for found detection

Things to cover:
- I'd like to be able to visually see the cache source (oc/gc) on the map and in lists (through icons or a marker...)
- oc offers multiple descriptions (possibly different languages), not supported yet
- oc offers cross-listing info. currently hacked into description, should go to details
- search should run asynch per source, otherwise more sources - longer search until map update!
- possibility to switch gc.com off as well.

probably more

Comments welcome!
