### PR TITLE
Implement Android Beam (NFC Sharing) for cgeo

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -14,12 +14,17 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.NFC" />
 
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
     <uses-feature
         android:name="android.hardware.screen.portrait"
+        android:required="false" />
+
+    <uses-feature
+        android:name="android.hardware.nfc"
         android:required="false" />
 
     <supports-screens

--- a/main/src/cgeo/calendar/CalendarAddon.java
+++ b/main/src/cgeo/calendar/CalendarAddon.java
@@ -35,7 +35,7 @@ public class CalendarAddon {
                     ICalendar.PARAM_NAME, cache.getName(),
                     ICalendar.PARAM_NOTE, StringUtils.defaultString(cache.getPersonalNote()),
                     ICalendar.PARAM_HIDDEN_DATE, hiddenDate != null ? String.valueOf(hiddenDate.getTime()) : StringUtils.EMPTY,
-                    ICalendar.PARAM_URL, StringUtils.defaultString(cache.getUrl()),
+                    ICalendar.PARAM_URL, StringUtils.defaultString(cache.getBrowserUrl()),
                     ICalendar.PARAM_COORDS, cache.getCoords() == null ? "" : cache.getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_RAW),
                     ICalendar.PARAM_LOCATION, StringUtils.defaultString(cache.getLocation()),
                     ICalendar.PARAM_SHORT_DESC, StringUtils.defaultString(cache.getShortDescription()),

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -606,6 +606,16 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         getSupportActionBar().setIcon(getResources().getDrawable(cache.getType().markerId));
 
+        // if we have a newer Android device setup Android Beam for easy cache sharing
+        initializeAndroidBeam(
+                new ActivitySharingInterface() {
+                    @Override
+                    public String getUri() {
+                        return cache.getCgeoUrl();
+                    }
+                }
+        );
+
         // reset imagesList so Images view page will be redrawn
         imagesList = null;
         reinitializeViewPager();
@@ -614,6 +624,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         invalidateOptionsMenuCompatible();
         progress.dismiss();
     }
