### PR TITLE
fix #5683 update waypoints after personal note change

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2361,7 +2361,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     @Override
     public void onFinishEditNoteDialog(final String note) {
         cache.setPersonalNote(note);
-        cache.parseWaypointsFromNote();
+        if (cache.parseWaypointsFromNote()) {
+            getViewCreator(Page.WAYPOINTS).notifyDataSetChanged();
+        }
 
         final TextView personalNoteView = ButterKnife.findById(this, R.id.personalnote);
         if (personalNoteView != null) {


### PR DESCRIPTION
Sending an `notifyDataSetChanged()` to the waypoints page after personal note was updated with new waypoints.