### PR TITLE
Fix #6546: Proposal for a new structure of the cache list menu

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -69,6 +69,11 @@
                 android:title="@string/caches_clear_offlinelogs"
                 android:visible="false"
                 app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_make_list_unique"
+                android:title="@string/caches_make_list_unique"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
         </menu>
     </item>
     <item
@@ -96,12 +101,7 @@
                 android:id="@+id/menu_rename_list"
                 android:title="@string/list_menu_rename"
                 app:showAsAction="ifRoom|withText"/>
-            <item
-                android:id="@+id/menu_make_list_unique"
-                android:title="@string/caches_make_list_unique"
-                android:visible="false"
-                app:showAsAction="never|withText"/>
-      </menu>
+        </menu>
     </item>
     <item
         android:id="@+id/menu_import"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -30,6 +30,19 @@
         android:title="@string/caches_select_invert"
         app:showAsAction="ifRoom|withText"/>
     <item
+        android:id="@+id/menu_cache_list_app_provider"
+        android:icon="@drawable/ic_menu_goto"
+        android:title="@string/caches_on_map"
+        android:visible="false"
+        app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
+        app:showAsAction="ifRoom|withText"/>
+    <item
+        android:id="@+id/menu_cache_list_app"
+        android:icon="@drawable/ic_menu_goto"
+        android:title="@null"
+        android:visible="false"
+        app:showAsAction="ifRoom|withText"/>
+    <item
         android:title="@string/menu_caches"
         app:showAsAction="never|withText">
         <!-- Cache operations -->
@@ -58,13 +71,6 @@
                 android:visible="false"
                 app:showAsAction="never|withText"/>
             <item
-                android:id="@+id/menu_cache_list_app_provider"
-                android:icon="@drawable/ic_menu_goto"
-                android:title="@string/caches_on_map"
-                android:visible="false"
-                app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
-                app:showAsAction="ifRoom|withText"/>
-            <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"
                 android:visible="false"
@@ -76,12 +82,6 @@
                 app:showAsAction="never|withText"/>
         </menu>
     </item>
-    <item
-        android:id="@+id/menu_cache_list_app"
-        android:icon="@drawable/ic_menu_goto"
-        android:title="@null"
-        android:visible="false"
-        app:showAsAction="ifRoom|withText"/>
     <item
         android:title="@string/menu_lists"
         app:showAsAction="never|withText">
@@ -134,7 +134,7 @@
                   android:id="@+id/menu_export_persnotes"
                   android:title="@string/export_persnotes"/>
           </menu>
-     </item>
+    </item>
     <item
         android:id="@+id/menu_remove_from_history"
         android:title="@string/cache_clear_history"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -69,6 +69,11 @@
                 android:title="@string/caches_clear_offlinelogs"
                 android:visible="false"
                 app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_make_list_unique"
+                android:title="@string/caches_make_list_unique"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
         </menu>
     </item>
     <item
@@ -142,9 +147,5 @@
         android:title="@string/cache_clear_history"
         android:visible="false"
         app:showAsAction="never|withText"/>
-    <item
-        android:id="@+id/menu_make_list_unique"
-        android:title="@string/caches_make_list_unique"
-        android:visible="false"
-        app:showAsAction="never|withText"/>
+
 </menu>

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -6,163 +6,145 @@
         android:id="@+id/menu_show_on_map"
         android:icon="@drawable/ic_menu_mapmode"
         android:title="@string/caches_on_map"
-        app:showAsAction="ifRoom">
-    </item>
+        app:showAsAction="ifRoom"/>
     <item
         android:id="@+id/menu_filter"
         android:icon="@drawable/ic_menu_filter"
         android:title="@string/caches_filter"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_sort"
         android:icon="@drawable/ic_menu_sort_alphabetically"
         android:showAsAction="always"
         android:title="@string/caches_sort"
         app:actionProviderClass="cgeo.geocaching.sorting.SortActionProvider"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_switch_select_mode"
         android:icon="@drawable/ic_menu_agenda"
         android:title="@string/caches_select_mode"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_invert_selection"
         android:icon="@drawable/ic_menu_mark"
         android:title="@string/caches_select_invert"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_cache_list_app_provider"
         android:icon="@drawable/ic_menu_goto"
         android:title="@string/caches_on_map"
         android:visible="false"
         app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:title="@string/menu_caches"
         app:showAsAction="never|withText">
         <!-- Cache operations -->
