### PR TITLE
fix #6552 confirm debug mode on start

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1583,5 +1583,7 @@
     <string name="event_fail">Failed to add event cache to calendar</string>
     <string name="init_low_disk_space">Running low on disk space</string>
     <string name="init_low_disk_space_message">The geocache data directory is running low on disk space. This can cause malfunctions of c:geo. Please free up some space.</string>
+    <string name="init_confirm_debug">c:geo is running in debug mode!</string>
+    <string name="list_confirm_debug_message">The debug mode can cause instabilities! Do you want to return to normal mode?</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -249,6 +249,15 @@ public class MainActivity extends AbstractActionBarActivity {
         if (LocalStorage.isRunningLowOnDiskSpace()) {
             Dialogs.message(this, res.getString(R.string.init_low_disk_space), res.getString(R.string.init_low_disk_space_message));
         }
+
+        if (Settings.isDebug()) {
+            Dialogs.confirmYesNo(this, R.string.init_confirm_debug, R.string.list_confirm_debug_message, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(final DialogInterface dialog, final int whichButton) {
+                    Settings.setDebug(false);
+                }
+            });
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1042,6 +1042,11 @@ public class Settings {
         return Log.isDebug();
     }
 
+    public static void setDebug(final boolean debug) {
+        Log.setDebug(debug);
+        putBoolean(R.string.pref_debug, debug);
+    }
+
     public static int getLiveMapHintShowCount() {
         return getInt(R.string.pref_livemaphintshowcount, 0);
     }


### PR DESCRIPTION
Showing a dialog on c:geo start when debug mode is active.  Explaining that this can cause instabilities and asking the user to return to normal mode.