### PR TITLE
Fix 5396: removed popup for "store Offline"

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -743,14 +743,19 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 invalidateOptionsMenuCompatible();
                 return true;
             case R.id.menu_refresh_stored:
-                Dialogs.confirmYesNo(this, R.string.caches_refresh_all, R.string.caches_refresh_all_warning, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(final DialogInterface dialog, final int id) {
-                        refreshStored(adapter.getCheckedOrAllCaches());
-                        invalidateOptionsMenuCompatible();
-                        dialog.cancel();
-                    }
-                });
+                if (type == CacheListType.OFFLINE) {
+                    Dialogs.confirmYesNo(this, R.string.caches_refresh_all, R.string.caches_refresh_all_warning, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(final DialogInterface dialog, final int id) {
+                            refreshStored(adapter.getCheckedOrAllCaches());
+                            invalidateOptionsMenuCompatible();
+                            dialog.cancel();
+                        }
+                    });
+                } else {
+                    refreshStored(adapter.getCheckedOrAllCaches());
+                    invalidateOptionsMenuCompatible();
+                }
                 return true;
             case R.id.menu_drop_caches:
                 deleteCachesWithConfirmation();


### PR DESCRIPTION
Fix for #5396.
Sorry I overlooked this case when implementing the refresh All. The menu item "refresh all" is reused for "store offline".
