### PR TITLE
fix #6284 log date format in system information

### DIFF
--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -8,28 +8,31 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.PocketQuery;
 import cgeo.geocaching.models.Waypoint;
 
-import org.apache.commons.lang3.StringUtils;
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
-import android.content.Context;
 import android.text.format.DateUtils;
 
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
 
 public final class Formatter {
 
     /** Text separator used for formatting texts */
     public static final String SEPARATOR = " · ";
 
-    private static final Context context = CgeoApplication.getInstance().getBaseContext();
-
     private Formatter() {
         // Utility class
+    }
+
+    private static Context getContext() {
+        return CgeoApplication.getInstance().getBaseContext();
     }
 
     /**
@@ -42,7 +45,7 @@ public final class Formatter {
      */
     @NonNull
     public static String formatTime(final long date) {
-        return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_TIME);
+        return DateUtils.formatDateTime(getContext(), date, DateUtils.FORMAT_SHOW_TIME);
     }
 
     /**
@@ -55,7 +58,7 @@ public final class Formatter {
      */
     @NonNull
     public static String formatDate(final long date) {
-        return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE);
+        return DateUtils.formatDateTime(getContext(), date, DateUtils.FORMAT_SHOW_DATE);
     }
 
     /**
@@ -69,8 +72,22 @@ public final class Formatter {
      */
     @NonNull
     public static String formatFullDate(final long date) {
-        return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE
+        return DateUtils.formatDateTime(getContext(), date, DateUtils.FORMAT_SHOW_DATE
                 | DateUtils.FORMAT_SHOW_YEAR);
+    }
+
+    /**
+     * Tries to get the date format pattern of the system short date.
+     *
+     * @return format pattern or empty String if it can't be retrieved
+     */
+    @NonNull
+    public static String getShortDateFormat() {
+        final DateFormat dateFormat = android.text.format.DateFormat.getDateFormat(getContext());
+        if (dateFormat instanceof SimpleDateFormat) {
+            return ((SimpleDateFormat)dateFormat).toPattern();
+        }
+        return StringUtils.EMPTY; // should not happen
     }
 
     /**
@@ -83,7 +100,7 @@ public final class Formatter {
      */
     @NonNull
     public static String formatShortDate(final long date) {
-        final DateFormat dateFormat = android.text.format.DateFormat.getDateFormat(context);
+        final DateFormat dateFormat = android.text.format.DateFormat.getDateFormat(getContext());
         return dateFormat.format(date);
     }
 
@@ -130,7 +147,7 @@ public final class Formatter {
      */
     @NonNull
     public static String formatShortDateTime(final long date) {
-        return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME | DateUtils.FORMAT_ABBREV_ALL);
+        return DateUtils.formatDateTime(getContext(), date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME | DateUtils.FORMAT_ABBREV_ALL);
     }
 
     /**
@@ -143,7 +160,7 @@ public final class Formatter {
      */
     @NonNull
     public static String formatDateTime(final long date) {
-        return DateUtils.formatDateTime(context, date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME);
+        return DateUtils.formatDateTime(getContext(), date, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -66,7 +66,7 @@ public final class SystemInformation {
         if (Settings.useEnglish()) {
             body.append(" (cgeo forced to English)");
         }
-        body.append("\nLog date format: ").append(Formatter.formatShortDate(System.currentTimeMillis()))
+        body.append("\nSystem date format: ").append(Formatter.getShortDateFormat())
                 .append("\nDebug mode active: ").append(Settings.isDebug() ? "yes" : "no");
         appendPermissions(context, body);
         appendConnectors(body);

--- a/tests/src-android/cgeo/geocaching/utils/FormatterTest.java
+++ b/tests/src-android/cgeo/geocaching/utils/FormatterTest.java
@@ -1,15 +1,27 @@
 package cgeo.geocaching.utils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.models.Waypoint;
 
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
 import junit.framework.TestCase;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FormatterTest extends TestCase {
+
+    /**
+     * The pattern we get from {@link Formatter#getShortDateFormat()} should be the one used by {@link Formatter#formatShortDate(long)}.
+     */
+    public static void testShortDateFormat() {
+        final long currentTimeMillis = System.currentTimeMillis();
+        final String formattedDate = Formatter.formatShortDate(currentTimeMillis);
+        final String pattern = Formatter.getShortDateFormat();
+        assertThat(new SimpleDateFormat(pattern, Locale.getDefault()).format(currentTimeMillis)).isEqualTo(formattedDate);
+    }
 
     public static void testParkingWaypoint() {
         assertFormatting(new Waypoint("you can park here", WaypointType.PARKING, false), WaypointType.PARKING.getL10n());


### PR DESCRIPTION
Changed `Log date format` in SystemInformation to `System date format` to make it clear what it is.
Used a cast to SimpleDateFormat to retrieve the data format pattern used.
Backed by a UnitTest.

I also resolved a warning in the `Formatter` class about a possible memory leak because the Context was stored in a static field.