### PR TITLE
Fixes #3000: Basic members caches missing on map

### DIFF
--- a/main/src/cgeo/geocaching/Geocache.java
+++ b/main/src/cgeo/geocaching/Geocache.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCConstants;
+import cgeo.geocaching.connector.gc.Tile;
 import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
@@ -135,7 +136,7 @@ public class Geocache implements ICache, IWaypoint {
     private final EnumSet<StorageLocation> storageLocation = EnumSet.of(StorageLocation.HEAP);
     private boolean finalDefined = false;
     private boolean logPasswordRequired = false;
-    private int zoomlevel = -1;
+    private int zoomlevel = Tile.ZOOMLEVEL_MIN - 1;
 
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 


### PR DESCRIPTION
Fixes #3000 - a second, much simpler fix (my first attempt being pull
request #3055).

The problem was that caches loaded from the nearby list were being
initialized with zoom level (max zoom level + 1), or 19. As far as I can
tell there was no useful purpose for that, but it was preventing caches
loaded from the live map at any zoom level from ever over-writing the null
coordinates. So I made caches initialize with zoom level -1 instead.
