### PR TITLE
Fix #6316: Partially revert 59f584e60ab0a62923f3fbb2ee8ea780976c8d71

### DIFF
--- a/main/src/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/cgeo/geocaching/network/HtmlImage.java
@@ -168,9 +168,6 @@ public class HtmlImage implements Html.ImageGetter {
     @Nullable
     @Override
     public BitmapDrawable getDrawable(final String url) {
-        if (url == null) {
-            throw new IllegalArgumentException("url cannot be null");
-        }
         if (cache.containsKey(url)) {
             return cache.get(url);
         }
@@ -190,13 +187,13 @@ public class HtmlImage implements Html.ImageGetter {
         return new ContainerDrawable(textView, drawable);
     }
 
-    public Observable<BitmapDrawable> fetchDrawable(@NonNull final String url) {
+    public Observable<BitmapDrawable> fetchDrawable(final String url) {
         return observableCache.get(url);
     }
 
     // Caches are loaded from disk on a computation scheduler to avoid using more threads than cores while decoding
     // the image. Downloads happen on downloadScheduler, in parallel with image decoding.
-    private Observable<BitmapDrawable> fetchDrawableUncached(@NonNull final String url) {
+    private Observable<BitmapDrawable> fetchDrawableUncached(final String url) {
         if (StringUtils.isBlank(url) || ImageUtils.containsPattern(url, BLOCKED)) {
             return Observable.just(ImageUtils.getTransparent1x1Drawable(resources));
         }


### PR DESCRIPTION
If an <img> tag has no src attribute getDrawable(null) is called.
Thus, we should not throw an exception in this case (and instead
return a transparent 1x1 image).