### PR TITLE
Implemented support for external Android Wear apps

### DIFF
--- a/main/res/values/ids.xml
+++ b/main/res/values/ids.xml
@@ -24,6 +24,7 @@
     <item name="cache_app_show_static_maps" type="id"/>
     <item name="cache_app_locus" type="id"/>
     <item name="cache_app_pebble" type="id"/>
+    <item name="cache_app_android_wear" type="id"/>
     <item name="cache_app_mapswithme" type="id"/>
     
 </resources>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -142,6 +142,7 @@
     <string name="pref_navigation_menu_google_maps_directions">navigationMapsDirections</string>
     <string name="pref_navigation_menu_where_you_go">navigationWhereYouGo</string>
     <string name="pref_navigation_menu_pebble">navigationPebble</string>
+    <string name="pref_navigation_menu_android_wear">navigationAndroidWear</string>
     <string name="pref_navigation_menu_mapswithme">navigationMapsWithMe</string>
     <string name="pref_ocpl_tokensecret">ocpl_tokensecret</string>
     <string name="pref_ocpl_tokenpublic">ocpl_tokenpublic</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -709,6 +709,7 @@
     <string name="cache_menu_oruxmaps">OruxMaps</string>
     <string name="cache_menu_navigon">Navigon</string>
     <string name="cache_menu_pebble">Pebble</string>
+    <string name="cache_menu_android_wear">Android Wear</string>
     <string name="cache_status">Status</string>
     <string name="cache_status_offline_log">Saved Log</string>
     <string name="cache_status_found">Found</string>

--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -18,6 +18,8 @@ public class Intents {
 
     public static final String EXTRA_ADDRESS = PREFIX + "address";
     public static final String EXTRA_COORDS = PREFIX + "coords";
+    public static final String EXTRA_LATITUDE = PREFIX + "latitude";
+    public static final String EXTRA_LONGITUDE = PREFIX + "longitude";
     public static final String EXTRA_COUNT = PREFIX + "count";
     public static final String EXTRA_GEOCODE = PREFIX + "geocode";
     public static final String EXTRA_GUID = PREFIX + "guid";

--- a/main/src/cgeo/geocaching/apps/cache/navi/AndroidWearApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/AndroidWearApp.java
@@ -1,0 +1,52 @@
+package cgeo.geocaching.apps.cache.navi;
+
+import cgeo.geocaching.Geocache;
+import cgeo.geocaching.Intents;
+import cgeo.geocaching.R;
+import cgeo.geocaching.Waypoint;
+import cgeo.geocaching.geopoint.Geopoint;
+import cgeo.geocaching.utils.ProcessUtils;
+
+import android.app.Activity;
+import android.content.Intent;
+
+/**
+ * For use with any Android Wear geocaching apps which can handle the intent action below.
+ */
+public class AndroidWearApp extends AbstractPointNavigationApp {
+    public static final String INTENT_ACTION = "cgeo.geocaching.wear.NAVIGATE_TO";
+
+    public AndroidWearApp() {
+        super(getString(R.string.cache_menu_android_wear), R.id.cache_app_android_wear, INTENT_ACTION, null);
+    }
+
+    @Override
+    public boolean isInstalled() {
+        return ProcessUtils.isIntentAvailable(INTENT_ACTION);
+    }
+
+    @Override
+    public void navigate(final Activity activity, final Geopoint coords) {
+        navigate(activity, null, null, coords);
+    }
+
+    @Override
+    public void navigate(final Activity activity, final Geocache cache) {
+        navigate(activity, cache.getName(), cache.getGeocode(), cache.getCoords());
+    }
+
+    @Override
+    public void navigate(final Activity activity, final Waypoint waypoint) {
+        navigate(activity, waypoint.getName(), waypoint.getGeocode(), waypoint.getCoords());
+    }
+
+    private static void navigate(final Activity activity, final String destName,
+                                 final String destCode, final Geopoint coords) {
+        final Intent launchIntent = new Intent(INTENT_ACTION);
+        launchIntent.putExtra(Intents.EXTRA_NAME, destName)
+                .putExtra(Intents.EXTRA_GEOCODE, destCode)
+                .putExtra(Intents.EXTRA_LATITUDE, coords.getLatitude())
+                .putExtra(Intents.EXTRA_LONGITUDE, coords.getLongitude());
+        activity.startService(launchIntent);
+    }
+}

--- a/main/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/NavigationAppFactory.java
@@ -73,6 +73,7 @@ public final class NavigationAppFactory extends AbstractAppFactory {
 
         WHERE_YOU_GO(new WhereYouGoApp(), 16, R.string.pref_navigation_menu_where_you_go),
         PEBBLE(new PebbleApp(), 17, R.string.pref_navigation_menu_pebble),
+        ANDROID_WEAR(new AndroidWearApp(), 18, R.string.pref_navigation_menu_android_wear),
         MAPSWITHME(new MapsWithMeApp(), 22, R.string.pref_navigation_menu_mapswithme);
 
         NavigationAppsEnum(final App app, final int id, final int preferenceKey) {

--- a/main/src/cgeo/geocaching/utils/ProcessUtils.java
+++ b/main/src/cgeo/geocaching/utils/ProcessUtils.java
@@ -98,7 +98,9 @@ public final class ProcessUtils {
         }
         final List<ResolveInfo> list = packageManager.queryIntentActivities(intent,
                 PackageManager.MATCH_DEFAULT_ONLY);
-        return CollectionUtils.isNotEmpty(list);
+        final List<ResolveInfo> servicesList = packageManager.queryIntentServices(intent,
+                PackageManager.MATCH_DEFAULT_ONLY);
+        return CollectionUtils.isNotEmpty(list) || CollectionUtils.isNotEmpty(servicesList);
     }
 
 }


### PR DESCRIPTION
In reference to issue #4063.

Android Wear apps can listen for the 'cgeo.geocaching.wear.NAVIGATE_TO'
intent to get cache info from c:geo, passed as Intent extras.

Altered ProcessUtils#isIntentAvailable(final String action, final Uri uri)
to scan for Services (instead of just activities) which can handle
a given action; my Wear app (as I imagine others will) mainly runs as a
Service and requires no activity to be launched.
