### PR TITLE
fix #6744 attach oc log image

### DIFF
--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -364,7 +364,7 @@ final class OkapiClient {
             }
 
             if (data.get("success").asBoolean()) {
-                return new ImageResult(StatusCode.NO_ERROR, "");
+                return new ImageResult(StatusCode.NO_ERROR, connector.getSchemeAndHost() + "/images/uploads/" + data.get("image_uuid").asText() + ".jpg");
             }
 
             return new ImageResult(StatusCode.LOGIMAGE_POST_ERROR, "");


### PR DESCRIPTION
It assumes the following pattern to derive the image URL from the `image_uuid` we get from the API call: 
`https://www.opencaching.de/images/uploads/{image_uuid}.jpg`

At least it works for opencaching.de, but I don't know if we can use this pattern for all OC plattforms.
Maybe @following5 can give some input.