### PR TITLE
fixes #2651 - exclude inaccessable dirs from choice

### DIFF
--- a/main/src/cgeo/geocaching/files/SimpleDirChooser.java
+++ b/main/src/cgeo/geocaching/files/SimpleDirChooser.java
@@ -238,7 +238,7 @@ public class SimpleDirChooser extends ListActivity {
         @Override
         public boolean accept(File dir, String filename) {
             File file = new File(dir, filename);
-            return file.isDirectory();
+            return file.isDirectory() && file.canWrite();
         }
 
     }


### PR DESCRIPTION
Don't offer inaccessable dirs in SimpleDirChooser. We can not list subdirs and will not be able to write to without root access.
