### PR TITLE
Live Mode not used correctly Fixes #2479 

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1117,7 +1117,7 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                 countVisibleCaches();
                 if (cachesCnt < Settings.getWayPointsThreshold() || geocodeIntent != null) {
                     waypoints.clear();
-                    if (mapMode == MapMode.LIVE || mapMode == MapMode.COORDS) {
+                    if (isLiveEnabled || mapMode == MapMode.LIVE || mapMode == MapMode.COORDS) {
                         //All visible waypoints
                         CacheType type = Settings.getCacheType();
                         Set<Waypoint> waypointsInViewport = cgData.loadWaypoints(viewport, excludeMine, excludeDisabled, type);
@@ -1125,6 +1125,8 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                     }
                     else
                     {
+                        // we don't want to see any stale
+                        waypoints.clear();
                         //All waypoints from the viewed caches
                         for (Geocache c : caches.getAsList()) {
                             waypoints.addAll(c.getWaypoints());


### PR DESCRIPTION
Due to the changes with #1990 the Waypoints were not shown, when the update was off in the live map.
