### PR TITLE
fixes #2507 - Waypoints only stored if not existing

### DIFF
--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -488,11 +488,18 @@ public class EditWaypointActivity extends AbstractActivity {
                     waypoint.setId(id);
 
                     Geocache cache = cgData.loadCache(geocode, LoadFlags.LOAD_WAYPOINTS);
-                    if (null != cache && cache.addOrChangeWaypoint(waypoint, true)) {
+                    if (cache == null) {
+                        finishHandler.sendEmptyMessage(SAVE_ERROR);
+                        return null;
+                    }
+                    Waypoint oldWaypoint = cache.getWaypointById(id);
+                    if (cache.addOrChangeWaypoint(waypoint, true)) {
                         cgData.saveCache(cache, EnumSet.of(SaveFlag.SAVE_DB));
-                        StaticMapsProvider.removeWpStaticMaps(id, geocode);
-                        if (Settings.isStoreOfflineWpMaps()) {
-                            StaticMapsProvider.storeWaypointStaticMap(cache, waypoint, false);
+                        if (!StaticMapsProvider.hasAllStaticMapsForWaypoint(geocode, waypoint)) {
+                            StaticMapsProvider.removeWpStaticMaps(oldWaypoint, geocode);
+                            if (Settings.isStoreOfflineWpMaps()) {
+                                StaticMapsProvider.storeWaypointStaticMap(cache, waypoint, false);
+                            }
                         }
                         final RadioButton modifyLocal = (RadioButton) findViewById(R.id.modify_cache_coordinates_local);
                         final RadioButton modifyBoth = (RadioButton) findViewById(R.id.modify_cache_coordinates_local_and_remote);

--- a/main/src/cgeo/geocaching/StaticMapsActivity.java
+++ b/main/src/cgeo/geocaching/StaticMapsActivity.java
@@ -134,7 +134,8 @@ public class StaticMapsActivity extends AbstractActivity {
                     for (int level = 1; level <= 5; level++) {
                         try {
                             if (waypoint_id != null) {
-                                final Bitmap image = StaticMapsProvider.getWaypointMap(geocode, waypoint_id, level);
+                                final Geocache cache = cgData.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+                                final Bitmap image = StaticMapsProvider.getWaypointMap(geocode, cache.getWaypointById(waypoint_id), level);
                                 if (image != null) {
                                     maps.add(image);
                                 }
@@ -186,8 +187,10 @@ public class StaticMapsActivity extends AbstractActivity {
         final Waypoint waypoint = cache.getWaypointById(waypoint_id);
         if (waypoint != null) {
             showToast(res.getString(R.string.info_storing_static_maps));
+            // refresh always removes old waypoint files
+            StaticMapsProvider.removeWpStaticMaps(waypoint, geocode);
             StaticMapsProvider.storeWaypointStaticMap(cache, waypoint, true);
-            return StaticMapsProvider.hasStaticMapForWaypoint(geocode, waypoint_id);
+            return StaticMapsProvider.hasStaticMapForWaypoint(geocode, waypoint);
         }
         showToast(res.getString(R.string.err_detail_not_load_map_static));
         return false;

--- a/main/src/cgeo/geocaching/Waypoint.java
+++ b/main/src/cgeo/geocaching/Waypoint.java
@@ -269,4 +269,13 @@ public class Waypoint implements IWaypoint, Comparable<Waypoint> {
     public boolean isVisited() {
         return visited;
     }
+
+    public int calculateStaticMapsHashcode() {
+        long hash = 0;
+        if (coords != null) {
+            hash = coords.hashCode();
+        }
+        hash = hash ^ waypointType.markerId;
+        return (int) hash;
+    }
 }

--- a/main/src/cgeo/geocaching/apps/cache/navi/AbstractStaticMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/AbstractStaticMapsApp.java
@@ -1,11 +1,11 @@
 package cgeo.geocaching.apps.cache.navi;
 
+import cgeo.geocaching.Geocache;
 import cgeo.geocaching.ILogable;
 import cgeo.geocaching.R;
 import cgeo.geocaching.StaticMapsActivity;
 import cgeo.geocaching.StaticMapsProvider;
 import cgeo.geocaching.Waypoint;
-import cgeo.geocaching.Geocache;
 import cgeo.geocaching.cgData;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.apps.AbstractApp;
@@ -34,9 +34,8 @@ abstract class AbstractStaticMapsApp extends AbstractApp implements CacheNavigat
             return false;
         }
         String geocode = waypoint.getGeocode();
-        int id = waypoint.getId();
         if (StringUtils.isNotEmpty(geocode) && cgData.isOffline(geocode, null)) {
-            return StaticMapsProvider.hasStaticMapForWaypoint(geocode, id);
+            return StaticMapsProvider.hasStaticMapForWaypoint(geocode, waypoint);
         }
         return false;
     }


### PR DESCRIPTION
Waypoints static maps are only downloaded when at least a static map image is missing or the hash code changes.

Found another bug for Android 4.x creating a new issue.
