### PR TITLE
Fix #4854: Direct users to settings if they try to log a GK without login

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -236,7 +236,8 @@
     <string name="info_stored_image">New image saved to:</string>
     <string name="info_storing_static_maps">Trying to store static maps</string>
     <string name="info_cache_saved">The cache has been stored locally</string>
-    <string name="err_trackable_log_not_anonymous">Logging trackables from c:geo cannot be done anonymously. Please, fill in your credentials in the %s settings.</string>
+    <string name="err_trackable_log_not_anonymous">Logging %1$s from c:geo cannot be done anonymously. Do you want to open the settings to fill in your credentials from %2$s?</string>
+    <string name="err_trackable_no_preference_activity">Sorry, cannot find a suitable preference screen.</string>
 
     <!-- location service -->
     <string name="loc_last">Last known</string>
@@ -389,6 +390,7 @@
     <string name="changelog_github">List of all changes</string>
     
     <!-- settings -->
+    <string name="settings_title_open_settings">Open settings?</string>
     <string name="settings_title_services">Services</string>
     <string name="settings_summary_services">Configure user account information and access to optional services.</string>
     <string name="settings_title_appearance">Appearance</string>

--- a/main/src/cgeo/geocaching/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/LogTrackableActivity.java
@@ -33,6 +33,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -466,10 +468,17 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
                 if (connector.isRegistered()) {
                     sendLog();
                 } else {
-                    showToast(res.getString(R.string.err_trackable_log_not_anonymous, connector.getServiceTitle()));
-                    if (connector.getPreferenceActivity() > 0) {
-                        SettingsActivity.openForScreen(connector.getPreferenceActivity(), this);
-                    }
+                    // Redirect user to concerned connector settings
+                    Dialogs.confirmYesNo(this, res.getString(R.string.settings_title_open_settings), res.getString(R.string.err_trackable_log_not_anonymous, trackable.getBrand().getLabel(), connector.getServiceTitle()), new OnClickListener() {
+                        @Override
+                        public void onClick(final DialogInterface dialog, final int which) {
+                            if (connector.getPreferenceActivity() > 0) {
+                                SettingsActivity.openForScreen(connector.getPreferenceActivity(), LogTrackableActivity.this);
+                            } else {
+                                showToast(res.getString(R.string.err_trackable_no_preference_activity, connector.getServiceTitle()));
+                            }
+                        }
+                    });
                 }
                 return true;
             default:


### PR DESCRIPTION
Rework of the message given to the user.
Remove the toast. Display a Yes/No Dialog.