### PR TITLE
fix #5614: main activity covering soft buttons

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -5,6 +5,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:layout_gravity="center"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity" >
 
     <fragment


### PR DESCRIPTION
I had removed the `android:fitsSystemWindows="true"` from the styles file in #5594 to fix the dialogs on MainActivity.
On my device with hardware buttons I couldn't see any drawback without this attribute.
In the [link here](https://stackoverflow.com/questions/26599805/android-alert-dialog-not-styled-properly-on-lollipop) it was mentioned that this attribute might be needed at the layout.xml file. 
So I tried to put it there and tested on Emulator with a device with soft buttons.
It seems to fix this issue.