### PR TITLE
do not merge - Add maven central as a repository for gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ apply plugin: 'idea'
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
This is a test for CI

```
22:41:37  FAILURE: Build failed with an exception.
22:41:37  
22:41:37  * What went wrong:
22:41:37  A problem occurred configuring project ':main'.
22:41:37  > Could not resolve all dependencies for configuration ':main:_nojitRcCompile'.
22:41:37     > Could not find com.android.support:appcompat-v7:20.0.0.
22:41:37       Searched in the following locations:
22:41:37           https://jcenter.bintray.com/com/android/support/appcompat-v7/20.0.0/appcompat-v7-20.0.0.pom
22:41:37           https://jcenter.bintray.com/com/android/support/appcompat-v7/20.0.0/appcompat-v7-20.0.0.jar
22:41:37           file:/opt/android-sdk-linux/extras/android/m2repository/com/android/support/appcompat-v7/20.0.0/appcompat-v7-20.0.0.pom
22:41:37           file:/opt/android-sdk-linux/extras/android/m2repository/com/android/support/appcompat-v7/20.0.0/appcompat-v7-20.0.0.jar
22:41:37           file:/opt/android-sdk-linux/extras/google/m2repository/com/android/support/appcompat-v7/20.0.0/appcompat-v7-20.0.0.pom
22:41:37           file:/opt/android-sdk-linux/extras/google/m2repository/com/android/support/appcompat-v7/20.0.0/appcompat-v7-20.0.0.jar
22:41:37       Required by:
22:41:37           cgeo continuous integration:main:unspecified
```