### PR TITLE
Add OsmAnd as navigation app

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -154,6 +154,7 @@
     <string translatable="false" name="pref_navigation_menu_navigon">navigationNavigon</string>
     <string translatable="false" name="pref_navigation_menu_sygic_walking">navigationSygicWalking</string>
     <string translatable="false" name="pref_navigation_menu_sygic_driving">navigationSygicDriving</string>
+    <string translatable="false" name="pref_navigation_menu_osmand">navigationOsmAnd</string>
     <string translatable="false" name="pref_navigation_menu_google_walk">navigationGoogleWalk</string>
     <string translatable="false" name="pref_navigation_menu_google_transit">navigationGoogleTransit</string>
     <string translatable="false" name="pref_navigation_menu_google_bike">navigationGoogleBike</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -829,6 +829,7 @@
     <string name="cache_menu_navigation_transit">Navigation (Transit)</string>
     <string name="cache_menu_navigation_bike">Navigation (Bike)</string>
     <string name="cache_menu_maps_directions">Google Maps Directions</string>
+    <string name="cache_menu_osmand">OsmAnd</string>
     <string name="cache_menu_sygic_walk">Sygic (Walking)</string>
     <string name="cache_menu_sygic_drive">Sygic (Driving)</string>
     <string name="cache_menu_radar">Radar</string>
@@ -1113,6 +1114,7 @@
     <string name="navigation_direct_navigation">Direct Navigation</string>
     <string name="navigation_target">Target</string>
     <string name="err_nav_no_coordinates">Cannot start navigation with no coordinates</string>
+    <string name="osmand_marker_cgeo">Marker from c:geo</string>
 
     <!-- license -->
     <string name="license">License</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -737,6 +737,11 @@
                 <CheckBoxPreference
                     android:defaultValue="true"
                     android:enabled="false"
+                    android:key="@string/pref_navigation_menu_osmand"
+                    android:title="@string/cache_menu_osmand" />
+                <CheckBoxPreference
+                    android:defaultValue="true"
+                    android:enabled="false"
                     android:key="@string/pref_navigation_menu_google_walk"
                     android:title="@string/cache_menu_navigation_walk" />
                 <CheckBoxPreference

--- a/main/src/cgeo/geocaching/apps/navi/NavigationAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/navi/NavigationAppFactory.java
@@ -67,8 +67,10 @@ public final class NavigationAppFactory {
         NAVIGON(new NavigonApp(), 10, R.string.pref_navigation_menu_navigon),
         /** The external Sygic app in walking mode */
         SYGIC_WALKING(new SygicNavigationWalkingApp(), 11, R.string.pref_navigation_menu_sygic_walking),
-        /** The external Sygic app in walking mode */
+        /** The external Sygic app in driving mode */
         SYGIC_DRIVING(new SygicNavigationDrivingApp(), 23, R.string.pref_navigation_menu_sygic_driving),
+        /** The external OsmAnd app */
+        OSM_AND(new OsmAndApp(), 26, R.string.pref_navigation_menu_osmand),
         /** Google Navigation in walking mode */
         GOOGLE_NAVIGATION_WALK(new GoogleNavigationWalkingApp(), 12, R.string.pref_navigation_menu_google_walk),
         /** Google Navigation in bike mode */

--- a/main/src/cgeo/geocaching/apps/navi/OsmAndApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/OsmAndApp.java
@@ -1,0 +1,75 @@
+package cgeo.geocaching.apps.navi;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.utils.ProcessUtils;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+
+public class OsmAndApp extends AbstractPointNavigationApp {
+
+    private static final String PARAM_NAME = "name";
+    private static final String PARAM_LAT = "lat";
+    private static final String PARAM_LON = "lon";
+    private static final String PREFIX = "osmand.api://";
+    private static final String GET_INFO = "get_info";
+    private static final String ADD_MAP_MARKER = "add_map_marker";
+
+    protected OsmAndApp() {
+        super(getString(R.string.cache_menu_osmand), null);
+    }
+
+    @Override
+    public boolean isInstalled() {
+        return ProcessUtils.isIntentAvailable(Intent.ACTION_VIEW, Uri.parse(PREFIX + GET_INFO));
+    }
+
+    @Override
+    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+        if (cache.getCoords() != null) {
+            navigate(activity, cache.getCoords(), cache.getName());
+        } else {
+            ActivityMixin.showToast(activity, activity.getResources().getString(R.string.err_nav_no_coordinates));
+        }
+    }
+
+    @Override
+    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
+        if (waypoint.getCoords() != null) {
+            navigate(activity, waypoint.getCoords(), waypoint.getName());
+        } else {
+            ActivityMixin.showToast(activity, activity.getResources().getString(R.string.err_nav_no_coordinates));
+        }
+    }
+
+    @Override
+    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
+        navigate(activity, coords, activity.getResources().getString(R.string.osmand_marker_cgeo));
+    }
+
+    private void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords, @NonNull final String markerName) {
+        final Parameters params = new Parameters(PARAM_LAT, String.valueOf(coords.getLatitude()),
+                PARAM_LON, String.valueOf(coords.getLongitude()),
+                PARAM_NAME, markerName);
+        activity.startActivity(buildIntent(params));
+    }
+
+    private Intent buildIntent(@Nullable final Parameters parameters) {
+        final StringBuilder stringBuilder = new StringBuilder(PREFIX);
+        stringBuilder.append(ADD_MAP_MARKER);
+        if (parameters != null && !parameters.isEmpty()) {
+            stringBuilder.append('?');
+            stringBuilder.append(parameters.toString());
+        }
+        return new Intent(Intent.ACTION_VIEW, Uri.parse(stringBuilder.toString()));
+    }
+}


### PR DESCRIPTION
This adds the possibility to add a navigation marker to OsmAnd / OsmAnd+ through the navigation menu.
See API description here: [OsmAnd API demo](https://github.com/osmandapp/osmand-api-demo)

Also one small comment error for the "Sygic app" was fixed.