### PR TITLE
fixes #3325 - warning on upload if personal note exceeds 4000

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -498,6 +498,8 @@
   <string name="cache_log_image_default_title">Bild</string>
   <string name="cache_personal_note">Persönliche Notiz</string>
   <string name="cache_personal_note_edit">Bearbeiten</string>
+  <string name="cache_personal_note_limit">Upload persönlicher Notizen begrenzt</string>
+  <string name="cache_personal_note_truncation">Diese persönliche Notiz wird von Geocaching.com nach %d Zeichen abgeschnitten.</string>
   <string name="cache_personal_note_upload">Hochladen</string>
   <string name="cache_personal_note_uploading">Persönliche Notizen werden gesendet</string>
   <string name="cache_personal_note_upload_done">Persönliche Notizen wurden hochgeladen</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -581,6 +581,8 @@
     <string name="cache_log_image_default_title">Photo</string>
     <string name="cache_personal_note">Personal note</string>
     <string name="cache_personal_note_edit">Edit</string>
+    <string name="cache_personal_note_limit">Personal note limit</string>
+    <string name="cache_personal_note_truncation">This personal note will be truncated after %d characters by Geocaching.com.</string>
     <string name="cache_personal_note_upload">Upload</string>
     <string name="cache_personal_note_uploading">Uploading personal note</string>
     <string name="cache_personal_note_upload_done">Personal note uploaded</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.compatibility.Compatibility;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
@@ -1521,7 +1522,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 personalNoteUpload.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        uploadPersonalNote();
+                        if (StringUtils.length(cache.getPersonalNote()) > GCConstants.PERSONAL_NOTE_MAX_CHARS) {
+                            warnPersonalNoteExceedsLimit();
+                        } else {
+                            uploadPersonalNote();
+                        }
                     }
                 });
             } else {
@@ -1625,6 +1630,33 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.dismiss();
                     storeCache(StoredList.STANDARD_LIST_ID, new StoreCachePersonalNoteHandler(CacheDetailActivity.this, progress));
+                }
+
+            });
+            final AlertDialog dialog = builder.create();
+            dialog.setOwnerActivity(CacheDetailActivity.this);
+            dialog.show();
+        }
+
+        private void warnPersonalNoteExceedsLimit() {
+            final AlertDialog.Builder builder = new AlertDialog.Builder(CacheDetailActivity.this);
+            builder.setTitle(R.string.cache_personal_note_limit);
+            String lang = getString(R.string.cache_personal_note_truncation, GCConstants.PERSONAL_NOTE_MAX_CHARS);
+            builder.setMessage(lang);
+            builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    // do nothing
+                }
+            });
+
+            builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                    uploadPersonalNote();
                 }
 
             });

--- a/main/src/cgeo/geocaching/PersonalNote.java
+++ b/main/src/cgeo/geocaching/PersonalNote.java
@@ -70,8 +70,10 @@ public class PersonalNote {
     private PersonalNote mergeOnlyProviderNotes(final PersonalNote other) {
         final PersonalNote result = new PersonalNote();
         if (StringUtils.isNotEmpty(other.providerNote) && StringUtils.isNotEmpty(providerNote)) {
-            if (providerNote.equals(other.providerNote)) {
-                result.providerNote = providerNote;
+            // Don't overwrite a stored personal note if provider note is different.
+            // Prevents the local personal note from being overwritten by a truncated note from GC.com.
+            if (StringUtils.startsWith(other.providerNote, providerNote)) {
+                result.providerNote = other.providerNote;
                 return result;
             }
             if (other.isOffline) {

--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -177,6 +177,8 @@ public final class GCConstants {
 
     /** Number of logs to retrieve from GC.com */
     public final static int NUMBER_OF_LOGS = 35;
+    /** Maximum number of chars for personal note. **/
+    public final static int PERSONAL_NOTE_MAX_CHARS = 500;
 
     private final static String SEQUENCE_GCID = "0123456789ABCDEFGHJKMNPQRTVWXYZ";
     private final static long GC_BASE31 = 31;

--- a/tests/src/cgeo/geocaching/PersonalNoteTest.java
+++ b/tests/src/cgeo/geocaching/PersonalNoteTest.java
@@ -1,6 +1,9 @@
 package cgeo.geocaching;
 
+import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.list.StoredList;
+
+import org.apache.commons.lang3.StringUtils;
 
 import junit.framework.TestCase;
 
@@ -23,6 +26,20 @@ public class PersonalNoteTest extends TestCase {
         PersonalNote parsedNote = new PersonalNote(cache);
         assertEquals(testString, parsedNote.toString());
         assertPersonalNote(parsedNote, null, "Simple provider note");
+    }
+
+    public static void testLocalNoteExceedsLimit() {
+        String testString = StringUtils.repeat("x", GCConstants.PERSONAL_NOTE_MAX_CHARS + 1);
+        Geocache truncCache = new Geocache();
+        truncCache.setPersonalNote(testString.substring(0, GCConstants.PERSONAL_NOTE_MAX_CHARS));
+        PersonalNote parsedNote = new PersonalNote(truncCache);
+
+        Geocache exceedingCache = new Geocache();
+        exceedingCache.setListId(StoredList.STANDARD_LIST_ID); // stored
+        exceedingCache.setPersonalNote(testString.toString());
+        PersonalNote otherNote = new PersonalNote(exceedingCache);
+        PersonalNote result = parsedNote.mergeWith(otherNote);
+        assertPersonalNote(result, null, testString.toString());
     }
 
     public static void testParseCgeoOnly() {


### PR DESCRIPTION
- Warning added on upload personal note if note exceeds 4000 (hard to do ...)
- Merge modified to compare only first 4000 chars of provider note
- Test added for merge
