### PR TITLE
fix #5643 share cache "See all" opens Navigation to Locus

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -627,10 +627,12 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 ensureSaved();
                 editPersonalNote(cache, this);
                 return true;
-            default:
+            case R.id.menu_navigate:
                 if (NavigationAppFactory.onMenuItemSelected(item, this, cache)) {
                     return true;
                 }
+                break;
+            default:
                 if (LoggingUI.onMenuItemSelected(item, this, cache)) {
                     refreshOnResume = true;
                     return true;


### PR DESCRIPTION
In `CacheDetailActivity.onOptionsItemSelected()` several submenus are handled. 
Unfortunately the Sharing Submenu "See all" menu entry had the same Id as the Navigation Submenu "Locus". So Locus Navigation was triggered whenever "See all" was selected in "Share cache".

I don't know why the `NavigationAppFactory.onMenuItemSelected()` was handled in the "default" section of the switch, but I moved it to it's own case, so it's not triggered on other menus.

Issue #5644 is related, but unfortunately not completely fixed by this PR. Locus can now be selected as share target, but it opens an empty Address search Dialog. Other share targets work properly. I guess Locus doesn't understand our text Intent.