### PR TITLE
fixes #2771 - parsed cache from GCParser should be detailed before adding

### DIFF
--- a/main/src/cgeo/geocaching/Geocache.java
+++ b/main/src/cgeo/geocaching/Geocache.java
@@ -175,7 +175,9 @@ public class Geocache implements ICache, IWaypoint {
     }
 
     /**
-     * Gather missing information from another cache object.
+     * Gather missing information for new Geocache object from the stored Geocache object.
+     * This is called in the new Geocache parsed from website to set information not yet
+     * parsed.
      *
      * @param other
      *            the other version, or null if non-existent
@@ -187,6 +189,8 @@ public class Geocache implements ICache, IWaypoint {
         }
 
         updated = System.currentTimeMillis();
+        // if parsed cache is not yet detailed and stored is, the information of
+        // the parsed cache will be overwritten
         if (!detailed && (other.detailed || zoomlevel < other.zoomlevel)) {
             detailed = other.detailed;
             detailedUpdate = other.detailedUpdate;
@@ -206,7 +210,7 @@ public class Geocache implements ICache, IWaypoint {
             onWatchlist = other.onWatchlist;
             logOffline = other.logOffline;
             finalDefined = other.finalDefined;
-            // archived is kept from the most recent data
+            archived = other.archived;
         }
 
         /*

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -330,9 +330,11 @@ public abstract class GCParser {
 
     static SearchResult parseCache(final String page, final CancellableHandler handler) {
         final SearchResult searchResult = parseCacheFromText(page, handler);
+        // attention: parseCacheFromText already stores implicitely through searchResult.addCache
         if (searchResult != null && !searchResult.getGeocodes().isEmpty()) {
             final Geocache cache = searchResult.getFirstCacheFromResult(LoadFlags.LOAD_CACHE_OR_DB);
             getExtraOnlineInfo(cache, page, handler);
+            // too late: it is already stored through parseCacheFromText
             cache.setDetailedUpdatedNow();
             if (CancellableHandler.isCancelled(handler)) {
                 return null;
@@ -726,6 +728,7 @@ public abstract class GCParser {
             return searchResult;
         }
 
+        cache.setDetailedUpdatedNow();
         searchResult.addCache(cache);
         return searchResult;
     }


### PR DESCRIPTION
Adding cache to SearchResult implicitely stores the cache. So before adding it at GCParser.parseFromText it should be set detailed.

Implicitely storing is not good. It is not the first time I myself didn't look through.
