### PR TITLE
fixes #3303 - SimpleDirChooser shows all readable directories now

### DIFF
--- a/main/res/layout/simple_dir_chooser.xml
+++ b/main/res/layout/simple_dir_chooser.xml
@@ -49,15 +49,17 @@
         <Button
             android:id="@+id/simple_dir_chooser_ok"
             style="@style/button_full"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@android:string/ok" />
 
         <Button
             android:id="@+id/simple_dir_chooser_cancel"
             style="@style/button_full"
-            android:layout_width="wrap_content"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
             android:text="@android:string/cancel" />
     </LinearLayout>
 

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -73,18 +73,20 @@ public class SettingsActivity extends PreferenceActivity {
      */
     private enum DirChooserType {
         GPX_IMPORT_DIR(1, R.string.pref_gpxImportDir,
-                Environment.getExternalStorageDirectory().getPath() + "/gpx"),
+                Environment.getExternalStorageDirectory().getPath() + "/gpx", false),
         GPX_EXPORT_DIR(2, R.string.pref_gpxExportDir,
-                Environment.getExternalStorageDirectory().getPath() + "/gpx"),
-        THEMES_DIR(3, R.string.pref_renderthemepath, "");
+                Environment.getExternalStorageDirectory().getPath() + "/gpx", true),
+        THEMES_DIR(3, R.string.pref_renderthemepath, "", false);
         public final int requestCode;
         public final int keyId;
         public final String defaultValue;
+        public final boolean writeMode;
 
-        DirChooserType(final int requestCode, final int keyId, final String defaultValue) {
+        DirChooserType(final int requestCode, final int keyId, final String defaultValue, final boolean writeMode) {
             this.requestCode = requestCode;
             this.keyId = keyId;
             this.defaultValue = defaultValue;
+            this.writeMode = writeMode;
         }
     }
 
@@ -306,6 +308,7 @@ public class SettingsActivity extends PreferenceActivity {
             // OI file manager not available
             final Intent dirChooser = new Intent(this, SimpleDirChooser.class);
             dirChooser.putExtra(Intents.EXTRA_START_DIR, startDirectory);
+            dirChooser.putExtra(SimpleDirChooser.EXTRA_CHOOSE_FOR_WRITING, dct.writeMode);
             startActivityForResult(dirChooser, dct.requestCode);
         }
     }


### PR DESCRIPTION
Some improvements to SimpleDirChooser
- now shows and navigates all readabled directories (previous only writeable were shown)
- in new write mode checkboxes of readOnly directories are disabled (e.g. GPX Export)
- button layout improvement (weigth 50% each)
