### PR TITLE
Convert Serializables Filters to Parcellable

### DIFF
--- a/main/src/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/cgeo/geocaching/CgeoApplication.java
@@ -20,13 +20,11 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.view.ViewConfiguration;
 
-import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Locale;
 
-public class CgeoApplication extends Application implements Serializable {
+public class CgeoApplication extends Application {
 
-    private static final long serialVersionUID = -521799146221365143L;
     private boolean forceRelog = false; // c:geo needs to log into cache providers
     public boolean showLoginToast = true; //login toast shown just once.
     private boolean liveMapHintShownInThisSession = false; // livemap hint has been shown

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -23,14 +23,11 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import rx.functions.Action1;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public abstract class AbstractConnector implements IConnector, Serializable {
-
-    private static final long serialVersionUID = 6247021667515396675L;
+public abstract class AbstractConnector implements IConnector {
 
     @Override
     public boolean canHandle(@NonNull final String geocode) {

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -77,7 +77,7 @@ public final class ConnectorFactory {
     @NonNull public static final UnknownTrackableConnector UNKNOWN_TRACKABLE_CONNECTOR = new UnknownTrackableConnector();
 
     @NonNull
- private static final Collection<TrackableConnector> TRACKABLE_CONNECTORS = Collections.unmodifiableCollection(Arrays.<TrackableConnector> asList(
+    private static final Collection<TrackableConnector> TRACKABLE_CONNECTORS = Collections.unmodifiableCollection(Arrays.<TrackableConnector> asList(
             new GeokretyConnector(),
             new SwaggieConnector(),
             TravelBugConnector.getInstance(), // travel bugs last, as their secret codes overlap with other connectors
@@ -212,6 +212,26 @@ public final class ConnectorFactory {
         }
         for (final IConnector connector : CONNECTORS) {
             if (connector.canHandle(geocode)) {
+                return connector;
+            }
+        }
+        // in case of errors, take UNKNOWN to avoid null checks everywhere
+        return UNKNOWN_CONNECTOR;
+    }
+
+    /**
+     * Obtain the connector by it's name.
+     * If connector is not found, return UNKNOWN_CONNECTOR.
+     *
+     * @param connectorName
+     *          connector name String
+     * @return
+     *          The connector matching name
+     */
+    @NonNull
+    public static IConnector getConnectorByName(final String connectorName) {
+        for (final IConnector connector : CONNECTORS) {
+            if (StringUtils.equals(connectorName, connector.getName())) {
                 return connector;
             }
         }

--- a/main/src/cgeo/geocaching/connector/GeocachingAustraliaConnector.java
+++ b/main/src/cgeo/geocaching/connector/GeocachingAustraliaConnector.java
@@ -7,8 +7,6 @@ import org.eclipse.jdt.annotation.NonNull;
 
 class GeocachingAustraliaConnector extends AbstractConnector {
 
-    private static final long serialVersionUID = 1610009200588682532L;
-
     @Override
     @NonNull
     public String getName() {

--- a/main/src/cgeo/geocaching/connector/GeopeitusConnector.java
+++ b/main/src/cgeo/geocaching/connector/GeopeitusConnector.java
@@ -7,8 +7,6 @@ import org.eclipse.jdt.annotation.NonNull;
 
 class GeopeitusConnector extends AbstractConnector {
 
-    private static final long serialVersionUID = 5158580104945089127L;
-
     @Override
     @NonNull
     public String getName() {

--- a/main/src/cgeo/geocaching/connector/TerraCachingConnector.java
+++ b/main/src/cgeo/geocaching/connector/TerraCachingConnector.java
@@ -9,7 +9,6 @@ import java.util.regex.Pattern;
 
 class TerraCachingConnector extends AbstractConnector {
 
-    private static final long serialVersionUID = -26645945616788719L;
     @NonNull private final static Pattern PATTERN_GEOCODE = Pattern.compile("TC[0-9A-Z]{1,3}", Pattern.CASE_INSENSITIVE);
 
     @Override

--- a/main/src/cgeo/geocaching/connector/UnknownConnector.java
+++ b/main/src/cgeo/geocaching/connector/UnknownConnector.java
@@ -8,8 +8,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 class UnknownConnector extends AbstractConnector {
 
-    private static final long serialVersionUID = -812361106797562631L;
-
     @Override
     @NonNull
     public String getName() {

--- a/main/src/cgeo/geocaching/connector/WaymarkingConnector.java
+++ b/main/src/cgeo/geocaching/connector/WaymarkingConnector.java
@@ -8,8 +8,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 class WaymarkingConnector extends AbstractConnector {
 
-    private static final long serialVersionUID = 7294592601900227991L;
-
     @Override
     @NonNull
     public String getName() {

--- a/main/src/cgeo/geocaching/connector/ec/ECConnector.java
+++ b/main/src/cgeo/geocaching/connector/ec/ECConnector.java
@@ -36,8 +36,6 @@ import java.util.regex.Pattern;
 
 public class ECConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter, ISearchByViewPort, ILogin, ICredentials {
 
-    private static final long serialVersionUID = -6877180120192235960L;
-
     @NonNull
     private static final String CACHE_URL = "http://extremcaching.com/index.php/output-2/";
 

--- a/main/src/cgeo/geocaching/connector/ec/ECLogin.java
+++ b/main/src/cgeo/geocaching/connector/ec/ECLogin.java
@@ -20,11 +20,9 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.io.IOException;
-import java.io.Serializable;
 
-public class ECLogin extends AbstractLogin implements Serializable {
+public class ECLogin extends AbstractLogin {
 
-    private static final long serialVersionUID = 4004108045549370174L;
     private final CgeoApplication app = CgeoApplication.getInstance();
     private String sessionId = null;
 

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -51,8 +51,6 @@ import java.util.regex.Pattern;
 
 public class GCConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter, ISearchByNextPage, ISearchByViewPort, ISearchByKeyword, ILogin, ICredentials, ISearchByOwner, ISearchByFinder, FieldNotesCapability, IgnoreCapability {
 
-    private static final long serialVersionUID = 3246646812479458224L;
-
     @NonNull
     private static final String CACHE_URL_SHORT = "http://coord.info/";
     // Double slash is used to force open in browser

--- a/main/src/cgeo/geocaching/connector/oc/OCApiConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCApiConnector.java
@@ -13,8 +13,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 public class OCApiConnector extends OCConnector implements ISearchByGeocode {
 
-    private static final long serialVersionUID = 5846386436165971078L;
-
     // Levels of Okapi we support
     // oldapi is around rev 500
     // current is from rev 798 onwards

--- a/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
@@ -29,7 +29,6 @@ import android.os.Handler;
 
 public class OCApiLiveConnector extends OCApiConnector implements ISearchByCenter, ISearchByViewPort, ILogin, ISearchByKeyword, ISearchByOwner, ISearchByFinder {
 
-    private static final long serialVersionUID = -4840623212163137408L;
     private final String cS;
     private final int isActivePrefKeyId;
     private final int tokenPublicPrefKeyId;

--- a/main/src/cgeo/geocaching/connector/oc/OCCZConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCCZConnector.java
@@ -8,7 +8,6 @@ import org.eclipse.jdt.annotation.Nullable;
 
 public class OCCZConnector extends OCConnector {
 
-    private static final long serialVersionUID = 6471034894452607120L;
     private static final String GEOCODE_PREFIX = "OZ";
 
     public OCCZConnector() {

--- a/main/src/cgeo/geocaching/connector/oc/OCConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCConnector.java
@@ -15,7 +15,6 @@ import java.util.regex.Pattern;
 
 public class OCConnector extends AbstractConnector {
 
-    private static final long serialVersionUID = -5082967274866303551L;
     private final String host;
     private final String name;
     private final Pattern codePattern;

--- a/main/src/cgeo/geocaching/connector/oc/UserInfo.java
+++ b/main/src/cgeo/geocaching/connector/oc/UserInfo.java
@@ -3,11 +3,7 @@ package cgeo.geocaching.connector.oc;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.oc.OkapiError.OkapiErrors;
 
-import java.io.Serializable;
-
-public class UserInfo implements Serializable {
-
-    private static final long serialVersionUID = 891569280239587363L;
+public class UserInfo {
 
     public enum UserInfoStatus {
         NOT_RETRIEVED(R.string.init_login_popup_working),

--- a/main/src/cgeo/geocaching/connector/ox/OXConnector.java
+++ b/main/src/cgeo/geocaching/connector/ox/OXConnector.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
  */
 public class OXConnector extends AbstractConnector implements ISearchByCenter, ISearchByGeocode, ISearchByViewPort, ISearchByKeyword {
 
-    private static final long serialVersionUID = -3989764719239446663L;
     private static final Pattern PATTERN_GEOCODE = Pattern.compile("OX[A-Z0-9]+", Pattern.CASE_INSENSITIVE);
 
     @Override

--- a/main/src/cgeo/geocaching/filter/AbstractFilter.java
+++ b/main/src/cgeo/geocaching/filter/AbstractFilter.java
@@ -6,14 +6,11 @@ import cgeo.geocaching.Geocache;
 import org.eclipse.jdt.annotation.NonNull;
 
 import android.os.Parcel;
-import android.os.Parcelable;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-abstract class AbstractFilter implements IFilter, Serializable {
-    private static final long serialVersionUID = -5918429378818997180L;
+abstract class AbstractFilter implements IFilter {
     @NonNull
     private final String name;
 
@@ -23,6 +20,10 @@ abstract class AbstractFilter implements IFilter, Serializable {
 
     protected AbstractFilter(@NonNull final String name) {
         this.name = name;
+    }
+
+    protected AbstractFilter(final Parcel in) {
+        name = in.readString();
     }
 
     @Override
@@ -59,30 +60,6 @@ abstract class AbstractFilter implements IFilter, Serializable {
 
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
-        dest.writeSerializable(this);
+        dest.writeString(name);
     }
-
-    public static final Creator<AbstractFilter> CREATOR
-            = new Parcelable.Creator<AbstractFilter>() {
-
-      /**
-      * Read the serialized concrete Filter from the parcel.
-      * @param in The parcel to read from
-      * @return An AbstractFilter
-      */
-        @Override
-        public AbstractFilter createFromParcel(final Parcel in) {
-            // Read serialized concrete Filter from parcel
-            return (AbstractFilter) in.readSerializable();
-        }
-
-        /**
-         * Required by Creator
-         */
-        @Override
-        public AbstractFilter[] newArray(final int size) {
-            return new AbstractFilter[size];
-        }
-    };
-
 }

--- a/main/src/cgeo/geocaching/filter/AbstractRangeFilter.java
+++ b/main/src/cgeo/geocaching/filter/AbstractRangeFilter.java
@@ -2,16 +2,29 @@ package cgeo.geocaching.filter;
 
 import cgeo.geocaching.CgeoApplication;
 
+import android.os.Parcel;
 
 abstract class AbstractRangeFilter extends AbstractFilter {
 
-    private static final long serialVersionUID = -4252986778995114530L;
     protected final float rangeMin;
     protected final float rangeMax;
 
     protected AbstractRangeFilter(final int ressourceId, final int range) {
         super(CgeoApplication.getInstance().getResources().getString(ressourceId) + ' ' + (range == 5 ? '5' : range + " + " + String.format("%.1f", range + 0.5)));
-        this.rangeMin = range;
+        rangeMin = range;
         rangeMax = rangeMin + 1f;
+    }
+
+    protected AbstractRangeFilter(final Parcel in) {
+        super(in);
+        rangeMin = in.readFloat();
+        rangeMax = in.readFloat();
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeFloat(rangeMin);
+        dest.writeFloat(rangeMax);
     }
 }

--- a/main/src/cgeo/geocaching/filter/AttributeFilter.java
+++ b/main/src/cgeo/geocaching/filter/AttributeFilter.java
@@ -7,18 +7,24 @@ import cgeo.geocaching.R;
 import org.eclipse.jdt.annotation.NonNull;
 
 import android.content.res.Resources;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 import java.util.LinkedList;
 import java.util.List;
 
 class AttributeFilter extends AbstractFilter {
 
-    private static final long serialVersionUID = -992613104646128606L;
     private final String attribute;
 
     public AttributeFilter(@NonNull final String name, final String attribute) {
         super(name);
         this.attribute = attribute;
+    }
+
+    protected AttributeFilter(final Parcel in) {
+        super(in);
+        attribute = in.readString();
     }
 
     private static String getName(final String attribute, final Resources res, final String packageName) {
@@ -34,8 +40,6 @@ class AttributeFilter extends AbstractFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = -6719278112259482848L;
-
         @Override
         @NonNull
         public List<IFilter> getFilters() {
@@ -50,4 +54,24 @@ class AttributeFilter extends AbstractFilter {
         }
 
     }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeString(attribute);
+    }
+
+    public static final Creator<AttributeFilter> CREATOR
+            = new Parcelable.Creator<AttributeFilter>() {
+
+        @Override
+        public AttributeFilter createFromParcel(final Parcel in) {
+            return new AttributeFilter(in);
+        }
+
+        @Override
+        public AttributeFilter[] newArray(final int size) {
+            return new AttributeFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/DifficultyFilter.java
+++ b/main/src/cgeo/geocaching/filter/DifficultyFilter.java
@@ -5,15 +5,20 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.List;
 
 class DifficultyFilter extends AbstractRangeFilter {
 
-    private static final long serialVersionUID = -5154908510447657327L;
-
     public DifficultyFilter(final int difficulty) {
         super(R.string.cache_difficulty, difficulty);
+    }
+
+    protected DifficultyFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -24,7 +29,6 @@ class DifficultyFilter extends AbstractRangeFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = -3207858180443543737L;
         private static final int DIFFICULTY_MIN = 1;
         private static final int DIFFICULTY_MAX = 5;
 
@@ -37,6 +41,19 @@ class DifficultyFilter extends AbstractRangeFilter {
             }
             return filters;
         }
-
     }
+
+    public static final Creator<DifficultyFilter> CREATOR
+            = new Parcelable.Creator<DifficultyFilter>() {
+
+        @Override
+        public DifficultyFilter createFromParcel(final Parcel in) {
+            return new DifficultyFilter(in);
+        }
+
+        @Override
+        public DifficultyFilter[] newArray(final int size) {
+            return new DifficultyFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/DistanceFilter.java
+++ b/main/src/cgeo/geocaching/filter/DistanceFilter.java
@@ -9,14 +9,14 @@ import cgeo.geocaching.sensors.Sensors;
 
 import org.eclipse.jdt.annotation.NonNull;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.List;
 
 class DistanceFilter extends AbstractFilter {
-    private static final long serialVersionUID = -4110173222670364694L;
-    private transient GeoData geo;
+    private final GeoData geo;
     private final int minDistance;
     private final int maxDistance;
 
@@ -27,8 +27,10 @@ class DistanceFilter extends AbstractFilter {
         geo = Sensors.getInstance().currentGeo();
     }
 
-    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
+    protected DistanceFilter(final Parcel in) {
+        super(in);
+        minDistance = in.readInt();
+        maxDistance = in.readInt();
         geo = Sensors.getInstance().currentGeo();
     }
 
@@ -47,7 +49,6 @@ class DistanceFilter extends AbstractFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = 1461003608933602211L;
         private static final int[] KILOMETERS = { 0, 2, 5, 10, 20, 50 };
 
         @Override
@@ -69,6 +70,26 @@ class DistanceFilter extends AbstractFilter {
             }
             return filters;
         }
-
     }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeInt(minDistance);
+        dest.writeInt(maxDistance);
+    }
+
+    public static final Creator<DistanceFilter> CREATOR
+            = new Parcelable.Creator<DistanceFilter>() {
+
+        @Override
+        public DistanceFilter createFromParcel(final Parcel in) {
+            return new DistanceFilter(in);
+        }
+
+        @Override
+        public DistanceFilter[] newArray(final int size) {
+            return new DistanceFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/IFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/IFilterFactory.java
@@ -2,10 +2,9 @@ package cgeo.geocaching.filter;
 
 import org.eclipse.jdt.annotation.NonNull;
 
-import java.io.Serializable;
 import java.util.List;
 
-interface IFilterFactory extends Serializable {
+interface IFilterFactory {
     @NonNull
     List<? extends IFilter> getFilters();
 }

--- a/main/src/cgeo/geocaching/filter/ModifiedFilter.java
+++ b/main/src/cgeo/geocaching/filter/ModifiedFilter.java
@@ -5,15 +5,20 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.Collections;
 import java.util.List;
 
 class ModifiedFilter extends AbstractFilter implements IFilterFactory {
 
-    private static final long serialVersionUID = 8209964082957501589L;
-
     public ModifiedFilter() {
         super(R.string.caches_filter_modified);
+    }
+
+    protected ModifiedFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -27,4 +32,18 @@ class ModifiedFilter extends AbstractFilter implements IFilterFactory {
     public List<ModifiedFilter> getFilters() {
         return Collections.singletonList(this);
     }
+
+    public static final Creator<ModifiedFilter> CREATOR
+            = new Parcelable.Creator<ModifiedFilter>() {
+
+        @Override
+        public ModifiedFilter createFromParcel(final Parcel in) {
+            return new ModifiedFilter(in);
+        }
+
+        @Override
+        public ModifiedFilter[] newArray(final int size) {
+            return new ModifiedFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/OfflineLogFilter.java
+++ b/main/src/cgeo/geocaching/filter/OfflineLogFilter.java
@@ -5,12 +5,17 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
-public class OfflineLogFilter extends AbstractFilter {
+import android.os.Parcel;
+import android.os.Parcelable;
 
-    private static final long serialVersionUID = -1770444119861730428L;
+public class OfflineLogFilter extends AbstractFilter {
 
     protected OfflineLogFilter() {
         super(R.string.caches_filter_offline_log);
+    }
+
+    protected OfflineLogFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -18,4 +23,17 @@ public class OfflineLogFilter extends AbstractFilter {
         return cache.isLogOffline();
     }
 
+    public static final Creator<OfflineLogFilter> CREATOR
+            = new Parcelable.Creator<OfflineLogFilter>() {
+
+        @Override
+        public OfflineLogFilter createFromParcel(final Parcel in) {
+            return new OfflineLogFilter(in);
+        }
+
+        @Override
+        public OfflineLogFilter[] newArray(final int size) {
+            return new OfflineLogFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/OriginFilter.java
+++ b/main/src/cgeo/geocaching/filter/OriginFilter.java
@@ -6,6 +6,9 @@ import cgeo.geocaching.connector.IConnector;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -13,12 +16,16 @@ import java.util.List;
 
 public class OriginFilter extends AbstractFilter {
 
-    private static final long serialVersionUID = -226131408218792315L;
     private final IConnector connector;
 
     public OriginFilter(@NonNull final IConnector connector) {
         super(connector.getName());
         this.connector = connector;
+    }
+
+    protected OriginFilter(final Parcel in) {
+        super(in);
+        connector = ConnectorFactory.getConnectorByName(in.readString());
     }
 
     @Override
@@ -27,8 +34,6 @@ public class OriginFilter extends AbstractFilter {
     }
 
     public static final class Factory implements IFilterFactory {
-
-        private static final long serialVersionUID = -7117455106869294095L;
 
         @Override
         @NonNull
@@ -51,4 +56,24 @@ public class OriginFilter extends AbstractFilter {
         }
 
     }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeString(connector.getName()); // Do not parcell the full Connector Object
+    }
+
+    public static final Creator<OriginFilter> CREATOR
+            = new Parcelable.Creator<OriginFilter>() {
+
+        @Override
+        public OriginFilter createFromParcel(final Parcel in) {
+            return new OriginFilter(in);
+        }
+
+        @Override
+        public OriginFilter[] newArray(final int size) {
+            return new OriginFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/OwnRatingFilter.java
+++ b/main/src/cgeo/geocaching/filter/OwnRatingFilter.java
@@ -6,6 +6,9 @@ import cgeo.geocaching.gcvote.GCVote;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -16,10 +19,12 @@ import java.util.List;
  */
 public class OwnRatingFilter extends AbstractFilter implements IFilterFactory {
 
-    private static final long serialVersionUID = -6442192261392930821L;
-
     protected OwnRatingFilter() {
         super(R.string.caches_filter_own_rating);
+    }
+
+    protected OwnRatingFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -33,4 +38,17 @@ public class OwnRatingFilter extends AbstractFilter implements IFilterFactory {
         return Collections.singletonList(this);
     }
 
+    public static final Creator<OwnRatingFilter> CREATOR
+            = new Parcelable.Creator<OwnRatingFilter>() {
+
+        @Override
+        public OwnRatingFilter createFromParcel(final Parcel in) {
+            return new OwnRatingFilter(in);
+        }
+
+        @Override
+        public OwnRatingFilter[] newArray(final int size) {
+            return new OwnRatingFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/PersonalDataFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/PersonalDataFilterFactory.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 public class PersonalDataFilterFactory implements IFilterFactory {
 
-    private static final long serialVersionUID = -3170575777061178786L;
-
     @Override
     @NonNull
     public List<? extends IFilter> getFilters() {

--- a/main/src/cgeo/geocaching/filter/PersonalNoteFilter.java
+++ b/main/src/cgeo/geocaching/filter/PersonalNoteFilter.java
@@ -6,6 +6,9 @@ import cgeo.geocaching.R;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -14,10 +17,12 @@ import java.util.List;
  */
 public class PersonalNoteFilter extends AbstractFilter implements IFilterFactory {
 
-    private static final long serialVersionUID = -6029553939024693792L;
-
     protected PersonalNoteFilter() {
         super(R.string.caches_filter_personal_note);
+    }
+
+    protected PersonalNoteFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -31,4 +36,17 @@ public class PersonalNoteFilter extends AbstractFilter implements IFilterFactory
         return Collections.singletonList(this);
     }
 
+    public static final Creator<PersonalNoteFilter> CREATOR
+            = new Parcelable.Creator<PersonalNoteFilter>() {
+
+        @Override
+        public PersonalNoteFilter createFromParcel(final Parcel in) {
+            return new PersonalNoteFilter(in);
+        }
+
+        @Override
+        public PersonalNoteFilter[] newArray(final int size) {
+            return new PersonalNoteFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/PopularityFilter.java
+++ b/main/src/cgeo/geocaching/filter/PopularityFilter.java
@@ -6,11 +6,13 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.List;
 
 class PopularityFilter extends AbstractFilter {
-    private static final long serialVersionUID = -8620115571186207865L;
     private final int minFavorites;
     private final int maxFavorites;
 
@@ -20,6 +22,12 @@ class PopularityFilter extends AbstractFilter {
         this.maxFavorites = maxFavorites;
     }
 
+    protected PopularityFilter(final Parcel in) {
+        super(in);
+        minFavorites = in.readInt();
+        maxFavorites = in.readInt();
+    }
+
     @Override
     public boolean accepts(@NonNull final Geocache cache) {
         return (cache.getFavoritePoints() > minFavorites) && (cache.getFavoritePoints() <= maxFavorites);
@@ -27,7 +35,6 @@ class PopularityFilter extends AbstractFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = 6709810849476663825L;
         private static final int[] FAVORITES = { 10, 20, 50, 100, 200, 500 };
 
         @Override
@@ -42,6 +49,26 @@ class PopularityFilter extends AbstractFilter {
             }
             return filters;
         }
-
     }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeInt(minFavorites);
+        dest.writeInt(maxFavorites);
+    }
+
+    public static final Creator<PopularityFilter> CREATOR
+            = new Parcelable.Creator<PopularityFilter>() {
+
+        @Override
+        public PopularityFilter createFromParcel(final Parcel in) {
+            return new PopularityFilter(in);
+        }
+
+        @Override
+        public PopularityFilter[] newArray(final int size) {
+            return new PopularityFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/PopularityRatioFilter.java
+++ b/main/src/cgeo/geocaching/filter/PopularityRatioFilter.java
@@ -8,6 +8,9 @@ import cgeo.geocaching.enumerations.LogType;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +18,6 @@ import java.util.List;
  * filters caches by popularity ratio (favorites per find in %).
  */
 class PopularityRatioFilter extends AbstractFilter {
-    private static final long serialVersionUID = -7606725476655532150L;
     private final int minRatio;
     private final int maxRatio;
 
@@ -23,6 +25,12 @@ class PopularityRatioFilter extends AbstractFilter {
         super(name);
         this.minRatio = minRatio;
         this.maxRatio = maxRatio;
+    }
+
+    protected PopularityRatioFilter(final Parcel in) {
+        super(in);
+        minRatio = in.readInt();
+        maxRatio = in.readInt();
     }
 
     @Override
@@ -51,7 +59,6 @@ class PopularityRatioFilter extends AbstractFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = -1304677116891707226L;
         private static final int[] RATIOS = { 10, 20, 30, 40, 50, 75 };
 
         @Override
@@ -65,6 +72,26 @@ class PopularityRatioFilter extends AbstractFilter {
             }
             return filters;
         }
-
     }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeInt(minRatio);
+        dest.writeInt(maxRatio);
+    }
+
+    public static final Creator<PopularityRatioFilter> CREATOR
+            = new Parcelable.Creator<PopularityRatioFilter>() {
+
+        @Override
+        public PopularityRatioFilter createFromParcel(final Parcel in) {
+            return new PopularityRatioFilter(in);
+        }
+
+        @Override
+        public PopularityRatioFilter[] newArray(final int size) {
+            return new PopularityRatioFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/RatingFilter.java
+++ b/main/src/cgeo/geocaching/filter/RatingFilter.java
@@ -6,6 +6,9 @@ import cgeo.geocaching.gcvote.GCVote;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 /**
  * Filter {@link Geocache}s if they have a locally stored {@link GCVote} rating. This filter will not do any network
  * request to find potentially missing local votes.
@@ -13,10 +16,12 @@ import org.eclipse.jdt.annotation.NonNull;
  */
 public class RatingFilter extends AbstractFilter {
 
-    private static final long serialVersionUID = -5316005528335584968L;
-
     protected RatingFilter() {
         super(R.string.caches_filter_rating);
+    }
+
+    protected RatingFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -24,4 +29,17 @@ public class RatingFilter extends AbstractFilter {
         return cache.getRating() > 0;
     }
 
+    public static final Creator<RatingFilter> CREATOR
+            = new Parcelable.Creator<RatingFilter>() {
+
+        @Override
+        public RatingFilter createFromParcel(final Parcel in) {
+            return new RatingFilter(in);
+        }
+
+        @Override
+        public RatingFilter[] newArray(final int size) {
+            return new RatingFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/SizeFilter.java
+++ b/main/src/cgeo/geocaching/filter/SizeFilter.java
@@ -5,16 +5,23 @@ import cgeo.geocaching.enumerations.CacheSize;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.LinkedList;
 import java.util.List;
 
 class SizeFilter extends AbstractFilter {
-    private static final long serialVersionUID = -2338070360641435415L;
     private final CacheSize cacheSize;
 
     public SizeFilter(@NonNull final CacheSize cacheSize) {
         super(cacheSize.id);
         this.cacheSize = cacheSize;
+    }
+
+    protected SizeFilter(final Parcel in) {
+        super(in);
+        cacheSize = CacheSize.values()[in.readInt()];
     }
 
     @Override
@@ -30,8 +37,6 @@ class SizeFilter extends AbstractFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = 5375423577550361483L;
-
         @Override
         @NonNull
         public List<IFilter> getFilters() {
@@ -46,4 +51,23 @@ class SizeFilter extends AbstractFilter {
         }
     }
 
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeInt(cacheSize.ordinal());
+    }
+
+    public static final Creator<SizeFilter> CREATOR
+            = new Parcelable.Creator<SizeFilter>() {
+
+        @Override
+        public SizeFilter createFromParcel(final Parcel in) {
+            return new SizeFilter(in);
+        }
+
+        @Override
+        public SizeFilter[] newArray(final int size) {
+            return new SizeFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/StateFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/StateFilterFactory.java
@@ -5,14 +5,15 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
 class StateFilterFactory implements IFilterFactory {
-
-    private static final long serialVersionUID = -4915854201507009125L;
 
     @Override
     @NonNull
@@ -43,10 +44,12 @@ class StateFilterFactory implements IFilterFactory {
 
     static class StateFoundFilter extends AbstractFilter {
 
-        private static final long serialVersionUID = -3767242360632349788L;
-
         public StateFoundFilter() {
             super(R.string.cache_status_found);
+        }
+
+        protected StateFoundFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
@@ -54,14 +57,29 @@ class StateFilterFactory implements IFilterFactory {
             return cache.isFound();
         }
 
+        public static final Creator<StateFoundFilter> CREATOR
+                = new Parcelable.Creator<StateFoundFilter>() {
+
+            @Override
+            public StateFoundFilter createFromParcel(final Parcel in) {
+                return new StateFoundFilter(in);
+            }
+
+            @Override
+            public StateFoundFilter[] newArray(final int size) {
+                return new StateFoundFilter[size];
+            }
+        };
     }
 
     static class StateNotFoundFilter extends AbstractFilter {
 
-        private static final long serialVersionUID = 19776079495156351L;
-
         public StateNotFoundFilter() {
             super(R.string.cache_not_status_found);
+        }
+
+        protected StateNotFoundFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
@@ -69,97 +87,229 @@ class StateFilterFactory implements IFilterFactory {
             return !cache.isFound();
         }
 
+        public static final Creator<StateNotFoundFilter> CREATOR
+                = new Parcelable.Creator<StateNotFoundFilter>() {
+
+            @Override
+            public StateNotFoundFilter createFromParcel(final Parcel in) {
+                return new StateNotFoundFilter(in);
+            }
+
+            @Override
+            public StateNotFoundFilter[] newArray(final int size) {
+                return new StateNotFoundFilter[size];
+            }
+        };
     }
 
     static class StateArchivedFilter extends AbstractFilter {
-        private static final long serialVersionUID = -4272399405273124686L;
 
         public StateArchivedFilter() {
             super(R.string.cache_status_archived);
+        }
+
+        protected StateArchivedFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return cache.isArchived();
         }
+
+        public static final Creator<StateArchivedFilter> CREATOR
+                = new Parcelable.Creator<StateArchivedFilter>() {
+
+            @Override
+            public StateArchivedFilter createFromParcel(final Parcel in) {
+                return new StateArchivedFilter(in);
+            }
+
+            @Override
+            public StateArchivedFilter[] newArray(final int size) {
+                return new StateArchivedFilter[size];
+            }
+        };
     }
 
     static class StateDisabledFilter extends AbstractFilter {
-        private static final long serialVersionUID = -3027505042498459672L;
 
         public StateDisabledFilter() {
             super(R.string.cache_status_disabled);
+        }
+
+        protected StateDisabledFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return cache.isDisabled();
         }
+
+        public static final Creator<StateDisabledFilter> CREATOR
+                = new Parcelable.Creator<StateDisabledFilter>() {
+
+            @Override
+            public StateDisabledFilter createFromParcel(final Parcel in) {
+                return new StateDisabledFilter(in);
+            }
+
+            @Override
+            public StateDisabledFilter[] newArray(final int size) {
+                return new StateDisabledFilter[size];
+            }
+        };
     }
 
     static class StatePremiumFilter extends AbstractFilter {
-        private static final long serialVersionUID = -4086779915486623739L;
 
         public StatePremiumFilter() {
             super(R.string.cache_status_premium);
+        }
+
+        protected StatePremiumFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return cache.isPremiumMembersOnly();
         }
+
+        public static final Creator<StatePremiumFilter> CREATOR
+                = new Parcelable.Creator<StatePremiumFilter>() {
+
+            @Override
+            public StatePremiumFilter createFromParcel(final Parcel in) {
+                return new StatePremiumFilter(in);
+            }
+
+            @Override
+            public StatePremiumFilter[] newArray(final int size) {
+                return new StatePremiumFilter[size];
+            }
+        };
     }
 
     static class StateNonPremiumFilter extends AbstractFilter {
-        private static final long serialVersionUID = 6427819310603779646L;
 
         public StateNonPremiumFilter() {
             super(R.string.cache_status_not_premium);
+        }
+
+        protected StateNonPremiumFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return !cache.isPremiumMembersOnly();
         }
+
+        public static final Creator<StateNonPremiumFilter> CREATOR
+                = new Parcelable.Creator<StateNonPremiumFilter>() {
+
+            @Override
+            public StateNonPremiumFilter createFromParcel(final Parcel in) {
+                return new StateNonPremiumFilter(in);
+            }
+
+            @Override
+            public StateNonPremiumFilter[] newArray(final int size) {
+                return new StateNonPremiumFilter[size];
+            }
+        };
     }
 
     private static class StateOfflineLogFilter extends AbstractFilter {
-        private static final long serialVersionUID = -6076510706828408970L;
 
         public StateOfflineLogFilter() {
             super(R.string.cache_status_offline_log);
+        }
+
+        protected StateOfflineLogFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return cache.isLogOffline();
         }
+
+        public static final Creator<StateOfflineLogFilter> CREATOR
+                = new Parcelable.Creator<StateOfflineLogFilter>() {
+
+            @Override
+            public StateOfflineLogFilter createFromParcel(final Parcel in) {
+                return new StateOfflineLogFilter(in);
+            }
+
+            @Override
+            public StateOfflineLogFilter[] newArray(final int size) {
+                return new StateOfflineLogFilter[size];
+            }
+        };
     }
 
     static class StateStoredFilter extends AbstractFilter {
-        private static final long serialVersionUID = -2455064686291969386L;
 
         public StateStoredFilter() {
             super(R.string.cache_status_stored);
+        }
+
+        protected StateStoredFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return cache.isOffline();
         }
+
+        public static final Creator<StateStoredFilter> CREATOR
+                = new Parcelable.Creator<StateStoredFilter>() {
+
+            @Override
+            public StateStoredFilter createFromParcel(final Parcel in) {
+                return new StateStoredFilter(in);
+            }
+
+            @Override
+            public StateStoredFilter[] newArray(final int size) {
+                return new StateStoredFilter[size];
+            }
+        };
     }
 
     static class StateNotStoredFilter extends AbstractFilter {
-        private static final long serialVersionUID = 1774243798304092972L;
 
         public StateNotStoredFilter() {
             super(R.string.cache_status_not_stored);
+        }
+
+        protected StateNotStoredFilter(final Parcel in) {
+            super(in);
         }
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return !cache.isOffline();
         }
+
+        public static final Creator<StateNotStoredFilter> CREATOR
+                = new Parcelable.Creator<StateNotStoredFilter>() {
+
+            @Override
+            public StateNotStoredFilter createFromParcel(final Parcel in) {
+                return new StateNotStoredFilter(in);
+            }
+
+            @Override
+            public StateNotStoredFilter[] newArray(final int size) {
+                return new StateNotStoredFilter[size];
+            }
+        };
     }
 
 }

--- a/main/src/cgeo/geocaching/filter/TerrainFilter.java
+++ b/main/src/cgeo/geocaching/filter/TerrainFilter.java
@@ -5,15 +5,20 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.ArrayList;
 import java.util.List;
 
 class TerrainFilter extends AbstractRangeFilter {
 
-    private static final long serialVersionUID = 860373316999710938L;
-
     public TerrainFilter(final int terrain) {
         super(R.string.cache_terrain, terrain);
+    }
+
+    protected TerrainFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -23,7 +28,6 @@ class TerrainFilter extends AbstractRangeFilter {
     }
 
     public static class Factory implements IFilterFactory {
-        private static final long serialVersionUID = 9030252058035089041L;
         private static final int TERRAIN_MIN = 1;
         private static final int TERRAIN_MAX = 7;
 
@@ -38,4 +42,17 @@ class TerrainFilter extends AbstractRangeFilter {
         }
     }
 
+    public static final Creator<TerrainFilter> CREATOR
+            = new Parcelable.Creator<TerrainFilter>() {
+
+        @Override
+        public TerrainFilter createFromParcel(final Parcel in) {
+            return new TerrainFilter(in);
+        }
+
+        @Override
+        public TerrainFilter[] newArray(final int size) {
+            return new TerrainFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/TrackablesFilter.java
+++ b/main/src/cgeo/geocaching/filter/TrackablesFilter.java
@@ -5,11 +5,17 @@ import cgeo.geocaching.R;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 class TrackablesFilter extends AbstractFilter {
-    private static final long serialVersionUID = 2280421779859292315L;
 
     public TrackablesFilter() {
         super(R.string.caches_filter_track);
+    }
+
+    protected TrackablesFilter(final Parcel in) {
+        super(in);
     }
 
     @Override
@@ -17,4 +23,17 @@ class TrackablesFilter extends AbstractFilter {
         return cache.hasTrackables();
     }
 
+    public static final Creator<TrackablesFilter> CREATOR
+            = new Parcelable.Creator<TrackablesFilter>() {
+
+        @Override
+        public TrackablesFilter createFromParcel(final Parcel in) {
+            return new TrackablesFilter(in);
+        }
+
+        @Override
+        public TrackablesFilter[] newArray(final int size) {
+            return new TrackablesFilter[size];
+        }
+    };
 }

--- a/main/src/cgeo/geocaching/filter/TypeFilter.java
+++ b/main/src/cgeo/geocaching/filter/TypeFilter.java
@@ -5,16 +5,23 @@ import cgeo.geocaching.enumerations.CacheType;
 
 import org.eclipse.jdt.annotation.NonNull;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.LinkedList;
 import java.util.List;
 
 class TypeFilter extends AbstractFilter {
-    private static final long serialVersionUID = 7077448921857694356L;
     private final CacheType cacheType;
 
     public TypeFilter(@NonNull final CacheType cacheType) {
         super(cacheType.id);
         this.cacheType = cacheType;
+    }
+
+    protected TypeFilter(final Parcel in) {
+        super(in);
+        cacheType = CacheType.values()[in.readInt()];
     }
 
     @Override
@@ -30,8 +37,6 @@ class TypeFilter extends AbstractFilter {
 
     public static class Factory implements IFilterFactory {
 
-        private static final long serialVersionUID = 147622536084847359L;
-
         @Override
         @NonNull
         public List<IFilter> getFilters() {
@@ -44,7 +49,25 @@ class TypeFilter extends AbstractFilter {
             }
             return filters;
         }
-
     }
 
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeInt(cacheType.ordinal());
+    }
+
+    public static final Creator<TypeFilter> CREATOR
+            = new Parcelable.Creator<TypeFilter>() {
+
+        @Override
+        public TypeFilter createFromParcel(final Parcel in) {
+            return new TypeFilter(in);
+        }
+
+        @Override
+        public TypeFilter[] newArray(final int size) {
+            return new TypeFilter[size];
+        }
+    };
 }


### PR DESCRIPTION
As discussed on 6d82792 Parcellable is a better way than Serialize.
Convert Filters to Parcellable and remove all added Serialize stuff
from last commits.
In OriginFilter we wouldn't Parcell the connectors, so we store
only the Connector name.