### PR TITLE
fixes #2515 - update live map icons by nearby search

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1101,6 +1101,8 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                 downloaded = true;
                 Set<Geocache> cachesFromSearchResult = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_WAYPOINTS);
                 // update the caches
+                // new collection type needs to remove first
+                caches.removeAll(cachesFromSearchResult);
                 caches.addAll(cachesFromSearchResult);
 
                 if (mapMode == MapMode.LIVE) {
@@ -1190,6 +1192,8 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
                 if (searchResult != null) {
                     Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);
                     // update the caches
+                    // new collection type needs to remove first
+                    caches.removeAll(result);
                     caches.addAll(result);
                     lastSearchResult = searchResult;
                 }


### PR DESCRIPTION
This is the missing fix of addAll in CGeoMap. Orange circled cache icons will be updated by nearby search now.
