### PR TITLE
Declare a new build type - legacy

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -80,6 +80,11 @@ android {
         release {
             signingConfig signingConfigs.release
         }
+        legacy {
+            defaultConfig.versionName = System.getenv('LEGACY_VERSION_NAME')
+            defaultConfig.versionCode = System.getenv('LEGACY_VERSION_CODE') as Integer
+            signingConfig signingConfigs.release
+        }
     }
     
     buildTypes.all { buildType ->
@@ -273,6 +278,7 @@ dependencies {
     def leakCanaryVersion = '1.5'
     debugCompile "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
     releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
+    legacyCompile "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
     nightlyCompile "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
     rcCompile "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
     testCompile "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"


### PR DESCRIPTION
Related to Next feature release #6334.
Necessary to build `cgeo-legacy` branch