### PR TITLE
Improves #5536, partly reverts #4633

### DIFF
--- a/main/src/cgeo/geocaching/enumerations/LoadFlags.java
+++ b/main/src/cgeo/geocaching/enumerations/LoadFlags.java
@@ -24,9 +24,9 @@ public interface LoadFlags {
     /** Retrieve cache from CacheCache only. Do not load from DB */
     EnumSet<LoadFlag> LOAD_CACHE_ONLY = EnumSet.of(LoadFlag.CACHE_BEFORE);
     /** Retrieve cache from CacheCache first. If not found load from DB */
-    EnumSet<LoadFlag> LOAD_CACHE_OR_DB = EnumSet.of(LoadFlag.CACHE_BEFORE, LoadFlag.DB_MINIMAL, LoadFlag.OFFLINE_LOG, LoadFlag.SPOILERS);
+    EnumSet<LoadFlag> LOAD_CACHE_OR_DB = EnumSet.of(LoadFlag.CACHE_BEFORE, LoadFlag.DB_MINIMAL, LoadFlag.OFFLINE_LOG);
     /** Retrieve cache (minimalistic information including waypoints) from DB first. If not found load from CacheCache */
-    EnumSet<LoadFlag> LOAD_WAYPOINTS = EnumSet.of(LoadFlag.CACHE_AFTER, LoadFlag.DB_MINIMAL, LoadFlag.WAYPOINTS, LoadFlag.OFFLINE_LOG, LoadFlag.SPOILERS);
+    EnumSet<LoadFlag> LOAD_WAYPOINTS = EnumSet.of(LoadFlag.CACHE_AFTER, LoadFlag.DB_MINIMAL, LoadFlag.WAYPOINTS, LoadFlag.OFFLINE_LOG);
     /** Retrieve cache (all stored informations) from DB only. Do not load from CacheCache */
     EnumSet<LoadFlag> LOAD_ALL_DB_ONLY = EnumSet.range(LoadFlag.DB_MINIMAL, LoadFlag.OFFLINE_LOG);
 

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1250,6 +1250,10 @@ public class Geocache implements IWaypoint {
         this.spoilers = spoilers;
     }
 
+    public boolean hasSpoilersSet() {
+        return this.spoilers != null;
+    }
+
     public void setLogCounts(final Map<LogType, Integer> logCounts) {
         this.logCounts = logCounts;
     }


### PR DESCRIPTION
Removed the LoadFlag.SPOILERS which were introduced in #4633 and causing performance issues in #5536. 
While debugging the Issue #4633 I realized that the Cache was saved twice in the DB. And the second time there were no Spoilers. The code in `DataStore.saveSpoilersWithoutTransaction()` first deletes all existing Spoilers and then inserts the new ones. 
Now I don't delete Spoilers when the Cache currently beeing saved doesn't contain Spoilers (assuming it was not properly loaded). So the Spoilers are kept in the DB and properly loaded in the last Step when the CacheDetailsActivity is loaded again.
One possible downside might be that when the Spoilers where removed completely from geocaching.com and the Cache is refreshed. Then we would keep the old Spoiler(s). 