### PR TITLE
Added a new comparator to sort cache lists on popularity ratio

### DIFF
--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">Terénu</string>
   <string name="caches_sort_size">Velikosti</string>
   <string name="caches_sort_favorites">Oblíbenosti</string>
+  <string name="caches_sort_favorites_ratio">Oblíbenosti [%]</string>
   <string name="caches_sort_name">Jména</string>
   <string name="caches_sort_geocode">Geokódu</string>
   <string name="caches_sort_rating">Hodnocení</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">Gelände</string>
   <string name="caches_sort_size">Größe</string>
   <string name="caches_sort_favorites">Beliebtheit</string>
+  <string name="caches_sort_favorites_ratio">Beliebtheit [%]</string>
   <string name="caches_sort_name">Name</string>
   <string name="caches_sort_geocode">Geo-Code</string>
   <string name="caches_sort_rating">Bewertung</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -216,6 +216,7 @@
   <string name="caches_sort_terrain">terreno</string>
   <string name="caches_sort_size">tamaño</string>
   <string name="caches_sort_favorites">popularidad</string>
+  <string name="caches_sort_favorites_ratio">popularidad [%]</string>
   <string name="caches_sort_name">nombre</string>
   <string name="caches_sort_geocode">Código</string>
   <string name="caches_sort_rating">valoración</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">terrain</string>
   <string name="caches_sort_size">taille</string>
   <string name="caches_sort_favorites">popularité</string>
+  <string name="caches_sort_favorites_ratio">popularité [%]</string>
   <string name="caches_sort_name">nom</string>
   <string name="caches_sort_geocode">Geocode</string>
   <string name="caches_sort_rating">note</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -223,6 +223,7 @@
   <string name="caches_sort_terrain">terep</string>
   <string name="caches_sort_size">méret</string>
   <string name="caches_sort_favorites">sikeresség</string>
+  <string name="caches_sort_favorites_ratio">sikeresség [%]</string>
   <string name="caches_sort_name">név</string>
   <string name="caches_sort_rating">osztályzat</string>
   <string name="caches_sort_vote">szavazat (saját osztályzat)</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">Terreno</string>
   <string name="caches_sort_size">Dimensione</string>
   <string name="caches_sort_favorites">Popolarità</string>
+  <string name="caches_sort_favorites_ratio">Popolarità [%]</string>
   <string name="caches_sort_name">Nome</string>
   <string name="caches_sort_geocode">Geo Code</string>
   <string name="caches_sort_rating">Voto</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">Terrein</string>
   <string name="caches_sort_size">Formaat</string>
   <string name="caches_sort_favorites">Populariteit</string>
+  <string name="caches_sort_favorites_ratio">Populariteit [%]</string>
   <string name="caches_sort_name">Naam</string>
   <string name="caches_sort_geocode">Geocode</string>
   <string name="caches_sort_rating">Waardering</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">terenu</string>
   <string name="caches_sort_size">rozmiaru</string>
   <string name="caches_sort_favorites">popularności</string>
+  <string name="caches_sort_favorites_ratio">popularności [%]</string>
   <string name="caches_sort_name">nazwy</string>
   <string name="caches_sort_geocode">Kod skrytki</string>
   <string name="caches_sort_rating">oceny</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">Terreno</string>
   <string name="caches_sort_size">Tamanho</string>
   <string name="caches_sort_favorites">Popularidade</string>
+  <string name="caches_sort_favorites_ratio">Popularidade [%]</string>
   <string name="caches_sort_name">Nome</string>
   <string name="caches_sort_geocode">Geo Código</string>
   <string name="caches_sort_rating">Pontuação</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -223,6 +223,7 @@
   <string name="caches_sort_terrain">terénu</string>
   <string name="caches_sort_size">veľkosti</string>
   <string name="caches_sort_favorites">obľúbenosti</string>
+  <string name="caches_sort_favorites_ratio">obľúbenosti [%]</string>
   <string name="caches_sort_name">názvu</string>
   <string name="caches_sort_geocode">Geokódu</string>
   <string name="caches_sort_rating">hodnotenia</string>

--- a/main/res/values-sl/strings.xml
+++ b/main/res/values-sl/strings.xml
@@ -246,6 +246,7 @@
   <string name="caches_sort_terrain">Teren</string>
   <string name="caches_sort_size">Velikost</string>
   <string name="caches_sort_favorites">Številu favoritov</string>
