### PR TITLE
Fix #4852: Log type field to small when logging a GK

### DIFF
--- a/main/res/layout/logtrackable_activity.xml
+++ b/main/res/layout/logtrackable_activity.xml
@@ -24,6 +24,13 @@
                 style="@style/button_full"
                 android:layout_width="0dip"
                 android:layout_weight="1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:baselineAligned="false"
+            android:orientation="horizontal" >
 
             <Button
                 android:id="@+id/date"


### PR DESCRIPTION
Move the date and time buttons on a separate line.