### PR TITLE
fix #5141 error message when fieldnote upload fails

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -483,6 +483,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
             final StatusCode loginState = GCLogin.getInstance().login();
             if (loginState != StatusCode.NO_ERROR) {
                 Log.e("FieldnoteExport.ExportTask upload: Login failed");
+                return false;
             }
         }
 

--- a/main/src/cgeo/geocaching/export/FieldnoteExport.java
+++ b/main/src/cgeo/geocaching/export/FieldnoteExport.java
@@ -133,12 +133,13 @@ public class FieldnoteExport extends AbstractExport {
         @Override
         protected Boolean doInBackgroundInternal(final Geocache[] caches) {
             // export field notes separately for each connector, so the file can be uploaded to the respective site afterwards
+            boolean success = true;
             for (final IConnector connector : ConnectorFactory.getConnectors()) {
                 if (connector instanceof FieldNotesCapability) {
-                    exportFieldNotes((FieldNotesCapability) connector, caches);
+                    success &= exportFieldNotes((FieldNotesCapability) connector, caches);
                 }
             }
-            return true;
+            return success;
         }
 
         private boolean exportFieldNotes(final FieldNotesCapability connector, final Geocache[] caches) {


### PR DESCRIPTION
- Evaluate return value from `exportFieldNotes()`
- Return false on login failure