### PR TITLE
Fix crash if no language has been selected on gc.com site

### DIFF
--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -11,6 +11,7 @@
     · Fix: Do not parse formulas in personal notes as waypoint coordinates\n
     · Fix: Remove wrong menu item from trackable logging screen\n
     · Fix: Apply API key for OSM:Cyclemap\n 
+    · Fix: Detect that no language has been selected on geocaching.com\n
     \n
     \n
 </string>

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -247,7 +247,8 @@ public class GCLogin extends AbstractLogin {
     }
 
     private boolean isLanguageEnglish(@NonNull final String page) {
-        return StringUtils.equals(Jsoup.parse(page).select("div.language-dropdown > select > option[selected=\"selected\"]").first().text(), "English");
+        final Element languageElement = Jsoup.parse(page).select("div.language-dropdown > select > option[selected=\"selected\"]").first();
+        return languageElement != null && StringUtils.equals(languageElement.text(), "English");
     }
 
     /**


### PR DESCRIPTION
If no language is selected, no option is selected in the language
selection drop-down menu, and first() returns null.