### PR TITLE
fix #5998 remove middle dot for waypoints

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -31,6 +31,7 @@ import cgeo.geocaching.gcvote.GCVote;
 import cgeo.geocaching.gcvote.GCVoteDialog;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
@@ -484,7 +485,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 if (selectedWaypoint != null) {
                     final Geopoint coordinates = selectedWaypoint.getCoords();
                     if (coordinates != null) {
-                        ClipboardUtils.copyToClipboard(coordinates.toString());
+                        ClipboardUtils.copyToClipboard(
+                                GeopointFormatter.reformatForClipboard(coordinates.toString()));
                         showToast(getResources().getString(R.string.clipboard_copy_ok));
                     }
                 }
@@ -1998,8 +2000,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                                 clickedItemText = ((TextView) view).getText();
                                 final CharSequence itemTitle = ((TextView) ((View) view.getParent()).findViewById(R.id.name)).getText();
                                 if (itemTitle.equals(res.getText(R.string.cache_coordinates))) {
-                                    // remove middle dot from some coordinate formats before copying to clipboard
-                                    clickedItemText = clickedItemText.toString().replace("· ", "");
+                                    clickedItemText = GeopointFormatter.reformatForClipboard(clickedItemText);
                                 }
                                 buildDetailsContextMenu(actionMode, menu, itemTitle, true);
                                 return true;

--- a/main/src/cgeo/geocaching/location/GeopointFormatter.java
+++ b/main/src/cgeo/geocaching/location/GeopointFormatter.java
@@ -124,4 +124,12 @@ public class GeopointFormatter {
         throw new IllegalStateException(); // cannot happen, if switch case is enum complete
     }
 
+    /**
+     * Reformats coordinates for Clipboard.
+     * It removes the middle dot if present.
+     */
+    public static CharSequence reformatForClipboard(CharSequence coordinatesToCopy) {
+        return coordinatesToCopy.toString().replace("· ", "");
+    }
+
 }

--- a/tests/src/cgeo/geocaching/location/GeoPointFormatterTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointFormatterTest.java
@@ -30,4 +30,12 @@ public class GeoPointFormatterTest extends TestCase {
         assertEquals(formatSecond, "N 51° 21' 06.240\"" + Formatter.SEPARATOR + "E 010° 15' 22.140\"", formatSecond);
     }
 
+    public static void testReformatForClipboardRemoveMiddleDot() {
+        assertThat(GeopointFormatter.reformatForClipboard("N 10° 12,345 · W 5° 12,345")).isEqualTo("N 10° 12,345 W 5° 12,345");
+    }
+
+    public static void testReformatForClipboardNoMiddleDotToRemove() {
+        assertThat(GeopointFormatter.reformatForClipboard("N 10° 12' 34\" W 5° 12' 34\"")).isEqualTo("N 10° 12' 34\" W 5° 12' 34\"");
+    }
+
 }


### PR DESCRIPTION
Remove middle dot when copying waypoint coordinates to clipboard.