### PR TITLE
Fix #2773 - Include log author in GPX export

### DIFF
--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -306,7 +306,8 @@ class GpxExport extends AbstractExport {
                         "type", log.type.type);
 
                 gpx.startTag(PREFIX_GROUNDSPEAK, "finder");
-                gpx.attribute("", "id", log.author);
+                gpx.attribute("", "id", "");
+                gpx.text(log.author);
                 gpx.endTag(PREFIX_GROUNDSPEAK, "finder");
 
                 gpx.startTag(PREFIX_GROUNDSPEAK, "text");


### PR DESCRIPTION
Fixes #2773.
Based on release
