### PR TITLE
fix #3819 (and #5202): make description text selectable

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -12,10 +12,10 @@
         android:orientation="vertical"
         android:padding="4dip" >
 
-        <!-- Short description -->
+        <!-- Description -->
 
         <cgeo.geocaching.ui.IndexOutOfBoundsAvoidingTextView
-            android:id="@+id/shortdesc"
+            android:id="@+id/description"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="12dip"
@@ -23,20 +23,7 @@
             android:linksClickable="true"
             android:textColor="?text_color"
             android:textColorLink="?text_color_link"
-            android:textSize="14sp"
-            android:visibility="gone" />
-
-        <!-- Long description -->
-
-        <cgeo.geocaching.ui.IndexOutOfBoundsAvoidingTextView
-            android:id="@+id/longdesc"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="12dip"
-            android:layout_marginTop="12dip"
-            android:linksClickable="true"
-            android:textColor="?text_color"
-            android:textColorLink="?text_color_link"
+            android:textIsSelectable="true"
             android:textSize="14sp"
             android:visibility="gone" />
 
@@ -83,13 +70,14 @@
                     android:text="@string/cache_hint" />
             </RelativeLayout>
 
-            <TextView
+            <cgeo.geocaching.ui.IndexOutOfBoundsAvoidingTextView
                 android:id="@+id/hint"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:linksClickable="true"
                 android:textColor="?text_color"
+                android:textIsSelectable="true"
                 android:textColorLink="?text_color_link"
                 android:textSize="14sp" />
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1431,8 +1431,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     protected class DescriptionViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
 
         @Bind(R.id.personalnote) protected TextView personalNoteView;
-        @Bind(R.id.shortdesc) protected IndexOutOfBoundsAvoidingTextView shortDescView;
-        @Bind(R.id.longdesc) protected IndexOutOfBoundsAvoidingTextView longDescView;
+        @Bind(R.id.description) protected IndexOutOfBoundsAvoidingTextView descView;
         @Bind(R.id.show_description) protected Button showDesc;
         @Bind(R.id.loading) protected View loadingView;
 
@@ -1448,7 +1447,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
             // cache short description
             if (StringUtils.isNotBlank(cache.getShortDescription())) {
-                loadDescription(cache.getShortDescription(), shortDescView, null);
+                loadDescription(cache.getShortDescription(), descView, null);
             }
 
             // long description
@@ -1578,7 +1577,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             loadingView.setVisibility(View.VISIBLE);
 
             final String longDescription = cache.getDescription();
-            loadDescription(longDescription, longDescView, loadingView);
+            loadDescription(longDescription, descView, loadingView);
         }
 
         private void warnPersonalNoteExceedsLimit() {
@@ -1611,12 +1610,16 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 addWarning(unknownTagsHandler, description);
                 if (StringUtils.isNotBlank(descriptionString)) {
                     try {
-                        descriptionView.setText(description, TextView.BufferType.SPANNABLE);
+                        if (descriptionView.getText().length() == 0) {
+                            descriptionView.setText(description, TextView.BufferType.SPANNABLE);
+                        } else {
+                            descriptionView.append(description);
+                        }
                     } catch (final Exception e) {
                         // On 4.1, there is sometimes a crash on measuring the layout: https://code.google.com/p/android/issues/detail?id=35412
                         Log.e("Android bug setting text: ", e);
                         // remove the formatting by converting to a simple string
-                        descriptionView.setText(description.toString());
+                        descriptionView.append(description.toString());
                     }
                     descriptionView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
                     fixTextColor(descriptionString, descriptionView);
@@ -1679,7 +1682,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
      * Hide the short description, if it is contained somewhere at the start of the long description.
      */
     public void potentiallyHideShortDescription() {
-        final View shortView = ButterKnife.findById(this, R.id.shortdesc);
+        final View shortView = ButterKnife.findById(this, R.id.description);
         if (shortView == null) {
             return;
         }
@@ -1937,12 +1940,55 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         context.startActivity(cachesIntent);
     }
 
+    private ActionMode mActionMode = null;
+    private IndexOutOfBoundsAvoidingTextView selectedTextView;
+
+    private class TextMenuItemClickListener implements MenuItem.OnMenuItemClickListener {
+
+        @Override
+        public boolean onMenuItemClick(MenuItem menuItem) {
+            int startSelection= selectedTextView.getSelectionStart();
+            int endSelection= selectedTextView.getSelectionEnd();
+            clickedItemText = selectedTextView.getText().subSequence(startSelection,endSelection);
+            return onClipboardItemSelected(mActionMode, menuItem, clickedItemText);
+        }
+    }
+
+    @Override
+    public void onSupportActionModeStarted(ActionMode mode) {
+        if (mActionMode == null && selectedTextView != null) {
+            mActionMode = mode;
+            Menu menu = mode.getMenu();
+            mode.getMenuInflater().inflate(R.menu.details_context, menu);
+            menu.findItem(R.id.menu_copy).setVisible(false);
+            menu.findItem(R.id.menu_cache_share_field).setOnMenuItemClickListener(new TextMenuItemClickListener());
+            menu.findItem(R.id.menu_translate_to_sys_lang).setOnMenuItemClickListener(new TextMenuItemClickListener());
+            menu.findItem(R.id.menu_translate_to_english).setOnMenuItemClickListener(new TextMenuItemClickListener());
+            buildDetailsContextMenu(mode, menu, res.getString(R.string.cache_description), false);
+            selectedTextView.setWindowFocusWait(true);
+        }
+        super.onSupportActionModeStarted(mode);
+    }
+
+    @Override
+    public void onSupportActionModeFinished(ActionMode mode) {
+        mActionMode = null;
+        if (selectedTextView != null)
+            selectedTextView.setWindowFocusWait(false);
+        selectedTextView = null;
+        super.onSupportActionModeFinished(mode);
+    }
+
     @Override
     public void addContextMenu(final View view) {
         view.setOnLongClickListener(new OnLongClickListener() {
 
             @Override
             public boolean onLongClick(final View v) {
+                if ((view.getId() == R.id.description) || (view.getId() == R.id.hint)) {
+                    selectedTextView = (IndexOutOfBoundsAvoidingTextView)view;
+                    return false;
+                }
                 currentActionMode = startSupportActionMode(new ActionMode.Callback() {
 
                     @Override
@@ -1958,27 +2004,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                                 final CharSequence itemTitle = ((TextView) ((View) view.getParent()).findViewById(R.id.name)).getText();
                                 buildDetailsContextMenu(actionMode, menu, itemTitle, true);
                                 return true;
-                            case R.id.shortdesc:
-                                clickedItemText = cache.getShortDescription();
-                                buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_description), false);
-                                return true;
-                            case R.id.longdesc:
-                                // combine short and long description
-                                final String shortDesc = cache.getShortDescription();
-                                if (StringUtils.isBlank(shortDesc)) {
-                                    clickedItemText = cache.getDescription();
-                                } else {
-                                    clickedItemText = shortDesc + "\n\n" + cache.getDescription();
-                                }
-                                buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_description), false);
-                                return true;
                             case R.id.personalnote:
                                 clickedItemText = cache.getPersonalNote();
                                 buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_personal_note), true);
-                                return true;
-                            case R.id.hint:
-                                clickedItemText = cache.getHint();
-                                buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_hint), false);
                                 return true;
                             case R.id.log:
                                 assert view instanceof TextView;

