### PR TITLE
Format date according to the current locale and the user's date-order preference.

### DIFF
--- a/main/src/cgeo/geocaching/ui/Formatter.java
+++ b/main/src/cgeo/geocaching/ui/Formatter.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import android.content.Context;
 import android.text.format.DateUtils;
 
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -70,8 +71,8 @@ public abstract class Formatter {
      * @return the formatted string
      */
     public static String formatShortDate(long date) {
-        return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE
-                | DateUtils.FORMAT_NUMERIC_DATE);
+        DateFormat dateFormat = android.text.format.DateFormat.getDateFormat(context);
+        return dateFormat.format(date);
     }
 
     /**


### PR DESCRIPTION
This is only a little fix, but now the current locale from the device is used to format dates.
I have setup my phone to output dates in the following format:

03/01/2013 (DD/MM/YYYY)

With this little patch c:geo also uses the system-wide date format.
