### PR TITLE
Remove superfluous try block.

### DIFF
--- a/main/src/cgeo/geocaching/maps/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/CachesOverlay.java
@@ -273,13 +273,7 @@ public class CachesOverlay extends AbstractItemizedOverlay {
 
     @Override
     public int size() {
-        try {
-            return items.size();
-        } catch (final Exception e) {
-            Log.e("CachesOverlay.size", e);
-        }
-
-        return 0;
+        return items.size();
     }
 
     private class RequestDetailsThread extends Thread {


### PR DESCRIPTION
The only possible exception is a NullPointerException but items is never null.