### PR TITLE
fix #6530 event list sorting improved

### DIFF
--- a/main/src/cgeo/geocaching/calendar/CalendarEntry.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarEntry.java
@@ -45,7 +45,7 @@ class CalendarEntry {
                 StringUtils.defaultString(cache.getPersonalNote()),
                 cache.getName(),
                 cache.getCoords() == null ? "" : cache.getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_RAW),
-                cache.guessEventTimeMinutes());
+                cache.getEventTimeMinutes());
     }
 
     private CalendarEntry(@NonNull final String shortDesc, @NonNull final Date hiddenDate, @NonNull final String url,

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1811,9 +1811,8 @@ public class Geocache implements IWaypoint {
         return !lists.isEmpty() && (lists.size() > 1 || lists.iterator().next() != StoredList.TEMPORARY_LIST.id);
     }
 
-    public int getEventTimeMinutes(){
-        if(eventTimeMinutes == null)
-        {
+    public int getEventTimeMinutes() {
+        if (eventTimeMinutes == null) {
             eventTimeMinutes = guessEventTimeMinutes();
         }
         return eventTimeMinutes.intValue();

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -372,6 +372,7 @@ public class Geocache implements IWaypoint {
             reliableLatLon = other.reliableLatLon;
         }
 
+        this.eventTimeMinutes = null; // will be recalculated if/when necessary
         return isEqualTo(other);
     }
 
@@ -710,10 +711,10 @@ public class Geocache implements IWaypoint {
                     setLocation(partial.getLocation());
                 }
             } else {
-                description = StringUtils.defaultString(description);
-                shortdesc = StringUtils.defaultString(shortdesc);
-                hint = StringUtils.defaultString(hint);
-                location = StringUtils.defaultString(location);
+                setDescription(StringUtils.defaultString(description));
+                setShortDescription(StringUtils.defaultString(shortdesc));
+                setHint(StringUtils.defaultString(hint));
+                setLocation(StringUtils.defaultString(location));
             }
         }
     }
@@ -806,6 +807,7 @@ public class Geocache implements IWaypoint {
 
     public void setDescription(final String description) {
         this.description = description;
+        this.eventTimeMinutes = null; // will be recalculated if/when necessary
     }
 
     public boolean isFound() {
@@ -986,6 +988,7 @@ public class Geocache implements IWaypoint {
 
     public void setShortDescription(final String shortdesc) {
         this.shortdesc = shortdesc;
+        this.eventTimeMinutes = null; // will be recalculated if/when necessary
     }
 
     public void setFavoritePoints(final int favoriteCnt) {
@@ -1322,6 +1325,7 @@ public class Geocache implements IWaypoint {
             throw new IllegalArgumentException("Illegal cache type");
         }
         this.cacheType = new UncertainProperty<>(cacheType);
+        this.eventTimeMinutes = null; // will be recalculated if/when necessary
     }
 
     public void setType(final CacheType cacheType, final int zoomlevel) {
@@ -1329,6 +1333,7 @@ public class Geocache implements IWaypoint {
             throw new IllegalArgumentException("Illegal cache type");
         }
         this.cacheType = new UncertainProperty<>(cacheType, zoomlevel);
+        this.eventTimeMinutes = null; // will be recalculated if/when necessary
     }
 
     public boolean hasDifficulty() {

--- a/main/src/cgeo/geocaching/sorting/EventDateComparator.java
+++ b/main/src/cgeo/geocaching/sorting/EventDateComparator.java
@@ -11,7 +11,7 @@ public class EventDateComparator extends DateComparator {
 
     @Override
     protected int sortSameDate(final Geocache left, final Geocache right) {
-        return compare(left.guessEventTimeMinutes(), right.guessEventTimeMinutes());
+        return compare(left.getEventTimeMinutes(), right.getEventTimeMinutes());
     }
 
     /**

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -20,6 +20,7 @@ import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.utils.Log;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -394,7 +395,7 @@ public class GeocacheTest extends CGeoTestCase {
         cache.setType(CacheType.EVENT);
         cache.setDescription(StringUtils.EMPTY);
         cache.setShortDescription("text 14:20 text");
-        assertThat(cache.guessEventTimeMinutes()).isEqualTo(14 * 60 + 20);
+        assertThat(cache.getEventTimeMinutes()).isEqualTo(14 * 60 + 20);
     }
 
     private static void assertTime(final String description, final int hours, final int minutes) {
@@ -402,14 +403,14 @@ public class GeocacheTest extends CGeoTestCase {
         cache.setDescription(description);
         cache.setType(CacheType.EVENT);
         final int minutesAfterMidnight = hours * 60 + minutes;
-        assertThat(cache.guessEventTimeMinutes()).isEqualTo(minutesAfterMidnight);
+        assertThat(cache.getEventTimeMinutes()).isEqualTo(minutesAfterMidnight);
     }
 
     private static void assertNoTime(final String description) {
         final Geocache cache = new Geocache();
         cache.setDescription(description);
         cache.setType(CacheType.EVENT);
-        assertThat(cache.guessEventTimeMinutes()).isEqualTo(-1);
+        assertThat(cache.getEventTimeMinutes()).isEqualTo(-1);
     }
 
     public static void testGetPossibleLogTypes() throws Exception {

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -20,7 +20,6 @@ import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogType;
-import cgeo.geocaching.utils.Log;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 


### PR DESCRIPTION
Fixes #6530 - Changed 2 things to improve sorting:
- store calculated value (eventTimeMinutes) so it doesn't need to be recalculated for every compare in EventDateComparator
- store regex-patterns in a static list so they don't have to be evaluated _every time_ for _every cache_