### PR TITLE
fix #6578 hide menu items by list type, disable items by current situation

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -67,21 +67,22 @@
             <item
                 android:id="@+id/menu_delete_events"
                 android:title="@string/caches_delete_events"
-                android:visible="false"
+                android:enabled="false"
                 app:showAsAction="never|withText"/>
             <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"
-                android:visible="false"
+                android:enabled="false"
                 app:showAsAction="never|withText"/>
             <item
                 android:id="@+id/menu_remove_from_history"
                 android:title="@string/cache_clear_history"
-                android:visible="false"
+                android:enabled="false"
                 app:showAsAction="never|withText"/>
         </menu>
     </item>
     <item
+        android:id="@+id/menu_lists"
         android:title="@string/menu_lists"
         app:showAsAction="never|withText">
         <!-- List operations -->
@@ -101,7 +102,7 @@
             <item
                 android:id="@+id/menu_make_list_unique"
                 android:title="@string/caches_make_list_unique"
-                android:visible="false"
+                android:enabled="false"
                 app:showAsAction="never|withText"/>
         </menu>
     </item>


### PR DESCRIPTION
~~As discussed in #6578 hide/show toplevel menu items and enable/disable submenu items.~~

As discussed in https://github.com/cgeo/cgeo/pull/6602#issuecomment-309776332:
Hide menu items not applicable for current list type.
Disable menu items not applicable for current situation.
Except "invert selection" which is only shown in select mode.

Search Result main menu:
![screenshot_20170622-212345](https://user-images.githubusercontent.com/5598124/27452350-8ec7d7c2-5792-11e7-9cf2-447cda07a2d6.png)

Search Result manage caches submenu:
![screenshot_20170621-223344](https://user-images.githubusercontent.com/5598124/27407149-9a6563b2-56d7-11e7-80f4-a98d3b98e7e9.png)

Concrete List main menu:
![screenshot_20170622-212154](https://user-images.githubusercontent.com/5598124/27452279-553bbfa0-5792-11e7-801b-e433bbc62069.png)

Concrete List manage caches submenu:
![screenshot_20170621-223406](https://user-images.githubusercontent.com/5598124/27407146-9a5f4fb8-56d7-11e7-928d-94c10c6c70a6.png)

Concrete List manage lists submenu:
![screenshot_20170621-224006](https://user-images.githubusercontent.com/5598124/27407145-9a5dda34-56d7-11e7-954e-fe81dc0c8f17.png)

Concrete List selection mode:
![screenshot_20170622-212202](https://user-images.githubusercontent.com/5598124/27452300-63622a1a-5792-11e7-9c38-71aee55add7d.png)

All caches main menu:
![screenshot_20170622-212253](https://user-images.githubusercontent.com/5598124/27452323-7b8dfd44-5792-11e7-80ff-f743f42b8891.png)

All caches manage lists submenu:
![screenshot_20170621-223559](https://user-images.githubusercontent.com/5598124/27407144-9a5d074e-56d7-11e7-9e3e-eee5dfb2b9fc.png)

History main menu:
![screenshot_20170622-212303](https://user-images.githubusercontent.com/5598124/27452338-84c0a7a4-5792-11e7-9548-4a18ff0221e3.png)

Default list (empty) main menu:
![screenshot_20170622-212243](https://user-images.githubusercontent.com/5598124/27452311-6fd699fc-5792-11e7-9173-ec648333f478.png)

Default list (empty) manage caches submenu:
![screenshot_20170621-233234](https://user-images.githubusercontent.com/5598124/27407828-47d8e670-56da-11e7-8914-878927128646.png)

Default list (empty) manage caches submenu:
![screenshot_20170621-225959](https://user-images.githubusercontent.com/5598124/27407153-9a80f29e-56d7-11e7-8eb5-9b48264980f6.png)
