### PR TITLE
fix #5472: error reading pq list, when no downloads available

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -1079,7 +1079,15 @@ public final class GCParser {
             }
 
             final Elements cells = row.select("td");
+            if (cells.size() < 6) {
+                Log.d("GCParser.getDownloadablePocketQueries: less then 6 table cells, looks like an empty table");
+                continue;
+            }
             final Element link = cells.get(2).select("a").first();
+            if (link == null) {
+                Log.w("GCParser.getDownloadablePocketQueries: Downloadlink not found");
+                continue;
+            }
             final String name = link.text();
             final String href = link.attr("href");
             final Uri uri = Uri.parse(href);


### PR DESCRIPTION
Handling of empty download PQ table. Checking available table cells and download link.

I don't have an empty download table at the moment. If someone is able to double check, would be good.