+  <string name="caches_sort_favorites_ratio_ratio">Številu favoritov [%]</string>
   <string name="caches_sort_name">Imenu</string>
   <string name="caches_sort_geocode">Geo kodi</string>
   <string name="caches_sort_rating">Glasovih</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -244,6 +244,7 @@
   <string name="caches_sort_terrain">Terräng</string>
   <string name="caches_sort_size">Storlek</string>
   <string name="caches_sort_favorites">Favoriter</string>
+  <string name="caches_sort_favorites_ratio">Favoriter [%]</string>
   <string name="caches_sort_name">Namn</string>
   <string name="caches_sort_geocode">Geo kod</string>
   <string name="caches_sort_rating">Betyg (GC-vote)</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -284,6 +284,7 @@
     <string name="caches_sort_terrain">Terrain</string>
     <string name="caches_sort_size">Size</string>
     <string name="caches_sort_favorites">Popularity</string>
+    <string name="caches_sort_favorites_ratio">Popularity [%]</string>
     <string name="caches_sort_name">Name</string>
     <string name="caches_sort_geocode">Geo Code</string>
     <string name="caches_sort_rating">Rating</string>

--- a/main/src/cgeo/geocaching/sorting/ComparatorUserInterface.java
+++ b/main/src/cgeo/geocaching/sorting/ComparatorUserInterface.java
@@ -47,6 +47,7 @@ public class ComparatorUserInterface {
         register(R.string.caches_sort_inventory, InventoryComparator.class);
         register(R.string.caches_sort_name, NameComparator.class);
         register(R.string.caches_sort_favorites, PopularityComparator.class);
+        register(R.string.caches_sort_favorites_ratio, PopularityRatioComparator.class);
         register(R.string.caches_sort_rating, RatingComparator.class);
         register(R.string.caches_sort_size, SizeComparator.class);
         register(R.string.caches_sort_state, StateComparator.class);

--- a/main/src/cgeo/geocaching/sorting/PopularityRatioComparator.java
+++ b/main/src/cgeo/geocaching/sorting/PopularityRatioComparator.java
@@ -1,0 +1,56 @@
+/**
+ *
+ */
+package cgeo.geocaching.sorting;
+
+import cgeo.geocaching.DataStore;
+import cgeo.geocaching.Geocache;
+import cgeo.geocaching.enumerations.LogType;
+
+/**
+ * sorts caches by popularity ratio (favorites per find in %).
+ * only caches with 10 finds and more are counted to obtain meaningful statistics
+ */
+public class PopularityRatioComparator extends AbstractCacheComparator {
+
+    @Override
+    protected boolean canCompare(final Geocache cache1, final Geocache cache2) {
+        return true;
+    }
+
+    @Override
+    protected int compareCaches(final Geocache cache1, final Geocache cache2) {
+
+        float ratio1 = 0.0f;
+        float ratio2 = 0.0f;
+
+        int finds1 = getFindsCount(cache1);
+        int finds2 = getFindsCount(cache2);
+
+        if (finds1 != 0 && finds1 > 9) {
+            ratio1 = (((float) cache1.getFavoritePoints()) / ((float) finds1));
+        }
+        if (finds2 != 0 && finds2 > 9) {
+            ratio2 = (((float) cache2.getFavoritePoints()) / ((float) finds2));
+        }
+
+        if ((ratio2 - ratio1) > 0.0f) {
+            return 1;
+        } else if ((ratio2 - ratio1) < 0.0f) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    private static int getFindsCount(Geocache cache) {
+        if (cache.getLogCounts().isEmpty()) {
+            cache.setLogCounts(DataStore.loadLogCounts(cache.getGeocode()));
+        }
+        Integer logged = cache.getLogCounts().get(LogType.FOUND_IT);
+        if (logged != null) {
+            return logged;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
The comparator enables to sort caches by the ratio of their favorite point count and finds. The limitation is the same as for the FindsComparator, i.e. it does only work once the caches are stored on the device and the number of finds is vaild and available.

The computation of the comparator's return value may seem to be strange. However, it's purpose is to prevent rounding to zero when we would return (ratio2 - ratio1) directly and thereby cast float to int. When you have caches with very few favorite points but many finds this rounding to zero can lead to cases were a cache with 1 favorite point is not sorted as being larger then a cache with 0 favorite points. 
