### PR TITLE
Add a test for null pointer when loading navigation app preferences

### DIFF
--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -152,7 +152,10 @@ public class SettingsActivity extends PreferenceActivity {
     private void initNavigationMenuPreferences() {
         for (final NavigationAppsEnum appEnum : NavigationAppsEnum.values()) {
             if (appEnum.app.isInstalled()) {
-                getPreference(appEnum.preferenceKey).setEnabled(true);
+                final Preference preference = getPreference(appEnum.preferenceKey);
+                if (preference != null) {
+                    preference.setEnabled(true);
+                }
             }
         }
         getPreference(R.string.preference_screen_basicmembers)


### PR DESCRIPTION
This fails when loading my external app that accepts the cgeo.geocaching.wear.NAVIGATE_TO Intent. The app does not have any preferences and so this line fails.
