### PR TITLE
DO NOT YET MERGE Fix #4954 - New FAQ links

### DIFF
--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -34,10 +34,10 @@
     </integer-array>
     
     <string name="settings_gc_legal_note_url" translatable="false">http://www.geocaching.com/about/termsofuse.aspx</string>
-    <string name="settings_offline_maps_url" translatable="false">http://faq.cgeo.org/#3_12</string>
-    <string name="settings_themes_url" translatable="false">http://faq.cgeo.org/#3_26</string>
+    <string name="settings_offline_maps_url" translatable="false">http://faq.cgeo.org/#osm-get-maps</string>
+    <string name="settings_themes_url" translatable="false">http://faq.cgeo.org/#osm-use-themes</string>
     <string name="settings_send2cgeo_url" translatable="false">http://send2.cgeo.org/</string>
-    <string name="settings_facebook_login_url" translatable="false">http://faq.cgeo.org/#1_38</string>
+    <string name="settings_facebook_login_url" translatable="false">http://faq.cgeo.org/#facebook-login</string>
 
     <!-- contributors -->
     <string name="contributors" translatable="false">

--- a/main/src/cgeo/geocaching/network/StatusUpdater.java
+++ b/main/src/cgeo/geocaching/network/StatusUpdater.java
@@ -42,7 +42,7 @@ public class StatusUpdater {
         }
 
         final static public Status CLOSEOUT_STATUS =
-                new Status("", "status_closeout_warning", "attribute_abandonedbuilding", "http://faq.cgeo.org/#7_69");
+                new Status("", "status_closeout_warning", "attribute_abandonedbuilding", "http://faq.cgeo.org/#install-fail");
 
         final static public Status defaultStatus(final Status upToDate) {
             if (upToDate != null && upToDate.message != null) {


### PR DESCRIPTION
To be merged only after the new website is live

Please kindly crosscheck if I missed occurences of links which will be invalid once we change the website.
I assumed that `send2.cgeo.org/*` server communication and the user entry URL (http://send2.cgeo.org) will stay as it is.