### PR TITLE
Added shortcut from compass to map by a single click

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -110,6 +110,16 @@ public class CompassActivity extends AbstractActivity {
 
         Views.inject(this);
 
+        // set the shortcut to map by clicking on the destination coordinates or cache info at the top of the compass
+        final View info = findViewById(R.id.info1);
+        info.setClickable(true);
+        info.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                CGeoMap.startActivityCoords(CompassActivity.this, dstCoords, null, title);
+            }
+        });
+
         // make sure we can control the TTS volume
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
     }


### PR DESCRIPTION
Now you can switch with just a single click between compass and map - and back.

You switch from compass to map by clicking on the compound info box at the top of the compass containing the destination coordinates and the cache info. From map to compass you can return also with just a single click on the back button - this has not changed.

I think that this is a very useful feature for those who often switch between map and compass.
