### PR TITLE
Support links encoded in some GeoKrety QRCode

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -614,6 +614,7 @@
                 <data android:host="geokrety.org" />
                 <data android:host="www.geokrety.org" />
                 <data android:pathPrefix="/konkret.php" />
+                <data android:pathPrefix="/m/qr.php" />
             </intent-filter>
 
             <!-- GeoKretyMap.org -->

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -323,6 +323,21 @@
             android:name=".LogTrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/trackable_touch" >
+
+            <!-- GeoKrety.org QRCode-->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="geokrety.org" />
+                <data android:host="www.geokrety.org" />
+                <data android:pathPrefix="/m/qr.php" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".ImagesActivity"

--- a/main/src/cgeo/geocaching/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/LogTrackableActivity.java
@@ -175,7 +175,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
         trackable = DataStore.loadTrackable(geocode);
 
         if (trackable == null) {
-            Log.e("LogTrackableActivity.onCreate: cannot load trackable " + geocode);
+            Log.e("LogTrackableActivity.onCreate, cannot load trackable: " + geocode);
             setResult(RESULT_CANCELED);
             finish();
             return;

--- a/main/src/cgeo/geocaching/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/LogTrackableActivity.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.LogResult;
 import cgeo.geocaching.connector.trackable.AbstractTrackableLoggingManager;
+import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.Loaders;
@@ -17,6 +18,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.LogEntry;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.TrackableLog;
+import cgeo.geocaching.network.AndroidBeam;
 import cgeo.geocaching.search.AutoCompleteAdapter;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.settings.Settings;
@@ -40,17 +42,22 @@ import cgeo.geocaching.utils.LogTemplateProvider.LogTemplate;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import rx.android.app.AppObservable;
+import rx.functions.Action1;
 import rx.functions.Func1;
+import rx.subscriptions.CompositeSubscription;
 
 import android.R.layout;
 import android.R.string;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.net.Uri;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -71,6 +78,7 @@ import android.widget.LinearLayout;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 
 public class LogTrackableActivity extends AbstractLoggingActivity implements DateDialogParent, TimeDialogParent, CoordinateUpdate, LoaderManager.LoaderCallbacks<List<LogTypeTrackable>> {
 
@@ -84,6 +92,9 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
     @Bind(R.id.tweet) protected CheckBox tweetCheck;
     @Bind(R.id.tweet_box) protected LinearLayout tweetBox;
 
+    private CompositeSubscription createSubscriptions;
+    private ProgressDialog waitDialog = null;
+
     private List<LogTypeTrackable> possibleLogTypesTrackable = new ArrayList<>();
     private String geocode = null;
     private Geopoint geopoint;
@@ -95,6 +106,8 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
     private Calendar date = Calendar.getInstance();
     private LogTypeTrackable typeSelected = LogTypeTrackable.getById(Settings.getTrackableAction());
     private Trackable trackable;
+    private TrackableBrand brand;
+    String trackingCode;
 
     TrackableConnector connector;
     private AbstractTrackableLoggingManager loggingManager;
@@ -149,11 +162,14 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState, R.layout.logtrackable_activity);
+        onCreate(savedInstanceState, R.layout.logtrackable_activity);
         ButterKnife.bind(this);
+        createSubscriptions = new CompositeSubscription();
 
         // get parameters
         final Bundle extras = getIntent().getExtras();
+        final Uri uri = AndroidBeam.getUri(getIntent());
+
         if (extras != null) {
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
 
@@ -164,55 +180,98 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
                     geocache = tmpGeocache;
                 }
             }
-            // Display tracking code if we have, and move cursor next
+            // Load Tracking Code
             if (StringUtils.isNotBlank(extras.getString(Intents.EXTRA_TRACKING_CODE))) {
-                trackingEditText.setText(extras.getString(Intents.EXTRA_TRACKING_CODE));
-                Dialogs.moveCursorToEnd(trackingEditText);
+                trackingCode = extras.getString(Intents.EXTRA_TRACKING_CODE);
             }
         }
 
