### PR TITLE
fix #5296

### DIFF
--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -114,6 +114,6 @@
         android:id="@+id/menu_edit_fieldnote"
         android:icon="@drawable/ic_menu_rotate"
         android:title="@string/cache_personal_note"
-        app:showAsAction="ifRoom">
+        android:visible="false">
     </item>
 </menu>

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -89,7 +89,6 @@ public final class CacheMenuHandler extends AbstractUIFactory {
             return;
         }
         final boolean hasCoords = cache.getCoords() != null;
-        menu.findItem(R.id.menu_edit_fieldnote).setVisible(true);
         menu.findItem(R.id.menu_default_navigation).setVisible(hasCoords);
         menu.findItem(R.id.menu_navigate).setVisible(hasCoords);
         menu.findItem(R.id.menu_caches_around).setVisible(hasCoords && cache.supportsCachesAround());


### PR DESCRIPTION
In #5296 are several issues named:
- crash when editing note from WP or Images Tab
- edit-note button / menu is shown if cache is not saved. 