### PR TITLE
 Fix #6546 (2): Proposal for a new structure of the cache list menu

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -43,6 +43,7 @@
         app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
         app:showAsAction="ifRoom|withText"/>
     <item
+        android:id="@+id/menu_caches"
         android:title="@string/menu_caches"
         app:showAsAction="never|withText">
         <!-- Cache operations -->

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -1,92 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto" >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/menu_show_on_map"
         android:icon="@drawable/ic_menu_mapmode"
         android:title="@string/caches_on_map"
-        app:showAsAction="ifRoom">
-    </item>
+        app:showAsAction="ifRoom"/>
     <item
         android:id="@+id/menu_filter"
         android:icon="@drawable/ic_menu_filter"
         android:title="@string/caches_filter"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_sort"
         android:icon="@drawable/ic_menu_sort_alphabetically"
         android:showAsAction="always"
         android:title="@string/caches_sort"
         app:actionProviderClass="cgeo.geocaching.sorting.SortActionProvider"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_switch_select_mode"
         android:icon="@drawable/ic_menu_agenda"
         android:title="@string/caches_select_mode"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_invert_selection"
         android:icon="@drawable/ic_menu_mark"
         android:title="@string/caches_select_invert"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_refresh_stored"
-        android:icon="@drawable/ic_menu_set_as"
-        android:title="@string/cache_offline_refresh"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_move_to_list"
-        android:title="@string/cache_menu_move_list"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_copy_to_list"
-        android:title="@string/cache_menu_copy_list"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_drop_caches"
-        android:icon="@drawable/ic_menu_delete"
-        android:title="@string/caches_remove_all"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_cache_list_app"
         android:icon="@drawable/ic_menu_goto"
         android:title="@null"
         android:visible="false"
-        app:showAsAction="ifRoom|withText">
-    </item>
+        app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_cache_list_app_provider"
         android:icon="@drawable/ic_menu_goto"
         android:title="@string/caches_on_map"
         android:visible="false"
         app:actionProviderClass="cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider"
-        app:showAsAction="ifRoom|withText">
+        app:showAsAction="ifRoom|withText"/>
+    <item
+        android:title="@string/menu_caches"
+        app:showAsAction="never|withText">
+        <!-- Cache operations -->
+        <menu>
+            <item
+                android:id="@+id/menu_refresh_stored"
+                android:icon="@drawable/ic_menu_set_as"
+                android:title="@string/cache_offline_refresh"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_move_to_list"
+                android:title="@string/cache_menu_move_list"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_copy_to_list"
+                android:title="@string/cache_menu_copy_list"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_drop_caches"
+                android:icon="@drawable/ic_menu_delete"
+                android:title="@string/caches_remove_all"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_delete_events"
+                android:title="@string/caches_delete_events"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_clear_offline_logs"
+                android:title="@string/caches_clear_offlinelogs"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_remove_from_history"
+                android:title="@string/cache_clear_history"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+        </menu>
     </item>
     <item
-        android:id="@+id/menu_create_list"
-        android:icon="@drawable/ic_menu_add"
-        android:title="@string/list_menu_create"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_drop_list"
-        android:icon="@drawable/ic_menu_delete"
-        android:title="@string/list_menu_drop"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
-        android:id="@+id/menu_rename_list"
-        android:title="@string/list_menu_rename"
-        app:showAsAction="ifRoom|withText">
+        android:title="@string/menu_lists"
+        app:showAsAction="never|withText">
+        <!-- List operations -->
+        <menu>
+            <item
+                android:id="@+id/menu_create_list"
+                android:icon="@drawable/ic_menu_add"
+                android:title="@string/list_menu_create"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_drop_list"
+                android:icon="@drawable/ic_menu_delete"
+                android:title="@string/list_menu_drop"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_rename_list"
+                android:title="@string/list_menu_rename"
+                app:showAsAction="ifRoom|withText"/>
+            <item
+                android:id="@+id/menu_make_list_unique"
+                android:title="@string/caches_make_list_unique"
+                android:visible="false"
+                app:showAsAction="never|withText"/>
+        </menu>
     </item>
     <item
         android:id="@+id/menu_import"
