### PR TITLE
fix #6065 no logs when parsing gc custom date failed

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -82,7 +82,7 @@ public final class GCConstants {
 
     static final Pattern PATTERN_AVATAR_IMAGE_PROFILE_PAGE = Pattern.compile("src=\"(https?://(img(?:cdn)?\\.geocaching\\.com|[^>\"]+\\.cloudfront\\.net)/avatar/[0-9a-f-]+\\.(" + IMAGE_FORMATS + "))\"[^>]*alt=\"");
     static final Pattern PATTERN_LOGIN_NAME_LOGIN_PAGE = Pattern.compile("ctl00_ContentBody_lbUsername\">.*<strong>(.*)</strong>");
-    static final Pattern PATTERN_CUSTOMDATE = Pattern.compile("name=\"SelectedDateFormat\".*?<option selected=\"selected\" value=\"(.+?)\">");
+    static final Pattern PATTERN_CUSTOMDATE = Pattern.compile("<option selected=\"selected\" value=\"((?:&#32;|[/.Mdy-])+)\">");
     static final Pattern PATTERN_HOME_LOCATION = Pattern.compile("<input class=\"search-coordinates\"[^>]* value=\"(.*?)\"");
     static final Pattern PATTERN_MAP_LOGGED_IN = Pattern.compile("<a href=\"https?://www.geocaching.com/my/\" class=\"CommonUsername\"");
     static final Pattern PATTERN_ENGLISH_SELECTION = Pattern.compile(Pattern.quote("doPostBack(&#39;") + "(.*?uxLocaleItem)" + Pattern.quote("&#39;"));

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -365,13 +365,17 @@ public class GCLogin extends AbstractLogin {
         final String result = Network.getResponseData(Network.getRequest("https://www.geocaching.com/account/settings/preferences"));
 
         if (result == null) {
-            Log.w("Login.detectGcCustomDate: result is null");
+            Settings.setGcCustomDate(GCConstants.DEFAULT_GC_DATE);
+            Log.w("Login.detectGcCustomDate: result is null, falling back to default");
             return;
         }
 
         final String customDate = TextUtils.getMatch(result, GCConstants.PATTERN_CUSTOMDATE, true, null);
         if (customDate != null) {
             Settings.setGcCustomDate(Html.fromHtml(customDate).toString());
+        } else {
+            Log.w("Login.detectGcCustomDate: text match is null, falling back to default");
+            Settings.setGcCustomDate(GCConstants.DEFAULT_GC_DATE);
         }
     }
 


### PR DESCRIPTION
fixes #6065 in release. Needs to be done differently for master, after @samueltardieu jsoup changes (which I appreciate). This fix shows that Regex parsing of HTML can fail too often.

As suspected some GC profiles don't have a selected default date format. So the Regex fetches an option from another selection later on on the preferences page. 

First I fixed that the Regex to fetch only Date Format patterns, including ones with `&#32;`, and falling back to the default gc custom dateformat when something fails.

There is already the default `MM/dd/yyyy` but c:geo somehow used `dd.MM.yyyy` here, don't know where this comes from.
