### PR TITLE
Translaton correction for #2271

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -651,7 +651,7 @@
   <string name="waypoint_save">Speichern</string>
   <string name="waypoint_loading">Lade Wegpunkt…</string>
   <string name="waypoint_unknown_coordinates">Koordinaten unbekannt</string>
-  <string name="waypoint_set_as_cache_coords">Als Cache-Koordinaten setzen</string>
+  <string name="waypoint_set_as_cache_coords">Als Cache-Koordinaten lokal setzen</string>
   <string name="waypoint_reset_cache_coords">Cache-Koordinaten zurücksetzen</string>
   <string name="waypoint_reset_cache_coords_on_website">Cache-Koordinaten auf Webseite zurücksetzen</string>
   <string name="waypoint_coordinates_has_been_reset_on_website">Koordinaten auf Webseite zurückgesetzt</string>
@@ -659,7 +659,7 @@
   <string name="waypoint_reset_cache_coords_info">Rücksetz-Optionen</string>
   <string name="waypoint_reset">Zurücksetzen</string>
   <string name="waypoint_localy_reset_cache_coords">Koodinaten lokal zurücksetzen</string>
-  <string name="waypoint_modify_on_website">Koordinaten auf der Webseite zurücksetzen</string>
+  <string name="waypoint_modify_on_website">Als Cache-Koordinaten auf der Webseite setzen</string>
   <string name="waypoint_coordinates_couldnt_be_modified_on_website">Cache-Koordinaten auf der Webseite konnten nicht zurückgesetzt werden</string>
   <string name="waypoint_coordinates_upload_error">Fehler beim Hochladen der Koordinaten zur Webseite</string>
   <string name="waypoint_coordinates_uploading_to_website">Setze %s auf der Webseite</string>


### PR DESCRIPTION
Wrong string "zurücksetzen" replaced by "setzen"
Aligned wording for setting local and remote in waypoint screen 
