### PR TITLE
Don't let the OAuth dialogs use the Dialog theme

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -20,12 +20,6 @@ public class AbstractActionBarActivity extends AbstractActivity {
         showProgress(false);
     }
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState, int resourceLayoutID, boolean useDialogTheme) {
-        super.onCreate(savedInstanceState, resourceLayoutID, useDialogTheme);
-        initUpAction();
-        showProgress(false);
-    }
 
     private void initUpAction() {
        getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -114,21 +114,14 @@ public abstract class AbstractActivity extends ActionBarActivity implements IAbs
     }
 
     protected void onCreate(final Bundle savedInstanceState, final int resourceLayoutID) {
-        onCreate(savedInstanceState, resourceLayoutID, false);
-    }
-
-    protected void onCreate(final Bundle savedInstanceState, final int resourceLayoutID, boolean useDialogTheme) {
 
         super.onCreate(savedInstanceState);
 
         initializeCommonFields();
 
         // non declarative part of layout
-        if (useDialogTheme) {
-            setTheme(ActivityMixin.getDialogTheme());
-        } else {
-            setTheme();
-        }
+        setTheme();
+
         setContentView(resourceLayoutID);
 
         // create view variables

--- a/main/src/cgeo/geocaching/network/OAuthAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/network/OAuthAuthorizationActivity.java
@@ -5,6 +5,7 @@ import butterknife.InjectView;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
+import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.utils.BundleUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
@@ -32,7 +33,7 @@ import android.widget.TextView;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
-public abstract class OAuthAuthorizationActivity extends AbstractActionBarActivity {
+public abstract class OAuthAuthorizationActivity extends AbstractActivity {
 
     public static final int NOT_AUTHENTICATED = 0;
     public static final int AUTHENTICATED = 1;
@@ -106,7 +107,7 @@ public abstract class OAuthAuthorizationActivity extends AbstractActionBarActivi
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState, R.layout.authorization_activity, true);
+        super.onCreate(savedInstanceState, R.layout.authorization_activity);
 
         Bundle extras = getIntent().getExtras();
         if (extras != null) {


### PR DESCRIPTION
This fixes the crash when a OAuth dialog is shown, a correct fix would to convert the OAuth dialogs to activities/DialogFragment but that is more work and can be done later.
