### PR TITLE
Removed duplicate SEPARATOR Constant, cleanup of location tests

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointFormatter.java
+++ b/main/src/cgeo/geocaching/location/GeopointFormatter.java
@@ -1,12 +1,13 @@
 package cgeo.geocaching.location;
 
+import cgeo.geocaching.utils.Formatter;
+
 import java.util.Locale;
 
 /**
  * Formatting of Geopoint.
  */
 public class GeopointFormatter {
-    private static final String SEPARATOR = " · ";
 
     private GeopointFormatter() {
         // utility class
@@ -75,19 +76,21 @@ public class GeopointFormatter {
 
             case LAT_LON_DECMINUTE: {
                 final Geopoint rgp = gp.roundedAt(60 * 1000);
-                return String.format(Locale.getDefault(), "%c %02d° %06.3f" + SEPARATOR + "%c %03d° %06.3f",
-                        rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMinRaw(), rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
+                return String.format(Locale.getDefault(), "%c %02d° %06.3f" + Formatter.SEPARATOR + "%c %03d° %06.3f",
+                        rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMinRaw(),
+                        rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
             }
 
             case LAT_LON_DECMINUTE_RAW: {
                 final Geopoint rgp = gp.roundedAt(60 * 1000);
                 return String.format((Locale) null, "%c %02d° %06.3f %c %03d° %06.3f",
-                        rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMinRaw(), rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
+                        rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMinRaw(),
+                        rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
             }
 
             case LAT_LON_DECSECOND: {
                 final Geopoint rgp = gp.roundedAt(3600 * 1000);
-                return String.format(Locale.getDefault(), "%c %02d° %02d' %06.3f\"" + SEPARATOR + "%c %03d° %02d' %06.3f\"",
+                return String.format(Locale.getDefault(), "%c %02d° %02d' %06.3f\"" + Formatter.SEPARATOR + "%c %03d° %02d' %06.3f\"",
                         rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMin(), rgp.getLatSecRaw(),
                         rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMin(), rgp.getLonSecRaw());
             }
@@ -131,7 +134,7 @@ public class GeopointFormatter {
      * It removes the middle dot if present.
      */
     public static CharSequence reformatForClipboard(final CharSequence coordinatesToCopy) {
-        return coordinatesToCopy.toString().replace(SEPARATOR, " ");
+        return coordinatesToCopy.toString().replace(Formatter.SEPARATOR, " ");
     }
 
 }

--- a/tests/src/cgeo/geocaching/location/DistanceParserTest.java
+++ b/tests/src/cgeo/geocaching/location/DistanceParserTest.java
@@ -1,30 +1,32 @@
 package cgeo.geocaching.location;
 
 import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 public class DistanceParserTest extends TestCase {
 
     private static final double MM = 1e-6; // 1mm, in kilometers
 
     public static void testFormats() {
-        assertEquals(1.2, DistanceParser.parseDistance("1200 m", true), MM);
-        assertEquals(1.2, DistanceParser.parseDistance("1.2 km", true), MM);
-        assertEquals(0.36576, DistanceParser.parseDistance("1200 ft", true), MM);
-        assertEquals(1.09728, DistanceParser.parseDistance("1200 yd", true), MM);
-        assertEquals(1.9312128, DistanceParser.parseDistance("1.2 mi", true), MM);
+        assertThat((double)DistanceParser.parseDistance("1200 m", true)).isEqualTo(1.2, offset(MM));
+        assertThat((double)DistanceParser.parseDistance("1.2 km", true)).isEqualTo(1.2, offset(MM));
+        assertThat((double)DistanceParser.parseDistance("1200 ft", true)).isEqualTo(0.36576, offset(MM));
+        assertThat((double)DistanceParser.parseDistance("1200 yd", true)).isEqualTo(1.09728, offset(MM));
+        assertThat((double)DistanceParser.parseDistance("1.2 mi", true)).isEqualTo(1.9312128, offset(MM));
     }
 
     public static void testImplicit() {
-        assertEquals(1.2, DistanceParser.parseDistance("1200", true), MM);
-        assertEquals(0.36576, DistanceParser.parseDistance("1200", false), MM);
+        assertThat((double)DistanceParser.parseDistance("1200", true)).isEqualTo(1.2, offset(MM));
+        assertThat((double)DistanceParser.parseDistance("1200", false)).isEqualTo(0.36576, offset(MM));
     }
 
     public static void testComma() {
-        assertEquals(1.2, DistanceParser.parseDistance("1,2km", true), MM);
+        assertThat((double)DistanceParser.parseDistance("1,2km", true)).isEqualTo(1.2, offset(MM));
     }
 
     public static void testFeet() {
-        assertEquals(0.36576, DistanceParser.parseDistance("1200 FT", true), MM);
+        assertThat((double)DistanceParser.parseDistance("1200 FT", false)).isEqualTo(0.36576, offset(MM));
     }
 
 }

--- a/tests/src/cgeo/geocaching/location/GeoPointFormatterTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointFormatterTest.java
@@ -2,8 +2,6 @@ package cgeo.geocaching.location;
 
 import junit.framework.TestCase;
 
-import cgeo.geocaching.utils.Formatter;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GeoPointFormatterTest extends TestCase {
@@ -16,18 +14,18 @@ public class GeoPointFormatterTest extends TestCase {
         final String formatMinute = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_RAW, point);
         assertThat(formatMinute).isEqualTo("N 50° 00.000 E 005° 00.000");
         final String formatSecond = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECSECOND, point).replaceAll(",", ".");
-        assertEquals(formatSecond, "N 50° 00' 00.000\"" + Formatter.SEPARATOR + "E 005° 00' 00.000\"", formatSecond);
+        assertThat(formatSecond).isEqualTo("N 50° 00' 00.000\" · E 005° 00' 00.000\"");
     }
 
     public static void testFormat() {
         // taken from GC30R6G
         final Geopoint point = new Geopoint("N 51° 21.104 E 010° 15.369");
         final String format = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECDEGREE_COMMA, point);
-        assertEquals(format, "51.351733,10.256150", format);
+        assertThat(format).isEqualTo("51.351733,10.256150");
         final String formatMinute = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_RAW, point);
-        assertEquals(formatMinute, "N 51° 21.104 E 010° 15.369", formatMinute);
+        assertThat(formatMinute).isEqualTo("N 51° 21.104 E 010° 15.369");
         final String formatSecond = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECSECOND, point).replaceAll(",", ".");
-        assertEquals(formatSecond, "N 51° 21' 06.240\"" + Formatter.SEPARATOR + "E 010° 15' 22.140\"", formatSecond);
+        assertThat(formatSecond).isEqualTo("N 51° 21' 06.240\" · E 010° 15' 22.140\"");
     }
 
     public static void testReformatForClipboardRemoveMiddleDot() {

--- a/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
@@ -3,8 +3,6 @@ package cgeo.geocaching.location;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
-import cgeo.geocaching.utils.Formatter;
-
 import junit.framework.TestCase;
 
 public class GeoPointParserTest extends TestCase {
@@ -67,7 +65,7 @@ public class GeoPointParserTest extends TestCase {
     }
 
     public static void testParseOurOwnSeparator() {
-        final Geopoint separator = GeopointParser.parse("N 49° 43' 57\"" + Formatter.SEPARATOR + "E 2 12' 35");
+        final Geopoint separator = GeopointParser.parse("N 49° 43' 57\" · E 2 12' 35");
         final Geopoint noSeparator = GeopointParser.parse("N 49 43.95 E2°12.5833333333");
         assertGeopointEquals(separator, noSeparator, (float) 1e-6);
     }

--- a/tests/src/cgeo/geocaching/location/UTMPointConversionTest.java
+++ b/tests/src/cgeo/geocaching/location/UTMPointConversionTest.java
@@ -33,8 +33,8 @@ public class UTMPointConversionTest {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        System.out.println("lat, lon; expected easting, northing; result easting, northing; diff easting, northing");
         return Arrays.asList(new Object[][]{
+                // lat, lon, zone, zoneLetter, easting, northing
                 {85d, 102d, 48, "Z", 470821.25d, 9440493.90d},
                 {84d, 102d, 48, "X", 465005.34493d, 9329005.2d},
                 {51d, 60d, 41, "U", 289511.142963d, 5654109.2d},


### PR DESCRIPTION
Removed duplicate Constant `SEPARATOR`.


I first thought about pushing this small improvement directly to master, but decided otherwise.

Not sure about usage of the Constant in `GeoPointFormatterTest`. I replace the hard coded middle dot with the Constant, to be consistent with the other two test methods. But sometimes its better for Unittests to use redundant hard coded values. To ring the bell when someone accidentally changes the Constant.
What do you think? 

