### PR TITLE
Waypoint naming when parsing text + unit test

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -123,7 +123,9 @@ android {
                 // TODO: espresso causes some dependency conflicts, therefore disable espresso tests temporarily
                 exclude '**/*EspressoTest.java'
                 exclude '**/*LogTrackableActivityTest.java'
-                exclude '**/*Waypoint*Test.java'
+                // there is a valid test WaypointTest which should run, so the pattern must be more specific
+                exclude '**/A*Waypoint*Test.java'
+                exclude '**/EditWaypoint*Test.java'
             }
             resources.srcDirs = ['../tests/src']
             res.srcDirs = ['../tests/res']

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -632,7 +632,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 ignoreCache();
                 return true;
             case R.id.menu_extract_waypoints:
-                cache.parseWaypointsFromText(HtmlUtils.extractText(cache.getDescription()), true);
+                cache.addWaypointsFromText(HtmlUtils.extractText(cache.getDescription()), true, res.getString(R.string.cache_description));
                 getViewCreator(Page.WAYPOINTS).notifyDataSetChanged();
                 return true;
             case R.id.menu_export_gpx:
@@ -2387,7 +2387,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     @Override
     public void onFinishEditNoteDialog(final String note) {
         cache.setPersonalNote(note);
-        if (cache.parseWaypointsFromNote()) {
+        if (cache.addWaypointsFromNote()) {
             getViewCreator(Page.WAYPOINTS).notifyDataSetChanged();
         }
 

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -201,7 +201,7 @@ public abstract class AbstractActivity extends ActionBarActivity implements IAbs
                 actionMode.finish();
                 return true;
             case R.id.menu_extract_waypoints:
-                if (cache != null && cache.parseWaypointsFromText(HtmlUtils.extractText(clickedItemText), true)) {
+                if (cache != null && cache.addWaypointsFromText(HtmlUtils.extractText(clickedItemText), true, res.getString(R.string.cache_description))) {
                     final Intent intent = new Intent(Intents.INTENT_CACHE_CHANGED);
                     intent.putExtra(Intents.EXTRA_WPT_PAGE_UPDATE, true);
                     LocalBroadcastManager.getInstance(this).sendBroadcast(intent);

--- a/main/src/cgeo/geocaching/location/UTMPoint.java
+++ b/main/src/cgeo/geocaching/location/UTMPoint.java
@@ -48,8 +48,8 @@ public class UTMPoint {
      */
     private char zoneLetter;
 
-    //                                                          ( 1   )(  2    )    (  3  )       (         4       )       (        5        )
-    private static final Pattern PATTERN_UTM = Pattern.compile("(^|\\s)(\\d\\d?)\\s*([A-Z])[\\sE]+(\\d+(?:[.,]\\d+)?)[\\sN]+(\\d+(?:[.,]\\d+)?)", Pattern.CASE_INSENSITIVE);
+    //                                                          ( 1   )(  2    )       (  3  )       (         4       )       (        5        )
+    private static final Pattern PATTERN_UTM = Pattern.compile("(^|\\s)(\\d\\d?)[ \\t]*([A-Z])[\\sE]+(\\d+(?:[.,]\\d+)?)[\\sN]+(\\d+(?:[.,]\\d+)?)", Pattern.CASE_INSENSITIVE);
 
     /**
      * Point to create if you are going to use the static methods to fill the

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1507,15 +1507,22 @@ public class Geocache implements IWaypoint {
     }
 
     /**
-     * Detect coordinates in the personal note and convert them to user defined waypoints. Works by rule of thumb.
+     * Detect coordinates in the personal note and add them to user defined waypoints.
      */
-    public boolean parseWaypointsFromNote() {
-        return parseWaypointsFromText(getPersonalNote(), false);
+    public boolean addWaypointsFromNote() {
+        return addWaypointsFromText(getPersonalNote(), false, CgeoApplication.getInstance().getString(R.string.cache_personal_note));
     }
 
-    public boolean parseWaypointsFromText(@Nullable final String text, final boolean updateDb) {
+    /**
+     * Detect coordinates in the given text and add them to user defined waypoints.
+     *
+     * @param text text which might contain coordinates
+     * @param updateDb if true the added waypoints are stored in DB right away
+     * @param namePrefix prefix for waypoint names
+     */
+    public boolean addWaypointsFromText(@Nullable final String text, final boolean updateDb, @NonNull final String namePrefix) {
         boolean changed = false;
-        for (final Waypoint waypoint : Waypoint.parseWaypointsFromNote(StringUtils.defaultString(text))) {
+        for (final Waypoint waypoint : Waypoint.parseWaypoints(StringUtils.defaultString(text), namePrefix)) {
             if (!hasIdenticalWaypoint(waypoint.getCoords())) {
                 addOrChangeWaypoint(waypoint, updateDb);
                 changed = true;

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -1,16 +1,13 @@
 package cgeo.geocaching.models;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.enumerations.CoordinatesType;
-import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
+import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.MatcherWrapper;
 
-import org.apache.commons.lang3.StringUtils;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -22,6 +19,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class Waypoint implements IWaypoint {
 
@@ -281,25 +280,27 @@ public class Waypoint implements IWaypoint {
     }
 
     /**
-     * Detect coordinates in the personal note and convert them to user defined waypoints. Works by rule of thumb.
+     * Detect coordinates in the given text and converts them to user defined waypoints.
+     * Works by rule of thumb.
      *
-     * @param initialNote Note content
+     * @param initialText Text to parse for waypoints
+     * @param namePrefix Prefix of the name of the waypoint
      * @return a collection of found waypoints
      */
-    public static Collection<Waypoint> parseWaypointsFromNote(@NonNull final String initialNote) {
+    public static Collection<Waypoint> parseWaypoints(@NonNull final String initialText, @NonNull final String namePrefix) {
         final List<Waypoint> waypoints = new LinkedList<>();
 
-        String note = initialNote;
-        MatcherWrapper matcher = new MatcherWrapper(PATTERN_COORDS, note);
+        String text = initialText;
+        MatcherWrapper matcher = new MatcherWrapper(PATTERN_COORDS, text);
         int count = 1;
         while (matcher.find()) {
             try {
-                final Geopoint point = new Geopoint(note.substring(matcher.start()));
+                final Geopoint point = new Geopoint(text.substring(matcher.start()));
                 // Coords must have non zero latitude and longitude and at least one part shall have fractional degrees.
                 if (point.getLatitudeE6() != 0 && point.getLongitudeE6() != 0 &&
                         ((point.getLatitudeE6() % 1000) != 0 || (point.getLongitudeE6() % 1000) != 0)) {
-                    final String name = CgeoApplication.getInstance().getString(R.string.cache_personal_note) + " " + count;
-                    final String potentialWaypointType = note.substring(Math.max(0, matcher.start() - 15));
+                    final String name = namePrefix + " " + count;
+                    final String potentialWaypointType = text.substring(Math.max(0, matcher.start() - 15));
                     final Waypoint waypoint = new Waypoint(name, parseWaypointType(potentialWaypointType), true);
                     waypoint.setCoords(point);
                     waypoints.add(waypoint);
@@ -308,8 +309,8 @@ public class Waypoint implements IWaypoint {
             } catch (final Geopoint.ParseException ignored) {
             }
 
-            note = note.substring(matcher.start() + 1);
-            matcher = new MatcherWrapper(PATTERN_COORDS, note);
+            text = text.substring(matcher.start() + 1);
+            matcher = new MatcherWrapper(PATTERN_COORDS, text);
         }
         return waypoints;
     }

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -1163,7 +1163,7 @@ public class DataStore {
             final Geocache existingCache = existingCaches.get(geocode);
             boolean dbUpdateRequired = !cache.gatherMissingFrom(existingCache) || cacheCache.getCacheFromCache(geocode) != null;
             // parse the note AFTER merging the local information in
-            dbUpdateRequired |= cache.parseWaypointsFromNote();
+            dbUpdateRequired |= cache.addWaypointsFromNote();
             cache.addStorageLocation(StorageLocation.CACHE);
             cacheCache.putCacheInCache(cache);
 

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -187,7 +187,7 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
     private static void assertWaypointsFromNote(final Geocache cache, final Geopoint[] expected, final String note) {
         cache.setPersonalNote(note);
         cache.setWaypoints(new ArrayList<Waypoint>(), false);
-        cache.parseWaypointsFromNote();
+        cache.addWaypointsFromNote();
         final List<Waypoint> waypoints = cache.getWaypoints();
         assertThat(waypoints).hasSize(expected.length);
         for (int i = 0; i < expected.length; i++) {
@@ -208,7 +208,7 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         cache.setWaypoints(new ArrayList<Waypoint>(), false);
         cache.setPersonalNote("\"Parking area at PARKING=N 50° 40.666E 006° 58.222\n" + "My calculated final coordinates: FINAL=N 50° 40.777E 006° 58.111\n" + "Get some ice cream at N 50° 40.555E 006° 58.000\"");
 
-        cache.parseWaypointsFromNote();
+        cache.addWaypointsFromNote();
         final List<Waypoint> waypoints = cache.getWaypoints();
 
         assertThat(waypoints).hasSize(3);

--- a/tests/src-android/cgeo/geocaching/connector/gc/WaypointsTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/WaypointsTest.java
@@ -1,27 +1,17 @@
 package cgeo.geocaching.connector.gc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import cgeo.CGeoTestCase;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.utils.DisposableHandler;
 
-import android.os.Message;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WaypointsTest extends CGeoTestCase {
 
-    public static final DisposableHandler handler = new DisposableHandler() {
-        @Override
-        protected void handleRegularMessage(final Message message) {
-            // Dummy
-        }
-    };
-
     private static Geocache downloadCache(final String geocode) {
-        final SearchResult searchResult = Geocache.searchByGeocode(geocode, null, true, handler);
+        final SearchResult searchResult = Geocache.searchByGeocode(geocode, null, true, null);
         assertThat(searchResult.getCount()).isEqualTo(1);
         return searchResult.getFirstCacheFromResult(LoadFlags.LOAD_WAYPOINTS);
     }

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -1,7 +1,5 @@
 package cgeo.geocaching.models;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import cgeo.CGeoTestCase;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
@@ -21,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GeocacheTest extends CGeoTestCase {
 
@@ -72,6 +71,14 @@ public class GeocacheTest extends CGeoTestCase {
         assertWaypointsParsed("Test N51 13.888 E007 03.444 Test N51 13.233 E007 03.444 Test N51 09.123 E007 03.444", 3);
     }
 
+    /**
+     * The first and the third waypoints are identical.
+     * Duplicates should be ignored, so expected size is 2.
+     */
+    public final void testUpdateWaypointsFromNoteWithDuplicates() {
+        assertWaypointsParsed("Test N51 13.888 E007 03.444 Test N51 13.233 E007 03.444 Test N51 13.888 E007 03.444", 2);
+    }
+
     private void assertWaypointsParsed(final String note, final int expectedWaypoints) {
         recordMapStoreFlags();
 
@@ -84,13 +91,12 @@ public class GeocacheTest extends CGeoTestCase {
             cache.setWaypoints(new ArrayList<Waypoint>(), false);
             for (int i = 0; i < 2; i++) {
                 cache.setPersonalNote(note);
-                cache.parseWaypointsFromNote();
+                cache.addWaypointsFromNote();
                 final List<Waypoint> waypoints = cache.getWaypoints();
                 assertThat(waypoints).isNotNull();
                 assertThat(waypoints).hasSize(expectedWaypoints);
                 final Waypoint waypoint = waypoints.get(0);
                 assertThat(waypoint.getCoords()).isEqualTo(new Geopoint("N51 13.888 E007 03.444"));
-                //            assertThat(waypoint.getNote()).isEqualTo("Test");
                 assertThat(waypoint.getName()).isEqualTo(CgeoApplication.getInstance().getString(R.string.cache_personal_note) + " 1");
                 cache.store(Collections.singleton(StoredList.TEMPORARY_LIST.id), null);
             }


### PR DESCRIPTION
Initially I just wanted to change the name of the parsed waypoints from the cache description from "Personal note #" to "Description #" as suggested in  https://github.com/cgeo/cgeo/issues/1249#issuecomment-274693217, but it got a bit more.
I wanted to add this to a UnitTest. Then I stumbled upon the `WaypointTest` class which didn't run. It took a while till I found out it was (accidentally) excluded by disabling the Espresso tests. The exclude pattern was to broad. Then I had to fix the test, because the UTM coordinate parsing caused a false match here. While at it I refactored a bit. Splitting tests, renaming methods to better reflect what they are doing.

Usually I prefer smaller changes, but here I came from one topic to the next.
I hope it's still ok, otherwise please object.

So, here is a summary of the changes:
- Waypoints extracted from Cache description now have "Description #" as name
- `WaypointTest` is reactivated (was excluded together with Espresso tests)
- `WaypointTest` extended and refactored
- `Geocache.parseWaypointsFrom...()` is renamed to `Geocache.addWaypointsFrom...()` to better reflect what it is doing
- `UTMPoint` regex pattern narrowed to prevent false positive from `WaypointTest`
- Added another test to `GeocacheText` which tests that duplicate waypoints don't overwrite waypoints which are already there.