### PR TITLE
fix #5353, fix #6223 waypoint storage

### DIFF
--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -71,6 +71,14 @@
             android:layout_height="wrap_content"
             android:hint="@string/waypoint_note"
             android:inputType="textMultiLine|textCapSentences"
+            android:minLines="5"/>
+
+        <EditText
+            android:id="@+id/user_note"
+            style="@style/edittext_full"
+            android:layout_height="wrap_content"
+            android:hint="@string/waypoint_user_note"
+            android:inputType="textMultiLine|textCapSentences"
             android:minLines="5" />
 
         <CheckBox

--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -95,6 +95,19 @@
         tools:visiblity="visible"
         tools:text="Note"/>
 
+    <TextView
+        android:id="@+id/user_note"
+        android:autoLink="all"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="12dp"
+        android:focusable="false"
+        android:textColor="?text_color"
+        android:textSize="14sp"
+        android:visibility="gone"
+        tools:visiblity="visible"
+        tools:text="User Note"/>
+
     <View
         style="@style/separator_horizontal"
         android:layout_marginTop="9dp" />

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -979,6 +979,7 @@
     <string name="waypoint_edit_title">Edit waypoint</string>
     <string name="waypoint_add_title">Add waypoint</string>
     <string name="waypoint_note">Note</string>
+    <string name="waypoint_user_note">User note</string>
     <string name="waypoint_visited">Visited</string>
     <string name="waypoint_save">Save</string>
     <string name="waypoint_cancel_edit">Cancel</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -446,8 +446,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 menu.findItem(R.id.menu_waypoint_reset_cache_coords).setVisible(isOriginalWaypoint);
                 menu.findItem(R.id.menu_waypoint_edit).setVisible(!isOriginalWaypoint);
                 menu.findItem(R.id.menu_waypoint_duplicate).setVisible(!isOriginalWaypoint);
-                final boolean userDefined = selectedWaypoint.isUserDefined() && selectedWaypoint.getWaypointType() != WaypointType.ORIGINAL;
-                menu.findItem(R.id.menu_waypoint_delete).setVisible(userDefined);
+                menu.findItem(R.id.menu_waypoint_delete).setVisible(!isOriginalWaypoint);
                 final boolean hasCoords = selectedWaypoint.getCoords() != null;
                 final MenuItem defaultNavigationMenu = menu.findItem(R.id.menu_waypoint_navigate_default);
                 defaultNavigationMenu.setVisible(hasCoords);
