### PR TITLE
Quickfix for #4434 when storing PQ results filtered by StateNotStoredFil...

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -285,7 +285,10 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             updateAdapter();
 
             if (msg.what > -1) {
-                cacheList.get(msg.what).setStatusChecked(false);
+                //Quickfix for #4434 the updateAdapter above clears the list when using StateNotStoredFilter.
+                if (msg.what < cacheList.size()) {
+                    cacheList.get(msg.what).setStatusChecked(false);
+                }
 
                 adapter.notifyDataSetChanged();
 


### PR DESCRIPTION
A first quickfix that prevents any crashes. Doesn't solve the bigger problem yet, although that bigger problem doesn't have any visible effects anymore after the quickfix.
