### PR TITLE
fix #3819: make description text selectable

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -12,10 +12,10 @@
         android:orientation="vertical"
         android:padding="4dip" >
 
-        <!-- Short description -->
+        <!-- Description -->
 
         <cgeo.geocaching.ui.IndexOutOfBoundsAvoidingTextView
-            android:id="@+id/shortdesc"
+            android:id="@+id/description"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="12dip"
@@ -23,20 +23,7 @@
             android:linksClickable="true"
             android:textColor="?text_color"
             android:textColorLink="?text_color_link"
-            android:textSize="14sp"
-            android:visibility="gone" />
-
-        <!-- Long description -->
-
-        <cgeo.geocaching.ui.IndexOutOfBoundsAvoidingTextView
-            android:id="@+id/longdesc"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="12dip"
-            android:layout_marginTop="12dip"
-            android:linksClickable="true"
-            android:textColor="?text_color"
-            android:textColorLink="?text_color_link"
+            android:textIsSelectable="true"
             android:textSize="14sp"
             android:visibility="gone" />
 

--- a/main/src/cgeo/geocaching/ui/IndexOutOfBoundsAvoidingTextView.java
+++ b/main/src/cgeo/geocaching/ui/IndexOutOfBoundsAvoidingTextView.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.ui;
 
 import android.content.Context;
+import android.text.Selection;
+import android.text.Spannable;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
@@ -50,6 +52,19 @@ public class IndexOutOfBoundsAvoidingTextView extends TextView {
 			super.setText(text, type);
         } catch (final IndexOutOfBoundsException ignored) {
 			setText(text.toString());
+		}
+	}
+
+	@Override
+	protected void onSelectionChanged(int selStart, int selEnd) {
+		if (selStart == -1 || selEnd == -1) {
+			// @hack : https://code.google.com/p/android/issues/detail?id=137509
+			CharSequence text = getText();
+			if (text instanceof Spannable) {
+				Selection.setSelection((Spannable) text, 0, 0);
+			}
+		} else {
+			super.onSelectionChanged(selStart, selEnd);
 		}
 	}
 }


### PR DESCRIPTION
with these changes it's possible to copy only parts of description. I removed the separation of short and long description to be able to select both in a single selection. 
Testing the new feature I run into https://code.google.com/p/android/issues/detail?id=137509 . The workaround for this works fine.
![screenshot_2015-12-30-18-48-22](https://cloud.githubusercontent.com/assets/937126/12056469/01122efa-af37-11e5-9e38-4df93d2e0e0a.png)