-        // Load Trackable from internal
-        trackable = DataStore.loadTrackable(geocode);
+        // try to get data from URI
+        if (geocode == null && uri != null) {
+            geocode = ConnectorFactory.getTrackableFromURL(uri.toString());
+            trackingCode = ConnectorFactory.getTrackableTrackingCodeFromURL(uri.toString());
 
+            final String uriHost = uri.getHost().toLowerCase(Locale.US);
+            if (uriHost.endsWith("geokrety.org")) {
+                brand = TrackableBrand.GEOKRETY;
+                if (geocode == null && trackingCode != null) {
+                    geocode = trackingCode;
+                }
+            }
+        }
+
+        // no given data
+        if (geocode == null) {
+            showToast(res.getString(R.string.err_tb_display));
+            finish();
+            return;
+        }
+
+        refreshTrackable(geocode);
+    }
+
+    private void refreshTrackable(final String message) {
+        waitDialog = ProgressDialog.show(this, message, res.getString(R.string.trackable_details_loading), true, true);
+
+        // create trackable connector
+        connector = ConnectorFactory.getTrackableConnector(geocode, brand);
+
+        createSubscriptions.add(AppObservable.bindActivity(this, ConnectorFactory.loadTrackable(geocode, null, null, brand)).singleOrDefault(null).subscribe(new Action1<Trackable>() {
+            @Override
+            public void call(final Trackable newTrackable) {
+                if (newTrackable != null && trackingCode != null) {
+                    newTrackable.setTrackingcode(trackingCode);
+                }
+                trackable = newTrackable;
+                // Start loading in background
+                getSupportLoaderManager().initLoader(connector.getTrackableLoggingManagerLoaderId(), null, LogTrackableActivity.this).forceLoad();
+                displayTrackable();
+            }
+        }));
+    }
+
+    private void displayTrackable() {
         if (trackable == null) {
             Log.e("LogTrackableActivity.onCreate, cannot load trackable: " + geocode);
+            if (waitDialog != null) {
+                waitDialog.dismiss();
+            }
+
+            if (StringUtils.isNotBlank(geocode)) {
+                showToast(res.getString(R.string.err_tb_find) + ' ' + geocode + '.');
+            } else {
+                showToast(res.getString(R.string.err_tb_find_that));
+            }
+
             setResult(RESULT_CANCELED);
             finish();
             return;
         }
 
-        if (StringUtils.isNotBlank(trackable.getName())) {
-            setTitle(res.getString(R.string.trackable_touch) + ": " + trackable.getName());
-        } else {
-            setTitle(res.getString(R.string.trackable_touch) + ": " + trackable.getGeocode());
-        }
-
         // We're in LogTrackableActivity, so trackable must be loggable ;)
         if (!trackable.isLoggable()) {
+            if (waitDialog != null) {
+                waitDialog.dismiss();
+            }
             showToast(res.getString(R.string.err_tb_not_loggable));
             finish();
             return;
         }
 
-        // create trackable connector
-        connector = ConnectorFactory.getTrackableConnector(geocode);
+        setTitle(res.getString(R.string.trackable_touch) + ": " + StringUtils.defaultIfBlank(trackable.getGeocode(), trackable.getName()));
 
-        // Start loading in background
-        getSupportLoaderManager().initLoader(connector.getTrackableLoggingManagerLoaderId(), null, this).forceLoad();
-
-        // Show retrieved infos
-        displayTrackable();
-        init();
-        requestKeyboardForLogging();
-    }
-
-    private void displayTrackable() {
-
-        if (StringUtils.isNotBlank(trackable.getName())) {
-            setTitle(res.getString(R.string.trackable_touch) + ": " + trackable.getName());
-        } else {
-            setTitle(res.getString(R.string.trackable_touch) + ": " + trackable.getGeocode());
+        // Display tracking code if we have, and move cursor next
+        if (trackingCode != null) {
+            trackingEditText.setText(trackingCode);
+            Dialogs.moveCursorToEnd(trackingEditText);
         }
+        init();
+
+        if (waitDialog != null) {
+            waitDialog.dismiss();
+        }
+
+        requestKeyboardForLogging();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/LogTrackableActivity.java
@@ -663,8 +663,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
             final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
             builder.setTitle(R.string.trackable_title_log_without_geocode);
 
-            final Context themedContext;
-            themedContext = Settings.isLightSkin() && VERSION.SDK_INT < VERSION_CODES.HONEYCOMB ? new ContextThemeWrapper(activity, R.style.dark) : activity;
+            final Context themedContext = Settings.isLightSkin() && VERSION.SDK_INT < VERSION_CODES.HONEYCOMB ? new ContextThemeWrapper(activity, R.style.dark) : activity;
 
             final View layout = View.inflate(themedContext, R.layout.logtrackable_without_geocode, null);
             builder.setView(layout);

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -7,8 +7,6 @@ import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.AbstractViewPagerActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
-import cgeo.geocaching.connector.trackable.TrackableConnector;
-import cgeo.geocaching.connector.trackable.TravelBugConnector;
 import cgeo.geocaching.enumerations.LogType;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.models.LogEntry;
@@ -18,7 +16,6 @@ import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.AbstractCachingPageViewCreator;
 import cgeo.geocaching.ui.AnchorAwareLinkMovementMethod;
 import cgeo.geocaching.ui.CacheDetailsCreator;
@@ -29,8 +26,6 @@ import cgeo.geocaching.ui.logs.TrackableLogsViewCreator;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.HtmlUtils;
 import cgeo.geocaching.utils.Log;
-import cgeo.geocaching.utils.AndroidRxUtils;
-import cgeo.geocaching.utils.RxUtils;
 import cgeo.geocaching.utils.UnknownTagsHandler;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -39,15 +34,11 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jdt.annotation.Nullable;
 
-import rx.Observable;
 import rx.Subscription;
 import rx.android.app.AppObservable;
 import rx.android.view.OnClickEvent;
 import rx.android.view.ViewObservable;
 import rx.functions.Action1;
-import rx.functions.Func0;
-import rx.functions.Func1;
-import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
 
@@ -219,7 +210,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
     private void refreshTrackable(final String message) {
         waitDialog = ProgressDialog.show(this, message, res.getString(R.string.trackable_details_loading), true, true);
-        createSubscriptions.add(AppObservable.bindActivity(this, loadTrackable(geocode, guid, id, brand)).singleOrDefault(null).subscribe(new Action1<Trackable>() {
+        createSubscriptions.add(AppObservable.bindActivity(this, ConnectorFactory.loadTrackable(geocode, guid, id, brand)).singleOrDefault(null).subscribe(new Action1<Trackable>() {
             @Override
             public void call(final Trackable trackable) {
                 if (trackable != null && trackingCode != null) {
@@ -271,50 +262,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
         }
         return super.onPrepareOptionsMenu(menu);
     }
-
-    private static Observable<Trackable> loadTrackable(final String geocode, final String guid, final String id, final TrackableBrand brand) {
-        if (StringUtils.isEmpty(geocode)) {
-            // Only solution is GC search by uid
-            return RxUtils.deferredNullable(new Func0<Trackable>() {
-                @Override
-                public Trackable call() {
-                    return TravelBugConnector.getInstance().searchTrackable(geocode, guid, id);
-                }
-            }).subscribeOn(AndroidRxUtils.networkScheduler);
-        }
-
-        // We query all the connectors that can handle the trackable in parallel as well as the local storage.
-        // We return the first positive result coming from a connector, or, if none, the result of loading from
-        // the local storage.
-
-        final Observable<Trackable> fromNetwork =
-                Observable.from(ConnectorFactory.getTrackableConnectors()).filter(new Func1<TrackableConnector, Boolean>() {
-                    @Override
-                    public Boolean call(final TrackableConnector trackableConnector) {
-                        return trackableConnector.canHandleTrackable(geocode, brand);
-                    }
-                }).flatMap(new Func1<TrackableConnector, Observable<Trackable>>() {
-                    @Override
-                    public Observable<Trackable> call(final TrackableConnector trackableConnector) {
-                        return RxUtils.deferredNullable(new Func0<Trackable>() {
-                            @Override
-                            public Trackable call() {
-                                return trackableConnector.searchTrackable(geocode, guid, id);
-                            }
-                        }).subscribeOn(AndroidRxUtils.networkScheduler);
-                    }
-                });
-
-        final Observable<Trackable> fromLocalStorage = RxUtils.deferredNullable(new Func0<Trackable>() {
-            @Override
-            public Trackable call() {
-                return DataStore.loadTrackable(geocode);
-            }
-        }).subscribeOn(Schedulers.io());
-
-        return fromNetwork.concatWith(fromLocalStorage).take(1);
-    }
-
+    
     public void displayTrackable() {
         if (trackable == null) {
             if (waitDialog != null) {

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -114,7 +114,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState, R.layout.viewpager_activity);
+        onCreate(savedInstanceState, R.layout.viewpager_activity);
         createSubscriptions = new CompositeSubscription();
 
         // set title in code, as the activity needs a hard coded title due to the intent filters
@@ -217,11 +217,11 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
         waitDialog = ProgressDialog.show(this, message, res.getString(R.string.trackable_details_loading), true, true);
         createSubscriptions.add(AppObservable.bindActivity(this, ConnectorFactory.loadTrackable(geocode, guid, id, brand)).singleOrDefault(null).subscribe(new Action1<Trackable>() {
             @Override
-            public void call(final Trackable trackable) {
-                if (trackable != null && trackingCode != null) {
-                    trackable.setTrackingcode(trackingCode);
+            public void call(final Trackable newTrackable) {
+                if (newTrackable != null && trackingCode != null) {
+                    newTrackable.setTrackingcode(trackingCode);
                 }
-                TrackableActivity.this.trackable = trackable;
+                trackable = newTrackable;
                 displayTrackable();
                 // reset imagelist
                 imagesList = null;
@@ -428,12 +428,12 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             }
 
             // trackable name
-            final TextView name = details.add(R.string.trackable_name, StringUtils.isNotBlank(trackable.getName()) ? Html.fromHtml(trackable.getName()).toString() : res.getString(R.string.trackable_unknown)).right;
-            addContextMenu(name);
+            final TextView nameTxtView = details.add(R.string.trackable_name, StringUtils.isNotBlank(trackable.getName()) ? Html.fromHtml(trackable.getName()).toString() : res.getString(R.string.trackable_unknown)).right;
+            addContextMenu(nameTxtView);
 
             // missing status
             if (trackable.isMissing()) {
-                name.setPaintFlags(name.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+                nameTxtView.setPaintFlags(nameTxtView.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
             }
 
             // trackable type

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -133,12 +133,12 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             geocache = extras.getString(Intents.EXTRA_GEOCACHE);
             brand = TrackableBrand.getById(extras.getInt(Intents.EXTRA_BRAND));
             trackingCode = extras.getString(Intents.EXTRA_TRACKING_CODE);
-
         }
 
         // try to get data from URI
         if (geocode == null && guid == null && id == null && uri != null) {
             geocode = ConnectorFactory.getTrackableFromURL(uri.toString());
+            trackingCode = ConnectorFactory.getTrackableTrackingCodeFromURL(uri.toString());
 
             final String uriHost = uri.getHost().toLowerCase(Locale.US);
             if (uriHost.endsWith("geocaching.com")) {
@@ -162,6 +162,11 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
                     showToast(res.getString(R.string.err_tb_details_open));
                     finish();
                     return;
+                }
+            } else if (uriHost.endsWith("geokrety.org")) {
+                brand = TrackableBrand.GEOKRETY;
+                if (geocode == null && trackingCode != null) {
+                    geocode = trackingCode;
                 }
             }
         }

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -191,8 +191,13 @@ public final class ConnectorFactory {
 
     @NonNull
     public static TrackableConnector getTrackableConnector(final String geocode) {
+        return getTrackableConnector(geocode, TrackableBrand.UNKNOWN);
+    }
+
+    @NonNull
+    public static TrackableConnector getTrackableConnector(final String geocode, final TrackableBrand brand) {
         for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
-            if (connector.canHandleTrackable(geocode)) {
+            if (connector.canHandleTrackable(geocode, brand)) {
                 return connector;
             }
         }
@@ -283,7 +288,7 @@ public final class ConnectorFactory {
     }
 
     /**
-     * Get trackable's geocode from an URL.
+     * Get trackable geocode from an URL.
      *
      * @return
      *          the geocode, {@code null} if the URL cannot be decoded
@@ -297,6 +302,26 @@ public final class ConnectorFactory {
             final String geocode = connector.getTrackableCodeFromUrl(url);
             if (StringUtils.isNotBlank(geocode)) {
                 return geocode;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get trackable Tracking Code from an URL.
+     *
+     * @return
+     *          the tracking code, {@code null} if the URL cannot be decoded
+     */
+    @Nullable
+    public static String getTrackableTrackingCodeFromURL(final String url) {
+        if (url == null) {
+            return null;
+        }
+        for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
+            final String trackableCode = connector.getTrackableTrackingCodeFromUrl(url);
+            if (StringUtils.isNotBlank(trackableCode)) {
+                return trackableCode;
             }
         }
         return null;

--- a/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
@@ -26,7 +26,6 @@ public abstract class AbstractTrackableConnector implements TrackableConnector {
         return false;
     }
 
-
     @Override
     public boolean canHandleTrackable(@Nullable final String geocode, @Nullable final TrackableBrand brand) {
         if (brand != null && brand != TrackableBrand.UNKNOWN) {
@@ -43,6 +42,12 @@ public abstract class AbstractTrackableConnector implements TrackableConnector {
     @Override
     @Nullable
     public String getTrackableCodeFromUrl(@NonNull final String url) {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public String getTrackableTrackingCodeFromUrl(@NonNull final String url) {
         return null;
     }
 

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -12,6 +12,7 @@ import cgeo.geocaching.network.Network;
 import cgeo.geocaching.network.Parameters;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.Version;
 
@@ -22,6 +23,10 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.xml.sax.InputSource;
 
+import rx.Observable;
+import rx.functions.Func0;
+import rx.functions.Func1;
+
 import android.content.Context;
 
 import java.io.InputStream;
@@ -31,12 +36,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import rx.Observable;
-import rx.functions.Func1;
-
 public class GeokretyConnector extends AbstractTrackableConnector {
 
     private static final Pattern PATTERN_GK_CODE = Pattern.compile("GK[0-9A-F]{4,}");
+    private static final Pattern PATTERN_GK_CODE_EXTENDED = Pattern.compile("(GK[0-9A-F]{4,})|([0-9A-Z]{6})");
     private static final String URL = "http://geokrety.org";
     private static final String URLPROXY = "http://api.geokretymap.org";
 
@@ -48,6 +51,14 @@ public class GeokretyConnector extends AbstractTrackableConnector {
     @Override
     public boolean canHandleTrackable(@Nullable final String geocode) {
         return geocode != null && PATTERN_GK_CODE.matcher(geocode).matches();
+    }
+
+    @Override
+    public boolean canHandleTrackable(@Nullable final String geocode, @Nullable final TrackableBrand brand) {
+        if (brand == null || brand != TrackableBrand.GEOKRETY) {
+            return canHandleTrackable(geocode);
+        }
+        return geocode != null && PATTERN_GK_CODE_EXTENDED.matcher(geocode).matches();
     }
 
     @Override
@@ -74,11 +85,26 @@ public class GeokretyConnector extends AbstractTrackableConnector {
 
     @Nullable
     public static Trackable searchTrackable(final String geocode) {
-        Log.d("GeokretyConnector.searchTrackable: gkid=" + getId(geocode));
+        final Integer gkid;
+
+        if (StringUtils.startsWithIgnoreCase(geocode, "GK")) {
+            gkid = getId(geocode);
+        } else {
+            // This probably a Tracking Code
+            Log.d("GeokretyConnector.searchTrackable: geocode=" + geocode);
+
+            final String geocodeFound = getGeocodeFromTrackingCode(geocode);
+            if (geocodeFound == null) {
+                return null;
+            }
+            gkid = getId(geocodeFound);
+        }
+
+        Log.d("GeokretyConnector.searchTrackable: gkid=" + gkid);
         try {
             final String urlDetails = (Settings.isGeokretyCacheActive() ? URLPROXY + "/export-details.php" : URL + "/export2.php");
 
-            final InputStream response = Network.getResponseStream(Network.getRequest(urlDetails + "?gkid=" + getId(geocode)));
+            final InputStream response = Network.getResponseStream(Network.getRequest(urlDetails + "?gkid=" + gkid));
             if (response == null) {
                 Log.e("GeokretyConnector.searchTrackable: No data from server");
                 return null;
@@ -191,6 +217,41 @@ public class GeokretyConnector extends AbstractTrackableConnector {
             return geocode(Integer.parseInt(gkmapId));
         }
         return null;
+    }
+
+    @Override
+    @Nullable
+    public String getTrackableTrackingCodeFromUrl(@NonNull final String url) {
+        // http://geokrety.org/m/qr.php?nr=<TRACKING_CODE>
+        final String gkTrackingCode = StringUtils.substringAfterLast(url, "qr.php?nr=");
+        if (StringUtils.isAlphanumeric(gkTrackingCode)) {
+            return gkTrackingCode;
+        }
+        return null;
+    }
+
+    /**
+     * Lookup Trackable Geocode from Tracking Code.
+     *
+     * @param trackingCode
+     *          the Trackable Tracking Code to lookup
+     * @return
+     *          the Trackable Geocode
+     */
+    @Nullable
+    public static String getGeocodeFromTrackingCode(final String trackingCode) {
+        return Observable.defer(new Func0<Observable<String>>() {
+            @Override
+            public Observable<String> call() {
+                final Parameters params = new Parameters("nr", trackingCode);
+                final String response = Network.getResponseData(Network.getRequest(URLPROXY + "/nr2id.php", params));
+                // An empty response means "not found"
+                if (response == null || StringUtils.equals(response, "0")) {
+                    return Observable.empty();
+                }
+                return Observable.just(geocode(Integer.parseInt(response)));
+            }
+        }).subscribeOn(AndroidRxUtils.networkScheduler).toBlocking().firstOrDefault(null);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -152,7 +152,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
     @Override
     @NonNull
     public Observable<TrackableLog> trackableLogInventory() {
-        return Observable.from(loadInventory(0)).map(new Func1<Trackable, TrackableLog>() {
+        return Observable.from(loadInventory()).map(new Func1<Trackable, TrackableLog>() {
             @Override
             public TrackableLog call(final Trackable trackable) {
                 return new TrackableLog(

--- a/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
@@ -99,7 +99,16 @@ public interface TrackableConnector {
      * @return the Trackable Geocode.
      */
     @Nullable
-    String getTrackableCodeFromUrl(final @NonNull String url);
+    String getTrackableCodeFromUrl(@NonNull final String url);
+
+    /**
+     * Return a Trackable Tracking Code from an url.
+     *
+     * @param url for one trackable
+     * @return the Trackable Tracking Code, {@code null} if the URL cannot be decoded.
+     */
+    @Nullable
+    String getTrackableTrackingCodeFromUrl(@NonNull final String url);
 
     /**
      * Return available user actions for the trackable.

--- a/main/src/cgeo/geocaching/models/Trackable.java
+++ b/main/src/cgeo/geocaching/models/Trackable.java
@@ -157,7 +157,7 @@ public class Trackable implements ILogable {
     }
 
     public void forceSetBrand(final TrackableBrand trackableBrand) {
-        this.brand = trackableBrand;
+        brand = trackableBrand;
     }
 
     public TrackableBrand getBrand() {
@@ -209,12 +209,7 @@ public class Trackable implements ILogable {
     }
 
     public void setReleased(@Nullable final Date released) {
-        if (released == null) {
-            this.released = null;
-        }
-        else {
-            this.released = new Date(released.getTime()); // avoid storing external reference in this object
-        }
+        this.released = released == null ? null : new Date(released.getTime()); // avoid storing external reference in this object
     }
 
     public float getDistance() {


### PR DESCRIPTION
Follow PR#5168

Code has been rebased.

@samueltardieu I've looked again at the call of `getGeocodeFromTrackingCode()`. The call is from `GeokretyConnector.searchTrackable()` which already deal with network calls. On the other side, `GeokretyConnector.searchTrackable()` is in turn called from inside `AppObservable.bindActivity()` in `TrackableActivity`. So I don't think this function is really problematic. May you please deeper look into this PR?