### PR TITLE
Fix #6606: Use weighted arithmetic mean to sort GCVote ratings

### DIFF
--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -4,7 +4,7 @@
   <string name="changelog_master" translatable="false">
     <b>Next feature release:</b>\n
     · New: Use abbreviation for name of geocaching service on main screen\n
-    · New: Caches with the same GCVote rating are sorted by the number of votes\n
+    · New: GCVote ratings are now sorted by a weighted arithmetic mean that also considers the number of votes\n
     \n
     \n
   </string>

--- a/main/src/cgeo/geocaching/sorting/RatingComparator.java
+++ b/main/src/cgeo/geocaching/sorting/RatingComparator.java
@@ -10,16 +10,19 @@ class RatingComparator extends AbstractCacheComparator {
 
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
-        final float rating1 = cache1.getRating();
-        final float rating2 = cache2.getRating();
+        return Float.compare(getWeightedArithmeticMean(cache2), getWeightedArithmeticMean(cache1));
+    }
 
-        // Voting can be disabled for caches, then assume an average rating instead
-        final int ratingComparison = Float.compare(rating2 != 0.0 ? rating2 : 2.5f, rating1 != 0.0 ? rating1 : 2.5f);
-        if (ratingComparison != 0) {
-            return ratingComparison;
-        }
+    private static float getWeightedArithmeticMean(final Geocache cache) {
+        // Add some artificial average ratings to weight caches with few ratings towards the average rating.
+        final int averageVotes = 5;
 
-        return compare(cache2.getVotes(), cache1.getVotes());
+        // Average rating of GC50*** determined on June 26th, 2017
+        final float averageRating = 3.4f;
+        final float rating = cache.getRating();
+        final int votes = cache.getVotes();
+
+        return (votes * rating + averageVotes * averageRating) / (votes + averageVotes);
     }
 
     /**


### PR DESCRIPTION
Intended as a basis for discussion.

Not tested yet.