@@ -1826,6 +1825,20 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 }
             } else {
                 noteView.setVisibility(View.GONE);
+            }
+
+            // user note
+            final TextView userNoteView = holder.userNoteView;
+            if (StringUtils.isNotBlank(wpt.getUserNote()) && !StringUtils.equals(wpt.getNote(), wpt.getUserNote())) {
+                userNoteView.setOnClickListener(new DecryptTextClickListener(userNoteView));
+                userNoteView.setVisibility(View.VISIBLE);
+                if (TextUtils.containsHtml(wpt.getUserNote())) {
+                    userNoteView.setText(Html.fromHtml(wpt.getUserNote(), new SmileyImage(cache.getGeocode(), userNoteView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+                } else {
+                    userNoteView.setText(wpt.getUserNote());
+                }
+            } else {
+                userNoteView.setVisibility(View.GONE);
             }
 
             final View wpNavView = holder.wpNavView;

--- a/main/src/cgeo/geocaching/WaypointViewHolder.java
+++ b/main/src/cgeo/geocaching/WaypointViewHolder.java
@@ -1,11 +1,12 @@
 package cgeo.geocaching;
 
+import cgeo.geocaching.ui.AbstractViewHolder;
+
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import butterknife.BindView;
-import cgeo.geocaching.ui.AbstractViewHolder;
 
 public class WaypointViewHolder extends AbstractViewHolder {
 
@@ -13,6 +14,7 @@ public class WaypointViewHolder extends AbstractViewHolder {
     @BindView(R.id.info) protected TextView infoView;
     @BindView(R.id.name) protected TextView nameView;
     @BindView(R.id.note) protected TextView noteView;
+    @BindView(R.id.user_note) protected TextView userNoteView;
     @BindView(R.id.wpDefaultNavigation) protected ImageView wpNavView;
 
     public WaypointViewHolder(final View rowView) {

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -762,6 +762,8 @@ public final class GCParser {
                     latlon = Html.fromHtml(TextUtils.getMatch(wp[7], GCConstants.PATTERN_WPPREFIXORLOOKUPORLATLON, false, 2, "", false)).toString().trim();
                     if (!StringUtils.startsWith(latlon, "???")) {
                         waypoint.setCoords(new Geopoint(latlon));
+                    } else {
+                        waypoint.setOriginalCoordsEmpty(true);
                     }
 
                     if (wpItems.length >= j) {

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -568,6 +568,8 @@ final class OkapiClient {
                 final Geopoint pt = parseCoords(wptResponse.get(WPT_LOCATION).asText());
                 if (pt != null) {
                     wpt.setCoords(pt);
+                } else {
+                    wpt.setOriginalCoordsEmpty(true);
                 }
                 if (result == null) {
                     result = new ArrayList<>();

--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -21,14 +21,14 @@ import org.apache.commons.lang3.StringUtils;
  * Enum listing waypoint types
  */
 public enum WaypointType {
-    FINAL("flag", "Final Location", R.string.wp_final, R.drawable.waypoint_flag),
-    OWN("own", "Own", R.string.wp_waypoint, R.drawable.waypoint_waypoint),
-    PARKING("pkg", "Parking Area", R.string.wp_pkg, R.drawable.waypoint_pkg),
-    PUZZLE("puzzle", "Virtual Stage", R.string.wp_puzzle, R.drawable.waypoint_puzzle),
-    STAGE("stage", "Physical Stage", R.string.wp_stage, R.drawable.waypoint_stage),
-    TRAILHEAD("trailhead", "Trailhead", R.string.wp_trailhead, R.drawable.waypoint_trailhead),
-    WAYPOINT("waypoint", "Reference Point", R.string.wp_waypoint, R.drawable.waypoint_waypoint),
-    ORIGINAL("original", "Original Coordinates", R.string.wp_original, R.drawable.waypoint_waypoint);
+    FINAL("flag", "Final Location", R.string.wp_final, R.drawable.waypoint_flag, 3),
+    OWN("own", "Own", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 5),
+    PARKING("pkg", "Parking Area", R.string.wp_pkg, R.drawable.waypoint_pkg, -1),
+    PUZZLE("puzzle", "Virtual Stage", R.string.wp_puzzle, R.drawable.waypoint_puzzle, 2),
+    STAGE("stage", "Physical Stage", R.string.wp_stage, R.drawable.waypoint_stage, 2),
+    TRAILHEAD("trailhead", "Trailhead", R.string.wp_trailhead, R.drawable.waypoint_trailhead, 1),
+    WAYPOINT("waypoint", "Reference Point", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 2),
+    ORIGINAL("original", "Original Coordinates", R.string.wp_original, R.drawable.waypoint_waypoint, 4);
 
     @NonNull
     public final String id;
@@ -37,11 +37,14 @@ public enum WaypointType {
     public final int stringId;
     public final int markerId;
 
-    WaypointType(@NonNull final String id, @NonNull final String gpx, final int stringId, final int markerId) {
+    public final int order;
+
+    WaypointType(@NonNull final String id, @NonNull final String gpx, final int stringId, final int markerId, final int order) {
         this.id = id;
         this.gpx = gpx;
         this.stringId = stringId;
         this.markerId = markerId;
+        this.order = order;
     }
 
     /**

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1447,7 +1447,7 @@ public class Geocache implements IWaypoint {
         if (waypoint.getId() < 0) {
             return false;
         }
-        if (waypoint.isUserDefined()) {
+        if (waypoint.getWaypointType() != WaypointType.ORIGINAL) {
             final int index = getWaypointIndex(waypoint);
             waypoints.remove(index);
             DataStore.deleteWaypoint(waypoint.getId());

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -35,9 +35,12 @@ public class Waypoint implements IWaypoint {
     private String name = "";
     private Geopoint coords = null;
     private String note = "";
+    private String userNote = "";
     private int cachedOrder = ORDER_UNDEFINED;
     private boolean own = false;
+
     private boolean visited = false;
+    private boolean originalCoordsEmpty = false;
 
     /**
      * require name and type for every waypoint
@@ -67,7 +70,7 @@ public class Waypoint implements IWaypoint {
             lookup = old.lookup;
         }
         if (StringUtils.isBlank(name)) {
-            setName(old.name);
+            name = old.name;
         }
         if (coords == null) {
             coords = old.coords;
@@ -75,8 +78,11 @@ public class Waypoint implements IWaypoint {
         if (StringUtils.isBlank(note)) {
             note = old.note;
         }
-        if (note != null && old.note != null && old.note.length() > note.length()) {
-            note = old.note;
+        if (StringUtils.isBlank(userNote)) {
+            userNote = old.userNote;
+        }
+        if (StringUtils.equals(note, userNote)) {
+            userNote = "";
         }
         if (id < 0) {
             id = old.id;
@@ -111,32 +117,9 @@ public class Waypoint implements IWaypoint {
         setPrefix(PREFIX_OWN);
     }
 
-    private int computeOrder() {
-        // first parking, then trailhead (as start of the journey)
-        // puzzles, stages, waypoints can all be mixed
-        // at last the final and the original coordinates of the final
-        switch (waypointType) {
-            case PARKING:
-                return -1;
-            case TRAILHEAD:
-                return 1;
-            case STAGE:
-            case PUZZLE:
-            case WAYPOINT:
-                return 2;
-            case FINAL:
-                return 3;
-            case ORIGINAL:
-                return 4;
-            case OWN:
-                return 5;
-        }
-        return 0;
-    }
-
     private int order() {
         if (cachedOrder == ORDER_UNDEFINED) {
-            cachedOrder = computeOrder();
+            cachedOrder = waypointType.order;
         }
         return cachedOrder;
     }
@@ -338,4 +321,19 @@ public class Waypoint implements IWaypoint {
         return new GeoitemRef(getGpxId(), getCoordType(), getGeocode(), getId(), getName(), getWaypointType().markerId);
     }
 
+    public String getUserNote() {
+        return userNote;
+    }
+
+    public void setUserNote(final String userNote) {
+        this.userNote = userNote;
+    }
+
+    public boolean isOriginalCoordsEmpty() {
+        return originalCoordsEmpty;
+    }
+
+    public void setOriginalCoordsEmpty(boolean originalCoordsEmpty) {
+        this.originalCoordsEmpty = originalCoordsEmpty;
+    }
 }

--- a/tests/src-android/cgeo/geocaching/activity/waypoint/AddWaypointActivityTest.java
+++ b/tests/src-android/cgeo/geocaching/activity/waypoint/AddWaypointActivityTest.java
@@ -37,6 +37,7 @@ public class AddWaypointActivityTest extends AbstractAddWaypointActivityTest {
     @Suppress
     public static void testFieldsAreEmpty() {
         onView(withId(R.id.note)).check(matches(withText("")));
+        onView(withId(R.id.user_note)).check(matches(withText("")));
         onView(withId(R.id.bearing)).check(matches(withText("")));
         onView(withId(R.id.distance)).check(matches(withText("")));
     }

--- a/tests/src-android/cgeo/geocaching/activity/waypoint/EditWaypointActivityTest.java
+++ b/tests/src-android/cgeo/geocaching/activity/waypoint/EditWaypointActivityTest.java
@@ -23,6 +23,10 @@ public class EditWaypointActivityTest extends AbstractEditWaypointActivityTest {
         assertThat(note).isNotEmpty();
         onView(withId(R.id.note)).check(matches(withText(note)));
 
+        final String userNote = getWaypoint().getUserNote();
+        assertThat(userNote).isNotEmpty();
+        onView(withId(R.id.user_note)).check(matches(withText(userNote)));
+
         onView(withId(R.id.type)).check(matches(withChild(withText(getWaypoint().getWaypointType().getL10n()))));
     }
 

--- a/tests/src-android/cgeo/geocaching/models/WaypointTest.java
+++ b/tests/src-android/cgeo/geocaching/models/WaypointTest.java
@@ -101,4 +101,54 @@ public class WaypointTest extends CGeoTestCase {
         assertWaypoint(iterator.next(), "Prefix 4", new Geopoint("N 45°50.305 E 9°43.991"));
     }
 
+    public static void testMerge() {
+        final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        local.setPrefix("S1");
+        local.setCoords(new Geopoint("N 45°49.739 E 9°45.038"));
+        local.setNote("Note");
+        local.setUserNote("User Note");
+        local.setVisited(true);
+        local.setId(4711);
+
+        final Waypoint server = new Waypoint("", WaypointType.STAGE, false);
+        server.merge(local);
+
+        assertThat(server.getPrefix()).isEqualTo("S1");
+        assertThat(server.getCoords()).isEqualTo(new Geopoint("N 45°49.739 E 9°45.038"));
+        assertThat(server.getNote()).isEqualTo("Note");
+        assertThat(server.getUserNote()).isEqualTo("User Note");
+        assertThat(server.isVisited()).isTrue();
+        assertThat(server.getId()).isEqualTo(4711);
+    }
+
+    public static void testMergeFinalWPWithLocalCoords() {
+        final Waypoint local = new Waypoint("Final", WaypointType.FINAL, false);
+        local.setCoords(new Geopoint("N 45°49.739 E 9°45.038"));
+        final Waypoint server = new Waypoint("Final", WaypointType.FINAL, false);
+        server.merge(local);
+        assertThat(server.getCoords()).isEqualTo(new Geopoint("N 45°49.739 E 9°45.038"));
+    }
+
+    public static void testMergeNote() {
+        final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        local.setNote("Old Note");
+        local.setUserNote("Local User Note");
+        final Waypoint server = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        server.setNote("New Note");
+        server.merge(local);
+        assertThat(server.getNote()).isEqualTo("New Note");
+        assertThat(server.getUserNote()).isEqualTo("Local User Note");
+    }
+
+    public static void testMergeNoteCleaningUpMigratedNote() {
+        final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        local.setNote("");
+        local.setUserNote("Note");
+        final Waypoint server = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        server.setNote("Note");
+        server.merge(local);
+        assertThat(server.getNote()).isEqualTo("Note");
+        assertThat(server.getUserNote()).isEqualTo("");
+    }
+
 }


### PR DESCRIPTION
Here is a proposal to change the waypoint storage to preserve local changes.

- Name (title): only editable if it is a user defined waypoint
- Coords: only editable if it is a user defined waypoint or if no coords were present (like finals)
- Note: only editable if it is a user defined waypoint
- User note: new field which is editable for all waypoints and not affected by server side changes

Migration:
Because we don't know which notes were edited locally, here I copy all `notes` into `user_note` and set the `note` to empty. On refresh the `note` field is set to the server side value and compared with the `user_note` field. If identical, the `user_note` field is emptied.

While testing this, it worked good for me. But of course I would like to have some feedback.