### PR TITLE
Fix #5246: Show file name after cache import

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -855,6 +855,7 @@
     <string name="gpx_import_loading_waypoints">Loading waypoints file</string>
     <string name="gpx_import_store_static_maps">Storing static maps</string>
     <string name="gpx_import_caches_imported">caches imported</string>
+    <string name="gpx_import_caches_imported_with_filename">%1$d caches imported from %2$s</string>
     <string name="gpx_import_static_maps_skipped">Download of static maps aborted</string>
     <string name="gpx_import_title_static_maps">Store static maps</string>
     <string name="gpx_import_title_reading_file">Reading file</string>
@@ -865,6 +866,7 @@
     <string name="gpx_import_error_parser">Bad File format</string>
     <string name="gpx_import_error_unexpected">Unexpected error</string>
     <string name="gpx_import_canceled">GPX import was canceled</string>
+    <string name="gpx_import_canceled_with_filename">GPX import from %1$s was canceled</string>
     <string name="gpx_import_delete_title">Delete file</string>
     <string name="gpx_import_delete_message">Do you want to delete %s?</string>
     <string name="gpx_import_select_list_title">Import GPX to list</string>

--- a/main/src/cgeo/geocaching/files/AbstractImportThread.java
+++ b/main/src/cgeo/geocaching/files/AbstractImportThread.java
@@ -39,7 +39,7 @@ abstract class AbstractImportThread extends Thread {
             // Do not put imported caches into the cachecache. That would consume lots of memory for no benefit.
 
             if (Settings.isStoreOfflineMaps() || Settings.isStoreOfflineWpMaps()) {
-                importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_STORE_STATIC_MAPS, R.string.gpx_import_store_static_maps, search.getCount()));
+                importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_STORE_STATIC_MAPS, R.string.gpx_import_store_static_maps, search.getCount(), getSourceDisplayName()));
                 final boolean finishedWithoutCancel = importStaticMaps(search);
                 // Skip last message if static maps where canceled
                 if (!finishedWithoutCancel) {
@@ -47,7 +47,7 @@ abstract class AbstractImportThread extends Thread {
                 }
             }
 
-            importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_FINISHED, search.getCount(), 0, search));
+            importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_FINISHED, search.getCount(), 0, getSourceDisplayName()));
         } catch (final IOException e) {
             Log.i("Importing caches failed - error reading data: ", e);
             importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_FINISHED_WITH_ERROR, R.string.gpx_import_error_io, 0, e.getLocalizedMessage()));
@@ -56,7 +56,7 @@ abstract class AbstractImportThread extends Thread {
             importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_FINISHED_WITH_ERROR, R.string.gpx_import_error_parser, 0, e.getLocalizedMessage()));
         } catch (final CancellationException ignored) {
             Log.i("Importing caches canceled");
-            importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_CANCELED));
+            importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_CANCELED, getSourceDisplayName()));
         } catch (final Exception e) {
             Log.e("Importing caches failed - unknown error: ", e);
             importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_FINISHED_WITH_ERROR, R.string.gpx_import_error_unexpected, 0, e.getLocalizedMessage()));
@@ -64,6 +64,13 @@ abstract class AbstractImportThread extends Thread {
     }
 
     protected abstract Collection<Geocache> doImport() throws IOException, ParserException;