@@ -95,16 +115,13 @@
         <menu>
             <item
                 android:id="@+id/menu_import_gpx"
-                android:title="@string/gpx_import_title">
-            </item>
+                android:title="@string/gpx_import_title"/>
             <item
                 android:id="@+id/menu_import_web"
-                android:title="@string/web_import_title">
-            </item>
+                android:title="@string/web_import_title"/>
             <item
                 android:id="@+id/menu_import_android"
-                android:title="@string/gpx_import_android">
-            </item>
+                android:title="@string/gpx_import_android"/>
         </menu>
     </item>
     <item
@@ -114,41 +131,13 @@
         <menu>
             <item
                 android:id="@+id/menu_export_gpx"
-                android:title="@string/export_gpx">
-            </item>
+                android:title="@string/export_gpx"/>
             <item
                 android:id="@+id/menu_export_fieldnotes"
-                android:title="@string/export_fieldnotes">
-            </item>
+                android:title="@string/export_fieldnotes"/>
             <item
                 android:id="@+id/menu_export_persnotes"
-                android:title="@string/export_persnotes">
-            </item>
+                android:title="@string/export_persnotes"/>
         </menu>
     </item>
-    <item
-        android:id="@+id/menu_delete_events"
-        android:title="@string/caches_delete_events"
-        android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
-    <item
-        android:id="@+id/menu_clear_offline_logs"
-        android:title="@string/caches_clear_offlinelogs"
-        android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
-    <item
-        android:id="@+id/menu_remove_from_history"
-        android:title="@string/cache_clear_history"
-        android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
-    <item
-        android:id="@+id/menu_make_list_unique"
-        android:title="@string/caches_make_list_unique"
-        android:visible="false"
-        app:showAsAction="never|withText">
-    </item>
-    
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -380,6 +380,7 @@
     <string name="caches_filter_missing_gcvote">Found caches not voted</string>
     
     <!-- caches lists -->
+    <string name="menu_lists">Manage lists</string>
     <string name="list_menu_create">Create new list</string>
     <string name="list_menu_drop">Remove current list</string>
     <string name="list_menu_rename">Rename current list</string>
@@ -867,6 +868,7 @@
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>
     <string name="around">Around %s</string>
+    <string name="menu_caches">Manage caches</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
     <string name="cache_menu_details">Details</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -724,6 +724,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setVisible(menu, R.id.menu_create_list, isOffline);
 
             setVisible(menu, R.id.menu_sort, !isEmpty && !isHistory);
+            setVisible(menu, R.id.menu_caches, !isEmpty);
             setVisible(menu, R.id.menu_refresh_stored, !isEmpty);
             setVisible(menu, R.id.menu_drop_caches, !isEmpty && (isHistory || isOffline));
             setVisible(menu, R.id.menu_delete_events, isConcrete && !isEmpty && containsPastEvents());


### PR DESCRIPTION
### Base of the PR
The proposal provided here suggests a new structure of the cache list menu like described in [Issue-6546](https://github.com/cgeo/cgeo/issues/6546). 

This PR is a updated version of [#6551](https://github.com/cgeo/cgeo/pull/6551) which couldn't be rebased/merged due to conflicts.

### Scope of the PR
The scope of the PR is to provide a much shorter main cache list menu by introducing sub menus. 

### Considerations
* A restructuring of the cache list menu seems necessary because new functionality often leads to an additionally menu item (see [#6528](https://github.com/cgeo/cgeo/issues/6528) or  [#6473](https://github.com/cgeo/cgeo/issues/6473)) .
* Two main menu items are added: "Manage caches", "Manage lists".

### Screenshots
| Before | After |
| ----- | ----- |
| ![device-2017-05-10-230544](https://cloud.githubusercontent.com/assets/18602334/25921314/40c71422-35d5-11e7-9ecd-cc743738452f.png) | ![screenshot_20170515-081710](https://cloud.githubusercontent.com/assets/18602334/26046380/fcb1653a-394e-11e7-87ed-d4d03f4a8fc3.png) |

### Testing
* Functionality was tested manually (Samsung Galaxy S3 with Kitkat, S6 with Nougat).