### PR TITLE
Radio buttons instead of check boxes in map strategy

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -55,22 +55,18 @@
                 android:checkableBehavior="single" >
                 <item
                     android:id="@+id/menu_strategy_fastest"
-                    android:checkable="true"
                     android:title="@string/map_strategy_fastest">
                 </item>
                 <item
                     android:id="@+id/menu_strategy_fast"
-                    android:checkable="true"
                     android:title="@string/map_strategy_fast">
                 </item>
                 <item
                     android:id="@+id/menu_strategy_auto"
-                    android:checkable="true"
                     android:title="@string/map_strategy_auto">
                 </item>
                 <item
                     android:id="@+id/menu_strategy_detailed"
-                    android:checkable="true"
                     android:title="@string/map_strategy_detailed">
                 </item>
             </group>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -586,11 +586,19 @@ public class CGeoMap extends AbstractMap implements OnMapDragListener, ViewFacto
 
             menu.findItem(R.id.submenu_strategy).setEnabled(isLiveEnabled);
 
-            Strategy strategy = Settings.getLiveMapStrategy();
-            menu.findItem(R.id.menu_strategy_fastest).setChecked(strategy == Strategy.FASTEST);
-            menu.findItem(R.id.menu_strategy_fast).setChecked(strategy == Strategy.FAST);
-            menu.findItem(R.id.menu_strategy_auto).setChecked(strategy == Strategy.AUTO);
-            menu.findItem(R.id.menu_strategy_detailed).setChecked(strategy == Strategy.DETAILED);
+            switch (Settings.getLiveMapStrategy()) {
+                case FASTEST:
+                    menu.findItem(R.id.menu_strategy_fastest).setChecked(true);
+                    break;
+                case FAST:
+                    menu.findItem(R.id.menu_strategy_fast).setChecked(true);
+                    break;
+                case AUTO:
+                    menu.findItem(R.id.menu_strategy_auto).setChecked(true);
+                    break;
+                default: // DETAILED
+                    menu.findItem(R.id.menu_strategy_detailed).setChecked(true);
+            }
         } catch (Exception e) {
             Log.e("CGeoMap.onPrepareOptionsMenu", e);
         }


### PR DESCRIPTION
Since only a single strategy can be selected, radio buttons are appropriate.
