### PR TITLE
fix #6189 fast-store with preselection on long press

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -789,6 +789,7 @@
     <string name="cache_list_text">List:</string>
     <string name="cache_list_change">Move</string>
     <string name="cache_list_unknown">Not in a list</string>
+    <string name="cache_list_select_last">Last Selection</string>
     <string name="cache_images">Images</string>
     <string name="cache_waypoints">Waypoints</string>
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -610,7 +610,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 dropCache();
                 return true;
             case R.id.menu_store_in_list:
-                storeCache();
+                storeCache(false);
                 return true;
             case R.id.menu_refresh:
                 refreshCache();
@@ -916,7 +916,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         cache.drop(new ChangeNotificationHandler(this, progress));
     }
 
-    private void storeCache() {
+    private void storeCache(final boolean fastStoreOnLastSelection) {
         if (progress.isShowing()) {
             showToast(res.getString(R.string.err_detail_still_working));
             return;
@@ -930,7 +930,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                         public void call(final Set<Integer> selectedListIds) {
                             storeCacheInLists(selectedListIds);
                         }
-                    }, true, cache.getLists());
+                    }, true, cache.getLists(), fastStoreOnLastSelection);
         } else {
             storeCacheInLists(Collections.singleton(StoredList.STANDARD_LIST_ID));
         }
@@ -1052,14 +1052,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             updateAttributesText();
             ButterKnife.findById(view, R.id.attributes_box).setVisibility(cache.getAttributes().isEmpty() ? View.GONE : View.VISIBLE);
 
-            updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), new OnLongClickListener() {
-
-                @Override
-                public boolean onLongClick(final View v) {
-                    moveCache();
-                    return true;
-                }
-            });
+            updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(),
+                    new StoreCacheClickListener(), new MoveCacheClickListener(), new StoreCacheClickListener());
 
             // list
             updateCacheLists(view, cache, res);
@@ -1154,12 +1148,25 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             }
         }
 
