### PR TITLE
fixes #3370 #2960 #1320 - keep empty and null values

### DIFF
--- a/main/src/cgeo/geocaching/Geocache.java
+++ b/main/src/cgeo/geocaching/Geocache.java
@@ -253,7 +253,7 @@ public class Geocache implements ICache, IWaypoint {
         if (hidden == null) {
             hidden = other.hidden;
         }
-        if (StringUtils.isBlank(getHint())) {
+        if (!detailed && StringUtils.isBlank(getHint())) {
             hint = other.getHint();
         }
         if (size == null || CacheSize.UNKNOWN == size) {
@@ -284,7 +284,7 @@ public class Geocache implements ICache, IWaypoint {
             final PersonalNote mergedNote = myNote.mergeWith(otherNote);
             personalNote = mergedNote.toString();
         }
-        if (StringUtils.isBlank(getShortDescription())) {
+        if (!detailed && StringUtils.isBlank(getShortDescription())) {
             shortdesc = other.getShortDescription();
         }
         if (StringUtils.isBlank(getDescription())) {
@@ -304,7 +304,7 @@ public class Geocache implements ICache, IWaypoint {
         if (myVote == 0) {
             myVote = other.myVote;
         }
-        if (attributes.isEmpty()) {
+        if (!detailed && attributes.isEmpty()) {
             attributes.clear();
             if (other.attributes != null) {
                 attributes.addAll(other.attributes);

--- a/tests/src/cgeo/geocaching/GeocacheTest.java
+++ b/tests/src/cgeo/geocaching/GeocacheTest.java
@@ -100,6 +100,11 @@ public class GeocacheTest extends CGeoTestCase {
         stored.setType(CacheType.TRADITIONAL);
         stored.setCoords(new Geopoint(40.0, 8.0));
         stored.setDescription("Test1");
+        ArrayList<String> attributes = new ArrayList<String>(1);
+        attributes.add("TestAttribute");
+        stored.setAttributes(attributes);
+        stored.setShortDescription("Short");
+        stored.setHint("Hint");
 
         Geocache download = new Geocache();
         download.setGeocode("GC12345");
@@ -117,6 +122,9 @@ public class GeocacheTest extends CGeoTestCase {
         assertEquals("Longitude not merged correctly", 9.0, download.getCoords().getLongitude(), 0.1);
         assertEquals("Latitude not merged correctly", 41.0, download.getCoords().getLatitude(), 0.1);
         assertEquals("Description not merged correctly", "Test2", download.getDescription());
+        assertEquals("ShortDescription not merged correctly", "", download.getShortDescription());
+        assertEquals("Attributes not merged correctly", new ArrayList<String>(0), download.getAttributes());
+        assertEquals("Hint not merged correctly", "", download.getHint());
     }
 
     public static void testMergeLivemapStored() {


### PR DESCRIPTION
On gatherMissingFrom now the following fields are taken from the new loaded cache if detailed:
- short description
- hint
- attributes
