### PR TITLE
Fix watchdog tests for gc.com

### DIFF
--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -172,6 +172,12 @@ public abstract class AbstractConnector implements IConnector {
     }
 
     @Override
+    @NonNull
+    public String getTestUrl() {
+        return getHostUrl();
+    }
+
+    @Override
     @Nullable
     public String getLongCacheUrl(final @NonNull Geocache cache) {
         return getCacheUrl(cache);

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -112,6 +112,13 @@ public interface IConnector {
     String getHostUrl();
 
     /**
+     * Get url to use when testing website availability (because host url may redirect)
+     *
+     */
+    @NonNull
+    String getTestUrl();
+
+    /**
      * Get cache data license text. This is displayed somewhere near the cache details.
      *
      */

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -153,6 +153,12 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    @NonNull
+    public String getTestUrl() {
+        return "https://" + getHost() + "/play";
+    }
+
+    @Override
     public SearchResult searchByGeocode(final @Nullable String geocode, final @Nullable String guid, final CancellableHandler handler) {
 
         CancellableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_loadpage);

--- a/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/AbstractTrackableConnector.java
@@ -70,6 +70,12 @@ public abstract class AbstractTrackableConnector implements TrackableConnector {
     }
 
     @Override
+    @NonNull
+    public String getTestUrl() {
+        return getHostUrl();
+    }
+
+    @Override
     @Nullable
     public String getProxyUrl() {
         return null;

--- a/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TrackableConnector.java
@@ -200,6 +200,13 @@ public interface TrackableConnector {
     String getHostUrl();
 
     /**
+     * Get url to use when testing website availability (because host url may redirect)
+     *
+     */
+    @NonNull
+    String getTestUrl();
+
+    /**
      * Get proxy url name of the connector server, if any, for dynamic loading of data.
      * Contains scheme.
      */

--- a/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -126,4 +126,10 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     public String getHost() {
         return "www.geocaching.com";
     }
+
+    @Override
+    @NonNull
+    public String getTestUrl() {
+        return "https://" + getHost() + "/play";
+    }
 }

--- a/tests/src-android/cgeo/watchdog/WatchdogTest.java
+++ b/tests/src-android/cgeo/watchdog/WatchdogTest.java
@@ -79,7 +79,7 @@ public class WatchdogTest extends CGeoTestCase {
     public static void testTrackableWebsites() {
         for (final TrackableConnector trackableConnector : ConnectorFactory.getTrackableConnectors()) {
             if (!trackableConnector.equals(ConnectorFactory.UNKNOWN_TRACKABLE_CONNECTOR)) {
-                checkWebsite("trackable website " + trackableConnector.getHost(), trackableConnector.getHostUrl());
+                checkWebsite("trackable website " + trackableConnector.getHost(), trackableConnector.getTestUrl());
                 if (StringUtils.isNotBlank(trackableConnector.getProxyUrl())) {
                     checkWebsite("trackable website " + trackableConnector.getHost() + " proxy " + trackableConnector.getProxyUrl(), trackableConnector.getProxyUrl());
                 }
@@ -91,7 +91,7 @@ public class WatchdogTest extends CGeoTestCase {
     public static void testGeocachingWebsites() {
         for (final IConnector connector : ConnectorFactory.getConnectors()) {
             if (!connector.equals(ConnectorFactory.UNKNOWN_CONNECTOR)) {
-                checkWebsite("geocaching website " + connector.getName(), connector.getHostUrl());
+                checkWebsite("geocaching website " + connector.getName(), connector.getTestUrl());
             }
         }
     }


### PR DESCRIPTION
Introduce a special test url, which does not redirect

there might be better possibilities, therefore as a PR