### PR TITLE
Export waypoints to Locus when they don't have coordinates

### DIFF
--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -147,18 +147,23 @@ public abstract class AbstractLocusApp extends AbstractApp {
         if (withWaypoints && cache.hasWaypoints()) {
             pg.waypoints = new ArrayList<>();
             for (final Waypoint waypoint : cache.getWaypoints()) {
-                if (waypoint == null || waypoint.getCoords() == null) {
+                if (waypoint == null) {
                     continue;
                 }
+
                 final PointGeocachingDataWaypoint wp = new PointGeocachingDataWaypoint();
-                wp.code = waypoint.getGeocode();
+                wp.code = waypoint.getLookup();
                 wp.name = waypoint.getName();
+                wp.description = waypoint.getNote();
                 final String locusWpId = toLocusWaypoint(waypoint.getWaypointType());
                 if (locusWpId != null) {
                     wp.type = locusWpId;
                 }
-                wp.lat = waypoint.getCoords().getLatitude();
-                wp.lon = waypoint.getCoords().getLongitude();
+
+                if (waypoint.getCoords() != null) {
+                    wp.lat = waypoint.getCoords().getLatitude();
+                    wp.lon = waypoint.getCoords().getLongitude();
+                }
                 pg.waypoints.add(wp);
             }
         }
@@ -275,5 +280,4 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 return null;
         }
     }
-
 }


### PR DESCRIPTION
When exporting geocaches to Locus, some valuable information is lost.
- when waypoints are defined without coordinates, those waypoints aren't exported, causing the loss of the other defined information
- trackables aren't exported
- logs aren't exported.

This patch does export defined waypoints without coordinates, exports the name of trackables (no other information is currently available) and exports the logs.