### PR TITLE
fix #6285 calendar time recognition

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1780,6 +1780,8 @@ public class Geocache implements IWaypoint {
         }
 
         final String searchText = getShortDescription() + ' ' + getDescription();
+        int start = -1;
+        int eventTimeMinutes = -1;
         for (final Pattern pattern : patterns) {
             final MatcherWrapper matcher = new MatcherWrapper(pattern, searchText);
             while (matcher.find()) {
@@ -1789,15 +1791,17 @@ public class Geocache implements IWaypoint {
                     if (matcher.groupCount() >= 2 && StringUtils.isNotEmpty(matcher.group(2))) {
                         minutes = Integer.parseInt(matcher.group(2));
                     }
-                    if (hours >= 0 && hours < 24 && minutes >= 0 && minutes < 60) {
-                        return hours * 60 + minutes;
+                    if (hours >= 0 && hours < 24 && minutes >= 0 && minutes < 60
+                         && (eventTimeMinutes == -1 || matcher.start() < start)) {
+                            eventTimeMinutes = hours * 60 + minutes;
+                            start = matcher.start();
                     }
                 } catch (final NumberFormatException ignored) {
                     // cannot happen, but static code analysis doesn't know
                 }
             }
         }
-        return -1;
+        return eventTimeMinutes;
     }
 
     public boolean hasStaticMap() {

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -1,7 +1,5 @@
 package cgeo.geocaching.models;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import cgeo.CGeoTestCase;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
@@ -11,8 +9,6 @@ import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogType;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -21,6 +17,9 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GeocacheTest extends CGeoTestCase {
 
@@ -327,6 +326,9 @@ public class GeocacheTest extends CGeoTestCase {
         assertTime("von 11 bis 13" + timeHours, 11, 00);
         assertTime("from 11 to 13" + timeHours, 11, 00);
         assertTime("von 19.15" + timeHours + " bis ca.20.30 " + timeHours + " statt", 19, 15);
+
+        // #6285
+        assertTime("Dienstag den 31. Januar ab 18:00" + timeHours + " (das Logbuch liegt bis mind. 20:30 " + timeHours + " aus)", 18, 00);
     }
 
     public static void testGuessEventTimeShortDescription() {


### PR DESCRIPTION
Scanning the cache description through all patterns and using the one which matches the earliest position in text.