### PR TITLE
Fix #5377: "refresh all" on "all caches" list

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1462,5 +1462,6 @@
     <string name="pq_as_cache_list">View cache list</string>
     <string name="pq_download_and_import">Import Pocket query</string>
     <string name="pq_my_finds">My finds</string>
-    
+    <string name="caches_refresh_all_warning">This action may lead to high network traffic. Are you sure you want to batch refresh all caches?</string>
+
 </resources>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -659,7 +659,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setVisible(menu, R.id.menu_create_list, isOffline);
 
             setVisible(menu, R.id.menu_sort, !isEmpty && !isHistory);
-            setVisible(menu, R.id.menu_refresh_stored, !isEmpty && (isConcrete || type != CacheListType.OFFLINE));
+            setVisible(menu, R.id.menu_refresh_stored, !isEmpty && isOffline);
             setVisible(menu, R.id.menu_drop_caches, !isEmpty && isOffline);
             setVisible(menu, R.id.menu_delete_events, isConcrete && !isEmpty && containsPastEvents());
             setVisible(menu, R.id.menu_move_to_list, isOffline && !isEmpty);
@@ -743,8 +743,14 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 invalidateOptionsMenuCompatible();
                 return true;
             case R.id.menu_refresh_stored:
-                refreshStored(adapter.getCheckedOrAllCaches());
-                invalidateOptionsMenuCompatible();
+                Dialogs.confirmYesNo(this, R.string.caches_refresh_all, R.string.caches_refresh_all_warning, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(final DialogInterface dialog, final int id) {
+                        refreshStored(adapter.getCheckedOrAllCaches());
+                        invalidateOptionsMenuCompatible();
+                        dialog.cancel();
+                    }
+                });
                 return true;
             case R.id.menu_drop_caches:
                 deleteCachesWithConfirmation();


### PR DESCRIPTION
As discussed in Issue #5377 I enabled the "refresh all" menu item on the "all caches" list.
I added a Dialog with a warning, that this might cause high network traffic. The same Dialog applies for concrete Lists.