### PR TITLE
make personalNote multiline, upload on OK and merge on refresh

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -134,6 +134,10 @@
                 android:id="@+id/edit_personalnote"
                 style="@style/button_small"
                 android:text="@string/cache_personal_note_edit" />
+            <Button
+                android:id="@+id/upload_personalnote"
+                style="@style/button_small"
+                android:text="@string/cache_personal_note_upload" />
         </LinearLayout>
     </LinearLayout>
 

--- a/main/res/layout/fragment_edit_note.xml
+++ b/main/res/layout/fragment_edit_note.xml
@@ -9,7 +9,7 @@
         android:id="@+id/note"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:imeOptions="actionDone"
-        android:inputType="text" />
+        android:inputType="textMultiLine"
+        android:lines="8" />
 
 </LinearLayout>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -533,6 +533,10 @@
     <string name="cache_log_image_default_title">Bild</string>
     <string name="cache_personal_note">Persönliche Notiz</string>
     <string name="cache_personal_note_edit">Bearbeiten</string>
+    <string name="cache_personal_note_upload">Hochladen</string>
+    <string name="cache_personal_note_uploading">Persönliche Notizen werden gesendet</string>
+    <string name="cache_personal_note_upload_done">Persönliche Notizen wurden hochgeladen</string>
+    <string name="cache_personal_note_upload_cancelled">Hochladen der Notizen abgebrochen</string>
     <string name="cache_personal_note_unstored">Cache noch nicht gespeichert</string>
     <string name="cache_personal_note_store">Der Cache wird zunächst gespeichert, damit persönliche Notizen möglich sind.</string>
     <string name="cache_description">Beschreibung</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -534,6 +534,10 @@
     <string name="cache_log_image_default_title">Photo</string>
     <string name="cache_personal_note">Personal note</string>
     <string name="cache_personal_note_edit">Edit</string>
+    <string name="cache_personal_note_upload">Upload</string>
+    <string name="cache_personal_note_uploading">Uploading personal note</string>
+    <string name="cache_personal_note_upload_done">Personal note uploaded</string>
+    <string name="cache_personal_note_upload_cancelled">Personal note upload cancelled</string>
     <string name="cache_personal_note_unstored">Cache not stored</string>
     <string name="cache_personal_note_store">The cache will be stored first to enable personal notes.</string>
     <string name="cache_description">Description</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1815,6 +1815,18 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     }
                 }
             });
+            final Button personalNoteUpload = (Button) view.findViewById(R.id.upload_personalnote);
+            if (cache.isOffline() && ConnectorFactory.getConnector(cache).supportsPersonalNote()) {
+                personalNoteUpload.setVisibility(View.VISIBLE);
+                personalNoteUpload.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        uploadPersonalNote();
+                    }
+                });
+            } else {
+                personalNoteUpload.setVisibility(View.GONE);
+            }
 
             // cache hint and spoiler images
             final View hintBoxView = view.findViewById(R.id.hint_box);
@@ -1883,6 +1895,21 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 final EditNoteDialog dialog = EditNoteDialog.newInstance(cache.getPersonalNote());
                 dialog.show(fm, "fragment_edit_note");
             }
+        }
+
+        Thread currentThread;
+
+        private void uploadPersonalNote() {
+            final SimpleHandler myHandler = new SimpleHandler();
+
+            Message cancelMessage = myHandler.cancelMessage(res.getString(R.string.cache_personal_note_upload_cancelled));
+            progress.show(CacheDetailActivity.this, res.getString(R.string.cache_personal_note_uploading), res.getString(R.string.cache_personal_note_uploading), true, cancelMessage);
+
+            if (currentThread != null) {
+                currentThread.interrupt();
+            }
+            currentThread = new UploadPersonalNoteThread(cache, myHandler);
+            currentThread.start();
         }
 
         private void setPersonalNote() {
@@ -2561,6 +2588,48 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 });
 
             }
