### PR TITLE
fix #5701 manage lists when "Ask for List" is disabled

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -903,7 +903,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             return;
         }
 
-        if (Settings.getChooseList()) {
+        if (Settings.getChooseList() || cache.isOffline()) {
             // let user select list to store cache in
             new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title,
                     new Action1<Set<Integer>>() {

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -150,7 +150,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
                 return;
             }
 
-            if (Settings.getChooseList()) {
+            if (Settings.getChooseList() || cache.isOffline()) {
                 // let user select list to store cache in
                 new StoredList.UserInterface(getActivity()).promptForMultiListSelection(R.string.lists_title,
                         new Action1<Set<Integer>>() {


### PR DESCRIPTION
Opening the List selection dialog when "manage" lists button is clicked even though in Settings "Ask for list" is disabled.