### PR TITLE
Ignore generated file (main/usage.txt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ private.properties
 main/build/
 mapswithme-api/build/
 build
+main/usage.txt


### PR DESCRIPTION
When building cgeo with gradle the file main/usage.txt is generated.
I think it should be ignored like the other generated files.