### PR TITLE
fix #6756 new build error

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -190,7 +190,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
             }
 
             Log.e("GCConnector.searchByGeocode: No data from server");
-            search.setError(StatusCode.COMMUNICATION_ERROR);
+            search.setError(StatusCode.CACHE_NOT_FOUND);
             return search;
         }
         assert page != null;


### PR DESCRIPTION
It changes the result of `GCConnector.searchByGeocode()` in case the page is empty.
The page is empty because it has a 404 http return code.
But I have no idea why this behaviour changed.

The other error I mentioned in #6756 was resolved by a change in the `cgeo.geocaching-preferences.xml` file. I just had to use my own gc userid.