-        <item
-            android:id="@+id/menu_refresh_stored"
-            android:icon="@drawable/ic_menu_set_as"
-            android:title="@string/cache_offline_refresh"
-            app:showAsAction="ifRoom|withText">
-        </item>
-        <item
-            android:id="@+id/menu_move_to_list"
-            android:title="@string/cache_menu_move_list"
-            app:showAsAction="ifRoom|withText">
-        </item>
-        <item
-            android:id="@+id/menu_copy_to_list"
-            android:title="@string/cache_menu_copy_list"
-            app:showAsAction="ifRoom|withText">
-        </item>
-        <item
-            android:id="@+id/menu_drop_caches"
-            android:icon="@drawable/ic_menu_delete"
-            android:title="@string/caches_remove_all"
-            app:showAsAction="ifRoom|withText">
-        </item>
-        <item
-            android:id="@+id/menu_delete_events"
-            android:title="@string/caches_delete_events"
-            android:visible="false"
-            app:showAsAction="never|withText">
-        </item>
-        <item
-            android:id="@+id/menu_clear_offline_logs"
-            android:title="@string/caches_clear_offlinelogs"
-            android:visible="false"
-            app:showAsAction="never|withText">
-        </item>
+        <menu>
+            <item
+                android:id="@+id/menu_refresh_stored"
+                android:icon="@drawable/ic_menu_set_as"
+                android:title="@string/cache_offline_refresh"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_move_to_list"
+                android:title="@string/cache_menu_move_list"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_copy_to_list"
+                android:title="@string/cache_menu_copy_list"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_drop_caches"
+                android:icon="@drawable/ic_menu_delete"
+                android:title="@string/caches_remove_all"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_delete_events"
+                android:title="@string/caches_delete_events"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_clear_offline_logs"
+                android:title="@string/caches_clear_offlinelogs"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+        </menu>
     </item>
     <item
         android:id="@+id/menu_cache_list_app"
         android:icon="@drawable/ic_menu_goto"
         android:title="@null"
         android:visible="false"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:title="@string/menu_lists"
         app:showAsAction="never|withText">
         <!-- List operations -->
-        <item
-            android:id="@+id/menu_create_list"
-            android:icon="@drawable/ic_menu_add"
-            android:title="@string/list_menu_create"
-            app:showAsAction="ifRoom|withText">
-        </item>
-        <item
-            android:id="@+id/menu_drop_list"
-            android:icon="@drawable/ic_menu_delete"
-            android:title="@string/list_menu_drop"
-            app:showAsAction="ifRoom|withText">
-        </item>
-        <item
-            android:id="@+id/menu_rename_list"
-            android:title="@string/list_menu_rename"
-            app:showAsAction="ifRoom|withText">
-        </item>
+        <menu>
+            <item
+                android:id="@+id/menu_create_list"
+                android:icon="@drawable/ic_menu_add"
+                android:title="@string/list_menu_create"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_drop_list"
+                android:icon="@drawable/ic_menu_delete"
+                android:title="@string/list_menu_drop"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_rename_list"
+                android:title="@string/list_menu_rename"
+                app:showAsAction="ifRoom|withText"/>
+      </menu>
     </item>
     <item
         android:title="@string/menu_io"
         app:showAsAction="never|withText">
         <!-- I/O -->
-        <item
-            android:id="@+id/menu_import"
-            android:title="@string/list_menu_import"
-            app:showAsAction="never|withText">
-            <menu>
-                <item
-                    android:id="@+id/menu_import_gpx"
-                    android:title="@string/gpx_import_title">
-                </item>
-                <item
-                    android:id="@+id/menu_import_web"
-                    android:title="@string/web_import_title">
-                </item>
-                <item
-                    android:id="@+id/menu_import_android"
-                    android:title="@string/gpx_import_android">
-                </item>
-            </menu>
-        </item>
-        <item
-            android:id="@+id/menu_export"
-            android:title="@string/export"
-            app:showAsAction="never|withText">
-            <menu>
-                <item
-                    android:id="@+id/menu_export_gpx"
-                    android:title="@string/export_gpx">
-                </item>
-                <item
-                    android:id="@+id/menu_export_fieldnotes"
-                    android:title="@string/export_fieldnotes">
-                </item>
-                <item
-                    android:id="@+id/menu_export_persnotes"
-                    android:title="@string/export_persnotes">
-                </item>
-            </menu>
-        </item>
+        <menu>
+            <item
+                android:id="@+id/menu_import"
+                android:title="@string/list_menu_import"
+                app:showAsAction="never|withText">
+                <menu>
+                    <item
+                        android:id="@+id/menu_import_gpx"
+                        android:title="@string/gpx_import_title"/>
+                    <item
+                        android:id="@+id/menu_import_web"
+                        android:title="@string/web_import_title"/>
+                    <item
+                        android:id="@+id/menu_import_android"
+                        android:title="@string/gpx_import_android"/>
+                </menu>
+            </item>
+            <item
+                  android:id="@+id/menu_export"
+                  android:title="@string/export"
+                  app:showAsAction="never|withText">
+                  <menu>
+                      <item
+                          android:id="@+id/menu_export_gpx"
+                          android:title="@string/export_gpx"/>
+                      <item
+                          android:id="@+id/menu_export_fieldnotes"
+                          android:title="@string/export_fieldnotes"/>
+                      <item
+                          android:id="@+id/menu_export_persnotes"
+                          android:title="@string/export_persnotes"/>
+                  </menu>
+             </item>
+        </menu>
     </item>
     <item
         android:id="@+id/menu_remove_from_history"
         android:title="@string/cache_clear_history"
         android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
