### PR TITLE
Fix #6736: Parse OC coordinates as double values

### DIFF
--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -19,6 +19,7 @@
     · Fix: TLS v1.2 Support for Android 4.1 - 4.4 devices\n
     · Fix: Improve sort of events\n
     · Fix: Raise personal note character limit\n
+    · Fix: Avoid failure when parsing OC coordinates\n
     \n
     \n
 </string>

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -685,7 +685,7 @@ final class OkapiClient {
         final String latitude = StringUtils.substringBefore(location, SEPARATOR_STRING);
         final String longitude = StringUtils.substringAfter(location, SEPARATOR_STRING);
         if (StringUtils.isNotBlank(latitude) && StringUtils.isNotBlank(longitude)) {
-            return new Geopoint(latitude, longitude);
+            return new Geopoint(Double.parseDouble(latitude), Double.parseDouble(longitude));
         }
 
         return null;
@@ -718,7 +718,7 @@ final class OkapiClient {
     private static void setLocation(@NonNull final Geocache cache, final String location) {
         final String latitude = StringUtils.substringBefore(location, SEPARATOR_STRING);
         final String longitude = StringUtils.substringAfter(location, SEPARATOR_STRING);
-        cache.setCoords(new Geopoint(latitude, longitude));
+        cache.setCoords(new Geopoint(Double.parseDouble(latitude), Double.parseDouble(longitude)));
     }
 
     @NonNull


### PR DESCRIPTION
Parsing the coordinates is not necessary because we already know their
format in advance. Futhermore, directly parsing the coordinates as
double values also support integer values, which would not be recognized
as valid latitude/longitude by the coordinate parser.