### PR TITLE
Fixed #5366: add ID to own-waypoints prefix

### DIFF
--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -82,7 +82,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
 
     private ProgressDialog waitDialog = null;
     private Waypoint waypoint = null;
-    private String prefix = "OWN";
+    private String prefix = "";
     private String lookup = "---";
     private boolean own = true;
     List<String> distanceUnits = null;

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -142,11 +142,12 @@ public class Waypoint implements IWaypoint {
         return cachedOrder;
     }
 
+    @NonNull
     public String getPrefix() {
         return prefix;
     }
 
-    public void setPrefix(final String prefix) {
+    public void setPrefix(final @NonNull String prefix) {
         this.prefix = prefix;
         cachedOrder = ORDER_UNDEFINED;
     }

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -201,7 +201,7 @@ public final class Formatter {
         if (waypointType != WaypointType.OWN && waypointType != null) {
             infos.add(waypointType.getL10n());
         }
-        if (Waypoint.PREFIX_OWN.equalsIgnoreCase(waypoint.getPrefix())) {
+        if (waypoint.isUserDefined()) {
             infos.add(CgeoApplication.getInstance().getString(R.string.waypoint_custom));
         } else {
             if (StringUtils.isNotBlank(waypoint.getPrefix())) {


### PR DESCRIPTION
Merging new and existing waypoints needs a unique waypoint prefix. 