### PR TITLE
Fix #4833: Write note for GC trackable no longer possible without tracking code

### DIFF
--- a/main/src/cgeo/geocaching/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/LogTrackableActivity.java
@@ -249,6 +249,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
         dateButton.setOnClickListener(new DateListener());
         setDate(date);
 
+        // show/hide Time selector
         if (loggingManager.canLogTime()) {
             timeButton.setOnClickListener(new TimeListener());
             setTime(date);
@@ -290,12 +291,21 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
     public void setType(final LogTypeTrackable type) {
         typeSelected = type;
         typeButton.setText(typeSelected.getLabel());
+
+        // show/hide Coordinate fields as Trackable needs
         if (LogTypeTrackable.isCoordinatesNeeded(typeSelected) && loggingManager.canLogCoordinates()) {
             geocacheEditText.setVisibility(View.VISIBLE);
             coordinatesButton.setVisibility(View.VISIBLE);
         } else {
             geocacheEditText.setVisibility(View.GONE);
             coordinatesButton.setVisibility(View.GONE);
+        }
+
+        // show/hide Tracking Code Field for note type
+        if (typeSelected != LogTypeTrackable.NOTE || typeSelected == LogTypeTrackable.NOTE && loggingManager.isTrackingCodeNeededToPostNote()) {
+            trackingEditText.setVisibility(View.VISIBLE);
+        } else {
+            trackingEditText.setVisibility(View.GONE);
         }
     }
 
@@ -482,7 +492,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
         }
 
         // Check Tracking Code existance
-        if (trackingEditText.getText().toString().isEmpty()) {
+        if (loggingManager.isTrackingCodeNeededToPostNote() && trackingEditText.getText().toString().isEmpty()) {
             showToast(res.getString(R.string.err_log_post_missing_tracking_code));
             return;
         }

--- a/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableLoggingManager.java
@@ -26,5 +26,10 @@ public abstract class AbstractTrackableLoggingManager extends AsyncTaskLoader<Li
     public abstract boolean isRegistered();
 
     @Override
+    public boolean isTrackingCodeNeededToPostNote() {
+        return false;
+    }
+
+    @Override
     public abstract boolean postReady();
 }

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyLoggingManager.java
@@ -89,6 +89,11 @@ public class GeokretyLoggingManager extends AbstractTrackableLoggingManager {
     }
 
     @Override
+    public boolean isTrackingCodeNeededToPostNote() {
+        return true;
+    }
+
+    @Override
     public boolean postReady() {
         return true;
     }

--- a/main/src/cgeo/geocaching/connector/trackable/TrackableLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TrackableLoggingManager.java
@@ -41,5 +41,7 @@ public interface TrackableLoggingManager {
 
     public boolean isRegistered();
 
+    public boolean isTrackingCodeNeededToPostNote();
+
     public boolean postReady();
 }


### PR DESCRIPTION
Create a loggingManager.isTrackingCodeNeededToPostNote() function.
Show/hide the tracking code field depending on Trackable properties.