### PR TITLE
Fix #4853: Do not show GK owner as "Unknown" when no information is present

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1356,5 +1356,6 @@
     <string name="init_geokrety_description">Store your API key in c:geo to ease logging GeoKrety</string>
     <string name="init_geokrety_cache_description">GeoKretyMap.org provides cached datas for GeoKrety trackables. Datas may not be up to date!\nPositions: ~30min.\nDescriptions: ~24h.</string>
     <string name="init_geokrety_cache">Use cached datas</string>
+    <string name="init_geokrety_userid">User Id: %s</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -80,11 +80,15 @@ public class GeokretyParser {
                     if (StringUtils.isNotBlank(imageName)) {
                         trackable.setImage("http://geokrety.org/obrazki/" + imageName);
                     }
+                    final String ownerId = attributes.getValue("owner_id");
+                    if (StringUtils.isNotBlank(ownerId)) {
+                        trackable.setOwner(CgeoApplication.getInstance().getString(R.string.init_geokrety_userid, ownerId));
+                    }
                 }
                 if (localName.equalsIgnoreCase("owner")) {
-                    final String owner = attributes.getValue("id");
-                    if (StringUtils.isNotBlank(owner)) {
-                        trackable.setOwnerGuid(getType(Integer.parseInt(owner)));
+                    final String ownerId = attributes.getValue("id");
+                    if (StringUtils.isNotBlank(ownerId)) {
+                        trackable.setOwner(CgeoApplication.getInstance().getString(R.string.init_geokrety_userid, ownerId));
                     }
                 }
                 if (localName.equalsIgnoreCase("type")) {
@@ -96,12 +100,12 @@ public class GeokretyParser {
                 // TODO: latitude/longitude could be parsed, but trackable doesn't support it, yet...
                 //if (localName.equalsIgnoreCase("position")) {
                 //final String latitude = attributes.getValue("latitude");
-                //if (StringUtils.isNotBlank(latitude)) {
-                //    trackable.setLatitude(getType(Integer.parseInt(latitude)));
+                //if (StringUtils.isNotBlank(latitude) {
+                //    trackable.setLatitude(latitude);
                 //}
                 //final String longitude = attributes.getValue("longitude");
-                //if (StringUtils.isNotBlank(longitude)) {
-                //    trackable.setLongitude(getType(Integer.parseInt(longitude)));
+                //if (StringUtils.isNotBlank(longitude) {
+                //    trackable.setLongitude(longitude);
                 //}
                 //}
             } catch (final NumberFormatException e) {


### PR DESCRIPTION

If whe only have userid, set the username to the (locally translated)
string "user Id: ####"

Remove unneeded cast user id to GeoKrety type...