### PR TITLE
Let user confirm "needs maintenance" logs

### DIFF
--- a/main/src/cgeo/geocaching/enumerations/LogType.java
+++ b/main/src/cgeo/geocaching/enumerations/LogType.java
@@ -156,7 +156,7 @@ public enum LogType {
      * @return True if user must confirm Log
      */
     public boolean mustConfirmLog() {
-        return isArchiveLog();
+        return isArchiveLog() || this == NEEDS_MAINTENANCE;
     }
 
     /**


### PR DESCRIPTION
This imitates the behavior of the geocaching.com website
that asks the user to confirm "needs maintenance" logs.