### PR TITLE
Fix #4865: Show logbook of GK trackables

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1078,7 +1078,6 @@
     <string name="trackable_spotted_unknown_location">Unknown location</string>
     <string name="trackable_spotted_owner">In the hands of its owner</string>
     <string name="trackable_spotted_archived">Archived</string>
-    <string name="trackable_spotted_travelling">Travelling</string>
     <string name="trackable_origin">Origin</string>
     <string name="trackable_unknown">Unknown</string>
     <string name="trackable_released">Released</string>
@@ -1102,6 +1101,7 @@
     <string name="user_menu_open_browser">Open profile in browser</string>
     <string name="user_menu_send_message">Send message</string>
     <string name="user_menu_open_contact">Open contact card</string>
+    <string name="user_unknown">Unknown user</string>
     
     <!-- navigation -->
     <string name="navigation">Navigation</string>

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -463,8 +463,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (StringUtils.isNotBlank(trackable.getSpottedName()) ||
                     trackable.getSpottedType() == Trackable.SPOTTED_UNKNOWN ||
                     trackable.getSpottedType() == Trackable.SPOTTED_OWNER ||
-                    trackable.getSpottedType() == Trackable.SPOTTED_ARCHIVED ||
-                    trackable.getSpottedType() == Trackable.SPOTTED_TRAVELLING) {
+                    trackable.getSpottedType() == Trackable.SPOTTED_ARCHIVED) {
 
                 final StringBuilder text;
                 boolean showTimeSpan = true;
@@ -485,9 +484,6 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
                         break;
                     case Trackable.SPOTTED_ARCHIVED:
                         text = new StringBuilder(res.getString(R.string.trackable_spotted_archived));
-                        break;
-                    case Trackable.SPOTTED_TRAVELLING:
-                        text = new StringBuilder(res.getString(R.string.trackable_spotted_travelling));
                         break;
                     default:
                         text = new StringBuilder("N/A");

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -454,13 +454,13 @@ public class GeokretyParser {
      */
     static String getLastSpottedUsername(final List<LogEntry> logsEntries) {
         for (final LogEntry log: logsEntries) {
-            if (log.getType() == LogType.NOTE) {
-                continue;
+            final LogType logType = log.getType();
+            if (logType == LogType.GRABBED_IT || logType == LogType.VISIT) {
+                return log.author;
             }
-            if (log.getType() != LogType.GRABBED_IT && log.getType() != LogType.VISIT) {
-                return CgeoApplication.getInstance().getString(R.string.user_unknown);
+            if (logType != LogType.NOTE) {
+                break;
             }
-            return log.author;
         }
         return CgeoApplication.getInstance().getString(R.string.user_unknown);
     }

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -211,7 +211,7 @@ public class GeokretyParser {
                     final Date date = DATE_FORMAT_SECONDS.parse(content);
                     trackable.setReleased(date);
                 }
-                if (StringUtils.isNotBlank(content) && (
+                if (StringUtils.isNotBlank(content) && !isInMoves && (
                         localName.equalsIgnoreCase("distancetravelled") || localName.equalsIgnoreCase("distancetraveled")
                 )) {
                     trackable.setDistance(Float.parseFloat(content));

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -43,7 +43,7 @@ public class GeokretyParser {
         private static final SynchronizedDateFormat DATE_FORMAT = new SynchronizedDateFormat("yyyy-MM-dd kk:mm:ss", TimeZone.getTimeZone("UTC"), Locale.US);
         private final List<Trackable> trackables = new ArrayList<>();
         private Trackable trackable;
-        private boolean isMessage = false;
+        private boolean isMultiline = false;
         private String content;
 
         @NonNull
@@ -114,7 +114,7 @@ public class GeokretyParser {
                     }
                 }
                 if (localName.equalsIgnoreCase("description")) {
-                    isMessage = true;
+                    isMultiline = true;
                 }
                 // TODO: latitude/longitude could be parsed, but trackable doesn't support it, yet...
                 //if (localName.equalsIgnoreCase("position")) {
@@ -151,7 +151,7 @@ public class GeokretyParser {
                 }
                 if (localName.equalsIgnoreCase("description")) {
                     trackable.setDetails(content);
-                    isMessage = false;
+                    isMultiline = false;
                 }
                 if (localName.equalsIgnoreCase("owner")) {
                     trackable.setOwner(content);
@@ -184,7 +184,7 @@ public class GeokretyParser {
         public final void characters(final char[] ch, final int start, final int length)
                 throws SAXException {
             final String text = StringUtils.trim(new String(ch, start, length));
-            content = isMessage ? StringUtils.join(content, text) : text;
+            content = isMultiline ? StringUtils.join(content, text) : text;
         }
 
         /**

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -266,8 +266,12 @@ public class GeokretyParser {
         @Override
         public final void characters(final char[] ch, final int start, final int length)
                 throws SAXException {
-            final String text = StringUtils.trim(new String(ch, start, length));
-            content = isMultiline ? StringUtils.join(content, text) : text;
+            final String text = new String(ch, start, length);
+            if (isMultiline) {
+                content = StringUtils.join(content, text.replaceAll("(\r\n|\n)", "<br />"));
+            } else {
+                content = StringUtils.trim(text);
+            }
         }
 
         /**

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -2,6 +2,9 @@ package cgeo.geocaching.connector.trackable;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.LogType;
+import cgeo.geocaching.models.Image;
+import cgeo.geocaching.models.LogEntry;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.SynchronizedDateFormat;
@@ -40,11 +43,20 @@ public class GeokretyParser {
     }
 
     static class GeokretyHandler extends DefaultHandler {
-        private static final SynchronizedDateFormat DATE_FORMAT = new SynchronizedDateFormat("yyyy-MM-dd kk:mm:ss", TimeZone.getTimeZone("UTC"), Locale.US);
+        private static final SynchronizedDateFormat DATE_FORMAT = new SynchronizedDateFormat("yyyy-MM-dd kk:mm", TimeZone.getTimeZone("UTC"), Locale.US);
+        private static final SynchronizedDateFormat DATE_FORMAT_SECONDS = new SynchronizedDateFormat("yyyy-MM-dd kk:mm:ss", TimeZone.getTimeZone("UTC"), Locale.US);
         private final List<Trackable> trackables = new ArrayList<>();
         private Trackable trackable;
+        private LogEntry.Builder logEntryBuilder;
+        private final List<LogEntry> logsEntries = new ArrayList<>();
+        private Image.Builder imageBuilder;
+
         private boolean isMultiline = false;
+        private boolean isInMoves = false;
+        private boolean isInImages = false;
+        private boolean isInComments = false;
         private String content;
+
 
         @NonNull
         public final List<Trackable> getTrackables() {
@@ -127,7 +139,44 @@ public class GeokretyParser {
                 //    trackable.setLongitude(longitude);
                 //}
                 //}
-            } catch (final NumberFormatException e) {
+                if (localName.equalsIgnoreCase("move")) {
+                    logEntryBuilder = new LogEntry.Builder();
+                    isInMoves = true;
+                }
+                if (localName.equalsIgnoreCase("date")) {
+                    final String movedDate = attributes.getValue("moved");
+                    if (StringUtils.isNotBlank(movedDate)) {
+                        logEntryBuilder.setDate(DATE_FORMAT.parse(movedDate).getTime());
+                    }
+                }
+                if (localName.equalsIgnoreCase("user")) {
+                    final String userId = attributes.getValue("id");
+                    if (StringUtils.isNotBlank(userId)) {
+                        logEntryBuilder.setAuthor(CgeoApplication.getInstance().getString(R.string.init_geokrety_userid, userId));
+                    }
+                }
+                if (localName.equalsIgnoreCase("comments")) {
+                    isInComments = true;
+                }
+                if (localName.equalsIgnoreCase("comment")) {
+                    isMultiline = true;
+                }
+                if (localName.equalsIgnoreCase("logtype")) {
+                    final String logtype = attributes.getValue("id");
+                    logEntryBuilder.setLogType(getLogType(Integer.parseInt(logtype)));
+                }
+                if (localName.equalsIgnoreCase("images")) {
+                    isInImages = true;
+                }
+                // TODO: Trackable doesn't support multiple image yet, so ignore other image tags if we're not in moves
+                if (localName.equalsIgnoreCase("image") && !isInImages) {
+                    imageBuilder = new Image.Builder();
+                    final String title = attributes.getValue("title");
+                    if (StringUtils.isNotBlank(title)) {
+                        imageBuilder.setTitle(title);
+                    }
+                }
+            } catch (final ParseException | NumberFormatException e) {
                 Log.e("Parsing GeoKret", e);
             }
         }
@@ -145,6 +194,8 @@ public class GeokretyParser {
                     if (trackable.getSpottedType() == Trackable.SPOTTED_TRAVELLING && trackable.getDistance() == 0) {
                         trackable.setSpottedType(Trackable.SPOTTED_OWNER);
                     }
+
+                    trackable.setLogs(logsEntries);
                 }
                 if (localName.equalsIgnoreCase("name")) {
                     trackable.setName(content);
@@ -157,14 +208,23 @@ public class GeokretyParser {
                     trackable.setOwner(content);
                 }
                 if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("datecreated")) {
-                    final Date date = DATE_FORMAT.parse(content);
+                    final Date date = DATE_FORMAT_SECONDS.parse(content);
                     trackable.setReleased(date);
                 }
                 if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("distancetravelled")) {
                     trackable.setDistance(Float.parseFloat(content));
                 }
+                if (localName.equalsIgnoreCase("images")) {
+                    isInImages = false;
+                }
                 if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("image")) {
-                    trackable.setImage("http://geokrety.org/obrazki/" + content);
+                    if (isInMoves) {
+                        imageBuilder.setUrl("http://geokrety.org/obrazki/" + content);
+                        logEntryBuilder.addLogImage(imageBuilder.build());
+                    } else if (!isInImages) {
+                        // TODO: Trackable doesn't support multiple image yet, so ignore other image tags if we're not in moves
+                        trackable.setImage("http://geokrety.org/obrazki/" + content);
+                    }
                 }
                 if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("state")) {
                     trackable.setSpottedType(getSpottedType(Integer.parseInt(content)));
@@ -174,6 +234,27 @@ public class GeokretyParser {
                 }
                 if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("waypoint")) {
                     trackable.setSpottedName(content);
+                }
+                if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("user")) {
+                    logEntryBuilder.setAuthor(content);
+                }
+                if (localName.equalsIgnoreCase("move")) {
+                    isInMoves = false;
+                    logsEntries.add(logEntryBuilder.build());
+                }
+                if (localName.equalsIgnoreCase("comments")) {
+                    isInComments = false;
+                }
+                if (localName.equalsIgnoreCase("comment") && !isInComments) {
+                    isMultiline = false;
+                    logEntryBuilder.setLog(content);
+                }
+                if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("wpt")) {
+                    //logEntryBuilder.setCacheGeocode(content); // TODO: also implement Geocode support in LogEntry
+                    logEntryBuilder.setCacheName(content);
+                }
+                if (localName.equalsIgnoreCase("id")) {
+                    logEntryBuilder.setId(Integer.parseInt(content));
                 }
             } catch (final ParseException | NumberFormatException e) {
                 Log.e("Parsing GeoKret", e);
@@ -208,6 +289,32 @@ public class GeokretyParser {
                 //case 2: // A comment (however this case doesn't exists in db)
             }
             return Trackable.SPOTTED_UNKNOWN;
+        }
+
+        /**
+         * Convert states from GK to c:geo spotted types.
+         *
+         * @param type
+         *          the GK Log type
+         * @return
+         *          The LogType
+         */
+        private static LogType getLogType(final int type) {
+            switch (type) {
+                case 0: // Dropped
+                    return LogType.PLACED_IT;
+                case 1: // Grabbed from
+                    return LogType.GRABBED_IT;
+                case 2: // A comment
+                    return LogType.NOTE;
+                case 3: // Seen in
+                    return LogType.DISCOVERED_IT;
+                case 4: // Archived
+                    return LogType.ARCHIVE;
+                case 5: // Visiting
+                    return LogType.VISIT;
+            }
+            return LogType.UNKNOWN;
         }
     }
 

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -211,7 +211,9 @@ public class GeokretyParser {
                     final Date date = DATE_FORMAT_SECONDS.parse(content);
                     trackable.setReleased(date);
                 }
-                if (StringUtils.isNotBlank(content) && localName.equalsIgnoreCase("distancetravelled")) {
+                if (StringUtils.isNotBlank(content) && (
+                        localName.equalsIgnoreCase("distancetravelled") || localName.equalsIgnoreCase("distancetraveled")
+                )) {
                     trackable.setDistance(Float.parseFloat(content));
                 }
                 if (localName.equalsIgnoreCase("images")) {

--- a/main/src/cgeo/geocaching/models/Trackable.java
+++ b/main/src/cgeo/geocaching/models/Trackable.java
@@ -29,7 +29,6 @@ public class Trackable implements ILogable {
     public static final int SPOTTED_UNKNOWN = 3;
     public static final int SPOTTED_OWNER = 4;
     public static final int SPOTTED_ARCHIVED = 5;
-    public static final int SPOTTED_TRAVELLING = 6;
 
     private String guid = "";
     private String geocode = "";

--- a/tests/res/raw/geokret145_xml.xml
+++ b/tests/res/raw/geokret145_xml.xml
@@ -2,9 +2,9 @@
 <gkxml version="1.0" date="2015-03-31 00:53:46"><geokrety>
   <geokret id="49728">
     <name><![CDATA[c:geo Test]]></name>
-    <description><![CDATA[Dieser Geokret dient zum Testen von c:geo.<br />
-Er befindet sich nicht wirklich im gelisteten Cache. <br />
-<br />
+    <description><![CDATA[Dieser Geokret dient zum Testen von c:geo.
+Er befindet sich nicht wirklich im gelisteten Cache.
+
 Bitte ignorieren.]]></description>
     <owner id="17135"><![CDATA[Lineflyer]]></owner>
     <datecreated>2015-03-29 00:12:15</datecreated>

--- a/tests/res/raw/geokret47496_details_xml.xml
+++ b/tests/res/raw/geokret47496_details_xml.xml
@@ -1,0 +1,106 @@
+<gkxml version="1.0" date="2016-07-26T20:16:00.263Z">
+    <geokrety>
+        <geokret id="47496">
+            <name><![CDATA[c:geo tests]]></name>
+            <description><![CDATA[virtual, just for testing c:geo app
+
+
+
+
+Test to break c:geo]]></description>
+            <owner id="26422"><![CDATA[kumy]]></owner>
+            <datecreated/>
+            <dateupdated>2016-07-26T20:16:00.263Z</dateupdated>
+            <distancetravelled unit="km">143</distancetravelled>
+            <places>2</places>
+            <state>1</state>
+            <missing>0</missing>
+            <waypoints>
+                <waypoint id="967656"/>
+            </waypoints>
+            <type id="0">Traditional</type>
+            <image title="test">1437081713r7ay7.jpg</image>
+            <images>
+                <image title="azaaaa">1447615839yuz2v.jpg</image>
+                <image title="sdqsd">1437081699py7j4.jpg</image>
+                <image title="">14266379429mpyj.jpeg</image>
+            </images>
+            <moves last_id="911689">
+                <move>
+                    <id>911689</id>
+                    <date moved="2016-05-02 12:00"/>
+                    <user id="26422"><![CDATA[kumy]]></user>
+                    <comment><![CDATA[test images in log]]></comment>
+                    <logtype id="2">A comment</logtype>
+                    <images>
+                        <image title="test logo 2">14622133503lxv2.png</image>
+                        <image title="test 1">1462213331lhaiu.png</image>
+                    </images>
+                </move>
+                <move>
+                    <id>967656</id>
+                    <date moved="2016-03-21 18:31"/>
+                    <user id="27829"><![CDATA[gueta]]></user>
+                    <comment><![CDATA[Grabbed]]></comment>
+                    <logtype id="1">Grabbed from</logtype>
+                </move>
+                <move>
+                    <id>967654</id>
+                    <position latitude="43.69365" longitude="6.86097"/>
+                    <wpt alt="fr">GC5BRQK</wpt>
+                    <date moved="2016-02-12 12:00"/>
+                    <user id="26422"><![CDATA[kumy]]></user>
+                    <comment><![CDATA[Multiline 1
+
+Multiline 2
+Multiline 3
+
+
+
+Multiline 4]]></comment>
+                    <logtype id="3">Seen in</logtype>
+                    <distancetravelled unit="km">0</distancetravelled>
+                </move>
+                <move>
+                    <id>912063</id>
+                    <position latitude="43.69365" longitude="6.86097"/>
+                    <wpt alt="fr">GC5BRQK</wpt>
+                    <date moved="2016-01-03 12:00"/>
+                    <user id="26422"><![CDATA[kumy]]></user>
+                    <comment><![CDATA[test drop]]></comment>
+                    <logtype id="0">Dropped to</logtype>
+                    <distancetravelled unit="km">143</distancetravelled>
+                    <comments>
+                        <comment type="missing">
+                            <user id="26422"><![CDATA[kumy]]></user>
+                            <message><![CDATA[Où est tu ?]]></message>
+                        </comment>
+                        <comment type="message">
+                            <user id="26422"><![CDATA[kumy]]></user>
+                            <message><![CDATA[test]]></message>
+                        </comment>
+                    </comments>
+                </move>
+                <move>
+                    <id>722027</id>
+                    <position latitude="44.12427" longitude="5.17875"/>
+                    <wpt alt="fr">GC2E895</wpt>
+                    <date moved="2015-07-04 00:00"/>
+                    <user id="26422"><![CDATA[kumy]]></user>
+                    <application using="API"><![CDATA[c:geo developerbuild]]></application>
+                    <comment><![CDATA[Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.]]></comment>
+                    <logtype id="5">Dipped in</logtype>
+                    <distancetravelled unit="km">0</distancetravelled>
+                </move>
+                <move>
+                    <id>673734</id>
+                    <date moved="2015-03-29 14:10"/>
+                    <user id="26422"><![CDATA[kumy]]></user>
+                    <application using="API"><![CDATA[c:geo developer build]]></application>
+                    <comment><![CDATA[Test]]></comment>
+                    <logtype id="2">A comment</logtype>
+                </move>
+            </moves>
+        </geokret>
+    </geokrety>
+</gkxml>

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
@@ -3,16 +3,22 @@ package cgeo.geocaching.connector.trackable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.enumerations.LogType;
+import cgeo.geocaching.models.LogEntry;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.test.AbstractResourceInstrumentationTestCase;
 import cgeo.geocaching.test.R;
 
+import cgeo.geocaching.utils.SynchronizedDateFormat;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.xml.sax.InputSource;
 
 import android.app.Application;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase {
 
@@ -136,5 +142,134 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         final Trackable trackable4 = trackables3.get(1);
         assertThat(trackable4).isNotNull();
         assertThat(trackable4.isMissing()).isTrue();
+    }
+
+    public void testFullDetails() throws Exception {
+        final Application app = CgeoApplication.getInstance();
+
+        final List<Trackable> trackables = GeokretyParser.parse(new InputSource(getResourceStream(R.raw.geokret47496_details_xml)));
+        assertThat(trackables).hasSize(1);
+
+        final Trackable trackable1 = trackables.get(0);
+        assertThat(trackable1).isNotNull();
+        assertThat(trackable1.getName()).isEqualTo("c:geo tests");
+        assertThat(trackable1.getGeocode()).isEqualTo("GKB988");
+        assertThat(trackable1.getType()).isEqualTo(app.getString(cgeo.geocaching.R.string.geokret_type_traditional));
+        assertThat(trackable1.getOwner()).isEqualTo("kumy");
+        assertThat(trackable1.getDistance()).isEqualTo(143);
+        assertThat(trackable1.isMissing()).isFalse();
+        assertThat(trackable1.getDetails()).isEqualTo("virtual, just for testing c:geo app<br />" +
+                "<br />" +
+                "<br />" +
+                "<br />" +
+                "<br />" +
+                "Test to break c:geo");
+        assertThat(trackable1.getSpottedType()).isEqualTo(Trackable.SPOTTED_USER);
+        assertThat(trackable1.getSpottedName()).isEqualTo("gueta");
+    }
+
+    public void testLogs() throws Exception {
+        final List<Trackable> trackables = GeokretyParser.parse(new InputSource(getResourceStream(R.raw.geokret47496_details_xml)));
+        assertThat(trackables).hasSize(1);
+        final Trackable trackable1 = trackables.get(0);
+
+        // Check the logs
+        final SynchronizedDateFormat DATE_FORMAT = new SynchronizedDateFormat("yyyy-MM-dd kk:mm", TimeZone.getTimeZone("UTC"), Locale.US);
+        final List<LogEntry> logs = trackable1.getLogs();
+        assertThat(logs).hasSize(6);
+
+        final LogEntry log6 = logs.get(5);
+        assertThat(log6.author).isEqualTo("kumy");
+        assertThat(log6.id).isEqualTo(673734);
+        assertThat(log6.date).isEqualTo(DATE_FORMAT.parse("2015-03-29 14:10").getTime());
+        assertThat(log6.getDisplayText()).isEqualTo("Test");
+        assertThat(log6.getType()).isEqualTo(LogType.NOTE);
+        assertThat(log6.cacheName).isNullOrEmpty();
+    }
+
+    public void testGetLastSpottedUsername() throws Exception {
+
+        final LogEntry note = new LogEntry.Builder()
+                .setLogType(LogType.NOTE)
+                .setAuthor("authorNote")
+                .build();
+
+        final LogEntry placed = new LogEntry.Builder()
+                .setLogType(LogType.PLACED_IT)
+                .setAuthor("authorPlaced")
+                .build();
+
+        final LogEntry grabbed = new LogEntry.Builder()
+                .setLogType(LogType.GRABBED_IT)
+                .setAuthor("authorGrabbed")
+                .build();
+
+        final LogEntry visit = new LogEntry.Builder()
+                .setLogType(LogType.VISIT)
+                .setAuthor("authorVisit")
+                .build();
+
+        final LogEntry discovered = new LogEntry.Builder()
+                .setLogType(LogType.DISCOVERED_IT)
+                .setAuthor("authorDiscovered")
+                .build();
+
+        final String userUnknown = CgeoApplication.getInstance().getString(cgeo.geocaching.R.string.user_unknown);
+        assertThat(GeokretyParser.getLastSpottedUsername(new ArrayList<LogEntry>())).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries1 = new ArrayList<>();
+        logsEntries1.add(note);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries1)).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries2 = new ArrayList<>();
+        logsEntries2.add(note);
+        logsEntries2.add(placed);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries2)).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries3 = new ArrayList<>();
+        logsEntries3.add(visit);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries3)).isEqualTo("authorVisit");
+
+        final List<LogEntry> logsEntries4 = new ArrayList<>();
+        logsEntries4.add(note);
+        logsEntries4.add(visit);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries4)).isEqualTo("authorVisit");
+
+        final List<LogEntry> logsEntries5 = new ArrayList<>();
+        logsEntries5.add(placed);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries5)).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries6 = new ArrayList<>();
+        logsEntries6.add(placed);
+        logsEntries6.add(visit);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries6)).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries7 = new ArrayList<>();
+        logsEntries7.add(visit);
+        logsEntries7.add(placed);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries7)).isEqualTo("authorVisit");
+
+        final List<LogEntry> logsEntries8 = new ArrayList<>();
+        logsEntries8.add(placed);
+        logsEntries8.add(visit);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries8)).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries9 = new ArrayList<>();
+        logsEntries9.add(grabbed);
+        logsEntries9.add(visit);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries9)).isEqualTo("authorGrabbed");
+
+        final List<LogEntry> logsEntries10 = new ArrayList<>();
+        logsEntries10.add(discovered);
+        logsEntries10.add(visit);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries10)).isEqualTo(userUnknown);
+
+        final List<LogEntry> logsEntries11 = new ArrayList<>();
+        logsEntries11.add(note);
+        logsEntries11.add(discovered);
+        logsEntries11.add(note);
+        logsEntries11.add(visit);
+        logsEntries11.add(note);
+        assertThat(GeokretyParser.getLastSpottedUsername(logsEntries11)).isEqualTo(userUnknown);
     }
 }

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
@@ -110,7 +110,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(trackable1.getGeocode()).isEqualTo("GKC240");
         assertThat(trackable1.getDistance()).isEqualTo(2254);
         assertThat(trackable1.getDetails()).isEqualTo("Dieser Geokret dient zum Testen von c:geo.<br />" +
-                "Er befindet sich nicht wirklich im gelisteten Cache. <br />" +
+                "Er befindet sich nicht wirklich im gelisteten Cache.<br />" +
                 "<br />" +
                 "Bitte ignorieren.");
     }


### PR DESCRIPTION
GKM api has been reworked, GK logbook is now available.

Not all available informations could be mapped into current `Trackable` `LogEntry`.
ex:
* comments on logs
* move traveled distance
* Lastlogid/lastmoveid (useful for #4867)
* Cache visit count

Example of full details https://api.gkm.kumy.org/gk/47496/details

Todo: add some unit tests with "complete" xml