### PR TITLE
Fix #2273 Disable upload of coordinates for non multi/mystery caches

### DIFF
--- a/main/res/layout/waypoint_new.xml
+++ b/main/res/layout/waypoint_new.xml
@@ -91,9 +91,11 @@
                 android:singleLine="false" />
 
             <LinearLayout
+                android:id="@+id/setAsCacheCoordsLayout"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:orientation="horizontal"
+                android:visibility="gone" >
 
                 <CheckBox
                     android:id="@+id/setAsCacheCoordsCheckBox"
@@ -108,15 +110,16 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/uploadCoordsToWebsiteLayout"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:orientation="horizontal"
+                android:visibility="gone" >
 
                 <CheckBox
                     android:id="@+id/uploadCoordsToWebsiteCheckBox"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone" />
+                    android:layout_height="wrap_content" />
 
                 <TextView
                     android:layout_width="fill_parent"

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -81,8 +81,8 @@ public class EditWaypointActivity extends AbstractActivity {
                     else {
                         ((EditText) findViewById(R.id.note)).setText(StringUtils.trimToEmpty(waypoint.getNote()));
                     }
-
-                    setUploadingCheckBoxVisibleByConnector(ConnectorFactory.getConnector(geocode));
+                    cgCache cache = cgData.loadCache(geocode, LoadFlags.LOAD_CACHE_ONLY);
+                    setCoordsCheckBoxesVisibility(ConnectorFactory.getConnector(geocode), cache);
                 }
 
                 if (own) {
@@ -160,10 +160,8 @@ public class EditWaypointActivity extends AbstractActivity {
 
         if (geocode != null) {
             cgCache cache = cgData.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-            if (cache != null && (cache.getType() == CacheType.MYSTERY || cache.getType() == CacheType.MULTI)) {
-                IConnector con = ConnectorFactory.getConnector(geocode);
-                setUploadingCheckBoxVisibleByConnector(con);
-            }
+            IConnector con = ConnectorFactory.getConnector(geocode);
+            setCoordsCheckBoxesVisibility(con, cache);
         }
 
         initializeDistanceUnitSelector();
@@ -171,9 +169,13 @@ public class EditWaypointActivity extends AbstractActivity {
         disableSuggestions((EditText) findViewById(R.id.distance));
     }
 
-    private void setUploadingCheckBoxVisibleByConnector(IConnector con) {
-        if (con.supportsOwnCoordinates()) {
-            findViewById(R.id.uploadCoordsToWebsiteCheckBox).setVisibility(View.VISIBLE);
+    private void setCoordsCheckBoxesVisibility(IConnector con, cgCache cache) {
+        if (cache != null && (cache.getType() == CacheType.MYSTERY || cache.getType() == CacheType.MULTI)) {
+            findViewById(R.id.setAsCacheCoordsLayout).setVisibility(View.VISIBLE);
+            findViewById(R.id.uploadCoordsToWebsiteLayout).setVisibility(con.supportsOwnCoordinates() ? View.VISIBLE : View.GONE);
+        } else {
+            findViewById(R.id.setAsCacheCoordsLayout).setVisibility(View.GONE);
+            findViewById(R.id.uploadCoordsToWebsiteLayout).setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
Disables upload of coords (do not show checkbox) for non-multi/mystery caches.

Doesn't prevent changing coordinates locally, but this is about discussion if we want to disable it too, for me, it makes sense to block it, but tell me what is your opinion and we can change it easily.
