### PR TITLE
Remove Thunderforest API key and provide user setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Request your personal API key for the various [OpenCaching](http://www.opencachi
 * [opencaching.us OKAPI signup](http://www.opencaching.us/okapi/signup.html)
 * [opencache.uk OKAPI signup](http://www.opencache.uk/okapi/signup.html)
 
-Request API key for OpenCycleMap from [Thunderforest](https://manage.thunderforest.com/users/sign_up?plan_id=5).
-
 ### Building with gradle
 
 Run `gradlew` from the root directory of the git repository. That will install the necessary build framework and display how to build cgeo. `gradlew assembleBasicDebug` might be a good start.

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -117,6 +117,7 @@
     <string translatable="false" name="pref_version">version</string>
     <string translatable="false" name="pref_usecompass">usecompass</string>
     <string translatable="false" name="pref_mapfile">mfmapfile</string>
+    <string translatable="false" name="pref_thunderforest_api_key">thunder_forest_api_key</string>
     <string translatable="false" name="pref_memberstatus">memberstatus</string>
     <string translatable="false" name="pref_coordinputformat">coordinputformat</string>
     <string translatable="false" name="pref_gccustomdate">gccustomdate</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1590,5 +1590,7 @@
     <string name="init_low_disk_space_message">The geocache data directory is running low on storage space. This can cause malfunctions of c:geo. Please free up some space.</string>
     <string name="init_confirm_debug">c:geo is running in debug mode!</string>
     <string name="list_confirm_debug_message">The debug mode causes instabilities! Do you want to deactivate the debug mode?</string>
+    <string name="init_thunderforest_api_key_note">API key for OSM: Cyclemap from Thunderforest. Please apply for an API key via http://www.thunderforest.com.</string>
+    <string name="init_thunderforest_api_key_name">Thunderforest API key</string>
 
 </resources>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -539,6 +539,20 @@
                 android:summary="@string/settings_summary_scale_map_text"
                 android:title="@string/settings_title_scale_map_text" />
         </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/map_source_osm_cyclemap" >
+            <cgeo.geocaching.settings.TextPreference
+                android:layout="@layout/text_preference"
+                android:text="@string/init_thunderforest_api_key_note" />
+            <EditTextPreference
+                android:dialogTitle="@string/init_thunderforest_api_key_name"
+                android:imeOptions="actionDone"
+                android:singleLine="true"
+                android:title="@string/init_thunderforest_api_key_name"
+                android:key="@string/pref_thunderforest_api_key"
+                />
+        </PreferenceCategory>
+
         <PreferenceCategory android:title="@string/settings_title_map_content" >
             <Preference
                 android:selectable="false"

--- a/main/src/cgeo/geocaching/maps/AbstractMapSource.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMapSource.java
@@ -40,6 +40,11 @@ public abstract class AbstractMapSource implements MapSource {
     }
 
     @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
     @NonNull
     public MapProvider getMapProvider() {
         return mapProvider;

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -9,15 +9,16 @@ import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Log;
 
-import org.apache.commons.lang3.StringUtils;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import android.view.Menu;
 import android.view.SubMenu;
 
 import java.util.ArrayList;
 import java.util.List;
+
+
+import org.apache.commons.lang3.StringUtils;
 
 public class MapProviderFactory {
 
@@ -121,4 +122,18 @@ public class MapProviderFactory {
         }
         mapSources.removeAll(deletion);
     }
+
+    /**
+     * remove map sources by id after changes of the settings
+     */
+    public static void deleteMapSourceById(final String id) {
+        final List<MapSource> deletion = new ArrayList<>();
+        for (final MapSource mapSource : mapSources) {
+            if (mapSource.getId().equals(id)) {
+                deletion.add(mapSource);
+            }
+        }
+        mapSources.removeAll(deletion);
+    }
+
 }

--- a/main/src/cgeo/geocaching/maps/interfaces/MapSource.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapSource.java
@@ -9,6 +9,8 @@ public interface MapSource {
 
     int getNumericalId();
 
+    String getId();
+
     @NonNull
     MapProvider getMapProvider();
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -35,9 +35,15 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         final Resources resources = CgeoApplication.getInstance().getResources();
 
         registerMapSource(new MapsforgeMapSource(MAPSFORGE_MAPNIK_ID, this, resources.getString(R.string.map_source_osm_mapnik), MapGeneratorInternal.MAPNIK));
-        registerMapSource(new MapsforgeMapSource(MAPSFORGE_CYCLEMAP_ID, this, resources.getString(R.string.map_source_osm_cyclemap), MapGeneratorInternal.THUNDERFOREST));
-
+        updateThunderforestOpenCycleMap();
         updateOfflineMaps();
+    }
+
+    public void updateThunderforestOpenCycleMap() {
+        MapProviderFactory.deleteMapSourceById(MAPSFORGE_CYCLEMAP_ID);
+        if (StringUtils.isNotBlank(Settings.getThunderForestApiKey())) {
+            registerMapSource(new MapsforgeMapSource(MAPSFORGE_CYCLEMAP_ID, this, CgeoApplication.getInstance().getResources().getString(R.string.map_source_osm_cyclemap), MapGeneratorInternal.THUNDERFOREST));
+        }
     }
 
     private static final class Holder {

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -1,6 +1,5 @@
 package cgeo.geocaching.maps.mapsforge;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
@@ -198,7 +197,7 @@ public class MapsforgeMapView extends MapView implements MapViewImpl {
         final MapGenerator mapGenerator = MapGeneratorFactory.createMapGenerator(newMapType);
         if (mapGenerator instanceof ThunderforestTileDownloader) {
             // need to inject apiKey after creation
-            ((ThunderforestTileDownloader) mapGenerator).setApiKey(CgeoApplication.getInstance().getString(R.string.thunderforest_api_key));
+            ((ThunderforestTileDownloader) mapGenerator).setApiKey(Settings.getThunderForestApiKey());
         }
 
         // When swapping map sources, make sure we aren't exceeding max zoom. See bug #1535

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -609,7 +609,7 @@ public class NewMap extends AbstractActionBarActivity {
             if (mapSource.getNumericalId() == MapsforgeMapProvider.MAPSFORGE_MAPNIK_ID.hashCode()) {
                 newLayer = new DownloadLayer(tileCache, this.mapView.getModel().mapViewPosition, OpenStreetMapMapnik.INSTANCE, AndroidGraphicFactory.INSTANCE);
             } else if (mapSource.getNumericalId() == MapsforgeMapProvider.MAPSFORGE_CYCLEMAP_ID.hashCode()) {
-                newLayer = new DownloadLayer(tileCache, this.mapView.getModel().mapViewPosition, ThunderforestMap.INSTANCE, AndroidGraphicFactory.INSTANCE);
+                newLayer = new DownloadLayer(tileCache, this.mapView.getModel().mapViewPosition, new ThunderforestMap(), AndroidGraphicFactory.INSTANCE);
             }
         }
         // Exchange layer

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/ThunderforestMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/ThunderforestMap.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
-import cgeo.geocaching.CgeoApplication;
-import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -16,12 +15,15 @@ import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
  */
 public class ThunderforestMap extends AbstractTileSource {
 
-    public static final ThunderforestMap INSTANCE = new ThunderforestMap(new String[]{"a.tile.thunderforest.com", "b.tile.thunderforest.com", "c.tile.thunderforest.com"}, 443);
     private final String apiKey;
 
     public ThunderforestMap(final String[] hostNames, final int port) {
         super(hostNames, port);
-        apiKey = CgeoApplication.getInstance().getString(R.string.thunderforest_api_key);
+        apiKey = Settings.getThunderForestApiKey();
+    }
+
+    public ThunderforestMap() {
+        this(new String[]{"a.tile.thunderforest.com", "b.tile.thunderforest.com", "c.tile.thunderforest.com"}, 443);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1,25 +1,5 @@
 package cgeo.geocaching.settings;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
-import android.os.Build;
-import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.apps.navi.NavigationAppFactory.NavigationAppsEnum;
@@ -54,6 +34,27 @@ import cgeo.geocaching.utils.CryptUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.FileUtils.FileSelector;
 import cgeo.geocaching.utils.Log;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * General c:geo preferences/settings set by the user
@@ -531,6 +532,18 @@ public class Settings {
     public static void setWebNameCode(final String name, final String code) {
         putString(R.string.pref_webDeviceName, name);
         putString(R.string.pref_webDeviceCode, code);
+    }
+
+    public static String getThunderForestApiKey() {
+        return getString(R.string.pref_thunderforest_api_key, StringUtils.EMPTY);
+    }
+
+    public static void setThunderForestApiKey(final String apiKey) {
+        putString(R.string.pref_thunderforest_api_key, apiKey);
+        MapsforgeMapProvider.getInstance().updateThunderforestOpenCycleMap();
+        if (StringUtils.isBlank(apiKey) && getMapSource().getId().equals(MapsforgeMapProvider.MAPSFORGE_CYCLEMAP_ID)) {
+            setMapSource(MapProviderFactory.getDefaultSource());
+        }
     }
 
     public static MapProvider getMapProvider() {

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -152,6 +152,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
     private void initPreferences() {
         initMapSourcePreference();
+        initThunderforestApiKeyPreferences();
         initExtCgeoDirPreference();
         initDirChoosers();
         initDefaultNavigationPreferences();
@@ -169,7 +170,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
         for (final int k : new int[] {
                 R.string.pref_pass_vote, R.string.pref_signature,
-                R.string.pref_mapsource, R.string.pref_renderthemepath,
+                R.string.pref_thunderforest_api_key, R.string.pref_mapsource, R.string.pref_renderthemepath,
                 R.string.pref_gpxExportDir, R.string.pref_gpxImportDir,
                 R.string.pref_fakekey_dataDir,
                 R.string.pref_mapDirectory, R.string.pref_defaultNavigationTool,
@@ -647,6 +648,10 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         Settings.putString(R.string.pref_webDeviceName, Settings.getWebDeviceName());
     }
 
+    private static void initThunderforestApiKeyPreferences() {
+        Settings.setThunderForestApiKey(Settings.getThunderForestApiKey());
+    }
+
     public void setAuthTitle(final int prefKeyId) {
         switch (prefKeyId) {
             case R.string.pref_fakekey_gc_authorization:
@@ -908,6 +913,13 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         } else if (isPreference(preference, R.string.pref_connectorGeokretyActive)) {
             preferenceManager.findPreference(getKey(R.string.preference_screen_geokrety)).setSummary(getServiceSummary((Boolean) value));
             redrawScreen(preferenceManager.findPreference(getKey(R.string.preference_screen_services)));
+        } else if (isPreference(preference, R.string.pref_thunderforest_api_key)) {
+            Settings.setThunderForestApiKey(stringValue);
+            preference.setSummary(stringValue);
+            final ListPreference mapSourcePref = (ListPreference) getPreference(R.string.pref_mapsource);
+            mapSourcePref.setValue(String.valueOf(Settings.getMapSource().getNumericalId()));
+            bindSummaryToStringValue(R.string.pref_mapsource);
+            initMapSourcePreference();
         } else {
             // For all other preferences, set the summary to the value's
             // simple string representation.

--- a/main/templates/keys.xml
+++ b/main/templates/keys.xml
@@ -3,9 +3,6 @@
     <!-- Google Maps -->
     <string name="maps_api_key" translatable="false">@maps.api.key@</string>
 
-    <!-- Thunderforest OpenCycleMap -->
-    <string name="thunderforest_api_key" translatable="false">@thunderforest.api.key@</string>
-
     <!-- Opencaching.de -->
     <string name="oc_de_okapi_consumer_key" translatable="false">@ocde.okapi.consumer.key@</string>
     <string name="oc_de_okapi_consumer_secret" translatable="false">@ocde.okapi.consumer.secret@</string>


### PR DESCRIPTION
Thunderforest API key for OSM Cyclemap is not provided by c:geo anymore, but supports it via a user setting.