### PR TITLE
Please test: parallel image loading in geocaches and trackable descriptions

### DIFF
--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -485,7 +485,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (StringUtils.isNotBlank(HtmlUtils.extractText(trackable.getGoal()))) {
                 goalBox.setVisibility(View.VISIBLE);
                 goalTextView.setVisibility(View.VISIBLE);
-                goalTextView.setText(Html.fromHtml(trackable.getGoal(), new HtmlImage(geocode, true, 0, false), null), TextView.BufferType.SPANNABLE);
+                goalTextView.setText(Html.fromHtml(trackable.getGoal(), new HtmlImage(geocode, true, 0, false, goalTextView), null), TextView.BufferType.SPANNABLE);
                 goalTextView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
                 addContextMenu(goalTextView);
             }
@@ -494,7 +494,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (StringUtils.isNotBlank(HtmlUtils.extractText(trackable.getDetails()))) {
                 detailsBox.setVisibility(View.VISIBLE);
                 detailsTextView.setVisibility(View.VISIBLE);
-                detailsTextView.setText(Html.fromHtml(trackable.getDetails(), new HtmlImage(geocode, true, 0, false), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+                detailsTextView.setText(Html.fromHtml(trackable.getDetails(), new HtmlImage(geocode, true, 0, false, detailsTextView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
                 detailsTextView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
                 addContextMenu(detailsTextView);
             }


### PR DESCRIPTION
While images were loaded in parallel in the images tab, the way we handled description was:
- display the description without any image;
- fetch the images through an `Html.ImageGetter` then redisplay the description with them.

This way, we could display a partial description if there were problems to access images on the network. Also, the `HtmlImage` getter implemented only serial loading, as expected by Android's `fromHtml()`.

Now, the `HtmlImage` getter can take an optional `TextView`. In this case, images are first replaced by dummy drawables and loaded in the background in parallel. As soon as an image is available, it gets displayed and the `TextView` is invalidated (using its `getText()` method) so that the version with the image is redrawn. This way, description images are shown as they are loaded, and a network stall for an image will not block anything. I have removed the pre-simpler-html display since it is of no use anymore.

Could some people please test this PR and make sure that it looks ok?
