### PR TITLE
fix #6533 access global type filter in filter bar of cache list

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -954,7 +954,16 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
      */
     @Override
     public void showFilterMenu(final View view) {
-        FilterActivity.selectFilter(this);
+        if (view != null && Settings.getCacheType() != CacheType.ALL) {
+            Dialogs.selectGlobalTypeFilter(this, new Action1<CacheType>() {
+                @Override
+                public void call(final CacheType cacheType) {
+                    refreshCurrentList();
+                }
+            });
+        } else {
+            FilterActivity.selectFilter(this);
+        }
     }
 
     private void setComparator(final CacheComparator comparator) {

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -35,7 +35,6 @@ import cgeo.geocaching.utils.Version;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
 import android.app.SearchManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -62,9 +61,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import butterknife.BindView;
@@ -524,51 +520,12 @@ public class MainActivity extends AbstractActionBarActivity {
     }
 
     protected void selectGlobalTypeFilter() {
-        final List<CacheType> cacheTypes = new ArrayList<>();
-
-        //first add the most used types
-        cacheTypes.add(CacheType.ALL);
-        cacheTypes.add(CacheType.TRADITIONAL);
-        cacheTypes.add(CacheType.MULTI);
-        cacheTypes.add(CacheType.MYSTERY);
-
-        // then add all other cache types sorted alphabetically
-        final List<CacheType> sorted = new ArrayList<>(Arrays.asList(CacheType.values()));
-        sorted.removeAll(cacheTypes);
-
-        Collections.sort(sorted, new Comparator<CacheType>() {
+        Dialogs.selectGlobalTypeFilter(this, new Action1<CacheType>() {
             @Override
-            public int compare(final CacheType left, final CacheType right) {
-                return TextUtils.COLLATOR.compare(left.getL10n(), right.getL10n());
-            }
-        });
-
-        cacheTypes.addAll(sorted);
-
-        int checkedItem = cacheTypes.indexOf(Settings.getCacheType());
-        if (checkedItem < 0) {
-            checkedItem = 0;
-        }
-
-        final String[] items = new String[cacheTypes.size()];
-        for (int i = 0; i < cacheTypes.size(); i++) {
-            items[i] = cacheTypes.get(i).getL10n();
-        }
-
-        final Builder builder = new AlertDialog.Builder(this);
-        builder.setTitle(R.string.menu_filter);
-        builder.setSingleChoiceItems(items, checkedItem, new DialogInterface.OnClickListener() {
-
-            @Override
-            public void onClick(final DialogInterface dialog, final int position) {
-                final CacheType cacheType = cacheTypes.get(position);
-                Settings.setCacheType(cacheType);
+            public void call(final CacheType cacheType) {
                 setFilterTitle();
-                dialog.dismiss();
             }
-
         });
-        builder.create().show();
     }
 
     public void updateCacheCounter() {

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -1,7 +1,11 @@
 package cgeo.geocaching.ui.dialog;
 
 import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.ImageUtils;
+import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
@@ -25,6 +29,10 @@ import android.widget.EditText;
 import android.widget.ListAdapter;
 import android.widget.TextView;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import butterknife.ButterKnife;
@@ -500,4 +508,48 @@ public final class Dialogs {
             dialog.dismiss();
         }
     }
+
+    public static void selectGlobalTypeFilter(final Activity activity, final Action1<CacheType> okayListener) {
+        final List<CacheType> cacheTypes = new ArrayList<>();
+
+        //first add the most used types
+        cacheTypes.add(CacheType.ALL);
+        cacheTypes.add(CacheType.TRADITIONAL);
+        cacheTypes.add(CacheType.MULTI);
+        cacheTypes.add(CacheType.MYSTERY);
+
+        // then add all other cache types sorted alphabetically
+        final List<CacheType> sorted = new ArrayList<>(Arrays.asList(CacheType.values()));
+        sorted.removeAll(cacheTypes);
+        Collections.sort(sorted, new Comparator<CacheType>() {
+            @Override
+            public int compare(final CacheType left, final CacheType right) {
+                return TextUtils.COLLATOR.compare(left.getL10n(), right.getL10n());
+            }
+        });
+        cacheTypes.addAll(sorted);
+
+        final int checkedItem = Math.max(0, cacheTypes.indexOf(Settings.getCacheType()));
+
+        final String[] items = new String[cacheTypes.size()];
+        for (int i = 0; i < cacheTypes.size(); i++) {
+            items[i] = cacheTypes.get(i).getL10n();
+        }
+
+        final Builder builder = new AlertDialog.Builder(activity);
+        builder.setTitle(R.string.menu_filter);
+        builder.setSingleChoiceItems(items, checkedItem, new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(final DialogInterface dialog, final int position) {
+                final CacheType cacheType = cacheTypes.get(position);
+                Settings.setCacheType(cacheType);
+                okayListener.call(cacheType);
+                dialog.dismiss();
+            }
+
+        });
+        builder.create().show();
+    }
+
 }


### PR DESCRIPTION
Without starting the big rework of the filter(s), here is a proposed solution for this issue:
If a global type filter is active a click on the filter bar is now showing global type filter dialog. A push on the filter icon in the action bar is always showing the Filter Activity. With this solution a user is still able to combine both filters. It's not ideal because the filterbar behaves differently depending on context, but the best I could think of at the moment.