### PR TITLE
fix #6232 one-click offline log does not save cache

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -337,7 +337,12 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         if (CacheMenuHandler.onMenuItemSelected(item, this, cache)) {
             return true;
         }
-        if (LoggingUI.onMenuItemSelected(item, getActivity(), cache)) {
+        if (LoggingUI.onMenuItemSelected(item, getActivity(), cache, new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                init();
+            }
+        })) {
             return true;
         }
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -648,7 +648,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 }
                 return true;
             default:
-                if (LoggingUI.onMenuItemSelected(item, this, cache)) {
+                if (LoggingUI.onMenuItemSelected(item, this, cache, null)) {
                     refreshOnResume = true;
                     return true;
                 }

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -952,7 +952,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         menu.findItem(R.id.menu_refresh).setVisible(isOffline);
         menu.findItem(R.id.menu_store_cache).setVisible(!isOffline);
 
-        LoggingUI.onPrepareOptionsMenu(menu, cache, adapterInfo.targetView);
+        LoggingUI.onPrepareOptionsMenu(menu, cache);
     }
 
     private void moveCachesToOtherList(final Collection<Geocache> caches) {
@@ -1038,7 +1038,18 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 // in Android:
                 // https://code.google.com/p/android/issues/detail?id=7139
                 lastMenuInfo = info;
-                LoggingUI.onMenuItemSelected(item, this, cache);
+                final View selectedView = adapterInfo.targetView;
+                LoggingUI.onMenuItemSelected(item, this, cache, new DialogInterface.OnDismissListener() {
+                    @Override
+                    public void onDismiss(DialogInterface dialog) {
+                        if (selectedView != null) {
+                            final CacheListAdapter.ViewHolder holder = (CacheListAdapter.ViewHolder) selectedView.getTag();
+                            if (holder != null) {
+                                CacheListAdapter.updateViewHolder(holder, cache, res);
+                            }
+                        }
+                    }
+                });
         }
 
         return true;

--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -219,7 +219,7 @@ public class CompassActivity extends AbstractActionBarActivity {
                 cache.showHintToast(this);
                 return true;
             default:
-                if (LoggingUI.onMenuItemSelected(item, this, cache)) {
+                if (LoggingUI.onMenuItemSelected(item, this, cache, null)) {
                     return true;
                 }
         }

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -684,10 +684,6 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
             new AsyncTask<Void, Void, Void>() {
                 @Override
                 protected Void doInBackground(final Void... params) {
-                    if (!cache.isOffline()) {
-                        cache.getLists().add(StoredList.STANDARD_LIST_ID);
-                        DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
-                    }
                     cache.logOffline(LogCacheActivity.this, log, date, typeSelected);
                     Settings.setLastCacheLog(log);
                     return null;

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -22,8 +22,6 @@ import java.util.List;
 
 public final class LoggingUI extends AbstractUIFactory {
 
-    private static WeakReference<View> selectedViewRef;
-
     private LoggingUI() {
         // utility class
     }
@@ -70,20 +68,20 @@ public final class LoggingUI extends AbstractUIFactory {
         }
     }
 
-    public static boolean onMenuItemSelected(final MenuItem item, final Activity activity, final Geocache cache) {
+    public static boolean onMenuItemSelected(final MenuItem item, final Activity activity, final Geocache cache, final DialogInterface.OnDismissListener listener) {
         switch (item.getItemId()) {
             case R.id.menu_log_visit:
                 cache.logVisit(activity);
                 return true;
             case R.id.menu_log_visit_offline:
-                showOfflineMenu(cache, activity);
+                showOfflineMenu(cache, activity, listener);
                 return true;
             default:
                 return false;
         }
     }
 
-    private static void showOfflineMenu(final Geocache cache, final Activity activity) {
+    private static void showOfflineMenu(final Geocache cache, final Activity activity, final DialogInterface.OnDismissListener listener) {
         final LogEntry currentLog = DataStore.loadLogOffline(cache.getGeocode());
         final LogType currentLogType = currentLog == null ? null : currentLog.getType();
 
@@ -119,18 +117,13 @@ public final class LoggingUI extends AbstractUIFactory {
                 } else {
                     cache.logOffline(activity, logTypeEntry.logType);
                 }
-                final View selectedView = selectedViewRef != null ? selectedViewRef.get() : null;
-                if (selectedView != null) {
-                    final ViewHolder holder = (ViewHolder) selectedView.getTag();
-                    if (holder != null) {
-                        CacheListAdapter.updateViewHolder(holder, cache, res);
-                    }
-                }
+                dialog.dismiss();
             }
         });
 
-        builder.create().show();
-
+        final AlertDialog alertDialog = builder.create();
+        alertDialog.setOnDismissListener(listener);
+        alertDialog.show();
     }
 
     public static void onPrepareOptionsMenu(final Menu menu, final Geocache cache) {
@@ -142,11 +135,6 @@ public final class LoggingUI extends AbstractUIFactory {
 
         final MenuItem itemOffline = menu.findItem(R.id.menu_log_visit_offline);
         itemOffline.setVisible(cache.supportsLogging() && Settings.getLogOffline());
-    }
-
-    public static void onPrepareOptionsMenu(final Menu menu, final Geocache cache, final View view) {
-        onPrepareOptionsMenu(menu, cache);
-        selectedViewRef = new WeakReference<>(view);
     }
 
     public static void addMenuItems(final Activity activity, final Menu menu, final Geocache cache) {

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -445,6 +445,12 @@ public class Geocache implements IWaypoint {
         if (logType == LogType.UNKNOWN) {
             return;
         }
+
+        if (!isOffline()) {
+            getLists().add(StoredList.STANDARD_LIST_ID);
+            DataStore.saveCache(this, LoadFlags.SAVE_ALL);
+        }
+
         final boolean status = DataStore.saveLogOffline(geocode, date.getTime(), logType, log);
 
         final Resources res = fromActivity.getResources();


### PR DESCRIPTION
Saving the cache was not a problem, but updating the map popup took me quite some time.
Closing the Dialog of the one-click offline log didn't trigger the `onResume()` method of the `CachePopupFragment`. I didn't want to extend the `LoggingUI` with yet another view to update, so I refactored that class and used an `OnDismissListener` which can be provided. With this I could also remove the WeakReference of the `CacheListAdapter.ViewHolder` which was used to perform an update, too.

Maybe @Bananeweizen and/or @samueltardieu can have a quick look if this solution is ok.