### PR TITLE
Fix #1641. Apply style colors to dialogs to match setting

### DIFF
--- a/main/res/layout/fieldnote_export_dialog.xml
+++ b/main/res/layout/fieldnote_export_dialog.xml
@@ -2,32 +2,30 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?background_color"
     android:orientation="vertical"
     android:padding="3dip" >
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="?text_color"
         android:text="@string/export_fieldnotes_info" />
 
     <CheckBox
         android:id="@+id/upload"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/checkbox_full"
         android:text="@string/export_fieldnotes_upload" />
 
     <CheckBox
         android:id="@+id/onlynew"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/checkbox_full"
         android:enabled="false"
         android:text="@string/export_fieldnotes_onlynew" />
 
     <Button
         android:id="@+id/export"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="3dip"
+        style="@style/button_full"
         android:text="@string/export" />
 
 </LinearLayout>

--- a/main/res/layout/gpx_export_dialog.xml
+++ b/main/res/layout/gpx_export_dialog.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?background_color"
     android:orientation="vertical"
     android:padding="3dip" >
 
@@ -9,19 +10,17 @@
         android:id="@id/info"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="?text_color"
         android:text="@string/export_gpx_info" />
 
     <CheckBox
         android:id="@+id/share"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/checkbox_full"
         android:text="@string/init_share_after_export" />
 
     <Button
         android:id="@+id/export"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="3dip"
+        style="@style/button_full"
         android:text="@string/export" />
 
 </LinearLayout>

--- a/main/res/layout/reset_cache_coords_dialog.xml
+++ b/main/res/layout/reset_cache_coords_dialog.xml
@@ -2,12 +2,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="?background_color"
     android:orientation="vertical"
     android:padding="3dip" >
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="?text_color"
         android:text="@string/waypoint_reset_cache_coords_info" />
 
     <RadioGroup
@@ -17,15 +19,13 @@
 
         <RadioButton
             android:id="@+id/reset_cache_coordinates_local"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            style="@style/radiobutton_wrap"
             android:checked="true"
             android:text="@string/waypoint_localy_reset_cache_coords" />
 
         <RadioButton
             android:id="@+id/reset_cache_coordinates_local_and_remote"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            style="@style/radiobutton_wrap"
             android:text="@string/waypoint_reset_local_and_remote_cache_coords"
             android:visibility="gone" />
     </RadioGroup>


### PR DESCRIPTION
Before, dialogs had a semi-transparent grey background and using light
skins could leave some text unreadable. This changes the background to
match settings choice and ensures text is colored accordingly.