+        }
+    }
+
+    public class SimpleHandler extends CancellableHandler {
+        public static final String SUCCESS_TEXT = "success_message";
+
+        @Override
+        public void handleRegularMessage(final Message msg) {
+            if (msg.getData() != null && msg.getData().getString(SUCCESS_TEXT) != null) {
+                showToast(msg.getData().getString(SUCCESS_TEXT));
+            }
+            progress.dismiss();
+            return;
+        }
+
+        @Override
+        public void handleCancel(final Object extra) {
+            showToast((String) extra);
+            progress.dismiss();
+        }
+    }
+
+    private class UploadPersonalNoteThread extends Thread {
+        private Geocache cache = null;
+        private CancellableHandler handler = null;
+
+        public UploadPersonalNoteThread(Geocache cache, CancellableHandler handler) {
+            this.cache = cache;
+            this.handler = handler;
+        }
+
+        @Override
+        public void run() {
+            IConnector con = ConnectorFactory.getConnector(cache);
+            if (con.supportsPersonalNote()) {
+                con.uploadPersonalNote(cache);
+            }
+            Message msg = Message.obtain();
+            Bundle bundle = new Bundle();
+            bundle.putString(SimpleHandler.SUCCESS_TEXT, res.getString(R.string.cache_personal_note_upload_done));
+            msg.setData(bundle);
+            handler.sendMessage(msg);
         }
     }
 

