### PR TITLE
Do not let uncaught OkHttp exceptions crash the application

### DIFF
--- a/main/src/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/cgeo/geocaching/CgeoApplication.java
@@ -28,18 +28,6 @@ public class CgeoApplication extends Application {
 
     private static CgeoApplication instance;
 
-    public static void dumpOnOutOfMemory(final boolean enable) {
-
-        if (enable) {
-
-            if (!OOMDumpingUncaughtExceptionHandler.activateHandler()) {
-                Log.e("OOM dumping handler not activated (either a problem occurred or it was already active)");
-            }
-        } else if (!OOMDumpingUncaughtExceptionHandler.resetToDefault()) {
-            Log.e("OOM dumping handler not resetted (either a problem occurred or it was not active)");
-        }
-    }
-
     public CgeoApplication() {
         setInstance(this);
     }
@@ -55,6 +43,8 @@ public class CgeoApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        OOMDumpingUncaughtExceptionHandler.installUncaughtExceptionHandler();
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             fixUserManagerMemoryLeak();

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -118,9 +118,7 @@ public class Settings {
             .getDefaultSharedPreferences(CgeoApplication.getInstance().getBaseContext());
     static {
         migrateSettings();
-        final boolean isDebug = sharedPrefs.getBoolean(getKey(R.string.pref_debug), false);
-        Log.setDebug(isDebug);
-        CgeoApplication.dumpOnOutOfMemory(isDebug);
+        Log.setDebug(sharedPrefs.getBoolean(getKey(R.string.pref_debug), false));
     }
 
     /**

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -437,9 +437,7 @@ public class SettingsActivity extends PreferenceActivity {
         p.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(final Preference preference, final Object newValue) {
-                final boolean isDebug = (Boolean) newValue;
-                Log.setDebug(isDebug);
-                CgeoApplication.dumpOnOutOfMemory(isDebug);
+                Log.setDebug((Boolean) newValue);
                 return true;
             }
         });


### PR DESCRIPTION
The OkHttp exceptions thrown in background threads are now intercepted
by an UncaughtExceptionHandler.

Also, this handler checks the "debug" settings dynamically rather than
installing or uninstalling itself when they are toggled.

This is part of the fix for #6114.