### PR TITLE
Change log and limitation update

### DIFF
--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -98,7 +98,7 @@
     · Improved and extended cache type detection on live map\n
     · Waypoints can be marked as visited\n
     · Possibility to delete offline logs in lists\n
-    · Use UTF8 for log text\n
+    · Support of language specific characters in log text equally to the website\n
     \n
     <b>Bugfixing:</b>\n
     · Final flag icon lost when updating cache with self defined final\n


### PR DESCRIPTION
#2538
#2565
#2507

Limitations:
- PNG parsing was extended so that now all common cache types can be identified, thus I removed that line
- The logbook fault was never coming up again (about to close that issue) #1973
- Limitation added for #2133
