### PR TITLE
fixes #3957 - only show cache static maps navigation for offline stored caches

### DIFF
--- a/main/src/cgeo/geocaching/apps/cache/navi/DownloadStaticMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/DownloadStaticMapsApp.java
@@ -13,22 +13,22 @@ class DownloadStaticMapsApp extends AbstractStaticMapsApp {
     }
 
     @Override
-    public boolean isEnabled(Geocache cache) {
-        return !cache.hasStaticMap();
+    public boolean isEnabled(final Geocache cache) {
+        return cache.isOffline() && !cache.hasStaticMap();
     }
 
     @Override
-    public boolean isEnabled(Waypoint waypoint) {
+    public boolean isEnabled(final Waypoint waypoint) {
         return !hasStaticMap(waypoint);
     }
 
     @Override
-    public void navigate(Activity activity, Geocache cache) {
+    public void navigate(final Activity activity, final Geocache cache) {
         invokeStaticMaps(activity, cache, null, true);
     }
 
     @Override
-    public void navigate(Activity activity, Waypoint waypoint) {
+    public void navigate(final Activity activity, final Waypoint waypoint) {
         invokeStaticMaps(activity, null, waypoint, true);
     }
 }

--- a/main/src/cgeo/geocaching/apps/cache/navi/StaticMapApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/StaticMapApp.java
@@ -13,22 +13,22 @@ class StaticMapApp extends AbstractStaticMapsApp {
     }
 
     @Override
-    public boolean isEnabled(Geocache cache) {
-        return cache.hasStaticMap();
+    public boolean isEnabled(final Geocache cache) {
+        return cache.isOffline() && cache.hasStaticMap();
     }
 
     @Override
-    public boolean isEnabled(Waypoint waypoint) {
+    public boolean isEnabled(final Waypoint waypoint) {
         return hasStaticMap(waypoint);
     }
 
     @Override
-    public void navigate(Activity activity, Geocache cache) {
+    public void navigate(final Activity activity, final Geocache cache) {
         invokeStaticMaps(activity, cache, null, false);
     }
 
     @Override
-    public void navigate(Activity activity, Waypoint waypoint) {
+    public void navigate(final Activity activity, final Waypoint waypoint) {
         invokeStaticMaps(activity, null, waypoint, false);
     }
 }


### PR DESCRIPTION
Hide cache static maps menu for live caches not stored for offline use.
