### PR TITLE
Fix #4092: MapsWithMe renamed to Maps.me

### DIFF
--- a/main/res/values-ca/strings.xml
+++ b/main/res/values-ca/strings.xml
@@ -279,7 +279,6 @@
   <string name="caches_move_all">Mou-ho tot</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exporta al Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Introduïu el text de la imatge. Això permet la baixada de les coordenades del catxé, que es pot desactivar a la configuració.</string>
   <string name="caches_recaptcha_hint">Text de la imatge</string>
@@ -644,7 +643,6 @@
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_navigon">Navigon</string>
   <string name="cache_menu_pebble">Pebble</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Estat</string>
   <string name="cache_status_offline_log">Registre desat</string>
   <string name="cache_status_found">Trobat</string>

--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -274,7 +274,6 @@
   <string name="caches_move_all">Přesunout vše</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exportovat do Locusu</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Prosím, opiš text z obrázku. Umožní to stažení souřadnic keše. Ověřování lze vypnout v Nastavení.</string>
   <string name="caches_recaptcha_hint">Text z obrázku</string>
@@ -624,7 +623,6 @@
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_navigon">Navigon</string>
   <string name="cache_menu_pebble">Pebble</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Stav</string>
   <string name="cache_status_offline_log">Připravený Log</string>
   <string name="cache_status_found">Nalezena</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -279,7 +279,6 @@
   <string name="caches_move_all">Alle verschieben</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exportieren nach Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Bitte Text vom Bild abschreiben. Wichtig, um Koordinaten des Caches laden zu können. Dies ist optional und kann in den Einstellungen deaktiviert werden.</string>
   <string name="caches_recaptcha_hint">Text vom Bild</string>
@@ -643,7 +642,6 @@
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_navigon">Navigon</string>
   <string name="cache_menu_pebble">Pebble Smartwatch</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Status</string>
   <string name="cache_status_offline_log">Gespeicherter Log</string>
   <string name="cache_status_found">Gefunden</string>

--- a/main/res/values-lt/strings.xml
+++ b/main/res/values-lt/strings.xml
@@ -280,7 +280,6 @@
   <string name="caches_move_all">Perkelti visas</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Eksportuoti į Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Prašome įvesti tekstą kurį matote paveikslėlyje. Tai leis atsisiųsti slėptuvės koordinates ir tai galima išjungti Nustatymuose.</string>
   <string name="caches_recaptcha_hint">Tekstas iš paveikslėlio</string>
@@ -638,7 +637,6 @@
   <string name="cache_menu_whereyougo">WhereYouGo</string>
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_pebble">Pebble</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Būsena</string>
   <string name="cache_status_offline_log">Išsaugotas įrašas</string>
   <string name="cache_status_found">Rasta</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -279,7 +279,6 @@
   <string name="caches_move_all">Verplaats alle</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exporteer naar Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Vul de tekst uit de afbeelding in. Dit is nodig voor het downloaden van de coördinaten van de caches. Dit is optioneel en kan in de instellingen uitgeschakeld worden.</string>
   <string name="caches_recaptcha_hint">Tekst uit de afbeelding</string>
@@ -644,7 +643,6 @@
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_navigon">Navigon</string>
   <string name="cache_menu_pebble">Pebble</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Status</string>
   <string name="cache_status_offline_log">Log opgeslagen</string>
   <string name="cache_status_found">Gevonden</string>

--- a/main/res/values-ro/strings.xml
+++ b/main/res/values-ro/strings.xml
@@ -269,7 +269,6 @@
   <string name="caches_move_all">Mută toate cutiile</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exportă către Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Tastează textul din imagine. Aceasta permite descărcarea coordonatelor cutiilor, acest lucru poate fi dezactivat în Opţiuni.</string>
   <string name="caches_recaptcha_hint">Textul din imagine</string>
@@ -624,7 +623,6 @@
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_navigon">Navigon</string>
   <string name="cache_menu_pebble">Ceas \"Pebble\"</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Stare</string>
   <string name="cache_status_offline_log">Jurnal salvat</string>
   <string name="cache_status_found">Găsit</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -273,7 +273,6 @@
   <string name="caches_move_all">Presunúť všetky</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exportovať do Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Opíšte text z obrázku. Je to dôležité pre stiahnutie súradníc skrýš. Túto vlastnosť je možné vypnúť v Nastaveniach.</string>
   <string name="caches_recaptcha_hint">Text z obrázku</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -272,7 +272,6 @@
   <string name="caches_move_all">Flytta alla</string>
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exportera till Locus</string>
-  <string name="caches_map_mapswithme">MapsWithMe</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
   <string name="caches_recaptcha_explanation">Skriv texten som syns i bilden. Det krävs för att hämta koordinaterna för cacherna i listan. Det går att fortsätta ändå (men med sämre funktionalitet).</string>
   <string name="caches_recaptcha_hint">Text från bilden</string>
@@ -633,7 +632,6 @@
   <string name="cache_menu_oruxmaps">OruxMaps</string>
   <string name="cache_menu_navigon">Navigon</string>
   <string name="cache_menu_pebble">Pebble</string>
-  <string name="cache_menu_mapswithme">MapsWithMe</string>
   <string name="cache_status">Status</string>
   <string name="cache_status_offline_log">Sparad logg</string>
   <string name="cache_status_found">Hittad</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -307,7 +307,6 @@
     <string name="caches_move_all">Move all</string>
     <string name="caches_map_locus">Locus</string>
     <string name="caches_map_locus_export">Export to Locus</string>
-    <string name="caches_map_mapswithme">MapsWithMe</string>
     <string name="caches_recaptcha_title">reCAPTCHA</string>
     <string name="caches_recaptcha_explanation">Please enter the text you see in the image. This enables downloading of cache coordinates, which can be disabled in Settings.</string>
     <string name="caches_recaptcha_hint">Text from image</string>
@@ -698,7 +697,6 @@
     <string name="cache_menu_oruxmaps">OruxMaps</string>
     <string name="cache_menu_navigon">Navigon</string>
     <string name="cache_menu_pebble">Pebble</string>
-    <string name="cache_menu_mapswithme">MapsWithMe</string>
     <string name="cache_status">Status</string>
     <string name="cache_status_offline_log">Saved Log</string>
     <string name="cache_status_found">Found</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -84,4 +84,7 @@
     <!-- cache menu -->
     <string name="cache_menu_sygic" translatable="false">Sygic</string>
 
+    <string name="caches_map_mapswithme" translatable="false">Maps.me</string>
+    <string name="cache_menu_mapswithme" translatable="false">Maps.me</string>
+
 </resources>


### PR DESCRIPTION
Deleted translations and marked string as translatable=false
