### PR TITLE
Use Android provided relative time span calculation

### DIFF
--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -406,12 +406,6 @@
   <string name="cache_offline_store">Uložit</string>
   <string name="cache_offline_stored">Uložena v zařízení</string>
   <string name="cache_offline_not_ready">Není připravena\npro použití offline</string>
-  <string name="cache_offline_time_about">přibližně před</string>
-  <string name="cache_offline_time_mins">minutami</string>
-  <string name="cache_offline_time_mins_few">několika minutami</string>
-  <string name="cache_offline_time_hour">jednou hodinou</string>
-  <string name="cache_offline_time_hours">hodinami</string>
-  <string name="cache_offline_time_days">dny</string>
   <string name="cache_premium">placený účet</string>
   <string name="cache_attributes">atributy</string>
   <string name="cache_inventory">Inventář</string>

--- a/main/res/values-da/strings.xml
+++ b/main/res/values-da/strings.xml
@@ -175,12 +175,6 @@
   <string name="cache_offline_store">Gem</string>
   <string name="cache_offline_stored">Gemt i telefon</string>
   <string name="cache_offline_not_ready">Ikke klar\ntil offline brug</string>
-  <string name="cache_offline_time_about">For</string>
-  <string name="cache_offline_time_mins">minutter siden</string>
-  <string name="cache_offline_time_mins_few">få minutter siden</string>
-  <string name="cache_offline_time_hour">en time siden</string>
-  <string name="cache_offline_time_hours">timer siden</string>
-  <string name="cache_offline_time_days">dage siden</string>
   <string name="cache_attributes">Attributter</string>
   <string name="cache_inventory">Inventar</string>
   <string name="cache_log_offline">Offline log</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -479,12 +479,6 @@
   <string name="cache_offline_store">Speichern</string>
   <string name="cache_offline_stored">Auf dem Gerät gespeichert</string>
   <string name="cache_offline_not_ready">Nicht offline verfügbar</string>
-  <string name="cache_offline_time_about">vor etwa</string>
-  <string name="cache_offline_time_mins">Minuten</string>
-  <string name="cache_offline_time_mins_few">vor ein paar Minuten</string>
-  <string name="cache_offline_time_hour">einer Stunde</string>
-  <string name="cache_offline_time_hours">Stunden</string>
-  <string name="cache_offline_time_days">Tagen</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attribute</string>
   <string name="cache_inventory">Inventar</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -392,12 +392,6 @@
   <string name="cache_offline_store">Guardar</string>
   <string name="cache_offline_stored">Guardado en el dispositivo</string>
   <string name="cache_offline_not_ready">No preparado\npara usar desconectado</string>
-  <string name="cache_offline_time_about">Acerca</string>
-  <string name="cache_offline_time_mins">minutos atrás</string>
-  <string name="cache_offline_time_mins_few">hace unos minutos</string>
-  <string name="cache_offline_time_hour">hace una hora</string>
-  <string name="cache_offline_time_hours">horas atrás</string>
-  <string name="cache_offline_time_days">días atrás</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Atributos</string>
   <string name="cache_inventory">Inventario</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -460,12 +460,6 @@
   <string name="cache_offline_store">Enregistrer</string>
   <string name="cache_offline_stored">Enregistrée</string>
   <string name="cache_offline_not_ready">Hors ligne indisponible</string>
-  <string name="cache_offline_time_about">il y a environ</string>
-  <string name="cache_offline_time_mins">minutes</string>
-  <string name="cache_offline_time_mins_few">il y a quelques minutes</string>
-  <string name="cache_offline_time_hour">une heure</string>
-  <string name="cache_offline_time_hours">heures</string>
-  <string name="cache_offline_time_days">jours</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attributs</string>
   <string name="cache_inventory">Inventaire</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -475,12 +475,6 @@
   <string name="cache_offline_store">Tárolás</string>
   <string name="cache_offline_stored">Tárolva az eszközön</string>
   <string name="cache_offline_not_ready">Nincs kész\noffline használathoz</string>
