### PR TITLE
Fixes #3104, Wrong parsed cache type not corrected by nearby search and/...

### DIFF
--- a/main/src/cgeo/geocaching/cgData.java
+++ b/main/src/cgeo/geocaching/cgData.java
@@ -2995,7 +2995,7 @@ public class cgData {
         for (String geocode : cachedGeocodes) {
             if (connector.canHandle(geocode)) {
                 Geocache geocache = cacheCache.getCacheFromCache(geocode);
-                if (geocache.getZoomLevel() <= maxZoom) {
+                if (geocache.getCoordZoomLevel() <= maxZoom) {
                     boolean found = false;
                     for (Tile tile : tiles) {
                         if (tile.containsPoint(geocache)) {

--- a/main/src/cgeo/geocaching/connector/gc/GCMap.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCMap.java
@@ -217,7 +217,7 @@ public class GCMap {
                         }
                     }
                 } else {
-                    cache.setType(CacheType.UNKNOWN);
+                    cache.setType(CacheType.UNKNOWN, tile.getZoomLevel());
                 }
 
                 boolean exclude = false;

--- a/main/src/cgeo/geocaching/connector/gc/IconDecoder.java
+++ b/main/src/cgeo/geocaching/connector/gc/IconDecoder.java
@@ -1,8 +1,8 @@
 package cgeo.geocaching.connector.gc;
 
 import cgeo.geocaching.Geocache;
-import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.settings.Settings;
 
 import android.graphics.Bitmap;
 
@@ -87,19 +87,19 @@ public abstract class IconDecoder {
         if (count > 1) { // 2 pixels need to detect same type and we say good to go
             switch (type) {
                 case CT_TRADITIONAL:
-                    cache.setType(CacheType.TRADITIONAL);
+                    cache.setType(CacheType.TRADITIONAL, zoomlevel);
                     return true;
                 case CT_MULTI:
-                    cache.setType(CacheType.MULTI);
+                    cache.setType(CacheType.MULTI, zoomlevel);
                     return true;
                 case CT_MYSTERY:
-                    cache.setType(CacheType.MYSTERY);
+                    cache.setType(CacheType.MYSTERY, zoomlevel);
                     return true;
                 case CT_EVENT:
-                    cache.setType(CacheType.EVENT);
+                    cache.setType(CacheType.EVENT, zoomlevel);
                     return true;
                 case CT_EARTH:
-                    cache.setType(CacheType.EARTH);
+                    cache.setType(CacheType.EARTH, zoomlevel);
                     return true;
                 case CT_FOUND:
                     cache.setFound(true);
@@ -108,22 +108,22 @@ public abstract class IconDecoder {
                     cache.setOwnerUserId(Settings.getUsername());
                     return true;
                 case CT_MEGAEVENT:
-                    cache.setType(CacheType.MEGA_EVENT);
+                    cache.setType(CacheType.MEGA_EVENT, zoomlevel);
                     return true;
                 case CT_CITO:
-                    cache.setType(CacheType.CITO);
+                    cache.setType(CacheType.CITO, zoomlevel);
                     return true;
                 case CT_WEBCAM:
-                    cache.setType(CacheType.WEBCAM);
+                    cache.setType(CacheType.WEBCAM, zoomlevel);
                     return true;
                 case CT_WHERIGO:
-                    cache.setType(CacheType.WHERIGO);
+                    cache.setType(CacheType.WHERIGO, zoomlevel);
                     return true;
                 case CT_VIRTUAL:
-                    cache.setType(CacheType.VIRTUAL);
+                    cache.setType(CacheType.VIRTUAL, zoomlevel);
                     return true;
                 case CT_LETTERBOX:
-                    cache.setType(CacheType.LETTERBOX);
+                    cache.setType(CacheType.LETTERBOX, zoomlevel);
                     return true;
             }
         }

--- a/main/src/cgeo/geocaching/utils/UncertainProperty.java
+++ b/main/src/cgeo/geocaching/utils/UncertainProperty.java
@@ -1,0 +1,39 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.connector.gc.Tile;
+
+public class UncertainProperty<T> {
+
+    private final T value;
+    private final int certaintyLevel;
+
+    public UncertainProperty(T value) {
+        this.value = value;
+        this.certaintyLevel = Tile.ZOOMLEVEL_MAX + 1;
+    }
+
+    public UncertainProperty(T value, int certaintyLevel) {
+        this.value = value;
+        this.certaintyLevel = certaintyLevel;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public int getCertaintyLevel() {
+        return certaintyLevel;
+    }
+
+    public UncertainProperty<T> getMergedProperty(final UncertainProperty<T> other) {
+        if (other == null) {
+            return this;
+        }
+        if (other.certaintyLevel > certaintyLevel) {
+            return other;
+        }
+
+        return this;
+    }
+
+}

--- a/tests/src/cgeo/geocaching/GeocacheTest.java
+++ b/tests/src/cgeo/geocaching/GeocacheTest.java
@@ -118,7 +118,7 @@ public class GeocacheTest extends AndroidTestCase {
 
         Geocache livemap = new Geocache();
         livemap.setGeocode("GC12345");
-        livemap.setType(CacheType.MULTI);
+        livemap.setType(CacheType.MULTI, 12);
         livemap.setCoords(new Geopoint(41.0, 9.0), 12);
 
         livemap.gatherMissingFrom(stored);
@@ -128,7 +128,7 @@ public class GeocacheTest extends AndroidTestCase {
         assertEquals("Type not merged correctly", CacheType.TRADITIONAL, livemap.getType());
         assertEquals("Longitude not merged correctly", 8.0, livemap.getCoords().getLongitude(), 0.1);
         assertEquals("Latitude not merged correctly", 40.0, livemap.getCoords().getLatitude(), 0.1);
-        assertEquals("Zoomlevel not merged correctly", stored.getZoomLevel(), livemap.getZoomLevel());
+        assertEquals("Zoomlevel not merged correctly", stored.getCoordZoomLevel(), livemap.getCoordZoomLevel());
     }
 
     public static void testMergeLivemapZoomin() {
@@ -148,19 +148,19 @@ public class GeocacheTest extends AndroidTestCase {
         assertEquals("Type not merged correctly", CacheType.MULTI, livemapSecond.getType());
         assertEquals("Longitude not merged correctly", 9.0, livemapSecond.getCoords().getLongitude(), 0.1);
         assertEquals("Latitude not merged correctly", 41.0, livemapSecond.getCoords().getLatitude(), 0.1);
-        assertEquals("Zoomlevel not merged correctly", 12, livemapSecond.getZoomLevel());
+        assertEquals("Zoomlevel not merged correctly", 12, livemapSecond.getCoordZoomLevel());
     }
 
     public static void testMergeLivemapZoomout() {
 
         Geocache livemapFirst = new Geocache();
         livemapFirst.setGeocode("GC12345");
-        livemapFirst.setType(CacheType.TRADITIONAL);
+        livemapFirst.setType(CacheType.TRADITIONAL, 12);
         livemapFirst.setCoords(new Geopoint(40.0, 8.0), 12);
 
         Geocache livemapSecond = new Geocache();
         livemapSecond.setGeocode("GC12345");
-        livemapSecond.setType(CacheType.MULTI);
+        livemapSecond.setType(CacheType.MULTI, 11);
         livemapSecond.setCoords(new Geopoint(41.0, 9.0), 11);
 
         livemapSecond.gatherMissingFrom(livemapFirst);
@@ -168,7 +168,7 @@ public class GeocacheTest extends AndroidTestCase {
         assertEquals("Type not merged correctly", CacheType.TRADITIONAL, livemapSecond.getType());
         assertEquals("Longitude not merged correctly", 8.0, livemapSecond.getCoords().getLongitude(), 0.1);
         assertEquals("Latitude not merged correctly", 40.0, livemapSecond.getCoords().getLatitude(), 0.1);
-        assertEquals("Zoomlevel not merged correctly", 12, livemapSecond.getZoomLevel());
+        assertEquals("Zoomlevel not merged correctly", 12, livemapSecond.getCoordZoomLevel());
     }
 
     public static void testMergePopupLivemap() {
@@ -188,7 +188,7 @@ public class GeocacheTest extends AndroidTestCase {
         assertEquals("Longitude not merged correctly", 8.0, popup.getCoords().getLongitude(), 0.1);
         assertEquals("Latitude not merged correctly", 40.0, popup.getCoords().getLatitude(), 0.1);
         assertTrue("Found not merged correctly", popup.isFound());
-        assertEquals("Zoomlevel not merged correctly", 12, popup.getZoomLevel());
+        assertEquals("Zoomlevel not merged correctly", 12, popup.getCoordZoomLevel());
     }
 
     public static void testMergeLivemapBMSearched() {
@@ -204,7 +204,7 @@ public class GeocacheTest extends AndroidTestCase {
 
         assertEquals("Longitude not merged correctly", 8.0, livemap.getCoords().getLongitude(), 0.1);
         assertEquals("Latitude not merged correctly", 40.0, livemap.getCoords().getLatitude(), 0.1);
-        assertEquals("Zoomlevel not merged correctly", 12, livemap.getZoomLevel());
+        assertEquals("Zoomlevel not merged correctly", 12, livemap.getCoordZoomLevel());
     }
 
     public static void testNameForSorting() {


### PR DESCRIPTION
...or popup

Introduced a new class 'UncertainProperty'
Used it for coords and cachetype
Removed global zoomlevel for geocache
