### PR TITLE
fix #5483: show geotagged images on map

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -288,6 +288,8 @@ dependencies {
  */
     compile 'org.jsoup:jsoup:1.8.3'
 
+    compile 'com.drewnoakes:metadata-extractor:2.8.1'
+
 }
 
 /*

--- a/main/res/layout/image_item.xml
+++ b/main/res/layout/image_item.xml
@@ -1,9 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/map_image"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:gravity="center"
-    tools:context=".ui.ImagesList" />
+    android:layout_height="wrap_content">
+
+    <ImageView
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/map_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        tools:context=".ui.ImagesList" />
+
+    <ImageView
+        android:id="@+id/geo_overlay"
+        android:src="@drawable/ic_menu_compass"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        android:layout_alignParentBottom="true"/>
+
+</RelativeLayout>

--- a/main/src/cgeo/geocaching/ui/ImagesList.java
+++ b/main/src/cgeo/geocaching/ui/ImagesList.java
@@ -2,10 +2,16 @@ package cgeo.geocaching.ui;
 
 import butterknife.ButterKnife;
 
+import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
+import cgeo.geocaching.apps.navi.NavigationAppFactory;
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Image;
+import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 
 import org.apache.commons.io.IOUtils;
@@ -35,9 +41,19 @@ import android.view.View;
 import android.webkit.MimeTypeMap;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.lang.GeoLocation;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.Tag;
+import com.drew.metadata.exif.GpsDirectory;
+
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -121,7 +137,7 @@ public class ImagesList {
                 descView.setVisibility(View.VISIBLE);
             }
 
-            final ImageView imageView = (ImageView) inflater.inflate(R.layout.image_item, rowView, false);
+            final RelativeLayout imageView = (RelativeLayout) inflater.inflate(R.layout.image_item, rowView, false);
             assert imageView != null;
             subscriptions.add(AppObservable.bindActivity(activity, imgGetter.fetchDrawable(img.getUrl())).subscribe(new Action1<BitmapDrawable>() {
                 @Override
@@ -136,7 +152,8 @@ public class ImagesList {
         return subscriptions;
     }
 
-    private void display(final ImageView imageView, final BitmapDrawable image, final Image img, final LinearLayout view) {
+    private void display(final RelativeLayout imageViewLayout, final BitmapDrawable image, final Image img, final LinearLayout view) {
+        final ImageView imageView = (ImageView)imageViewLayout.findViewById(R.id.map_image);
         if (image != null) {
             bitmaps.add(image.getBitmap());
 
@@ -153,14 +170,57 @@ public class ImagesList {
             activity.registerForContextMenu(imageView);
             imageView.setImageDrawable(image);
             imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
-            imageView.setLayoutParams(new LinearLayout.LayoutParams(bounds.width(), bounds.height()));
+            imageView.setLayoutParams(new RelativeLayout.LayoutParams(bounds.width(), bounds.height()));
 
             view.findViewById(R.id.progress_bar).setVisibility(View.GONE);
 
             imageView.setId(image.hashCode());
+            addGeoOverlay(imageViewLayout, img);
             images.put(imageView.getId(), img);
 
             view.invalidate();
+        }
+    }
+
+    private void addGeoOverlay(final RelativeLayout imageViewLayout, final Image img) {
+        try {
+            final File file = LocalStorage.getStorageFile(geocode, img.getUrl(), true, false);
+            final Metadata metadata = ImageMetadataReader.readMetadata(file);
+            final Collection<GpsDirectory> gpsDirectories = metadata.getDirectoriesOfType(GpsDirectory.class);
+            if (gpsDirectories == null) {
+                return;
+            }
+
+            for (final GpsDirectory gpsDirectory : gpsDirectories) {
+                // Try to read out the location, making sure it's non-zero
+                final GeoLocation geoLocation = gpsDirectory.getGeoLocation();
+                if (geoLocation != null && !geoLocation.isZero()) {
+                    final ImageView geoOverlay = (ImageView) imageViewLayout.findViewById(R.id.geo_overlay);
+                    geoOverlay.setVisibility(View.VISIBLE);
+                    geoOverlay.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(final View wpNavView) {
+                            final Geopoint gpt = new Geopoint(geoLocation.getLatitude(), geoLocation.getLongitude());
+                            wpNavView.setOnClickListener(new View.OnClickListener() {
+                                @Override
+                                public void onClick(final View v) {
+                                    NavigationAppFactory.startDefaultNavigationApplication(1, activity, gpt);
+                                }
+                            });
+                            wpNavView.setOnLongClickListener(new View.OnLongClickListener() {
+                                @Override
+                                public boolean onLongClick(final View v) {
+                                    NavigationAppFactory.startDefaultNavigationApplication(2, activity, gpt);
+                                    return true;
+                                }
+                            });
+                        }
+                    });
+                    break; // add only the first found geoLocation
+                }
+            }
+        } catch (final Exception e) {
+            Log.e("ImagesList.addGeoOverlay", e);
         }
     }
 


### PR DESCRIPTION
Added an Overlay to the images in the Cachlisting "images" tab if coordinates are available in the image.
Added onClick() and onLongClick() handler to start Navigation.

Unfortunately the Images are parsed twice (first to create the Bitmap and later to read the Exif data). I don't know if this is a problem. I couldn't recognize longer loading times on my device. 
Please test on yours.
If it's a problem maybe we should add a preference to turn it on and off.
