### PR TITLE
#6276 prevent deletion of logs on error

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -1509,6 +1509,9 @@ public class DataStore {
     }
 
     private static void saveLogsWithoutTransaction(final String geocode, final Iterable<LogEntry> logs) {
+        if (!logs.iterator().hasNext()) {
+            return;
+        }
         // TODO delete logimages referring these logs
         database.delete(dbTableLogs, "geocode = ?", new String[]{geocode});
 


### PR DESCRIPTION
It just partly fixes #6276. It prevents the deletion of the logs we have in the database when the refresh returns an empty list because of an error.

The user should be informed by a Toast that the logs couldn't be updated. But I got lost in RxJava error handling.