### PR TITLE
fix #2632: custom waypoints lost after version update

### DIFF
--- a/main/res/values-ca/strings.xml
+++ b/main/res/values-ca/strings.xml
@@ -570,8 +570,6 @@
   <string name="cache_personal_note_uploading">S\'està pujant la nota personal</string>
   <string name="cache_personal_note_upload_done">S\'ha pujat la nota personal</string>
   <string name="cache_personal_note_upload_cancelled">S\'ha cancel·lat la pujada de la nota personal</string>
-  <string name="cache_personal_note_unstored">El catxé no s\'ha desat</string>
-  <string name="cache_personal_note_store">El catxé es desa en primer lloc per permetre una nota personal.</string>
   <string name="cache_description">Descripció</string>
   <string name="cache_description_long">Descripció llarga</string>
   <string name="cache_description_table_note">La descripció conté un format que pot necessitar visualitzar-se a %s per a veure\'s correctament.</string>

--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -563,8 +563,6 @@
   <string name="cache_personal_note_uploading">Nahrávání osobní poznámky</string>
   <string name="cache_personal_note_upload_done">Osobní poznámka nahrána</string>
   <string name="cache_personal_note_upload_cancelled">Nahrávání osobní poznámky přerušeno</string>
-  <string name="cache_personal_note_unstored">Keš neuložena</string>
-  <string name="cache_personal_note_store">Keš bude nejdříve uložena kvůli povolení osobních poznámek.</string>
   <string name="cache_description">Popis</string>
   <string name="cache_description_long">Dlouhý popis</string>
   <string name="cache_description_table_note">Popis obsahuje tabulkové formátování, které je pravděpodobně nutné prohlížet na %s, aby bylo správně zobrazené.</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -573,8 +573,6 @@
   <string name="cache_personal_note_uploading">Persönliche Notiz wird gesendet</string>
   <string name="cache_personal_note_upload_done">Persönliche Notiz wurde hochgeladen</string>
   <string name="cache_personal_note_upload_cancelled">Hochladen der Notiz abgebrochen</string>
-  <string name="cache_personal_note_unstored">Cache noch nicht gespeichert</string>
-  <string name="cache_personal_note_store">Der Cache wird zunächst gespeichert, damit die persönliche Notiz möglich ist.</string>
   <string name="cache_description">Beschreibung</string>
   <string name="cache_description_long">Ausführliche Beschreibung</string>
   <string name="cache_description_table_note">Diese Beschreibung enthält Tabellenelemente, die evtl. nur auf %s korrekt angezeigt werden.</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -572,8 +572,6 @@
   <string name="cache_personal_note_uploading">Envoi de la note personnelle</string>
   <string name="cache_personal_note_upload_done">Note personnelle envoyée</string>
   <string name="cache_personal_note_upload_cancelled">Envoi de la note personnelle annulé</string>
-  <string name="cache_personal_note_unstored">Cache non sauvegardée localement</string>
-  <string name="cache_personal_note_store">La cache va être sauvegardée localement avant d\'autoriser les notes personnelles.</string>
   <string name="cache_description">Description</string>
   <string name="cache_description_long">Description longue</string>
   <string name="cache_description_table_note">La description contient des informations de formattages qui nécessitent possiblement d\'être vues sur le site %s pour être affichées correctement.</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -560,8 +560,6 @@
   <string name="cache_personal_note_uploading">Nota personale in caricamento</string>
   <string name="cache_personal_note_upload_done">Nota personale caricata</string>
   <string name="cache_personal_note_upload_cancelled">Caricamento nota personale annullato</string>
-  <string name="cache_personal_note_unstored">Cache non salvati</string>
-  <string name="cache_personal_note_store">Il cache verrà prima salvato per abilitare le note personali.</string>
   <string name="cache_description">Descrizione</string>
   <string name="cache_description_long">Descrizione estesa</string>
   <string name="cache_description_table_note">La descrizione contiene una tabella formattata in modo tale che potresti aver bisogno di andare su %s per vederla correttamente.</string>

--- a/main/res/values-ja/strings.xml
+++ b/main/res/values-ja/strings.xml
@@ -513,8 +513,6 @@
   <string name="cache_personal_note_uploading">パーソナルノートをアップロード中</string>
   <string name="cache_personal_note_upload_done">パーソナルノートをアップロードしました</string>
   <string name="cache_personal_note_upload_cancelled">パーソナルノートのアップロードをキャンセルしました</string>
-  <string name="cache_personal_note_unstored">キャッシュ情報が保存されていません</string>
-  <string name="cache_personal_note_store">パーソナルノートを有効にするためにキャッシュ情報を保存します。</string>
   <string name="cache_description">説明</string>
   <string name="cache_description_long">全て表示</string>
   <string name="cache_description_table_note">キャッシュ情報の説明にはhtmlを使ったテーブル表が含まれています。正しく表示するには%sで開く必要があるかもしれません。</string>

