### PR TITLE
Fix #4858: TravelBug doesn't have good icon in CacheDetailsActivity inventory

### DIFF
--- a/main/src/cgeo/geocaching/DataStore.java
+++ b/main/src/cgeo/geocaching/DataStore.java
@@ -2,6 +2,7 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.Tile;
+import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -153,7 +154,7 @@ public class DataStore {
      */
     private static final CacheCache cacheCache = new CacheCache();
     private static SQLiteDatabase database = null;
-    private static final int dbVersion = 68;
+    private static final int dbVersion = 69;
     public static final int customListIdOffset = 10;
     private static final @NonNull String dbName = "data";
     private static final @NonNull String dbTableCaches = "cg_caches";
@@ -299,7 +300,8 @@ public class DataStore {
             + "released long, "
             + "goal text, "
             + "description text, "
-            + "geocode text "
+            + "geocode text, "
+            + "brand integer "
             + "); ";
 
     private static final String dbCreateSearchDestinationHistory = ""
@@ -804,6 +806,15 @@ public class DataStore {
                             db.execSQL("alter table " + dbTableCaches + " add column logPasswordRequired integer default 0");
                         } catch (final Exception e) {
                             Log.e("Failed to upgrade to ver. 68", e);
+
+                        }
+                    }
+                    // Introduces trackableBrand
+                    if (oldVersion < 69) {
+                        try {
+                            db.execSQL("alter table " + dbTableTrackables + " add column brand integer default 0");
+                        } catch (final Exception e) {
+                            Log.e("Failed to upgrade to ver. 69", e);
 
                         }
                     }
@@ -1514,6 +1525,7 @@ public class DataStore {
                 }
                 values.put("goal", trackable.getGoal());
                 values.put("description", trackable.getDetails());
+                values.put("brand", trackable.getBrand().getId());
 
                 database.insert(dbTableTrackables, null, values);
 
@@ -1995,7 +2007,7 @@ public class DataStore {
 
         final Cursor cursor = database.query(
                 dbTableTrackables,
-                new String[]{"_id", "updated", "tbcode", "guid", "title", "owner", "released", "goal", "description"},
+                new String[]{"_id", "updated", "tbcode", "guid", "title", "owner", "released", "goal", "description", "brand"},
                 "geocode = ?",
                 new String[]{geocode},
                 null,
@@ -2022,7 +2034,7 @@ public class DataStore {
 
         final Cursor cursor = database.query(
                 dbTableTrackables,
-                new String[]{"updated", "tbcode", "guid", "title", "owner", "released", "goal", "description"},
+                new String[]{"updated", "tbcode", "guid", "title", "owner", "released", "goal", "description", "brand"},
                 "tbcode = ?",
                 new String[]{geocode},
                 null,
@@ -2055,6 +2067,7 @@ public class DataStore {
         }
         trackable.setGoal(cursor.getString(cursor.getColumnIndex("goal")));
         trackable.setDetails(cursor.getString(cursor.getColumnIndex("description")));
+        trackable.forceSetBrand(TrackableBrand.getById(cursor.getInt(cursor.getColumnIndex("brand"))));
         trackable.setLogs(loadLogs(trackable.getGeocode()));
         return trackable;
     }


### PR DESCRIPTION
The list in CacheDetailsActivity is filled from the cache page. In this
page, there is only de guid information, no Trackable serial number.

When trackable are parsed in GCParser, they are stored in the Datastore.
In this parsing, Trackable brand is set.

Save Trackable brand in datastore.
So Travelbug will have the good logo instead of unknown.