### PR TITLE
fix #5483 'add waypoint' context menu for geotagged images

### DIFF
--- a/main/res/menu/images_list_context.xml
+++ b/main/res/menu/images_list_context.xml
@@ -13,6 +13,12 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
+        android:id="@+id/image_add_waypoint"
+        android:title="@string/cache_image_add_waypoint"
+        app:showAsAction="ifRoom|withText"
+        android:visible="false">
+    </item>
+    <item
         android:id="@+id/menu_navigate"
         android:icon="@drawable/ic_menu_goto"
         android:title="@string/cache_menu_navigate"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -895,6 +895,7 @@
     <string name="cache_image">Image</string>
     <string name="cache_image_open_file">Open as file</string>
     <string name="cache_image_open_browser">Open in browser</string>
+    <string name="cache_image_add_waypoint">Add waypoint</string>
     <string name="cache_share_field">Share</string>
     <string name="cache_time_full_hours">o\'clock</string>
     <string name="cache_listed_on">Listed on %s</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -790,7 +790,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         @Override
         public void onReceive(final Context context, final Intent intent) {
-            notifyDataSetChanged();
+            if (intent.getBooleanExtra(Intents.EXTRA_WPT_PAGE_UPDATE, false)) {
+                getViewCreator(Page.WAYPOINTS).notifyDataSetChanged();
+            } else {
+                notifyDataSetChanged();
+            }
         }
     };
 
@@ -836,7 +840,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (imageView == null) {
             return;
         }
-        imagesList = new ImagesList(this, cache.getGeocode());
+        imagesList = new ImagesList(this, cache.getGeocode(), cache);
         createSubscriptions.add(imagesList.loadImages(imageView, cache.getImages()));
     }
 

--- a/main/src/cgeo/geocaching/ImagesActivity.java
+++ b/main/src/cgeo/geocaching/ImagesActivity.java
@@ -50,7 +50,7 @@ public class ImagesActivity extends AbstractActionBarActivity {
         setContentView(R.layout.images_activity);
         setTitle(res.getString(imgType.getTitle()));
 
-        imagesList = new ImagesList(this, geocode);
+        imagesList = new ImagesList(this, geocode, null);
 
         imageNames = extras.getParcelableArrayList(Intents.EXTRA_IMAGES);
         if (CollectionUtils.isEmpty(imageNames)) {

--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -36,6 +36,7 @@ public class Intents {
     public static final String EXTRA_LIST_ID = PREFIX + "list_id";
     public static final String EXTRA_COORD_DESCRIPTION = PREFIX + "coord_description";
     public static final String EXTRA_SCALE = PREFIX + "scale";
+    public static final String EXTRA_WPT_PAGE_UPDATE = PREFIX + "wpt_page_update";
 
     public static final String EXTRA_WPTTYPE = PREFIX + "wpttype";
     public static final String EXTRA_MAPSTATE = PREFIX + "mapstate";

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -379,7 +379,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
         if (imageView == null) {
             return;
         }
-        imagesList = new ImagesList(this, trackable.getGeocode());
+        imagesList = new ImagesList(this, trackable.getGeocode(), null);
         createSubscriptions.add(imagesList.loadImages(imageView, trackable.getImages()));
     }
 


### PR DESCRIPTION
Geotagged images on the CacheDetailsActivity Images Page have now a new context menu entry "Add waypoint" which adds a new waypoint with the name of the image and its coordinates.