### PR TITLE
Visual compass state and transient status

### DIFF
--- a/main/res/layout-land/compass_activity.xml
+++ b/main/res/layout-land/compass_activity.xml
@@ -36,6 +36,19 @@
             android:textColor="?text_color"
             android:textSize="14sp" />
 
+        <ToggleButton
+            android:id="@+id/use_compass"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="false"
+            android:layout_alignParentTop="false"
+            android:layout_below="@+id/cacheinfo"
+            android:layout_centerHorizontal="true"
+            android:layout_gravity="center"
+            android:gravity="center_horizontal"
+            android:textOn="@string/attribute_compass_yes"
+            android:textOff="@string/attribute_compass_no" />
+
         <TextView
             android:id="@+id/heading"
             android:layout_width="wrap_content"

--- a/main/res/layout/compass_activity.xml
+++ b/main/res/layout/compass_activity.xml
@@ -33,6 +33,14 @@
             android:textSize="14sp"
             tools:text="Cache information (D/T/S)" />
 
+        <ToggleButton
+            android:id="@+id/use_compass"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textOn="@string/attribute_compass_yes"
+            android:textOff="@string/attribute_compass_no" />
+
         <RelativeLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content" >

--- a/main/res/menu/compass_activity_options.xml
+++ b/main/res/menu/compass_activity_options.xml
@@ -43,23 +43,5 @@
             </item>
         </menu>
     </item>
-    <item
-        android:id="@+id/menu_compass_sensor"
-        android:icon="@drawable/ic_menu_compass"
-        android:title="@string/compass_sensors"
-        app:showAsAction="never|withText"> <!-- will be replaced in code -->
-        <menu>
-            <group android:checkableBehavior="single" >
-                <item
-                    android:id="@+id/menu_compass_sensor_gps"
-                    android:title="@string/use_gps">
-                </item>
-                <item
-                    android:id="@+id/menu_compass_sensor_magnetic"
-                    android:title="@string/use_compass">
-                </item>
-            </group>
-        </menu>
-    </item>
 
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -980,9 +980,6 @@
     <!-- navigation -->
     <string name="navigation">Navigation</string>
     <string name="compass_title">Compass</string>
-    <string name="compass_sensors">Active Sensors</string>
-    <string name="use_gps">Use GPS only</string>
-    <string name="use_compass">Use GPS and Compass</string>
     <string name="destination_select">Select destination</string>
     <string name="navigation_direct_navigation">Direct Navigation</string>
     <string name="navigation_target">Target</string>


### PR DESCRIPTION
Discussions in #432 and #3675 as well as frequent reports from users show that:
- the user might not know or understand that the compass has been disabled and that only the GPS will be used for direction;
- the user might forget that they disabled the compass.

This PR, opened for testing, makes the *compass disabled* state transient (instead of saving it into the preferences), and switches to a always-visible toggle on the compass activity.

Please comment on feature and suggest style changes. It might be adapted easily for the `release` branch if needed. I have reused the `attribute_compass_yes` and `attribute_compass_no` strings so as not to require new translations if we decide to add it to the release, it will be changed later for specific strings after the release.