### PR TITLE
fixes #3207 - correct check for maxXY for unscaled images

### DIFF
--- a/main/src/cgeo/geocaching/ImageSelectActivity.java
+++ b/main/src/cgeo/geocaching/ImageSelectActivity.java
@@ -272,7 +272,7 @@ public class ImageSelectActivity extends AbstractActivity {
     private String writeScaledImage(final String filePath) {
         scaleChoiceIndex = scaleView.getSelectedItemPosition();
         final int maxXY = getResources().getIntArray(R.array.log_image_scale_values)[scaleChoiceIndex];
-        if (maxXY == 0) {
+        if (maxXY <= 0) {
             return filePath;
         }
         BitmapFactory.Options sizeOnlyOptions = new BitmapFactory.Options();


### PR DESCRIPTION
Thanks to @rsudev finding the problem. Just a simple fix.