+
+    /**
+     * Return a user presentable name of the imported source
+     *
+     * @return The import source display name
+     */
+    protected abstract String getSourceDisplayName();
 
     private boolean importStaticMaps(final SearchResult importedCaches) {
         int storedCacheMaps = 0;

--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -184,7 +184,7 @@ public class GPXImporter {
 
                 case IMPORT_STEP_STORE_STATIC_MAPS:
                     progress.dismiss();
-                    final Message skipMessage = importStepHandler.obtainMessage(IMPORT_STEP_STATIC_MAPS_SKIPPED, msg.arg2, 0);
+                    final Message skipMessage = importStepHandler.obtainMessage(IMPORT_STEP_STATIC_MAPS_SKIPPED, msg.arg2, 0, msg.obj);
                     progress.show(fromActivity, res.getString(R.string.gpx_import_title_static_maps), res.getString(R.string.gpx_import_store_static_maps), ProgressDialog.STYLE_HORIZONTAL, skipMessage);
                     progress.setMaxProgressAndReset(msg.arg2);
                     break;
@@ -193,14 +193,14 @@ public class GPXImporter {
                     progress.dismiss();
                     progressHandler.cancel();
                     final StringBuilder bufferSkipped = new StringBuilder(20);
-                    bufferSkipped.append(res.getString(R.string.gpx_import_static_maps_skipped)).append(", ").append(msg.arg1).append(' ').append(res.getString(R.string.gpx_import_caches_imported));
+                    bufferSkipped.append(res.getString(R.string.gpx_import_static_maps_skipped)).append(", ").append(res.getString(R.string.gpx_import_caches_imported_with_filename, msg.arg1, msg.obj));
                     Dialogs.message(fromActivity, R.string.gpx_import_title_caches_imported, bufferSkipped.toString());
                     importFinished();
                     break;
 
                 case IMPORT_STEP_FINISHED:
                     progress.dismiss();
-                    Dialogs.message(fromActivity, R.string.gpx_import_title_caches_imported, msg.arg1 + " " + res.getString(R.string.gpx_import_caches_imported));
+                    Dialogs.message(fromActivity, R.string.gpx_import_title_caches_imported, res.getString(R.string.gpx_import_caches_imported_with_filename, msg.arg1, msg.obj));
                     importFinished();
                     break;
 
@@ -216,8 +216,8 @@ public class GPXImporter {
                     break;
 
                 case IMPORT_STEP_CANCELED:
-                    final StringBuilder bufferCanceled = new StringBuilder(20);
-                    bufferCanceled.append(res.getString(R.string.gpx_import_canceled));
+                    final StringBuilder bufferCanceled = new StringBuilder(30);
+                    bufferCanceled.append(res.getString(R.string.gpx_import_canceled_with_filename, msg.obj));
                     ActivityMixin.showShortToast(fromActivity, bufferCanceled.toString());
                     importFinished();
                     break;

--- a/main/src/cgeo/geocaching/files/ImportGpxAttachmentThread.java
+++ b/main/src/cgeo/geocaching/files/ImportGpxAttachmentThread.java
@@ -61,4 +61,9 @@ public class ImportGpxAttachmentThread extends AbstractImportGpxThread {
         }
         return null;
     }
+
+    @Override
+    protected String getSourceDisplayName() {
+        return uri.getLastPathSegment();
+    }
 }

--- a/main/src/cgeo/geocaching/files/ImportGpxFileThread.java
+++ b/main/src/cgeo/geocaching/files/ImportGpxFileThread.java
@@ -36,4 +36,9 @@ class ImportGpxFileThread extends AbstractImportGpxThread {
         }
         return caches;
     }
+
+    @Override
+    protected String getSourceDisplayName() {
+        return cacheFile.getName();
+    }
 }

--- a/main/src/cgeo/geocaching/files/ImportGpxZipAttachmentThread.java
+++ b/main/src/cgeo/geocaching/files/ImportGpxZipAttachmentThread.java
@@ -25,4 +25,9 @@ class ImportGpxZipAttachmentThread extends AbstractImportGpxZipThread {
     protected InputStream getInputStream() throws IOException {
         return contentResolver.openInputStream(uri);
     }
+
+    @Override
+    protected String getSourceDisplayName() {
+        return uri.getLastPathSegment();
+    }
 }

--- a/main/src/cgeo/geocaching/files/ImportGpxZipFileThread.java
+++ b/main/src/cgeo/geocaching/files/ImportGpxZipFileThread.java
@@ -23,4 +23,9 @@ class ImportGpxZipFileThread extends AbstractImportGpxZipThread {
     protected InputStream getInputStream() throws IOException {
         return new FileInputStream(cacheFile);
     }
+
+    @Override
+    protected String getSourceDisplayName() {
+        return cacheFile.getName();
+    }
 }

--- a/main/src/cgeo/geocaching/files/ImportLocAttachmentThread.java
+++ b/main/src/cgeo/geocaching/files/ImportLocAttachmentThread.java
@@ -9,6 +9,8 @@ import android.content.ContentResolver;
 import android.net.Uri;
 import android.os.Handler;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -32,7 +34,12 @@ class ImportLocAttachmentThread extends AbstractImportThread {
         try {
             return parser.parse(is, progressHandler);
         } finally {
-            is.close();
+            IOUtils.closeQuietly(is);
         }
+    }
+
+    @Override
+    protected String getSourceDisplayName() {
+        return uri.getLastPathSegment();
     }
 }

--- a/main/src/cgeo/geocaching/files/ImportLocFileThread.java
+++ b/main/src/cgeo/geocaching/files/ImportLocFileThread.java
@@ -26,4 +26,9 @@ class ImportLocFileThread extends AbstractImportThread {
         final LocParser parser = new LocParser(listId);
         return parser.parse(file, progressHandler);
     }
+
+    @Override
+    protected String getSourceDisplayName() {
+        return file.getName();
+    }
 }


### PR DESCRIPTION
Hello,

this is a proposal for feature #5246. I tested it with some of the GPX files in "tests\res\raw\".

Please have a look at the change in line 50 of AbstractImportThread.java. I didn't see the SearchResult object being used in the importStepHandler of the GPXImporter class, so I reused the msg.obj field for the "sourceDisplayName".
Can this change be made or are there some other places where the SearchResult object from the msg.obj was used?