### PR TITLE
for #6427 check diskspace on startup

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1581,5 +1581,7 @@
 
     <!-- calendar adder -->
     <string name="event_fail">Failed to add event cache to calendar</string>
+    <string name="init_low_disk_space">Running low on disk space</string>
+    <string name="init_low_disk_space_message">The geocache data directory is running low on disk space. This can cause malfunctions of c:geo. Please free up some space.</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -23,6 +23,7 @@ import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
@@ -248,6 +249,10 @@ public class MainActivity extends AbstractActionBarActivity {
         init();
 
         checkShowChangelog();
+
+        if (LocalStorage.isRunningLowOnDiskSpace()) {
+            Dialogs.message(this, res.getString(R.string.init_low_disk_space), res.getString(R.string.init_low_disk_space_message));
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -35,6 +35,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public final class LocalStorage {
 
+    public static final Pattern GEOCACHE_FILE_PATTERN = Pattern.compile("^(GC|TB|TC|CC|LC|EC|GK|MV|TR|VI|MS|EV|CT|GE|GA|WM|O)[A-Z0-9]{2,7}$");
+
     private static final String FILE_SYSTEM_TABLE_PATH = "/system/etc/vold.fstab";
     private static final String CGEO_DIRNAME = "cgeo";
     private static final String DATABASES_DIRNAME = "databases";
@@ -44,8 +46,7 @@ public final class LocalStorage {
     private static final String LEGACY_CGEO_DIR_NAME = ".cgeo";
     private static final String GEOCACHE_PHOTOS_DIR_NAME = "GeocachePhotos";
     private static final String GEOCACHE_DATA_DIR_NAME = "GeocacheData";
-
-    public static final Pattern GEOCACHE_FILE_PATTERN = Pattern.compile("^(GC|TB|TC|CC|LC|EC|GK|MV|TR|VI|MS|EV|CT|GE|GA|WM|O)[A-Z0-9]{2,7}$");
+    private static final long LOW_DISKSPACE_THRESHOLD = 1024 * 1024 * 100; // 100 MB in bytes
 
     private static File internalCgeoDirectory;
     private static File externalPrivateCgeoDirectory;
@@ -358,5 +359,7 @@ public final class LocalStorage {
         });
     }
 
-
+    public static boolean isRunningLowOnDiskSpace() {
+        return FileUtils.getFreeDiskSpace(getExternalPrivateCgeoDirectory()) < LOW_DISKSPACE_THRESHOLD;
+    }
 }


### PR DESCRIPTION
It's not fully fixing the issue, but presenting a warning on startup if the geocache data directory has less then 5 MB of free disk space.
It's only checking this directory because this is the biggest one (with all the images etc.). There could also be a problem with the internal one, but normally there is a warning from the device if it is running low on internal memory.

@Lineflyer please check if this is sufficient for now. Also the wording of the message and the 5 MB threshold.