### PR TITLE
fixes #5949 delete caches from history and search result list

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1392,16 +1392,20 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         @Override
         protected void doCommand() {
-            if (listId == PseudoList.ALL_LIST.id) {
+            if (appliesToAllLists()) {
                 oldCachesLists.putAll(DataStore.markDropped(getCaches()));
             } else {
                 DataStore.removeFromList(getCaches(), listId);
             }
         }
 
+        private boolean appliesToAllLists() {
+            return listId == PseudoList.ALL_LIST.id || listId == PseudoList.HISTORY_LIST.id || listId == StoredList.TEMPORARY_LIST.id;
+        }
+
         @Override
         protected void undoCommand() {
-            if (listId == PseudoList.ALL_LIST.id) {
+            if (appliesToAllLists()) {
                 DataStore.addToLists(getCaches(), oldCachesLists);
             } else {
                 DataStore.addToList(getCaches(), listId);

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -3264,14 +3264,18 @@ public class DataStore {
 
         database.beginTransaction();
         try {
+            final Set<String> geocodes = new HashSet<>(caches.size());
             for (final Geocache cache : caches) {
                 oldLists.put(cache.getGeocode(), loadLists(cache.getGeocode()));
 
                 remove.bindString(1, cache.getGeocode());
                 remove.execute();
+                geocodes.add(cache.getGeocode());
 
                 cache.getLists().clear();
             }
+            clearVisitDate(geocodes);
+
             database.setTransactionSuccessful();
         } finally {
             database.endTransaction();


### PR DESCRIPTION
Caches removed via long press from history or search result will be dropped from all lists.

BUT: caches with offline logs will still appear (stay) on history. We still don't have an agreement to delete offline Logs in these cases.