### PR TITLE
update to android-gradle 2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
 		classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
 	
 		// Android gradle plugin
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     
 		// Android annotation processor
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
@@ -156,7 +156,7 @@ buildScan {
  * common configuration for the Java projects
  */
 
-ext.buildToolsVersion = "23.0.3"
+ext.buildToolsVersion = "25.0.2" // android-gradle 2.3 requires at least 25.0
 ext.minSdkVersion = 14
 
 subprojects {


### PR DESCRIPTION
This is the most recent version of the gradle build support for Android.
It also requires updating SDK build to 25.0 or better. So it seems
reasonable to take the latest version of SDK build.

If you see local warnings, please also upgrade Android Studio itself to
2.3.

This change probably requires Jenkins nodes to be upgraded.