+
 
     /**
      * Tries to navigate to the {@link Geocache} of this activity.
@@ -1598,7 +1609,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 if (unknownTagsHandler.isProblematicDetected()) {
                     final int startPos = description.length();
                     final IConnector connector = ConnectorFactory.getConnector(cache);
-                    final Spanned tableNote = Html.fromHtml(res.getString(R.string.cache_description_table_note, "<a href=\"" + cache.getUrl() + "\">" + connector.getName() + "</a>"));
+                    final Spanned tableNote = Html.fromHtml(res.getString(R.string.cache_description_table_note, "<a href=\"" + cache.getBrowserUrl() + "\">" + connector.getName() + "</a>"));
                     ((Editable) description).append("\n\n").append(tableNote);
                     ((Editable) description).setSpan(new StyleSpan(Typeface.ITALIC), startPos, description.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 }

--- a/main/src/cgeo/geocaching/Geocache.java
+++ b/main/src/cgeo/geocaching/Geocache.java
@@ -501,7 +501,7 @@ public class Geocache implements ICache, IWaypoint {
     }
 
     private String getCacheUrl() {
-        return getConnector().getCacheUrl(this);
+        return getConnector().getCacheBrowserUrl(this);
     }
 
     private String getBrowserCacheUrl() {
@@ -722,14 +722,16 @@ public class Geocache implements ICache, IWaypoint {
         final Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
         intent.putExtra(Intent.EXTRA_SUBJECT, subject.toString());
-        intent.putExtra(Intent.EXTRA_TEXT, getUrl());
+        intent.putExtra(Intent.EXTRA_TEXT, getBrowserUrl());
 
         return intent;
     }
 
-    public String getUrl() {
-        return getConnector().getCacheUrl(this);
+    public String getBrowserUrl() {
+        return getConnector().getCacheBrowserUrl(this);
     }
+
+    public String getCgeoUrl() { return getConnector().getCgeoCacheUrl(this); }
 
     public boolean supportsGCVote() {
         return StringUtils.startsWithIgnoreCase(geocode, "GC");

--- a/main/src/cgeo/geocaching/Trackable.java
+++ b/main/src/cgeo/geocaching/Trackable.java
@@ -38,8 +38,12 @@ public class Trackable implements ILogable {
     private List<LogEntry> logs = new ArrayList<LogEntry>();
     private String trackingcode = null;
 
-    public String getUrl() {
-        return getConnector().getUrl(this);
+    public String getBrowserUrl() {
+        return getConnector().getBrowserUrl(this);
+    }
+
+    public String getCgeoUrl() {
+        return getConnector().getCgeoUrl(this);
     }
 
     private TrackableConnector getConnector() {

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -111,6 +111,16 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (waitDialog != null) {
                 waitDialog.dismiss();
             }
+
+            // if we have a newer Android device setup Android Beam for easy cache sharing
+            initializeAndroidBeam(
+                    new ActivitySharingInterface() {
+                        @Override
+                        public String getUri() {
+                            return trackable.getCgeoUrl();
+                        }
+                    }
+            );
         }
     };
 
@@ -241,7 +251,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
                 LogTrackableActivity.startActivity(this, trackable);
                 return true;
             case R.id.menu_browser_trackable:
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(trackable.getUrl())));
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(trackable.getBrowserUrl())));
                 return true;
             default:
                 return false;
@@ -252,7 +262,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
     public boolean onPrepareOptionsMenu(Menu menu) {
         if (trackable != null) {
             menu.findItem(R.id.menu_log_touch).setEnabled(StringUtils.isNotBlank(geocode) && trackable.isLoggable());
-            menu.findItem(R.id.menu_browser_trackable).setEnabled(StringUtils.isNotBlank(trackable.getUrl()));
+            menu.findItem(R.id.menu_browser_trackable).setEnabled(StringUtils.isNotBlank(trackable.getBrowserUrl()));
         }
         return super.onPrepareOptionsMenu(menu);
     }

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -16,8 +16,14 @@ import org.apache.commons.lang3.StringUtils;
 import rx.Subscription;
 import rx.subscriptions.Subscriptions;
 
+import android.annotation.TargetApi;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.nfc.NdefMessage;
+import android.nfc.NdefRecord;
+import android.nfc.NfcAdapter;
+import android.nfc.NfcEvent;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.view.ContextMenu;
@@ -197,5 +203,35 @@ public abstract class AbstractActivity extends ActionBarActivity implements IAbs
             default:
                 return false;
         }
+    }
+
+    // Do not support older devices than Android 4.0
+    // Although there even are 2.3 devices  (Nexus S)
+    // these are so few that we don't want to deal with the older (non Android Beam) API
+
+    public interface ActivitySharingInterface {
+        /** Return an URL that represent the current activity for sharing */
+        public String getUri();
+    }
+
+    protected void initializeAndroidBeam(ActivitySharingInterface sharingInterface) {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+            initializeICSAndroidBeam(sharingInterface);
+    }
+
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    protected void initializeICSAndroidBeam(final ActivitySharingInterface sharingInterface) {
+        NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(this);
+        if (nfcAdapter == null) {
+            return;
+        }
+        nfcAdapter.setNdefPushMessageCallback(new NfcAdapter.CreateNdefMessageCallback() {
+            @Override
+            public NdefMessage createNdefMessage(NfcEvent event) {
+                NdefRecord record = NdefRecord.createUri(sharingInterface.getUri());
+                return new NdefMessage(new NdefRecord[]{record});
+            }
+        }, this);
+
     }
 }

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -142,7 +142,12 @@ public abstract class AbstractConnector implements IConnector {
 
     @Override
     public String getLongCacheUrl(final @NonNull Geocache cache) {
-        return getCacheUrl(cache);
+        return getCacheBrowserUrl(cache);
+    }
+
+    @Override
+    public String getCgeoCacheUrl(@NonNull Geocache cache) {
+        return getLongCacheUrl(cache);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/GeocachingAustraliaConnector.java
+++ b/main/src/cgeo/geocaching/connector/GeocachingAustraliaConnector.java
@@ -14,7 +14,7 @@ public class GeocachingAustraliaConnector extends AbstractConnector {
     }
 
     @Override
-    public String getCacheUrl(final @NonNull Geocache cache) {
+    public String getCacheBrowserUrl(final @NonNull Geocache cache) {
         return getCacheUrlPrefix() + cache.getGeocode();
     }
 

--- a/main/src/cgeo/geocaching/connector/GeopeitusConnector.java
+++ b/main/src/cgeo/geocaching/connector/GeopeitusConnector.java
@@ -14,7 +14,7 @@ public class GeopeitusConnector extends AbstractConnector {
     }
 
     @Override
-    public String getCacheUrl(final @NonNull Geocache cache) {
+    public String getCacheBrowserUrl(final @NonNull Geocache cache) {
         return getCacheUrlPrefix() + StringUtils.stripStart(cache.getGeocode().substring(2), "0");
     }
 

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -34,7 +34,15 @@ public interface IConnector {
      * @param cache
      * @return
      */
-    public String getCacheUrl(final @NonNull Geocache cache);
+    public String getCacheBrowserUrl(final @NonNull Geocache cache);
+
+    /**
+     * Get the URL that will default to CGEO opening the cache
+     *
+     * @param cache
+     * @return
+     */
+    public String getCgeoCacheUrl(final @NonNull Geocache cache);
 
     /**
      * get long browser URL for the given cache

--- a/main/src/cgeo/geocaching/connector/UnknownConnector.java
+++ b/main/src/cgeo/geocaching/connector/UnknownConnector.java
@@ -14,7 +14,7 @@ public class UnknownConnector extends AbstractConnector {
     }
 
     @Override
-    public String getCacheUrl(@NonNull Geocache cache) {
+    public String getCacheBrowserUrl(@NonNull Geocache cache) {
         return null; // we have no url for these caches
     }
 

--- a/main/src/cgeo/geocaching/connector/WaymarkingConnector.java
+++ b/main/src/cgeo/geocaching/connector/WaymarkingConnector.java
@@ -14,7 +14,7 @@ public class WaymarkingConnector extends AbstractConnector {
     }
 
     @Override
-    public String getCacheUrl(@NonNull Geocache cache) {
+    public String getCacheBrowserUrl(@NonNull Geocache cache) {
         return getCacheUrlPrefix() + cache.getGeocode();
     }
 

--- a/main/src/cgeo/geocaching/connector/ec/ECConnector.java
+++ b/main/src/cgeo/geocaching/connector/ec/ECConnector.java
@@ -68,7 +68,7 @@ public class ECConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
-    public String getCacheUrl(@NonNull Geocache cache) {
+    public String getCacheBrowserUrl(@NonNull Geocache cache) {
         return CACHE_URL + cache.getGeocode().replace("EC", "");
     }
 
@@ -178,7 +178,7 @@ public class ECConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     public String getLicenseText(final @NonNull Geocache cache) {
         // NOT TO BE TRANSLATED
-        return "© " + cache.getOwnerDisplayName() + ", <a href=\"" + getCacheUrl(cache) + "\">" + getName() + "</a>, CC BY-NC-ND 3.0, alle Logeinträge © jeweiliger Autor";
+        return "© " + cache.getOwnerDisplayName() + ", <a href=\"" + getCacheBrowserUrl(cache) + "\">" + getName() + "</a>, CC BY-NC-ND 3.0, alle Logeinträge © jeweiliger Autor";
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -84,12 +84,17 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    public String getCgeoCacheUrl(@NonNull Geocache cache) {
+        return getLongCacheUrl(cache).replace("//", "/");
+    }
+
+    @Override
     public String getLongCacheUrl(@NonNull Geocache cache) {
         return CACHE_URL_LONG + cache.getGeocode();
     }
 
     @Override
-    public String getCacheUrl(@NonNull Geocache cache) {
+    public String getCacheBrowserUrl(@NonNull Geocache cache) {
         return CACHE_URL_SHORT + cache.getGeocode();
     }
 

--- a/main/src/cgeo/geocaching/connector/oc/OCApiConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCApiConnector.java
@@ -45,7 +45,7 @@ public class OCApiConnector extends OCConnector implements ISearchByGeocode {
     @Override
     public String getLicenseText(final @NonNull Geocache cache) {
         // NOT TO BE TRANSLATED
-        return "© " + cache.getOwnerDisplayName() + ", <a href=\"" + getCacheUrl(cache) + "\">" + getName() + "</a>, " + licenseString;
+        return "© " + cache.getOwnerDisplayName() + ", <a href=\"" + getCacheBrowserUrl(cache) + "\">" + getName() + "</a>, " + licenseString;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/oc/OCConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCConnector.java
@@ -39,7 +39,7 @@ public class OCConnector extends AbstractConnector {
     }
 
     @Override
-    public String getCacheUrl(@NonNull Geocache cache) {
+    public String getCacheBrowserUrl(@NonNull Geocache cache) {
         return getCacheUrlPrefix() + cache.getGeocode();
     }
 

--- a/main/src/cgeo/geocaching/connector/ox/OXConnector.java
+++ b/main/src/cgeo/geocaching/connector/ox/OXConnector.java
@@ -35,7 +35,7 @@ public class OXConnector extends AbstractConnector implements ISearchByCenter, I
     }
 
     @Override
-    public String getCacheUrl(@NonNull Geocache cache) {
+    public String getCacheBrowserUrl(@NonNull Geocache cache) {
         return getCacheUrlPrefix() + cache.getGeocode();
     }
 
@@ -52,7 +52,7 @@ public class OXConnector extends AbstractConnector implements ISearchByCenter, I
     @Override
     public String getLicenseText(@NonNull Geocache cache) {
         // NOT TO BE TRANSLATED
-        return "<a href=\"" + getCacheUrl(cache) + "\">" + getName() + "</a> data licensed under the Creative Commons CC-BY-SA 3.0 License";
+        return "<a href=\"" + getCacheBrowserUrl(cache) + "\">" + getName() + "</a> data licensed under the Creative Commons CC-BY-SA 3.0 License";
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.connector.trackable;
 
+import cgeo.geocaching.Trackable;
 import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.connector.UserAction;
 
@@ -19,6 +20,11 @@ public abstract class AbstractTrackableConnector implements TrackableConnector {
     public @Nullable
     String getTrackableCodeFromUrl(@NonNull String url) {
         return null;
+    }
+
+    @Override
+    public String getCgeoUrl(Trackable trackable) {
+        return getBrowserUrl(trackable);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -20,7 +20,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
     }
 
     @Override
-    public String getUrl(Trackable trackable) {
+    public String getBrowserUrl(Trackable trackable) {
         return "http://geokrety.org/konkret.php?id=" + getId(trackable.getGeocode());
     }
 
@@ -38,7 +38,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
             final String hex = geocode.substring(2);
             return Integer.parseInt(hex, 16);
         } catch (final NumberFormatException e) {
-            Log.e("Trackable.getUrl", e);
+            Log.e("Trackable.getBrowserUrl", e);
         }
         return -1;
     }

--- a/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
@@ -16,7 +16,9 @@ public interface TrackableConnector {
 
     public boolean canHandleTrackable(final String geocode);
 
-    public String getUrl(final Trackable trackable);
+    public String getBrowserUrl(final Trackable trackable);
+
+    public String getCgeoUrl(final Trackable trackable);
 
     public boolean isLoggable();
 

--- a/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -25,7 +25,12 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     }
 
     @Override
-    public String getUrl(Trackable trackable) {
+    public String getCgeoUrl(Trackable trackable) {
+        return getBrowserUrl(trackable).replace("//", "/");
+    }
+
+    @Override
+    public String getBrowserUrl(Trackable trackable) {
         return "http://www.geocaching.com//track/details.aspx?tracker=" + trackable.getGeocode();
     }
 

--- a/main/src/cgeo/geocaching/connector/trackable/UnknownTrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/UnknownTrackableConnector.java
@@ -12,7 +12,7 @@ public class UnknownTrackableConnector extends AbstractTrackableConnector {
     }
 
     @Override
-    public String getUrl(Trackable trackable) {
+    public String getBrowserUrl(Trackable trackable) {
         return StringUtils.EMPTY;
     }
 

--- a/main/src/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/cgeo/geocaching/export/GpxSerializer.java
@@ -111,7 +111,7 @@ public final class GpxSerializer {
             XmlUtils.multipleTexts(gpx, PREFIX_GPX,
                     "name", cache.getGeocode(),
                     "desc", cache.getName(),
-                    "url", cache.getUrl(),
+                    "url", cache.getCgeoUrl(),
                     "urlname", cache.getName(),
                     "sym", cache.isFound() ? "Geocache Found" : "Geocache",
                     "type", "Geocache|" + cache.getType().pattern);

--- a/main/src/cgeo/geocaching/utils/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/utils/LogTemplateProvider.java
@@ -202,11 +202,11 @@ public final class LogTemplateProvider {
             public String getValue(LogContext context) {
                 Trackable trackable = context.getTrackable();
                 if (trackable != null) {
-                    return trackable.getUrl();
+                    return trackable.getBrowserUrl();
                 }
                 Geocache cache = context.getCache();
                 if (cache != null) {
-                    return cache.getUrl();
+                    return cache.getBrowserUrl();
                 }
                 return StringUtils.EMPTY;
             }


### PR DESCRIPTION
To support direct opening of CGEO on the other device, introduce a distinction between getBrowserURL and getCgeoURL in providers.

Sending to the other device is implemented for Geocaches and trackables.
