### PR TITLE
fixes #3348 - Direction to cache still displayed in lists although deselected

### DIFF
--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -60,6 +60,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> {
     private boolean selectMode = false;
     private IFilter currentFilter = null;
     private List<Geocache> originalList = null;
+    private boolean isLiveList = Settings.isLiveList();
 
     final private Set<CompassMiniView> compasses = new LinkedHashSet<CompassMiniView>();
     final private Set<DistanceView> distances = new LinkedHashSet<DistanceView>();
@@ -433,7 +434,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> {
         }
 
         // only show the direction if this is enabled in the settings
-        if (Settings.isLiveList()) {
+        if (isLiveList) {
             if (cache.getCoords() != null) {
                 holder.direction.setVisibility(View.VISIBLE);
                 holder.dirImg.setVisibility(View.GONE);


### PR DESCRIPTION
Up to now only the update of the direction indicator in the cache list was disabled when deactivating the corresponding option in the settings. This led to the behavior that the indicator was still shown but not updated. Now the direction indicator is not shown at all as it is expected by disbaling the option in the settings.
