### PR TITLE
fix #5872 sort order for history

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -1212,7 +1213,9 @@ public final class GCParser {
                 Log.i("Log successfully posted to cache #" + cacheid);
 
                 if (geocode != null) {
-                    DataStore.saveVisitDate(geocode);
+                    final Calendar visitedDate = Calendar.getInstance();
+                    visitedDate.set(year, month - 1, day);
+                    DataStore.saveVisitDate(geocode, visitedDate.getTimeInMillis());
                 }
 
                 gcLogin.getLoginStatus(page);

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -450,7 +450,7 @@ public class Geocache implements IWaypoint {
         final Resources res = fromActivity.getResources();
         if (status) {
             ActivityMixin.showToast(fromActivity, res.getString(R.string.info_log_saved));
-            DataStore.saveVisitDate(geocode);
+            DataStore.saveVisitDate(geocode, date.getTimeInMillis());
             logOffline = Boolean.TRUE;
 
             offlineLog = DataStore.loadLogOffline(geocode);

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -3246,8 +3246,8 @@ public class DataStore {
 
     }
 
-    public static void saveVisitDate(final String geocode) {
-        setVisitDate(Collections.singletonList(geocode), System.currentTimeMillis());
+    public static void saveVisitDate(final String geocode, final long visitedDate) {
+        setVisitDate(Collections.singletonList(geocode), visitedDate);
     }
 
     public static Map<String, Set<Integer>> markDropped(final Collection<Geocache> caches) {


### PR DESCRIPTION
When logging the `visiteddate` was set to the current timestamp, but it should be the data/time the user chose in the Log Dialog.