### PR TITLE
Prevent subscriptions from capturing their environment

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -194,6 +194,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
     @Override
     public void onPause() {
         resumeSubscription.unsubscribe();
+        resumeSubscription = Subscriptions.empty();
         super.onPause();
     }
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -384,6 +384,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         final boolean start;
         if (Settings.useLowPowerMode()) {
             geoDataSubscription.unsubscribe();
+            geoDataSubscription = Subscriptions.empty();
             start = requireGeodata;
         } else {
             start = initial;
@@ -414,12 +415,14 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     @Override
     public void onPause() {
         geoDataSubscription.unsubscribe();
+        geoDataSubscription = Subscriptions.empty();
         super.onPause();
     }
 
     @Override
     public void onDestroy() {
         createSubscriptions.unsubscribe();
+        createSubscriptions = null;
         super.onDestroy();
     }
 

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -602,6 +602,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     @Override
     public void onPause() {
         resumeSubscription.unsubscribe();
+        resumeSubscription = null;
         super.onPause();
     }
 

--- a/main/src/cgeo/geocaching/ImagesActivity.java
+++ b/main/src/cgeo/geocaching/ImagesActivity.java
@@ -69,6 +69,7 @@ public class ImagesActivity extends AbstractActionBarActivity {
     public void onStop() {
         // Reclaim native memory faster than the finalizers would
         subscription.unsubscribe();
+        subscription = null;
         super.onStop();
     }
 

--- a/main/src/cgeo/geocaching/StatusFragment.java
+++ b/main/src/cgeo/geocaching/StatusFragment.java
@@ -92,6 +92,7 @@ public class StatusFragment extends Fragment {
     @Override
     public void onDestroyView() {
         statusSubscription.unsubscribe();
+        statusSubscription = Subscriptions.empty();
         super.onDestroyView();
         unbinder.unbind();
     }

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -210,6 +210,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
     @Override
     public void onPause() {
         geoDataSubscription.unsubscribe();
+        geoDataSubscription = Subscriptions.empty();
         super.onPause();
     }
 
@@ -675,6 +676,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
     @Override
     protected void onDestroy() {
         createSubscriptions.unsubscribe();
+        createSubscriptions = null;
         super.onDestroy();
     }
 

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -94,6 +94,7 @@ public abstract class AbstractActivity extends ActionBarActivity implements IAbs
     @Override
     public void onPause() {
         resumeSubscription.unsubscribe();
+        resumeSubscription = Subscriptions.empty();
         super.onPause();
     }
 

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -620,6 +620,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
     @Override
     public void onPause() {
         resumeSubscription.unsubscribe();
+        resumeSubscription = Subscriptions.empty();
         savePrefs();
 
         mapView.destroyDrawingCache();

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -649,6 +649,7 @@ public class NewMap extends AbstractActionBarActivity {
     private void terminateLayers() {
 
         this.resumeSubscription.unsubscribe();
+        this.resumeSubscription = Subscriptions.empty();
 
         this.caches.onDestroy();
         this.caches = null;

--- a/main/src/cgeo/geocaching/speech/SpeechService.java
+++ b/main/src/cgeo/geocaching/speech/SpeechService.java
@@ -116,6 +116,7 @@ public class SpeechService extends Service implements OnInitListener {
     @Override
     public void onDestroy() {
         initSubscription.unsubscribe();
+        initSubscription = Subscriptions.empty();
         if (tts != null) {
             tts.stop();
             tts.shutdown();

--- a/main/src/cgeo/geocaching/ui/CompassView.java
+++ b/main/src/cgeo/geocaching/ui/CompassView.java
@@ -125,6 +125,7 @@ public class CompassView extends View {
     @Override
     public void onDetachedFromWindow() {
         periodicUpdate.unsubscribe();
+        periodicUpdate = Subscriptions.empty();
 
         super.onDetachedFromWindow();
 


### PR DESCRIPTION
It is possible that custom unsubscriptions methods reference an outer
class. In this case, unless the subscription has been itself added to a
CompositeSubscription, it may be kept referenced even after being
unsubscribed.

By nulling or emptying the subscriptions after unsubscribing, we prevent
such references from being captured. Such references were detected by
LeakCanary.