### PR TITLE
Include send2cgeo into search

### DIFF
--- a/send2cgeo/send2cgeo.user.js
+++ b/send2cgeo/send2cgeo.user.js
@@ -76,7 +76,7 @@ s.textContent =  '(' + function() {
 
     map.innerHTML = map.innerHTML.replace('Log Visit</span>', html);
   } else if(document.getElementById('searchResultsTable') != null){
-    // geocaching.com seach
+    // geocaching.com search
     
     $("#searchResultsTable th").first().after('<th class="mobile-show"><a class="outbound-link">Send to c:geo</a></th>');
     $("#searchResultsTable col").first().after('<col></col>');
@@ -90,7 +90,7 @@ s.textContent =  '(' + function() {
         var html = '<td class="mobile-show" >'
              + '<a href="https://send2.cgeo.org/add.html?cache=' + GCCode + '" '
              + 'onclick="window.s2geo(\'' + GCCode + '\'); return false;">'
-             + '<img height="50" src="http://send2.cgeo.org/content/images/send2cgeo.png" '
+             + '<img height="50" src="https://send2.cgeo.org/content/images/send2cgeo.png" '
              + 'border="0"> '
              + '</a></td>';
 

--- a/send2cgeo/send2cgeo.user.js
+++ b/send2cgeo/send2cgeo.user.js
@@ -90,7 +90,7 @@ s.textContent =  '(' + function() {
         var html = '<td class="mobile-show" >'
              + '<a href="https://send2.cgeo.org/add.html?cache=' + GCCode + '" '
              + 'onclick="window.s2geo(\'' + GCCode + '\'); return false;">'
-             + '<img height="50" src="https://send2.cgeo.org/content/images/send2cgeo.png" '
+             + '<img height="50" src=" https://send2.cgeo.org/send2cgeo.png" '
              + 'border="0"> '
              + '</a></td>';
 

--- a/send2cgeo/send2cgeo.user.js
+++ b/send2cgeo/send2cgeo.user.js
@@ -3,6 +3,7 @@
 // @namespace      http://send2.cgeo.org/
 // @description    Add button "Send to c:geo" to geocaching.com
 // @grant          none
+// @include        https://www.geocaching.com/play/search/*
 // @include        http://www.geocaching.com/seek/cache_details*
 // @include        https://www.geocaching.com/map/*
 // @include        http://www.geocaching.com/geocache/*
@@ -74,7 +75,30 @@ s.textContent =  '(' + function() {
              + '<span>Send to c:geo</span>';
 
     map.innerHTML = map.innerHTML.replace('Log Visit</span>', html);
-  } else if(document.getElementById('ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode') != null){
+  } else if(document.getElementById('searchResultsTable') != null){
+    // geocaching.com seach
+    
+    $("#searchResultsTable th").first().after('<th class="mobile-show"><a class="outbound-link">Send to c:geo</a></th>');
+    $("#searchResultsTable col").first().after('<col></col>');
+    
+    var caches = $(".cache-details");
+    caches.each(function() {
+        
+        var GCCode = $(this ).text();
+        GCCode = GCCode.slice( GCCode.indexOf("|") + 1 ).trim();
+        
+        var html = '<td class="mobile-show" >'
+             + '<a href="https://send2.cgeo.org/add.html?cache=' + GCCode + '" '
+             + 'onclick="window.s2geo(\'' + GCCode + '\'); return false;">'
+             + '<img height="50" src="http://send2.cgeo.org/content/images/send2cgeo.png" '
+             + 'border="0"> '
+             + '</a></td>';
+
+             $(this).parent().parent().after(html);
+             
+    });
+    
+    } else if(document.getElementById('ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode') != null){
     // geocaching.com cache detail page
     var GCCode = $('#ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode')
                   .html();


### PR DESCRIPTION
I often download a complete search result or the 10 most faved caches in an area. With this modification a new column is added to the search results with a  send2cgeo image as link. Perhaps this feature is useful for a lot of people.