### PR TITLE
Fix #2007 - Save waypoint edits by refacotring EditWaypointActivity

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -111,8 +111,7 @@
             android:windowSoftInputMode="stateHidden" >
         </activity>
         <activity
-            android:name=".EditWaypointActivity"
-            android:configChanges="keyboardHidden|orientation"
+            android:name=".EditWaypointActivity_"
             android:label="@string/waypoint_edit_title"
             android:windowSoftInputMode="stateHidden" >
         </activity>

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -21,12 +21,14 @@
             <Button
                 android:id="@+id/buttonLatitude"
                 style="@style/button_full"
-                android:hint="@string/latitude" />
+                android:hint="@string/latitude"
+                android:freezesText="true" />
 
             <Button
                 android:id="@+id/buttonLongitude"
                 style="@style/button_full"
-                android:hint="@string/longitude" />
+                android:hint="@string/longitude"
+                android:freezesText="true" />
 
             <EditText
                 android:id="@+id/bearing"
@@ -62,7 +64,8 @@
             <Spinner
                 android:id="@+id/type"
                 android:layout_width="fill_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
 
             <EditText
                 android:id="@+id/note"


### PR DESCRIPTION
Used Android Annotations. 
Let Android handle config change for views.
Remove unneeded code.
Pull values from controls on screen rather than storing copies.
