### PR TITLE
fix #1914 include UTM format in cache details

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointFormatter.java
+++ b/main/src/cgeo/geocaching/location/GeopointFormatter.java
@@ -45,7 +45,10 @@ public class GeopointFormatter {
         LON_DECMINUTE,
 
         /** Example: "W 5 12,345" */
-        LON_DECMINUTE_RAW
+        LON_DECMINUTE_RAW,
+
+        /** Example: "32U E 549996 N 5600860" */
+        UTM
     }
 
     /**
@@ -111,6 +114,10 @@ public class GeopointFormatter {
             case LON_DECMINUTE_RAW: {
                 final Geopoint rgp = gp.roundedAt(60 * 1000);
                 return String.format(Locale.getDefault(), "%c %03d %06.3f", rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
+            }
+
+            case UTM: {
+                return UTMPoint.latLong2UTM(gp).toString();
             }
 
         }

--- a/main/src/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/cgeo/geocaching/location/GeopointParser.java
@@ -2,11 +2,12 @@ package cgeo.geocaching.location;
 
 import cgeo.geocaching.utils.MatcherWrapper;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import android.support.annotation.NonNull;
 
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Parse coordinates.
@@ -70,7 +71,15 @@ class GeopointParser {
                 final double lon = Double.parseDouble(StringUtils.strip(parts[1], " \t\u00a0"));
                 return new Geopoint(lat, lon);
             }
-        } catch (final NumberFormatException e) {
+        } catch (final NumberFormatException ignored) {
+            // ignore and continue parsing textual formats
+        }
+
+        // try to parse UTM string
+        try {
+            final UTMPoint utmPoint = new UTMPoint(text);
+            return utmPoint.toLatLong();
+        } catch (final Exception ignored) {
             // ignore and continue parsing textual formats
         }
 

--- a/main/src/cgeo/geocaching/location/UTMPoint.java
+++ b/main/src/cgeo/geocaching/location/UTMPoint.java
@@ -1,0 +1,337 @@
+package cgeo.geocaching.location;
+
+import cgeo.geocaching.utils.MatcherWrapper;
+
+import android.support.annotation.NonNull;
+
+import java.util.regex.Pattern;
+
+/**
+ * A class representing a UTM co-ordinate.
+ * <p>
+ *
+ * Derived from https://github.com/OpenMap-java/openmap
+ *
+ * Adapted to Java by Colin Mummery (colin_mummery@yahoo.com) from C++ code by
+ * Chuck Gantz (chuck.gantz@globalstar.com)
+ */
+public class UTMPoint {
+
+    private static final double WGS_84_RADIUS = 6378137.0d;
+    private static final double WGS_84_ECC_SQUARED = 0.00669438d;
+    private static final double ECC_PRIME_SQUARED = (WGS_84_ECC_SQUARED) / (1 - WGS_84_ECC_SQUARED);
+    private static final double ECC_SQUARED_2 = WGS_84_ECC_SQUARED * WGS_84_ECC_SQUARED;
+    private static final double ECC_SQUARED_3 = ECC_SQUARED_2 * WGS_84_ECC_SQUARED;
+    private static final double E_1 = (1 - Math.sqrt(1 - WGS_84_ECC_SQUARED)) / (1 + Math.sqrt(1 - WGS_84_ECC_SQUARED));
+    private static final double K_0 = 0.9996;
+    private static final double FALSE_EASTING = 500000.0d;
+    private static final double FALSE_NORTHING = 10000000.0d;
+
+    /**
+     * The northing component of the coordinate.
+     */
+    private double northing;
+
+    /**
+     * The easting component of the coordinate.
+     */
+    private double easting;
+
+    /**
+     * The zone number of the coordinate, must be between 1 and 60.
+     */
+    private int zoneNumber;
+
+    /**
+     * A-Z
+     */
+    private char zoneLetter;
+
+    //                                                          ( 1   )(  2    )    (  3  )       (         4       )       (        5        )
+    private static final Pattern PATTERN_UTM = Pattern.compile("(^|\\s)(\\d\\d?)\\s*([A-Z])[\\sE]+(\\d+(?:[.,]\\d+)?)[\\sN]+(\\d+(?:[.,]\\d+)?)", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Point to create if you are going to use the static methods to fill the
+     * values in.
+     */
+    public UTMPoint(final String utmString) {
+        final MatcherWrapper matcher = new MatcherWrapper(PATTERN_UTM, utmString);
+        try {
+            if (matcher.find()) {
+                this.zoneNumber = Integer.parseInt(matcher.group(2));
+                this.zoneLetter = checkZone(matcher.group(3).charAt(0));
+                this.easting = Double.parseDouble(matcher.group(4).replace(",", "."));
+                this.northing = Double.parseDouble(matcher.group(5).replace(",", "."));
+            } else {
+                throw new ParseException("Unable to recognize UTM format in String '" + utmString + "'");
+            }
+        } catch (final NumberFormatException ignored) {
+            throw new ParseException("Error parsing UTM numbers in String '" + utmString + "'");
+        }
+    }
+
+    /**
+     * Constructs a new UTM instance.
+     * 
+     * @param zoneNumber The zone of the coordinate.
+     * @param zoneLetter For UTM, 'A' .. 'Z'
+     * @param easting The easting component.
+     * @param northing The northing component.
+     * @throws IllegalArgumentException zoneLetter is out of range.
+     */
+    public UTMPoint(final int zoneNumber, final char zoneLetter, final double easting, final double northing) {
+        this.zoneNumber = zoneNumber;
+        this.zoneLetter = checkZone(zoneLetter);
+        this.easting = easting;
+        this.northing = northing;
+    }
+
+    public boolean equals(final Object obj) {
+        if (obj instanceof UTMPoint) {
+            final UTMPoint pnt = (UTMPoint) obj;
+            return northing == pnt.northing
+                    && easting == pnt.easting
+                    && zoneNumber == pnt.zoneNumber
+                    && zoneLetter == pnt.zoneLetter;
+        }
+        return false;
+    }
+
+    /**
+     * Method that provides a check for UTM zone letters. Returns an uppercase
+     * version of any valid letter passed in, 'A' .. 'Z'.
+     * 
+     * @throws IllegalArgumentException if zone letter is invalid.
+     */
+    private char checkZone(final char inZone) {
+        final char zone = Character.toUpperCase(inZone);
+
+        if (zone < 'A' || zone > 'Z') {
+            throw new IllegalArgumentException("Invalid UTMPoint zone letter: " + zone);
+        }
+
+        return zone;
+    }
+
+    /**
+     * Returns a string representation of the object.
+     * 
+     * @return String representation
+     */
+    public String toString() {
+        return String.format("%d%c E %d N %d", zoneNumber, zoneLetter, Math.round(easting), Math.round(northing));
+    }
+
+    /**
+     * Converts UTM coords to lat/long.
+     * <p>
+     * Equations from USGS Bulletin 1532 <br>
+     * East Longitudes are positive, West longitudes are negative. <br>
+     * North latitudes are positive, South latitudes are negative.
+     *
+     * @throws IllegalArgumentException if zoneNumber is out of range.
+     */
+    @NonNull
+    public Geopoint toLatLong() {
+        // check the ZoneNumber is valid
+        if (zoneNumber < 0 || zoneNumber > 60) {
+            throw new IllegalArgumentException("ZoneNumber out of range [0-60]: " + zoneNumber);
+        }
+
+        // remove 500,000 meter offset for longitude
+        final double x = easting - FALSE_EASTING;
+        final double y = zoneLetter < 'N' ? northing - FALSE_NORTHING : northing;
+
+        // There are 60 zones with zone 1 being at West -180 to -174
+        final double longOrigin = (zoneNumber - 1) * 6 - 180 + 3; // +3 puts origin in middle of zone
+
+        final double m = y / K_0;
+        final double mu = m / (WGS_84_RADIUS * (1 - WGS_84_ECC_SQUARED / 4 - 3 * ECC_SQUARED_2 / 64 - 5 * ECC_SQUARED_3 / 256));
+
+        final double phi1Rad =
+                mu + (3 * E_1 / 2 - 27 * E_1 * E_1 * E_1 / 32) * Math.sin(2 * mu) + (21 * E_1 * E_1 / 16 - 55 * E_1 * E_1 * E_1 * E_1 / 32)
+                        * Math.sin(4 * mu) + (151 * E_1 * E_1 * E_1 / 96) * Math.sin(6 * mu);
+
+        final double n1 = WGS_84_RADIUS / Math.sqrt(1 - WGS_84_ECC_SQUARED * Math.sin(phi1Rad) * Math.sin(phi1Rad));
+        final double t1 = Math.tan(phi1Rad) * Math.tan(phi1Rad);
+        final double c1 = ECC_PRIME_SQUARED * Math.cos(phi1Rad) * Math.cos(phi1Rad);
+        final double r1 = WGS_84_RADIUS * (1 - WGS_84_ECC_SQUARED) / Math.pow(1 - WGS_84_ECC_SQUARED * Math.sin(phi1Rad) * Math.sin(phi1Rad), 1.5);
+        final double d = x / (n1 * K_0);
+
+        final double latRad =
+                phi1Rad
+                        - (n1 * Math.tan(phi1Rad) / r1)
+                        * (d * d / 2 - (5 + 3 * t1 + 10 * c1 - 4 * c1 * c1 - 9 * ECC_PRIME_SQUARED) * d * d * d * d / 24 + (61 + 90
+                        * t1 + 298 * c1 + 45 * t1 * t1 - 252 * ECC_PRIME_SQUARED - 3 * c1 * c1)
+                        * d * d * d * d * d * d / 720);
+        final double lonRad =
+                (d - (1 + 2 * t1 + c1) * d * d * d / 6 + (5 - 2 * c1 + 28 * t1 - 3 * c1 * c1 + 8 * ECC_PRIME_SQUARED + 24 * t1 * t1)
+                        * d * d * d * d * d / 120)
+                        / Math.cos(phi1Rad);
+        return new Geopoint(Math.toDegrees(latRad), longOrigin + Math.toDegrees(lonRad));
+    }
+
+    /**
+     * Converts a set of Longitude and Latitude co-ordinates to UTM.
+     *
+     * @param geopoint the coordinate
+     * @return An UTM class instance
+     */
+    @NonNull
+    public static UTMPoint latLong2UTM(final Geopoint geopoint) {
+        final int zoneNumber = getZoneNumber(geopoint.getLatitude(), geopoint.getLongitude());
+        final double latRad = Math.toRadians(geopoint.getLatitude());
+        final double longRad = Math.toRadians(geopoint.getLongitude());
+
+        // in middle of zone
+        final double longOrigin = (zoneNumber - 1) * 6 - 180 + 3; // +3 puts origin
+        final double longOriginRad = Math.toRadians(longOrigin);
+
+        final double tanLatRad = Math.tan(latRad);
+        final double sinLatRad = Math.sin(latRad);
+        final double cosLatRad = Math.cos(latRad);
+
+        final double n = WGS_84_RADIUS / Math.sqrt(1 - WGS_84_ECC_SQUARED * sinLatRad * sinLatRad);
+        final double t = tanLatRad * tanLatRad;
+        final double c = ECC_PRIME_SQUARED * cosLatRad * cosLatRad;
+        final double a = cosLatRad * (longRad - longOriginRad);
+
+        final double m =
+                WGS_84_RADIUS
+                        * ((1 - WGS_84_ECC_SQUARED / 4 - 3 * ECC_SQUARED_2 / 64 - 5 * ECC_SQUARED_3 / 256) * latRad
+                        - (3 * WGS_84_ECC_SQUARED / 8 + 3 * ECC_SQUARED_2 / 32 + 45 * ECC_SQUARED_3 / 1024) * Math.sin(2 * latRad)
+                        + (15 * ECC_SQUARED_2 / 256 + 45 * ECC_SQUARED_3 / 1024) * Math.sin(4 * latRad) - (35 * ECC_SQUARED_3 / 3072)
+                        * Math.sin(6 * latRad));
+
+        final double utmEasting =
+                (K_0
+                        * n
+                        * (a + (1 - t + c) * a * a * a / 6.0d + (5 - 18 * t + t * t + 72 * c - 58 * ECC_PRIME_SQUARED) * a * a * a
+                        * a * a / 120.0d) + FALSE_EASTING);
+
+        final double utmNorthing =
+                (K_0 * (m + n
+                        * Math.tan(latRad)
+                        * (a * a / 2 + (5 - t + 9 * c + 4 * c * c) * a * a * a * a / 24.0d + (61 - 58 * t + t * t + 600 * c - 330 * ECC_PRIME_SQUARED)
+                        * a * a * a * a * a * a / 720.0d)));
+
+        final char zoneLetter = getLetterDesignator(geopoint.getLatitude());
+
+        return new UTMPoint(zoneNumber, zoneLetter, utmEasting, geopoint.getLatitude() < 0f ? utmNorthing + FALSE_NORTHING : utmNorthing);
+    }
+
+    /**
+     * Find zone number based on the given latitude and longitude in *degrees*.
+     * 
+     * @param lat in decimal degrees
+     * @param lon in decimal degrees
+     * @return zone number for UTM zone for lat, lon
+     */
+    private static int getZoneNumber(final double lat, final double lon) {
+        // Make sure the longitude 180.00 is in Zone 60
+        if (lon == 180) {
+            return 60;
+        }
+
+        // Special zone for Norway
+        if (lat >= 56.0f && lat < 64.0f && lon >= 3.0f && lon < 12.0f) {
+            return 32;
+        }
+
+        // Special zones for Svalbard
+        if (lat >= 72.0f && lat < 84.0f) {
+            if (lon >= 0.0f && lon < 9.0f) {
+                return 31;
+            } else if (lon >= 9.0f && lon < 21.0f) {
+                return 33;
+            } else if (lon >= 21.0f && lon < 33.0f) {
+                return 35;
+            } else if (lon >= 33.0f && lon < 42.0f) {
+                return 37;
+            }
+        }
+
+        return (int) ((lon + 180) / 6) + 1;
+    }
+
+    /**
+     * Determines the correct MGRS letter designator for the given latitude
+     * returns 'Z' if latitude is outside the MGRS limits of 84N to 80S.
+     *
+     * TODO: maybe we should handle the zones A,B, Y and Z
+     *
+     * @param lat The float value of the latitude.
+     * @return A char value which is the MGRS zone letter.
+     */
+    private static char getLetterDesignator(final double lat) {
+        if ((84 >= lat) && (lat >= 72)) {
+            return 'X';
+        } else if ((72 > lat) && (lat >= 64)) {
+            return 'W';
+        } else if ((64 > lat) && (lat >= 56)) {
+            return 'V';
+        } else if ((56 > lat) && (lat >= 48)) {
+            return 'U';
+        } else if ((48 > lat) && (lat >= 40)) {
+            return 'T';
+        } else if ((40 > lat) && (lat >= 32)) {
+            return 'S';
+        } else if ((32 > lat) && (lat >= 24)) {
+            return 'R';
+        } else if ((24 > lat) && (lat >= 16)) {
+            return 'Q';
+        } else if ((16 > lat) && (lat >= 8)) {
+            return 'P';
+        } else if ((8 > lat) && (lat >= 0)) {
+            return 'N';
+        } else if ((0 > lat) && (lat >= -8)) {
+            return 'M';
+        } else if ((-8 > lat) && (lat >= -16)) {
+            return 'L';
+        } else if ((-16 > lat) && (lat >= -24)) {
+            return 'K';
+        } else if ((-24 > lat) && (lat >= -32)) {
+            return 'J';
+        } else if ((-32 > lat) && (lat >= -40)) {
+            return 'H';
+        } else if ((-40 > lat) && (lat >= -48)) {
+            return 'G';
+        } else if ((-48 > lat) && (lat >= -56)) {
+            return 'F';
+        } else if ((-56 > lat) && (lat >= -64)) {
+            return 'E';
+        } else if ((-64 > lat) && (lat >= -72)) {
+            return 'D';
+        } else if ((-72 > lat) && (lat >= -80)) {
+            return 'C';
+        }
+
+        // This is here as an error flag to show that the Latitude is outside MGRS limits
+        return 'Z';
+    }
+
+    public int getZoneNumber() {
+        return this.zoneNumber;
+    }
+
+    public char getZoneLetter() {
+        return this.zoneLetter;
+    }
+
+    public double getEasting() {
+        return easting;
+    }
+
+    public double getNorthing() {
+        return northing;
+    }
+
+    public static class ParseException extends NumberFormatException {
+        private static final long serialVersionUID = 1L;
+
+        public ParseException(final String msg) {
+            super(msg);
+        }
+    }
+
+}

--- a/main/src/cgeo/geocaching/ui/CoordinatesFormatSwitcher.java
+++ b/main/src/cgeo/geocaching/ui/CoordinatesFormatSwitcher.java
@@ -16,7 +16,8 @@ public class CoordinatesFormatSwitcher implements OnClickListener {
     private static final GeopointFormatter.Format[] availableFormats = {
             GeopointFormatter.Format.LAT_LON_DECMINUTE,
             GeopointFormatter.Format.LAT_LON_DECSECOND,
-            GeopointFormatter.Format.LAT_LON_DECDEGREE
+            GeopointFormatter.Format.LAT_LON_DECDEGREE,
+            GeopointFormatter.Format.UTM
     };
 
     private int position = 0;

--- a/tests/src/cgeo/geocaching/location/UTMPointConversionTest.java
+++ b/tests/src/cgeo/geocaching/location/UTMPointConversionTest.java
@@ -1,0 +1,139 @@
+package cgeo.geocaching.location;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test the UTMPoint class with testcases from an Excel sheet provided here: http://www.uwgb.edu/dutchs/UsefulData/UTMFormulas.htm
+ *
+ * Other Tools to verify results:
+ * Online Batch Converter: http://www.hamstermap.com/
+ * http://www.latlong.net/lat-long-utm.html
+ * http://www.rcn.montana.edu/resources/converter.aspx
+ * http://www.synnatschke.de/geo-tools/coordinate-converter.php
+ */
+@RunWith(Parameterized.class)
+public class UTMPointConversionTest {
+
+    private final double lat;
+    private final double lon;
+    private final int zone;
+    private final String zoneLetter;
+    private final double easting;
+    private final double northing;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        System.out.println("lat, lon; expected easting, northing; result easting, northing; diff easting, northing");
+        return Arrays.asList(new Object[][]{
+                {85d, 102d, 48, "Z", 470821.25d, 9440493.90d},
+                {84d, 102d, 48, "X", 465005.34493d, 9329005.2d},
+                {51d, 60d, 41, "U", 289511.142963d, 5654109.2d},
+                {37d, 151d, 56, "S", 322037.81022d, 4096742.1d},
+                {24d, 14d, 33, "R", 398285.44617d, 2654587.6d},
+                {-21d, 17d, 33, "K", 707889.2160d, 7676551.7d},
+                {-36d, 85d, 45, "H", 319733.3418d, 6014201.8d},
+                {-50d, 117d, 50, "F", 500000d, 4461369.3d},
+                {-68d, 146d, 55, "D", 458196.7256d, 2456797.5d},
+                {-81d, 171d, 59, "B", 500000d, 1006795.6d}, // should be B, but some lib say Z
+                {-83d, -12d, 29, "A", 459200.2563d, 782480.6d}, // should be A, but some lib say Z
+                {-61d, -164d, 3, "E", 554084.38101d, 3236799.8d},
+                {-43d, -92d, 15, "G", 581508.6478d, 5238700.1d},
+                {-21d, -53d, 22, "K", 292110.7839d, 7676551.7d},
+                {15d, -33d, 25, "P", 500000d, 1658326.0d},
+                {32d, -122d, 10, "S", 594457.4634d, 3540872.5d},
+                {57d, -82d, 17, "V", 439253.3763d, 6317830.5d},
+                {74d, -177d, 1, "X", 500000d, 8212038.1d},
+                {-55.98d, -67.28917d, 19, "F", 606750d, 3794825d},
+                {-61.453333d, -55.495752d, 21, "E", 580191d, 3185792d},
+                {37.81972d, -122.47861d, 10, "S", 545889d, 4185941d},
+                {40.713d, -74.0135d, 18, "T", 583326d, 4507366d},
+                {3.15785d, 101.71165d, 47, "N", 801396d, 349434d},
+                {27.98806d, 86.92528d, 45, "R", 492652d, 3095881d},
+                {-3.07583d, 37.35333d, 37, "M", 317004d, 9659884d},
+                {25.19714d, 55.27411d, 40, "R", 326103d, 2787892d},
+                {41.00855d, 28.97994d, 35, "T", 666499d, 4541594d},
+                {41.90222d, 12.45333d, 33, "T", 288761d, 4642057d},
+                {48.85822d, 2.2945d, 31, "U", 448252d, 5411935d},
+                {71.1725d, 25.78444d, 35, "W", 456220d, 7897075d},
+                {-34.35806d, 18.47194d, 34, "H", 267496d, 6195246d},
+                {83.627d, -32.664d, 25, "X", 504163.90d, 9286465.67d},
+                {-55.98d, -67.28917d, 19, "F", 606750d, 3794825d},
+                {-61.453333d, -55.495752d, 21, "E", 580191d, 3185792},
+                {37.81972d, -122.47861d, 10, "S", 545889d, 4185941},
+                {40.713d, -74.0135d, 18, "T", 583326d, 4507366},
+                {3.15785d, 101.71165d, 47, "N", 801396d, 349434},
+                {27.98806d, 86.92528d, 45, "R", 492652d, 3095881},
+                {-3.07583d, 37.35333d, 37, "M", 317004d, 9659884},
+                {25.19714d, 55.27411d, 40, "R", 326103d, 2787892},
+                {41.00855d, 28.97994d, 35, "T", 666499d, 4541594},
+                {41.90222d, 12.45333d, 33, "T", 288761d, 4642057},
+                {48.85822d, 2.2945d, 31, "U", 448252d, 5411935},
+                {71.1725d, 25.78444d, 35, "W", 456220d, 7897075},
+                {-34.35806d, 18.47194d, 34, "H", 267496d, 6195246},
+                {-13.16333d, -72.54556d, 18, "L", 766062d, 8543503},
+                {-32.65343d, -70.01108d, 19, "H", 405179d, 6386681},
+                {-43.59575d, 170.14104d, 59, "G", 430668d, 5172667},
+                {-33.85867d, 151.21403d, 56, "H", 334786d, 6252080},
+                {25.03361d, 121.565d, 51, "R", 355224d, 2769437},
+                {35.35806d, 138.73111d, 54, "S", 293848d, 3915114},
+                {56.05611d, 160.64417d, 57, "V", 602389d, 6213543},
+                {71.38889d, -156.47917d, 4, "W", 589769d, 7922642},
+                {21.365d, -157.95d, 4, "Q", 608862d, 2362907},
+                {-27.11667d, -109.36667d, 12, "J", 661897d, 6999591},
+                {-37.11111d, -12.28833d, 28, "H", 740947d, 5889360},
+                {-77.85d, 166.66667d, 58, "C", 539154d, 1357814},
+
+                // some testcases from geocaching.com
+
+                // https://www.geocaching.com/geocache/GC4DF1X_my-precious
+                {82.42825d, -62.1368333d, 20, "X", 512697d, 9152728},
+
+                // https://www.geocaching.com/geocache/GCC3E3_byrd-surface-camp
+                {-80.01405d, -119.5220833d, 11, "A", 451190, 1115787}, // should be A, but some lib say Z
+
+                // https://www.geocaching.com/geocache/GC636CW_bulandet-kapell
+                // Zone 32V is bigger, because Norway wanted to be in one Zone only
+                {61.2832667d, 4.6271d, 32, "V", 265719, 6802185},
+
+                // https://www.geocaching.com/geocache/GC2Y0BW_panelian-aseman-metsa
+                {61.19925d, 21.9684667, 34, "V", 552050, 6785366}
+        });
+    }
+
+    public UTMPointConversionTest(final double lat, final double lon, final int zone, final String zoneLetter, final double easting, final double northing) {
+        this.lat = lat;
+        this.lon = lon;
+        this.zone = zone;
+        this.zoneLetter = zoneLetter;
+        this.easting = easting;
+        this.northing = northing;
+    }
+
+    @Test
+    public void testLatLong2UTM() throws Exception {
+        final UTMPoint utm = UTMPoint.latLong2UTM(new Geopoint(this.lat, this.lon));
+        Assert.assertEquals(this.easting, utm.getEasting(), 1.1d);
+        Assert.assertEquals(this.northing, utm.getNorthing(), 1.1d);
+        Assert.assertEquals(this.zone, utm.getZoneNumber());
+        if ("ABY".contains(this.zoneLetter)) { // if we expect A,B or Y then Z is ok, too
+            Assert.assertThat(String.valueOf(utm.getZoneLetter()), CoreMatchers.anyOf(CoreMatchers.is("Z"), CoreMatchers.is(this.zoneLetter)));
+        } else {
+            Assert.assertEquals(this.zoneLetter, String.valueOf(utm.getZoneLetter()));
+        }
+    }
+
+    @Test
+    public void testUTM2LatLong() throws Exception {
+        final Geopoint gp = new UTMPoint(this.zone, this.zoneLetter.charAt(0), this.easting, this.northing).toLatLong();
+        Assert.assertEquals(this.lat, gp.getLatitude(), 1.1d);
+        Assert.assertEquals(this.lon, gp.getLongitude(), 1.1d);
+    }
+
+}

--- a/tests/src/cgeo/geocaching/location/UTMPointFormatTest.java
+++ b/tests/src/cgeo/geocaching/location/UTMPointFormatTest.java
@@ -1,0 +1,96 @@
+package cgeo.geocaching.location;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test the UTMPoint parsing and formatting.
+ */
+public class UTMPointFormatTest {
+
+    @Test
+    public void testParseUTMStringSimple() {
+        final UTMPoint utm = new UTMPoint("54S 293848 3915114");
+
+        Assert.assertEquals(54, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114, utm.getNorthing(), 1.1d);
+    }
+
+    @Test
+    public void testParseUTMStringWithEandN() {
+        final UTMPoint utm = new UTMPoint("54S E 293848 N 3915114");
+
+        Assert.assertEquals(54, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114, utm.getNorthing(), 1.1d);
+    }
+
+    @Test
+    public void testParseUTMStringWithDecimals() {
+        final UTMPoint utm = new UTMPoint("54S 293848.4 3915114.5");
+
+        Assert.assertEquals(54, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848.4, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114.5, utm.getNorthing(), 1.1d);
+    }
+
+    @Test
+    public void testParseUTMStringWithLowerCaseLetters() {
+        final UTMPoint utm = new UTMPoint("54s e 293848 n 3915114");
+
+        Assert.assertEquals(54, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114, utm.getNorthing(), 1.1d);
+    }
+
+    @Test
+    public void testParseUTMStringWithCommaAsDecimalSeparator() {
+        final UTMPoint utm = new UTMPoint("54S 293848,4 3915114,5");
+
+        Assert.assertEquals(54, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848.4, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114.5, utm.getNorthing(), 1.1d);
+    }
+
+    @Test
+    public void testParseUTMStringWithBlankAfterZoneNumber() {
+        final UTMPoint utm = new UTMPoint("54 S 293848 3915114");
+
+        Assert.assertEquals(54, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114, utm.getNorthing(), 1.1d);
+    }
+
+    @Test
+    public void testParseUTMStringWithSingleDigitZoneNumber() {
+        final UTMPoint utm = new UTMPoint("5S 293848 3915114");
+
+        Assert.assertEquals(5, utm.getZoneNumber());
+        Assert.assertEquals('S', utm.getZoneLetter());
+        Assert.assertEquals(293848, utm.getEasting(), 1.1d);
+        Assert.assertEquals(3915114, utm.getNorthing(), 1.1d);
+    }
+
+    @Test(expected = UTMPoint.ParseException.class)
+    public void testParseUTMStringWithException() {
+        new UTMPoint("5S blah blub");
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("54S E 293848 N 3915114", new UTMPoint(54, 'S', 293848, 3915114).toString());
+    }
+
+    @Test
+    public void testToStringWithRoundedDecimals() {
+        Assert.assertEquals("54S E 293848 N 3915114", new UTMPoint(54, 'S', 293847.5, 3915114.3).toString());
+    }
+
+}


### PR DESCRIPTION
Extended the `GeopointFormatter` and `CoordinatesFormatSwitcher` to support UTM coords.