### PR TITLE
Show Favorites Info only if there is at least one point

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1139,8 +1139,10 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             details.addTerrain(cache);
             details.addRating(cache);
 
-            // favourite count
-            details.add(R.string.cache_favourite, cache.getFavoritePoints() + "×");
+            // favorite count
+            if (cache.getFavoritePoints() > 0) {
+                details.add(R.string.cache_favourite, cache.getFavoritePoints() + "×");
+            }
 
             // own rating
             if (cache.getMyVote() > 0) {


### PR DESCRIPTION
Show the favorites infos in the CacheDetailsActivity only if there is
at least one favorite point set.
