### PR TITLE
add Log Visit option to cache quick window from Live Map

### DIFF
--- a/main/res/menu/navigate_any_point_activity_options.xml
+++ b/main/res/menu/navigate_any_point_activity_options.xml
@@ -16,6 +16,12 @@
         app:showAsAction="ifRoom">
     </item>
     <item
+        android:id="@+id/menu_log_visit"
+        android:icon="@drawable/ic_menu_edit"
+        android:title="@string/cache_menu_visit"
+        app:showAsAction="ifRoom">
+    </item>
+    <item
         android:id="@+id/menu_caches_around"
         android:icon="@drawable/ic_menu_rotate"
         android:title="@string/cache_menu_around"

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -57,6 +57,9 @@ public final class CacheMenuHandler extends AbstractUIFactory {
                     return true;
                 }
                 return false;
+            case R.id.menu_log_visit:
+                cache.logVisit(activity);
+                return true;
             case R.id.menu_caches_around:
                 activityInterface.cachesAround();
                 return true;
@@ -87,6 +90,7 @@ public final class CacheMenuHandler extends AbstractUIFactory {
         final boolean hasCoords = cache.getCoords() != null;
         menu.findItem(R.id.menu_default_navigation).setVisible(hasCoords);
         menu.findItem(R.id.menu_navigate).setVisible(hasCoords);
+        menu.findItem(R.id.menu_log_visit).setVisible(hasCoords);
         menu.findItem(R.id.menu_caches_around).setVisible(hasCoords && cache.supportsCachesAround());
         menu.findItem(R.id.menu_calendar).setVisible(cache.canBeAddedToCalendar());
         menu.findItem(R.id.menu_show_in_browser).setVisible(cache.canOpenInBrowser());


### PR DESCRIPTION
This will add the "Log Visit" option to the Cache Quick Window that opens over the Live Map so users can take action more easily.