+        app:showAsAction="never|withText"/>
     <item
         android:id="@+id/menu_make_list_unique"
         android:title="@string/caches_make_list_unique"
         android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
+        app:showAsAction="never|withText"/>
 </menu>

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -89,42 +89,46 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
-        android:id="@+id/menu_import"
-        android:title="@string/list_menu_import"
+        android:title="@string/list_menu_io"
         app:showAsAction="never|withText">
-        <menu>
-            <item
-                android:id="@+id/menu_import_gpx"
-                android:title="@string/gpx_import_title">
-            </item>
-            <item
-                android:id="@+id/menu_import_web"
-                android:title="@string/web_import_title">
-            </item>
-            <item
-                android:id="@+id/menu_import_android"
-                android:title="@string/gpx_import_android">
-            </item>
-        </menu>
-    </item>
-    <item
-        android:id="@+id/menu_export"
-        android:title="@string/export"
-        app:showAsAction="never|withText">
-        <menu>
-            <item
-                android:id="@+id/menu_export_gpx"
-                android:title="@string/export_gpx">
-            </item>
-            <item
-                android:id="@+id/menu_export_fieldnotes"
-                android:title="@string/export_fieldnotes">
-            </item>
-            <item
-                android:id="@+id/menu_export_persnotes"
-                android:title="@string/export_persnotes">
-            </item>
-        </menu>
+        <item
+            android:id="@+id/menu_import"
+            android:title="@string/list_menu_import"
+            app:showAsAction="never|withText">
+            <menu>
+                <item
+                    android:id="@+id/menu_import_gpx"
+                    android:title="@string/gpx_import_title">
+                </item>
+                <item
+                    android:id="@+id/menu_import_web"
+                    android:title="@string/web_import_title">
+                </item>
+                <item
+                    android:id="@+id/menu_import_android"
+                    android:title="@string/gpx_import_android">
+                </item>
+            </menu>
+        </item>
+        <item
+            android:id="@+id/menu_export"
+            android:title="@string/export"
+            app:showAsAction="never|withText">
+            <menu>
+                <item
+                    android:id="@+id/menu_export_gpx"
+                    android:title="@string/export_gpx">
+                </item>
+                <item
+                    android:id="@+id/menu_export_fieldnotes"
+                    android:title="@string/export_fieldnotes">
+                </item>
+                <item
+                    android:id="@+id/menu_export_persnotes"
+                    android:title="@string/export_persnotes">
+                </item>
+            </menu>
+        </item>
     </item>
     <item
         android:id="@+id/menu_delete_events"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -72,21 +72,26 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
-        android:id="@+id/menu_create_list"
-        android:icon="@drawable/ic_menu_add"
-        android:title="@string/list_menu_create"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_drop_list"
-        android:icon="@drawable/ic_menu_delete"
-        android:title="@string/list_menu_drop"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_rename_list"
-        android:title="@string/list_menu_rename"
-        app:showAsAction="ifRoom|withText">
+        android:title="@string/list_menu"
+        app:showAsAction="never|withText">
+        <!-- List operations -->
+        <item
+            android:id="@+id/menu_create_list"
+            android:icon="@drawable/ic_menu_add"
+            android:title="@string/list_menu_create"
+            app:showAsAction="ifRoom|withText">
+        </item>
+        <item
+            android:id="@+id/menu_drop_list"
+            android:icon="@drawable/ic_menu_delete"
+            android:title="@string/list_menu_drop"
+            app:showAsAction="ifRoom|withText">
+        </item>
+        <item
+            android:id="@+id/menu_rename_list"
+            android:title="@string/list_menu_rename"
+            app:showAsAction="ifRoom|withText">
+        </item>
     </item>
     <item
         android:title="@string/list_menu_io"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -69,7 +69,6 @@
                 android:title="@string/caches_clear_offlinelogs"
                 android:visible="false"
                 app:showAsAction="never|withText"/>
