### PR TITLE
Add checkbox style to ensure proper formatting

### DIFF
--- a/main/res/layout/edit_waypoint_activity.xml
+++ b/main/res/layout/edit_waypoint_activity.xml
@@ -92,14 +92,12 @@
 
             <CheckBox
                 android:id="@+id/setAsCacheCoordsCheckBox"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
+                style="@style/checkbox_full"
                 android:text="@string/waypoint_set_as_cache_coords" />
 
             <CheckBox
                 android:id="@+id/uploadCoordsToWebsiteCheckBox"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
+                style="@style/checkbox_full"
                 android:text="@string/waypoint_modify_on_website" />
 
             <Button

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -26,6 +26,15 @@
         <item name="android:capitalize">none</item>
     </style>
 
+    <style name="checkbox" parent="@android:style/Widget.CompoundButton.CheckBox">
+        <item name="android:textColor">?text_color</item>
+    </style>
+
+    <style name="checkbox_full" parent="checkbox">
+        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
     <!-- own definitions -->
     <!-- actionbar -->
     <style name="action_bar">


### PR DESCRIPTION
With introduction of using text field of checkbox widget,
a stlye needs to be applied to ensure the formatting is
consistent.

This fixes text color not being formatted as shown in image below.

![Image of missing text](http://i.imgur.com/OY2qE.png)
