### PR TITLE
fix #5490: fix selection for LinkMovement enabled TextView

### DIFF
--- a/main/src/cgeo/geocaching/ui/AnchorAwareLinkMovementMethod.java
+++ b/main/src/cgeo/geocaching/ui/AnchorAwareLinkMovementMethod.java
@@ -1,8 +1,14 @@
 package cgeo.geocaching.ui;
 
+import android.support.annotation.NonNull;
+import android.text.Layout;
+import android.text.Selection;
 import android.text.Spannable;
 import android.text.method.LinkMovementMethod;
+import android.text.method.Touch;
+import android.text.style.ClickableSpan;
 import android.view.MotionEvent;
+import android.view.View;
 import android.widget.TextView;
 
 /**
@@ -28,10 +34,53 @@ public class AnchorAwareLinkMovementMethod extends LinkMovementMethod {
     @Override
     public boolean onTouchEvent(final TextView widget, final Spannable buffer, final MotionEvent event) {
         try {
-            return super.onTouchEvent(widget, buffer, event);
+            final int action = event.getAction();
+
+            if (action == MotionEvent.ACTION_UP ||
+                    action == MotionEvent.ACTION_DOWN) {
+                int x = (int) event.getX();
+                int y = (int) event.getY();
+
+                x -= widget.getTotalPaddingLeft();
+                y -= widget.getTotalPaddingTop();
+
+                x += widget.getScrollX();
+                y += widget.getScrollY();
+
+                final Layout layout = widget.getLayout();
+                final int line = layout.getLineForVertical(y);
+                final int off = layout.getOffsetForHorizontal(line, x);
+
+                final ClickableSpan[] link = buffer.getSpans(off, off, ClickableSpan.class);
+
+                if (link.length != 0) {
+                    if (action == MotionEvent.ACTION_UP) {
+                        link[0].onClick(widget);
+                    } else {
+                        Selection.setSelection(buffer,
+                                buffer.getSpanStart(link[0]),
+                                buffer.getSpanEnd(link[0]));
+                    }
+                    return true;
+                }
+            }
+
+            return Touch.onTouchEvent(widget, buffer, event);
         } catch (final Exception ignored) {
             // local links to anchors don't work
         }
         return false;
+    }
+
+    @Override
+    public void onTakeFocus(TextView view, @NonNull Spannable text, int dir) {
+        if ((dir & (View.FOCUS_FORWARD | View.FOCUS_DOWN)) != 0) {
+            if (view.getLayout() == null) {
+                // This shouldn't be null, but do something sensible if it is.
+                Selection.setSelection(text, text.length());
+            }
+        } else {
+            Selection.setSelection(text, text.length());
+        }
     }
 }


### PR DESCRIPTION
same fix, now based on release branch. Also removed the no longer needed workaround.