-
         </menu>
     </item>
     <item

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -69,11 +69,7 @@
                 android:title="@string/caches_clear_offlinelogs"
                 android:visible="false"
                 app:showAsAction="never|withText"/>
-            <item
-                android:id="@+id/menu_make_list_unique"
-                android:title="@string/caches_make_list_unique"
-                android:visible="false"
-                app:showAsAction="never|withText"/>
+
         </menu>
     </item>
     <item
@@ -101,7 +97,12 @@
                 android:id="@+id/menu_rename_list"
                 android:title="@string/list_menu_rename"
                 app:showAsAction="ifRoom|withText"/>
-        </menu>
+            <item
+                android:id="@+id/menu_make_list_unique"
+                android:title="@string/caches_make_list_unique"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+      </menu>
     </item>
 
     <item

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -103,45 +103,39 @@
                 app:showAsAction="ifRoom|withText"/>
         </menu>
     </item>
+
     <item
-        android:title="@string/menu_io"
+        android:id="@+id/menu_import"
+        android:title="@string/list_menu_import"
         app:showAsAction="never|withText">
-        <!-- I/O -->
         <menu>
             <item
-                android:id="@+id/menu_import"
-                android:title="@string/list_menu_import"
-                app:showAsAction="never|withText">
-                <menu>
-                    <item
-                        android:id="@+id/menu_import_gpx"
-                        android:title="@string/gpx_import_title"/>
-                    <item
-                        android:id="@+id/menu_import_web"
-                        android:title="@string/web_import_title"/>
-                    <item
-                        android:id="@+id/menu_import_android"
-                        android:title="@string/gpx_import_android"/>
-                </menu>
-            </item>
+                android:id="@+id/menu_import_gpx"
+                android:title="@string/gpx_import_title"/>
             <item
-                  android:id="@+id/menu_export"
-                  android:title="@string/export"
-                  app:showAsAction="never|withText">
-                  <menu>
-                      <item
-                          android:id="@+id/menu_export_gpx"
-                          android:title="@string/export_gpx"/>
-                      <item
-                          android:id="@+id/menu_export_fieldnotes"
-                          android:title="@string/export_fieldnotes"/>
-                      <item
-                          android:id="@+id/menu_export_persnotes"
-                          android:title="@string/export_persnotes"/>
-                  </menu>
-             </item>
+                android:id="@+id/menu_import_web"
+                android:title="@string/web_import_title"/>
+            <item
+                android:id="@+id/menu_import_android"
+                android:title="@string/gpx_import_android"/>
         </menu>
     </item>
+    <item
+          android:id="@+id/menu_export"
+          android:title="@string/export"
+          app:showAsAction="never|withText">
+          <menu>
+              <item
+                  android:id="@+id/menu_export_gpx"
+                  android:title="@string/export_gpx"/>
+              <item
+                  android:id="@+id/menu_export_fieldnotes"
+                  android:title="@string/export_fieldnotes"/>
+              <item
+                  android:id="@+id/menu_export_persnotes"
+                  android:title="@string/export_persnotes"/>
+          </menu>
+     </item>
     <item
         android:id="@+id/menu_remove_from_history"
         android:title="@string/cache_clear_history"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -30,6 +30,13 @@
         android:title="@string/caches_select_invert"
         app:showAsAction="ifRoom|withText"/>
     <item
+        android:id="@+id/menu_cache_list_app_provider"
+        android:icon="@drawable/ic_menu_goto"
+        android:title="@string/caches_on_map"
+        android:visible="false"
+        app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
+        app:showAsAction="ifRoom|withText"/>
+    <item
         android:title="@string/menu_caches"
         app:showAsAction="never|withText">
         <!-- Cache operations -->
@@ -57,13 +64,6 @@
                 android:title="@string/caches_delete_events"
                 android:visible="false"
                 app:showAsAction="never|withText"/>