-  <string name="cache_offline_time_about">Információ mentve</string>
-  <string name="cache_offline_time_mins">perccel ezelőtt</string>
-  <string name="cache_offline_time_mins_few">néhány perccel ezelőtt</string>
-  <string name="cache_offline_time_hour">egy órával ezelőtt</string>
-  <string name="cache_offline_time_hours">órával ezelőtt</string>
-  <string name="cache_offline_time_days">nappal ezelőtt</string>
   <string name="cache_premium">Prémium</string>
   <string name="cache_attributes">Tulajdonságok</string>
   <string name="cache_inventory">Tárgyak</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -475,12 +475,6 @@
   <string name="cache_offline_store">Salva</string>
   <string name="cache_offline_stored">Salvato nel dispositivo</string>
   <string name="cache_offline_not_ready">Non disponibile offline</string>
-  <string name="cache_offline_time_about">circa</string>
-  <string name="cache_offline_time_mins">minuti fa</string>
-  <string name="cache_offline_time_mins_few">qualche minuto fa</string>
-  <string name="cache_offline_time_hour">un\'ora fa</string>
-  <string name="cache_offline_time_hours">ore fa</string>
-  <string name="cache_offline_time_days">giorni fa</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attributi</string>
   <string name="cache_inventory">Oggetti</string>

--- a/main/res/values-ja/strings.xml
+++ b/main/res/values-ja/strings.xml
@@ -468,12 +468,6 @@
   <string name="cache_offline_store">保存</string>
   <string name="cache_offline_stored">デバイスに保存済み</string>
   <string name="cache_offline_not_ready">オフライン用に保存されていません</string>
-  <string name="cache_offline_time_about">約</string>
-  <string name="cache_offline_time_mins">分前</string>
-  <string name="cache_offline_time_mins_few">数分前</string>
-  <string name="cache_offline_time_hour">1時間前</string>
-  <string name="cache_offline_time_hours">時間前</string>
-  <string name="cache_offline_time_days">日前</string>
   <string name="cache_premium">プレミアム会員</string>
   <string name="cache_attributes">属性</string>
   <string name="cache_inventory">目録</string>

--- a/main/res/values-nb/strings.xml
+++ b/main/res/values-nb/strings.xml
@@ -247,12 +247,6 @@
   <string name="cache_offline_store">Lagre</string>
   <string name="cache_offline_stored">Lagret på enheten for</string>
   <string name="cache_offline_not_ready">Kan ikke brukes\noffline (ikke lagret)</string>
-  <string name="cache_offline_time_about"></string>
-  <string name="cache_offline_time_mins">minutter siden</string>
-  <string name="cache_offline_time_mins_few">en liten stund siden</string>
-  <string name="cache_offline_time_hour">én time siden</string>
-  <string name="cache_offline_time_hours">timer siden</string>
-  <string name="cache_offline_time_days">dager siden</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attributer</string>
   <string name="cache_inventory">Inventar</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -440,12 +440,6 @@
   <string name="cache_offline_store">Opslaan</string>
   <string name="cache_offline_stored">Opgeslagen in apparaat</string>
   <string name="cache_offline_not_ready">Niet gereed voor\n offline gebruik</string>
-  <string name="cache_offline_time_about">ongeveer</string>
-  <string name="cache_offline_time_mins">minuten geleden</string>
-  <string name="cache_offline_time_mins_few">paar minuten geleden</string>
-  <string name="cache_offline_time_hour">een uur geleden</string>
-  <string name="cache_offline_time_hours">uren geleden</string>
-  <string name="cache_offline_time_days">dagen geleden</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attributen</string>
   <string name="cache_inventory">Inventaris</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -480,12 +480,6 @@
   <string name="cache_offline_store">Zapisz</string>
   <string name="cache_offline_stored">Zapisane w pamięci</string>
   <string name="cache_offline_not_ready">Nie jest gotowy\ndo użytku offline</string>
-  <string name="cache_offline_time_about">około</string>
-  <string name="cache_offline_time_mins">minut temu</string>
-  <string name="cache_offline_time_mins_few">przed kilkoma minutami</string>
-  <string name="cache_offline_time_hour">przed jedną godziną</string>
-  <string name="cache_offline_time_hours">przed godzinami</string>
-  <string name="cache_offline_time_days">przed kilkoma dniami</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Atrybuty</string>
   <string name="cache_inventory">Inwentarz</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -476,12 +476,6 @@
   <string name="cache_offline_store">Arquivar</string>
   <string name="cache_offline_stored">Arquivada no dispositivo</string>
   <string name="cache_offline_not_ready">Não está pronta\npara utilização offline</string>
