### PR TITLE
fix #4564 mass upload of personal notes

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -120,6 +120,10 @@
                 android:id="@+id/menu_export_fieldnotes"
                 android:title="@string/export_fieldnotes">
             </item>
+            <item
+                android:id="@+id/menu_export_persnotes"
+                android:title="@string/export_persnotes">
+            </item>
         </menu>
     </item>
     <item

--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -108,6 +108,10 @@
                 android:id="@+id/menu_export_fieldnotes"
                 android:title="@string/export_fieldnotes">
             </item>
+            <item
+                android:id="@+id/menu_export_persnotes"
+                android:title="@string/export_persnotes">
+            </item>
         </menu>
     </item>
     <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1177,7 +1177,10 @@
     <string name="export_gpx_to">Send exported GPX to</string>
     <string name="export_confirm_title">Exporting %1$s</string>
     <string name="export_confirm_message">To Path: %1$s\nFile Name: %2$s</string>
-    
+    <string name="export_persnotes">Personal notes</string>
+    <string name="export_persnotes_uploading">Uploading personal note %1$d</string>
+    <string name="export_persnotes_upload_success">Uploaded %1$d notes successfully</string>
+
     <!-- GC attributes -->
     <string name="attribute_dogs_yes">Dogs allowed</string>
     <string name="attribute_dogs_no">Dogs not allowed</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -27,6 +27,7 @@ import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.export.FieldnoteExport;
 import cgeo.geocaching.export.GpxExport;
+import cgeo.geocaching.export.PersonalnoteExport;
 import cgeo.geocaching.gcvote.GCVote;
 import cgeo.geocaching.gcvote.GCVoteDialog;
 import cgeo.geocaching.list.StoredList;
@@ -635,6 +636,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 return true;
             case R.id.menu_export_fieldnotes:
                 new FieldnoteExport().export(Collections.singletonList(cache), this);
+                return true;
+            case R.id.menu_export_persnotes:
+                new PersonalnoteExport().export(Collections.singletonList(cache), this);
                 return true;
             case R.id.menu_edit_fieldnote:
                 ensureSaved();

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.export.FieldnoteExport;
 import cgeo.geocaching.export.GpxExport;
+import cgeo.geocaching.export.PersonalnoteExport;
 import cgeo.geocaching.files.GPXImporter;
 import cgeo.geocaching.filter.FilterActivity;
 import cgeo.geocaching.filter.IFilter;
@@ -803,6 +804,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 return true;
             case R.id.menu_export_fieldnotes:
                 new FieldnoteExport().export(adapter.getCheckedOrAllCaches(), this);
+                return true;
+            case R.id.menu_export_persnotes:
+                new PersonalnoteExport().export(adapter.getCheckedOrAllCaches(), this);
                 return true;
             case R.id.menu_remove_from_history:
                 removeFromHistoryCheck();

--- a/main/src/cgeo/geocaching/export/PersonalnoteExport.java
+++ b/main/src/cgeo/geocaching/export/PersonalnoteExport.java
@@ -1,0 +1,86 @@
+package cgeo.geocaching.export;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.capability.PersonalNoteCapability;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.AsyncTaskWithProgress;
+import cgeo.geocaching.utils.Log;
+
+import android.app.Activity;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Exports personal notes.
+ */
+public class PersonalnoteExport extends AbstractExport {
+
+    private int persNotesCount = 0;
+
+    public PersonalnoteExport() {
+        super(R.string.export_persnotes);
+    }
+
+    @Override
+    public void export(@NonNull final List<Geocache> cachesList, @Nullable final Activity activity) {
+        final Geocache[] caches = cachesList.toArray(new Geocache[cachesList.size()]);
+        new ExportTask(activity).execute(caches);
+    }
+
+    private class ExportTask extends AsyncTaskWithProgress<Geocache, Boolean> {
+        /**
+         * Instantiates and configures the task for exporting personal notes.
+         */
+        ExportTask(@Nullable final Activity activity) {
+            super(activity, getProgressTitle(), CgeoApplication.getInstance().getString(R.string.export_persnotes));
+        }
+
+        @Override
+        protected Boolean doInBackgroundInternal(final Geocache[] caches) {
+            try {
+                int i = 0;
+                for (final Geocache cache : caches) {
+                    final IConnector connector = ConnectorFactory.getConnector(cache);
+                    publishProgress(++i);
+                    if (connector instanceof PersonalNoteCapability && StringUtils.isNotBlank(cache.getPersonalNote())) {
+                        ((PersonalNoteCapability)connector).uploadPersonalNote(cache);
+                        persNotesCount++;
+                    }
+                }
+            } catch (final Exception e) {
+                Log.e("PersonalnoteExport.ExportTask uploading personal notes", e);
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        protected void onPostExecuteInternal(final Boolean result) {
+            if (activity != null) {
+                final Context nonNullActivity = activity;
+                if (result) {
+                    ActivityMixin.showToast(activity, nonNullActivity.getString(R.string.export_persnotes_upload_success, persNotesCount));
+                } else {
+                    ActivityMixin.showToast(activity, nonNullActivity.getString(R.string.export_failed));
+                }
+            }
+        }
+
+        @Override
+        protected void onProgressUpdateInternal(final Integer status) {
+            if (activity != null) {
+                setMessage(activity.getString(R.string.export_persnotes_uploading, persNotesCount));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
There is a new Export submenu "Personal note" which can be used to mass upload personal notes.

The only issue is the 500 character warning in the original single upload function. Do you think it is necessary here? I could only scan all personal notes and if one of them is > 500 chars add such a message to the user. But I'm not a fan of it.

I'm not sure about the proper case for the word `notes`. We have `Personal notes`, but `Field Notes`. On geocaching.com I can find both version `Field Notes` and `field notes`.