### PR TITLE
upgrade support annotations to 23.3.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -292,8 +292,8 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.5'
 
     // enforce same version of the support annotations for the main app and the test app
-    compile 'com.android.support:support-annotations:23.2.1'
-    androidTestCompile 'com.android.support:support-annotations:23.2.1'
+    compile 'com.android.support:support-annotations:23.3.0'
+    androidTestCompile 'com.android.support:support-annotations:23.3.0'
 
     // Junit only needed for local unit tests
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
We need to upgrade to a recent version of the annotations. Butterknife 8.0.0 requires them transitively.

Creating a PR instead of normal commit, since I'm not sure if our slaves can handle the upgrade.