### PR TITLE
fixes #3354 - Position not saved on logbook screen

### DIFF
--- a/main/src/cgeo/geocaching/ui/AbstractCachingPageViewCreator.java
+++ b/main/src/cgeo/geocaching/ui/AbstractCachingPageViewCreator.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.ui;
 
 import cgeo.geocaching.activity.AbstractViewPagerActivity.PageViewCreator;
 
+import android.os.Bundle;
 import android.view.View;
 
 /**
@@ -29,4 +30,22 @@ public abstract class AbstractCachingPageViewCreator<ViewClass extends View> imp
 
     @Override
     public abstract ViewClass getDispatchedView();
+
+    /**
+     * Gets the state of the view but returns an empty state if not overridden
+     *
+     * @return empty bundle
+     */
+    @Override
+    public Bundle getViewState() {
+        return new Bundle();
+    }
+
+    /**
+     * Restores the state of the view but just returns if not overridden.
+     */
+    @Override
+    public void setViewState(Bundle state) {
+        return;
+    }
 }

--- a/main/src/cgeo/geocaching/ui/logs/CacheLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/ui/logs/CacheLogsViewCreator.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.ui.UserActionsClickListener;
 import org.apache.commons.lang3.StringUtils;
 
 import android.content.res.Resources;
+import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
 
@@ -109,4 +110,37 @@ public class CacheLogsViewCreator extends LogsViewCreator {
         return new UserActionsClickListener(getCache());
     }
 
+    /**
+     * Get the state of the current view
+     *
+     * @return the state encapsulated in a bundle
+     */
+    @Override
+    public Bundle getViewState() {
+        if (view == null) {
+            return null;
+        }
+        int position = view.getFirstVisiblePosition();
+        View child = view.getChildAt(0);
+        int positionFromTop = (child == null) ? 0 : child.getTop();
+        Bundle state = new Bundle();
+        state.putInt("position", position);
+        state.putInt("positionFromTop", positionFromTop);
+        return state;
+    }
+
+    /**
+     * Restore a previously stored state of the view
+     *
+     */
+    @Override
+    public void setViewState(Bundle state) {
+        if (view == null) {
+            return;
+        }
+        int logViewPosition = state.getInt("position");
+        int logViewPositionFromTop = state.getInt("positionFromTop");
+        view.setSelectionFromTop(logViewPosition, logViewPositionFromTop);
+        return;
+    }
 }


### PR DESCRIPTION
The root cause of this issue is that the scroll positions of the ListViews showing the logbook and the friends logbook are not persistet when flipping more then two pages away - i.e. when the ViewPagerAdapter destroys the corresponding views and reinstantiates them later.

Therefore, I added a methods to the PageViewCreator interface to save and restore the state of the encapsulated view, provided an empty implementation in the AbstractCachingPageViewCreator to be compatible with all existing page views, and a concrete implementation for the CacheLogsViewCreator. Saving and restoring the view states is done in the ViewPagerAdapter.         
