### PR TITLE
4086 offline log for unsaved caches

### DIFF
--- a/main/src/cgeo/geocaching/loaders/HistoryGeocacheListLoader.java
+++ b/main/src/cgeo/geocaching/loaders/HistoryGeocacheListLoader.java
@@ -18,7 +18,7 @@ public class HistoryGeocacheListLoader extends AbstractSearchLoader {
 
     @Override
     public SearchResult runSearch() {
-        return DataStore.getHistoryOfCaches(true, coords != null ? Settings.getCacheType() : CacheType.ALL);
+        return DataStore.getHistoryOfCaches(coords != null ? Settings.getCacheType() : CacheType.ALL);
     }
 
 }

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -1171,7 +1171,7 @@ public class DataStore {
 
             // Only save the cache in the database if it is requested by the caller and
             // the cache contains detailed information.
-            if (saveFlags.contains(SaveFlag.DB) && cache.isDetailed() && dbUpdateRequired) {
+            if (saveFlags.contains(SaveFlag.DB) && dbUpdateRequired) {
                 toBeStored.add(cache);
             }
         }
@@ -2343,12 +2343,9 @@ public class DataStore {
     }
 
     @NonNull
-    private static Set<String> loadBatchOfHistoricGeocodes(final boolean detailedOnly, final CacheType cacheType) {
+    private static Set<String> loadBatchOfHistoricGeocodes(final CacheType cacheType) {
         final StringBuilder selection = new StringBuilder("visiteddate > 0");
 
-        if (detailedOnly) {
-            selection.append(" AND detailed = 1");
-        }
         String[] selectionArgs = null;
         if (cacheType != CacheType.ALL) {
             selection.append(" AND type = ?");
@@ -3297,8 +3294,8 @@ public class DataStore {
     }
 
     @NonNull
-    public static SearchResult getHistoryOfCaches(final boolean detailedOnly, final CacheType cacheType) {
-        final Set<String> geocodes = loadBatchOfHistoricGeocodes(detailedOnly, cacheType);
+    public static SearchResult getHistoryOfCaches(final CacheType cacheType) {
+        final Set<String> geocodes = loadBatchOfHistoricGeocodes(cacheType);
         return new SearchResult(geocodes, getAllHistoryCachesCount());
     }
 

--- a/tests/src-android/cgeo/geocaching/storage/DataStoreTest.java
+++ b/tests/src-android/cgeo/geocaching/storage/DataStoreTest.java
@@ -1,7 +1,5 @@
 package cgeo.geocaching.storage;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import cgeo.CGeoTestCase;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.gc.GCConnector;
@@ -16,14 +14,15 @@ import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DataStoreTest extends CGeoTestCase {
 
@@ -176,7 +175,7 @@ public class DataStoreTest extends CGeoTestCase {
         int sumCaches = 0;
         int allCaches = 0;
         for (final CacheType cacheType : CacheType.values()) {
-            final SearchResult historyOfType = DataStore.getHistoryOfCaches(false, cacheType);
+            final SearchResult historyOfType = DataStore.getHistoryOfCaches(cacheType);
             assertThat(historyOfType).isNotNull();
             if (cacheType != CacheType.ALL) {
                 sumCaches += historyOfType.getCount();


### PR DESCRIPTION
This is still WIP and I'm still testing it.
Don't know all side effects for saving caches which have `detailed = false`.
Looks a bit awkward, too, when such a Cache is viewed in CacheDetailActivity. I guess this can confuse users. Maybe a visible indication would be necessary that the Cache was not properly loaded and a hit on refresh can solve it.