--- a/main/src/cgeo/geocaching/ui/DecryptTextClickListener.java
+++ b/main/src/cgeo/geocaching/ui/DecryptTextClickListener.java
@@ -19,11 +19,6 @@ public class DecryptTextClickListener implements View.OnClickListener {
     @Override
     public final void onClick(final View view) {
         try {
-            // do not run the click listener if a link was clicked
-            if (targetView.getSelectionStart() != -1 || targetView.getSelectionEnd() != -1) {
-                return;
-            }
-
             final CharSequence text = targetView.getText();
             if (text instanceof Spannable) {
                 targetView.setText(CryptUtils.rot13((Spannable) text));

--- a/main/src/cgeo/geocaching/ui/IndexOutOfBoundsAvoidingTextView.java
+++ b/main/src/cgeo/geocaching/ui/IndexOutOfBoundsAvoidingTextView.java
@@ -1,7 +1,10 @@
 package cgeo.geocaching.ui;
 
 import android.content.Context;
+import android.text.Selection;
+import android.text.Spannable;
 import android.util.AttributeSet;
+import android.view.MenuItem;
 import android.widget.TextView;
 
 /**
@@ -14,14 +17,17 @@ public class IndexOutOfBoundsAvoidingTextView extends TextView {
 
     public IndexOutOfBoundsAvoidingTextView(final Context context, final AttributeSet attrs, final int defStyle) {
 		super(context, attrs, defStyle);
+		shouldWindowFocusWait = false;
 	}
 
 	public IndexOutOfBoundsAvoidingTextView(final Context context, final AttributeSet attrs) {
 		super(context, attrs);
+		shouldWindowFocusWait = false;
 	}
 
 	public IndexOutOfBoundsAvoidingTextView(final Context context) {
 		super(context);
+		shouldWindowFocusWait = false;
 	}
 
 	@Override
@@ -50,6 +56,32 @@ public class IndexOutOfBoundsAvoidingTextView extends TextView {
 			super.setText(text, type);
         } catch (final IndexOutOfBoundsException ignored) {
 			setText(text.toString());
+		}
+	}
+
+	@Override
+	protected void onSelectionChanged(int selStart, int selEnd) {
+		if (selStart == -1 || selEnd == -1) {
+			// @hack : https://code.google.com/p/android/issues/detail?id=137509
+			CharSequence text = getText();
+			if (text instanceof Spannable) {
+				Selection.setSelection((Spannable) text, 0, 0);
+			}
+		} else {
+			super.onSelectionChanged(selStart, selEnd);
+		}
+	}
+
+	// https://code.google.com/p/android/issues/detail?id=23381
+	private boolean shouldWindowFocusWait;
+	public void setWindowFocusWait(final boolean shouldWindowFocusWait) {
+		this.shouldWindowFocusWait = shouldWindowFocusWait;
+	}
+
+	@Override
+	public void onWindowFocusChanged(boolean hasWindowFocus) {
+		if (!shouldWindowFocusWait) {
+			super.onWindowFocusChanged(hasWindowFocus);
 		}
 	}
 }


### PR DESCRIPTION
with these changes it's possible to copy, share and translate only parts of description. I removed the separation of short and long description to be able to select both in a single selection.

Testing the new feature I run into https://code.google.com/p/android/issues/detail?id=137509 and https://code.google.com/p/android/issues/detail?id=23381. The workarounds are working fine.