-            <item
-                android:id="@+id/menu_cache_list_app_provider"
-                android:icon="@drawable/ic_menu_goto"
-                android:title="@string/caches_on_map"
-                android:visible="false"
-                app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
-                app:showAsAction="ifRoom|withText"/>
             <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -30,13 +30,6 @@
         android:title="@string/caches_select_invert"
         app:showAsAction="ifRoom|withText"/>
     <item
-        android:id="@+id/menu_cache_list_app_provider"
-        android:icon="@drawable/ic_menu_goto"
-        android:title="@string/caches_on_map"
-        android:visible="false"
-        app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
-        app:showAsAction="ifRoom|withText"/>
-    <item
         android:title="@string/menu_caches"
         app:showAsAction="never|withText">
         <!-- Cache operations -->
@@ -64,6 +57,13 @@
                 android:title="@string/caches_delete_events"
                 android:visible="false"
                 app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_cache_list_app_provider"
+                android:icon="@drawable/ic_menu_goto"
+                android:title="@string/caches_on_map"
+                android:visible="false"
+                app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
+                app:showAsAction="ifRoom|withText"/>
             <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -35,26 +35,51 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
-        android:id="@+id/menu_refresh_stored"
-        android:icon="@drawable/ic_menu_set_as"
-        android:title="@string/cache_offline_refresh"
+        android:id="@+id/menu_cache_list_app_provider"
+        android:icon="@drawable/ic_menu_goto"
+        android:title="@string/caches_on_map"
+        android:visible="false"
+        app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
         app:showAsAction="ifRoom|withText">
     </item>
     <item
-        android:id="@+id/menu_move_to_list"
-        android:title="@string/cache_menu_move_list"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_copy_to_list"
-        android:title="@string/cache_menu_copy_list"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_drop_caches"
-        android:icon="@drawable/ic_menu_delete"
-        android:title="@string/caches_remove_all"
-        app:showAsAction="ifRoom|withText">
+        android:title="@string/menu_caches"
+        app:showAsAction="never|withText">
+        <!-- Cache operations -->
+        <item
+            android:id="@+id/menu_refresh_stored"
+            android:icon="@drawable/ic_menu_set_as"
+            android:title="@string/cache_offline_refresh"
+            app:showAsAction="ifRoom|withText">
+        </item>
+        <item
+            android:id="@+id/menu_move_to_list"
+            android:title="@string/cache_menu_move_list"
+            app:showAsAction="ifRoom|withText">
+        </item>
+        <item
+            android:id="@+id/menu_copy_to_list"
+            android:title="@string/cache_menu_copy_list"
+            app:showAsAction="ifRoom|withText">
+        </item>
+        <item
+            android:id="@+id/menu_drop_caches"
+            android:icon="@drawable/ic_menu_delete"
+            android:title="@string/caches_remove_all"
+            app:showAsAction="ifRoom|withText">
+        </item>
+        <item
+            android:id="@+id/menu_delete_events"
+            android:title="@string/caches_delete_events"
+            android:visible="false"
+            app:showAsAction="never|withText">
+        </item>
+        <item
+            android:id="@+id/menu_clear_offline_logs"
+            android:title="@string/caches_clear_offlinelogs"
+            android:visible="false"
+            app:showAsAction="never|withText">
+        </item>
     </item>
     <item
         android:id="@+id/menu_cache_list_app"
@@ -64,15 +89,7 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
-        android:id="@+id/menu_cache_list_app_provider"
-        android:icon="@drawable/ic_menu_goto"
-        android:title="@string/caches_on_map"
-        android:visible="false"
-        app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:title="@string/list_menu"
+        android:title="@string/menu_lists"
         app:showAsAction="never|withText">
         <!-- List operations -->
         <item
@@ -94,8 +111,9 @@
         </item>
     </item>
     <item
-        android:title="@string/list_menu_io"
+        android:title="@string/menu_io"
         app:showAsAction="never|withText">
+        <!-- I/O -->
         <item
             android:id="@+id/menu_import"
             android:title="@string/list_menu_import"
@@ -136,18 +154,6 @@
         </item>
     </item>
     <item
-        android:id="@+id/menu_delete_events"
-        android:title="@string/caches_delete_events"
-        android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
-    <item
-        android:id="@+id/menu_clear_offline_logs"
-        android:title="@string/caches_clear_offlinelogs"
-        android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
-    <item
         android:id="@+id/menu_remove_from_history"
         android:title="@string/cache_clear_history"
         android:visible="false"
@@ -159,5 +165,4 @@
         android:visible="false"
         app:showAsAction="never|withText">
     </item>
