### PR TITLE
Fix #5734: Do not show archived caches when filtering for disabled ones

### DIFF
--- a/main/src/cgeo/geocaching/filter/StateFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/StateFilterFactory.java
@@ -236,7 +236,7 @@ class StateFilterFactory implements IFilterFactory {
 
         @Override
         public boolean accepts(@NonNull final Geocache cache) {
-            return cache.isDisabled();
+            return cache.isDisabled() && !cache.isArchived();
         }
 
         public static final Creator<StateDisabledFilter> CREATOR

--- a/tests/src-android/cgeo/geocaching/filter/StateDisabledFilterTest.java
+++ b/tests/src-android/cgeo/geocaching/filter/StateDisabledFilterTest.java
@@ -10,6 +10,7 @@ public class StateDisabledFilterTest extends TestCase {
 
     private StateFilterFactory.StateDisabledFilter disabledFilter;
     private Geocache disabledCache;
+    private Geocache archivedCache;
 
     @Override
     protected void setUp() throws Exception {
@@ -18,10 +19,15 @@ public class StateDisabledFilterTest extends TestCase {
         disabledFilter = new StateFilterFactory.StateDisabledFilter();
         disabledCache = new Geocache();
         disabledCache.setDisabled(true);
+
+        archivedCache = new Geocache();
+        archivedCache.setArchived(true);
+        archivedCache.setDisabled(true);
     }
 
     public void testAccepts() {
         assertThat(disabledFilter.accepts(disabledCache)).isTrue();
+        assertThat(disabledFilter.accepts(archivedCache)).isFalse();
         assertThat(disabledFilter.accepts(new Geocache())).isFalse();
     }
 


### PR DESCRIPTION
I currently cannot test the patch on emulator/device but I hope the fix is quite obvious.