### PR TITLE
fix #6092 crash when refreshing certain caches

### DIFF
--- a/main/src/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/cgeo/geocaching/network/HtmlImage.java
@@ -232,7 +232,9 @@ public class HtmlImage implements Html.ImageGetter {
                         final ImmutablePair<BitmapDrawable, Boolean> loaded = loadFromDisk();
                         final BitmapDrawable bitmap = loaded.left;
                         if (loaded.right) {
-                            emitter.onNext(bitmap);
+                            if (!onlySave) {
+                                emitter.onNext(bitmap);
+                            }
                             emitter.onComplete();
                             return;
                         }


### PR DESCRIPTION
Looks like `onNext(bitmap)` was called with a null `bitmap`, which is not allowed.