### PR TITLE
Fixes #3929, Long press options in logbook no longer working

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1857,6 +1857,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         context.startActivity(cachesIntent);
     }
 
+    @Override
     public void addContextMenu(final View view) {
         view.setOnLongClickListener(new OnLongClickListener() {
 
@@ -1932,7 +1933,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                         return onClipboardItemSelected(actionMode, menuItem, clickedItemText);
                     }
                 });
-                return false;
+                return true;
             }
         });
     }

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -527,6 +527,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
     }
 
+    @Override
     public void addContextMenu(final View view) {
         view.setOnLongClickListener(new OnLongClickListener() {
 

--- a/main/src/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -1,20 +1,21 @@
 package cgeo.geocaching.activity;
 
 import android.os.Bundle;
+import android.view.View;
 
 /**
  * Classes actually having an ActionBar (as opposed to the Dialog activities)
  */
 public class AbstractActionBarActivity extends AbstractActivity {
     @Override
-    protected void onCreate(Bundle savedInstanceState, int resourceLayoutID) {
+    protected void onCreate(final Bundle savedInstanceState, final int resourceLayoutID) {
         super.onCreate(savedInstanceState, resourceLayoutID);
         initUpAction();
         showProgress(false);
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         initUpAction();
         showProgress(false);
@@ -26,9 +27,17 @@ public class AbstractActionBarActivity extends AbstractActivity {
     }
 
     @Override
-    public void setTitle(CharSequence title) {
+    public void setTitle(final CharSequence title) {
         super.setTitle(title);
         // reflect the title in the actionbar
         ActivityMixin.setTitle(this, title);
+    }
+
+    /**
+     * @param view
+     *            view to activate the context ActionBar for
+     */
+    public void addContextMenu(final View view) {
+        // placeholder for derived implementations
     }
 }

--- a/main/src/cgeo/geocaching/ui/logs/LogsViewCreator.java
+++ b/main/src/cgeo/geocaching/ui/logs/LogsViewCreator.java
@@ -3,7 +3,7 @@ package cgeo.geocaching.ui.logs;
 import cgeo.geocaching.ImagesActivity;
 import cgeo.geocaching.LogEntry;
 import cgeo.geocaching.R;
-import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.ui.AbstractCachingListViewPageViewCreator;
@@ -28,9 +28,9 @@ import java.util.List;
 
 public abstract class LogsViewCreator extends AbstractCachingListViewPageViewCreator {
 
-    protected final AbstractActivity activity;
+    protected final AbstractActionBarActivity activity;
 
-    public LogsViewCreator(final AbstractActivity activity) {
+    public LogsViewCreator(final AbstractActionBarActivity activity) {
         this.activity = activity;
     }
 
@@ -60,6 +60,8 @@ public abstract class LogsViewCreator extends AbstractCachingListViewPageViewCre
 
                 final LogEntry log = getItem(position);
                 fillViewHolder(convertView, holder, log);
+                final View logView = rowView.findViewById(R.id.log);
+                activity.addContextMenu(logView);
                 return rowView;
             }
         });


### PR DESCRIPTION
- enable contextual action bar for log view in cache details and trackables

a little unsure about how and where to place the common entry point to activate the contextual actionbar, therefore up for review
