### PR TITLE
fix #6292 waypoint projection fields

### DIFF
--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -25,32 +25,38 @@
             android:freezesText="true"
             android:hint="@string/longitude" />
 
-        <EditText
-            android:id="@+id/bearing"
-            style="@style/edittext_full"
-            android:hint="@string/waypoint_bearing"
-            android:inputType="numberDecimal" />
-
         <LinearLayout
+            android:id="@+id/projection"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal" >
-
+            android:orientation="vertical">
             <EditText
-                android:id="@+id/distance"
+                android:id="@+id/bearing"
                 style="@style/edittext_full"
-                android:layout_width="0dip"
-                android:layout_weight="1"
-                android:hint="@string/waypoint_distance"
+                android:hint="@string/waypoint_bearing"
                 android:inputType="numberDecimal" />
 
-            <Spinner
-                android:id="@+id/distanceUnit"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:entries="@array/distance_units"
-                tools:listitem="@android:layout/simple_spinner_item" />
+                android:orientation="horizontal" >
 
+                <EditText
+                    android:id="@+id/distance"
+                    style="@style/edittext_full"
+                    android:layout_width="0dip"
+                    android:layout_weight="1"
+                    android:hint="@string/waypoint_distance"
+                    android:inputType="numberDecimal" />
+
+                <Spinner
+                    android:id="@+id/distanceUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:entries="@array/distance_units"
+                    tools:listitem="@android:layout/simple_spinner_item" />
+
+            </LinearLayout>
         </LinearLayout>
 
         <Spinner

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -967,6 +967,11 @@
 
     <!-- waypoint -->
     <string name="waypoint">Waypoint</string>
+    <string name="waypoint_coordinates">Coordinates</string>
+    <array name="waypoint_coordinates_options">
+        <item>@string/waypoint_copy_coordinates</item>
+        <item>@string/waypoint_duplicate</item>
+    </array>
     <string name="waypoint_cache_coordinates">Cache coordinates</string>
     <string name="waypoint_custom">Custom</string>
     <string name="waypoint_my_coordinates">My coordinates</string>
@@ -1000,6 +1005,7 @@
     <string name="waypoint_coordinates_has_been_modified_on_website">Cache coordinates on website have been modified to: %s.</string>
     <string name="waypoint_done">Done</string>
     <string name="waypoint_duplicate">Duplicate</string>
+    <string name="waypoint_duplicated">Waypoint duplicated</string>
     <string name="waypoint_copy_of">Copy of</string>
     <string name="search_history">History</string>
     <string name="search_history_empty">No previous destinations</string>


### PR DESCRIPTION
If coords are not editable hide the projection fields and offer a dialog to copy the coords to clipboard or duplicate the waypoint.