-        private class StoreCacheClickListener implements View.OnClickListener {
+        private class StoreCacheClickListener implements View.OnClickListener, View.OnLongClickListener {
             @Override
             public void onClick(final View arg0) {
-                storeCache();
+                storeCache(false);
             }
 
+            @Override
+            public boolean onLongClick(View v) {
+                storeCache(true);
+                return true;
+            }
+        }
+
+        private class MoveCacheClickListener implements OnLongClickListener {
+            @Override
+            public boolean onLongClick(final View v) {
+                moveCache();
+                return true;
+            }
         }
 
         private class DropCacheClickListener implements View.OnClickListener {
@@ -2230,7 +2237,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final OnClickListener refreshCacheClickListener,
             final OnClickListener dropCacheClickListener,
             final OnClickListener storeCacheClickListener,
-            final OnLongClickListener moveCacheListener) {
+            final OnLongClickListener moveCacheListener,
+            final OnLongClickListener storeCachePreselectedListener) {
         // offline use
         final TextView offlineText = ButterKnife.findById(view, R.id.offline_text);
         final ImageButton offlineRefresh = ButterKnife.findById(view, R.id.offline_refresh);
@@ -2239,6 +2247,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         offlineStoreDrop.setClickable(true);
         offlineStoreDrop.setOnClickListener(storeCacheClickListener);
+        offlineStoreDrop.setOnLongClickListener(storeCachePreselectedListener);
+
         if (moveCacheListener != null) {
             offlineEdit.setOnLongClickListener(moveCacheListener);
         }
@@ -2264,6 +2274,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             offlineText.setText(res.getString(R.string.cache_offline_stored) + "\n" + ago);
 
             offlineStoreDrop.setOnClickListener(dropCacheClickListener);
+            offlineStoreDrop.setOnLongClickListener(null);
             offlineStoreDrop.setClickable(true);
             offlineStoreDrop.setImageResource(R.drawable.ic_menu_delete);
 

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1228,7 +1228,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                         public void call(final Set<Integer> selectedListIds) {
                             refreshStoredInternal(caches, selectedListIds);
                         }
-                    }, true, Collections.singleton(StoredList.TEMPORARY_LIST.id), Collections.<Integer>emptySet(), listNameMemento);
+                    }, true, Collections.singleton(StoredList.TEMPORARY_LIST.id), Collections.<Integer>emptySet(), listNameMemento, false);
         } else {
             final Set<Integer> additionalListIds = new HashSet<>();
             if (type != CacheListType.OFFLINE && type != CacheListType.HISTORY) {

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -130,7 +130,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
             addCacheDetails();
 
             // offline use
-            CacheDetailActivity.updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), null);
+            CacheDetailActivity.updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), null, new StoreCacheClickListener());
 
             CacheDetailActivity.updateCacheLists(view, cache, res);
         } catch (final Exception e) {
@@ -164,9 +164,19 @@ public class CachePopupFragment extends AbstractDialogFragment {
         init();
     }
 
-    private class StoreCacheClickListener implements View.OnClickListener {
+    private class StoreCacheClickListener implements View.OnClickListener, View.OnLongClickListener {
         @Override
         public void onClick(final View arg0) {
+            selectListsAndStore(false);
+        }
+
+        @Override
+        public boolean onLongClick(View v) {
+            selectListsAndStore(true);
+            return true;
+        }
+
+        private void selectListsAndStore(final boolean fastStoreOnLastSelection) {
             if (progress.isShowing()) {
                 showToast(res.getString(R.string.err_detail_still_working));
                 return;
@@ -178,19 +188,21 @@ public class CachePopupFragment extends AbstractDialogFragment {
                         new Action1<Set<Integer>>() {
                             @Override
                             public void call(final Set<Integer> selectedListIds) {
-                                storeCache(selectedListIds);
+                                storeCacheOnLists(selectedListIds);
                             }
-                        }, true, cache.getLists());
+                        }, true, cache.getLists(), fastStoreOnLastSelection);
             } else {
-                storeCache(Collections.singleton(StoredList.STANDARD_LIST_ID));
+                storeCacheOnLists(Collections.singleton(StoredList.STANDARD_LIST_ID));
             }
         }
 
-        protected void storeCache(final Set<Integer> listIds) {
+        private void storeCacheOnLists(final Set<Integer> listIds) {
             if (cache.isOffline()) {
                 // cache already offline, just add to another list
                 DataStore.saveLists(Collections.singletonList(cache), listIds);
-                CacheDetailActivity.updateOfflineBox(getView(), cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), null);
+                CacheDetailActivity.updateOfflineBox(getView(), cache, res,
+                        new RefreshCacheClickListener(), new DropCacheClickListener(),
+                        new StoreCacheClickListener(), null, new StoreCacheClickListener());
                 CacheDetailActivity.updateCacheLists(getView(), cache, res);
             } else {
                 final StoreCacheHandler storeCacheHandler = new StoreCacheHandler(CachePopupFragment.this, R.string.cache_dialog_offline_save_message);
@@ -207,7 +219,9 @@ public class CachePopupFragment extends AbstractDialogFragment {
                         activity.supportInvalidateOptionsMenu();
                         final View view = getView();
                         if (view != null) {
-                            CacheDetailActivity.updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), null);
+                            CacheDetailActivity.updateOfflineBox(view, cache, res,
+                                    new RefreshCacheClickListener(), new DropCacheClickListener(),
+                                    new StoreCacheClickListener(), null, new StoreCacheClickListener());
                             CacheDetailActivity.updateCacheLists(view, cache, res);
                         }
                     }

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -770,7 +770,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                             public void call(final Set<Integer> selectedListIds) {
                                 storeCaches(geocodes, selectedListIds);
                                     }
-                        }, true, Collections.<Integer>emptySet());
+                        }, true, Collections.<Integer>emptySet(), false);
                     } else {
                         storeCaches(geocodes, Collections.singleton(StoredList.STANDARD_LIST_ID));
                     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -382,7 +382,7 @@ public class NewMap extends AbstractActionBarActivity {
                             public void call(final Set<Integer> selectedListIds) {
                                 storeCaches(geocodes, selectedListIds);
                             }
-                        }, true, Collections.singleton(StoredList.TEMPORARY_LIST.id));
+                        }, true, Collections.singleton(StoredList.TEMPORARY_LIST.id), false);
                     } else {
                         storeCaches(geocodes, Collections.singleton(StoredList.STANDARD_LIST_ID));
                     }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -496,11 +496,6 @@ public class Settings {
     }
 
     public static Set<Integer> getLastSelectedLists() {
-        // only remember the last selected lists over a short period of time
-        final long lastSelectionTimeMillis = getLong(R.string.pref_last_selected_lists_time, 0);
-        if (System.currentTimeMillis() - lastSelectionTimeMillis > 600 * 1000) {
-            return Collections.emptySet();
-        }
         final Set<Integer> lastSelectedLists = new HashSet<>();
         for (final String lastSelectedListString : getStringList(R.string.pref_last_selected_lists, StringUtils.EMPTY)) {
             try {
@@ -515,7 +510,6 @@ public class Settings {
      */
     public static void setLastSelectedLists(final Set<Integer> lastSelectedLists) {
         putStringList(R.string.pref_last_selected_lists, lastSelectedLists);
-        putLong(R.string.pref_last_selected_lists_time, System.currentTimeMillis());
     }
 
     public static void setWebNameCode(final String name, final String code) {


### PR DESCRIPTION
This (proposed) change adds a third button on the list selection dialog to preselect the lists from last store.
It add a `fast-store` function on the store buttons triggered by a long press. The `fast-store` uses the last remembered list selection and stores immediately without showing a list selection. It falls back to show the dialog if there are no remembered lists.
The timeout for remembering the lists is removed.
The store menu items don't offer the `fast-store` option, see comment https://github.com/cgeo/cgeo/issues/6189#issuecomment-273444179