### PR TITLE
Workaround for #2851

### DIFF
--- a/send2cgeo/send2cgeo.user.js
+++ b/send2cgeo/send2cgeo.user.js
@@ -4,9 +4,10 @@
 // @description    Add button "Send to c:geo" to geocaching.com
 // @include        http://www.geocaching.com/seek/cache_details*
 // @include        http://www.geocaching.com/map/*
+// @include        http://www.geocaching.com/geocache/*
 // @icon           http://send2.cgeo.org/content/images/logo.png
 // @updateURL      http://send2.cgeo.org/send2cgeo.user.js
-// @version        0.26
+// @version        0.27
 // ==/UserScript==
 
 // Inserts javascript that will be called by the s2cgeo button. The closure
@@ -81,6 +82,7 @@ s.textContent =  '(' + function() {
              + '/>';
 
     $('#Download p:last').append(html);
+    $('#Download dd:last').append(html);
   }
 } + ')();';
 


### PR DESCRIPTION
I inserted the include option for the temporary cache detail page and added an append command for the dd tag which is used instead of a p tag in the new cache page.

I know that the append is called twice in this case, but I have no knowledge how to add a selector to differentiate between both sites.
Maybe someone can optimize it but I have tested this change with both URLs and it seems not to show any side effects.
