### PR TITLE
fix #2208 - notifyDataSetChanged instead only one view

### DIFF
--- a/main/src/cgeo/geocaching/files/SimpleDirChooser.java
+++ b/main/src/cgeo/geocaching/files/SimpleDirChooser.java
@@ -196,7 +196,7 @@ public class SimpleDirChooser extends ListActivity {
                 okButton.setEnabled(false);
                 okButton.setVisibility(View.INVISIBLE);
             }
-            arg0.refreshDrawableState();
+            adapter.notifyDataSetChanged();
         }
     }
 


### PR DESCRIPTION
Single line fix for SimpleDirChooser view update #2208.
