### PR TITLE
Fix #6438 - Improve strings for storage settings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -436,7 +436,7 @@
     <string name="settings_title_map_data">Map Data</string>
     <string name="settings_title_map_content">Map Content</string>
     <string name="settings_title_gpx">GPX</string>
-    <string name="settings_title_data_dir">Geocache Data</string>
+    <string name="settings_title_data_dir">Geocache Data Location</string>
     <string name="settings_title_basicmembers">Options for Basic Members</string>
     <string name="settings_title_navigation">Navigation</string>
     <string name="settings_summary_navigation">Choose preferred navigation methods and select external navigation apps.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -587,7 +587,7 @@
     <string name="init_gpx_exportdir">GPX Export Directory</string>
     <string name="init_gpx_importdir">GPX Import Directory</string>
     <string name="init_dataDir">Select Geocache data directory</string>
-    <string name="init_dataDir_note">You may choose to store the geocache data (e.g. spoilers, log images, …) on emulated or real external storage. Depending on your device if a real external SD card is available or not.</string>
+    <string name="init_dataDir_note">You may choose to store the additional data for geocaches (spoilers, log images, …) on emulated or real external storage. It is depending on your device if a real external SD card is available or not.</string>
     <string name="init_maptrail">Show Trail</string>
     <string name="init_summary_maptrail">Show trail on Map</string>
     <string name="init_share_after_export">Open share menu after GPX export</string>
@@ -607,8 +607,8 @@
     <string name="init_debug_note">c:geo can generate a lot of debugging information. Activating this setting can however affect the stability of c:geo and is only recommended if you are asked to send a log to the developers.</string>
     <string name="init_debug">Activate debug log</string>
     <string name="init_dbonsdcard_title">Database location</string>
-    <string name="init_dbonsdcard_note">You may store the database of c:geo on your external storage medium. Doing so will save internal memory, but you may lose a bit of performance and c:geo will not work if your SD card isn\'t available.</string>
-    <string name="init_dbonsdcard">On external storage</string>
+    <string name="init_dbonsdcard_note">You may store the database of c:geo either system internally or in a directory on the public file system. Depending on the file system setup of your device, having it on the public filesystem may free some internal memory, but you may lose a bit of performance and c:geo and will not work if the external file system is not accessible or you remove the database file.</string>
+    <string name="init_dbonsdcard">On public file system</string>
     <string name="init_dbmove_dbmove">Moving Database</string>
     <string name="init_dbmove_running">Moving Database</string>
     <string name="init_dbmove_success">Successfully moved the database.</string>


### PR DESCRIPTION
I could not find any string for the caption of the Geocache data section (like e.g. `<string name="init_datadir_title">`. I would like this to be renamed to "Geocache Data Location".

It seems hardcoded right now. Will open a dedicated issue after checking.
