### PR TITLE
Fix maven repository version of Android Annotations (3.1 instead of 3.1....

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -26,7 +26,7 @@ gradle connectedCheck
 //Testing guide : http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Testing
 //https://github.com/stephanenicolas/Quality-Tools-for-Android
 
-def AAVersion = '3.1.0'
+def AAVersion = '3.1'
 def RXVersion = '0.20.4'
 def JacksonCoreVersion = '2.4.1.1'
 def JacksonDatabindVersion = '2.4.1.3'


### PR DESCRIPTION
...0) for the gradle build.
