### PR TITLE
fix #6036: use status.cgeo.org when possible

### DIFF
--- a/main/src/cgeo/geocaching/network/StatusUpdater.java
+++ b/main/src/cgeo/geocaching/network/StatusUpdater.java
@@ -63,7 +63,7 @@ public class StatusUpdater {
                 final Application app = CgeoApplication.getInstance();
                 final String installer = Version.getPackageInstaller(app);
                 final Parameters installerParameters = StringUtils.isNotBlank(installer) ? new Parameters("installer", installer) : null;
-                Network.requestJSON("https://cgeo-status.herokuapp.com/api/status.json",
+                Network.requestJSON("https://status.cgeo.org/api/status.json",
                         Parameters.merge(new Parameters("version_code", String.valueOf(Version.getVersionCode(app)),
                                 "version_name", Version.getVersionName(app),
                                 "locale", Locale.getDefault().toString()), installerParameters))

--- a/main/src/cgeo/geocaching/staticmaps/StaticMapsProvider.java
+++ b/main/src/cgeo/geocaching/staticmaps/StaticMapsProvider.java
@@ -37,7 +37,7 @@ public final class StaticMapsProvider {
     private static final String ROADMAP = "roadmap";
     private static final String WAYPOINT_PREFIX = "wp";
     private static final String MAP_FILENAME_PREFIX = "map_";
-    private static final String MARKERS_URL = "https://cgeo-status.herokuapp.com/assets/markers/";
+    private static final String MARKERS_URL = "https://status.cgeo.org/assets/markers/";
 
     private static volatile long last403 = 0;
 


### PR DESCRIPTION
We now have a valid SSL certificate on status.cgeo.org for API calls.