### PR TITLE
fix #6450, #6451 handling of missing sd card

### DIFF
--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -79,7 +79,7 @@ public final class LocalStorage {
         final List<File> extDirs = new ArrayList<>();
         final File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(CgeoApplication.getInstance(), null);
         for (final File dir : externalFilesDirs) {
-            if (EnvironmentCompat.getStorageState(dir).equals(Environment.MEDIA_MOUNTED)) {
+            if (dir != null && EnvironmentCompat.getStorageState(dir).equals(Environment.MEDIA_MOUNTED)) {
                 extDirs.add(dir);
             }
         }


### PR DESCRIPTION
There was already a fallback to the emulated sdcard and internal storage, but there was a null check missing.