### PR TITLE
fix #5371: dialogs out of shape on MainActivity

### DIFF
--- a/main/res/values-v19/themes.xml
+++ b/main/res/values-v19/themes.xml
@@ -3,7 +3,6 @@
     <style name="cgeo_main" parent="cgeo_main.base">
 
         <!-- KitKat's transparent navigation -->
-        <item name="android:fitsSystemWindows">true</item>
         <item name="android:windowTranslucentNavigation">true</item>
     </style>
 </resources>


### PR DESCRIPTION
The attribute android:fitsSystemWindows="true" for the MainActivity styles was the culprit.

See:
https://stackoverflow.com/questions/26599805/android-alert-dialog-not-styled-properly-on-lollipop

I can't see any problems after removing this attribute. I'm on Android 5.1. Should be tested with older versions, too.