### PR TITLE
upgrade support annotations library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,13 +131,18 @@ allprojects {
 	repositories {
 		mavenCentral()
 		jcenter()
-		// hosts e.g. viewpagerindicator
 		maven {
+			// hosts e.g. viewpagerindicator
 			url "https://jitpack.io"
 		}
-		// viewpager fork
 		maven {
+			// viewpager fork
 			url 'https://dl.bintray.com/alexeydanilov/maven'
+		}
+		maven {
+			// support libraries are no longer maintained in SDK manager, but in this maven repo
+			url 'https://maven.google.com'
+			// Alternative URL is 'https://dl.google.com/dl/android/maven2/'
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.3.2'
     
 		// un-mocking of portable Android classes
-		classpath 'de.mobilej.unmock:UnMockPlugin:0.6.0'
+		classpath 'de.mobilej.unmock:UnMockPlugin:0.6.2'
 
 		// Google Services (App Invite) has its own Gradle plugin
 		classpath 'com.google.gms:google-services:2.1.0'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -327,7 +327,7 @@ dependencies {
 	compile 'com.yqritc:recyclerview-flexibledivider:1.4.0'
 
     // Support Annotations. enforce same version for the main app and the test app
-    def supportAnnotationsVersion = '24.2.1'
+    def supportAnnotationsVersion = '25.3.1'
     compile "com.android.support:support-annotations:$supportAnnotationsVersion"
     androidTestCompile "com.android.support:support-annotations:$supportAnnotationsVersion"
 


### PR DESCRIPTION
This change should fail on our slaves, since they normally do not
contain the latest version of the support library.