### PR TITLE
fix #6437 add more prefixes to geocache data pattern

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -25,6 +25,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.search.SearchSuggestionCursor;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -970,7 +971,7 @@ public class DataStore {
             for (final File file : files) {
                 if (file.isDirectory()) {
                     final String geocode = file.getName();
-                    if (LocalStorage.GEOCACHE_FILE_PATTERN.matcher(geocode).find()) {
+                    if (!HtmlImage.SHARED.equals(geocode)) {
                         synchronized (select) {
                             select.bindString(1, geocode);
                             if (select.simpleQueryForLong() == 0) {

--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -44,7 +44,7 @@ public final class LocalStorage {
     private static final String GEOCACHE_PHOTOS_DIR_NAME = "GeocachePhotos";
     private static final String GEOCACHE_DATA_DIR_NAME = "GeocacheData";
 
-    public static final Pattern GEOCACHE_FILE_PATTERN = Pattern.compile("^(GC|TB|EC|GK|O)[A-Z0-9]{2,7}$");
+    public static final Pattern GEOCACHE_FILE_PATTERN = Pattern.compile("^(GC|TB|TC|CC|LC|EC|GK|MV|TR|VI|MS|EV|CT|GE|GA|WM|O)[A-Z0-9]{2,7}$");
 
     private static File internalCgeoDirectory;
     private static File externalPrivateCgeoDirectory;


### PR DESCRIPTION
Added more patterns from other platforms.
Removed pattern matching for orphaned files cleanup (we now have the GeocacheData directory with only cached Data).