### PR TITLE
Fix #2729 - Remove illegal characters from log before export

### DIFF
--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -331,7 +331,8 @@ class GpxExport extends AbstractExport {
 
                 gpx.startTag(PREFIX_GROUNDSPEAK, "text");
                 gpx.attribute("", "encoded", "False");
-                gpx.text(log.log);
+                // remove illegal characters
+                gpx.text(log.log.replaceAll("[\u0000-\u001f]", ""));
                 gpx.endTag(PREFIX_GROUNDSPEAK, "text");
 
                 gpx.endTag(PREFIX_GROUNDSPEAK, "log");


### PR DESCRIPTION
Fixes #2729.
See #2729 for discussion on ways to solve the problem.