--- a/main/res/values-lt/strings.xml
+++ b/main/res/values-lt/strings.xml
@@ -570,8 +570,6 @@
   <string name="cache_personal_note_uploading">Įkeliama asmeninė pastaba</string>
   <string name="cache_personal_note_upload_done">Asmeninė pastaba įkelta</string>
   <string name="cache_personal_note_upload_cancelled">Asmeninės pastabos įkėlimas atšauktas</string>
-  <string name="cache_personal_note_unstored">Slėptuvė neišsaugota</string>
-  <string name="cache_personal_note_store">Rašyti asmeninę pastabą galima tik išsaugotos slėptuvės aprašyme.</string>
   <string name="cache_description">Aprašymas</string>
   <string name="cache_description_long">Ilgas aprašymas</string>
   <string name="cache_description_table_note">Aprašymas turi lentelės formatavimą ir norint pamatyti jį atvaizduotą teisingai gali tekti apsilankyti %s.</string>

--- a/main/res/values-nb/strings.xml
+++ b/main/res/values-nb/strings.xml
@@ -555,8 +555,6 @@
   <string name="cache_personal_note_uploading">Laster opp personlig cachenotat</string>
   <string name="cache_personal_note_upload_done">Personlig cachenotat er lastet opp</string>
   <string name="cache_personal_note_upload_cancelled">Personlig cachenotat ble avbrutt under opplasting</string>
-  <string name="cache_personal_note_unstored">Cachen er ikke lagret</string>
-  <string name="cache_personal_note_store">Cachen vil bli lagret for å skrive personlig cachenotat.</string>
   <string name="cache_description">Beskrivelse</string>
   <string name="cache_description_long">Full beskrivelse</string>
   <string name="cache_description_table_note">Beskrivelsen inneholder tabellformatering og må åpnes på %s for å vises riktig.</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -570,8 +570,6 @@
   <string name="cache_personal_note_uploading">Uploading persoonlijke notitie</string>
   <string name="cache_personal_note_upload_done">Persoonlijke notitie geupload</string>
   <string name="cache_personal_note_upload_cancelled">Persoonlijk notitie uploaden geannulleerd</string>
-  <string name="cache_personal_note_unstored">Cache niet opgeslagen</string>
-  <string name="cache_personal_note_store">De cache zal eerst opgeslagen worden om persoonlijke notities toe te kunnen voegen.</string>
   <string name="cache_description">Omschrijving</string>
   <string name="cache_description_long">Lange omschrijving</string>
   <string name="cache_description_table_note">Omschrijving bevat een tabel-layout welke misschien op %s bekeken moet worden.</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -565,8 +565,6 @@
   <string name="cache_personal_note_uploading">Wysyłam osobistą notatkę</string>
   <string name="cache_personal_note_upload_done">Notatka osobista wysłana</string>
   <string name="cache_personal_note_upload_cancelled">Wysyłanie notatki osobistej anulowane</string>
-  <string name="cache_personal_note_unstored">Skrzynka nie jest zapisana</string>
-  <string name="cache_personal_note_store">Skrzynka będzie najpierw zapisana aby umożliwić dodawanie notatek osobistych.</string>
   <string name="cache_description">Opis</string>
   <string name="cache_description_long">Długi opis</string>
   <string name="cache_description_table_note">Opis zawiera formatowanie w formie tabeli, które w celu poprawnego wyświetlania może wymagać odwiedzenia %s.</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -563,8 +563,6 @@
   <string name="cache_personal_note_uploading">A enviar nota pessoal</string>
   <string name="cache_personal_note_upload_done">Nota pessoal enviada</string>
   <string name="cache_personal_note_upload_cancelled">Envio de nota pessoal cancelado</string>
-  <string name="cache_personal_note_unstored">Cache não guaradada</string>
-  <string name="cache_personal_note_store">A cache vai ser guardada primeiro para permitir notas pessoais.</string>
   <string name="cache_description">Descrição</string>
   <string name="cache_description_long">Descrição longa</string>
   <string name="cache_description_table_note">A descrição contém a formatação da tabela que pode ser necessário para ser vista correctamente em %s.</string>

--- a/main/res/values-ro/strings.xml
+++ b/main/res/values-ro/strings.xml
@@ -567,8 +567,6 @@
   <string name="cache_personal_note_uploading">Încărcare notă personală</string>
   <string name="cache_personal_note_upload_done">Nota personală a fost încărcată</string>
   <string name="cache_personal_note_upload_cancelled">Încărcarea notei personale a fost anulată</string>
