### PR TITLE
fix #3085 - set string encoding for json StringEntity

### DIFF
--- a/main/src/cgeo/geocaching/network/Network.java
+++ b/main/src/cgeo/geocaching/network/Network.java
@@ -178,7 +178,7 @@ public abstract class Network {
         request.addHeader("Content-Type", "application/json; charset=utf-8");
         if (json != null) {
             try {
-                request.setEntity(new StringEntity(json.toString()));
+                request.setEntity(new StringEntity(json.toString(), CharEncoding.UTF_8));
             } catch (UnsupportedEncodingException e) {
                 Log.e("postJsonRequest:JSON Entity: UnsupportedEncodingException");
                 return null;


### PR DESCRIPTION
I'm not totally sure this solves the upload of personal notes, but encoding was missing here.
My emulator doesn't take special chars from keyboard.