-  <string name="cache_offline_time_about">há</string>
-  <string name="cache_offline_time_mins">minutos atrás</string>
-  <string name="cache_offline_time_mins_few">alguns minutos atrás</string>
-  <string name="cache_offline_time_hour">uma hora atrás</string>
-  <string name="cache_offline_time_hours">horas atrás</string>
-  <string name="cache_offline_time_days">dias atrás</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Atributos</string>
   <string name="cache_inventory">Inventário</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -475,12 +475,6 @@
   <string name="cache_offline_store">Uložiť</string>
   <string name="cache_offline_stored">Uložená v zariadení</string>
   <string name="cache_offline_not_ready">Nie je pripravená\nna použitie offline</string>
-  <string name="cache_offline_time_about">približne pred</string>
-  <string name="cache_offline_time_mins">minútami</string>
-  <string name="cache_offline_time_mins_few">pred niekoľkými minútami</string>
-  <string name="cache_offline_time_hour">pred hodinou</string>
-  <string name="cache_offline_time_hours">pred hodinami</string>
-  <string name="cache_offline_time_days">pred dňami</string>
   <string name="cache_premium">platený účet</string>
   <string name="cache_attributes">Atribúty</string>
   <string name="cache_inventory">Obsah</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -484,12 +484,6 @@
   <string name="cache_offline_store">Spara</string>
   <string name="cache_offline_stored">Sparad i enheten</string>
   <string name="cache_offline_not_ready">Inte redo\nför användning offline</string>
-  <string name="cache_offline_time_about">för</string>
-  <string name="cache_offline_time_mins">minuter sedan</string>
-  <string name="cache_offline_time_mins_few">för några minuter sedan</string>
-  <string name="cache_offline_time_hour">en timme sedan</string>
-  <string name="cache_offline_time_hours">timmar sedan</string>
-  <string name="cache_offline_time_days">dagar sedan</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attribut</string>
   <string name="cache_inventory">Innehåll</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -486,12 +486,6 @@
   <string name="cache_offline_store">Store</string>
   <string name="cache_offline_stored">Stored in device</string>
   <string name="cache_offline_not_ready">Not available offline</string>
-  <string name="cache_offline_time_about">about</string>
-  <string name="cache_offline_time_mins">minutes ago</string>
-  <string name="cache_offline_time_mins_few">a few minutes ago</string>
-  <string name="cache_offline_time_hour">one hour ago</string>
-  <string name="cache_offline_time_hours">hours ago</string>
-  <string name="cache_offline_time_days">days ago</string>
   <string name="cache_premium">Premium</string>
   <string name="cache_attributes">Attributes</string>
   <string name="cache_inventory">Inventory</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2408,21 +2408,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         final Button offlineStore = (Button) view.findViewById(R.id.offline_store);
 
         if (cache.isOffline()) {
-            long diff = (System.currentTimeMillis() / (60 * 1000)) - (cache.getDetailedUpdate() / (60 * 1000)); // minutes
-
-            String ago;
-            if (diff < 15) {
-                ago = res.getString(R.string.cache_offline_time_mins_few);
-            } else if (diff < 50) {
-                ago = res.getString(R.string.cache_offline_time_about) + " " + diff + " " + res.getString(R.string.cache_offline_time_mins);
-            } else if (diff < 90) {
-                ago = res.getString(R.string.cache_offline_time_about) + " " + res.getString(R.string.cache_offline_time_hour);
-            } else if (diff < (48 * 60)) {
-                ago = res.getString(R.string.cache_offline_time_about) + " " + (diff / 60) + " " + res.getString(R.string.cache_offline_time_hours);
-            } else {
-                ago = res.getString(R.string.cache_offline_time_about) + " " + (diff / (24 * 60)) + " " + res.getString(R.string.cache_offline_time_days);
-            }
-
+            final CharSequence ago = DateUtils.getRelativeTimeSpanString(cache.getDetailedUpdate(), System.currentTimeMillis(),DateUtils.SECOND_IN_MILLIS, 0);
             offlineText.setText(res.getString(R.string.cache_offline_stored) + "\n" + ago);
             offlineRefresh.setOnClickListener(refreshCacheClickListener);
 


### PR DESCRIPTION
Android already gets localized relative timespan computations. Rather than cooking up our own, we could just reuse it.

The display will change (for example, we used to generate "about 5 minutes ago" while this will now print "5 minutes ago"), but this is probably for the better.