-  <string name="cache_personal_note_unstored">Cutia nu este salvată</string>
-  <string name="cache_personal_note_store">Cutia va fi mai întâi salvată pentru a permite adăugarea de note personale.</string>
   <string name="cache_description">Descriere</string>
   <string name="cache_description_long">Descriere completă</string>
   <string name="cache_description_table_note">Descrierea conţine tabele sau formatări care ar trebui vizualizate aici %s pentru a fi afişate corect.</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -555,8 +555,6 @@
   <string name="cache_personal_note_uploading">Nahrať osobnú poznámku</string>
   <string name="cache_personal_note_upload_done">Osobná poznámka nahraná</string>
   <string name="cache_personal_note_upload_cancelled">Nahrávanie osobnej poznámky zrušené</string>
-  <string name="cache_personal_note_unstored">Cache nie je uložená</string>
-  <string name="cache_personal_note_store">Cache sa najskôr uložia aby sa povolila osobná poznámka.</string>
   <string name="cache_description">Popis</string>
   <string name="cache_description_long">Dlhý popis</string>
   <string name="cache_description_table_note">Popis obsahuje formátovanie tabuľky, ktorý môže byť pre správne zobrazenie potrebné otvoriť v %s.</string>

--- a/main/res/values-sl/strings.xml
+++ b/main/res/values-sl/strings.xml
@@ -564,8 +564,6 @@
   <string name="cache_personal_note_uploading">Nalagam lastno opombo na spletno stran</string>
   <string name="cache_personal_note_upload_done">Lastna opomba je bila uspešno naložena na spletno stran</string>
   <string name="cache_personal_note_upload_cancelled">Nalaganje lastne opombe je bilo preklicano</string>
-  <string name="cache_personal_note_unstored">Zaklad ni shranjen</string>
-  <string name="cache_personal_note_store">Za vklop opomb bo zaklad najprej shranjen na napravo.</string>
   <string name="cache_description">Opis</string>
   <string name="cache_description_long">Daljši opis</string>
   <string name="cache_description_table_note">Opis vsebuje oblikovanje s tabelami. Za pravilen prikaz opisa bo mogoče potrebno obiskati %s.</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -570,8 +570,6 @@
   <string name="cache_personal_note_uploading">Laddar upp personlig anteckning</string>
   <string name="cache_personal_note_upload_done">Den personliga anteckning har laddats upp</string>
   <string name="cache_personal_note_upload_cancelled">Uppladdningen av personliga anteckning avbruten</string>
-  <string name="cache_personal_note_unstored">Cachen ej sparad</string>
-  <string name="cache_personal_note_store">Cachen kommer att sparas först för att kunna hantera personlig anteckning.</string>
   <string name="cache_description">Beskrivning</string>
   <string name="cache_description_long">Lång beskrivning</string>
   <string name="cache_description_table_note">Beskrivningen innehåller tabellformatering som eventuellt behöver läsas på %s för att se korrekt ut.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -625,8 +625,6 @@
     <string name="cache_personal_note_uploading">Uploading personal note</string>
     <string name="cache_personal_note_upload_done">Personal note uploaded</string>
     <string name="cache_personal_note_upload_cancelled">Personal note upload cancelled</string>
-    <string name="cache_personal_note_unstored">Cache not stored</string>
-    <string name="cache_personal_note_store">The cache will be stored first to allow a personal note.</string>
     <string name="cache_description">Description</string>
     <string name="cache_description_long">Long Description</string>
     <string name="cache_description_table_note">Description contains table formatting which may need to be viewed at %s to be seen correctly.</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1410,11 +1410,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             personalNoteEdit.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(final View v) {
-                    if (cache.isOffline()) {
-                        editPersonalNote(cache, CacheDetailActivity.this);
-                    } else {
-                        warnPersonalNoteNeedsStoring();
-                    }
+                    ensureSaved();
+                    editPersonalNote(cache, CacheDetailActivity.this);
                 }
             });
             final Button personalNoteUpload = (Button) view.findViewById(R.id.upload_personalnote);
@@ -1522,19 +1519,6 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     }
                 }
             }
-        }
-
-        private void warnPersonalNoteNeedsStoring() {
-            Dialogs.confirm(CacheDetailActivity.this, R.string.cache_personal_note_unstored, R.string.cache_personal_note_store,
-                    new DialogInterface.OnClickListener() {
-
-                @Override
-                public void onClick(final DialogInterface dialog, final int which) {
-                    dialog.dismiss();
-                    storeCache(StoredList.STANDARD_LIST_ID, new StoreCachePersonalNoteHandler(CacheDetailActivity.this, progress));
-                }
-
-            });
         }
 
         private void warnPersonalNoteExceedsLimit() {


### PR DESCRIPTION
This triggers an automatic saving of the cache in the standard list before any waypoint manipulation.
