### PR TITLE
fix #6560 fallback for gpx export directory

### DIFF
--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -272,7 +272,12 @@ public final class LocalStorage {
 
     @NonNull
     public static File getGpxExportDirectory() {
-        return new File(Settings.getGpxExportDir());
+        final File gpxExportDir =  new File(Settings.getGpxExportDir());
+        FileUtils.mkdirs(gpxExportDir);
+        if (!gpxExportDir.isDirectory() || !gpxExportDir.canWrite()) {
+            return getDefaultGpxDirectory();
+        }
+        return gpxExportDir;
     }
 
     @NonNull


### PR DESCRIPTION
It might happen, that the gpx export directory setting points to an outdated location (e.g. from a device migration).
If this directory is not available we use the default gpx directory as a fallback.