-    
 </menu>

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -101,7 +101,7 @@
                 android:id="@+id/menu_rename_list"
                 android:title="@string/list_menu_rename"
                 app:showAsAction="ifRoom|withText"/>
-      </menu>
+        </menu>
     </item>
     <item
         android:title="@string/menu_io"

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -104,7 +104,6 @@
                 app:showAsAction="never|withText"/>
       </menu>
     </item>
-
     <item
         android:id="@+id/menu_import"
         android:title="@string/list_menu_import"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,7 +380,7 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
-    <string name="menu_lists">Manage lists &#8230;</string>
+    <string name="menu_lists">Manage lists</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
@@ -868,7 +868,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
-    <string name="menu_caches">Manage caches &#8230;</string>
+    <string name="menu_caches">Manage caches</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,9 +380,11 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
+    <string name="menu_lists">Lists</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
+    <string name="menu_io">I/O</string>
     <string name="list_menu_import">Import</string>
     <string name="list_title">Pick a list</string>
     <string name="lists_title">Pick the lists</string>
@@ -867,6 +869,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
+    <string name="menu_caches">Caches</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -384,7 +384,6 @@
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
-    <string name="menu_io">In &amp; Out ...</string>
     <string name="list_menu_import">Import</string>
     <string name="list_title">Pick a list</string>
     <string name="lists_title">Pick the lists</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,11 +380,11 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
-    <string name="menu_lists">Lists</string>
+    <string name="menu_lists">Lists ...</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
-    <string name="menu_io">I/O</string>
+    <string name="menu_io">I/O ...</string>
     <string name="list_menu_import">Import</string>
     <string name="list_title">Pick a list</string>
     <string name="lists_title">Pick the lists</string>
@@ -869,7 +869,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
-    <string name="menu_caches">Caches</string>
+    <string name="menu_caches">Caches ...</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,11 +380,11 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
-    <string name="menu_lists">Lists &#133;</string>
+    <string name="menu_lists">Lists ...</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
-    <string name="menu_io">In &amp; Out &#133;</string>
+    <string name="menu_io">In &amp; Out ...</string>
     <string name="list_menu_import">Import</string>
     <string name="list_title">Pick a list</string>
     <string name="lists_title">Pick the lists</string>
@@ -869,7 +869,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
-    <string name="menu_caches">Caches &#133;</string>
+    <string name="menu_caches">Caches ...</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,11 +380,11 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
-    <string name="menu_lists">Lists ...</string>
+    <string name="menu_lists">Lists &#133;</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
-    <string name="menu_io">I/O ...</string>
+    <string name="menu_io">In &amp; Out &#133;</string>
     <string name="list_menu_import">Import</string>
     <string name="list_title">Pick a list</string>
     <string name="lists_title">Pick the lists</string>
@@ -869,7 +869,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
-    <string name="menu_caches">Caches ...</string>
+    <string name="menu_caches">Caches &#133;</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,7 +380,7 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
-    <string name="menu_lists">Lists ...</string>
+    <string name="menu_lists">Manage lists &#8230;</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
@@ -868,7 +868,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
-    <string name="menu_caches">Caches ...</string>
+    <string name="menu_caches">Manage caches &#8230;</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>


### PR DESCRIPTION
### Base of the PR
The proposal provided here suggests a new structure of the cache list menu like described in [Issue-6546](https://github.com/cgeo/cgeo/issues/6546). 

### Scope of the PR
The scope of the PR is to provide a much shorter main cache list menu by introducing sub menus. 

### Considerations
* A restructuring of the cache list menu seems necessary because new functionality often leads to an additionally menu item (see [#6528](https://github.com/cgeo/cgeo/issues/6528) or  [#6473](https://github.com/cgeo/cgeo/issues/6473)) .
* Three main menu items are added: "Caches", "Lists", and "In & Out".
* The new menu items are written with three dots (`&#133;`) to symbolize the sub menu which will be opened. This makes sense since only Android N shows a special symbol indicating a sub menu.

### Screenshots
| Before | After |
| ----- | ----- |
| ![device-2017-05-10-230544](https://cloud.githubusercontent.com/assets/18602334/25921314/40c71422-35d5-11e7-9ecd-cc743738452f.png) | ![screenshot_20170515-081710](https://cloud.githubusercontent.com/assets/18602334/26046380/fcb1653a-394e-11e7-87ed-d4d03f4a8fc3.png) |

### Testing
* Functionality was tested manually (Samsung Galaxy S3 with Kitkat, S6 with Nougat).