### PR TITLE
Fix #2007 - Save waypoint edits on screen lock and rotation

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -112,7 +112,6 @@
         </activity>
         <activity
             android:name=".EditWaypointActivity"
-            android:configChanges="keyboardHidden|orientation"
             android:label="@string/waypoint_edit_title"
             android:windowSoftInputMode="stateHidden" >
         </activity>


### PR DESCRIPTION
Save all editable fields into a bundle and restore when
activity is recreated.
