### PR TITLE
Improve usability of pq download activity

### DIFF
--- a/main/res/layout/pocketquery_item.xml
+++ b/main/res/layout/pocketquery_item.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pocketquery_item"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:layout_margin="3dip"
     android:background="?background_color"
-    android:orientation="vertical"
     android:paddingBottom="7dip"
     android:paddingLeft="5dip"
     android:paddingRight="5dip"
     android:paddingTop="7dip"
-    tools:context=".ui.PocketQueryListAdapter" >
+    tools:context=".ui.PocketQueryListAdapter">
 
     <TextView
         android:id="@+id/label"
@@ -23,7 +22,17 @@
         android:singleLine="false"
         android:textColor="?text_color"
         android:textIsSelectable="false"
-        android:textSize="22sp" />
+        android:textSize="22sp"
+        android:layout_alignParentLeft="true"/>
+
+    <Button
+        android:id="@+id/download"
+        android:layout_width="96dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:background="@android:color/transparent"
+        android:drawableRight="@drawable/ic_menu_save"
+        android:gravity="right|center_vertical" />
 
     <TextView
         android:id="@+id/caches"
@@ -36,6 +45,8 @@
         android:singleLine="true"
         android:textColor="?text_color"
         android:textIsSelectable="false"
-        android:textSize="12sp" />
+        android:textSize="12sp"
+        android:layout_below="@id/label"
+        android:layout_alignParentLeft="true"/>
 
-</LinearLayout>
+</RelativeLayout>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1588,38 +1588,22 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         context.startActivity(cachesIntent);
     }
 
+    public static void startActivityPocketDownload(final @NonNull Activity context, final @NonNull PocketQuery pocketQuery) {
+        final String guid = pocketQuery.getGuid();
+        if (guid == null) {
+            ActivityMixin.showToast(context, CgeoApplication.getInstance().getString(R.string.warn_pocket_query_select));
+            return;
+        }
+        startActivityWithAttachment(context, pocketQuery);
+    }
+
     public static void startActivityPocket(final @NonNull Activity context, final @NonNull PocketQuery pocketQuery) {
         final String guid = pocketQuery.getGuid();
         if (guid == null) {
             ActivityMixin.showToast(context, CgeoApplication.getInstance().getString(R.string.warn_pocket_query_select));
             return;
         }
-        if (pocketQuery.isDownloadable()) {
-            // ask user to import pq or view cache list
-            final AlertDialog.Builder dialog = new AlertDialog.Builder(context);
-            dialog.setTitle(CgeoApplication.getInstance().getString(R.string.pq_available_for_download));
-            dialog.setMessage(CgeoApplication.getInstance().getString(R.string.pq_available_for_download_description));
-            dialog.setCancelable(true);
-            dialog.setNegativeButton(CgeoApplication.getInstance().getString(R.string.pq_as_cache_list), new DialogInterface.OnClickListener() {
-
-                @Override
-                public void onClick(final DialogInterface dialog, final int id) {
-                    startActivityPocket(context, pocketQuery, CacheListType.POCKET);
-                }
-            });
-            dialog.setPositiveButton(CgeoApplication.getInstance().getString(R.string.pq_download_and_import), new DialogInterface.OnClickListener() {
-
-                @Override
-                public void onClick(final DialogInterface dialog, final int id) {
-                    startActivityWithAttachment(context, pocketQuery);
-                }
-            });
-
-            final AlertDialog alert = dialog.create();
-            alert.show();
-        } else {
-            startActivityPocket(context, pocketQuery, CacheListType.POCKET);
-        }
+        startActivityPocket(context, pocketQuery, CacheListType.POCKET);
     }
 
     private static void startActivityWithAttachment(final @NonNull Activity context, final @NonNull PocketQuery pocketQuery) {

--- a/main/src/cgeo/geocaching/connector/gc/PocketQueryListAdapter.java
+++ b/main/src/cgeo/geocaching/connector/gc/PocketQueryListAdapter.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.TextView;
 
 import butterknife.Bind;
@@ -24,6 +25,7 @@ public class PocketQueryListAdapter extends ArrayAdapter<PocketQuery> {
     protected static final class ViewHolder extends AbstractViewHolder {
         @Bind(R.id.label) protected TextView label;
         @Bind(R.id.caches) protected TextView caches;
+        @Bind(R.id.download) protected Button download;
 
         public ViewHolder(final View view) {
             super(view);
@@ -50,8 +52,7 @@ public class PocketQueryListAdapter extends ArrayAdapter<PocketQuery> {
             holder = (ViewHolder) view.getTag();
         }
 
-        view.setOnClickListener(new View.OnClickListener() {
-
+        holder.label.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
                 final Activity activity = (Activity) v.getContext();
@@ -59,12 +60,22 @@ public class PocketQueryListAdapter extends ArrayAdapter<PocketQuery> {
             }
         });
 
+        holder.download.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(final View v) {
+                final Activity activity = (Activity) v.getContext();
+                CacheListActivity.startActivityPocketDownload(activity, pocketQuery);
+            }
+        });
+        holder.download.setVisibility(pocketQuery.isDownloadable()?View.VISIBLE:View.INVISIBLE);
+
         holder.label.setText(pocketQuery.getName());
-        holder.label.setCompoundDrawablesWithIntrinsicBounds(pocketQuery.getIcon(), 0, 0, 0);
+        holder.label.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_menu_info_details, 0, 0, 0);
         final int caches = pocketQuery.getMaxCaches();
         holder.caches.setText(caches >= 0 ? CgeoApplication.getInstance().getResources().getQuantityString(R.plurals.cache_counts, caches, caches) : StringUtils.EMPTY);
 
         return view;
     }
+
 
 }

--- a/main/src/cgeo/geocaching/models/PocketQuery.java
+++ b/main/src/cgeo/geocaching/models/PocketQuery.java
@@ -34,12 +34,4 @@ public final class PocketQuery {
         return name;
     }
 
-    @DrawableRes
-    public int getIcon() {
-        if (isDownloadable()) {
-            return R.drawable.ic_menu_save;
-        }
-        return R.drawable.ic_menu_info_details;
-    }
-
 }


### PR DESCRIPTION
According to the comment from @Bananeweizen at #4267 I made use of the new PocketQueryListActivity to get rid of the awkward dialog.
I made the download icon appear on the right side of the list item, if the pq is downloadable.
A click on the rest of the list item shows the cache list as before. 
No need for the extra dialog anymore.