### PR TITLE
Added a popularity filter that allows to filter out caches that have more  then a predefined number of favorite points

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -289,6 +289,7 @@
   <string name="caches_filter_modified">Mit geänderten Koordinaten</string>
   <string name="caches_filter_origin">Herkunft</string>
   <string name="caches_filter_distance">Entfernung</string>
+  <string name="caches_filter_popularity">Beliebtheit</string>
   <string name="caches_removing_from_history">Lösche aus Verlauf…</string>
   <string name="caches_clear_offlinelogs">Offline-Logs löschen</string>
   <string name="caches_clear_offlinelogs_progress">Lösche Offline-Logs</string>
@@ -1022,6 +1023,7 @@
   <string name="tts_one_foot">ein Fuß</string>
   <string name="tts_one_oclock">ein Uhr</string>
   <string name="tts_oclock">%s Uhr</string>
+  <string name="tts_one_favorite_point">ein Favoritenpunkt</string>
   <string name="clipboard_copy_ok">In Zwischenablage kopiert</string>
   <string-array name="log_image_scales">
     <item>Keine Skalierung</item>
@@ -1061,5 +1063,9 @@
   <plurals name="days_ago">
     <item quantity="one">gestern</item>
     <item quantity="other">vor %d Tagen</item>
+  </plurals>
+  <plurals name="tts_favorite_points">
+    <item quantity="one">%s Favoritenpunkt</item>
+    <item quantity="other">%s Favoritenpunkte</item>
   </plurals>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -329,6 +329,7 @@
     <string name="caches_filter_modified">With modified coordinates</string>
     <string name="caches_filter_origin">Origin</string>
     <string name="caches_filter_distance">Distance</string>
+    <string name="caches_filter_popularity">Popularity</string>
     <string name="caches_removing_from_history">Removing from History…</string>
     <string name="caches_clear_offlinelogs">Clear offline logs</string>
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
@@ -1187,6 +1188,11 @@
     <plurals name="days_ago">
         <item quantity="one">yesterday</item>
         <item quantity="other">%d days ago</item>
+    </plurals>
+    <string name="tts_one_favorite_point">one favorite point</string>
+    <plurals name="tts_favorite_points">
+        <item quantity="one">%s favorite point</item>
+        <item quantity="other">%s favorite points</item>
     </plurals>
 
 </resources>

--- a/main/src/cgeo/geocaching/filter/FilterUserInterface.java
+++ b/main/src/cgeo/geocaching/filter/FilterUserInterface.java
@@ -56,6 +56,7 @@ public final class FilterUserInterface {
         register(R.string.caches_filter_modified, ModifiedFilter.class);
         register(R.string.caches_filter_origin, OriginFilter.Factory.class);
         register(R.string.caches_filter_distance, DistanceFilter.Factory.class);
+        register(R.string.caches_filter_popularity, PopularityFilter.Factory.class);
 
         // sort by localized names
         Collections.sort(registry, new Comparator<FactoryEntry>() {

--- a/main/src/cgeo/geocaching/filter/PopularityFilter.java
+++ b/main/src/cgeo/geocaching/filter/PopularityFilter.java
@@ -1,0 +1,43 @@
+package cgeo.geocaching.filter;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.Geocache;
+import cgeo.geocaching.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class PopularityFilter extends AbstractFilter {
+    private final int minFavorites;
+    private final int maxFavorites;
+
+    public PopularityFilter(String name, final int minFavorites, final int maxFavorites) {
+        super(name);
+        this.minFavorites = minFavorites;
+        this.maxFavorites = maxFavorites;
+    }
+
+    @Override
+    public boolean accepts(final Geocache cache) {
+        return (cache.getFavoritePoints() > minFavorites) && (cache.getFavoritePoints() <= maxFavorites);
+    }
+
+    public static class Factory implements IFilterFactory {
+
+        private static final int[] FAVORITES = { 10, 20, 50, 100, 200, 500 };
+
+        @Override
+        public List<IFilter> getFilters() {
+            final List<IFilter> filters = new ArrayList<IFilter>(FAVORITES.length);
+            for (int i = 0; i < FAVORITES.length; i++) {
+                final int minRange = FAVORITES[i];
+                final int maxRange = Integer.MAX_VALUE;
+                final String range = "> " + minRange;
+                final String name = CgeoApplication.getInstance().getResources().getQuantityString(R.plurals.tts_favorite_points, minRange, range);
+                filters.add(new PopularityFilter(name, minRange, maxRange));
+            }
+            return filters;
+        }
+
+    }
+}


### PR DESCRIPTION
Sorry - I messed up the first pull request by using the wrong browser. Here is the same again:

The filter allows to filter caches with more than 10,20,50,100,200, and 500 favorite points.

BTW: I would recommend to rename the German translation of Popularity from "Beliebtheit" to "Favoriten" since this makes the filters and sorts much more intuitive to use for a German cacher. I have not changed anything because I guess that such an HMI change would require a formal request in some forum. So my ask is: where can I request it?
If it is approved I would set up a new pull request for the name change.

As for the tts_ string naming: I took it from another similar filter, the DistanceFilter, assuming that this is the reference implementation for a filter.
