### PR TITLE
Fix #6573: Parse GPX original coordinates as double values

### DIFF
--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -5,6 +5,7 @@
     <b>Next bugfix release:</b>\n
     · Fix: Avoid crash during file operation\n
     · Fix: Avoid crash when checking for Locus installation\n
+    · Fix: Avoid failure when parsing original coordinates of a GPX file\n
     · Removed: Link to Android Wear app in useful apps\n
     \n
     \n

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -1007,7 +1007,7 @@ abstract class GPXParser extends FileParser {
     protected void addOriginalCoordinates() {
         if (StringUtils.isNotEmpty(originalLat) && StringUtils.isNotEmpty(originalLon)) {
             final Waypoint waypoint = new Waypoint(CgeoApplication.getInstance().getString(R.string.cache_coordinates_original), WaypointType.ORIGINAL, false);
-            waypoint.setCoords(new Geopoint(originalLat, originalLon));
+            waypoint.setCoords(new Geopoint(Double.parseDouble(originalLat), Double.parseDouble(originalLon)));
             cache.addOrChangeWaypoint(waypoint, false);
             cache.setUserModifiedCoords(true);
         }


### PR DESCRIPTION
Parsing the coordinates is not necessary because we already know their
format in advance. Futhermore, directly parsing the coordinates as
double values also support integer values, which would not be recognized
as valid latitude/longitude by the coordinate parser.