### PR TITLE
fix #6259: do not save cookie store with Google

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -119,7 +119,6 @@
     <string translatable="false" name="pref_memberstatus">memberstatus</string>
     <string translatable="false" name="pref_coordinputformat">coordinputformat</string>
     <string translatable="false" name="pref_gccustomdate">gccustomdate</string>
-    <string translatable="false" name="pref_cookiestore">cookiestore</string>
     <string translatable="false" name="pref_googleplayservices">googleplayservices</string>
     <string translatable="false" name="pref_lowpowermode">lowpowerlocation</string>
     <string translatable="false" name="pref_lastdetailspage">lastdetailspage</string>

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -8,7 +8,7 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.network.AndroidBeam;
 import cgeo.geocaching.network.Cookies;
-import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.settings.DiskCookieStore;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.EditUtils;
@@ -153,7 +153,7 @@ public abstract class AbstractActivity extends ActionBarActivity implements IAbs
         app = (CgeoApplication) this.getApplication();
 
         // only needed in some activities, but implemented in super class nonetheless
-        Cookies.restoreCookieStore(Settings.getCookieStore());
+        Cookies.restoreCookieStore(DiskCookieStore.getCookieStore());
         ActivityMixin.onCreate(this, keepScreenOn);
     }
 

--- a/main/src/cgeo/geocaching/connector/AbstractLogin.java
+++ b/main/src/cgeo/geocaching/connector/AbstractLogin.java
@@ -6,7 +6,7 @@ import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.network.Cookies;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.settings.Credentials;
-import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.settings.DiskCookieStore;
 
 import org.apache.commons.lang3.StringUtils;
 import android.support.annotation.NonNull;
@@ -60,7 +60,7 @@ public abstract class AbstractLogin {
 
     protected void resetLoginStatus() {
         Cookies.clearCookies();
-        Settings.setCookieStore(null);
+        DiskCookieStore.setCookieStore(null);
 
         setActualLoginStatus(false);
     }

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.network.Parameters;
 import cgeo.geocaching.settings.Credentials;
+import cgeo.geocaching.settings.DiskCookieStore;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
@@ -100,7 +101,7 @@ public class GCLogin extends AbstractLogin {
             }
 
             Cookies.clearCookies();
-            Settings.setCookieStore(null);
+            DiskCookieStore.setCookieStore(null);
 
             final String[] viewstates = getViewstates(tryLoggedInData);
             if (isEmpty(viewstates)) {
@@ -131,7 +132,7 @@ public class GCLogin extends AbstractLogin {
                     return login(false, credentials);
                 }
                 Log.i("Successfully logged in Geocaching.com as " + username + " (" + Settings.getGCMemberStatus() + ')');
-                Settings.setCookieStore(Cookies.dumpCookieStore());
+                DiskCookieStore.setCookieStore(Cookies.dumpCookieStore());
                 setHomeLocation();
                 refreshMemberStatus();
                 detectGcCustomDate();

--- a/main/src/cgeo/geocaching/settings/DiskCookieStore.java
+++ b/main/src/cgeo/geocaching/settings/DiskCookieStore.java
@@ -1,0 +1,35 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.CgeoApplication;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class DiskCookieStore {
+
+    private static final SharedPreferences COOKIES_PREFS = CgeoApplication.getInstance().getSharedPreferences("cookies", Context.MODE_PRIVATE);
+    private static final String COOKIES_KEY = "cookies";
+
+    private DiskCookieStore() {
+        // Utility class, do not instantiate
+    }
+
+    public static void setCookieStore(@Nullable final String cookies) {
+        final SharedPreferences.Editor e = COOKIES_PREFS.edit();
+        if (StringUtils.isBlank(cookies)) {
+            // erase cookies
+            e.remove(COOKIES_KEY);
+        } else {
+            e.putString(COOKIES_KEY, cookies);
+        }
+        e.apply();
+    }
+
+    @Nullable
+    public static String getCookieStore() {
+        return COOKIES_PREFS.getString(COOKIES_KEY, null);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -199,7 +199,6 @@ public class Settings {
             e.putBoolean(getKey(R.string.pref_loaddirectionimg), prefsV0.getBoolean(getKey(R.string.pref_loaddirectionimg), true));
             e.putString(getKey(R.string.pref_gccustomdate), prefsV0.getString(getKey(R.string.pref_gccustomdate), GCConstants.DEFAULT_GC_DATE));
             e.putInt(getKey(R.string.pref_showwaypointsthreshold), prefsV0.getInt(getKey(R.string.pref_showwaypointsthreshold), SHOW_WP_THRESHOLD_DEFAULT));
-            e.putString(getKey(R.string.pref_cookiestore), prefsV0.getString(getKey(R.string.pref_cookiestore), null));
             e.putBoolean(getKey(R.string.pref_opendetailslastpage), prefsV0.getBoolean(getKey(R.string.pref_opendetailslastpage), false));
             e.putInt(getKey(R.string.pref_lastdetailspage), prefsV0.getInt(getKey(R.string.pref_lastdetailspage), 1));
             e.putInt(getKey(R.string.pref_defaultNavigationTool), prefsV0.getInt(getKey(R.string.pref_defaultNavigationTool), NavigationAppsEnum.COMPASS.id));
@@ -440,19 +439,6 @@ public class Settings {
     @NonNull
     public static String getSignature() {
         return StringUtils.defaultString(getString(R.string.pref_signature, StringUtils.EMPTY));
-    }
-
-    public static void setCookieStore(final String cookies) {
-        if (StringUtils.isBlank(cookies)) {
-            // erase cookies
-            remove(R.string.pref_cookiestore);
-        }
-        // save cookies
-        putString(R.string.pref_cookiestore, cookies);
-    }
-
-    public static String getCookieStore() {
-        return getString(R.string.pref_cookiestore, null);
     }
 
     public static void setUseGooglePlayServices(final boolean value) {


### PR DESCRIPTION
Keeping the cookie store separate from the preferences allows not to
backup it with the backup manager.