### PR TITLE
Implements #2811, Login status after enabled cache sources

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -176,9 +176,16 @@
         android:orientation="vertical" >
 
         <TextView
-            android:id="@+id/user_info"
+            android:id="@+id/user_info_gc"
             style="@style/location_current"
-            android:text="@string/init_login_popup_working" />
+            android:text="@string/init_login_popup_working"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/user_info_ocde"
+            style="@style/location_current"
+            android:text="@string/init_login_popup_working"
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/nav_location"

--- a/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.cgeoapplication;
 import cgeo.geocaching.connector.ILoggingManager;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.capability.ISearchByViewPort;
+import cgeo.geocaching.connector.oc.OkapiClient.UserInfo;
 import cgeo.geocaching.geopoint.Geopoint;
 import cgeo.geocaching.geopoint.Viewport;
 import cgeo.geocaching.utils.CryptUtils;
@@ -19,6 +20,7 @@ import android.app.Activity;
 public class OCApiLiveConnector extends OCApiConnector implements ISearchByCenter, ISearchByViewPort {
 
     private String cS;
+    private UserInfo userInfo = new UserInfo(StringUtils.EMPTY, 0, false);
 
     public OCApiLiveConnector(String name, String host, String prefix, int cKResId, int cSResId, ApiSupport apiSupport) {
         super(name, host, prefix, CryptUtils.rot13(cgeoapplication.getInstance().getResources().getString(cKResId)), apiSupport);
@@ -96,5 +98,22 @@ public class OCApiLiveConnector extends OCApiConnector implements ISearchByCente
     @Override
     public boolean canLog(Geocache cache) {
         return true;
+    }
+
+    public boolean supportsPersonalization() {
+        return getSupportedAuthLevel() == OAuthLevel.Level3;
+    }
+
+    public boolean retrieveUserInfo() {
+        userInfo = OkapiClient.getUserInfo(this);
+        return userInfo.isRetrieveSuccessful();
+    }
+
+    public Object getUserName() {
+        return userInfo.getName();
+    }
+
+    public int getCachesFound() {
+        return userInfo.getFinds();
     }
 }

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -100,6 +100,8 @@ final public class OkapiClient {
     private static final String LOG_USER = "user";
 
     private static final String USER_USERNAME = "username";
+    private static final String USER_CACHES_FOUND = "caches_found";
+    private static final String USER_INFO_FIELDS = "username|caches_found";
 
     // the several realms of possible fields for cache retrieval:
     // Core: for livemap requests (L3 - only with level 3 auth)
@@ -674,6 +676,69 @@ final public class OkapiClient {
                 return "Webcam";
             default:
                 return "";
+        }
+    }
+
+    public static UserInfo getUserInfo(OCApiLiveConnector connector) {
+        final Parameters params = new Parameters("fields", USER_INFO_FIELDS);
+
+        final JSONObject data = request(connector, OkapiService.SERVICE_USER, params);
+
+        if (data == null) {
+            return new UserInfo(StringUtils.EMPTY, 0, false);
+        }
+
+        String name = StringUtils.EMPTY;
+        int finds = 0;
+        boolean success = true;
+
+        if (!data.isNull(USER_USERNAME)) {
+            try {
+                name = data.getString(USER_USERNAME);
+            } catch (JSONException e) {
+                Log.e("OkapiClient.getUserInfo - name", e);
+                success = false;
+            }
+        } else {
+            success = false;
+        }
+
+        if (!data.isNull(USER_CACHES_FOUND)) {
+            try {
+                finds = data.getInt(USER_CACHES_FOUND);
+            } catch (JSONException e) {
+                Log.e("OkapiClient.getUserInfo - finds", e);
+                success = false;
+            }
+        } else {
+            success = false;
+        }
+
+        return new UserInfo(name, finds, success);
+    }
+
+    public static class UserInfo {
+
+        private final String name;
+        private final int finds;
+        private final boolean retrieveSuccessful;
+
+        UserInfo(String name, int finds, boolean retrieveSuccessful) {
+            this.name = name;
+            this.finds = finds;
+            this.retrieveSuccessful = retrieveSuccessful;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getFinds() {
+            return finds;
+        }
+
+        public boolean isRetrieveSuccessful() {
+            return retrieveSuccessful;
         }
     }
 

--- a/main/src/cgeo/geocaching/connector/oc/OkapiService.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiService.java
@@ -7,7 +7,8 @@ enum OkapiService {
     SERVICE_CACHE("/okapi/services/caches/geocache", OAuthLevel.Level1),
     SERVICE_SEARCH_AND_RETRIEVE("/okapi/services/caches/shortcuts/search_and_retrieve", OAuthLevel.Level1),
     SERVICE_MARK_CACHE("/okapi/services/caches/mark", OAuthLevel.Level3),
-    SERVICE_SUBMIT_LOG("/okapi/services/logs/submit", OAuthLevel.Level3);
+    SERVICE_SUBMIT_LOG("/okapi/services/logs/submit", OAuthLevel.Level3),
+    SERVICE_USER("/okapi/services/users/user", OAuthLevel.Level1);
 
     final String methodName;
     final OAuthLevel level;


### PR DESCRIPTION
Not yet fully dynamic, only two possible source. Generalization to remove the explicit reference to Login and access through the connector can be the next step.
