### PR TITLE
Fixes #2538 - German umlauts for image upload

### DIFF
--- a/main/src/cgeo/geocaching/utils/HtmlUtils.java
+++ b/main/src/cgeo/geocaching/utils/HtmlUtils.java
@@ -67,7 +67,7 @@ public class HtmlUtils {
         for (int i = 0; i < inputLen; i++) {
             char c = input.charAt(i);
 
-            if (c > 300) {
+            if (c > 127) {
                 output.append("&#");
                 output.append(Integer.toString(c));
                 output.append(';');


### PR DESCRIPTION
This works for log, image description and image text.

Please think about this a minute. Could it do any harm?
