### PR TITLE
If the database is unusable, delete it from device

### DIFF
--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -259,6 +259,13 @@ public class cgData {
             database = dbHelper.getWritableDatabase();
         } catch (Exception e) {
             Log.e("cgData.init: unable to open database for R/W", e);
+            if (!newlyCreatedDatabase) {
+                newlyCreatedDatabase = true;
+                if (databasePath().delete()) {
+                    Log.w("cgData.init: resetting unusable database");
+                    init();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Since we are unable to open it, let's delete it instead.
