### PR TITLE
Fix #5948, Live map crashing

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCMap.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCMap.java
@@ -65,7 +65,7 @@ public class GCMap {
             final Parameters params = new Parameters("i", geocodeList, "_", String.valueOf(System.currentTimeMillis()));
             params.add("app", "cgeo");
             final String referer = GCConstants.URL_LIVE_MAP_DETAILS;
-            final String data = Tile.requestMapInfo(referer, params, referer).toBlocking().value();
+            final String data = Tile.requestMapInfo(referer, params, referer).onErrorResumeNext(Single.just("")).toBlocking().value();
 
             // Example JSON information
             // {"status":"success",


### PR DESCRIPTION
Silently handle failures to get additional info for the popup.

Is this the desired approach? Or should we notify in a toast?
@samueltardieu my implementation is just guessing by analogy. Is this correct?