### PR TITLE
fix #6744 attach oc log image

### DIFF
--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -135,6 +135,7 @@ final class OkapiClient {
     private static final String TRK_GEOCODE = "code";
     private static final String TRK_NAME = "name";
 
+    private static final String LOG_UUID = "log_uuid";
     private static final String LOG_TYPE = "type";
     private static final String LOG_COMMENT = "comment";
     private static final String LOG_DATE = "date";
@@ -148,6 +149,7 @@ final class OkapiClient {
 
     private static final String IMAGE_CAPTION = "caption";
     private static final String IMAGE_URL = "url";
+    private static final String IMAGE_UUID = "uuid";
 
     // the several realms of possible fields for cache retrieval:
     // Core: for livemap requests (L3 - only with level 3 auth)
@@ -364,7 +366,7 @@ final class OkapiClient {
             }
 
             if (data.get("success").asBoolean()) {
-                return new ImageResult(StatusCode.NO_ERROR, "");
+                return new ImageResult(StatusCode.NO_ERROR, getLogImageUrl(logId, data.get("image_uuid").asText(), connector));
             }
 
             return new ImageResult(StatusCode.LOGIMAGE_POST_ERROR, "");
@@ -372,6 +374,27 @@ final class OkapiClient {
             Log.e("OkapiClient.postLogImage", e);
         }
         return new ImageResult(StatusCode.LOGIMAGE_POST_ERROR, "");
+    }
+
+    @NonNull
+    private static String getLogImageUrl(@NonNull final String logUuid, @NonNull final String imageUuid, @NonNull final OCApiConnector connector) {
+        final Parameters params = new Parameters(LOG_UUID, logUuid);
+        params.add("fields", LOG_IMAGES);
+
+        final JSONResult result = getRequest(connector, OkapiService.SERVICE_LOG_ENTRY, params);
+        if (!result.isSuccess) {
+            return "";
+        }
+
+        final ArrayNode images = (ArrayNode) result.data.get(LOG_IMAGES);
+        if (images != null) {
+            for (final JsonNode imageResponse: images) {
+                if (imageUuid.equalsIgnoreCase(imageResponse.get(IMAGE_UUID).asText())) {
+                    return imageResponse.get(IMAGE_URL).asText();
+                }
+            }
+        }
+        return "";
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/connector/oc/OkapiService.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiService.java
@@ -13,7 +13,10 @@ enum OkapiService {
     SERVICE_ADD_LOG_IMAGE("/okapi/services/logs/images/add", OAuthLevel.Level3),
     SERVICE_USER("/okapi/services/users/user", OAuthLevel.Level1),
     SERVICE_USER_BY_USERNAME("/okapi/services/users/by_username", OAuthLevel.Level1),
-    SERVICE_UPLOAD_PERSONAL_NOTE("/okapi/services/caches/save_personal_notes", OAuthLevel.Level3), SERVICE_RESOLVE_URL("/okapi/services/caches/search/by_urls", OAuthLevel.Level1), SERVICE_API_INSTALLATION("/okapi/services/apisrv/installation", OAuthLevel.Level0);
+    SERVICE_UPLOAD_PERSONAL_NOTE("/okapi/services/caches/save_personal_notes", OAuthLevel.Level3),
+    SERVICE_RESOLVE_URL("/okapi/services/caches/search/by_urls", OAuthLevel.Level1),
+    SERVICE_API_INSTALLATION("/okapi/services/apisrv/installation", OAuthLevel.Level0),
+    SERVICE_LOG_ENTRY("/okapi/services/logs/entry", OAuthLevel.Level1);
 
     @NonNull
     final String methodName;


### PR DESCRIPTION
Until we have the the `image_url` in the response of the post image call as mentioned in https://github.com/cgeo/cgeo/issues/6744#issuecomment-333675587, we have to retrieve the log entry and extract the image url from there.