### PR TITLE
Fix #4806: GK requests to GC

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1859,7 +1859,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     final Object selection = arg0.getItemAtPosition(arg2);
                     if (selection instanceof Trackable) {
                         final Trackable trackable = (Trackable) selection;
-                        TrackableActivity.startActivity(CacheDetailActivity.this, trackable.getGuid(), trackable.getGeocode(), trackable.getName(), cache.getGeocode());
+                        TrackableActivity.startActivity(CacheDetailActivity.this, trackable.getGuid(), trackable.getGeocode(), trackable.getName(), cache.getGeocode(), trackable.getBrand().getId());
                     }
                 }
             });

--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -24,6 +24,7 @@ public class Intents {
     public static final String EXTRA_GEOCODE = PREFIX + "geocode";
     public static final String EXTRA_GEOCACHE = PREFIX + "geocache";
     public static final String EXTRA_GUID = PREFIX + "guid";
+    public static final String EXTRA_BRAND = PREFIX + "brand";
     public static final String EXTRA_IMAGES = PREFIX + "images";
     public static final String EXTRA_ID = PREFIX + "id";
     public static final String EXTRA_KEYWORD = PREFIX + "keyword";

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.activity.ShowcaseViewBuilder;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
+import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointFormatter;
@@ -79,7 +80,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
 
         // search suggestion for a trackable
         if (Intents.ACTION_TRACKABLE.equals(intent.getAction())) {
-            TrackableActivity.startActivity(this, null, intent.getStringExtra(SearchManager.QUERY), null, null);
+            TrackableActivity.startActivity(this, null, intent.getStringExtra(SearchManager.QUERY), null, null, TrackableBrand.UNKNOWN.getId());
             finish();
             return;
         }

--- a/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
@@ -27,6 +27,15 @@ public abstract class AbstractTrackableConnector implements TrackableConnector {
         return false;
     }
 
+
+    @Override
+    public boolean canHandleTrackable(final String geocode, final TrackableBrand brand) {
+        if (brand != null && brand != TrackableBrand.UNKNOWN) {
+            return brand == getBrand() && canHandleTrackable(geocode);
+        }
+        return canHandleTrackable(geocode);
+    }
+
     @Override
     public boolean hasTrackableUrls() {
         return true;

--- a/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
@@ -29,6 +29,8 @@ public interface TrackableConnector {
 
     public boolean canHandleTrackable(final String geocode);
 
+    public boolean canHandleTrackable(final String geocode, final TrackableBrand brand);
+
     /**
      * Return the Title of the service the connector is attached to.
      * Title may be used in messages given to the user, like to say which connector need to


### PR DESCRIPTION
The TrackableActivity try every connector and return the first one matching
the pattern. TravelBugConnector also match GK numbers as Tracking Code search.

This patch limit 'bad' requests made to GC services. It ONLY works if we open
the TrackableActivity from CacheDetailActivity as we know the brand of the
trackable we would open. This is not the case when opening trackableActivity
from the 'search bar', which is good. Issue #4822 still happens in this case.