### PR TITLE
Added a popularity ratio filter to filter on favorites per find.

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -289,6 +289,7 @@
   <string name="caches_filter_modified">Mit geänderten Koordinaten</string>
   <string name="caches_filter_origin">Herkunft</string>
   <string name="caches_filter_distance">Entfernung</string>
+  <string name="caches_filter_popularity_ratio">Beliebtheit [%]</string>
   <string name="caches_removing_from_history">Lösche aus Verlauf…</string>
   <string name="caches_clear_offlinelogs">Offline-Logs löschen</string>
   <string name="caches_clear_offlinelogs_progress">Lösche Offline-Logs</string>
@@ -1062,4 +1063,5 @@
     <item quantity="one">gestern</item>
     <item quantity="other">vor %d Tagen</item>
   </plurals>
+  <string name="percent_favorite_points">% Favoriten</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -329,6 +329,7 @@
     <string name="caches_filter_modified">With modified coordinates</string>
     <string name="caches_filter_origin">Origin</string>
     <string name="caches_filter_distance">Distance</string>
+    <string name="caches_filter_popularity_ratio">Popularity [%]</string>
     <string name="caches_removing_from_history">Removing from History…</string>
     <string name="caches_clear_offlinelogs">Clear offline logs</string>
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
@@ -1188,5 +1189,7 @@
         <item quantity="one">yesterday</item>
         <item quantity="other">%d days ago</item>
     </plurals>
+    
+    <string name="percent_favorite_points">%\  favorites</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/filter/FilterUserInterface.java
+++ b/main/src/cgeo/geocaching/filter/FilterUserInterface.java
@@ -56,6 +56,7 @@ public final class FilterUserInterface {
         register(R.string.caches_filter_modified, ModifiedFilter.class);
         register(R.string.caches_filter_origin, OriginFilter.Factory.class);
         register(R.string.caches_filter_distance, DistanceFilter.Factory.class);
+        register(R.string.caches_filter_popularity_ratio, PopularityRatioFilter.Factory.class);
 
         // sort by localized names
         Collections.sort(registry, new Comparator<FactoryEntry>() {

--- a/main/src/cgeo/geocaching/filter/PopularityRatioFilter.java
+++ b/main/src/cgeo/geocaching/filter/PopularityRatioFilter.java
@@ -1,0 +1,73 @@
+package cgeo.geocaching.filter;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.DataStore;
+import cgeo.geocaching.Geocache;
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.LogType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * filters caches by popularity ratio (favorites per find in %).
+ */
+class PopularityRatioFilter extends AbstractFilter {
+    private final int minRatio;
+    private final int maxRatio;
+
+    public PopularityRatioFilter(String name, final int minRatio, final int maxRatio) {
+        super(name);
+        this.minRatio = minRatio;
+        this.maxRatio = maxRatio;
+    }
+
+    @Override
+    public boolean accepts(final Geocache cache) {
+
+        int finds;
+        int favorites;
+        float ratio;
+
+        finds = getFindsCount(cache);
+
+        // prevent division by zero
+        if (finds == 0) {
+            return false;
+        }
+
+        favorites = cache.getFavoritePoints();
+        ratio = ((float) favorites / (float) finds) * 100.0f;
+
+        return (ratio > minRatio) && (ratio <= maxRatio);
+    }
+
+    private static int getFindsCount(Geocache cache) {
+        if (cache.getLogCounts().isEmpty()) {
+            cache.setLogCounts(DataStore.loadLogCounts(cache.getGeocode()));
+        }
+        Integer logged = cache.getLogCounts().get(LogType.FOUND_IT);
+        if (logged != null) {
+            return logged;
+        }
+        return 0;
+    }
+
+    public static class Factory implements IFilterFactory {
+
+        private static final int[] RATIOS = { 10, 20, 30, 40, 50, 75 };
+
+        @Override
+        public List<IFilter> getFilters() {
+            final List<IFilter> filters = new ArrayList<IFilter>(RATIOS.length);
+            for (int i = 0; i < RATIOS.length; i++) {
+                final int minRange = RATIOS[i];
+                final int maxRange = Integer.MAX_VALUE;
+                final String name = "> " + minRange + " " + CgeoApplication.getInstance().getResources().getString(R.string.percent_favorite_points);
+                filters.add(new PopularityRatioFilter(name, minRange, maxRange));
+            }
+            return filters;
+        }
+
+    }
+}

--- a/main/src/cgeo/geocaching/sorting/PopularityRatioComparator.java
+++ b/main/src/cgeo/geocaching/sorting/PopularityRatioComparator.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.enumerations.LogType;
 
 /**
  * sorts caches by popularity ratio (favorites per find in %).
- * only caches with 10 finds and more are counted to obtain meaningful statistics
  */
 public class PopularityRatioComparator extends AbstractCacheComparator {
 
@@ -27,10 +26,10 @@ public class PopularityRatioComparator extends AbstractCacheComparator {
         int finds1 = getFindsCount(cache1);
         int finds2 = getFindsCount(cache2);
 
-        if (finds1 != 0 && finds1 > 9) {
+        if (finds1 != 0) {
             ratio1 = (((float) cache1.getFavoritePoints()) / ((float) finds1));
         }
-        if (finds2 != 0 && finds2 > 9) {
+        if (finds2 != 0) {
             ratio2 = (((float) cache2.getFavoritePoints()) / ((float) finds2));
         }
 


### PR DESCRIPTION
This complements my pull requests  #3385 and #3389 where I proposed a comparator to sort on popularity ratio and a filter to filter on pure popularity.  With this pull request I propose a filter to filter on popularity ratio as well.

As a result of these three pull requests a user can now 
- sort and filter on pure popularity (favorite count)
- sort and filter on popularity ratio (favorites per find)

Furthermore, I removed the constraint that only caches > 9 finds are handled in the popularity ratio sorts and filters. Showing it to potential users they rather got confused by this not apparent tweaking of the statistics, when a cache with 8 finds and 2 favorites did not appear in the >20% filter. As a consequence, now a cache with a single find and a single favorite (having a ratio of 100%) will lead a sort and pass the >75% filter even though it may not be very attractive due to the low number of ratings. This however, is then obvious to the user since he clearly can see in the cache list that this cache has only a single favorite.     
