### PR TITLE
show caches with offline logs to help with #5955

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2357,7 +2357,7 @@ public class DataStore {
         }
 
         try {
-            return queryToColl(dbTableCaches,
+            final Set<String> historicCaches = queryToColl(dbTableCaches,
                     new String[]{"geocode"},
                     selection.toString(),
                     selectionArgs,
@@ -2365,6 +2365,17 @@ public class DataStore {
                     null,
                     new HashSet<String>(),
                     GET_STRING_0);
+
+            historicCaches.addAll(queryToColl(dbTableLogsOffline,
+                    new String[]{"geocode"},
+                    null,
+                    null,
+                    "date",
+                    null,
+                    new HashSet<String>(),
+                    GET_STRING_0));
+
+            return historicCaches;
         } catch (final Exception e) {
             Log.e("DataStore.loadBatchOfHistoricGeocodes", e);
         }


### PR DESCRIPTION
As long as we discuss a proper solution for #5955 I think it would help to see the Geocaches with offline logs (but `visiteddate` == `0`) in the history. These are swallowed right now. It gives the users the possibility to see and delete them manually.