### PR TITLE
fixes #3959 - don't crop static maps due to Google license

### DIFF
--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -265,7 +265,7 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:onClick="showNavigationMenu"
-                android:scaleType="centerCrop"
+                android:scaleType="fitCenter"
                 android:src="@null" />
         </LinearLayout>
     </LinearLayout>

--- a/main/res/layout/staticmaps_activity_item.xml
+++ b/main/res/layout/staticmaps_activity_item.xml
@@ -7,4 +7,4 @@
     android:layout_marginBottom="10dip"
     android:gravity="center"
     android:padding="3dip"
-    android:scaleType="centerCrop" />
+    android:scaleType="fitCenter" />


### PR DESCRIPTION
Now just squared images due to google license. Maybe we have to adapt the image creation to get a more screen fitting image.