--- a/main/src/cgeo/geocaching/Geocache.java
+++ b/main/src/cgeo/geocaching/Geocache.java
@@ -280,8 +280,14 @@ public class Geocache implements ICache, IWaypoint {
         if (elevation == null) {
             elevation = other.elevation;
         }
-        if (personalNote == null) { // don't use StringUtils.isBlank here. Otherwise we cannot recognize a note which was deleted on GC
+        // don't use StringUtils.isBlank here. Otherwise we cannot recognize a note which was deleted on GC
+        if (personalNote == null) {
             personalNote = other.personalNote;
+        } else if (other.personalNote != null && !personalNote.equals(other.personalNote)) {
+            final PersonalNote myNote = new PersonalNote(this);
+            final PersonalNote otherNote = new PersonalNote(other);
+            final PersonalNote mergedNote = myNote.mergeWith(otherNote);
+            personalNote = mergedNote.toString();
         }
         if (StringUtils.isBlank(getShortDescription())) {
             shortdesc = other.getShortDescription();

--- a/main/src/cgeo/geocaching/PersonalNote.java
+++ b/main/src/cgeo/geocaching/PersonalNote.java
@@ -1,0 +1,112 @@
+package cgeo.geocaching;
+
+import org.apache.commons.lang3.StringUtils;
+
+
+public class PersonalNote {
+    private static final String MERGED_PREFIX = "merged:\n";
+    private static final String SEPARATOR = "--\n";
+    private String cgeoNote;
+    private String providerNote;
+    private boolean isOffline;
+
+    private PersonalNote() {
+        // Empty default constructor
+    }
+
+    public PersonalNote(final Geocache cache) {
+        final String personalNote = cache.getPersonalNote();
+        if (!StringUtils.startsWith(personalNote, MERGED_PREFIX)) {
+            this.providerNote = personalNote;
+            return;
+        }
+        final String[] notes = StringUtils.splitByWholeSeparator(personalNote, SEPARATOR);
+        if (notes.length > 0) {
+            notes[0] = StringUtils.removeStart(notes[0], MERGED_PREFIX);
+            notes[0] = StringUtils.removeEnd(notes[0], "\n");
+        }
+        if (notes.length > 1) {
+            this.cgeoNote = notes[0];
+            this.providerNote = notes[1];
+        } else {
+            this.providerNote = notes[0];
+        }
+        this.isOffline = cache.isOffline();
+    }
+
+    public PersonalNote mergeWith(final PersonalNote other) {
+        if (StringUtils.isEmpty(cgeoNote) && StringUtils.isEmpty(other.cgeoNote)) {
+            return mergeOnlyProviderNotes(other);
+        }
+        final PersonalNote result = new PersonalNote();
+        if (cgeoNote != null && other.cgeoNote != null) {
+            if (other.isOffline) {
+                result.cgeoNote = other.cgeoNote;
+            } else {
+                result.cgeoNote = cgeoNote;
+            }
+        }
+        if (other.cgeoNote != null) {
+            result.cgeoNote = other.cgeoNote;
+        } else {
+            result.cgeoNote = cgeoNote;
+        }
+        if (providerNote != null && other.providerNote != null) {
+            if (isOffline) {
+                result.providerNote = providerNote;
+            } else {
+                result.providerNote = other.providerNote;
+            }
+        }
+        if (providerNote != null) {
+            result.providerNote = providerNote;
+        } else {
+            result.providerNote = other.providerNote;
+        }
+        return result;
+    }
+
+    /**
+     * Merge different provider notes from c:geo and provider.
+     *
+     * @param other
+     *            The note to merge
+     * @return PersonalNote The merged note
+     */
+    private PersonalNote mergeOnlyProviderNotes(final PersonalNote other) {
+        final PersonalNote result = new PersonalNote();
+        if (StringUtils.isNotEmpty(other.providerNote) && StringUtils.isNotEmpty(providerNote)) {
+            if (providerNote.equals(other.providerNote)) {
+                result.providerNote = providerNote;
+                return result;
+            }
+            if (other.isOffline) {
+                result.cgeoNote = other.providerNote;
+                result.providerNote = providerNote;
+            } else {
+                result.cgeoNote = providerNote;
+                result.providerNote = other.providerNote;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer buffer = new StringBuffer();
+        if (cgeoNote != null) {
+            buffer.append(MERGED_PREFIX).append(cgeoNote).append("\n").append(SEPARATOR);
+        }
+        buffer.append(providerNote);
+        return buffer.toString();
+    }
+
+    public String getCgeoNote() {
+        return cgeoNote;
+    }
+
+    public String getProviderNote() {
+        return providerNote;
+    }
+
+}

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -31,30 +31,22 @@ public abstract class AbstractConnector implements IConnector {
     }
 
     @Override
+    public boolean supportsPersonalNote() {
+        return false;
+    }
+
+    @Override
+    public boolean uploadPersonalNote(Geocache cache) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean supportsOwnCoordinates() {
         return false;
     }
 
-    /**
-     * Uploading modified coordinates to website
-     *
-     * @param cache
-     * @param wpt
-     * @return success
-     */
     @Override
     public boolean uploadModifiedCoordinates(Geocache cache, Geopoint wpt) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Uploading personal note to website
-     *
-     * @param cache
-     * @return success
-     */
-    @Override
-    public boolean uploadPersonalNote(Geocache cache) {
         throw new UnsupportedOperationException();
     }
 

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -144,11 +144,11 @@ public interface IConnector {
     public String getGeocodeFromUrl(final String url);
 
     /**
-     * enable/disable uploading modified coordinates to website
+     * enable/disable uploading personal note
      *
      * @return true, when uploading is possible
      */
-    public boolean supportsOwnCoordinates();
+    public boolean supportsPersonalNote();
 
     /**
      * Uploading personal note to website
@@ -159,7 +159,14 @@ public interface IConnector {
     public boolean uploadPersonalNote(Geocache cache);
 
     /**
-     * Reseting of modified coordinates on website to details
+     * enable/disable uploading modified coordinates to website
+     *
+     * @return true, when uploading is possible
+     */
+    public boolean supportsOwnCoordinates();
+
+    /**
+     * Resetting of modified coordinates on website to details
      *
      * @param cache
      * @return success

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -69,6 +69,11 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    public boolean supportsPersonalNote() {
+        return true;
+    }
+
+    @Override
     public boolean supportsOwnCoordinates() {
         return true;
     }

--- a/main/src/cgeo/geocaching/ui/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/EditNoteDialog.java
@@ -1,21 +1,17 @@
 package cgeo.geocaching.ui;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.R.string;
 
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
-import android.view.WindowManager.LayoutParams;
-import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
-import android.widget.TextView;
-import android.widget.TextView.OnEditorActionListener;
 
-public class EditNoteDialog extends DialogFragment implements OnEditorActionListener {
+public class EditNoteDialog extends DialogFragment {
 
     public interface EditNoteDialogListener {
         void onFinishEditNoteDialog(final String inputText);
@@ -37,34 +33,35 @@ public class EditNoteDialog extends DialogFragment implements OnEditorActionList
     }
 
     @Override
-    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
-                             final Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_edit_note, container);
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+        View view = inflater.inflate(R.layout.fragment_edit_note, null);
         mEditText = (EditText) view.findViewById(R.id.note);
         initialNote = getArguments().getString(ARGUMENT_INITIAL_NOTE);
         if (initialNote != null) {
             mEditText.setText(initialNote);
             initialNote = null;
         }
-        getDialog().setTitle(string.cache_personal_note);
-        mEditText.requestFocus();
-        getDialog().getWindow().setSoftInputMode(
-                LayoutParams.SOFT_INPUT_STATE_VISIBLE);
-        mEditText.setOnEditorActionListener(this);
 
-        return view;
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.cache_personal_note);
+        builder.setView(view);
+        builder.setPositiveButton(android.R.string.ok,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        final EditNoteDialogListener activity = (EditNoteDialogListener) getActivity();
+                        activity.onFinishEditNoteDialog(mEditText.getText().toString());
+                        dialog.dismiss();
+                    }
+                });
+        builder.setNegativeButton(android.R.string.cancel,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        dialog.dismiss();
+                    }
+                });
+        return builder.create();
     }
-
-    @Override
-    public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
-        if (EditorInfo.IME_ACTION_DONE == actionId) {
-            final EditNoteDialogListener activity = (EditNoteDialogListener) getActivity();
-            activity.onFinishEditNoteDialog(mEditText.getText().toString());
-            dismiss();
-            return true;
-        }
-        return false;
-    }
-
-
 }

--- a/tests/src/cgeo/geocaching/PersonalNoteTest.java
+++ b/tests/src/cgeo/geocaching/PersonalNoteTest.java
@@ -1,0 +1,68 @@
+package cgeo.geocaching;
+
+import junit.framework.TestCase;
+
+public class PersonalNoteTest extends TestCase {
+
+    public static void testParse() {
+        final String testString = "merged:\nSimple cgeo note\n--\nSimple provider note";
+        Geocache cache = new Geocache();
+        cache.setPersonalNote(testString);
+        PersonalNote parsedNote = new PersonalNote(cache);
+        assertEquals(testString, parsedNote.toString());
+        assertPersonalNote(parsedNote, "Simple cgeo note", "Simple provider note");
+
+    }
+
+    public static void testParseProviderOnly() {
+        final String testString = "Simple provider note";
+        Geocache cache = new Geocache();
+        cache.setPersonalNote(testString);
+        PersonalNote parsedNote = new PersonalNote(cache);
+        assertEquals(testString, parsedNote.toString());
+        assertPersonalNote(parsedNote, null, "Simple provider note");
+    }
+
+    public static void testParseCgeoOnly() {
+        final String testString = "merged:\nSimple cgeo note";
+        Geocache cache = new Geocache();
+        cache.setPersonalNote(testString);
+        PersonalNote parsedNote = new PersonalNote(cache);
+        assertEquals("Simple cgeo note", parsedNote.toString());
+        assertPersonalNote(parsedNote, null, "Simple cgeo note");
+    }
+
+    public static void testSimpleMerge() {
+        Geocache cache1 = new Geocache(); // not stored
+        cache1.setPersonalNote("merged:\nSimple cgeo note\n--\nSimple provider note");
+        PersonalNote myNote = new PersonalNote(cache1);
+        Geocache cache2 = new Geocache();
+        cache2.setListId(StoredList.STANDARD_LIST_ID); // stored
+        cache2.setPersonalNote("merged:\ncgeo note\n--\nProvider note");
+        PersonalNote otherNote = new PersonalNote(cache2);
+        PersonalNote result = myNote.mergeWith(otherNote);
+        assertEquals("merged:\ncgeo note\n--\nSimple provider note", result.toString());
+        assertPersonalNote(result, "cgeo note", "Simple provider note");
+    }
+
+    public static void testMixedMerge() {
+        Geocache cache1 = new Geocache(); // not stored
+        cache1.setPersonalNote("merged:\nSimple cgeo note\n--\nSimple provider note");
+        PersonalNote myNote = new PersonalNote(cache1);
+        Geocache cache2 = new Geocache();
+        cache2.setListId(StoredList.STANDARD_LIST_ID); // stored
+        cache2.setPersonalNote("Provider note");
+        PersonalNote otherNote = new PersonalNote(cache2);
+        PersonalNote result = myNote.mergeWith(otherNote);
+        assertEquals("merged:\nSimple cgeo note\n--\nSimple provider note", result.toString());
+        assertPersonalNote(result, "Simple cgeo note", "Simple provider note");
+        result = otherNote.mergeWith(myNote);
+        assertEquals("merged:\nSimple cgeo note\n--\nProvider note", result.toString());
+        assertPersonalNote(result, "Simple cgeo note", "Provider note");
+    }
+
+    private static void assertPersonalNote(final PersonalNote note, final String cgeoNote, final String providerNote) {
+        assertEquals(cgeoNote, note.getCgeoNote());
+        assertEquals(providerNote, note.getProviderNote());
+    }
+}


### PR DESCRIPTION
Okay, this is a more clear PR.
- IConnector.supportPersonalNote
- personalNote became multiLine again
- uploadPersonalNote for supported connectors on OK
- merge in gatherMissingFrom
- new Class PersonalNote to parse and merge personal note
- added PersonalNoteTest
- removed javadoc in IConnector due to Samuels comment
- changed order in IConnector that uploadPersonalNote is not between supportOwnCoordinates and xyzModifiedCoordinates

Comments apreciated.
