### PR TITLE
Changed display string of "popularity" to "favorites" for [en] and [de]

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -245,8 +245,8 @@
   <string name="caches_sort_difficulty">Schwierigkeit</string>
   <string name="caches_sort_terrain">Gelände</string>
   <string name="caches_sort_size">Größe</string>
-  <string name="caches_sort_favorites">Beliebtheit</string>
-  <string name="caches_sort_favorites_ratio">Beliebtheit [%]</string>
+  <string name="caches_sort_favorites">Favoriten</string>
+  <string name="caches_sort_favorites_ratio">Favoriten [%]</string>
   <string name="caches_sort_name">Name</string>
   <string name="caches_sort_geocode">Geo-Code</string>
   <string name="caches_sort_rating">Bewertung</string>
@@ -289,8 +289,8 @@
   <string name="caches_filter_modified">Mit geänderten Koordinaten</string>
   <string name="caches_filter_origin">Herkunft</string>
   <string name="caches_filter_distance">Entfernung</string>
-  <string name="caches_filter_popularity">Beliebtheit</string>
-  <string name="caches_filter_popularity_ratio">Beliebtheit [%]</string>
+  <string name="caches_filter_popularity">Favoriten</string>
+  <string name="caches_filter_popularity_ratio">Favoriten [%]</string>
   <string name="caches_removing_from_history">Lösche aus Verlauf…</string>
   <string name="caches_clear_offlinelogs">Offline-Logs löschen</string>
   <string name="caches_clear_offlinelogs_progress">Lösche Offline-Logs</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -285,8 +285,8 @@
     <string name="caches_sort_difficulty">Difficulty</string>
     <string name="caches_sort_terrain">Terrain</string>
     <string name="caches_sort_size">Size</string>
-    <string name="caches_sort_favorites">Popularity</string>
-    <string name="caches_sort_favorites_ratio">Popularity [%]</string>
+    <string name="caches_sort_favorites">Favorites</string>
+    <string name="caches_sort_favorites_ratio">Favorites [%]</string>
     <string name="caches_sort_name">Name</string>
     <string name="caches_sort_geocode">Geo Code</string>
     <string name="caches_sort_rating">Rating</string>
@@ -330,8 +330,8 @@
     <string name="caches_filter_origin">Origin</string>
     <string name="caches_filter_distance">Distance</string>
     <string name="caches_filter_personal_note">With personal note</string>
-    <string name="caches_filter_popularity">Popularity</string>
-    <string name="caches_filter_popularity_ratio">Popularity [%]</string>
+    <string name="caches_filter_popularity">Favorites</string>
+    <string name="caches_filter_popularity_ratio">Favorites [%]</string>
     <string name="caches_removing_from_history">Removing from History…</string>
     <string name="caches_clear_offlinelogs">Clear offline logs</string>
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>


### PR DESCRIPTION
Changed [en] from "popularity" to "favorites" 
Changed [de] from "Beliebtheit" to "Favoriten"

I feel strongly that this change makes the usage of the sorts and filters in cgeo much more intuitive for German and English speaking cachers. 
