### PR TITLE
Fix race conditions when displaying single waypoints

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1259,8 +1259,10 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                     itemsToDisplay.add(getCacheItem(cache));
                 }
             }
-
-            overlayCaches.updateItems(itemsToDisplay);
+            // don't add other waypoints to overlayCaches if just one point should be displayed
+            if (coordsIntent == null) {
+                overlayCaches.updateItems(itemsToDisplay);
+            }
             displayHandler.sendEmptyMessage(INVALIDATE_MAP);
 
             displayHandler.sendEmptyMessage(UPDATE_TITLE);


### PR DESCRIPTION
This small patch is a proposal of a possible bug fix for #4188 by avoiding to add the wrong waypoints (e.g. the main coordinates of the cache itself) to overlayCaches.

If the map view was opened via an Intent with waypoint coordinates, only the waypoint which was added via displayPoint() should be displayed.
