### PR TITLE
 fix to #6711 Copy WP coordinates in selectable format

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -317,9 +317,9 @@
   <string name="caches_manage">Správa</string>
   <string name="caches_remove_all">Odstranit vše</string>
   <plurals name="caches_remove_all_confirm">
-    <item quantity="one">Chcete odstranit tuto keš ze seznamu?</item>
-    <item quantity="few">Chcete odstranit všechny %d keše ze seznamu?</item>
-    <item quantity="other">Chcete odstranit všech %d keší ze seznamu?</item>
+    <item quantity="one">Chceš odstranit tuto keš ze seznamu?</item>
+    <item quantity="few">Chceš odstranit všechny %d keše ze seznamu?</item>
+    <item quantity="other">Chceš odstranit všech %d keší ze seznamu?</item>
   </plurals>
   <string name="caches_remove_selected">Odstranit vybrané</string>
   <plurals name="caches_remove_selected_confirm">
@@ -423,7 +423,7 @@
   <string name="settings_title_gpx">GPX</string>
   <string name="settings_title_data_dir">Umístění dat keše</string>
   <string name="settings_title_data_dir_usage">Adresář dat keše (%1$s použito)</string>
-  <string name="calculate_dataDir_title">Použití úložistě kešemi</string>
+  <string name="calculate_dataDir_title">Využití úložiště kešemi</string>
   <string name="calculate_dataDir">Propočítávání využití úložiště kešemi</string>
   <string name="settings_data_dir_item">%1$s (%2$s volných)</string>
   <string name="confirm_data_dir_move_title">Přesunout adresář s daty keší?</string>
@@ -1458,7 +1458,7 @@
   <string name="cgeo_shortcut">c:geo zástupce</string>
   <string name="create_shortcut">Vytvořit zástupce</string>
   <string name="send">Odeslat</string>
-  <string name="confirm_log_title">Neobvyklý typ logu</string>
+  <string name="confirm_log_title">Speciální typ logu</string>
   <string name="confirm_log_message">Opravdu chceš zalogovat „%s“?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Aktivovat</string>
@@ -1533,5 +1533,5 @@
   <string name="init_low_disk_space">V úložišti dochází volné místo</string>
   <string name="init_low_disk_space_message">V adresáři dat keší dochází volné místo. To může způsobit nesprávné fungování aplikace c:geo. Uvolni nějaké místo.</string>
   <string name="init_confirm_debug">c:geo běží v režimu ladění!</string>
-  <string name="list_confirm_debug_message">Režim ladění může způsobit nestabilitu aplikace. Chcete režim ladění vypnout?</string>
+  <string name="list_confirm_debug_message">Režim ladění může způsobit nestabilitu aplikace. Chceš režim ladění vypnout?</string>
 </resources>

--- a/main/res/values-da/strings.xml
+++ b/main/res/values-da/strings.xml
@@ -591,6 +591,7 @@
   <string name="init_debug_note">c:geo kan generere en stor mængde fejlfindingsoplysninger. Aktivering af denne indstilling vil påvirke stabiliteten af c:geo og kan kun anbefales, hvis du bliver bedt om at sende en fejlfindingslog til udviklerne. Denne indstilling bør være deaktiveret under normal brug af c:geo!</string>
   <string name="init_debug">Aktivér fejlfindingslogning</string>
   <string name="init_dbonsdcard_title">Databaseplacering</string>
+  <string name="init_dbonsdcard">På brugerlager</string>
   <string name="init_dbmove_dbmove">Flytter database</string>
   <string name="init_dbmove_running">Flytter database</string>
   <string name="init_dbmove_success">Databasen blev flyttet.</string>
@@ -1437,7 +1438,7 @@
   <string name="cgeo_shortcut">c:geo genvej</string>
   <string name="create_shortcut">Opret genvej</string>
   <string name="send">Send</string>
-  <string name="confirm_log_title">Usædvanlig logtype</string>
+  <string name="confirm_log_title">Særlig logtype</string>
   <string name="confirm_log_message">Du er ved at logge \"%s\". Er du sikker?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Aktivér</string>
@@ -1498,6 +1499,10 @@
   <string name="cache_list_remove_from">Fjern fra liste</string>
   <string name="list_list_headline">Lister:</string>
   <string name="cache_store_list">Gem i liste</string>
+  <plurals name="extract_waypoints_result">
+    <item quantity="one">%d waypoint udtrukket</item>
+    <item quantity="other">%d waypoints udtrukket</item>
+  </plurals>
   <!-- calendar adder -->
   <string name="event_fail">Kunne ikke tilføje eventcachen til kalenderen</string>
   <string name="init_low_disk_space">Datalageret er næsten fyldt</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -1443,7 +1443,7 @@
   <string name="cgeo_shortcut">c:geo Shortcut</string>
   <string name="create_shortcut">Shortcut erstellen</string>
   <string name="send">Senden</string>
-  <string name="confirm_log_title">Ungewöhnlicher Log-Typ</string>
+  <string name="confirm_log_title">Spezieller Log Typ</string>
   <string name="confirm_log_message">Du möchtest „%s“ loggen. Bist du dir sicher?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Aktivieren</string>

--- a/main/res/values-fi/strings.xml
+++ b/main/res/values-fi/strings.xml
@@ -78,6 +78,7 @@
   <string name="log_tb_nothing">Ei toimintoa</string>
   <string name="log_tb_visit">Vieraili</string>
   <string name="log_tb_drop">Jätetty paikalle</string>
+  <string name="log_tb_sortby">Järjestä reissaajat</string>
   <string name="log_tb_changeall">Muuta kaikki</string>
   <string name="log_tb_grabbed">Otettu muualta</string>
   <string name="log_tb_note">Muistiinpano</string>
@@ -416,6 +417,11 @@
   <string name="settings_title_map_data">Kartan tiedot</string>
   <string name="settings_title_map_content">Kartan sisältö</string>
   <string name="settings_title_gpx">GPX</string>
+  <string name="settings_title_data_dir">Kätködatan kansio</string>
+  <string name="settings_title_data_dir_usage">Kätködatan kansio (%1$s käytetty)</string>
+  <string name="calculate_dataDir">Lasketaan kätködatan määrä levyllä</string>
+  <string name="settings_data_dir_item">%1$s (%2$s vapaana)</string>
+  <string name="confirm_data_dir_move_title">Siirrä kätködatan kansio?</string>
   <string name="confirm_data_dir_move">Kätködatan siirtäminen voi kestää todella kauan riippuen laitteestasi sekä datan määrästä.</string>
   <string name="settings_title_basicmembers">Peruskäyttäjän asetukset</string>
   <string name="settings_title_navigation">Navigointi</string>
@@ -462,7 +468,7 @@
   <string name="init_summary_su">Lataa kätköt palvelusta Geocaching.su</string>
   <string name="settings_activate_su">Aktivoi</string>
   <string name="init_gcvote">GCvote.com</string>
-  <string name="init_gcvote_password_description">Voidaksesi arvostella kätköjä, sinun täytyy hyväksyä GCVote,com:in ehdot ja antaa salasanasi GCvote:en.</string>
+  <string name="init_gcvote_password_description">Voidaksesi arvostella kätköjä, seuraa ohjeita GCVote.com:ssa ja syötä GCvoten salasanasi tänne.</string>
   <string name="err_gcvote_send_rating">Virhe arvostelun lähettämisessä, tarkista GCVote:n salasana asetuksista tai poista arvostelu käytöstä tyhjentämällä salasana-kenttä.</string>
   <string name="gcvote_sent">Ääni lähetetty onnistuneesti</string>
   <string name="init_twitter">Twitter</string>
@@ -494,8 +500,8 @@
   <string name="init_signature_template_name">Nimi</string>
   <string name="init_signature_template_url">URL</string>
   <string name="init_signature_template_log">Lokiteksti</string>
-  <string name="init_ratingwanted">GCVote arvostelu</string>
-  <string name="init_summary_ratingwanted">Lataa kätkön arvostelu GCVote:sta</string>
+  <string name="init_ratingwanted">GCVote-arvostelu</string>
+  <string name="init_summary_ratingwanted">Lataa kätkön arvostelu GCVotesta</string>
   <string name="init_friends_and_own_logs_wanted">Näytä ystävien/omat</string>
   <string name="init_summary_friends_and_own_logs_wanted">Näytä erillinen lokikirjan sivu omille sekä ystävien lokeille</string>
   <string name="init_openlastdetailspage">Viimeisimmät tiedot -sivu</string>
@@ -555,6 +561,7 @@
   <string name="init_map_directory_description">Offline-karttojen polku</string>
   <string name="init_gpx_exportdir">GPX:n vientikansio</string>
   <string name="init_gpx_importdir">GPX:n tuontikansio</string>
+  <string name="init_dataDir">Valitse kätködatan kansio</string>
   <string name="init_maptrail">Näytä reitti</string>
   <string name="init_summary_maptrail">Näytä reitti kartalla</string>
   <string name="init_share_after_export">Avaa jakovalikko GPX-tiedoston tuomisen jälkeen</string>
@@ -580,6 +587,7 @@
   <string name="init_dbmove_failed">Tietojen siirto epäonnistui</string>
   <string name="init_datadirmove_datadirmove">Siirretään kätködataa toiseen kansioon</string>
   <string name="init_datadirmove_running">Siirretään kätködataa toiseen kansioon</string>
+  <string name="init_datadirmove_success">Kätködatan kansion siirto onnistui.</string>
   <string name="init_plain_logs">Yksinkertaiset lokit</string>
   <string name="init_summary_plain_logs">Näytä loki ilman värejä</string>
   <string name="init_use_native_ua">Android-selain</string>
@@ -805,6 +813,7 @@
   <string name="cache_menu_spoilers">Spoiler-kuvat</string>
   <string name="cache_menu_around">Kätköt lähistöllä</string>
   <string name="around">%s:n ympärillä</string>
+  <string name="menu_caches">Hallitse kätköjä</string>
   <string name="cache_menu_event">Lisää kalenteriin</string>
   <string name="cache_menu_extract_waypoints">Poimi reittipisteet</string>
   <string name="cache_menu_details">Tarkat tiedot</string>
@@ -944,6 +953,8 @@
   <string name="waypoint_coordinates_uploading_to_website">Ladataan koordinaatteja %s nettisivulle.</string>
   <string name="waypoint_coordinates_has_been_modified_on_website">Kätkökoordinaatit nettisivulla on muutettu: %s.</string>
   <string name="waypoint_done">Valmis</string>
+  <string name="waypoint_duplicate">Monista reittipiste</string>
+  <string name="waypoint_duplicated">Reittipiste monistettu</string>
   <string name="waypoint_copy_of">Kopio</string>
   <string name="search_history">Historiatiedot</string>
   <string name="search_history_empty">Ei aikaisempia kohteita</string>
@@ -1409,7 +1420,6 @@
   <string name="cgeo_shortcut">c:geo pikakuvake</string>
   <string name="create_shortcut">Luo pikakuvake</string>
   <string name="send">Lähetä</string>
-  <string name="confirm_log_title">Epätavallinen lokityyppi</string>
   <string name="confirm_log_message">Haluat lokata \'%s\'. Oletko varma?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Aktivoi</string>
@@ -1448,6 +1458,10 @@
   <string name="command_rename_list_result">Uudelleen nimetty luettelo</string>
   <string name="command_delete_list_result">Poistettu luettelo</string>
   <string name="command_unique_list_result">Kätköt poistettiin muilta listoilta</string>
+  <plurals name="fav_points_remaining">
+    <item quantity="one">Lisää kätkö suosikkeihin (%d jäljellä)</item>
+    <item quantity="other">Lisää kätkö suosikkeihin (%d jäljellä)</item>
+  </plurals>
   <!-- distance units -->
   <string name="unit_m">m</string>
   <string name="unit_km">km</string>
@@ -1472,4 +1486,7 @@
   </plurals>
   <!-- calendar adder -->
   <string name="event_fail">Tapahtumakätkön lisääminen kalenteriin epäonnistui</string>
+  <string name="init_low_disk_space">Tallennustila on vähissä</string>
+  <string name="init_confirm_debug">c:geo on vianmääritystilassa!</string>
+  <string name="list_confirm_debug_message">Vianmääritystila aiheuttaa epävakautta! Haluatko poistaa sen käytöstä?</string>
 </resources>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -1443,7 +1443,7 @@
   <string name="cgeo_shortcut">Raccourci c:geo</string>
   <string name="create_shortcut">Créer un raccourci</string>
   <string name="send">Envoyer</string>
-  <string name="confirm_log_title">Type inhabituel pour une visite</string>
+  <string name="confirm_log_title">Type de visite spécial</string>
   <string name="confirm_log_message">Vous allez envoyer \'%s\'. Êtes-vous sûr(e) ?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Activer</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -883,7 +883,7 @@
   <string name="cache_coordinates">Koordináták</string>
   <string name="cache_coordinates_original">Eredeti koordináták</string>
   <string name="cache_spoiler_images_title">Spoiler képek</string>
-  <string name="cache_log_types">Bejegyzés típusok</string>
+  <string name="cache_log_types">Bejegyzéstípusok</string>
   <string name="cache_coordinates_no">Ennek a ládának nincsenek koordinátái.</string>
   <string name="cache_clear_history">Előzmények törlése</string>
   <string name="cache_remove_from_history">Törlés az előzményekből</string>
@@ -1443,7 +1443,7 @@
   <string name="cgeo_shortcut">c:geo parancsikon</string>
   <string name="create_shortcut">Parancsikon létrehozása</string>
   <string name="send">Küldés</string>
-  <string name="confirm_log_title">Különleges logtípus</string>
+  <string name="confirm_log_title">Speciális bejegyzéstípus</string>
   <string name="confirm_log_message">Logod a következő: \'%s\'. Biztosan ezt akarod?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Aktiválás</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -92,6 +92,7 @@
   <string name="log_posting_twitter">Caricamento tweet…</string>
   <string name="log_posting_gcvote">Caricamento GCVote…</string>
   <string name="log_posting_image">Caricamento immagine…</string>
+  <string name="log_posting_generic_trackable">Sto pubblicando %1$s %2$d/%3$d</string>
   <string name="log_clear">Azzera</string>
   <string name="log_post_not_possible">Download dei dati in corso…\nRiprovare tra alcuni secondi o controllare la connessione a internet.</string>
   <string name="log_post_geocode_missing">Geocode mancante…</string>
@@ -314,6 +315,10 @@
   <string name="caches_nearby">Qui vicino</string>
   <string name="caches_manage">Gestisci</string>
   <string name="caches_remove_all">Elimina tutti</string>
+  <plurals name="caches_remove_all_confirm">
+    <item quantity="one">Vuoi rimuovere questo cache da questa lista?</item>
+    <item quantity="other">Vuoi rimuovere tutti i %d cache da questa lista?</item>
+  </plurals>
   <string name="caches_remove_selected">Elimina selezionati</string>
   <plurals name="caches_remove_selected_confirm">
     <item quantity="one">Si desidera rimuovere questo cache dal tuo dispositivo?</item>
@@ -358,6 +363,7 @@
   <string name="caches_make_list_unique">Marca la lista come unica</string>
   <string name="caches_filter_missing_gcvote">Trovati cache non votati</string>
   <!-- caches lists -->
+  <string name="menu_lists">Gestisci liste</string>
   <string name="list_menu_create">Crea nuova lista</string>
   <string name="list_menu_drop">Elimina la lista corrente</string>
   <string name="list_menu_rename">Rinomina la lista corrente</string>
@@ -417,6 +423,7 @@
   <string name="calculate_dataDir_title">Dati Geocache usati</string>
   <string name="calculate_dataDir">Calcola lo spazio disco usato dai Geocache</string>
   <string name="settings_data_dir_item">%1$s (%2$s liberi)</string>
+  <string name="confirm_data_dir_move_title">Vuoi spostare la directory geocache?</string>
   <string name="confirm_data_dir_move">Lo spostamento dei dati geocache potrebbe richiedere molto tempo, a seconda del dispositivo e la quantità di dati.</string>
   <string name="settings_title_basicmembers">Opzioni per i membri di base (non Premium)</string>
   <string name="settings_title_navigation">Navigazione</string>
@@ -819,6 +826,7 @@
   <string name="cache_menu_spoilers">Immagini spoiler</string>
   <string name="cache_menu_around">Cache qui intorno</string>
   <string name="around">Nei dintorni di %s</string>
+  <string name="menu_caches">Gestisci i cache</string>
   <string name="cache_menu_event">Aggiungi al calendario</string>
   <string name="cache_menu_extract_waypoints">Estrazione dei waypoint</string>
   <string name="cache_menu_details">Dettagli</string>
@@ -1427,7 +1435,7 @@
   <string name="cgeo_shortcut">collegamento a c:geo</string>
   <string name="create_shortcut">Crea collegamento</string>
   <string name="send">Invia</string>
-  <string name="confirm_log_title">Tipo di Log non usuale</string>
+  <string name="confirm_log_title">Tipo di log speciale</string>
   <string name="confirm_log_message">Si desidera registrare \'%s\'. Sei sicuro?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Attiva</string>
@@ -1466,6 +1474,10 @@
   <string name="command_rename_list_result">Lista rinominata</string>
   <string name="command_delete_list_result">Lista eliminata</string>
   <string name="command_unique_list_result">Cache eliminati da altri elenchi</string>
+  <plurals name="fav_points_remaining">
+    <item quantity="one">Aggiungi questo cache ai preferiti (%d restanti)</item>
+    <item quantity="other">Aggiungi questo cache ai preferiti (%d restanti)</item>
+  </plurals>
   <!-- distance units -->
   <string name="unit_m">m</string>
   <string name="unit_km">km</string>
@@ -1490,4 +1502,8 @@
   </plurals>
   <!-- calendar adder -->
   <string name="event_fail">Impossibile aggiungere l\'evento al calendario</string>
+  <string name="init_low_disk_space">Sto esaurendo lo spazio su disco</string>
+  <string name="init_low_disk_space_message">La directory dei dati geocache sta esaurendo lo spazio su disco. Questo può causare malfunzionamenti di c:geo. Si prega di liberare spazio.</string>
+  <string name="init_confirm_debug">c:geo è in esecuzione in modalità di debug!</string>
+  <string name="list_confirm_debug_message">La modalità di debug può causare instabilità! Vuoi tornare alla modalità normale?</string>
 </resources>

--- a/main/res/values-ko/strings.xml
+++ b/main/res/values-ko/strings.xml
@@ -1409,7 +1409,7 @@
   <string name="cgeo_shortcut">c:geo 바로가기</string>
   <string name="create_shortcut">바로가기 만들기</string>
   <string name="send">보내기</string>
-  <string name="confirm_log_title">특이한 로그 유형</string>
+  <string name="confirm_log_title">특별 로그 유형</string>
   <string name="confirm_log_message">정말 \'%s\'를 로그하시겠습니까?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">활성화</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -1443,7 +1443,7 @@
   <string name="cgeo_shortcut">c:geo snelkoppeling</string>
   <string name="create_shortcut">Maak snelkoppeling</string>
   <string name="send">Verzenden</string>
-  <string name="confirm_log_title">Ongebruikelijk logtype</string>
+  <string name="confirm_log_title">Speciaal log type</string>
   <string name="confirm_log_message">Je wilt \'%s\' loggen. Weet je het zeker?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Activeren</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -1451,7 +1451,7 @@
   <string name="cgeo_shortcut">skrót do c:geo</string>
   <string name="create_shortcut">Utwórz skrót</string>
   <string name="send">Wyślij</string>
-  <string name="confirm_log_title">Niezwykły typ wpisu</string>
+  <string name="confirm_log_title">Specjalny typ wpisu</string>
   <string name="confirm_log_message">Chcesz wpisać \'%s\'. Czy jesteś pewien?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Aktywuj</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -11,9 +11,9 @@
   <string name="latitude">Latitude</string>
   <string name="longitude">Longitude</string>
   <!-- actionbar -->
-  <string name="settings_titlebar">c:geo Definições</string>
+  <string name="settings_titlebar">Definições c:geo</string>
   <!-- caches -->
-  <string name="all_types">Todos os tipos</string>
+  <string name="all_types">Todos os tipos de Caches</string>
   <string name="traditional">Cache tradicional</string>
   <string name="multi">Multi-cache</string>
   <string name="mystery">Cache mistério</string>
@@ -28,8 +28,8 @@
   <string name="wherigo">Cache wherigo</string>
   <string name="lostfound">Cache evento Perdidos e achados</string>
   <string name="ape">Cache projecto APE</string>
-  <string name="gchq">Groundspeak hq</string>
-  <string name="gps">Cache exposição GPS</string>
+  <string name="gchq">Sede Groundspeak</string>
+  <string name="gps">Exposição GPS Adventures</string>
   <string name="block">Groundspeak Block Party</string>
   <string name="unknown">Tipo Desconhecido</string>
   <!-- cache sizes -->
@@ -48,19 +48,19 @@
   <string name="wp_stage">Etapa da multi-cache</string>
   <string name="wp_puzzle">Pergunta para responder</string>
   <string name="wp_pkg">Parque de estacionamento</string>
-  <string name="wp_trailhead">Início</string>
+  <string name="wp_trailhead">Inicio de trilho</string>
   <string name="wp_waypoint">Ponto de referência</string>
   <string name="wp_original">Coordenadas Originais</string>
   <!-- logs -->
   <string name="log_found">Encontrei</string>
   <string name="log_dnf">Não encontrei</string>
   <string name="log_note">Nota</string>
-  <string name="log_published">Publicado</string>
-  <string name="log_enabled">Activo</string>
+  <string name="log_published">Publicada</string>
+  <string name="log_enabled">Activada</string>
   <string name="log_disabled">Desactivo</string>
   <string name="log_attend">Vou participar</string>
   <string name="log_attended">Participei</string>
-  <string name="log_retrieved">Retirado</string>
+  <string name="log_retrieved">Recolhido</string>
   <string name="log_placed">Colocado</string>
   <string name="log_grabbed">Recolhido algures</string>
   <string name="log_movecollection">Mover para colecção</string>
@@ -71,31 +71,31 @@
   <string name="log_archived">Arquivada</string>
   <string name="log_unarchived">Desarquivada</string>
   <string name="log_needs_archived">Precisa de arquivamento</string>
-  <string name="log_discovered">Descoberta</string>
+  <string name="log_discovered">Avistado</string>
   <string name="log_reviewer">Nota de revisão</string>
   <string name="log_submit_for_review">Enviar para revisão</string>
-  <string name="log_retractlisting">Retirar Lista</string>
-  <string name="log_marked_missing">Marcado em falta</string>
+  <string name="log_retractlisting">Anular publicação</string>
+  <string name="log_marked_missing">Dado como desaparecido</string>
   <string name="log_tb_nothing">Não fazer nada</string>
   <string name="log_tb_visit">Visitei</string>
   <string name="log_tb_drop">Deixei aqui</string>
   <string name="log_tb_sortby">Ordenar Trackable</string>
   <string name="log_tb_changeall">Alterar todos</string>
-  <string name="log_tb_grabbed">Agarrado noutro lugar</string>
+  <string name="log_tb_grabbed">Recolhido algures</string>
   <string name="log_tb_note">Nota</string>
   <string name="log_tb_discovered">Descoberto</string>
-  <string name="log_tb_archived">Arquivado</string>
+  <string name="log_tb_archived">Arquivada</string>
   <string name="log_save">Guardar offline</string>
   <string name="log_saving">A gravar o registo…</string>
-  <string name="log_saving_and_uploading">A enviar o registo e a efetuar upload da imagem…</string>
-  <string name="log_posting_log">A publicar log…</string>
+  <string name="log_saving_and_uploading">A publicar o registo e envio da imagem…</string>
+  <string name="log_posting_log">A publicar o registo…</string>
   <string name="log_posting_twitter">A publicar tweet…</string>
   <string name="log_posting_gcvote">A publicar GCVote…</string>
   <string name="log_posting_image">A publicar imagem…</string>
   <string name="log_posting_generic_trackable">A publicar %1$s %2$d/%3$d</string>
   <string name="log_clear">Limpar</string>
   <string name="log_post_not_possible">Transferência de dados em curso…\nPor favor tente novamente dentro de alguns segundos ou verifique a sua ligação à internet.</string>
-  <string name="log_post_geocode_missing">Geocódigo em falta…</string>
+  <string name="log_post_geocode_missing">Código GC em falta…</string>
   <string name="log_date_future_not_allowed">Registos com datas futuras não são permitidos.</string>
   <string name="log_add">Adicionar</string>
   <string name="log_repeat">Repetir último registo</string>
@@ -111,7 +111,7 @@
   <string name="log_stars_5_description">Excelente</string>
   <string name="log_webcam">Fotografia tirada pela webcam</string>
   <string name="log_new_log">Registar</string>
-  <string name="log_new_log_text">Registar texto</string>
+  <string name="log_new_log_text">Texto do registo</string>
   <string name="log_announcement">Anúncio</string>
   <string name="log_today">Hoje</string>
   <string name="log_yesterday">Ontem</string>
@@ -155,7 +155,7 @@
   <string name="err_maintenance">Geocaching.com está em manutenção. O c:geo funciona offline com as caches Arquivadas.</string>
   <string name="err_license">O utilizador não concordou com a licença de utilização de Geocaching.com, por isso c:geo não pode carregar as coordenadas da cache.</string>
   <string name="err_unvalidated_account">Deve validar a sua conta primeiro em Geocaching.com.</string>
-  <string name="err_unpublished">A cache pedida não está publicada.</string>
+  <string name="err_unpublished">A cache solicitada não está publicada.</string>
   <string name="err_cache_not_found">A cache solicitada não pôde ser encontrada.</string>
   <string name="err_premium_only">Esta cache só está disponível para membros premium do Geocaching.com.</string>
   <string name="err_detail_open">O c:geo não consegue abrir os detalhes da geocache.</string>
@@ -169,18 +169,18 @@
   <string name="err_detail_not_load_map_static">O c:geo falhou o carregamento de mapas estáticos.</string>
   <string name="err_detail_still_working">A trabalhar noutra tarefa.</string>
   <string name="err_watchlist_still_managing">Ainda a gerir a sua watchlist.</string>
-  <string name="err_watchlist_failed">A gestão da sua watchlist falhou.</string>
+  <string name="err_watchlist_failed">Falhou a alteração da sua lista de observação.</string>
   <string name="err_application_no">O c:geo não encontra a aplicação correcta.</string>
   <string name="err_auth_initialize">O c:geo falhou a iniciar o processo de autorização.</string>
   <string name="err_auth_process">Processo de autorização falhou.</string>
-  <string name="err_cannot_log_visit">O c:geo não tem informação suficiente para registar a visita. Por favor, faça-o a partir dos detalhes completos da cache.</string>
+  <string name="err_cannot_log_visit">O c:geo não consegue registar a sua visita. Por favor, faça-o a partir da vista dos detalhes completos da cache.</string>
   <string name="err_download_fail">O c:geo falhou o download das caches porque </string>
   <string name="err_dwld_details_failed">O c:geo falhou o download dos detalhes da cache.</string>
   <string name="err_load_descr_failed">O c:geo não consegue carregar a descrição.</string>
   <string name="err_location_unknown">O c:geo não sabe a localização da cache.</string>
   <string name="err_missing_device_name">Por favor insira um nome para este dispositivo antes de registar.</string>
   <string name="err_favorite_failed">Alteração do estado de favorito falhou.</string>
-  <string name="err_select_logimage_failed">Selecionar uma imagem para o registo falhado.</string>
+  <string name="err_select_logimage_failed">Selecção de imagem para o registo falhou.</string>
   <string name="err_acquire_image_failed">Aquisição de uma imagem falhou.</string>
   <string name="err_tb_display">O c:geo não consegue mostrar o trackable pretendido. É mesmo um trackable?</string>
   <string name="err_tb_details_open">O c:geo não consegue abrir os detalhes do trackable.</string>
@@ -228,7 +228,7 @@
   <string name="warn_deprecated_mapfile">Está a utilizar um ficheiro de mapa de uma versão obsoleta.\nConsidere mudar o mapa para a versão 0.3.0.\nNa próxima versão vamos deixar de suportar a 0.2.4.</string>
   <string name="warn_nonexistant_mapfile">O ficheiro de mapa selecionado não existe.\nMapas offline não estão disponíveis.</string>
   <string name="warn_rendertheme_missing">Tema de mapa não encontrado.</string>
-  <string name="warn_pocket_query_select">Nenhuma pocket query selecionada.</string>
+  <string name="warn_pocket_query_select">Nenhuma pocket query seleccionada.</string>
   <string name="warn_no_pocket_query_found">Nenhuma pocket query encontrada on-line.</string>
   <string name="err_read_pocket_query_list">Erro ao ler a lista de Pocket Query.</string>
   <string name="info_log_posted">O c:geo publicou o registo com sucesso.</string>
@@ -241,7 +241,7 @@
   <string name="info_log_type_changed">O tipo de registo foi alterado!</string>
   <string name="info_select_logimage_cancelled">A selecção ou captura de imagem foi cancelada.</string>
   <string name="info_stored_image">Nova imagem guardada em:</string>
-  <string name="info_storing_static_maps">A tentar arquivar mapas estáticos.</string>
+  <string name="info_storing_static_maps">A tentar armazenar mapas estáticos</string>
   <string name="info_cache_saved">A cache foi armazenada localmente</string>
   <string name="err_trackable_log_not_anonymous">Logar %1$s a partir do c:geo não pode ser feito de forma anónima. Quer abrir as configurações para preencher as suas credenciais de %2$s?</string>
   <string name="err_trackable_no_preference_activity">Desculpa, não posso encontrar uma tela de preferência apropriada.</string>
@@ -267,18 +267,18 @@
   <string name="menu_filter">Filtro</string>
   <string name="menu_scan_geo">Scan geocode</string>
   <string name="menu_pocket_queries">Pocket queries</string>
-  <string name="menu_scan_description">c:geo pode digitalizar geocódigos impressos em código QR. A aplicação necessária não está instalada. Deseja abrir o Google Play para a intalar?</string>
+  <string name="menu_scan_description">O c:geo pode fazer a leitura de geo-códigos impressos num código QR. A aplicação necessária não está instalada. Deseja abrir o Google Play para a instalar?</string>
   <!-- main screen -->
   <string name="live_map_button">Ao vivo</string>
   <string name="caches_nearby_button">Por perto</string>
   <string name="advanced_search_button">Pesquisar</string>
   <string name="stored_caches_button">Arquivo</string>
   <string name="any_button">Ir para</string>
-  <string name="unknown_scan">Sem resultados do scan.</string>
+  <string name="unknown_scan">Não se encontrou geo-códigos na leitura realizada.</string>
   <!-- caches -->
   <string name="caches_no_cache">Nenhuma cache</string>
-  <string name="caches_more_caches">Mais caches</string>
-  <string name="caches_more_caches_no">Mais nenhuma cache</string>
+  <string name="caches_more_caches">Carregar mais caches</string>
+  <string name="caches_more_caches_no">Sem mais caches</string>
   <string name="caches_more_caches_loading">A carregar caches…</string>
   <string name="caches_more_caches_currently">actualmente</string>
   <string name="caches_downloading">A descarregar caches…\nTempo estimado: </string>
@@ -288,7 +288,7 @@
     <item quantity="other">%d minutos</item>
   </plurals>
   <string name="caches_store_offline">Arquivar para uso offline</string>
-  <string name="caches_store_selected">Arquivar selecionadas</string>
+  <string name="caches_store_selected">Arquivar seleccionadas</string>
   <string name="caches_history">Histórico</string>
   <string name="caches_on_map">Mostrar no mapa</string>
   <string name="caches_sort">Ordenar</string>
@@ -299,7 +299,7 @@
   <string name="caches_sort_favorites">Popularidade</string>
   <string name="caches_sort_favorites_ratio">Popularidade [%]</string>
   <string name="caches_sort_name">Nome</string>
-  <string name="caches_sort_geocode">Geo Código</string>
+  <string name="caches_sort_geocode">Código GC</string>
   <string name="caches_sort_rating">Pontuação</string>
   <string name="caches_sort_vote">Votos (pontuação própria)</string>
   <string name="caches_sort_inventory">Somatório do Inventário</string>
@@ -319,14 +319,14 @@
     <item quantity="one">Quer remover esta cache da lista actual?</item>
     <item quantity="other">Quer remover todas as %d caches da lista actual?</item>
   </plurals>
-  <string name="caches_remove_selected">Remover selecionadas</string>
+  <string name="caches_remove_selected">Remover seleccionadas</string>
   <plurals name="caches_remove_selected_confirm">
     <item quantity="one">Quer remover esta cache do seu dispositivo?</item>
     <item quantity="other">Quer remover as %d caches seleccionadas do seu dispositivo?</item>
   </plurals>
   <string name="caches_remove_progress">A remover caches</string>
   <string name="caches_delete_events">Eliminar eventos passados</string>
-  <string name="caches_refresh_selected">Actualizar seleccionada</string>
+  <string name="caches_refresh_selected">Actualizar seleccionada(s)</string>
   <string name="caches_refresh_all">Actualizar todas</string>
   <string name="caches_move_selected">Mover seleccionadas</string>
   <string name="caches_move_all">Mover todas</string>
@@ -335,7 +335,7 @@
   <string name="caches_map_locus">Locus</string>
   <string name="caches_map_locus_export">Exportar para Locus</string>
   <string name="caches_recaptcha_title">reCAPTCHA</string>
-  <string name="caches_recaptcha_explanation">Por favor, escreva o texto da imagem. É importante para fazer o download das coordenadas das caches. É opcional e pode ser desactivado nas Definições.</string>
+  <string name="caches_recaptcha_explanation">Por favor, escreva o texto da imagem. Isto permite o download das coordenadas das caches. Pode ser desactivado nas Definições.</string>
   <string name="caches_recaptcha_hint">Texto da imagem</string>
   <string name="caches_recaptcha_continue">Continuar</string>
   <string name="caches_filter">Filtrar</string>
@@ -355,7 +355,7 @@
   <string name="caches_filter_rating">Com classificação</string>
   <string name="caches_filter_own_rating">Com própria classificação</string>
   <string name="caches_filter_multi_listing">Multi-listagem com estado diferente</string>
-  <string name="caches_filter_own_waypoint">Com waypoints definidos pelo utilizador</string>
+  <string name="caches_filter_own_waypoint">Com pontos adicionais definidos pelo utilizador</string>
   <string name="caches_removing_from_history">A remover do histórico…</string>
   <string name="caches_clear_offlinelogs">Limpar registos offline</string>
   <string name="caches_clear_offlinelogs_message">Quer apagar os registos offline?</string>
@@ -394,7 +394,7 @@
   <string name="about_donation_more">Doar\ndesenvolvimento</string>
   <string name="about_contributors">Contribuidores</string>
   <string name="about_license">Licença</string>
-  <string name="about_apache_license"><a href="">Apache License, Version 2.0</a></string>
+  <string name="about_apache_license"><a href="">Apache License, Versão 2.0</a></string>
   <string name="about_help">Ajuda</string>
   <string name="about_system_include">Por favor inclua as seguintes informações de sistema ao enviar um relatório de bug ou ao pedir mais informações sobre c:geo:</string>
   <string name="about_system_info_send_button">Enviar por email…</string>
@@ -411,10 +411,10 @@
   <string name="settings_summary_cachedetails">Personalizar a exibição de informações da cache.</string>
   <string name="settings_title_offlinedata">Dados Offline</string>
   <string name="settings_summary_offlinedata">Configurar mapas estáticos e outros dados de armazenamento offline.</string>
-  <string name="settings_title_logging">A fazer o registo</string>
-  <string name="settings_summary_logging">Configure a sua assinatura e as suas contas.</string>
+  <string name="settings_title_logging">Registos</string>
+  <string name="settings_summary_logging">Configure a sua assinatura e as opções de registo.</string>
   <string name="settings_title_map">Mapa</string>
-  <string name="settings_summary_map">Selecione o tipo de mapa, configurações de mapa offline e detalhes do mapa.</string>
+  <string name="settings_summary_map">Defina a fonte do mapa, definições de mapa offline e detalhes do mapa.</string>
   <string name="settings_title_map_data">Dados do Mapa</string>
   <string name="settings_title_map_content">Conteúdo do Mapa</string>
   <string name="settings_title_gpx">GPX</string>
@@ -442,9 +442,9 @@
   <string name="settings_activate_gc">Activar</string>
   <string name="settings_activate_ec">Activar</string>
   <string name="settings_activate_ox">Activar</string>
-  <string name="settings_gc_legal_note">Quando você usa do serviço do geocaching.com, você aceita os termos de uso da Groundspeak.</string>
+  <string name="settings_gc_legal_note">Ao usar o serviço de geocaching.com, está a aceitar os Termos de Utilização da Groundspeak.</string>
   <string name="settings_info_facebook_login_title">Facebook Login</string>
-  <string name="settings_info_facebook_login" tools:ignore="Typos">Não consegue que c:geo faça o login em geocaching.com com a sua conta do Facebook. Mas existe uma solução simples…</string>
+  <string name="settings_info_facebook_login" tools:ignore="Typos">Não consegue que o c:geo inicie a sessão em geocaching.com com a sua conta do Facebook. Mas existe uma solução simples…</string>
   <string name="settings_authorize">Autorizar c:geo</string>
   <string name="settings_reauthorize">Reautorizar c:geo</string>
   <string name="settings_gc_description">Autorize o c:geo a pesquisar caches em geocaching.com.</string>
@@ -478,18 +478,18 @@
   <string name="init_summary_su">Carregar caches de Geocaching.su</string>
   <string name="settings_activate_su">Activar</string>
   <string name="init_gcvote">GCvote.com</string>
-  <string name="init_gcvote_password_description">Para poder classificar uma cache, tem que seguir as instruções em GCVote.com e digitar a sua senha GCVote aqui.</string>
-  <string name="err_gcvote_send_rating">Erro ao enviar a classificação, verifique a senha do GCVote nas configurações ou limpe a mesma.</string>
+  <string name="init_gcvote_password_description">Para poder classificar uma cache, tem que seguir as instruções em GCVote.com e inserir a sua palavra-passe do GCVote aqui.</string>
+  <string name="err_gcvote_send_rating">Erro ao enviar a classificação, verifique a palavra-passe do GCVote nas configurações ou limpe a mesma.</string>
   <string name="gcvote_sent">Votação enviada com sucesso</string>
   <string name="init_twitter">Twitter</string>
   <string name="settings_activate_twitter">Activar</string>
   <string name="init_username">Nome de utilizador</string>
-  <string name="init_password">Password</string>
-  <string name="init_login">Verificar login</string>
-  <string name="init_login_popup">Login</string>
-  <string name="init_login_popup_working">Logging to Geocaching.com…</string>
-  <string name="init_login_popup_ok">Login OK</string>
-  <string name="init_login_popup_failed">Login falhado.</string>
+  <string name="init_password">Palavra-passe</string>
+  <string name="init_login">Verificar autenticação</string>
+  <string name="init_login_popup">Iniciar sessão</string>
+  <string name="init_login_popup_working">A iniciar a sessão…</string>
+  <string name="init_login_popup_ok">Sessão iniciada</string>
+  <string name="init_login_popup_failed">Falha ao iniciar sessão</string>
   <string name="init_login_popup_failed_reason">Início de sessão falhou: %s</string>
   <string name="init_login_popup_not_authorized">Não autorizado</string>
   <string name="init_login_popup_invalid_timestamp">Hora local inválida, altere a hora do aparelho</string>
@@ -499,7 +499,7 @@
   <string name="settings_service_active">Activo</string>
   <string name="settings_navigation_disabled">Esta aplicação parece não estar instalada</string>
   <string name="init_signature">Assinatura</string>
-  <string name="init_template_help">Sequências de caracteres como [nome] serão expandidas mais tarde quando este formato for usado.</string>
+  <string name="init_template_help">Sequências de caracteres como [NAME] serão expandidas mais tarde quando este modelo for usado.</string>
   <string name="init_signature_template_button">Inserir modelo</string>
   <string name="init_signature_template_date">Data</string>
   <string name="init_signature_template_time">Hora</string>
@@ -512,34 +512,34 @@
   <string name="init_signature_template_log">Texto de registo</string>
   <string name="init_ratingwanted">Carregar a pontuação da cache de GCvote.com</string>
   <string name="init_summary_ratingwanted">Carregar a pontuação da cache de GCvote.com</string>
-  <string name="init_friends_and_own_logs_wanted">Mostrar de amigos/próprios</string>
-  <string name="init_summary_friends_and_own_logs_wanted">Mostrar página adicional de registo com registos de amigos e próprias</string>
-  <string name="init_openlastdetailspage">Abrir detalhes da última página vizualizada</string>
-  <string name="init_summary_openlastdetailspage">Abrir detalhes da última página vizualizada</string>
-  <string name="init_skin">Tema leve (precisa reiniciar o c:geo)</string>
-  <string name="init_summary_skin">Tema leve (precisa reiniciar o c:geo)</string>
-  <string name="init_address">Mostrar endereços no ecrã principal</string>
-  <string name="init_summary_address">Mostrar endereços no ecrã principal</string>
-  <string name="init_captcha">Mostrar CAPTCHA se necessário</string>
-  <string name="init_summary_captcha">Mostrar CAPTCHA se necessário</string>
-  <string name="init_useenglish">Utilizar inglês no c:geo\n(necessário reiniciar)</string>
-  <string name="init_summary_useenglish">Utilizar inglês no c:geo\n(necessário reiniciar)</string>
-  <string name="init_exclude">Excluir caches encontradas e minhas</string>
+  <string name="init_friends_and_own_logs_wanted">Mostrar de amigos/individuais</string>
+  <string name="init_summary_friends_and_own_logs_wanted">Mostra uma página adicional com os registos dos seus amigos e registos individuais</string>
+  <string name="init_openlastdetailspage">Abrir na última página de detalhes</string>
+  <string name="init_summary_openlastdetailspage">Abre detalhes da última página visualizada</string>
+  <string name="init_skin">Tema claro</string>
+  <string name="init_summary_skin">Tema claro (necessário reiniciar o c:geo)</string>
+  <string name="init_address">Mostrar endereço</string>
+  <string name="init_summary_address">Mostrar endereço em vez das coordenadas no ecrã principal</string>
+  <string name="init_captcha">Mostrar CAPTCHA</string>
+  <string name="init_summary_captcha">Mostrar CAPTCHA se necessário (apenas para Membros Básicos)</string>
+  <string name="init_useenglish">Utilizar inglês</string>
+  <string name="init_summary_useenglish">Use o c:geo em inglês (necessário reiniciar)</string>
+  <string name="init_exclude">Excluir Encontradas e Minhas</string>
   <string name="init_summary_exclude">Excluir caches encontradas e minhas</string>
-  <string name="init_showwaypoints">Mostrar Waypoints no mapa</string>
-  <string name="init_showwaypoint_description">Se menos do que o número de caches encontradas são mostradas no mapa, os seus waypoints são mostrados adicionalmente.</string>
+  <string name="init_showwaypoints">Mostrar Pontos Adicionais</string>
+  <string name="init_showwaypoint_description">Se o número de caches apresentado no mapa for inferior ao determinado, são mostrados adicionalmente os seus pontos adicionais.</string>
   <string name="init_disabled">Excluir caches desactivadas</string>
   <string name="init_summary_disabled">Excluir caches desactivadas</string>
   <string name="init_offline">Armazenar a cache de mapas estáticos para utilização offline</string>
-  <string name="init_summary_offline">Armazenar a cache de mapas estáticos para utilização offline</string>
-  <string name="init_offline_wp">Armazenar waypoints de mapas estáticos para utilização offline</string>
-  <string name="init_summary_offline_wp">Armazenar waypoints de mapas estáticos para utilização offline</string>
+  <string name="init_summary_offline">Armazena os mapas estáticos da cache para utilização offline</string>
+  <string name="init_offline_wp">Mapas estáticos (P. Adicionais)</string>
+  <string name="init_summary_offline_wp">Armazena mapas estáticos de pontos adicionais para utilização offline</string>
   <string name="init_save_log_img">Guardar imagens dos registos</string>
   <string name="init_summary_save_log_img">Guardar imagens dos registos</string>
   <string name="init_units">Utilizar distância nas unidades do sistema imperial</string>
   <string name="init_summary_units">Utilizar distância nas unidades do sistema imperial</string>
-  <string name="init_log_offline">Activar registo offline\n(Não mostrar o registo online quando fôr registar, não enviar o registo online)</string>
-  <string name="init_summary_log_offline">Activar registo offline\n(Não mostrar o registo online quando fôr registar, não enviar o registo online)</string>
+  <string name="init_log_offline">Registos Offline</string>
+  <string name="init_summary_log_offline">Activa os registos offline\n(A vista de \"registos online\" não é mostrada quando está a registar; os registos não são enviados)</string>
   <string name="init_choose_list">Pedir Lista</string>
   <string name="init_summary_choose_list">Pedir lista quando guarda as caches</string>
   <string name="init_livelist">Mostrar a direcção para a cache na lista</string>
@@ -581,13 +581,13 @@
   <string name="init_summary_trackautovisit">Marcar automaticamente os trackables como \"visitados\"</string>
   <string name="init_sigautoinsert">Inserir automaticamente</string>
   <string name="init_loaddirectionimg">Carregar a imagem de dricção se necessário</string>
-  <string name="init_summary_loaddirectionimg">Carregar a imagem de dricção se necessário</string>
+  <string name="init_summary_loaddirectionimg">Se necessário transferir a imagem da seta direccional (apenas necessário para membros básicos)</string>
   <string name="init_default_navigation_tool">Navegador principal</string>
   <string name="init_secondary_navigation_tool">Navegação secundária</string>
-  <string name="init_default_navigation_tool_description">Aqui pode selecionar o seu navegador preferido.</string>
-  <string name="init_default_navigation_tool_select">Escolher ferramenta</string>
-  <string name="init_default_navigation_tool_2_description">Aqui define a sua segunda preferida ferramenta de navefação. É activada com clique longo no ícone ao lado do títula da cache.</string>
-  <string name="init_navigation_menu_description">Aqui você pode selecionar qual dos métodos de navegação disponíveis serão mostrados no menu de navegação para um cache ou um ponto de referência. Métodos desativados não estão instalados neste dispositivo.</string>
+  <string name="init_default_navigation_tool_description">Aqui pode seleccionar o instrumento de navegação preferido.</string>
+  <string name="init_default_navigation_tool_select">Escolher navegador</string>
+  <string name="init_default_navigation_tool_2_description">Aqui pode seleccionar a seu segundo instrumento de navegação preferido. Active-o com um toque longo no ícone de navegação ao lado do título da cache.</string>
+  <string name="init_navigation_menu_description">Aqui pode selecionar quais dos métodos de navegação disponíveis serão mostrados no menu de navegação para uma cache ou um ponto de referência. As opções a cinzento não estão instaladas neste dispositivo.</string>
   <string name="init_debug_title">Informação de depuração</string>
   <string name="init_debug_note">c:Geo pode gerar uma grande quantidade de informações de depuração. Ativar essa configuração afetará a estabilidade do c:geo e só é recomendado se for solicitado o envio de um log para os programadores. Por favor, mantenha o registo de depuração desativado durante o uso normal do c:geo!</string>
   <string name="init_debug">Activar depuração</string>
@@ -604,12 +604,12 @@
   <string name="init_datadirmove_failed">A transferência da pasta de dados de geocache falhou parcial ou totalmente. Verifique, por favor, antigas e novas pastas e transfira manualmente se necessário.</string>
   <string name="init_plain_logs">Mostrar os logs sem as cores</string>
   <string name="init_summary_plain_logs">Mostrar os logs sem as cores</string>
-  <string name="init_use_native_ua">Identificar como se fosse o browser do Android. Resolve os problemas de login em alguns provedores de rede.</string>
-  <string name="init_summary_use_native_ua">Identificar como se fosse o browser do Android. Resolve os problemas de login em alguns provedores de rede.</string>
+  <string name="init_use_native_ua">Browser do Android</string>
+  <string name="init_summary_use_native_ua">Identificar como se fosse o browser do Android. Resolve os problemas de inicio de sessão em alguns fornecedores de Internet.</string>
   <string name="init_rendertheme_folder">Directório de Temas de Mapas</string>
   <string name="init_maintenance">Manutenção</string>
-  <string name="init_maintenance_directories_note">c:geo armazena imagens, registo de imagens e outros ficheiros relacionados com uma cache numa pasta separada. Nalguns casos (como ao importar/exportar a base de dados) esta pasta pode conter ficheiros desatualizados, que podem ser apagados aqui.</string>
-  <string name="init_maintenance_directories">Apagar ficheiros orfãos</string>
+  <string name="init_maintenance_directories_note">O c:geo armazena imagens, registo de imagens e outros ficheiros relacionados com uma cache numa pasta separada. Nalguns casos (como ao importar/exportar a base de dados) esta pasta pode conter ficheiros desactualizados, que podem ser apagados aqui.</string>
+  <string name="init_maintenance_directories">Apagar ficheiros obsoletos</string>
   <string name="init_location">Geolocalização</string>
   <string name="init_location_note">Em dispositivos equipados com serviços Google Play, o c:geo pode automaticamente usar um melhor fornecedor de geolocalização. No entanto, isso impede o uso de um receptor GPS BlueTooth externo.</string>
   <string name="init_location_googleplayservices">Utilizar serviços Google Play</string>
@@ -647,7 +647,7 @@
   <string name="feature_search_keyword">Procurar por palavra-chave</string>
   <string name="feature_search_live_map">Mapa ao vivo</string>
   <string name="feature_search_center">Procura por posição</string>
-  <string name="feature_search_geocode">Procura por geocódigo</string>
+  <string name="feature_search_geocode">Pesquisa por código GC</string>
   <string name="feature_search_owner">Procura por dono</string>
   <string name="feature_search_finder">Procura por quem encontrou</string>
   <string name="init_experimental_title">Funcionalidades experimentais</string>
@@ -704,7 +704,7 @@
   <string name="auth_dialog_completed_oc">c:geo está agora autorizado a interagir com %s.</string>
   <!-- auth geokrety -->
   <string name="auth_dialog_completed_geokrety">c:geo está agora autorizado a interagir com %s.</string>
-  <string name="err_auth_geokrety_bad_password">O utilizador/senha parecem inválidos.</string>
+  <string name="err_auth_geokrety_bad_password">O seu nome de utilizador/palavra-passe parecem inválidos.</string>
   <string name="err_auth_geokrety_unknown">%1$s retornou: %2$s.</string>
   <!-- cache -->
   <plurals name="cache_counts">
@@ -759,7 +759,7 @@
   <string name="cache_personal_note_upload_cancelled">Envio de nota pessoal cancelado</string>
   <string name="cache_description">Descrição</string>
   <string name="cache_description_long">Descrição longa</string>
-  <string name="cache_description_table_note">A descrição contém a formatação da tabela que pode ser necessário para ser vista correctamente em %s.</string>
+  <string name="cache_description_table_note">A descrição contém formatação de tabela pelo que pode ser necessário vê-la em %s para ser vista correctamente.</string>
   <string name="cache_watchlist_on">Esta cache está na sua lista de observação.</string>
   <string name="cache_watchlist_on_extra">Este cache está na sua lista de observação (Observadores: %1d).</string>
   <string name="cache_watchlist_not_on">Esta cache não está na sua lista de observação.</string>
@@ -775,10 +775,10 @@
   <string name="cache_list_unknown">Não está numa lista</string>
   <string name="cache_list_select_last">Última seleção</string>
   <string name="cache_images">Imagens</string>
-  <string name="cache_waypoints">Pontos de referência</string>
+  <string name="cache_waypoints">Pontos adicionais</string>
   <plurals name="waypoints">
-    <item quantity="one">1 Waypoint</item>
-    <item quantity="other">%d Waypoints</item>
+    <item quantity="one">1 Ponto Adicional</item>
+    <item quantity="other">%d Pontos Adicionais</item>
   </plurals>
   <string name="cache_waypoints_add">Adicionar ponto de referência</string>
   <string name="cache_hint">Pista</string>
@@ -790,7 +790,7 @@
   <string name="cache_dialog_loading_details_status_details">A processar os detalhes</string>
   <string name="cache_dialog_loading_details_status_spoilers">A carregar as imagens spoiler</string>
   <string name="cache_dialog_loading_details_status_logs">A carregar os registo</string>
-  <string name="cache_dialog_loading_details_status_waypoints">A processar os waypoints</string>
+  <string name="cache_dialog_loading_details_status_waypoints">A processar os pontos adicionais</string>
   <string name="cache_dialog_loading_details_status_gcvote">A carregar GCVote</string>
   <string name="cache_dialog_loading_details_status_cache">A carregar dados</string>
   <string name="cache_dialog_loading_details_status_render">A renderizar a vista</string>
@@ -834,7 +834,7 @@
   <string name="around">Perto de %s</string>
   <string name="menu_caches">Gerir caches</string>
   <string name="cache_menu_event">Adicionar ao calendário</string>
-  <string name="cache_menu_extract_waypoints">Extrair waypoints</string>
+  <string name="cache_menu_extract_waypoints">Extrair pontos adicionais</string>
   <string name="cache_menu_details">Detalhes</string>
   <string name="cache_menu_refresh">Actualizar</string>
   <string name="cache_menu_share">Partilhar cache</string>
@@ -909,8 +909,8 @@
   <!-- gpx -->
   <string name="gpx_import_loading_caches">A carregar as caches do ficheiro .gpx</string>
   <string name="gpx_import_loading_caches_with_filename">A carregar caches de %1$s</string>
-  <string name="gpx_import_loading_waypoints">A carregar o ficheiro dos waypoints</string>
-  <string name="gpx_import_loading_waypoints_with_filename">A carregar coordenadas de %1$s</string>
+  <string name="gpx_import_loading_waypoints">A carregar o ficheiro dos pontos adicionais</string>
+  <string name="gpx_import_loading_waypoints_with_filename">A carregar pontos adicionais de %1$s</string>
   <string name="gpx_import_store_static_maps">A gravar mapas estáticos</string>
   <string name="gpx_import_caches_imported">caches importadas</string>
   <string name="gpx_import_caches_imported_with_filename">%1$d caches importadas de %2$s</string>
@@ -1048,7 +1048,7 @@
   <string name="search_pocket_select">Escolher Pocket Query</string>
   <!-- trackable -->
   <string name="trackable">Trackable</string>
-  <string name="trackable_details_loading">A carregar os detalhes trackable…</string>
+  <string name="trackable_details_loading">A carregar detalhes do trackable…</string>
   <string name="trackable_log_touch">Registar toque</string>
   <string name="trackable_browser_open">Abrir no browser</string>
   <string name="trackable_refresh">Actualizar</string>
@@ -1124,7 +1124,7 @@
   <string name="helper_wear_title">c:geo Wear</string>
   <string name="helper_wear_description">c:geo Wear é um plugin para o c:geo que permite que você navegue para geocaches usando seu smartwatch Android Wear.</string>
   <string name="helper_where_you_go_title">WhereYouGo</string>
-  <string name="helper_where_you_go_description">WhereYouGo permite jogar e pesquisar geocaches do tipo Wherigo. c:Geo pode acionar o download automático dos cartuchos nesta aplicação.</string>
+  <string name="helper_where_you_go_description">WhereYouGo permite jogar e procurar geocaches do tipo Wherigo. O c:geo pode iniciar automaticamente a transferência dos cartuchos nessa aplicação.</string>
   <string name="helper_brouter_title">BRouter navegação off-line</string>
   <string name="helper_brouter_description">BRouter fornece cálculo de percursos off-line. Se está instalado e tem os ficheiros necessários descarregados, o c:geo exibirá automaticamente uma rota para a cache no mapa interno.</string>
   <!-- add-ons -->
@@ -1443,7 +1443,7 @@
   <string name="cgeo_shortcut">Atalho c:geo</string>
   <string name="create_shortcut">Criar atalho</string>
   <string name="send">Enviar</string>
-  <string name="confirm_log_title">Tipo de registo invulgar</string>
+  <string name="confirm_log_title">Tipo de registo especial</string>
   <string name="confirm_log_message">Quer fazer o registo \'%s\'. Tem a certeza?</string>
   <!-- Geokrety -->
   <string name="settings_activate_geokrety">Activar</string>
@@ -1505,8 +1505,8 @@
   <string name="list_list_headline">Listas:</string>
   <string name="cache_store_list">Armazenar na lista</string>
   <plurals name="extract_waypoints_result">
-    <item quantity="one">%d ponto de referência extraído</item>
-    <item quantity="other">%d pontos de referência extraídos</item>
+    <item quantity="one">%d ponto adicional extraído</item>
+    <item quantity="other">%d pontos adicionais extraídos</item>
   </plurals>
   <!-- calendar adder -->
   <string name="event_fail">Falha ao adicionar cache evento ao calendário</string>

--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -2,6 +2,11 @@
 <resources>
   <!-- changelog for the release branch -->
   <string name="changelog_release" translatable="false">\n
+    <b>2017.08.22-RC (Beta):</b>\n
+    · Fix: Logging caches might fail due to website changes\n
+    · Fix: Username not shown on main screen login status\n
+    \n
+    \n
     <b>2017.07.24:</b>\n
     · New: Cache list menu restructured, see <a href="http://www.cgeo.org/faq#new-list-menu">FAQ</a> for details.\n
     · New: Use abbreviation for name of geocaching service on main screen\n

--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -2,7 +2,7 @@
 <resources>
   <!-- changelog for the release branch -->
   <string name="changelog_release" translatable="false">\n
-    <b>2017.08.22-RC (Beta):</b>\n
+    <b>2017.08.23:</b>\n
     · Fix: Logging caches might fail due to website changes\n
     · Fix: Username not shown on main screen login status\n
     \n

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1831,7 +1831,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             } else {
                 coordinatesView.setVisibility(View.GONE);
             }
-            
+
             // info
             final String waypointInfo = Formatter.formatWaypointInfo(wpt);
             final TextView infoView = holder.infoView;

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1826,11 +1826,12 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             if (coordinates != null) {
                 coordinatesView.setOnClickListener(new CoordinatesFormatSwitcher(coordinates));
                 coordinatesView.setText(coordinates.toString());
+                addContextMenu(coordinatesView);
                 coordinatesView.setVisibility(View.VISIBLE);
             } else {
                 coordinatesView.setVisibility(View.GONE);
             }
-
+            
             // info
             final String waypointInfo = Formatter.formatWaypointInfo(wpt);
             final TextView infoView = holder.infoView;
@@ -2099,6 +2100,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                                 buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_event), true);
                                 menu.findItem(R.id.menu_calendar).setVisible(cache.canBeAddedToCalendar());
                                 return true;
+                            case R.id.coordinates:
+                                clickedItemText = ((TextView) view).getText();
+                                clickedItemText = GeopointFormatter.reformatForClipboard(clickedItemText);
+                                buildDetailsContextMenu(actionMode, menu, res.getText(R.string.cache_coordinates), true);
+                                return true;
                         }
                         return false;
                     }
@@ -2111,7 +2117,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     @Override
                     public boolean onCreateActionMode(final ActionMode actionMode, final Menu menu) {
                         actionMode.getMenuInflater().inflate(R.menu.details_context, menu);
-                        prepareClipboardActionMode(view, actionMode, menu);
+                        prepareClipboardActionMode(view, actionMode, menu); // Calling method in lifecycle api level 22 and down...
                         // Return true so that the action mode is shown
                         return true;
                     }

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -221,9 +221,10 @@ public class GCLogin extends AbstractLogin {
         setActualStatus(CgeoApplication.getInstance().getString(R.string.init_login_popup_ok));
 
         // on every page except login page
-        setActualLoginStatus(TextUtils.matches(page, GCConstants.PATTERN_LOGIN_NAME));
+        final String username = GCParser.getUsername(page);
+        setActualLoginStatus(StringUtils.isNotBlank(username));
         if (isActualLoginStatus()) {
-            setActualUserName(TextUtils.stripHtml(TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME, true, "???")));
+            setActualUserName(username);
             int cachesCount = 0;
             try {
                 cachesCount = Integer.parseInt(removeDotAndComma(TextUtils.getMatch(page, GCConstants.PATTERN_CACHES_FOUND, true, "0")));

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -2131,4 +2131,20 @@ public final class GCParser {
         }
         return 0;
     }
+
+    @Nullable
+    public static String getUsername(final String page) {
+        final Document document = Jsoup.parse(page);
+
+        // New website top bar
+        final String username = TextUtils.stripHtml(document.select("span.user-name").text());
+        if (StringUtils.isNotEmpty(username)) {
+            return username;
+        }
+
+        // Old style webpage fallback
+        final String usernameOld = TextUtils.stripHtml(document.select("span.li-user-info > span:first-child").text());
+
+        return StringUtils.isNotEmpty(usernameOld) ? usernameOld : null;
+    }
 }

--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -375,6 +375,7 @@ public final class LocalStorage {
         final File nomedia = new File(getGeocacheDataDirectory(), ".nomedia");
         if (!nomedia.exists()) {
             try {
+                FileUtils.mkdirs(nomedia.getParentFile());
                 nomedia.createNewFile();
             } catch (final IOException e) {
                 Log.w("Couldn't create the .nomedia file in " + getGeocacheDataDirectory(), e);

--- a/main/src/cgeo/geocaching/ui/CalculateButton.java
+++ b/main/src/cgeo/geocaching/ui/CalculateButton.java
@@ -6,7 +6,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.support.v4.content.ContextCompat;
 import android.text.Editable;

--- a/main/src/cgeo/geocaching/ui/CalculatorVariable.java
+++ b/main/src/cgeo/geocaching/ui/CalculatorVariable.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.CalculationUtils;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.GridLayout;

--- a/main/src/cgeo/geocaching/utils/AngleUtils.java
+++ b/main/src/cgeo/geocaching/utils/AngleUtils.java
@@ -36,7 +36,12 @@ public final class AngleUtils {
      */
     public static float normalize(final float angle) {
         final float mod = angle % 360;
-        return mod >= 0 ? mod : (mod + 360) % 360;
+        float result = mod >= 0 ? mod : (mod + 360) % 360;
+        // normalize -0 and +0 both to the positive side
+        if (result == 0f) {
+            return 0f;
+        }
+        return result;
     }
 
     public static int getRotationOffset() {

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -273,7 +273,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
             public void run() {
                 final SearchResult search = GCParser.searchByUsername("blafoo", CacheType.WEBCAM);
                 assertThat(search).isNotNull();
-                assertThat(search.getTotalCountGC()).isEqualTo(7);
+                assertThat(search.getTotalCountGC()).isEqualTo(9);
                 assertThat(search.getGeocodes()).contains("GCP0A9");
             }
         });

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -299,4 +299,11 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(GCParser.fullScaleImageUrl("http://imgcdn.geocaching.com/track/display/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg"))
                 .isEqualTo("http://imgcdn.geocaching.com/track/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg");
     }
+
+    public void testGetUsername() {
+        // Old style page
+        assertThat(GCParser.getUsername(MockedCache.readCachePage("GC2CJPF"))).isEqualTo("storc");
+        // New style page
+        assertThat(GCParser.getUsername(MockedCache.readCachePage("GC5BRQK"))).isEqualTo("kumy");
+    }
 }

--- a/tests/src/cgeo/geocaching/connector/ec/ECApiTest.java
+++ b/tests/src/cgeo/geocaching/connector/ec/ECApiTest.java
@@ -1,11 +1,13 @@
 package cgeo.geocaching.connector.ec;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import junit.framework.TestCase;
 
-public class ECApiTest extends TestCase {
+import org.junit.Test;
 
-    public static void testGetIdFromGeocode() throws Exception {
+public class ECApiTest {
+
+    @Test
+    public void testGetIdFromGeocode() throws Exception {
         assertThat(ECApi.getIdFromGeocode("EC242")).isEqualTo("242");
         assertThat(ECApi.getIdFromGeocode("ec242")).isEqualTo("242");
     }

--- a/tests/src/cgeo/geocaching/connector/gc/AutoZoomTest.java
+++ b/tests/src/cgeo/geocaching/connector/gc/AutoZoomTest.java
@@ -7,11 +7,12 @@ import cgeo.geocaching.location.Viewport;
 
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class AutoZoomTest extends TestCase {
+public class AutoZoomTest {
 
-    public static void testZoom1() {
+    @Test
+    public void testZoom1() {
         final Geopoint bottomLeft = new Geopoint(49.3, 8.3);
         final Geopoint topRight = new Geopoint(49.4, 8.4);
 
@@ -27,7 +28,8 @@ public class AutoZoomTest extends TestCase {
 
     }
 
-    public static void testZoom2() {
+    @Test
+    public void testZoom2() {
         final Geopoint bottomLeft = new Geopoint(49.3, 8.3);
         final Geopoint topRight = new Geopoint(49.4, 8.4);
 
@@ -43,7 +45,8 @@ public class AutoZoomTest extends TestCase {
 
     }
 
-    public static void testTiles1x2() {
+    @Test
+    public void testTiles1x2() {
         final Geopoint bottomLeft = new Geopoint(49.3, 8.3);
         final Geopoint topRight = new Geopoint(49.4, 8.4);
 
@@ -52,7 +55,8 @@ public class AutoZoomTest extends TestCase {
         assertThat(tiles).hasSize(2);
     }
 
-    public static void testTiles2x3() {
+    @Test
+    public void testTiles2x3() {
         final Geopoint bottomLeft = new Geopoint(49.3, 8.3);
         final Geopoint topRight = new Geopoint(49.4, 8.4);
 
@@ -61,7 +65,8 @@ public class AutoZoomTest extends TestCase {
         assertThat(tiles).hasSize(6);
     }
 
-    public static void testTilesZoom13() {
+    @Test
+    public void testTilesZoom13() {
         final Geopoint bottomLeft = new Geopoint(49.3, 8.3);
         final Geopoint topRight = new Geopoint(49.4, 8.4);
 

--- a/tests/src/cgeo/geocaching/connector/gc/UTFGridPositionTest.java
+++ b/tests/src/cgeo/geocaching/connector/gc/UTFGridPositionTest.java
@@ -2,15 +2,17 @@ package cgeo.geocaching.connector.gc;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class UTFGridPositionTest extends TestCase {
+public class UTFGridPositionTest {
 
-    public static void testValidUTFGridPosition() {
+    @Test
+    public void testValidUTFGridPosition() {
         assertThat(new UTFGridPosition(0, 0)).isNotNull();
     }
 
-    public static void testInvalidUTFGridPosition() {
+    @Test
+    public void testInvalidUTFGridPosition() {
         boolean valid = true;
         try {
             assertThat(new UTFGridPosition(-1, 0)).isNotNull();
@@ -20,7 +22,8 @@ public class UTFGridPositionTest extends TestCase {
         assertThat(valid).isFalse();
     }
 
-    public static void testFromString() throws Exception {
+    @Test
+    public void testFromString() throws Exception {
         assertXYFromString("(1, 2)", 1, 2);
         assertXYFromString("(12, 34)", 12, 34);
         assertXYFromString("(34,56)", 34, 56);

--- a/tests/src/cgeo/geocaching/connector/gc/UncertainPropertyTest.java
+++ b/tests/src/cgeo/geocaching/connector/gc/UncertainPropertyTest.java
@@ -1,17 +1,20 @@
 package cgeo.geocaching.connector.gc;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import junit.framework.TestCase;
 
-public class UncertainPropertyTest extends TestCase {
+public class UncertainPropertyTest {
 
-    public static void testHigherCertaintyWins() {
+    @Test
+    public void testHigherCertaintyWins() {
         final UncertainProperty<String> prop1 = new UncertainProperty<>("prop1", 10);
         final UncertainProperty<String> prop2 = new UncertainProperty<>("prop2", 20);
         assertThat(UncertainProperty.getMergedProperty(prop1, prop2)).isEqualTo(prop2);
     }
 
-    public static void testAvoidNull() {
+    @Test
+    public void testAvoidNull() {
         final UncertainProperty<String> prop1 = new UncertainProperty<>("prop1", 10);
         final UncertainProperty<String> prop2 = new UncertainProperty<>(null, 20);
         assertThat(UncertainProperty.getMergedProperty(prop1, prop2)).isEqualTo(prop1);
@@ -23,7 +26,8 @@ public class UncertainPropertyTest extends TestCase {
         assertThat(UncertainProperty.getMergedProperty(null, null)).isEqualTo(null);
     }
 
-    public static void testEquals() {
+    @Test
+    public void testEquals() {
         final UncertainProperty<String> prop1 = new UncertainProperty<>("prop1", 10);
         final UncertainProperty<String> prop2 = new UncertainProperty<>(null, 20);
         assertThat(UncertainProperty.equalValues(null, null)).isTrue();

--- a/tests/src/cgeo/geocaching/connector/oc/OCCZConnectorTest.java
+++ b/tests/src/cgeo/geocaching/connector/oc/OCCZConnectorTest.java
@@ -1,11 +1,13 @@
 package cgeo.geocaching.connector.oc;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import junit.framework.TestCase;
 
-public class OCCZConnectorTest extends TestCase {
+import org.junit.Test;
 
-    public static void testGetGeocodeFromUrl() throws Exception {
+public class OCCZConnectorTest {
+
+    @Test
+    public void testGetGeocodeFromUrl() throws Exception {
         final OCCZConnector connector = new OCCZConnector();
         assertThat(connector.getGeocodeFromUrl("http://opencaching.cz/viewcache.php?cacheid=610")).isEqualTo("OZ0262");
         assertThat(connector.getGeocodeFromUrl("http://www.opencaching.de/viewcache.php?cacheid=151223")).isNull();

--- a/tests/src/cgeo/geocaching/connector/trackable/UnknownTrackableConnectorTest.java
+++ b/tests/src/cgeo/geocaching/connector/trackable/UnknownTrackableConnectorTest.java
@@ -1,22 +1,25 @@
 package cgeo.geocaching.connector.trackable;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import cgeo.geocaching.models.Trackable;
 
-import junit.framework.TestCase;
-
-public class UnknownTrackableConnectorTest extends TestCase {
+public class UnknownTrackableConnectorTest {
 
     private static UnknownTrackableConnector getConnector() {
         return new UnknownTrackableConnector();
     }
 
-    public static void testCanHandleTrackable() throws Exception {
+    @Test
+    public void testCanHandleTrackable() throws Exception {
         assertThat(getConnector().canHandleTrackable("TB1234")).isFalse();
     }
 
-    public static void testGetUrl() throws Exception {
+    @Test
+    public void testGetUrl() throws Exception {
         try {
             getConnector().getUrl(new Trackable());
             fail("IllegalStateException expected");
@@ -25,23 +28,28 @@ public class UnknownTrackableConnectorTest extends TestCase {
         }
     }
 
-    public static void testSearchTrackable() throws Exception {
+    @Test
+    public void testSearchTrackable() throws Exception {
         assertThat(getConnector().searchTrackable("TB1234", null, null)).isNull();
     }
 
-    public static void testIsLoggable() throws Exception {
+    @Test
+    public void testIsLoggable() throws Exception {
         assertThat(getConnector().isLoggable()).isFalse();
     }
 
-    public static void testGetTrackableCodeFromUrl() throws Exception {
+    @Test
+    public void testGetTrackableCodeFromUrl() throws Exception {
         assertThat(getConnector().getTrackableCodeFromUrl("http://www.sometrackable.com/1234")).isNull();
     }
 
-    public static void testGetUserActions() throws Exception {
+    @Test
+    public void testGetUserActions() throws Exception {
         assertThat(getConnector().getUserActions()).isEmpty();
     }
 
-    public static void testRecommendGeocode() throws Exception {
+    @Test
+    public void testRecommendGeocode() throws Exception {
         assertThat(getConnector().recommendLogWithGeocode()).isFalse();
     }
 

--- a/tests/src/cgeo/geocaching/enumerations/CacheSizeTest.java
+++ b/tests/src/cgeo/geocaching/enumerations/CacheSizeTest.java
@@ -1,20 +1,22 @@
 package cgeo.geocaching.enumerations;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import java.util.Locale;
 
-import junit.framework.TestCase;
+public class CacheSizeTest {
 
-public class CacheSizeTest extends TestCase {
-
-    public static void testOrder() {
+    @Test
+    public void testOrder() {
         assertThat(CacheSize.MICRO.comparable).isLessThan(CacheSize.SMALL.comparable);
         assertThat(CacheSize.SMALL.comparable).isLessThan(CacheSize.REGULAR.comparable);
         assertThat(CacheSize.REGULAR.comparable).isLessThan(CacheSize.LARGE.comparable);
     }
 
-    public static void testGetById() {
+    @Test
+    public void testGetById() {
         assertThat(CacheSize.getById("")).isEqualTo(CacheSize.UNKNOWN);
         assertThat(CacheSize.getById(null)).isEqualTo(CacheSize.UNKNOWN);
         assertThat(CacheSize.getById("random garbage")).isEqualTo(CacheSize.UNKNOWN);
@@ -22,7 +24,8 @@ public class CacheSizeTest extends TestCase {
         assertThat(CacheSize.getById("LARGE")).isEqualTo(CacheSize.LARGE);
     }
 
-    public static void testGetByIdComplete() {
+    @Test
+    public void testGetByIdComplete() {
         for (final CacheSize size : CacheSize.values()) {
             assertThat(CacheSize.getById(size.id)).isEqualTo(size);
             assertThat(CacheSize.getById(size.id.toLowerCase(Locale.US))).isEqualTo(size);
@@ -30,12 +33,14 @@ public class CacheSizeTest extends TestCase {
         }
     }
 
-    public static void testGetByIdNumeric() {
+    @Test
+    public void testGetByIdNumeric() {
         assertThat(CacheSize.getById("3")).isEqualTo(CacheSize.REGULAR);
         assertThat(CacheSize.getById("-1")).isEqualTo(CacheSize.UNKNOWN);
     }
 
-    public static void testGetByIdVeryLarge() throws Exception {
+    @Test
+    public void testGetByIdVeryLarge() throws Exception {
         assertThat(CacheSize.getById("Very large")).isEqualTo(CacheSize.VERY_LARGE);
         assertThat(CacheSize.getById("very_large")).as("size from website icon").isEqualTo(CacheSize.VERY_LARGE);
     }

--- a/tests/src/cgeo/geocaching/enumerations/CacheTypeTest.java
+++ b/tests/src/cgeo/geocaching/enumerations/CacheTypeTest.java
@@ -1,30 +1,33 @@
 package cgeo.geocaching.enumerations;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import cgeo.geocaching.models.Geocache;
 
 import java.util.Locale;
 
-import junit.framework.TestCase;
+public class CacheTypeTest {
 
-public class CacheTypeTest extends TestCase {
-
-    public static void testGetById() {
+    @Test
+    public void testGetById() {
         assertThat(CacheType.getById("")).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getById(null)).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getById("random garbage")).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getById("wherigo")).isEqualTo(CacheType.WHERIGO);
     }
 
-    public static void testGetByPattern() {
+    @Test
+    public void testGetByPattern() {
         assertThat(CacheType.getByPattern("")).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getByPattern(null)).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getByPattern("random garbage")).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getByPattern("cache in trash out event")).isEqualTo(CacheType.CITO);
     }
 
-    public static void testGetByIdComplete() {
+    @Test
+    public void testGetByIdComplete() {
         for (final CacheType type : CacheType.values()) {
             assertThat(CacheType.getById(type.id)).isEqualTo(type);
             assertThat(CacheType.getById(type.id.toLowerCase(Locale.US))).isEqualTo(type);
@@ -32,7 +35,8 @@ public class CacheTypeTest extends TestCase {
         }
     }
 
-    public static void testGetByPatternComplete() {
+    @Test
+    public void testGetByPatternComplete() {
         for (final CacheType type : CacheType.values()) {
             assertThat(CacheType.getByPattern(type.pattern)).isEqualTo(type);
             assertThat(CacheType.getByPattern(type.pattern.toLowerCase(Locale.US))).isEqualTo(type);
@@ -40,7 +44,8 @@ public class CacheTypeTest extends TestCase {
         }
     }
 
-    public static void testContainsCache() {
+    @Test
+    public void testContainsCache() {
         final Geocache traditional = new Geocache();
         traditional.setType(CacheType.TRADITIONAL);
 
@@ -49,7 +54,8 @@ public class CacheTypeTest extends TestCase {
         assertThat(CacheType.MYSTERY.contains(traditional)).isFalse();
     }
 
-    public static void testEventCacheTypes() throws Exception {
+    @Test
+    public void testEventCacheTypes() throws Exception {
         assertThat(CacheType.EVENT.isEvent()).isTrue();
         assertThat(CacheType.MEGA_EVENT.isEvent()).isTrue();
         assertThat(CacheType.GIGA_EVENT.isEvent()).isTrue();

--- a/tests/src/cgeo/geocaching/files/ProgressInputStreamTest.java
+++ b/tests/src/cgeo/geocaching/files/ProgressInputStreamTest.java
@@ -3,12 +3,12 @@ package cgeo.geocaching.files;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+public class ProgressInputStreamTest {
 
-public class ProgressInputStreamTest extends TestCase {
-
-    public static void testRead() throws Exception {
+    @Test
+    public void testRead() throws Exception {
         final ProgressInputStream stream = new ProgressInputStream(IOUtils.toInputStream("test", "UTF-8"));
         assertThat(stream.getProgress()).isEqualTo(0);
 

--- a/tests/src/cgeo/geocaching/filter/SizeFilterTest.java
+++ b/tests/src/cgeo/geocaching/filter/SizeFilterTest.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.filter;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 
@@ -9,16 +10,14 @@ import cgeo.geocaching.enumerations.CacheSize;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class SizeFilterTest extends TestCase {
+public class SizeFilterTest {
 
     private Geocache micro;
     private Geocache regular;
     private SizeFilter microFilter;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-
+    @Before
+    public void setUp() throws Exception {
         // cache initialization can only be done without errors after application setup
         micro = new Geocache();
         micro.setSize(CacheSize.MICRO);
@@ -29,16 +28,19 @@ public class SizeFilterTest extends TestCase {
         microFilter = new SizeFilter(CacheSize.MICRO);
     }
 
+    @Test
     public void testAccepts() {
         assertThat(microFilter.accepts(micro)).isTrue();
         assertThat(microFilter.accepts(regular)).isFalse();
     }
 
-    public static void testGetAllFilters() {
+    @Test
+    public void testGetAllFilters() {
         final int expectedSizes = CacheSize.values().length - 1; // hide "UNKNOWN"
         assertThat(new SizeFilter.Factory().getFilters()).hasSize(expectedSizes);
     }
 
+    @Test
     public void testFilter() {
         final ArrayList<Geocache> list = new ArrayList<>();
         list.add(regular);

--- a/tests/src/cgeo/geocaching/filter/TypeFilterTest.java
+++ b/tests/src/cgeo/geocaching/filter/TypeFilterTest.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.filter;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 
@@ -9,15 +10,14 @@ import cgeo.geocaching.enumerations.CacheType;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class TypeFilterTest extends TestCase {
+public class TypeFilterTest {
 
     private TypeFilter traditionalFilter;
     private Geocache traditional;
     private Geocache mystery;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         traditionalFilter = new TypeFilter(CacheType.TRADITIONAL);
 
         traditional = new Geocache();
@@ -27,11 +27,13 @@ public class TypeFilterTest extends TestCase {
         mystery.setType(CacheType.MYSTERY);
     }
 
+    @Test
     public void testAccepts() {
         assertThat(traditionalFilter.accepts(traditional)).isTrue();
         assertThat(traditionalFilter.accepts(mystery)).isFalse();
     }
 
+    @Test
     public void testFilter() {
         final ArrayList<Geocache> list = new ArrayList<>();
         traditionalFilter.filter(list);
@@ -46,7 +48,8 @@ public class TypeFilterTest extends TestCase {
 
     }
 
-    public static void testGetAllFilters() {
+    @Test
+    public void testGetAllFilters() {
         final int expectedEntries = CacheType.values().length - 1; // hide "all"
         assertThat(new TypeFilter.Factory().getFilters()).hasSize(expectedEntries);
     }

--- a/tests/src/cgeo/geocaching/location/DistanceParserTest.java
+++ b/tests/src/cgeo/geocaching/location/DistanceParserTest.java
@@ -1,15 +1,16 @@
 package cgeo.geocaching.location;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
-import junit.framework.TestCase;
-
-public class DistanceParserTest extends TestCase {
+public class DistanceParserTest {
 
     private static final double MM = 1e-6; // 1mm, in kilometers
 
-    public static void testFormats() {
+    @Test
+    public void testFormats() {
         assertThat((double) DistanceParser.parseDistance("1200 m", true)).isEqualTo(1.2, offset(MM));
         assertThat((double) DistanceParser.parseDistance("1.2 km", true)).isEqualTo(1.2, offset(MM));
         assertThat((double) DistanceParser.parseDistance("1200 ft", true)).isEqualTo(0.36576, offset(MM));
@@ -17,16 +18,19 @@ public class DistanceParserTest extends TestCase {
         assertThat((double) DistanceParser.parseDistance("1.2 mi", true)).isEqualTo(1.9312128, offset(MM));
     }
 
-    public static void testImplicit() {
+    @Test
+    public void testImplicit() {
         assertThat((double) DistanceParser.parseDistance("1200", true)).isEqualTo(1.2, offset(MM));
         assertThat((double) DistanceParser.parseDistance("1200", false)).isEqualTo(0.36576, offset(MM));
     }
 
-    public static void testComma() {
+    @Test
+    public void testComma() {
         assertThat((double) DistanceParser.parseDistance("1,2km", true)).isEqualTo(1.2, offset(MM));
     }
 
-    public static void testFeet() {
+    @Test
+    public void testFeet() {
         assertThat((double) DistanceParser.parseDistance("1200 FT", false)).isEqualTo(0.36576, offset(MM));
     }
 

--- a/tests/src/cgeo/geocaching/location/GeoPointFormatterTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointFormatterTest.java
@@ -1,12 +1,13 @@
 package cgeo.geocaching.location;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class GeoPointFormatterTest extends TestCase {
+public class GeoPointFormatterTest {
 
-    public static void testConfluence() {
+    @Test
+    public void testConfluence() {
         // From issue #2624: coordinate is wrong near to a confluence point
         final Geopoint point = new Geopoint(49.9999999999999, 5.0);
         final String format = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECDEGREE_COMMA, point);
@@ -17,7 +18,8 @@ public class GeoPointFormatterTest extends TestCase {
         assertThat(formatSecond).isEqualTo("N 50° 00' 00.000\" · E 005° 00' 00.000\"");
     }
 
-    public static void testFormat() {
+    @Test
+    public void testFormat() {
         // taken from GC30R6G
         final Geopoint point = new Geopoint("N 51° 21.104 E 010° 15.369");
         final String format = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECDEGREE_COMMA, point);
@@ -28,7 +30,8 @@ public class GeoPointFormatterTest extends TestCase {
         assertThat(formatSecond).isEqualTo("N 51° 21' 06.239\" · E 010° 15' 22.140\"");
     }
 
-    public static void testFormatNeg() {
+    @Test
+    public void testFormatNeg() {
         // taken from GC30R6G
         final Geopoint point = new Geopoint("S 51° 21.104 W 010° 15.369");
         final String format = GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECDEGREE_COMMA, point);
@@ -39,17 +42,19 @@ public class GeoPointFormatterTest extends TestCase {
         assertThat(formatSecond).isEqualTo("S 51° 21' 06.239\" · W 010° 15' 22.140\"");
     }
 
-    public static void testReformatForClipboardRemoveMiddleDotReplaceCommaWithPoint() {
+    @Test
+    public void testReformatForClipboardRemoveMiddleDotReplaceCommaWithPoint() {
         assertThat(GeopointFormatter.reformatForClipboard("N 10° 12,345 · W 5° 12,345")).isEqualTo("N 10° 12.345 W 5° 12.345");
     }
 
-    public static void testReformatForClipboardNoChange() {
+    @Test
+    public void testReformatForClipboardNoChange() {
         assertThat(GeopointFormatter.reformatForClipboard("N 10° 12' 34\" W 5° 12' 34\"")).isEqualTo("N 10° 12' 34\" W 5° 12' 34\"");
     }
 
-    public static void testReformatForClipboardReplaceCommaWithPoint() {
+    @Test
+    public void testReformatForClipboardReplaceCommaWithPoint() {
         assertThat(GeopointFormatter.reformatForClipboard("10,123456 -0,123456")).isEqualTo("10.123456 -0.123456");
     }
-
 
 }

--- a/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
@@ -1,24 +1,30 @@
 package cgeo.geocaching.location;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.offset;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.within;
+import static org.assertj.core.api.Assertions.fail;
 
-import junit.framework.TestCase;
-
-public class GeoPointParserTest extends TestCase {
+public class GeoPointParserTest {
 
     private static final double refLongitude = 8.0 + 38.564 / 60.0;
     private static final double refLatitude = 49.0 + 56.031 / 60.0;
 
-    public static void testParseLatitude() {
-        assertEquals(refLatitude, GeopointParser.parseLatitude("N 49° 56.031"), 1e-8);
+    @Test
+    public void testParseLatitude() {
+        assertThat(GeopointParser.parseLatitude("N 49° 56.031")).isCloseTo(refLatitude, within(1e-8));
     }
 
-    public static void testParseLongitude() {
-        assertEquals(refLongitude, GeopointParser.parseLongitude("E 8° 38.564"), 1e-8);
+    @Test
+    public void testParseLongitude() {
+        assertThat(GeopointParser.parseLongitude("E 8° 38.564")).isCloseTo(refLongitude, within(1e-8));
     }
 
-    public static void testFullCoordinates() {
+    @Test
+    public void testFullCoordinates() {
         final Geopoint goal = new Geopoint(refLatitude, refLongitude);
         assertGeopointEquals(goal, GeopointParser.parse("N 49° 56.031 | E 8° 38.564"), 1e-6f);
     }
@@ -32,48 +38,56 @@ public class GeoPointParserTest extends TestCase {
     private static void assertParsingFails(final String geopointToParse) {
         try {
             GeopointParser.parse(geopointToParse);
-            fail();
+            failBecauseExceptionWasNotThrown(Geopoint.ParseException.class);
         } catch (final Geopoint.ParseException e) {
             // expected
         }
     }
 
-    public static void testCoordinateMissingPart() {
+    @Test
+    public void testCoordinateMissingPart() {
         // we are trying to parse a _point_, but have only a latitude. Don't accept the numerical part as longitude!
         assertParsingFails("N 49° 56.031");
     }
 
-    public static void testCoordinateMissingDegree() {
+    @Test
+    public void testCoordinateMissingDegree() {
         // Some home coordinates on geocaching.com lack the degree part.
         final Geopoint point = GeopointParser.parse("N 51° 23.123' W ° 17.123");
         assertThat(point).isEqualTo(new Geopoint("N", "51", "23", "123", "W", "0", "17", "123"));
     }
 
-    public static void testSouth() {
+    @Test
+    public void testSouth() {
         assertThat(GeopointParser.parseLatitude("S 49° 56.031")).isEqualTo(-refLatitude, offset(1e-8));
     }
 
-    public static void testWest() {
+    @Test
+    public void testWest() {
         assertThat(GeopointParser.parseLongitude("W 8° 38.564")).isEqualTo(-refLongitude, offset(1e-8));
     }
 
-    public static void testLowerCase() {
+    @Test
+    public void testLowerCase() {
         assertThat(GeopointParser.parseLongitude("e 8° 38.564")).isEqualTo(refLongitude, offset(1e-8));
     }
 
-    public static void testVariousFormats() {
+    @Test
+    public void testVariousFormats() {
         final Geopoint goal1 = GeopointParser.parse("N 49° 43' 57\" | E 2 12' 35");
         final Geopoint goal2 = GeopointParser.parse("N 49 43.95 E2°12.5833333333");
         assertGeopointEquals(goal1, goal2, 1e-6f);
     }
 
-    public static void testParseOurOwnSeparator() {
+    @Test
+    public void testParseOurOwnSeparator() {
         final Geopoint separator = GeopointParser.parse("N 49° 43' 57\" · E 2 12' 35");
         final Geopoint noSeparator = GeopointParser.parse("N 49 43.95 E2°12.5833333333");
         assertGeopointEquals(separator, noSeparator, 1e-6f);
     }
 
-    public static void testInSentence() {
+    @Test
+    public void testInSentence() {
         final Geopoint p1 = GeopointParser.parse("Station3: N51 21.523 / E07 02.680");
         final Geopoint p2 = GeopointParser.parse("N51 21.523 E07 02.680");
         assertThat(p1).isNotNull();
@@ -81,11 +95,13 @@ public class GeoPointParserTest extends TestCase {
         assertThat(p2).isEqualTo(p1);
     }
 
-    public static void testUnrelatedParts() {
+    @Test
+    public void testUnrelatedParts() {
         assertParsingFails("N51 21.523 and some words in between, so there is no relation E07 02.680");
     }
 
-    public static void testComma() {
+    @Test
+    public void testComma() {
         final Geopoint pointComma = GeopointParser.parse("N 46° 27' 55,65''\n" +
                 "E 15° 53' 41,68''");
         final Geopoint pointDot = GeopointParser.parse("N 46° 27' 55.65''\n" +
@@ -95,64 +111,79 @@ public class GeoPointParserTest extends TestCase {
         assertThat(pointDot).isEqualTo(pointComma);
     }
 
-    public static void testBlankAddedByAutocorrectionDot() {
+    @Test
+    public void testBlankAddedByAutocorrectionDot() {
         assertThat(GeopointParser.parseLatitude("N 49° 56. 031")).isEqualTo(refLatitude, offset(1e-8));
     }
 
-    public static void testBlankAddedByAutocorrectionComma() {
+    @Test
+    public void testBlankAddedByAutocorrectionComma() {
         assertThat(GeopointParser.parseLatitude("N 49° 56, 031")).isEqualTo(refLatitude, offset(1e-8));
     }
 
-    public static void testNonTrimmed() {
+    @Test
+    public void testNonTrimmed() {
         assertThat(GeopointParser.parseLatitude("    N 49° 56, 031   ")).isEqualTo(refLatitude, offset(1e-8));
     }
 
-    public static void testEquatorGC53() {
+    @Test
+    public void testEquatorGC53() {
         assertThat(GeopointParser.parse("00° 00.000 E 036° 00.000")).isEqualTo(new Geopoint(0, 36));
     }
 
-    public static void testMeridian() {
+    @Test
+    public void testMeridian() {
         assertThat(GeopointParser.parse("N 23° 00.000 00° 00.000")).isEqualTo(new Geopoint(23, 0));
     }
 
-    public static void testEquatorMeridian() {
+    @Test
+    public void testEquatorMeridian() {
         assertThat(GeopointParser.parse("00° 00.000 00° 00.000")).isEqualTo(Geopoint.ZERO);
     }
 
-    public static void testFloatingPointLatitude() {
+    @Test
+    public void testFloatingPointLatitude() {
         assertThat(GeopointParser.parseLatitude("47.648883")).isEqualTo(GeopointParser.parseLatitude("N 47° 38.933"), offset(1e-6));
     }
 
-    public static void testFloatingPointNegativeLatitudeMeansSouth() {
+    @Test
+    public void testFloatingPointNegativeLatitudeMeansSouth() {
         assertThat(GeopointParser.parseLatitude("-47.648883")).isEqualTo(GeopointParser.parseLatitude("S 47° 38.933"), offset(1e-6));
     }
 
-    public static void testFloatingPointBoth() {
+    @Test
+    public void testFloatingPointBoth() {
         assertGeopointEquals(GeopointParser.parse("47.648883  122.348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47.648883  -122.348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
     }
 
-    public static void testFloatingPointNbsp() {
+    @Test
+    public void testFloatingPointNbsp() {
         assertGeopointEquals(GeopointParser.parse("47.648883  122.348067\u00a0"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
     }
 
-    public static void testDoubleComma() {
+    @Test
+    public void testDoubleComma() {
         assertThat(GeopointParser.parse("47.648883,122.348067").equals(GeopointParser.parse("47.648883 122.348067")));
     }
 
-    public static void testGerman() {
+    @Test
+    public void testGerman() {
         assertThat(GeopointParser.parse("N 47° 38.933 O 122° 20.884")).isEqualTo(GeopointParser.parse("N 47° 38.933 E 122° 20.884"));
     }
 
-    public static void testNoSpace() {
+    @Test
+    public void testNoSpace() {
         assertThat(GeopointParser.parse("N47°38.933E122°20.884")).isEqualTo(GeopointParser.parse("N 47° 38.933 E 122° 20.884"));
     }
 
-    public static void testUTM() {
+    @Test
+    public void testUTM() {
         GeopointParser.parse("54S E 293848 N 3915114");
     }
 
-    public static void testZero() {
+    @Test
+    public void testZero() {
         GeopointParser.parse("00° 00.000′ 000° 00.00′");
         GeopointParser.parse("00° 00′ 00.00″ 000° 00′ 00.00″");
         GeopointParser.parse("00° 00′ 000° 00′");
@@ -163,7 +194,8 @@ public class GeoPointParserTest extends TestCase {
         assertParsingFails("01° E 000°");
     }
 
-    public static void testFormula() {
+    @Test
+    public void testFormula() {
         assertParsingFails("N 12° 23.345′ E 123° 34.5AB′");
         assertParsingFails("N 12° 23′ E 123° 3A′");
         assertParsingFails("N 12° E 12A°");
@@ -172,13 +204,15 @@ public class GeoPointParserTest extends TestCase {
         assertParsingFails("-12.345678° 23.4ABCDE°");
     }
 
-    public static void testInvalidCombinations() {
+    @Test
+    public void testInvalidCombinations() {
         assertParsingFails("N 07° 59.999′ W 059° 42′ 17.12″");
         assertParsingFails("S 59° 42′ 17.12″ -0.497234");
         assertParsingFails("0.497234 E 007° 59.999′");
     }
 
-    public static void testDMSBounds() {
+    @Test
+    public void testDMSBounds() {
         GeopointParser.parse("S 90° 00′ 00.00″ W 180° 00′ 00.00″");
         GeopointParser.parse("S 89° 59′ 59.99″ W 179° 59′ 59.99″");
         assertParsingFails("S 90° 00′ 00.01″ W 180° 00′ 00.00″");
@@ -189,7 +223,8 @@ public class GeoPointParserTest extends TestCase {
         assertParsingFails("S 89° 59′ 59.99″ W 179° 60′ 00.00″");
     }
 
-    public static void testMinBounds() {
+    @Test
+    public void testMinBounds() {
         GeopointParser.parse("S 90° 00′ W 180° 00′");
         GeopointParser.parse("S 89° 59′ W 179° 59′");
         assertParsingFails("S 90° 01′ W 180° 00′");
@@ -198,7 +233,8 @@ public class GeoPointParserTest extends TestCase {
         assertParsingFails("S 90° 00′ W 179° 60′");
     }
 
-    public static void testMinDecBounds() {
+    @Test
+    public void testMinDecBounds() {
         GeopointParser.parse("S 90° 00.000′ W 180° 00.000′");
         GeopointParser.parse("S 89° 59.999′ W 179° 59.999′");
         assertParsingFails("S 90° 00.001′ W 180° 00.000′");
@@ -207,26 +243,29 @@ public class GeoPointParserTest extends TestCase {
         assertParsingFails("S 90° 00.000′ W 179° 60.000′");
     }
 
-    public static void testNull() {
+    @Test
+    public void testNull() {
         try {
             GeopointParser.parseLatitude(null);
-            fail();
+            failBecauseExceptionWasNotThrown(Geopoint.ParseException.class);
         } catch (final Geopoint.ParseException e) {
             // expected
         }
         try {
             GeopointParser.parseLongitude(null);
-            fail();
+            failBecauseExceptionWasNotThrown(Geopoint.ParseException.class);
         } catch (final Geopoint.ParseException e) {
             // expected
         }
     }
 
-    public static void test922() {
+    @Test
+    public void test922() {
         assertParsingFails("L 12\n M 13\n N 14\n O 15");
     }
 
-    public static void test5538() {
+    @Test
+    public void test5538() {
         assertParsingFails("A=6 B=0 C=5 D=4 E=13\n" +
                            "N 48° 53.(A*C*E)+194   E 009° 11.((D*71)-0)-1\n" +
                            "N 48° 53.(6*5*13)+194  E 009° 11.((4*71)-0)-1\n" +
@@ -234,7 +273,8 @@ public class GeoPointParserTest extends TestCase {
         assertParsingFails("S1: N 49 27.253");
     }
 
-    public static void test5790() {
+    @Test
+    public void test5790() {
         GeopointParser.parse("N 52° 36.123 E 010° 06.456'");
         GeopointParser.parse("N52° 36.123 E010°06.456");
         GeopointParser.parse("N52 36.123 E010 06.456");
@@ -244,7 +284,8 @@ public class GeoPointParserTest extends TestCase {
         GeopointParser.parse("52.55123° 10.56789°");
     }
 
-    public static void test6090() {
+    @Test
+    public void test6090() {
         // Issue #6090
         final Geopoint ref = new Geopoint(12.576117, -1.390933);
 

--- a/tests/src/cgeo/geocaching/location/GeopointTest.java
+++ b/tests/src/cgeo/geocaching/location/GeopointTest.java
@@ -1,27 +1,31 @@
 package cgeo.geocaching.location;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.offset;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import android.os.Build;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class GeopointTest extends TestCase {
+public class GeopointTest {
 
-    public static void testCreation() {
+    @Test
+    public void testCreation() {
         final Geopoint gp = new Geopoint(48.2, 3.5);
         assertThat(gp.getLatitude()).isEqualTo(48.2, offset(1e-8));
         assertThat(gp.getLongitude()).isEqualTo(3.5, offset(1e-8));
     }
 
-    public static void testCreationWithParsing() {
+    @Test
+    public void testCreationWithParsing() {
         final Geopoint gp = new Geopoint("N 52° 25,111 E 009° 39,111");
         assertThat(gp.getLatitude()).isEqualTo(52.41852, offset(1e-4));
         assertThat(gp.getLongitude()).isEqualTo(9.65185, offset(1e-4));
     }
 
-    public static void testCreationAtLimit() {
+    @Test
+    public void testCreationAtLimit() {
         // No exception should be raised.
         final Geopoint gp1 = new Geopoint(90.0, 10.0);
         assertThat(gp1.getLatitude()).isEqualTo(90, offset(1e-8));
@@ -33,7 +37,8 @@ public class GeopointTest extends TestCase {
         assertThat(gp3.getLongitude()).isEqualTo(180, offset(1e-8));
     }
 
-    public static void testEqual() {
+    @Test
+    public void testEqual() {
         final Geopoint gp1 = new Geopoint(48.2, 2.31);
         //noinspection EqualsWithItself
         assertThat(gp1.equals(gp1)).isTrue();
@@ -41,7 +46,8 @@ public class GeopointTest extends TestCase {
         assertThat(gp1.equals(gp2)).isFalse();
     }
 
-    public static void testEqualExternal() {
+    @Test
+    public void testEqualExternal() {
         final Geopoint gp1 = new Geopoint(48.2, 2.31);
         assertThat(Geopoint.equals(gp1, gp1)).isTrue();
         final Geopoint gp2 = new Geopoint(48.3, 2.31);
@@ -51,13 +57,15 @@ public class GeopointTest extends TestCase {
         assertThat(Geopoint.equals(gp1, null)).isFalse();
     }
 
-    public static void testGetE6() {
+    @Test
+    public void testGetE6() {
         final Geopoint gp = new Geopoint(41.2, -3.4);
         assertThat((double) gp.getLatitudeE6()).isEqualTo(41200000.0, offset(1e-6));
         assertThat((double) gp.getLongitudeE6()).isEqualTo(-3400000.0, offset(1e-6));
     }
 
-    public static void testBearingDistance() {
+    @Test
+    public void testBearingDistance() {
         final Geopoint gp1 = new Geopoint(-30.4, -1.2);
         final Geopoint gp2 = new Geopoint(-30.1, -2.3);
 
@@ -78,7 +86,8 @@ public class GeopointTest extends TestCase {
         assertThat((double) gp2.bearingTo(gp1)).isEqualTo(107.715, offset(1e-3));
     }
 
-    public static void testDDD() {
+    @Test
+    public void testDDD() {
         // Maximum acceptable deviation for degrees is 1e-5 (fractional part is scaled up by 1e5)
 
         // case 1
@@ -146,7 +155,8 @@ public class GeopointTest extends TestCase {
         assertThat(gp1.getLongitude()).isEqualTo(gp2.getLongitude(), offset(tolerance));
     }
 
-    public static void testRaw() {
+    @Test
+    public void testRaw() {
         final Geopoint gp1 = new Geopoint(51.3d, 13.8d);
         assertThat(gp1.getLatMinRaw()).isEqualTo(18);
         assertThat(gp1.getLonMinRaw()).isEqualTo(48);
@@ -168,7 +178,8 @@ public class GeopointTest extends TestCase {
         assertThat(gp4.getLonMinRaw()).isEqualTo(0.0534, offset(1e-4));
     }
 
-    public static void testDMM() {
+    @Test
+    public void testDMM() {
         // Maximum acceptable deviation for degrees+minutes is 2e-5 (fractional part is scaled up by 1e3)
 
         // case 1
@@ -243,7 +254,8 @@ public class GeopointTest extends TestCase {
         assertThat(gp.getLonMinFrac()).isEqualTo(lonMinFrac);
     }
 
-    public static void testDMS() {
+    @Test
+    public void testDMS() {
         // case 1
         final Geopoint gp1 = new Geopoint(51.3d, 13.8d);
 
@@ -307,7 +319,8 @@ public class GeopointTest extends TestCase {
         }
     }
 
-    public static void testParseParam1() {
+    @Test
+    public void testParseParam1() {
         assertParseException(new Runnable() {
 
             @SuppressWarnings("unused")
@@ -318,7 +331,8 @@ public class GeopointTest extends TestCase {
         });
     }
 
-    public static void testParseParam2() {
+    @Test
+    public void testParseParam2() {
         assertParseException(new Runnable() {
 
             @SuppressWarnings("unused")
@@ -329,7 +343,8 @@ public class GeopointTest extends TestCase {
         });
     }
 
-    public static void testParseParam6() {
+    @Test
+    public void testParseParam6() {
         assertParseException(new Runnable() {
 
             @SuppressWarnings("unused")
@@ -340,7 +355,8 @@ public class GeopointTest extends TestCase {
         });
     }
 
-    public static void testParseParam8() {
+    @Test
+    public void testParseParam8() {
         assertParseException(new Runnable() {
 
             @SuppressWarnings("unused")
@@ -351,7 +367,8 @@ public class GeopointTest extends TestCase {
         });
     }
 
-    public static void testParseParam10() {
+    @Test
+    public void testParseParam10() {
         assertParseException(new Runnable() {
 
             @SuppressWarnings("unused")
@@ -362,7 +379,8 @@ public class GeopointTest extends TestCase {
         });
     }
 
-    public static void testValid() {
+    @Test
+    public void testValid() {
         assertThat(new Geopoint(0, 0).isValid()).isTrue();
         assertThat(new Geopoint(90, 0).isValid()).isTrue();
         assertThat(new Geopoint(91, 0).isValid()).isFalse();
@@ -374,7 +392,8 @@ public class GeopointTest extends TestCase {
         assertThat(new Geopoint(0, -181).isValid()).isFalse();
     }
 
-    public static void testRounded() {
+    @Test
+    public void testRounded() {
         final Geopoint gp = new Geopoint(1.234567, 0.123456);
         assertThat(gp.roundedAt(1)).isEqualTo(new Geopoint(1, 0));
         assertThat(gp.roundedAt(10)).isEqualTo(new Geopoint(1.2, 0.1));

--- a/tests/src/cgeo/geocaching/location/ViewportTest.java
+++ b/tests/src/cgeo/geocaching/location/ViewportTest.java
@@ -2,9 +2,10 @@ package cgeo.geocaching.location;
 
 import android.annotation.SuppressLint;
 
-import junit.framework.TestCase;
 
 import android.support.annotation.NonNull;
+
+import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Locale;
@@ -16,45 +17,51 @@ import static cgeo.geocaching.location.Viewport.containing;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class ViewportTest extends TestCase {
+public class ViewportTest {
 
     @NonNull
     private static final Viewport vpRef = new Viewport(new Geopoint(-1.0, -2.0), new Geopoint(3.0, 4.0));
 
-    public static void assertBounds(final Viewport vp) {
+    private static void assertBounds(final Viewport vp) {
         assertThat(vp.center).isEqualTo(new Geopoint(1.0, 1.0));
         assertThat(vp.topRight).isEqualTo(new Geopoint(3.0, 4.0));
         assertThat(vp.bottomLeft).isEqualTo(new Geopoint(-1.0, -2.0));
     }
 
-    public static void testCreationBounds() {
+    @Test
+    public void testCreationBounds() {
         assertBounds(new Viewport(new Geopoint(-1.0, -2.0), new Geopoint(3.0, 4.0)));
         assertBounds(new Viewport(new Geopoint(3.0, 4.0), new Geopoint(-1.0, -2.0)));
         assertBounds(new Viewport(new Geopoint(-1.0, 4.0), new Geopoint(3.0, -2.0)));
         assertBounds(new Viewport(new Geopoint(3.0, -2.0), new Geopoint(-1.0, 4.0)));
     }
 
-    public static void testCreationCenter() {
+    @Test
+    public void testCreationCenter() {
         assertBounds(new Viewport(new Geopoint(1.0, 1.0), 4.0, 6.0));
     }
 
-    public static void testCreationSeparate() {
+    @Test
+    public void testCreationSeparate() {
         assertBounds(vpRef);
     }
 
-    public static void testMinMax() {
+    @Test
+    public void testMinMax() {
         assertThat(vpRef.getLatitudeMin()).isEqualTo(-1.0);
         assertThat(vpRef.getLatitudeMax()).isEqualTo(3.0);
         assertThat(vpRef.getLongitudeMin()).isEqualTo(-2.0);
         assertThat(vpRef.getLongitudeMax()).isEqualTo(4.0);
     }
 
-    public static void testSpans() {
+    @Test
+    public void testSpans() {
         assertThat(vpRef.getLatitudeSpan()).isEqualTo(4.0);
         assertThat(vpRef.getLongitudeSpan()).isEqualTo(6.0);
     }
 
-    public static void testInViewport() {
+    @Test
+    public void testInViewport() {
         assertThat(vpRef.contains(new Geopoint(-2.0, -2.0))).isFalse();
         assertThat(vpRef.contains(new Geopoint(4.0, 4.0))).isFalse();
         assertThat(vpRef.contains(Geopoint.ZERO)).isTrue();
@@ -63,7 +70,8 @@ public class ViewportTest extends TestCase {
     }
 
     @SuppressLint("DefaultLocale")
-    public static void testSqlWhere() {
+    @Test
+    public void testSqlWhere() {
         assertThat(vpRef.sqlWhere(null).toString()).isEqualTo("latitude >= -1.0 and latitude <= 3.0 and longitude >= -2.0 and longitude <= 4.0");
         assertThat(vpRef.sqlWhere("t").toString()).isEqualTo("t.latitude >= -1.0 and t.latitude <= 3.0 and t.longitude >= -2.0 and t.longitude <= 4.0");
         Locale current = null;
@@ -77,25 +85,29 @@ public class ViewportTest extends TestCase {
         }
     }
 
-    public static void testEquals() {
+    @Test
+    public void testEquals() {
         assertThat(vpRef).isEqualTo(vpRef);
         assertThat(new Viewport(vpRef.bottomLeft, vpRef.topRight)).isEqualTo(vpRef);
         assertThat(vpRef.equals(new Viewport(new Geopoint(0.0, 0.0), 1.0, 1.0))).isFalse();
     }
 
-    public static void testResize() {
+    @Test
+    public void testResize() {
         assertThat(vpRef.resize(1.0)).isEqualTo(vpRef);
         assertThat(vpRef.resize(2.0)).isEqualTo(new Viewport(new Geopoint(-3.0, -5.0), new Geopoint(5.0, 7.0)));
         assertThat(vpRef.resize(0.5)).isEqualTo(new Viewport(new Geopoint(0.0, -0.5), new Geopoint(2.0, 2.5)));
     }
 
-    public static void testIncludes() {
+    @Test
+    public void testIncludes() {
         assertThat(vpRef.includes(vpRef)).isTrue();
         assertThat(vpRef.includes(vpRef.resize(0.5))).isTrue();
         assertThat(vpRef.includes(vpRef.resize(2.0))).isFalse();
     }
 
-    public static void testContaining() {
+    @Test
+    public void testContaining() {
         assertThat(containing(singleton((ICoordinates) null))).isNull();
         final Set<Geopoint> points = new HashSet<>();
         points.add(vpRef.bottomLeft);

--- a/tests/src/cgeo/geocaching/models/DestinationTest.java
+++ b/tests/src/cgeo/geocaching/models/DestinationTest.java
@@ -1,21 +1,22 @@
 package cgeo.geocaching.models;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import cgeo.geocaching.location.Geopoint;
 
-import junit.framework.TestCase;
-
-public class DestinationTest extends TestCase {
+public class DestinationTest {
 
     private Destination dest = null;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         dest = new Destination(1, 10000, new Geopoint(52.5, 9.33));
     }
 
+    @Test
     public void testSomething() {
         assertThat(dest.getId()).isEqualTo(1);
         assertThat(dest.getDate()).isEqualTo(10000);

--- a/tests/src/cgeo/geocaching/models/GeocodeComparatorTest.java
+++ b/tests/src/cgeo/geocaching/models/GeocodeComparatorTest.java
@@ -6,14 +6,15 @@ import cgeo.geocaching.sorting.GeocodeComparator;
 
 import android.support.annotation.NonNull;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junit.framework.TestCase;
+public class GeocodeComparatorTest {
 
-public class GeocodeComparatorTest extends TestCase {
-
+    @Test
     public void testSomething() {
         final List<Geocache> caches = new ArrayList<>();
         caches.add(createGeocache("GC1ABCD"));

--- a/tests/src/cgeo/geocaching/models/PersonalNoteTest.java
+++ b/tests/src/cgeo/geocaching/models/PersonalNoteTest.java
@@ -1,12 +1,13 @@
 package cgeo.geocaching.models;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class PersonalNoteTest extends TestCase {
+public class PersonalNoteTest {
 
-    public static void testParse() {
+    @Test
+    public void testParse() {
         final String testString = "Simple cgeo note\n--\nSimple provider note";
         final Geocache cache = new Geocache();
         cache.setPersonalNote(testString);
@@ -16,7 +17,8 @@ public class PersonalNoteTest extends TestCase {
 
     }
 
-    public static void testParseProviderOnly() {
+    @Test
+    public void testParseProviderOnly() {
         final String testString = "Simple provider note";
         final Geocache cache = new Geocache();
         cache.setPersonalNote(testString);
@@ -25,7 +27,8 @@ public class PersonalNoteTest extends TestCase {
         assertPersonalNote(parsedNote, null, "Simple provider note");
     }
 
-    public static void testParseCgeoOnly() {
+    @Test
+    public void testParseCgeoOnly() {
         final String testString = "Simple cgeo note";
         final Geocache cache = new Geocache();
         cache.setPersonalNote(testString);

--- a/tests/src/cgeo/geocaching/network/NetworkTest.java
+++ b/tests/src/cgeo/geocaching/network/NetworkTest.java
@@ -1,12 +1,13 @@
 package cgeo.geocaching.network;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import junit.framework.TestCase;
+public class NetworkTest {
 
-public class NetworkTest extends TestCase {
-
-    public static void testRfc3986URLEncode() {
+    @Test
+    public void testRfc3986URLEncode() {
         assertThat(Network.rfc3986URLEncode("*")).isEqualTo("*");
         assertThat(Network.rfc3986URLEncode("~")).isEqualTo("~");
         assertThat(Network.rfc3986URLEncode(" ")).isEqualTo("%20");

--- a/tests/src/cgeo/geocaching/network/OAuthTest.java
+++ b/tests/src/cgeo/geocaching/network/OAuthTest.java
@@ -1,13 +1,16 @@
 package cgeo.geocaching.network;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import junit.framework.TestCase;
+public class OAuthTest {
 
-public class OAuthTest extends TestCase {
-
-   // Test example from https://dev.twitter.com/oauth/overview/creating-signatures
-   public static void testOAuthSignature() {
+    /**
+     * Test example from https://dev.twitter.com/oauth/overview/creating-signatures
+     */
+   @Test
+   public void testOAuthSignature() {
        final Parameters params = new Parameters(
                "status", "Hello Ladies + Gentlemen, a signed OAuth request!",
                "include_entities", "true",

--- a/tests/src/cgeo/geocaching/network/ParametersTest.java
+++ b/tests/src/cgeo/geocaching/network/ParametersTest.java
@@ -1,16 +1,17 @@
 package cgeo.geocaching.network;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
+public class ParametersTest {
 
-public class ParametersTest extends TestCase {
-
-    static final List<Character> UNRESERVED = new ArrayList<>();
+    private static final List<Character> UNRESERVED = new ArrayList<>();
 
     static {
         // unreserved characters: ALPHA / DIGIT / "-" / "." / "_" / "~"
@@ -27,7 +28,8 @@ public class ParametersTest extends TestCase {
         UNRESERVED.add('~');
     }
 
-    public static void testException() {
+    @Test
+    public void testException() {
         try {
             final Parameters params = new Parameters("aaa", "AAA", "bbb");
             params.clear(); // this will never be invoked, but suppresses warnings about unused objects
@@ -44,13 +46,15 @@ public class ParametersTest extends TestCase {
         }
     }
 
-    public static void testMultipleValues() {
+    @Test
+    public void testMultipleValues() {
         final Parameters params = new Parameters("aaa", "AAA", "bbb", "BBB");
         params.put("ccc", "CCC", "ddd", "DDD");
         assertThat(params.toString()).isEqualTo("aaa=AAA&bbb=BBB&ccc=CCC&ddd=DDD");
     }
 
-    public static void testSort() {
+    @Test
+    public void testSort() {
         final Parameters params = new Parameters();
         params.put("aaa", "AAA");
         params.put("ccc", "CCC");
@@ -60,21 +64,24 @@ public class ParametersTest extends TestCase {
         assertThat(params.toString()).isEqualTo("aaa=AAA&bbb=BBB&ccc=CCC");
     }
 
-    public static void testToString() {
+    @Test
+    public void testToString() {
         final Parameters params = new Parameters();
         params.put("name", "foo&bar");
         params.put("type", "moving");
         assertThat(params.toString()).isEqualTo("name=foo%26bar&type=moving");
     }
 
-    public static void testUnreservedCharactersMustNotBeEncoded() {
+    @Test
+    public void testUnreservedCharactersMustNotBeEncoded() {
         for (final Character c : UNRESERVED) {
             final String charAsString = String.valueOf(c);
-            assertEquals("wrong OAuth encoding for " + c, charAsString, Parameters.percentEncode(charAsString));
+            assertThat(charAsString).isEqualTo(Parameters.percentEncode(charAsString));
         }
     }
 
-    public static void testOtherCharactersMustBeEncoded() {
+    @Test
+    public void testOtherCharactersMustBeEncoded() {
         for (int i = 32; i < 127; i++) {
             final Character c = (char) i;
             if (!UNRESERVED.contains(c)) {
@@ -86,11 +93,13 @@ public class ParametersTest extends TestCase {
         }
     }
 
-    public static void testAsterisk() {
+    @Test
+    public void testAsterisk() {
         assertThat("*".equals(Parameters.percentEncode("*"))).isFalse();
     }
 
-    public static void testPercentEncoding() {
+    @Test
+    public void testPercentEncoding() {
         final Parameters params = new Parameters("oauth_callback", "callback://www.cgeo.org/");
         assertThat(params.toString()).isEqualTo("oauth_callback=callback://www.cgeo.org/");
         params.usePercentEncoding();

--- a/tests/src/cgeo/geocaching/sorting/DistanceComparatorTest.java
+++ b/tests/src/cgeo/geocaching/sorting/DistanceComparatorTest.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.sorting;
 
+import org.junit.Test;
+
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 
@@ -7,11 +9,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junit.framework.TestCase;
+public class DistanceComparatorTest {
 
-public class DistanceComparatorTest extends TestCase {
-
-    public static void testCompareCaches() {
+    @Test
+    public void testCompareCaches() {
         final List<Geocache> caches = new ArrayList<>();
         for (int i = 0; i < 37; i++) {
             final Geocache cache = new Geocache();

--- a/tests/src/cgeo/geocaching/sorting/NameComparatorTest.java
+++ b/tests/src/cgeo/geocaching/sorting/NameComparatorTest.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.sorting;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import cgeo.geocaching.models.Geocache;
@@ -7,9 +9,7 @@ import cgeo.geocaching.models.Geocache;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import junit.framework.TestCase;
-
-public class NameComparatorTest extends TestCase {
+public class NameComparatorTest {
 
     private static class NamedCache extends Geocache {
 
@@ -20,17 +20,20 @@ public class NameComparatorTest extends TestCase {
 
     private final NameComparator comp = new NameComparator();
 
+    @Test
     public void testLexical() {
         assertSorted(new NamedCache("A"), new NamedCache("Z"));
         assertNotSorted(new NamedCache("Z"), new NamedCache("A"));
     }
 
+    @Test
     public void testNumericalNamePart() {
         assertSorted(new NamedCache("AHR#2"), new NamedCache("AHR#11"));
         assertSorted(new NamedCache("AHR#7 LP"), new NamedCache("AHR#11 Bonsaibuche"));
         assertSorted(new NamedCache("2"), new NamedCache("11"));
     }
 
+    @Test
     public void testDuplicateNumericalParts() {
         assertSortedNames("GR8 01-01", "GR8 01-02", "GR8 01-03", "GR8 01-04", "GR8 01-05", "GR8 01-06", "GR8 01-07", "GR8 01-08", "GR8 01-09");
     }
@@ -50,6 +53,7 @@ public class NameComparatorTest extends TestCase {
         }
     }
 
+    @Test
     public void testNumericalWithSuffix() {
         assertSorted(new NamedCache("abc123def"), new NamedCache("abc123xyz"));
         assertThat((new NamedCache("abc123def456")).getNameForSorting()).isEqualTo("abc000123def000456");

--- a/tests/src/cgeo/geocaching/test/mock/GC5BRQK.html
+++ b/tests/src/cgeo/geocaching/test/mock/GC5BRQK.html
@@ -1,0 +1,2442 @@
+
+
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head id="ctl00_Head1"><meta charset="utf-8" /><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /><title>
+	GC5BRQK Chemin de l'Escourachie (Traditional Cache) in Provence-Alpes-Côte d'Azur, France created by kumy
+</title><meta name="DC.title" content="Geocaching&#32;-&#32;The&#32;Official&#32;Global&#32;GPS&#32;Cache&#32;Hunt&#32;Site" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="Geocaching:&#32;Join&#32;the&#32;world&#39;s&#32;largest&#32;treasure&#32;hunt." /><meta name="twitter:description" content="There&#32;are&#32;millions&#32;of&#32;geocaches&#32;worldwide&#32;and&#32;probably&#32;even&#32;some&#32;near&#32;you&#32;right&#32;now.&#32;Visit&#32;Geocaching.com&#32;to&#32;see&#32;just&#32;how&#32;many&#32;geocaches&#32;are&#32;nearby&#32;and&#32;to&#32;get&#32;the&#32;free&#32;Official&#32;Geocaching&#32;app." /><meta name="twitter:image:src" content="https://www.geocaching.com/play/Content/images/preview-lg.jpg" /><meta id="ctl00_ogUrl" name="og:url" property="og:url" content="https://www.geocaching.com/seek/cache_details.aspx?wp=GC5BRQK&amp;title=chemin-de-lescourachie" /><meta name="author" content="Geocaching" /><meta name="DC.creator" content="Geocaching" /><meta name="Copyright" content="Copyright (c) 2000-2017 Groundspeak, Inc. All Rights Reserved." /><!-- Copyright (c) 2000-2017 Groundspeak, Inc. All Rights Reserved. --><meta name="description" content="Geocaching&#32;is&#32;a&#32;treasure&#32;hunting&#32;game&#32;where&#32;you&#32;use&#32;a&#32;GPS&#32;to&#32;hide&#32;and&#32;seek&#32;containers&#32;with&#32;other&#32;participants&#32;in&#32;the&#32;activity.&#32;Geocaching.com&#32;is&#32;the&#32;listing&#32;service&#32;for&#32;geocaches&#32;around&#32;the&#32;world." /><meta name="DC.subject" content="Geocaching&#32;is&#32;a&#32;treasure&#32;hunting&#32;game&#32;where&#32;you&#32;use&#32;a&#32;GPS&#32;to&#32;hide&#32;and&#32;seek&#32;containers&#32;with&#32;other&#32;participants&#32;in&#32;the&#32;activity.&#32;Geocaching.com&#32;is&#32;the&#32;listing&#32;service&#32;for&#32;geocaches&#32;around&#32;the&#32;world." /><meta http-equiv="imagetoolbar" content="no" /><meta name="distribution" content="global" /><meta name="MSSmartTagsPreventParsing" content="true" /><meta name="rating" content="general" /><meta name="revisit-after" content="1&#32;days" /><meta name="robots" content="all" /><link href="//fonts.googleapis.com/css?family=Noto+Sans:400,700&amp;subset=latin,latin-ext" rel="stylesheet" type="text/css" /><link id="ctl00_icon" rel="icon" href="/favicon.ico" /><link id="ctl00_scIcon" rel="shortcut&#32;icon" href="/favicon.ico" /><link rel="apple-touch-icon" href="/apple-touch-icon.png" /><link id="ctl00_imageSrcC" rel="image_src" href="/preview.png" /><link href="/content/coreCSS?v=A4Ozo7MgLmpHth1Qy1WnhrAi6gpRJ3-uuDMMvYUPIB01" rel="stylesheet"/>
+<link href="/css/jqueryui1104/jqUI?v=G2XN-0HsvYJqSZehzmbzhJiIBnEZ9PaVHVjIweqiSx41" rel="stylesheet"/>
+<link rel="stylesheet" type="text/css" media="print" href="../css/tlnMasterPrint.css" /><script src="/bundle/modernizer?v=3xlOpAyQtZ5Nz9mv8hV6AvMndwqUqLzznnsEM15MXG81"></script>
+<script src="/bundle/coreJS?v=uKjd3XRiFC1C29gkUc0JuDRCF6PuUu7R8PpzGjgXDEc1"></script>
+
+        
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-N3KS8V2');</script>
+        <!-- End Google Tag Manager -->
+
+        <script type="text/javascript">
+
+            var googletag = googletag || {};
+            googletag.cmd = googletag.cmd || [];
+
+            (function () {
+                var gads = document.createElement('script');
+                gads.async = true;
+                gads.type = 'text/javascript';
+                var useSSL = 'https:' == document.location.protocol;
+                gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+                var node = document.getElementsByTagName('script')[0];
+                node.parentNode.insertBefore(gads, node);
+            })();
+
+            //=============
+
+            (function (i, s, o, g, r, a, m) {
+                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+                    (i[r].q = i[r].q || []).push(arguments)
+                }, i[r].l = 1 * new Date(); a = s.createElement(o),
+                    m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+            })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+
+            
+            ga('create', 'UA-2020240-1', 'auto', {userId: 3829532});
+            
+            ga('require', 'linkid');
+        </script>
+        
+        <script type="text/javascript">
+            var appInsights=window.appInsights||function(config){
+            function i(config){t[config]=function(){var i=arguments;t.queue.push(function(){t[config].apply(t,i)})}}var t={config:config},u=document,e=window,o="script",s="AuthenticatedUserContext",h="start",c="stop",l="Track",a=l+"Event",v=l+"Page",y=u.createElement(o),r,f;y.src=config.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js";u.getElementsByTagName(o)[0].parentNode.appendChild(y);try{t.cookie=u.cookie}catch(p){}for(t.queue=[],t.version="1.0",r=["Event","Exception","Metric","PageView","Trace","Dependency"];r.length;)i("track"+r.pop());return i("set"+s),i("clear"+s),i(h+a),i(c+a),i(h+v),i(c+v),i("flush"),config.disableExceptionTracking||(r="onerror",i("_"+r),f=e[r],e[r]=function(config,i,u,e,o){var s=f&&f(config,i,u,e,o);return s!==!0&&t["_"+r](config,i,u,e,o),s}),t
+            }({
+                instrumentationKey: '056eb48d-5e41-4e08-a9a7-35fadca95242',
+                disableTelemetry: false,
+                samplingPercentage: 5,
+                disableAjaxTracking: false
+            });
+
+            appInsights.queue.push(function () {
+                appInsights.context.addTelemetryInitializer(function (envelope) {
+                    var telemetryItem = envelope.data.baseData;
+                    if (envelope.name === Microsoft.ApplicationInsights.Telemetry.RemoteDependencyData.envelopeType) {
+                        var dropRemoteDependencyRegEx = new RegExp('(.* /api/geocode)|(.* /api/proxy/web/v1/LogDrafts\\?take=1\u0026properties=referenceCode)|(.* /api/proxy/web/v1/lists\\?type=bm\u0026skip=0\u0026take=100)|(.* .*hotjar\\.com.*)|(.* /images/.*)|(.* .*/api/communication-service.*)|(.* /account/oauth/token)|(.* /account/messagecenter/headerwidget/params)|(.* .*doubleclick\\.net.*)|(.* .*communication-service\\.geocaching\\.com.*)', "i");
+                        if(envelope.data.baseData.data && envelope.data.baseData.data.match(dropRemoteDependencyRegEx))
+                        {
+                            return false;
+                        }
+                    }
+                });
+            });
+
+             
+                appInsights.setAuthenticatedUserContext('kumy');
+            
+
+            window.appInsights=appInsights;
+            appInsights.trackPageView();
+        </script>
+
+    
+    <script type="text/javascript">
+        ga('set', 'page', '/geocache/cache_details.aspx');
+        ga('set', 'title', 'Geocaching Detail Page');
+    </script>
+
+    
+    <script type="text/javascript">
+        ga('send', 'pageview');
+    </script>
+    
+    
+<script type="text/javascript">
+    var serverParameters = {
+        'user:info': {
+            isLoggedIn: true,
+            username: "kumy",
+            userType: "Premium",
+            publicGuid: "f8690ec6-6e92-41fc-86dc-8d7991634c6c",
+            avatarUrl: "https://img.geocaching.com/avatar/d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png",
+            dateFormat: "MM/dd/yyyy"
+        },
+        'app:options': {
+            localRegion: "en-US"
+        }
+    }
+</script>
+    
+     
+    <link href="/css/fancybox/jquery.fancybox.css" rel="stylesheet" type="text/css" />
+    <link href="/js/jquery_plugins/icalendar/jquery.icalendar.css" rel="stylesheet" type="text/css" />
+    <link href="/js/jquery_plugins/qtip/jquery.qtip.css" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" type="text/css" media="all" href="/static/js/leaflet/0.7.2/leaflet.css" />
+    <link rel="stylesheet" type="text/css" media="screen" href="/css/seek/beta.css" />
+    <link rel="stylesheet" href="/css/animate.css"/>
+    <script type="text/javascript" src="/static/js/leaflet/0.7.2/leaflet.js"></script>
+    <script type="text/javascript" src="/js/leaflet-util.js"></script>
+    <script type="text/javascript" src="/scripts/utilities.js"></script>
+    <script type="text/javascript" src="/scripts/jquery.noty.packaged.min.js"></script>
+    <script src="https://www.google.com/recaptcha/api.js"></script>
+    <script type="text/javascript">
+        var userToken = null,
+                urlParams = {},
+                mapLatLng = null,
+                cmapAdditionalWaypoints = [],
+                initalLogs = null, totalLogs = 0, includeAvatars = false;
+
+        (function () {
+            var e,
+            d = function (s) { return decodeURIComponent(s.replace(/\+/g, " ")); },
+            q = window.location.search.substring(1),
+            r = /([^&=]+)=?([^&]*)/g;
+
+            while (e = r.exec(q)) {
+                urlParams[d(e[1])] = d(e[2]);
+            }
+        })();
+    </script>
+<script>function utmx_section(){}function utmx(){}(function(){var k='3682814-19',d=document,l=d.location,c=d.cookie; if(l.search.indexOf('utm_expid='+k)>0)return; function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.length:j))}}}var x=f('__utmx'),xx=f('__utmxx'),h=l.hash;d.write('<sc'+'ript src=" '+'http'+(l.protocol=='https:'?'s://ssl':'://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+'&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+'" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();</script><script>utmx('url','A/B');</script><meta name="og:type" content="article" property="og:type" /><meta name="fb:app_id" content="251051881589204" property="fb:app_id" /><meta name="og:description" content="Use&#32;a&#32;smartphone&#32;or&#32;GPS&#32;device&#32;to&#32;navigate&#32;to&#32;the&#32;provided&#32;coordinates.&#32;Look&#32;for&#32;a&#32;small&#32;hidden&#32;container.&#32;When&#32;you&#32;find&#32;it,&#32;write&#32;your&#32;name&#32;and&#32;date&#32;in&#32;the&#32;logbook.&#32;If&#32;you&#32;take&#32;something&#32;from&#32;the&#32;container,&#32;leave&#32;something&#32;in&#32;exchange.&#32;The&#32;terrain&#32;is&#32;1.5&#32;and&#32;difficulty&#32;is&#32;1&#32;(out&#32;of&#32;5)." property="og:description" /><meta name="og:title" content="Chemin&#32;de&#32;l&#39;Escourachie" property="og:title" /><meta name="og:image" content="https://www.geocaching.com/images/facebook/wpttypes/2.png" property="og:image" /><meta name="description" content="Chemin de l&#39;Escourachie (GC5BRQK) was created by kumy on 08/27/2014. It&#39;s a Small size geocache, with difficulty of 1, terrain of 1.5. It&#39;s located in Provence-Alpes-Côte d&#39;Azur, France.C&#39;est Pâques, et les cloches sont passées..." /><link rel="canonical" href="https://www.geocaching.com/seek/cache_details.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4" /><link rel="alternate" href="../datastore/rss_galleryimages.ashx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4" type="application/rss+xml" title="[Gallery Images]" id="GalleryImages" /></head>
+<body background="https://d1u1p2xjjiahg3.cloudfront.net/afd5fb0d-bdba-4dbe-9614-61bc60f3007f.jpg" class="CacheDetailsPage">
+    <form method="post" action="/geocache/GC5BRQK_chemin-de-lescourachie" id="aspnetForm">
+<div class="aspNetHidden">
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="__VIEWSTATEFIELDCOUNT" id="__VIEWSTATEFIELDCOUNT" value="3" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="Vg5GnNlMq3DcdNWxZlzbHb8LeNf/kAcOciAXhA9a7cuX4YKtpqpKTTQ/x5pvq3IHSInJPZCMOQv2qS/8Td2RLSE4jTFTnhmv29DMTNFE1N/h+lcbrzgnKN68z0kqNJZt0Q5qfcLg6xZgo8ww5HE4IOtY1XSwzVr69PQD+bCuTfCb/YnHATL/5+u9nseBJZm82gxXRk5hKk2vYr8j/kKrpU0tBAaEl9AM/jtc0+002ODwUrWx0uiD/NCFMMirEGPJ8k/fcPbuR/+NH/drViQ4Z34GaMU2UdABFbo5GtX6EAmXNbf+2TFggVOwWAIT9NTyIiN22Fzhw22mFw4WMUR+PuB1eLNhdhqcOaavwLl8KsZB7l3QGhJ7NyZCiVHwhDnhVfKvwMsWRoSZQnGXs8sNAYwSaIw48i+KFuqVJIQHV1N6h/CWtXuBtpySbbYkrxNYW59FLlWvxEAHk0+RMwEXeXrhHiYtitGbm6s6ubsxQp5ZUsvXMyqxZ+xkPShXdW8UqI3gx+7Ty9Qs8FFOy6B5ViUHyxsYzQmQ7ROQjWT3nlnlpZAb6Amk+ktq8pyhebsUKnKXwLIo+O0s73ToSu0DSKXMlz1fTuziwOSMOak2kh3NIOSdVrPYxcm30XMvQntK2zJ30cNZqF+rZSvYFv4Esc7qa3wo/T1h3gB1ajgwuB7AYA0juM7VZoBB/rQmHOQiQxLWA1eYZqqQHaW1N/nDc0W6G1aH2uOG7D2GiD5e+LV3RbKyB55oJu6ssKeI6YqIvNBfY+/uI/ooKbRzp7NHuyckJOyh1dpZPCRDBkEOxD8n9lmse07+0OZdV/NuoOwQzBg+nxr9sMDcgbb6UN5tF23hrmShPAuYlsqRfrpoepfRYw/LYI8cY5TN7oERUbqBF5zZbh6ltuGzq+LaV2qLzGiNc9sfs0ONbww9jIpWRmwtZD9UGm1z4AbQyoik+DVcBepuOe1KwGD6CgFMN5Z6x1bzi0sCTWNjXOAsjN6VIcozCyf2PFmU7bvvVQjmvdyZDYGH72LYXrGQoRbyFeBa6QEtabCAhrYeJHWQ7GVHv222kxgOhCGKXzg2cs75rX4vgRww7F7LyWMMPyhZaMKtmzoSO0PvBQ+B+FbzJ/bJ2+RC0+GSU77SOxD1eSO7fyp9XsJMW2+LrMB78TR+vWUj2XfkjICgEzleKxaYg0MoyhCQzTH5lQMf8dkli9P42NbLqkKuISFA2UFzVYibZVqMseK2ruUv4LQJkBoaHqmbT7O3mwc1aJDolJ37iSnKwphJYx7HPOpzQGdkgsajhdZ5GF36IQyG1r4V1K/6TKWNkq8VFfsCtp+LGtLqVfSG9qL2jLwh95wZSfarE/K3xs57UdTxok6EcTQ48gLufvXIUKUhS3GeOneSqAcyOjX5LqeH91VVnWOv93myNnfGJRtWhUtBkpW15fV5FPn1HEbwNZpXOK6YE0vLQBWZgzjwzzXFHvKP/AlmHwrGbmWMHAjGbp2Q7KkQfxnqqSMgUE4b8dnoSDIKd02KsbxTL8A/VJtNACMjP38rTQ2vizDIoYLvr4OzI4HqGdlppO8jsu4kLcEdi+eRMF7K8K8fmmVDaT7lGJYgChmvI3d8Pyqk3CiA+NzluhMMymBEFtNLXLm+SpyOghMYc/599TeTiLQFt23ZijSFIQhcNsWroDRDJHpO+9xvIHufvJNELTKNExIiSw+MOG32Au+Mau2yU8CMoLw4fdtAN/Ep4WAN07wwSATvDDt2hmd7eXbpyYEiRv7huovDPs0xwQyzCgiYaCLLW5yzsKJz3AAIthrK1wZAxvriLLWtX+0oqZN2Xyag3gP6Zx7xJTOQ7Q8ZXPk1hd4fCkAevL798fhsjnpIwFvUsv2nAd5IvLKX6+QbgVGBA7ED84wZnLXpMUiGS4YtmG5pw7LRUyPQ537wlTT/TXefuYhCIwUsBI4+TADKQuIeeg/XmtfzkC38V+O/wJLE6CkljQPuYTf3vay4Kp1G9yzEJGFks+0gaDrkIQFlPE9rrkAW+0BiDg33fy+gYxDL79FCGmkk4e8D+Wu3Jt0122tk5EM4FtDUzZ/fe6zCkh70ivFpbhUZUtCmulLKFL3Yc48IwquWanRoSn6PovK/fXL9kKFVNUooXsu+4Fn5anDtTFo9C541mV6+eiB+AdHzujapzcDpcez4mZkFaWzOTjgvWDxE8NgRAG7vx2RLqzhCQsHlUZ36ln/kMfn0AAE/fKuPnOg3GOtOcBeIYQ++XnVpGQBan7D+mXUGDJxzpNP0lXL+Ndrx4aT3rk9yATdb8tz2UyTobPuhDAn0/7H/+p72h/g1fWoiRdYNKLdtSxCCsrgcJvbKkKZWw/H9RPakKXctEdVfKwZR0BMKeIYeiFyy1KOxvhkuESkupaLU1lRSsSDlQfLZC2N3XBp2zvAzoAyxNLsB/RhCnhsXotvAIn6wqAxFXqfVsHoSdDd3VP/7B6/rjqvKvfjsI4OAZFkDpLXHzLgEWzgv3+Vt6TucenTlG7m1nfQL94cA9MBemq8dglYwpc1w8tl+QoAB/SwTzkQG1qjjvq8tcdJ6hy0ASoOkax42yJQnI7aUSYcouiQML5eVyMox+R9shUpMK8FHE9LuBvazH3KGDnhS8r+PzKi9ABxjD6WKU4RRr8g6GGwFlaa+7xPA6GJlFbJna5iQPKqst5IfXRH0l64H5ZK9cFeZHBgGOVzRs73OE6/wMWtv8zGHt9szLlwOow7QnArvwWg2sRhoQ7KM2CPTnLack8neblCapETVpIGFkA132unkQuYTQW009OK9xtxmMPb4nGXPAGdykB78hj5QH0waZAgwaM0IklV/CdBnxz3E9YDwDx4UwVuF6mG1eOnyIT0ZocpiAzQLDwj8FQX7XuBnOr3RYHopa5mLwdYXuFqgj0ztXDsPpLHx1ZH1jwhHzFaShnQ8cBj7lZN307jT1WogvbDcMPJv9q8XzE2i9ER8QXMdidf8PViCKhf7zzTjXK3xPNaRQG5FWmMStH+H/eqXWKiaKxQjXtKGSECXjY7D7G9SSIp6DqDl1tQD1Mc6gyzof2sRhuRgxHPZIh6XVerynSRkBz0/4Dq+HRfz4j/9cPJlWG67gwJtELBzpsQx47s+os8Hwh1wSwLc4HDwRbck2HuyvN0KwnWgpGhHRLK8zpsE//rAlMuFbSOGnVuOa2OBKqSHUXKCnhjm63cYq64eLVY+c9XT8uYrxYHEU2PyPgiuJfAPtMp/eiMfvNU+t6h3F2Q4u9Lnw7gORO+gPBpcFD77JFLLlabckjlONl1c6TWmPllmL2j/BfH2eawID9bKRxAh+Tgv3dewVTC5dh5yV3FU93rlrzQm4gxKlaC2X+m9bYBd0E7kQ7BUkCg1Bm/CPDCRSxuxKxDkEYaEj+4Q8HHQ6rc76Oj/NU9Bx/VhHRCBixay5LK4FcyCs0TMLZmZfeuJiJvm2ntyGmHu6TyaQyFzzg6I1j8ltp+dLObghpPvbQaqQatBUJe6mzmzXobWldVl318odPCatUfrMp/bnmHpDQ/ldTkTEY4+2ZbBoIMCUC5/6J4LiFCvUaTSKlRO6oIc2M6AwqNY2Y/Bx3TCdPJ0GZXFSjx84J840Ddl7GxVXpv4hy5nOFeacAoaFNhE2lWcHXu+JAlKbU6bviiJSKthBSlTRgT438ykgHkdcBJyvvQDlinSDhsXv3NF3DUiJ6YoRPdIi7w5zsos0P4/vr+Ww7aWZTqoB8le9OPhDl3/0k2J7818rVJoT72TqUhwFrVKz8rxp3hshuozQ07cPFkk0Xyz65KOtiwTCSMdA0uaXnZma2hAgPwDxK9TJRqv8QVkd5ldcvzg0phEKW0yIhQvN7sRBVxEHYy0MSuJiTu5z2ymwt/l7mwfdhJ0C1UO4/qJq0GHH+AudbdCrFc/TB7v6JihUcQQcUH82Zq+wG8igKTiAPDyco2S/MbVjAh3Sx85wF1GTgic5ld9pZaFIdF22pHE2Zq+aExNizLzr5jeV++l5CT5lrsRKb3zS1XtaDfAm2B+hbQixYKOER1H/3HN9NF4soW+xGW3LCvrQRpmdnRBHg0Vrd1s14sPd2vYuwC2rFMTZgqoEEjj9IxZnPX3M+0TUQOLoMr/EZZPh1RSNFv6Bhutq5dJCKMxmC0kiRyahxWnVP3Vi8DI9qMmLrUMW6OYi1hIrcg9ZEW1kNZgZlsJAHPdpyRJCdRovi9Ach1r+48Ru4P0YQ0POPFu76hkcFL6038VKAxvv5BrdBd49dfDd1IKrDUBtDjfgvUczLgbe1zihrVtTNmMJSK/04/gEt/Z2dcvfriZZb+3nl3GSmM8prfK47a9Q2BP4jFi/NuUFwTbz4UCQyn91wz2Qe7UVssEbpjlg7UYLlVK2E2ojgxjxIWoDJ5li1DIJpAgc4nvCQDcP2yelUzefy2/dK+Rto84VOgMWwWjD/1Wk8J24bEJ/pBtTGv/o0nzt0UPzRhRjTN1jsZELpevB9VPGdqUIqBk9YcbWYLag/KGSl0uDN6YtAvOCBEl4J/agTUcz1y6o9VlcpsG++O20Y89wMGNHayFWRaZtIaZ9zfawR+VZ/e438srG4qq5Jex2qfA7VEws3lBZsGu1Qm2+sw0i0NAkUotJzFI7mhIQCWhTSsiBBe4wU4fakuS0hNYg706UMLaTQTY5v54ZugbXGxzCmRH+tk/YY0cxsxKlm3QWqWC7lBKVw7VOk3l5stt1hgdd452nmfT8Ss+/arTetZWK7oJX25u8xkrtT07jm2JntgccPSA6YuHjvjqkWdwnDlD23NkSqvWyQEMJ8CXTfLDERjlm+vRTUpL/1SnJMECHRQoVdNuepUZVFreAcwd1yCLoxYGBSsD3YENqt+q+grlA6vlbzYb7LV3MPlPg6QI+3uRioJk/wYcOtolQXPiaCwWYXYrtyeBeQ8gw66N9BhhL1AsmnWKJqHZsQmus9HBHSLNWKsoogrTDdpU+ov8XEfWD3L9ev/+ttpZc6Gii+KcbmLIcp78yhq4UmMbxUqr5biN7o95CKFjKAAt+/QaMl2hGGsMpzvXWZ/b0yxyr2URg2MUy6aBmme/jiJ+lpbD7IbMNWl+QgqRj1SXmiG6qnJ4dwRQmZ3k" />
+<input type="hidden" name="__VIEWSTATE1" id="__VIEWSTATE1" value="9WMqaEUgHrkHvY89BMFJrCwqwOR6q6Dkar4wDdpmEGzLIYriPUIzrPX0z5y8xiT7ld8nK66XykAFUTg+3kUpTkDDyAASt+rmmzsM6vIVh4ripAFqq7UMcCc+95upR4PbMqtgcEiFD+nCsaG8gd41vWdXJa0+t2uLvhkmW02ruFRa0ua5xiLNcLZsjCBQt9JmnOE+dbKVee928vWUVfOS3u3KFcEtYf5gewgMBPvBfKuDjNn08IaOEViPmbV6fKaDhhgwymeF97a9elJSjSyIQ2b46vKBPsCxWplEDxWgnXJll165qJXOT4HakYrC3kH3Bmb9exyUJknCbb85iK0+Tm3zZysAnldlrb1L0TDlPHZZxewIsn0FXBfX8vL5d7idlLgTEyTtAHlX0V1jx9qmjVzZkW5TuYQy0Imkmf+OB48sV3LPo5mbSpN+l29ooX1Sbm0H0VWCjZIHz861MqfXHt/RJXRpPFzVjGY+1/l3x8U7o4pUI0amUNQHmAOGqqS3G8pAvrHmYCkk/WpIkZGGXus1RVu0BkkyryS7wD/HXnT3uHI9JVt6/jmDfSmEohgerlzSDHZAR6EBBCblS8Snf4V3UD5QwfJ1DMCb8cIXKASZr8YyelQF1yKr2tuTiSeTFedo9Ca3T4VrakaC6oibifyV70buNjObhOqPZTXLqAgCY8lUfrTDgvRbdlbBkYvDcMv0LyqgYdCzQi2OybBYGS0l7CBA+JqrNW9KW3YXoRrkrn35wTdRmTYgxWqc/rTXQOq4vIJYjBCe9517W74qzKb/6l/n+LCKzRtHRQXo310VC8xWTs2KPtFvvM/YD83ulD/FqCLx369tBRLYl86J/vJDxE8wt2fTPJzayXQJ74i/WxPW/8DqApWFjQ/KeQSoG9AoSoWoXi68m6Lum5fPxLsimqKqecJb874iDGaX+/Smhf53YiMn+RGVCT3xW9i+vJfkX0Epfa4ySddPnSXa7N0AiXHQzp4aEfbqe+H2xP6qGQU99AZvDdl1zKXNnmENy8HUm/UjEL4h1wFe64QJa+ngqUlnpxFW//1pSSz7rxUgdosDPpRqb0hDUS9nYiICRM7A/Tqy7ezfZ7TTFzXwF5vOHhdGYWRfjjQuS71yFhAwBl4y6ESgmEQnElz3GvJazPIuP3bNEKlniLkW1HW8pjTcp4JcMpqy4Y/zc6lDbCzGJONwKYrtgNYh+mDjG6LeP+N5FRHFAgNxQkCNczVzMDc/CawlN2JR0+rMI+GYyRErRm2KED/P3XO96PvrzpP34+Nm5638rNng3en68Q+58zkOkO4NaIsVIIOsaP9Zl1oW/QRRRW4oDqHUUsu//uIBY6njQo2lFLxFb3PSWSnDgPT9OjRaw7cJjYELJd2xXDgbpA94THMalRJDJe+77BNKcuQsmVUS6a4LsQIRtAv96k/2PfJaQzxH9Hk9c6C2VqBGyh+N860vqJuxHLpwYlNE9k4V4VIslbX1LKVqFXYUqutuDxv0qufwZsZUL8+QbtnNqDcR4Ra3huTOfD22eoIwGHxCI3ivYT5aLdpnvpdmLqnrOIbbtBzJwiE7v9ByY9OdW43vZz8P19knv9Z8d9gy2VN5KnleGCRLPud9oIzk/XLP950eIUnPT+FjecxLogpQyQ0G5dTh8wYe2bzgrCh3AqUi+PCDQXkKc783y5uIXLzos+PS27leoSbe1DIy8rOXasv/1VobRey1crHtZd1cKRpSYlOat1VKbpC5Dx8kWVBXtFNyeor46lhIL7eyvZMB3Yag/SdDDf3Tuxd5Njp7xyemtTbW0Gi4fKH6HFxx69npbEvyyk4MtwmS9DB4AMWhbe4Nh55TztSV23Y+H6CRJBF2cFcoEfn8q71iDnAvmFjZzg94FsBS402FM94c8og2xrheSC1ujtMDSIA0dAghGJ+C9gpx5/IXLC/ZNxPpD6P4YdNC2Dnf4tiFM7kuk0teb2clYlVRjkvd6ABgfz8EoM36HlV4lNEg3Yk+efKkQWJBpB8mN4VzZ0Q5S5e0x3Y3uhN8eQdcICJLLzkqPNLhpvma68m4An1elgRYjUeb/wDRb+Rxv+UODn9uVgqzs4KUDX16i0C4WiXbVNtzPP8BmWZxmV9Bi+S4WH4MdCFV3LZneXDgnihReNfJt3qVSM4ANbNrD8JFK5xovBzidVIwXhA1ClZv1cYJ+kTSTb3a1RGQnmaYVhlt1vyGSWbeFUiw/jUUWqvHj0a5mJ6M7EbpLMkPWvpqy1OB1w8qAWZn5suRg98gILR7Df942n5k7Gvl0sWVtv98oJa1vhj1M4aYBdVXsCCZ5pBJKZ4pzQfYhjB4lQy+I6lTsEd/eHT42iylQ7FKwJDlZ2okK7eL4P9VVRiq+BqTOlL7duZJYfP7ejamvpnwKQWdvDMqWq7D4BRkMSNIjlFKKxvpAS4UElvNLKMeNoGqF8GrHaq7t0nRYFb9BZYDMVsY7BAZdeipC+zCUFSvCzEFVjmTE1mPF8h/y/lfm4RRGK1WECmeddyWRWnR8MbLVGCdPh6Z3zD6rpnLg0WJuP4NVMzpwaLKL+zdY9KoFB+iuzwo5xd/fv0M8w8shAZxBbGxyZd/RAkipFF2kz1hFY9IFzYf/nRz9yyoOZMmZ12tBahTdJXBgqu/PehadHpKmuFQ8WqgOlo6f8Kv1vtBgLxLSyCP801U6VpCTNZcNc4hwlNVVKD7WpFBNnxrojeQvU3VMLM5fUwRBEA/5c0qDbCC0G+F8aZbZCwdiFaUSGoEIxEdjGkEVpsUp4SubAHd9M8SwEJLKqnzs7zCk3Rj2ULoDgJRC80caVTMV80Ef34UGmWvJ5NSV3X/yosqrMDDGhYsNd4K3XXctQ2RknBA938oPxUBQVjxvnGdgN6flPFe9jThVlXDfDBsY19dwjp0VJ2QnRCKJmJauIYGedMFTW6bD59RiglglhtFUwE3qojaVm+AGF6BPPjCHCv4q3ohelxvDJwP0zcZ20r9P/FBGelC/I2/MyiHhKOYyMeXHKmCCBbnbcJrYjNWqMCNVENSgmt8dKbp465qWKa0WQcnne9AseMK26KvQcummc3uYuVZyM3yKue7DvPh0LlcjnAz31R44bhjuUQdWbnJrWfxAaYiMLjGNTTMJwCQof0oGnlJskjCXoaW1TTq1zZCzS+m9pvHa6aKAnZR96KZrkpXHGGvrnTMo2UKIm8lvmFXI9Y/x7ntEu9REVedugCWaxYnQn43y3+87TtBmWL7oNu8aKo8VEMde7rDKBAKXHTmCTcCoIcorqlnsZHB+A0JJxcMzX9SZJKZe2jl/z8j5TjYzQdjjH6np9+cAf+7ARrWG5ZJt2q2D4a9hKbtlWztce8BoThbjfUppHAb6Cbf6USFpKsGPjgdZK61aBhxnzkNFShwBaYgQwaBUuczFHs2FvMWueeaNDJDcnsJOV6aySqjkhqbr2Dn1cBnZSYhfVWyY0RrNA/RCd19xVD+B4Lw8qNlsxpbGfOjjunMC32G32PU6BIs0rUXSyXUqSvL3gt0cgA1JXcPjeiKFDxAo9Z1zKM2rNZLnqR6+MPIGFg6Sa0aSPmJi/i3rsFLwAitiCw2m9CVSyIUkKpySzY6nz8YiAnGGD5s35bBlWK9PcodcFoQ0X+IQXjD4ahGLqTdL4wlOLNgxNM4ZfQMufygUNyvo6eFfrLQAkdWJBm+iTnWDy01+FvRbfCZGn4w/KgSPXNNRkrhEDBrlkNw+MhgipGYpuTt/+ly2t4LtuLYp91n57AT1mTlapIYQW2ofiFZ5w9fqX9Kv2UtlQ0BJ3Q5kFuL2zAWup1bim+OlrhTIkL7nBjMo02Fbl7A8o+VovjXwXVQ8X2lVdtN2WIcRf0Kln47JNpw3HADaNQ5znBvBiwSJBP2Eq2Bg09PZ039dB8MOI1CvS0gI4hboEKBeqYadO4szq2G5dLXtQIVU8sZdhoJ6xRsksB9Hrozi15Su9JSijYZdxoqBA573b/EbgD8v4qe++Nj1IYzR7UKYKoefZh5voVCH8bsPo/be23rdszwdjxXJi0jj1jxJJfSS7KEEyhO8SzD1TwEQKjfLwLDdiPsXpmxziWbYMOLWXtxg4LCOQYRaUFGoZgu2L0GUCUZlt6CXQjNxz1DbaxsGjYlZKZtKJRHEAxkwpwZC25AHk+D+ZQAQkng/0uXmGcjsCAM4u6Wbo5xPUrJE+Zo1gS8IuI5mRm40DeBiOt3JCrCnEgTr29kQpSgowv8HGYypvh223YksUCstg08Vl8aTQncp7GCT5qxdqkcWXfAETmnicTRNGGcxc7A0zWMxp7rZ9f6JlGdLgPxivSAReIKyKdKCp0MaHtLu9zdCvp1G+lep59b6enYBiIeVCnRLdnaCdB9n5ndQePsHw4YeU0CIdSVSdn/kQwmYOo5mrkEVCQ+XgpGEiAlMgc89fa+Cl32lQCx4/vXIyS+k28nKR4xYfnIZ5WvRp8XVjtdtw8mZ+/E7iSBhNIjdxz5tcGyq6igWqLG1w8K0W9b2cTCdMqEv0rrQQGKtDlvw7Xhk3O2bdrNBmsVpjmbaqJg8WddvdLEyLXX0npPB3xd5z3lKR1hP5zYj6zpADqRDNmvdVsBMgNqCBuctiCGxaPmVxgfgxiHzz9yfq3ZwFYha0kz7F0SpdtNJxPsj0I+1NUZTB8jng18m6lmpVrbf7ZbcpE92uFnHuEhbLvYO+CgxXQjYF/CYcrYiE4KlQucqPINTplijxYcp33xf4vSj3sWu4suo5y++Mf//F/aKapoyDUiQig3o2pK34W86ZDm72hnIlGo8FXRX5hFSjnnUWV9ptZMVkSmB2T82oMEy+0XiLf+AtEo2r8SrmIXoQO2j2yAiM8UBzNFKaPEVVxfHYfY+lXEAnK5KdcLPu9s81/w7UNZL1GENYw8RMw7pABsxmQP9rkkdl8lvEOAEbdLiGLNHXNSUiDcigtxUUKqDFsp0CgvezDDqt27Zo/gkNB95tNl1X7aDkjARH/gnROma474fhg+7la505sAW6hemLDtsX0iJWhg9ePKXnXHcNMoYJvfNtAZnfAxrNL0/0JTaMM9xTGrKJrC73Cx5UN8oPYtFSZVnjOZ1CLETs/I5NinZQ53OjIa6yny6mRO" />
+<input type="hidden" name="__VIEWSTATE2" id="__VIEWSTATE2" value="1cf7UURnMzii16CebtjOyc+yAgb0K3+HBsiX7LVP+ls6XTqLDc8HC5wN/4LHqbPvQ2iFijDcEg8c2VyFyd1z514ylij5re/qABbCjDPunOfJlzanoOSjYkWHGf6aDb+o95g84SGMBGdE6rdn5XFQd/nUR/YYiKcG43PZiqK8XtEssLBJR+7Cic1A84i9sh7/0LzeGpRDUO3xMP4oIHeKkrPOksPqWsxX8MmVA54T20NMPTnQlq2Sv9XRfTTVyEnNkW2ht3AO4UEVuiGTl6sbskTJavodBIeGnY8VLfa4f7cnLNUO3t8DCkzybw9TUNMXU9j1QHd/kxurAGVpWzdRi+NJJ1tMS4M5O+qZSYqDTC8EZiNCbcgQ1krF5sDJosnRGHvxiAPsoQBsvL5x1Fvz3LSCedVCP/IJUr+IJ0OHFdBqvFjBFOKRpYyAgy/FVyjziKuVBKliJaUSqtOzSSgOR4ws0DISOb7OAAO9UGgRaYppIis4cvSEZf9sisFQcmimd/gcMTzjr1HV/PoZWJ9fwpGRnDELnUETfjd/1uQiw898xBx63LtZnHi5y1zBapKZd8xPWdpmPAqqF2s2NlJGcVkvAJLWVEH3zJTZCZJ8H3JBPb8Q+kLI9iRuWLD4jhLRJJjkyULKVRp0XSdfQHg2IxCOaBQ/aErzdbHp28QGnaVXWg8bWAm8hRnqyjWcmMBQo6FZBZfiwlSUwtv3vaA1lec74mbkeiBlPnrW0iMode5DcmJJC+d3AcEJ6bHKovK1QVF8Yn9xjPdl+Mm6HM97LHwWYcHmBl30Pt0S86ZGVKQUsZr0uFF7Vo4EUKC53YhPwraRQQ==" />
+</div>
+
+<script type="text/javascript">
+//<![CDATA[
+var theForm = document.forms['aspnetForm'];
+if (!theForm) {
+    theForm = document.aspnetForm;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
+    }
+}
+//]]>
+</script>
+
+
+<script src="/WebResource.axd?d=pynGkmcFUV13He1Qd6_TZETFLbdR8wwRMdub1eDU5ILCHE7OhotblLUuaNwx3HQ7rYen0g2&amp;t=636283241079212703" type="text/javascript"></script>
+
+
+<script src="/ScriptResource.axd?d=uHIkleVeDJf4xS50Krz-yEJRbXY2x1dOBEdM7W-QkNpgaumdwaefPzMErSeG_W29-lHX6vl5G7uDafHaYWCx8Z9aLlo8tZwVtV42ISp6LhT6LbxuVUWMo5GyApWAyPOqkSkf1vCyntgT-PmPv-C6FWxsbWo1&amp;t=ffffffff824935cd" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=Jw6tUGWnA15YEa3ai3FadDbNvwkajNGIHz7aGm4w_MLRMuZ5hwlk3bfOsTs3E4cZZ4ktnTFE_MzciTx4exD15JXabrPKGazf6xj6fW1A8vXJoc3OCqf4cg_BDlVl8fQEsQiziDh4kHnJRWZEQotwuLoezlg1&amp;t=ffffffff824935cd" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=5Vlco-tkaLydA6UKPHa9ZOL0yHQrXU3CW9sDMmK8wAZAD42oSbnRnWZYxxGuBAFiLA_Y9p1dD1l9ilrxPux1jWHrJqOiuNOwu0S9gJOWhgVajPrMuVOZ-9UuhBpXVBtU8zv2w_-531-wxyzCxLzmbM7sDsU1" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=fmtDho8qPAtutRWiK9rge81s5q8GEAgUNw5c-RC8zcgBzegTYokNp2Gm1G1izD44tI8Iz9RR22_3zbjKkV62FL81Vhcwf9PiRZ1b2IN4lWH5h-RUVO3Rv0xq4E8UpS3uC9wuLlQS_GVO5yw4jnbnQQJGdvcq5PdZoXeCnt6BYCzTxP7xQ3kcQYola6VTulxFjMO69GrwFE5u12CDhhZF76BqXlTNRV-kzRj0S_rtQk5_KiIkuOdAP0cgaBpP-Njozw1CpDm9eSUmJEjFCDZJeJnemef4PjVjbQRVc1Gnj2kSs_v1zTVi5ByeJNWvYJLHFNPc6odfgkZZy0218kC2POl5Zo5h-xAa47oMJ9omKkvbRgALV__kHDsirQ815btCE1veHfykm5yGniRoyEuOEY7i6eLe9HfS-T5KQLTnQxNE_HFO70JC4HhzmSZSHxDm73UuDtrfpZ1jqSnMDDNI6APuxXeKTgTxIkQAydsW7gB3GnA08BKbUjJ8bm4rln1bkCeoqh7oI8l_pJq-xuM8DZ0UpUK8KxGsprX_21n9ZFWgsCboHbV8yMLLJlDtDxIvYCzxOElwjWRZ4nzDnvFa1nyv5gvwYWkFu3vrDcyDAQ6nMr236M11E0UCW8V9tt2ZDjO1rqRkRpZpWOb7PHkXgHvSNKUKQSo0L0nYhChY9XUrGW-G0" type="text/javascript"></script>
+<script src="../seek/js/cachedetails.js" type="text/javascript"></script>
+<script src="../js/latlng.js" type="text/javascript"></script>
+<div class="aspNetHidden">
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="C05D5804" />
+	<input type="hidden" name="__SCROLLPOSITIONX" id="__SCROLLPOSITIONX" value="0" />
+	<input type="hidden" name="__SCROLLPOSITIONY" id="__SCROLLPOSITIONY" value="0" />
+</div>
+    <script type="text/javascript">
+//<![CDATA[
+Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnetForm', [], [], [], 90, 'ctl00');
+//]]>
+</script>
+
+
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N3KS8V2"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    <a id="ctl00_hlSkipLinksContent" accesskey="-" title="Skip&#32;to&#32;Content" class="visually-hidden" href="#Content">Skip to Content</a>
+    
+    <!--[if lte IE 8]>
+        <div class="WarningMessage PhaseOut">
+            <p>Geocaching is phasing out support for older browsers. Visit the <a href="http://support.groundspeak.com/index.php?pg=kb.page&id=215" title="Browser Support Information">Help Center</a> for more information.</p>
+        </div>
+    <![endif]-->
+    
+    
+    <div class="PrintOnly">
+        
+        <svg viewBox="0 0 196 29" height="29" width="196">
+            <use xlink:href="/images/branding/logo-geocaching.svg#gcLogo"></use>
+        </svg>
+        <hr />
+        
+    </div>
+    
+    <header id="ctl00_siteHeader">
+    </header>
+    
+    <nav id="gcNavigation">
+        <div class="wrapper">
+            <a href="../" id="ctl00_ctl23_HDHomeLink" class="logo" title="Geocaching" accesskey="0">
+    <svg viewBox="0 0 196 29"  class="icon icon-svg-fill white">
+        <use xlink:href="/images/branding/logo-geocaching.svg#gcLogo"></use>
+    </svg>
+</a>
+
+<ul class="menu">
+    <li class="attention-link-parent">
+        <a id="ctl00_ctl23_hlNavPlay" accesskey="2" class="dropdown" href="../play/search/">Play</a>
+        <ul class="submenu">
+
+            <li class="li-attention">
+                <a id="ctl00_ctl23_hlSubNavSearch" accesskey="f" href="../play/search">
+                    <svg class="icon icon-svg-fill charcoal" height="24px" width="24px">
+                        <use xlink:href="../ui-icons/sprites/global.svg#icon-spyglass-svg-fill"></use>
+                    </svg>
+                    <span>Search</span>
+                </a>
+            </li>
+            <li class="li-attention">
+                <a id="ctl00_ctl23_HyperLink1" accesskey="v" href="../map/">
+                    <svg class="icon icon-svg-fill charcoal" height="24px" width="24px">
+                        <use xlink:href="../ui-icons/sprites/global.svg#icon-map-no-border-svg-fill"></use>
+                    </svg>
+                    <span>View map</span>
+                </a>
+            </li>
+
+            <li>
+                <a id="ctl00_ctl23_hlSubNavHide" accesskey="h" href="../play/hide/">Hide a geocache</a></li>
+            <li id="ctl00_ctl23_liSubNavLogCache">
+                <a id="ctl00_ctl23_hlSubNavLogCache" accesskey="l" href="../my/recentlyviewedcaches.aspx">Log a geocache</a></li>
+            <li>
+                <a id="ctl00_ctl23_hlSubNavTrackables" accesskey="t" href="../track/">Trackables</a></li>
+
+            <li>
+                <a id="ctl00_ctl23_hlSubNavGeoTours" accesskey="g" href="../play/geotours">GeoTours</a>
+            </li>
+            <li id="ctl00_ctl23_liSubNavPocketQueries">
+                <a id="ctl00_ctl23_hlSubNavPocketQueries" accesskey="q" href="../pocket/">Pocket queries</a></li>
+            <li id="ctl00_ctl23_liSubNavFieldNotes">
+                <a id="ctl00_ctl23_hlSubNavFieldNotes" accesskey="n" href="../my/fieldnotes.aspx">Drafts</a></li>
+            <li id="ctl00_ctl23_liSubNavLeaderboard">
+                <a id="ctl00_ctl23_hlSubNavLeaderboard" accesskey="p" href="../play/friendleague">Friend League</a></li>
+        </ul>
+    </li>
+        <li class="mobile">
+        <a class="dropdown" href="/account/dashboard/">Account</a>
+
+        <ul class="submenu">
+            <li>
+                <a href="/account/settings" title="Settings"><!-- todo localize -->
+                    <span class="link-text">
+                        Settings
+                    </span>
+                </a>
+            </li>
+            <li>
+                <a href="https://www.geocaching.com/help" title="Help Center"><!-- todo localize -->
+                    <span class="link-text">Help Center</span>
+                </a>
+            </li>
+            <li>
+                <!-- if signed in -->
+                <button type="submit" title="@resource.SignOut" accesskey="s">
+                    <span class="link-text">SignOut</span>
+                </button>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <a id="ctl00_ctl23_hlNavCommunity" accesskey="3" class="dropdown" href="../forums/">Community</a>
+        <ul class="submenu">
+            <li>
+                <a id="ctl00_ctl23_hlSubNavVolunteers" accesskey="o" href="../volunteers/">Volunteers</a></li>
+            <li>
+                <a id="ctl00_ctl23_hlSubNavDiscussionForums" accesskey="d" href="../forums/">Discussion forums</a></li>
+            <li>
+                <a id="ctl00_ctl23_hlSubNavBlog" accesskey="b" rel="external" href="http://blog.geocaching.com/">Blog</a></li>
+            <li>
+                <a id="ctl00_ctl23_hlSubNavEvents" accesskey="e" href="../calendar/">Events</a></li>
+            <li>
+                <a id="ctl00_ctl23_hlSubNavGeocaching2Minutes" accesskey="y" href="../videos/default.aspx#cat=PL939C3CBDC2F2F385&amp;vid=1YTqitVK-Ts">Videos</a></li>
+        </ul>
+    </li>
+    <li>
+        <a id="ctl00_ctl23_hlNavShop" accesskey="4" class="dropdown" href="http://shop.geocaching.com/?utm_source=Geocaching&amp;utm_medium=Links&amp;utm_content=Header&amp;utm_campaign=Geocaching+Links">Shop</a>
+        <ul class="submenu">
+            <li>
+                <a id="ctl00_ctl23_hlSubNavShop" accesskey="s" rel="external" href="http://shop.geocaching.com/?utm_source=Geocaching&amp;utm_medium=Links&amp;utm_content=Header&amp;utm_campaign=Geocaching+Links">USA/Canada shop</a></li>
+            <li>
+                <a id="ctl00_ctl23_hlSubNavIntlRetailers" accesskey="i" rel="external" href="http://shop.geocaching.com/default/international-retailers/">International retailers</a></li>
+            <li>
+                <a id="ctl00_ctl23_SubNavBulkCodes" href="/account/orders">Bulk trackable codes</a>
+            </li>
+            <li>
+                <a id="ctl00_ctl23_hlBecomePremium" accesskey="m" href="https://payments.geocaching.com/?upgrade=true">Become a Premium member</a>
+            </li>
+            <li>
+                <a id="ctl00_ctl23_SubNavGiftMembership" href="https://payments.geocaching.com/gift">Gift a Premium membership</a>
+            </li>
+
+        </ul>
+    </li>
+</ul>
+
+            
+
+<ul id="ctl00_uxLoginStatus_divSignedIn" class="logged-in-user&#32;profile-panel&#32;detailed&#32;with-membership">   
+    
+       
+
+    <li class="messagecenterheaderwidget li-messages">
+        <a href="/account/messagecenter" title="Message center">
+            
+            <svg class="icon icon-svg-fill white" width="24px" height="24px">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="../ui-icons/sprites/global.svg#icon-message-center"></use>
+            </svg>
+        </a>
+    </li>
+    
+    <li class="li-user">
+        <a class="SignedInProfileLink li-user-info" href="/my/default.aspx" title="View Your Profile">
+            <span class="user-avatar">
+                <img id="ctl00_uxLoginStatus_hlHeaderAvatar" src="https://img.geocaching.com/avatar/d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png" />
+            </span>
+            <span class="user-name">kumy</span>
+            <span class="cache-count">353 Finds</span>
+        </a>
+        <button type="button" class="li-user-toggle dropdown">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="14px" viewBox="0 0 12 7" version="1.1"><title>Open Menu</title><g stroke="none" stroke-width="0" fill="nonme" fill-rule="evenodd"><g class="arrow" transform="translate(-1277.000000, -25.000000)"><path d="M1280.43401 23.3387013C1280.20315 23.5702719 1280.20315 23.945803 1280.43401 24.1775793L1284.82138 28.5825631 1280.43401 32.9873411C1280.20315 33.2191175 1280.20315 33.5944429 1280.43401 33.8262192 1280.54934 33.9420045 1280.70072 34 1280.8519 34 1281.00307 34 1281.15425 33.9422102 1281.26978 33.8262192L1286.07462 29.0018993C1286.30548 28.7701229 1286.30548 28.3947975 1286.07462 28.1630212L1281.26958 23.3387013C1281.03872 23.106925 1280.66487 23.106925 1280.43401 23.3387013Z" transform="translate(1283.254319, 28.582435) scale(1, -1) rotate(-90.000000) translate(-1283.254319, -28.582435) " /></g></g></svg>
+        </button>                       
+        <ul class="submenu">     
+            <li>
+                <a title="Edit&#32;Account&#32;Settings" href="/account/settings">Settings</a>
+            </li>  
+            <li>
+                <a href="https://www.geocaching.com/help">Help Center</a>
+            </li>                                        
+            <li>
+                <button type="button" AccessKey="s" class="sign-out">
+                    Sign Out
+                </button>
+            </li>
+            
+              
+        </ul>
+    </li>                
+</ul>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        var $formLogout = $('#form-logout');
+        $formLogout.find('input').val(window.location.href);
+
+        $('.sign-out').bind('click', function () {
+            $formLogout.submit();
+        });
+    });
+</script>
+        </div>
+    </nav>
+
+    <section id="Content">
+        
+    
+
+        
+        
+        <div class="container">
+            
+
+            <div id="divContentMain" class="span-24&#32;last">
+	
+                
+    
+    
+    
+    
+    <div id="ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoLinkPanel" class="CoordInfoLinkWidget">
+		
+    <p>
+        <a href="#" class="CoordInfoLink">
+            <span id="ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode" class="CoordInfoCode">GC5BRQK</span>
+            <span class="arrow">&#9660;</span> </a>
+    </p>
+
+	</div>
+<div id="dlgClipboard">
+    <input type="text" class="TextFormat" />
+    <a href="#" onclick="$('#dlgClipboard').hide();return false;" title="Close" class="Close">
+        x</a>
+</div>
+<script type="text/javascript">
+    $("a.CoordInfoLink").click(function (e) {
+        e.preventDefault();
+
+        $("#dlgClipboard")
+                    .show()
+                    .position({
+                        of: $("a.CoordInfoLink"),
+                        my: "right top",
+                        at: "right bottom",
+                        offset: "0 5"
+                    })
+                    .find("input")
+                        .val('https://coord.info/' + $('.CoordInfoCode').text())
+                        .focus()
+                        .select();
+
+        $(document).mouseup(function (e) {
+            if ($(e.target).parent("div#dlgClipboard").length == 0) {
+                $(this).unbind(e);
+                $("div#dlgClipboard").hide();
+            }
+        });
+
+        return false;
+    });
+
+ 
+</script>
+
+    
+    <div class="span-17">
+        
+        <div class="span-17 last BottomSpacing" id="cacheDetails">
+            <p class="cacheImage">
+                <a href="/about/cache_types.aspx" target="_blank" title="About Cache Types"><img src="/images/WptTypes/2.gif" alt="Traditional Geocache" title="Traditional Geocache" /></a>
+            </p>
+            
+            <h2 class="NoBottomSpacing">
+                <span id="ctl00_ContentBody_CacheName">Chemin de l'Escourachie</span>
+            </h2>
+            <div class="minorCacheDetails Clear">
+                <div id="ctl00_ContentBody_mcd1">
+                    A cache by <a href="https://www.geocaching.com/profile/?guid=f8690ec6-6e92-41fc-86dc-8d7991634c6c&wid=a9493b25-e4af-4677-81b3-4dd63d44caa4&ds=2">kumy</a>
+                    <span class="message__owner">                        
+                        <svg width="25px" height="12px" viewBox="0 0 25 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+                            <title>Send Message to Owner</title>
+                            <defs>
+                                <path d="M1.98946751,1.37469233 L15.0220577,1.37469233 L8.61273139,7.72639296 C8.55386063,7.78494241 8.4576646,7.78494241 8.39849038,7.72639296 L1.98946751,1.37469233 L1.98946751,1.37469233 Z M12.4435791,8.38476934 L14.966525,10.8853188 L1.964584,10.8853188 L4.48783329,8.38476934 C4.65170035,8.22253857 4.65170035,7.95937098 4.48783329,7.79714021 C4.32396623,7.63460449 4.05874436,7.63460449 3.89487729,7.79714021 L1.40956019,10.2598765 L1.40956019,1.97543409 L7.80553438,8.31402209 C7.99853336,8.50552758 8.25222385,8.60128033 8.50561088,8.60128033 C8.75930137,8.60128033 9.0126884,8.50552758 9.20568739,8.31402209 L15.6016616,1.97543409 L15.6022685,10.3397721 L13.0365351,7.79714021 C12.8726681,7.63460449 12.6074462,7.63460449 12.4435791,7.79714021 C12.2797121,7.95937098 12.2797121,8.22253857 12.4435791,8.38476934 L12.4435791,8.38476934 Z M15.6016616,0.266521981 L1.40956019,0.266521981 C0.792934505,0.266521981 0.291319221,0.763582427 0.291319221,1.37469233 L0.291319221,10.8853188 C0.291319221,11.4964287 0.792934505,11.9934892 1.40956019,11.9934892 L15.6016616,11.9934892 C16.2185907,11.9934892 16.720206,11.4964287 16.720206,10.8853188 L16.720206,1.37469233 C16.720206,0.763582427 16.2185907,0.266521981 15.6016616,0.266521981 L15.6016616,0.266521981 Z" id="path-1"></path>
+                            </defs>
+                            <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                <g transform="translate(-346.000000, -201.000000)">
+                                    <g id="Message-this-owner-+-Send-Message" transform="translate(346.000000, 200.000000)">
+                                        <g id="Send-Message" transform="translate(0.000000, 1.000000)">
+                                            <g id="Group-3" transform="translate(7.889896, 0.000000)">
+                                                <mask id="mask-2" fill="white">
+                                                    <use xlink:href="#path-1"></use>
+                                                </mask>
+                                                <g id="Clip-2"></g>
+                                                <path d="M0.291319221,0.266521981 L16.720206,0.266521981 L16.720206,11.9934892 L0.291319221,11.9934892 L0.291319221,0.266521981 Z" id="Fill-1" class="message__owner-fill" mask="url(#mask-2)"></path>
+                                            </g>
+                                            <path d="M8.60726915,3.48857147 L5.00371108,3.48155774 C4.77338682,3.48094785 4.58433278,3.66787917 4.58038784,3.89902752 C4.5770498,4.13017588 4.76033815,4.31802203 4.99035895,4.31832698 L8.53383243,4.32534072"  class="message__owner-fill" ></path>
+                                            <path d="M8.60726915,5.93331601 L3.21391862,5.92630227 C2.98389781,5.92569238 2.79454032,6.11262371 2.79089883,6.34377206 C2.78725734,6.57522536 2.97084914,6.76276657 3.20056648,6.76307152 L8.53383243,6.77008525"  class="message__owner-fill" ></path>
+                                            <path d="M8.60726915,8.37806055 L0.576569292,8.37104681 C0.34654849,8.37043692 0.157190996,8.55736824 0.153549506,8.78882154 C0.149908016,9.0199699 0.333499817,9.20751111 0.563520618,9.20781605 L8.53383243,9.21482979" class="message__owner-fill" ></path>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </svg>
+                        <a id="lnkMessageOwner" href="/account/messagecenter?recipientId=f8690ec6-6e92-41fc-86dc-8d7991634c6c&amp;gcCode=GC5BRQK">Message this owner</a>
+                    </span>
+                </div>
+                <div id="ctl00_ContentBody_mcd2">
+                    Hidden
+                    :
+                    08/27/2014
+                    
+                </div>
+                <div>
+                    
+                </div>
+            </div>
+        </div>
+        <div id="ctl00_ContentBody_diffTerr" class="CacheStarLabels&#32;span-6&#32;BottomSpacing">
+            
+            <dl>
+                <dt>
+                    Difficulty:</dt>
+                <dd>
+                    <span id="ctl00_ContentBody_uxLegendScale" title="(1&#32;is&#32;easiest,&#32;5&#32;is&#32;hardest)"><img src="/images/stars/stars1.gif" alt="1 out of 5" /></span>
+                </dd>
+            </dl>
+            <dl>
+                <dt>
+                    Terrain:</dt> 
+                <dd>
+                    <span id="ctl00_ContentBody_Localize12" title="(1&#32;is&#32;easiest,&#32;5&#32;is&#32;hardest)"><img src="/images/stars/stars1_5.gif" alt="1.5 out of 5" /></span>
+                </dd>
+            </dl>
+            
+        </div>
+        <div id="ctl00_ContentBody_size" class="CacheSize&#32;span-5">
+            
+            <p class="AlignCenter">
+                Size:&nbsp;<span class="minorCacheDetails"><img src="/images/icons/container/small.gif" alt="Size: small" title="Size: small" />&nbsp<small>(small)</small></span>
+            </p>
+            
+        </div>
+        <div class="span-6 right last">
+            
+            
+                <div class="favorite right">
+                    <a id="uxFavContainerLink" href="javascript:void(0);">
+                        <div class="favorite-container"><!-- TODO! -->
+                            <span class="favorite-value">
+                                1 
+                            </span>
+                            Favorites
+                        </div>
+                    </a>
+                    <div class="favorite-dropdown">
+                        
+                        <ul>
+                            <li class="favorite-score">
+                            </li>
+                            <li>
+                                <a id="hlViewWhoFavorited" title="View&#32;Who&#32;Favorited" href="/seek/cache_favorited.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4">View Who Favorited</a>
+                            </li>
+                            <li>
+                                <a id="hlAboutFavorites" title="About&#32;Favorites" href="http://support.groundspeak.com/index.php?pg=kb.page&amp;id=287" target="_blank">About Favorites</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            
+            
+        </div>
+        
+        <p class="Clear">
+
+            
+
+        </p>
+        
+        
+        
+        <div id="ctl00_ContentBody_CacheInformationTable" class="CacheInformationTable">
+            <div class="LocationData FloatContainer">
+                <div class="span-9">
+                    <p class="NoBottomSpacing">
+                        <a id="uxLatLonLink" title="Correct&#32;these&#32;coordinates" class="edit-cache-coordinates" href="../seek/#">
+                            <strong>
+                                <span id="uxLatLon">N 43° 41.618 E 006° 51.656</span>
+                            </strong>
+                        </a>
+
+                        <br />
+                        <span id="ctl00_ContentBody_LocationSubPanel">
+                            UTM: 32T E 327620 N 4840069<br />
+                        </span>
+                    </p>
+                </div>
+                <div class="span-7 last AlignRight">
+                    <span id="ctl00_ContentBody_Location">In Provence-Alpes-Côte d'Azur, France</span><br />
+                    <span id="lblDistFromHome"><img src="/images/icons/compass/SE.gif" alt="SE" style="vertical-align:text-bottom" />&nbsp;SE 1.1&nbsp;km from your home location</span>
+                </div>
+            </div>
+            <div class="DownloadLinks">
+                <dl id="Print">
+                    <dt class="label">
+                        <span id="ctl00_ContentBody_uxPrintHeader">Print</span>:
+                    </dt>
+                    <dd>              
+                        <a id="ctl00_ContentBody_lnkPrintFriendly" href="../seek/cdpf.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4" target="_blank">No Logs</a>
+                        <a id="ctl00_ContentBody_lnkPrintFriendly5Logs" href="../seek/cdpf.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4&amp;lc=5" target="_blank" style="display:inline-block;">5 Logs</a>
+                        <a id="ctl00_ContentBody_lnkPrintFriendly10Logs" href="../seek/cdpf.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4&amp;lc=10" target="_blank" style="display:inline-block;">10 Logs</a>
+                        <a id="ctl00_ContentBody_lnkPrintDirectionsSimple" class="DrivingDirections" href="http://maps.google.com/maps?f=d&amp;hl=en&amp;saddr=43.699108,6.849461&#32;(Home&#32;Location)&amp;daddr=43.693632,6.860931&#32;(Chemin%20de%20l%27Escourachie)" target="_blank">Driving Directions</a>
+                    </dd>
+                </dl> 
+                <dl id="ctl00_ContentBody_uxPrintPDFSection" style="display:&#32;none;">
+                    <dt>
+                        PDF:
+                    </dt>
+                    <dd>
+                        <a id="ctl00_ContentBody_lnkPDFPrintNoLogs" href="javascript:pl(0);">No Logs</a>
+                        <a id="ctl00_ContentBody_lnkPDFPrint5Logs" href="javascript:pl(5);">5 Logs</a>
+                        <a id="ctl00_ContentBody_lnkPDFPrint10Logs" href="javascript:pl(10);">10 Logs</a>
+                    </dd>
+                </dl>
+                <dl id="Download">
+                    <dt class="label">
+                        <span id="ctl00_ContentBody_uxDownloadLabel">Download</span>:
+                    </dt>
+                    <dd>
+                        <a id="ctl00_ContentBody_lnkDownloads" title="Read&#32;about&#32;waypoint&#32;downloads" href="/software/default.aspx">Read about waypoint downloads</a>
+                    </dd>
+                    <dt></dt>
+                    <dd>
+                        <input type="submit" name="ctl00$ContentBody$btnLocDL" value="LOC&#32;waypoint&#32;file" id="ctl00_ContentBody_btnLocDL" /><input type="submit" name="ctl00$ContentBody$btnGPXDL" value="GPX&#32;file" id="ctl00_ContentBody_btnGPXDL" /><input type="submit" name="ctl00$ContentBody$btnSendToGPS" value="Send&#32;to&#32;My&#32;GPS" onclick="s2gps(&#39;a9493b25-e4af-4677-81b3-4dd63d44caa4&#39;);return&#32;false;" id="ctl00_ContentBody_btnSendToGPS" />
+                    </dd>
+                </dl>
+            </div>
+        </div>
+        
+            <div class="Note Disclaimer">
+                <strong>
+                    Please note
+                </strong>
+                Use of geocaching.com services is subject to the terms and conditions <a href="/about/disclaimer.aspx" title="Read Our Disclaimer">in our disclaimer</a>.
+            </div>
+        
+        
+            <div class="Note PersonalCacheNote">
+                <strong>
+                    Personal Cache Note
+                </strong>
+                <img src="/images/icons/16/help.png" id="pcn_help" class="CacheNoteHelpImg" />
+                
+                <span id="cache_note"></span>
+            </div>
+        
+        <h3 class="CacheDescriptionHeader">Geocache Description:</h3>
+        
+        <div class="UserSuppliedContent">
+            
+            <span id="ctl00_ContentBody_ShortDescription"><font color="green">C'est Pâques, et les cloches sont passées... :)</font>
+<p>Trouvez les oeufs de Pâques cachés dans Saint-Vallier-de-Thiey - <u>Idéal pour les enfants !</u></p>
+
+</span>
+            
+        </div>
+        
+        <br />
+        <div class="UserSuppliedContent">
+            
+            <span id="ctl00_ContentBody_LongDescription"><p><a href="http://coord.info/GC5BRQK">Chemin de l'Escourachie</a><br />
+<a href="http://coord.info/GC5C1PJ">Chapelle Saint-Pons</a><br />
+<a href="http://coord.info/GC5QPBK">Le lavoir "Lou Valerenc"</a><br />
+<a href="http://coord.info/GC5QPA7">Chapelle Sainte-Luce</a></p>
+<p><img src="https://d1u1p2xjjiahg3.cloudfront.net/b085d560-8cf5-4c30-a2c3-84be9aae7b09.png" /></p>
+Petite cache sur le sentier de l'Escourachie.<br />
+<br />
+"Escourachie" signifie "Eau qui suinte". Ce petit sentier vous conduira à travers la forêt du domaine de l'Escourachie jusqu'au village de Saint-Vallier-de-Thiey. La cache se trouve à 200 pas du début du sentier... <!-- Piwik Image Tracker-->
+<img src="https://piwik.kumy.net/piwik.php?idsite=38&amp;rec=1&amp;action_name=Escourachie" alt="" style="border:0;" /><img src="https://piwik.kumy.net/piwik.php?idsite=42&amp;rec=1&amp;action_name=Escourachie" alt="" style="border:0;" /> <!-- End Piwik -->
+<p>Background Image: <a href="http://www.freepik.com/free-vector/easter-eggs-seamless-pattern_710997.htm">Designed by Freepik</a></p></span>
+            
+        </div>
+        
+        <p>
+            
+
+        </p>
+        
+        
+        <p id="ctl00_ContentBody_hints">
+            <strong>
+                Additional Hints</strong>
+            (<a id="ctl00_ContentBody_lnkDH" onclick="dht(this);return&#32;false;" title="Decrypt" href="../seek/#">Decrypt</a>) </p><div id="div_hint" class="span-8 WrapFix">
+            Fbhf ha gnf qr cvreerf.</div><div id='dk' style="display: block;" class="span-9 last">
+            <span id="ctl00_ContentBody_EncryptionKey" class="right"><div class="DecryptionKeyWidget"> <p class="WidgetHeader">Decryption Key</p> <p class="WidgetBody">A|B|C|D|E|F|G|H|I|J|K|L|M<br /> -------------------------<br /> N|O|P|Q|R|S|T|U|V|W|X|Y|Z</p> <p class="WidgetFooter">(letter above equals below, and vice versa)</p></div></span>
+        </div>
+        <div class="Clear">
+        </div><br /><br />
+        
+    </div>
+    
+    
+    <div class="span-6 prepend-1 last sidebar">
+        
+        
+<div class="CacheDetailNavigation NoPrint">
+    <div id="ctl00_ContentBody_GeoNav_foundStatus" class="FoundStatus">
+        <img src="/images/logtypes/48/2.png" id="ctl00_ContentBody_GeoNav_logTypeImage" />
+        <p>
+            <strong id="ctl00_ContentBody_GeoNav_logText">Found It!</strong>
+            <small id="ctl00_ContentBody_GeoNav_logDate"><a href="/seek/log.aspx?LUID=6b83bdb4-0628-42b3-88cc-784b4d4d2e27" title="View Your Log">Logged on: 08/27/2015</a></small>
+        </p>
+    </div>
+    <a href="/seek/log.aspx?ID=4557982&lcn=1" id="ctl00_ContentBody_GeoNav_logButton" class="btn&#32;btn-primary">Log a new visit</a>
+    <ul>
+        <li><a href="/seek/gallery.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4">View Gallery</a> (4)</li>
+        <li><a href="/my/watchlist.aspx?w=4557982">Watch</a> (0)</li>
+        <li><a class="btn-add-to-list" data-gcRefCode="GC5BRQK" href="/bookmarks/mark.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4&amp;WptTypeID=2">Add to list</a></li>
+        <li><a href="/bookmarks/ignore.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4&amp;WptTypeID=2">Ignore</a></li>
+    </ul>
+    <ul id="ctl00_ContentBody_GeoNav_adminTools">
+
+        <li><strong>Admin Tools</strong></li>
+        
+
+        
+
+        <li><a href="/hide/report.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4">Edit</a></li>
+        <li><a href="/hide/attributes.aspx?WptID=4557982">Edit Attributes</a></li>
+        <li><a href="/hide/wptlist.aspx?RefWptID=a9493b25-e4af-4677-81b3-4dd63d44caa4&amp;DS=1">Waypoints</a></li>
+        <li><a href="/seek/upload.aspx?id=4557982">Upload Images</a></li>
+
+        <li id="ctl00_ContentBody_GeoNav_uxArchivedLogType"><a href="/seek/log.aspx?id=4557982&amp;LogType=5">Archive</a></li>
+
+        <li><a href="/seek/log.aspx?id=4557982&amp;LogType=22">Disable</a></li>
+    </ul>
+    
+</div>
+
+
+<script type="text/javascript" src="../account/scripts/ui-js-core/public/vendor.js"></script>
+<script type="text/javascript" src="../account/scripts/ui-js-core/public/synced-lists-map.js"></script>
+
+
+<link rel="stylesheet" type="text/css" href="../map/css/lists.css">
+<script type="text/javascript">
+    var ListResources = {
+        'maxItemsInList': "Lists hold a max of 1000 caches. You have too many.",
+        'serverError': 'Something went wrong. Try refreshing the page.',
+        'badRequest': 'Something went wrong. Try refreshing the page.',
+        'saveSuccess': 'Saved!',
+        'maxSelectedForList': 'Lists hold a max of 1000 caches. You have too many.',
+        'isPremium': 'True'
+        }
+</script>
+<script id="loc_upsellcontent" type="text/html">
+    Lists are a Geocaching Premium feature. <a href="https://payments.geocaching.com">Upgrade Now.</a>
+                
+</script>
+<script type="text/x-handlebars-template" id="addMenu">
+    <div class="add-menu" style="margin:10px">
+        <label for="newListName" style="display:block;">Create a New List</label>
+        <div class="input-control">
+            <input type="text" class="" id="newListName" name="newListName" maxlength="150" placeholder="List Name "></input>
+            <div class="add-list-status" style="height: 38px; margin:0;">
+                <button class="add-list-submit event-tracking" type="button">
+                    Add
+                </button>
+            </div>
+        </div>
+        <p class="status-message"></p>
+    </div>
+    {{#if availableLists.length}}
+    <label class="add-list-label" style="margin:0 10px 3px">Add to an Existing List</label>
+    <ul class="add-list" style="margin:0 10px 10px">
+        {{#each availableLists.models}}
+            <li data-cid="{{cid}}">
+                <button class="list-item event-tracking" type="button" {{#if testFull}}disabled{{/if}}>{{attributes.name}}</button>
+                <span class="status {{#if testFull}}error{{/if}}" 
+                    {{#if testFull}}title="Lists hold a max of 1000 caches. You have too many." {{/if}}
+                ></span>
+                <p class="status-message">
+                    {{#if testFull}}Lists hold a max of 1000 caches. You have too many.{{/if}}
+                </p>
+            </li>
+        {{/each}}
+    </ul>
+    {{/if}}
+</script>
+
+<script type="text/x-handlebars-template" id="spinnerTemplate">
+    <div class="loading"></div>
+</script>
+        
+        
+        <div id="ctl00_ContentBody_detailWidget" class="CacheDetailNavigationWidget&#32;TopSpacing&#32;BottomSpacing">
+            
+            <h3 class="WidgetHeader">
+                Attributes
+            </h3>
+            <div class="WidgetBody">
+                <img src="/images/attributes/dogs-yes.gif" alt="dogs allowed" title="dogs allowed" width="30" height="30" /> <img src="/images/attributes/hike_short-yes.gif" alt="hike shorter than 1km" title="hike shorter than 1km" width="30" height="30" /> <img src="/images/attributes/attribute-blank.gif" alt="blank" title="blank" width="30" height="30" /> <img src="/images/attributes/attribute-blank.gif" alt="blank" title="blank" width="30" height="30" /> <img src="/images/attributes/attribute-blank.gif" alt="blank" title="blank" width="30" height="30" /> <img src="/images/attributes/attribute-blank.gif" alt="blank" title="blank" width="30" height="30" /> <p class="NoBottomSpacing"><small><a href="/about/icons.aspx" title="What are Attributes?">What are Attributes?</a></small></p>
+            </div>
+            
+        </div>
+        
+        
+        <div id="ctl00_ContentBody_uxBanManWidget" class="InlinePageAds">
+		
+            
+            <script type='text/javascript'>
+googletag.cmd.push(function() {{
+googletag.defineSlot('/1011121/cache_details_pg_250x250', [250, 250], 'div_e70aa94a-4115-47e1-822c-c93f601ee1da').addService(googletag.pubads());
+googletag.pubads().enableSingleRequest();
+googletag.enableServices();
+}});
+</script>
+<div id='div_e70aa94a-4115-47e1-822c-c93f601ee1da'>
+<script type='text/javascript'>
+googletag.cmd.push(function() { googletag.display('div_e70aa94a-4115-47e1-822c-c93f601ee1da'); });
+</script>
+</div>
+
+            <p>
+                <small><a href="../about/advertising.aspx" id="ctl00_ContentBody_advertisingWithUs" title="Advertising&#32;with&#32;Us">Advertising with Us</a></small> </p>
+	</div><div class="GoogleAds AlignCenter BottomSpacing">
+            
+        </div>
+        <div class="clear">
+        </div>
+        
+        <span id="ctl00_ContentBody_lnkTravelBugs"></span>
+        
+        
+<div class="CacheDetailNavigationWidget">
+    
+    <h3 class="WidgetHeader">
+        <span id="ctl00_ContentBody_uxTravelBugList_uxInventoryLabel">Inventory</span>
+    </h3>
+    <div class="WidgetBody">
+        
+        
+            <div id="ctl00_ContentBody_uxTravelBugList_uxNoTrackableItems">
+		
+                <p class="NoBottomSpacing"><span id="ctl00_ContentBody_uxTravelBugList_uxNoTrackableItemsLabel">There are no Trackables in this cache.</span></p>
+            
+	</div>
+            <div class="TopSpacing">
+                
+                <p class="NoBottomSpacing"><a id="ctl00_ContentBody_uxTravelBugList_uxTrackableItemsHistory" href="../track/search.aspx?wid=a9493b25-e4af-4677-81b3-4dd63d44caa4">View past Trackables</a></p>
+                <p class="NoBottomSpacing"><a id="ctl00_ContentBody_uxTravelBugList_uxWhatAreTrackables" title="What&#32;are&#32;Trackable&#32;Items?" href="../track/default.aspx">What are Trackable Items?</a></p>
+            </div>
+
+        
+    </div>
+    
+    
+</div>
+
+        
+        
+        
+    </div>
+    
+    
+    <div id="ctl00_ContentBody_bottomSection" class="span-24&#32;last">
+        
+        <p>
+            <span id="ctl00_ContentBody_WaypointsInfo" style="font-weight:bold;">Additional Waypoints</span>&nbsp;<span id="ctl00_ContentBody_addEditWptLink">(<a id="ctl00_ContentBody_uxAddEditWaypoints" href="/hide/wptlist.aspx?RefWptID=a9493b25-e4af-4677-81b3-4dd63d44caa4&amp;DS=1">Add / Edit waypoints</a>)</span> <br />
+            
+            
+<script type="text/javascript">
+    <!--
+    var checkflag = false;
+    function checkAll(obj) {
+        if (checkflag == false) {
+            checkflag = true;
+        } else {
+            checkflag = false;
+        }
+        var arrInput = document.getElementsByTagName("input");
+        for (i = 0; i < arrInput.length; i++) {
+            if (arrInput[i].type == 'checkbox') {
+                arrInput[i].checked = checkflag;
+            }
+        }
+    }
+
+    //  End -->
+</script>
+
+        <table class="Table" id="ctl00_ContentBody_Waypoints">
+            <thead>
+                <tr>
+                    <th scope="col" class="AlignCenter">
+                        <a href="javascript:checkAll(this);">
+                            <img id="ctl00_ContentBody_Waypoints_Waypoints_ctl00_imgCheckAll" title="Click&#32;to&#32;Check/Uncheck&#32;all&#32;Items" src="/images/icons/16/check.png" style="height:16px;width:16px;" /></a>
+                    </th>
+                    <th scope="col">
+                        &nbsp;
+                    </th>
+                    <th scope="col">
+                        &nbsp;
+                    </th>
+                    <th scope="col">
+                        Prefix
+                    </th>
+                    <th scope="col">
+                        Lookup
+                    </th>
+                    <th scope="col">
+                        Name
+                    </th>
+                    <th scope="col" id="wptCoordHeader">
+                        Coordinate
+                    </th>
+                    <th scope="col">
+                        &nbsp;
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+    
+        <tr class="BorderBottom " ishidden="false">
+            <td class="AlignCenter">
+                <span class="Checkbox"><input id="ctl00_ContentBody_Waypoints_Waypoints_ctl01_wptChk" type="checkbox" name="ctl00$ContentBody$Waypoints$Waypoints$ctl01$wptChk" /></span>
+            </td>
+            <td>
+                <img width="16" height="16" src="/images/icons/icon_viewable.jpg" alt="Visible" title="Visible" />
+            </td>
+            <td>
+                <img width="16" height="16" src="/images/wpttypes/sm/pkg.jpg" alt="Parking Area" title="Parking Area" />
+            </td>
+            <td>
+                <span id="awpt_PK">
+                    PK</span>
+            </td>
+            <td>
+                PK
+            </td>
+            <td>
+                <a href="https://www.geocaching.com/seek/wpt.aspx?WID=0ea1a383-5936-4423-9ef3-ba3641469621&RefID=a9493b25-e4af-4677-81b3-4dd63d44caa4&RefDS=1">Parking</a> (Parking Area)
+            </td>
+            <td>
+                N 43° 41.496 E 006° 51.741&nbsp;
+                
+            </td>
+            <td>
+                <a id="ctl00_ContentBody_Waypoints_Waypoints_ctl01_uxEdit" title="Edit" href="/hide/wptlist.aspx?WID=0ea1a383-5936-4423-9ef3-ba3641469621&amp;DS=1&amp;RefWptID=a9493b25-e4af-4677-81b3-4dd63d44caa4#edit"><img title="Edit" src="../images/icons/16/edit.png" alt="Edit" /></a>&nbsp;
+                <a id="ctl00_ContentBody_Waypoints_Waypoints_ctl01_uxMap" title="Map" href="../map/default.aspx?lat=43.6916&amp;lng=6.86235" target="_blank"><img title="Map" src="../images/icons/16/view_map.png" alt="Map" /></a>&nbsp;
+                <input type="image" name="ctl00$ContentBody$Waypoints$Waypoints$ctl01$uxRemove" id="ctl00_ContentBody_Waypoints_Waypoints_ctl01_uxRemove" title="Remove" class="Button" src="../images/icons/16/delete.png" alt="Remove" onclick="return&#32;confirm(&#39;Are&#32;you&#32;sure&#32;you&#32;want&#32;to&#32;remove&#32;this&#32;waypoint?&#39;);" />
+            </td>
+        </tr>
+        <tr class="BorderBottom ">
+            <td>
+                &nbsp;
+            </td>
+            <td>
+            Note:
+            </td>
+            <td colspan="6">
+                
+            </td>
+        </tr>
+    
+        <tr class="BorderBottom AlternatingRow" ishidden="false">
+            <td class="AlignCenter">
+                <span class="Checkbox"><input id="ctl00_ContentBody_Waypoints_Waypoints_ctl02_wptChk" type="checkbox" name="ctl00$ContentBody$Waypoints$Waypoints$ctl02$wptChk" /></span>
+            </td>
+            <td>
+                <img width="16" height="16" src="/images/icons/icon_viewable.jpg" alt="Visible" title="Visible" />
+            </td>
+            <td>
+                <img width="16" height="16" src="/images/wpttypes/sm/trailhead.jpg" alt="Trailhead" title="Trailhead" />
+            </td>
+            <td>
+                <span id="awpt_SE">
+                    SE</span>
+            </td>
+            <td>
+                1
+            </td>
+            <td>
+                <a href="https://www.geocaching.com/seek/wpt.aspx?WID=16032e89-60f2-4503-8c1e-d97b932c640a&RefID=a9493b25-e4af-4677-81b3-4dd63d44caa4&RefDS=1">Début du sentier</a> (Trailhead)
+            </td>
+            <td>
+                N 43° 41.556 E 006° 51.746&nbsp;
+                
+            </td>
+            <td>
+                <a id="ctl00_ContentBody_Waypoints_Waypoints_ctl02_uxEdit" title="Edit" href="/hide/wptlist.aspx?WID=16032e89-60f2-4503-8c1e-d97b932c640a&amp;DS=1&amp;RefWptID=a9493b25-e4af-4677-81b3-4dd63d44caa4#edit"><img title="Edit" src="../images/icons/16/edit.png" alt="Edit" /></a>&nbsp;
+                <a id="ctl00_ContentBody_Waypoints_Waypoints_ctl02_uxMap" title="Map" href="../map/default.aspx?lat=43.6926&amp;lng=6.86244" target="_blank"><img title="Map" src="../images/icons/16/view_map.png" alt="Map" /></a>&nbsp;
+                <input type="image" name="ctl00$ContentBody$Waypoints$Waypoints$ctl02$uxRemove" id="ctl00_ContentBody_Waypoints_Waypoints_ctl02_uxRemove" title="Remove" class="Button" src="../images/icons/16/delete.png" alt="Remove" onclick="return&#32;confirm(&#39;Are&#32;you&#32;sure&#32;you&#32;want&#32;to&#32;remove&#32;this&#32;waypoint?&#39;);" />
+            </td>
+        </tr>
+        <tr class="BorderBottom AlternatingRow">
+            <td>
+                &nbsp;
+            </td>
+            <td>
+            Note:
+            </td>
+            <td colspan="6">
+                
+            </td>
+        </tr>
+    
+        </tbody> </table>
+    
+<p>
+    <input type="submit" name="ctl00$ContentBody$Waypoints$btnDelete" value="Bulk&#32;Remove" id="ctl00_ContentBody_Waypoints_btnDelete" class="Button" />
+    <span id="ShowHideLink">|
+    <a id="ctl00_ContentBody_Waypoints_uxShowHiddenCoordinates" href="../controls/#">Show Hidden Waypoints</a>
+    <a id="ctl00_ContentBody_Waypoints_uxHideHiddenCoordinates" href="../controls/#">Hide Hidden Waypoints</a></span>
+</p>
+
+<script type="text/javascript" language="javascript">
+    var hiddenLinkCookieName = "hiddenlinks";
+
+    jQuery(function () {
+        var $ = jQuery;
+        var hiddenLinkCookie = jQuery.cookie(hiddenLinkCookieName);
+
+        $('#ctl00_ContentBody_Waypoints_uxShowHiddenCoordinates').click(function (e) {
+            setHiddenCoordState(true);
+            return false;
+        });
+
+        $('#ctl00_ContentBody_Waypoints_uxHideHiddenCoordinates').click(function (e) {
+            setHiddenCoordState(false);
+            return false;
+        });
+
+        if ($("#ctl00_ContentBody_Waypoints tbody tr[ishidden='true']").length > 0) {
+            $("#ShowHideLink").show();
+        } else {
+            $("#ShowHideLink").hide();
+        }
+        
+        if (hiddenLinkCookie == null || hiddenLinkCookie == "false") {
+            setHiddenCoordState(false);
+        } else {
+            setHiddenCoordState(true);
+        }
+
+    });
+
+
+
+    function setHiddenCoordState(show) {
+        var $ = jQuery;
+        if (show) {
+            $('#ctl00_ContentBody_Waypoints tbody')
+                    .find("tr.AlternatingRow")
+                        .removeClass("AlternatingRow")
+                        .end()
+                    .find("tr")
+                        .show()
+                        .end()
+                    .find("tr:even:visible")
+                        .each(function(i) {
+                            if (i % 2 == 1)
+                                $(this).addClass("AlternatingRow").next().addClass("AlternatingRow");
+                        })
+                    .end();
+
+            $("#ctl00_ContentBody_Waypoints_uxShowHiddenCoordinates").hide();
+            $("#ctl00_ContentBody_Waypoints_uxHideHiddenCoordinates").show();
+
+            $.cookie(hiddenLinkCookieName, "true");
+
+        } else {
+            $('#ctl00_ContentBody_Waypoints tbody')
+                    .find("tr.AlternatingRow")
+                        .removeClass("AlternatingRow")
+                        .end()
+                    .find("tr[ishidden='true']").each(function() {
+                        $(this).hide().next().hide();
+                    })
+                        .end()
+                    .find("tr:even:visible")
+                        .each(function(i) {
+                            if (i % 2 == 1)
+                                $(this).addClass("AlternatingRow").next().addClass("AlternatingRow");
+                        })
+                    .end();
+
+            $("#ctl00_ContentBody_Waypoints_uxShowHiddenCoordinates").show();
+            $("#ctl00_ContentBody_Waypoints_uxHideHiddenCoordinates").hide();
+
+            $.cookie(hiddenLinkCookieName, "false");
+        }
+
+        return false;
+    }
+</script>
+
+        <p>
+        <div id="uxlrgMap" class="FloatRight&#32;TopSpacing">
+		
+            <div class="PageBreakBefore">
+                
+            </div>
+            <div class="CDMapWidget">
+                <p class="WidgetHeader NoBottomSpacing">
+                    <a id="ctl00_ContentBody_uxViewLargerMap" title="View&#32;Larger&#32;Map" href="/map/default.aspx?lat=43.693632&amp;lng=6.860931" target="_blank">View Larger Map</a>
+                </p>
+                
+                <div id="map_canvas" style="width: 325px; height: 325px;">
+                </div>
+                <p class="WidgetFooter">
+                    <a id="ctl00_ContentBody_uxNotesAboutPrinting" href="#mapPrintingNotes" class="NoPrint">Notes about Printing Maps</a>
+                </p>
+            </div>
+            <div style="display: none;">
+                <div id="mapPrintingNotes">
+                    To print the map in Firefox and Opera, enable background images in the print dialog.
+                    <a href="#dlgMapPrintWarning" class="dialog" onclick="$.fancybox.close()">
+                        Close
+                    </a>
+                </div>
+            </div>
+        
+	</div>
+        
+        <p class="NoPrint">
+            <span id="ctl00_ContentBody_uxFindLinksHeader" style="font-weight:bold;">Find...</span>
+            <br />
+            <span id="ctl00_ContentBody_FindText"></span>
+        </p>
+        <ul class="NoPrint">
+            <li>
+                ...other caches <a href="/seek/nearest.aspx?u=kumy">hidden</a> or <a href="/seek/nearest.aspx?ul=kumy">found</a> by this user
+            </li>
+            
+                <li>
+                    ...nearby <a href="/seek/nearest.aspx?tx=32bc9333-5e52-4957-b0f6-5a2c8fc7b257&lat=43.693632&lng=6.860931">caches of this type</a>, <a href="/seek/nearest.aspx?tx=32bc9333-5e52-4957-b0f6-5a2c8fc7b257&lat=43.693632&lng=6.860931&f=1">that I haven't found</a>
+                </li>
+                <li>
+                    ...all nearby <a href="/seek/nearest.aspx?lat=43.693632&lng=6.860931">caches</a>, <a href="/seek/nearest.aspx?lat=43.693632&lng=6.860931&f=1">that I haven't found</a>
+                </li>
+                <li>
+                    ...all nearby <a href="http://www.waymarking.com/directory.aspx?f=1&lat=43.693632&lon=6.860931">waymarks on Waymarking.com</a>
+                </li>
+            
+            
+        </ul>
+        <p class="NoPrint">
+            <span id="ctl00_ContentBody_uxMapLinkHeader" style="font-weight:bold;">For online maps...</span>
+        </p>
+        <span class="NoPrint">
+            
+<ul>
+    <span id="ctl00_ContentBody_MapLinks_MapLinks"><li><a href="http://www.geocaching.com/map/default.aspx?lat=43.69363&lng=6.86093" target="_blank">Geocaching.com Map</a></li><li><a href="http://maps.google.com/maps?q=N%2043%C2%B0%2041.618%20E%20006%C2%B0%2051.656%20%28GC5BRQK%29+" target="_blank">Google Maps</a></li><li><a href="http://www.mapquest.com/maps/map.adp?searchtype=address&formtype=latlong&latlongtype=decimal&latitude=43.69363&longitude=6.86093&zoom=10" target="_blank">MapQuest</a></li><li><a href="http://www.bing.com/maps/default.aspx?v=2&lvl=14&sp=point.43.69363_6.86093_GC5BRQK" target="_blank">Bing Maps</a></li><li><a href="http://www.opencyclemap.org/?zoom=12&lat=43.69363&lon=6.86093" target="_blank">OpenCycleMap</a></li><li><a href="http://www.openstreetmap.org/?mlat=43.69363&mlon=6.86093&zoom=12" target="_blank">OpenStreetMap</a></li></span>
+</ul>
+
+        </span>
+        <ul class="CachePageImages NoPrint">
+            <li><a href="https://img.geocaching.com/cache/large/5a99fd4d-8f51-43ae-87a6-94da82d0ff34.png" rel="lightbox">c:geo logo</a> <span class="minorDetails"> | <a href="/seek/image.aspx?imgid=3653348" title="Edit">Edit</a></span><span class="description">the official c:geo logo&#13;&#10;(test picture)</span></li>
+        </ul>
+        
+            <div class="InformationWidget Clear">
+                <h3>
+                    66 Logged Visits
+                </h3>
+                <div class="EncryptDecrypt">
+                    <a href="#" class="decrypt-link">
+                        Decrypt
+                    </a>
+                </div>
+                <span id="ctl00_ContentBody_lblFindCounts"><p class="LogTotals"><img src="/images/logtypes/2.png" alt="Found it" title="Found it" /> 45&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="/images/logtypes/3.png" alt="Didn't find it" title="Didn't find it" /> 3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="/images/logtypes/4.png" alt="Write note" title="Write note" /> 16&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="/images/logtypes/24.png" alt="Publish Listing" title="Publish Listing" /> 1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src="/images/logtypes/46.png" alt="Owner Maintenance" title="Owner Maintenance" /> 1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p></span>
+                <p class="HalfLeft">
+                    <a id="ctl00_ContentBody_uxLogbookLink" href="../seek/cache_logbook.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4">View Logbook</a> | <a id="ctl00_ContentBody_uxGalleryImagesLink" DisplayFormatPlural="View&#32;the&#32;Image&#32;Gallery&#32;of&#32;{0:#,###}&#32;images" DisplayFormatSingular="View&#32;the&#32;Image&#32;Gallery" href="../seek/gallery.aspx?guid=a9493b25-e4af-4677-81b3-4dd63d44caa4">View the Image Gallery of 4 images</a>
+                </p>
+                <p class="NoBottomSpacing AlignRight">
+                    <span class="Warning">**Warning!</span> <a href="/about/glossary.aspx#spoiler" title="Spoilers">Spoilers</a> may be included in the descriptions or links.
+                </p>
+            </div>
+            
+            <div id="cache_logs_container" class="span-24">
+                <table id="cache_logs_table" class="LogsTable NoBottomSpacing">
+                    <tbody>
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td class="AlignCenter">
+                                <div id="pnlLazyLoad" style="display: none;">
+                                    <img src="/images/loading2.gif" class="StatusIcon" alt="Loading" />
+                                    Loading Cache Logs...
+                                </div>
+                                <div id="pnlButtonLoad" style="display: none;">
+                                    <a class="MobileButton">
+                                        Load More Logs...</a>
+                                </div>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+            <p>
+                <small>
+                    Current Time: <time datetime="2017-08-22T10:53:42Z">08/22/2017 10:53:42 Pacific Daylight Time (17:53 GMT)</time><br/>Last Updated: <time class="timeago" datetime="2017-08-22T17:40:16Z">2017-08-22T17:40:16Z</time> on 08/22/2017 10:40:16 Pacific Daylight Time (17:40 GMT) <br/>Last Found: <time class="timeago" datetime="2017-05-21T15:41:25Z">2017-05-21T15:41:25Z</time> on 05/21/2017 15:41:25 Pacific Daylight Time (22:41 GMT) <br/>Published By: <a href="https://www.geocaching.com/profile/?guid=11d66922-0273-45fa-9bac-cf439f724a8d" id="8176128">Repassaire</a><br/>Rendered From:Unknown<br />Coordinates are in the WGS84 datum
+                </small>
+            </p>
+            <div id="topScroll" class="TopScroll" style="display: none;">
+                <a href="#Top">&nbsp;</a> </div></div><script id="tmpl_CacheLogRow" type="text/x-jquery-tmpl">
+        <tr class="log-row" data-encoded="${IsEncoded}">
+            <td>
+                <div class="FloatLeft LogDisplayLeft">
+                    <p class="logOwnerProfileName">
+                        <strong><a id="143568283" href="/profile/?guid=${AccountGuid}">${UserName}</a></strong>
+                    </p>
+                    <p class="logOwnerBadge">
+                        <img title="${creator.GroupTitle}" src="${creator.GroupImageUrl}">${creator.GroupTitle}
+                    </p>
+                    <p class="logOwnerAvatar">
+                        <a href="/profile/?guid=${AccountGuid}">{{if includeAvatars && AvatarImage}}
+                                <img width="48" height="48" src="https://img.geocaching.com/user/avatar/${AvatarImage}">
+                            {{else includeAvatars }}
+                                <img width="48" height="48" src="/images/default_avatar.png">
+                            {{/if}}
+                        </a>
+                    </p>
+                    <p class="logOwnerStats">
+                        {{if GeocacheFindCount > 0 }}
+                            <img title="Caches Found" src="/images/icons/16/found.png">${GeocacheFindCount}
+                        {{/if}}
+                    </p>
+                </div>
+                <div class="FloatLeft LogDisplayRight">
+                    <div class="HalfLeft LogType">
+                        <strong>
+                            <img title="${LogType}" alt="${LogType}" src="/images/logtypes/${LogTypeImage}">&nbsp;${LogType}</strong>
+                    </div>
+                    <div class="HalfRight AlignRight">
+                        <span class="minorDetails LogDate">${Visited}</span>
+                    </div>
+                    <div class="Clear LogContent markdown-output">
+                        {{if LatLonString.length > 0}}
+                            <span class="WaypointLog">${LatLonString}</span>
+                        {{/if}}
+                            <span class="LogText">{{html LogText}}</span>
+                        {{if Images.length > 0}}
+                                <table cellspacing="0" cellpadding="3" class="LogImagesTable">
+                                    {{tmpl(Images) "tmplCacheLogImages"}}
+                                </table>
+                        {{/if}}
+                            
+                        <div class="AlignRight">
+                            <small><a title="View Log" href="/seek/log.aspx?LUID=${LogGuid}" target="_blank">{{if (userInfo.ID==AccountID)}}
+                                       View / Edit Log / Images
+                                    {{else}}
+                                       View Log
+                                    {{/if}}
+                            </a></small>&nbsp;
+                                {{if (userInfo.ID==AccountID)}}
+                                <small><a title="Upload Image" href="/seek/upload.aspx?LID=${LogID}" target="_blank">Upload Image</a></small>
+                            {{/if}}
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+    </script><script id="tmpl_CacheLogImages" type="text/x-jquery-tmpl">
+            <tr>
+                <td>
+                    <a class="tb_images lnk" rel="tb_images[grp${LogID}]" href="https://img.geocaching.com/cache/log/large/${FileName}" data-title="{{tmpl "tmplCacheLogImagesTitle"}}">
+                        <img title="Photo" alt="Photo" src="/images/icons/16/photo.png"> 
+                        <span>${ $('<div />').text($('<div />').html($item.data.Name.length != 0 ? $item.data.Name : $item.data.Descr).text()).html() }</span>
+                    </a>
+                </td>
+            </tr>
+    </script><script id="tmpl_CacheLogImagesTitle" type="text/x-jquery-tmpl">
+            &lt;span class=&quot;LogImgTitle&quot;&gt; ${ $('<div />
+            ').text($('<div />
+            ').text($('<div />
+            ').html($item.data.Name).text()).html()).html() } &nbsp;&lt;/span&gt;&lt;span class=&quot;LogImgLink&quot;&gt;
+
+                &lt;a target=&quot;_blank&quot; href=&quot;/seek/log.aspx?LUID=${$item.parent.parent.data.LogGuid}&IID=${ImageGuid}&quot;>View Log&lt;/a&gt;&nbsp;
+        
+                &lt;a href=&quot;https://img.geocaching.com/cache/log/large/${FileName}&quot;>Print Picture&lt;/a&gt;&lt;/span&gt;
+
+                {{if (Descr && Descr.length > 0) }}
+                   &lt;br /&gt;&lt;p class=&quot;LogImgDescription&quot;&gt;${ $('<div />
+            ').text($('<div />
+            ').text($('<div />
+            ').html($item.data.Descr).text()).html()).html() }&lt;/p&gt;
+                {{/if}}
+    </script><script id="tmpl_CacheCoordinateUpdate" type="text/x-jquery-tmpl">
+        <div class="ccu-update" data-lat="${ll[0]}" data-lng="${ll[1]}">
+            <h4 class="BottomSpacing">Corrected Coordinates (hidden from others)</h4>
+            <dl>
+                <dt>Original:</dt>
+                <dd>${ll_formatted} <a href="#" class="ccu-restore">Restore</a></dd>
+            </dl>
+            <dl class="ccu-parse">
+                <dt>Change To:</dt>
+                <dd>
+                    <input type="text" max="40" size="35" class="cc-parse-text">
+                    <button class="ccu-button ccu-parse">Submit</button>
+                </dd>
+            </dl>
+            <dl class="ccu-parseverify" style="display: none;">
+                <dt>Change To:</dt>
+                <dd>
+                    <span class="ccu-parseverify-coords">N 32Â°38.880â€², W 097Â°23.755â€²</span>
+                </dd>
+                <dt>&nbsp;</dt>
+                <dd>
+                    <button class="ccu-button ccu-parseverify-accept">Accept</button>&nbsp;
+                    <button class="ccu-button ccu-parseverify-cancel">Cancel</button>
+                </dd>
+            </dl>
+        </div>
+    </script>
+
+            
+</div>
+
+            
+        </div>
+    </section>
+
+    <footer>
+        
+
+<div class="wrapper">
+    <section class="links container">
+        <dl>
+            <dt>Get to Know Us</dt>
+            <dd><a id="ctl00_ctl24_hlFooterJobs" accesskey="j" href="http://www.geocaching.com/jobs/">Careers</a></dd>
+            <dd><a id="ctl00_ctl24_lnkBrandedPromotions" accesskey="a" href="/play/partnerwithus">Partner With Us</a></dd>
+        </dl>
+
+        <dl>
+            <dt>Legal</dt>
+            <dd><a id="ctl00_ctl24_hlFooterLogo" accesskey="u" href="../about/logousage.aspx">Logo Usage Guidelines</a></dd>
+            <dd><a id="ctl00_ctl24_hlFooterParksPoliceLink" accesskey="k" href="../parksandpolice/">Parks & Police</a></dd>
+        </dl>
+
+        <dl>
+            <dt>Shop Geocaching</dt>
+            <dd><a id="ctl00_ctl24_lnkUSAShop" accesskey="$" href="http://shop.geocaching.com/">USA/Canada Shop</a></dd>
+            <dd><a id="ctl00_ctl24_lnkInternationalShop" accesskey="c" href="http://shop.geocaching.com/default/international-retailers/">International Retailers</a></dd>
+        </dl>
+        <dl>
+            <dt>Contact Us</dt>
+            <dd><a id="ctl00_ctl24_lnkHelpCenterLink" accesskey="?" rel="external" href="https://www.geocaching.com/help/">Help Center</a></dd>
+            <dd><a id="ctl00_ctl24_lnkMedia" accesskey="z" href="../press/faq.aspx">Media Inquiries</a></dd>
+        </dl>
+        
+
+<div class="language-dropdown">
+    <div class="LocaleText">
+        Choose Language
+    </div>
+    <div class="LocaleList">
+        
+        <div class="selected-language">
+            
+            <a href="#">English</a>
+            
+        </div>
+        <ul class="language-list">
+            
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl00_uxLocaleItem" class="selected" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl00$uxLocaleItem&#39;,&#39;&#39;)">English</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl01_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl01$uxLocaleItem&#39;,&#39;&#39;)">Català</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl02_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl02$uxLocaleItem&#39;,&#39;&#39;)">Čeština</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl03_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl03$uxLocaleItem&#39;,&#39;&#39;)">Dansk</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl04_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl04$uxLocaleItem&#39;,&#39;&#39;)">Deutsch</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl05_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl05$uxLocaleItem&#39;,&#39;&#39;)">Ελληνικά</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl06_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl06$uxLocaleItem&#39;,&#39;&#39;)">Eesti</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl07_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl07$uxLocaleItem&#39;,&#39;&#39;)">Español</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl08_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl08$uxLocaleItem&#39;,&#39;&#39;)">Français</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl09_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl09$uxLocaleItem&#39;,&#39;&#39;)">Italiano</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl10_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl10$uxLocaleItem&#39;,&#39;&#39;)">日本語</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl11_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl11$uxLocaleItem&#39;,&#39;&#39;)">한국어</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl12_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl12$uxLocaleItem&#39;,&#39;&#39;)">Latviešu</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl13_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl13$uxLocaleItem&#39;,&#39;&#39;)">Lëtzebuergesch</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl14_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl14$uxLocaleItem&#39;,&#39;&#39;)">Magyar</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl15_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl15$uxLocaleItem&#39;,&#39;&#39;)">Nederlands</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl16_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl16$uxLocaleItem&#39;,&#39;&#39;)">Norsk, Bokmål</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl17_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl17$uxLocaleItem&#39;,&#39;&#39;)">Polski</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl18_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl18$uxLocaleItem&#39;,&#39;&#39;)">Português</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl19_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl19$uxLocaleItem&#39;,&#39;&#39;)">Română</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl20_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl20$uxLocaleItem&#39;,&#39;&#39;)">Русский</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl21_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl21$uxLocaleItem&#39;,&#39;&#39;)">Suomi</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl22_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl22$uxLocaleItem&#39;,&#39;&#39;)">Slovenščina</a></li>
+                
+                    <li><a id="ctl00_ctl24_uxLocaleList_uxLocaleList_ctl23_uxLocaleItem" href="javascript:__doPostBack(&#39;ctl00$ctl24$uxLocaleList$uxLocaleList$ctl23$uxLocaleItem&#39;,&#39;&#39;)">Svenska</a></li>
+                
+        </ul>
+        
+    </div>
+</div>
+<script type="text/javascript">
+
+    jQuery(document).ready(function () {
+        jQuery(".selected-language a").click(function (e) {
+            e.preventDefault();
+            var $loc = jQuery(this).parent().next();
+            jQuery($loc).show().position({
+                of: $loc.parent(),
+                my: "left bottom",
+                at: "left top-10",
+                collision: "fit fit"
+            });
+            jQuery(this).addClass("Expanded");
+            jQuery(document).click(function () {
+                jQuery(".language-list").fadeOut("fast");
+                jQuery(".selected-language a").removeClass("Expanded");
+            });
+            return false;
+        });
+    });
+</script>
+    </section>
+</div>
+
+<section class="copyright">
+    <div class="container">
+        <p role="contentinfo">
+            &copy; 2000-2017
+            <a href="http://www.groundspeak.com/" title="Groundspeak, Inc.">Groundspeak, Inc.</a>
+            All Rights Reserved.
+            <a id="ctl00_ctl24_hlFooterTerms" title="Groundspeak&#32;Terms&#32;of&#32;Use" href="../about/termsofuse.aspx">Groundspeak Terms of Use</a>
+            |
+    <a id="ctl00_ctl24_hlFooterPrivacy" accesskey="x" href="../about/privacypolicy.aspx">Privacy Policy</a>
+        </p>
+
+        <ul class="links-social">
+            <li>
+                <a id="ctl00_ctl24_hlFacebook" title="Facebook" href="http://www.facebook.com/geocaching"></a>
+            </li>
+            <li>
+                <a id="ctl00_ctl24_hlYouTube" title="YouTube" href="http://www.youtube.com/user/GoGeocaching"></a>
+            </li>
+            <li>
+                <a id="ctl00_ctl24_hlInstagram" title="Instagram" href="http://instagram.com/geocaching/"></a>
+            </li>
+            <li>
+                <a id="ctl00_ctl24_hlTwitter" title="Twitter" href="http://twitter.com/GoGeocaching"></a>                         
+            </li>
+        </ul>
+    </div>
+</section>
+    </footer>
+
+        <a id="ctl00_hlSkipLinksTop" accesskey="^" title="Return&#32;to&#32;the&#32;Top&#32;of&#32;the&#32;Page" class="visually-hidden" href="#gcNavigation">Return to the Top of the Page</a>
+
+    
+
+<script type="text/javascript">
+//<![CDATA[
+$(function() { ga('send', 'event', 'Geocaching', 'CacheDetailsMemberType', 'Premium'); });var isLoggedIn = true;
+var userDefinedCoords = {"status":"success","data":{"isUserDefined":false,"oldLatLngDisplay":"N 43° 41.618' E 006° 51.656'"}};
+cmapAdditionalWaypoints = [{"lat":43.6916,"lng":6.86235,"type":217,"name":"Parking (Parking Area)","pf":"PK","editurl":"https://www.geocaching.com/hide/wpt.aspx?WID=0ea1a383-5936-4423-9ef3-ba3641469621"},{"lat":43.6926,"lng":6.86244,"type":221,"name":"Début du sentier (Trailhead)","pf":"SE","editurl":"https://www.geocaching.com/hide/wpt.aspx?WID=16032e89-60f2-4503-8c1e-d97b932c640a"}];
+mapLatLng = {"lat":43.69363,"lng":6.86093,"type":2,"name":"Chemin de l'Escourachie"};
+var ccConversions = [{"t":"Decimal","k":"DD","d":"WGS84","v":"43.693632, 006.860931"},{"t":"DDD MM SS.SSS","k":"DMS","d":"WGS84","v":"N 43° 41' 37.075\" E 006° 51' 39.352\""},{"t":"UTM","k":"UTM","d":"WGS84","v":"32T E 327620 N 4840069"}];
+var dh=false;userInfo = {ID: 3829532};
+userToken = 'ID5R2NBJDBPQYKFGO3AFUUY36MPRTMXUK47SHALLSAJODGCUBMMSL2WBXSWP4QZO7BLGGSLMHIWGNBAHLGGULWXA7I544LFXYCL74F76HLT3WMJ4ZWRIMVDVGQQY3CS5TVOV2VQ5TZ3K24YUFYHKOULM3V5XKXD3ZSBBDHOSIRASATOGZSYMMQO7IG7YSGZ6M4TNM6PZAGQTQWCZIOXNFWB7DIIXCDKH6AOIYFBCEPO36W5CQZ2KYDEXVSIP2Z6S7ER7NJQFIUNNKHCLM6EL5BHF3O3PBRFYNVZYXHI2DALMGQSBNBGQFKJYSURIZC2B';
+includeAvatars = true;
+var lat=43.693632, lng=6.860931, guid='a9493b25-e4af-4677-81b3-4dd63d44caa4';
+initalLogs = {"status":"success", "data": [{"LogID":714290650,"CacheID":4557982,"LogGuid":"ac8d3031-0a2b-42e8-8693-4d14b8ec6687","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714284625,"CacheID":4557982,"LogGuid":"4bfb3557-e726-4864-bb31-e07630b9b5b1","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714271472,"CacheID":4557982,"LogGuid":"fee040e1-b57c-4c5b-a680-c5a500e0d37c","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714188732,"CacheID":4557982,"LogGuid":"19d3c4dd-0ce9-4386-a419-21c9de34a17a","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714188721,"CacheID":4557982,"LogGuid":"d60cca1f-dea6-42f2-9828-aed7354e893f","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714154156,"CacheID":4557982,"LogGuid":"b73e1b0b-4cb7-4360-a8f9-9728bd696645","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714154145,"CacheID":4557982,"LogGuid":"b1d173e7-c2e9-4b4b-9652-b40df172188a","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714154132,"CacheID":4557982,"LogGuid":"7300040c-41de-48b9-8dec-e2ec70781516","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714154115,"CacheID":4557982,"LogGuid":"b434bc4f-7383-4c20-9e1c-1cd81b3b07bd","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/22/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714154300,"CacheID":4557982,"LogGuid":"d28283a4-3af7-48c6-bd99-9bea9e8d148b","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/21/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":714154293,"CacheID":4557982,"LogGuid":"6405c1c0-54a0-486c-95ea-fd9c46df059e","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/22/2017","Visited":"08/21/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":713012140,"CacheID":4557982,"LogGuid":"da473d02-0d45-4f71-be7a-2512cd1f9af8","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/19/2017","Visited":"08/19/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":712163723,"CacheID":4557982,"LogGuid":"fa78e33a-5cbc-4e9b-b694-deb773cab6a9","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/16/2017","Visited":"08/16/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":712066310,"CacheID":4557982,"LogGuid":"4e88d704-22ba-4af0-817d-db93fcba315b","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/15/2017","Visited":"08/15/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":712065824,"CacheID":4557982,"LogGuid":"352e4688-ec62-4737-a3ad-9b41e182d8c5","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Write note","LogTypeImage":"4.png","LogText":"<p>Cgeo test</p>\n","Created":"08/15/2017","Visited":"08/15/2017","UserName":"kumy","MembershipLevel":3,"AccountID":3829532,"AccountGuid":"f8690ec6-6e92-41fc-86dc-8d7991634c6c","Email":"","AvatarImage":"d0c6a8c9-2b7f-4d56-b8e7-a16508e33733.png","GeocacheFindCount":353,"GeocacheHideCount":35,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":687544896,"CacheID":4557982,"LogGuid":"36874d3f-ca63-4097-9437-3dd538b47edd","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Toujours accompagné de sarah 😍 cache trouvée. Belle balade</p>\n","Created":"05/21/2017","Visited":"05/21/2017","UserName":"sylvie324","MembershipLevel":3,"AccountID":20143495,"AccountGuid":"78b67ff2-6b29-439c-87a7-f9feb5f258ad","Email":"","AvatarImage":"a385d224-2bde-4b66-8295-680faba05113.jpeg","GeocacheFindCount":11,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":666707629,"CacheID":4557982,"LogGuid":"6bbe73ae-bce9-4750-aec8-ab50fcf44942","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Joli sentier et localisation très précise. Merci</p>\n","Created":"02/25/2017","Visited":"02/25/2017","UserName":"Cacou83","MembershipLevel":3,"AccountID":12917313,"AccountGuid":"a4805a36-8aee-4916-b04c-6347ad466a4d","Email":"","AvatarImage":"0ace0b64-4041-4f0a-ab1a-35b81280f8fc.jpg","GeocacheFindCount":6114,"GeocacheHideCount":22,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":657950076,"CacheID":4557982,"LogGuid":"c98bfa03-ad2d-4fb9-81d1-985109cd3b8e","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Ok</p>\n","Created":"12/30/2016","Visited":"12/30/2016","UserName":"robinetmat","MembershipLevel":1,"AccountID":19120758,"AccountGuid":"d4213cf3-5cd0-4a21-bb35-c3c38a092850","Email":"","AvatarImage":"","GeocacheFindCount":6,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Member","GroupImageUrl":"/images/icons/reg_user.gif"},"Images":[]},{"LogID":654558435,"CacheID":4557982,"LogGuid":"00183144-4b11-443f-873c-826c07bd7598","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Décidément, les cloches ont été généreuses à St Vallier ! Merci encore pour ces jolis sentiers découverts aujourd'hui. Avec une magnifique lumière de fin de journée 👍</p>\n","Created":"12/06/2016","Visited":"12/04/2016","UserName":"Grafista","MembershipLevel":3,"AccountID":17856910,"AccountGuid":"8cdcc409-5479-40e5-92a3-fda4ac829661","Email":"","AvatarImage":"fe51a5b8-e707-4b32-90ef-140fef378e3a.png","GeocacheFindCount":182,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":648080391,"CacheID":4557982,"LogGuid":"40d5b295-f036-456a-9cd8-de4f4f5f8d18","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>La dernière de la journée avant l apéro et la nuit mplc jolie coin de vue à l horizon </p>\n","Created":"10/30/2016","Visited":"10/30/2016","UserName":"cara88","MembershipLevel":1,"AccountID":9232240,"AccountGuid":"b374add3-c998-4a4b-a5d0-c9686c2c7194","Email":"","AvatarImage":"","GeocacheFindCount":275,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Member","GroupImageUrl":"/images/icons/reg_user.gif"},"Images":[]},{"LogID":642933208,"CacheID":4557982,"LogGuid":"fd56b7f1-32c6-4f74-95ce-10c6432758ac","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Will et aymeric bonne cache 2em trouvé en 10 min 👌</p>\n","Created":"10/09/2016","Visited":"10/09/2016","UserName":"will06460","MembershipLevel":1,"AccountID":18690969,"AccountGuid":"5a833786-2a97-4795-a208-e22a59220ef6","Email":"","AvatarImage":"","GeocacheFindCount":3,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Member","GroupImageUrl":"/images/icons/reg_user.gif"},"Images":[]},{"LogID":640837606,"CacheID":4557982,"LogGuid":"c2fb5c7b-ae74-4c77-a08d-5b43795ab649","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Apres une escursion dans le var en compagnie de beaucoup de geocacheurs du 06 et quelque locaux, je décide de continuer l'aventure jusqu'au 12 coup de minuit. Pour ce faire je me lance sur cette série de drive in pour faire au plus vite.</p>\n<p>De nouveau un petit footing, mais zut, qu'elle est loin en fait si j'avais mieux regardé !!! le début du chemin a été un peu problematique a trouvé mais le tout terrain du coin est quand meme simple.<br />\nSur place je tombe directement sur la boite, le temps est donc bien géré !!<br />\nMerci kumy</p>\n","Created":"10/01/2016","Visited":"09/18/2016","UserName":"poik","MembershipLevel":3,"AccountID":12971608,"AccountGuid":"2a462043-15ad-4dca-8dae-bf3bab9ac38e","Email":"","AvatarImage":"d3be2fcb-6ea3-4bed-a61f-a52d2dbe09ac.jpg","GeocacheFindCount":1325,"GeocacheHideCount":48,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":633435206,"CacheID":4557982,"LogGuid":"6670c12f-cc0d-4d68-8e51-d4a7e1546321","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Quelle surprise de découvrir ce sentier entretenu et apparemment fréquenté au milieu des propriétés privées ! La boîte est trouvée et bien garnie.<br />\nMerci pour ce bout de chemin et la cache !</p>\n","Created":"08/31/2016","Visited":"08/22/2016","UserName":"dome83","MembershipLevel":3,"AccountID":9136896,"AccountGuid":"58f83593-eb17-4d6b-adc3-2be28ab279bc","Email":"","AvatarImage":"","GeocacheFindCount":1094,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Premium Member","GroupImageUrl":"/images/icons/prem_user.gif"},"Images":[]},{"LogID":626532805,"CacheID":4557982,"LogGuid":"b6cb4ca4-9326-4ae4-a4c8-52130bfc5b21","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Yesss gevonden! Moeilijke verstopplaats maar toch gelukt! Een tip: ligt onder grote bijna platte steen omringt door allemaal andere stenen :) </p>\n","Created":"08/09/2016","Visited":"08/05/2016","UserName":"Janna Wolff","MembershipLevel":1,"AccountID":9491483,"AccountGuid":"fe06eeba-34ba-4d37-b5dd-763e7c2631a3","Email":"","AvatarImage":"91d7d533-3102-4bca-958f-59d0a89f40df.png","GeocacheFindCount":22,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Member","GroupImageUrl":"/images/icons/reg_user.gif"},"Images":[]},{"LogID":625121999,"CacheID":4557982,"LogGuid":"560fc32c-1bb8-495d-b5e8-faa9ec76c3dd","Latitude":null,"Longitude":null,"LatLonString":"","LogType":"Found it","LogTypeImage":"2.png","LogText":"<p>Attention au dos pour cette cache et aux ronces 😁</p>\n","Created":"08/05/2016","Visited":"08/05/2016","UserName":"manu29031976","MembershipLevel":1,"AccountID":10171965,"AccountGuid":"1bfc03ed-42a6-4208-acd1-494a2d65ac5b","Email":"","AvatarImage":"","GeocacheFindCount":15,"GeocacheHideCount":0,"ChallengesCompleted":0,"IsEncoded":false,"creator":{"GroupTitle":"Member","GroupImageUrl":"/images/icons/reg_user.gif"},"Images":[]}], "pageInfo": { "idx":1, "size": 25, "totalRows": 66, "rows": 66 } };
+var gaToken = 'UA-2020240-1';
+theForm.oldSubmit = theForm.submit;
+theForm.submit = WebForm_SaveScrollPositionSubmit;
+
+theForm.oldOnSubmit = theForm.onsubmit;
+theForm.onsubmit = WebForm_SaveScrollPositionOnSubmit;
+//]]>
+</script>
+</form>
+    
+    <form action="/account/logout" method="post" id="form-logout">
+        <input type="hidden" name="returnUrl" />
+    </form>
+
+    <script src="/account/scripts/custom/message-center-header-widget.js"></script>
+    <script src="/play/scripts/custom/jquery.draftlogs-badge.js"></script>
+    <script src="/bundle/layoutJS?v=tWP6f2KqcE6QvMkoPaIaiIumiiQBaEc0pnKoiGlcv6w1"></script>
+
+    
+    
+    <script type="text/javascript">
+
+
+        <!--
+
+
+    function s2gps(guid) {
+        var w = window.open('/seek/sendtogps.aspx?guid=' + guid, 's2gps', config='width=450,height=450,toolbar=no,menubar=no,scrollbars=no,resizable=no,location=no,directories=no,status=no');
+        w.focus();
+    }
+
+    function pl(lc) {
+        document.location.href='/seek/cache_details_print.aspx?guid=' + guid + '&numlogs=' + lc +'&pt=full&lt=letter&decrypt='+ ((dh)?'y':'n');
+    }
+    
+    function setNotification(id) {
+        //new Effect.Highlight(id, {startcolor:'#ffffff', endcolor:'#ffff99', restorecolor:'#ffff99', duration:3.0, queue:'front'});
+        //new Effect.Highlight(id, {startcolor:'#ffff99', endcolor:'#ffffff', restorecolor:'#ffffff', duration:5.0, queue:'end'});
+    }
+    
+    function cmo(id) {
+        Cookie.set('sn', true);
+    }
+
+    function pp(img) {
+        var w = window.open(img);
+        w.focus();
+    }
+        
+    var map, bounds;
+    var canUpdateFavoriteStatus = true;
+    var decryptLogs = (urlParams["decrypt"] && urlParams["decrypt"] == "y") ? true : false;
+    var logInitialLoaded = false;
+    var $tfoot = $("#cache_logs_table").find("tfoot");
+    var currentPageIdx = 1, totalPages = 1, pageSize = 10;
+    var isBusy = false;
+        
+    var locString = {
+        decrypt: 'Decrypt',
+        encrypt: 'Encrypt'
+    };
+
+    $("#tmpl_CacheLogImagesTitle").template("tmplCacheLogImagesTitle");
+    $("#tmpl_CacheLogImages").template("tmplCacheLogImages");
+    $("#tmpl_CacheLogRow").template("tmplCacheLogRow");
+
+    $(".EncryptDecrypt")
+        .button({ icons: { secondary: 'ui-icon-arrowreturnthick-1-w'} })
+        .click(function (e) {
+            e.preventDefault();
+            $("tr.log-row").each(function (i, obj) {
+                var $obj = $(obj);
+                if ($obj.data("encoded") == true) {
+                    var lt = $obj.find("span.LogText");
+                    //var ltDecoded = $('<div />').html(lt.html()).text();
+                    lt.html(convertROTStringWithBrackets(lt.html()));
+                }
+            });
+
+            decryptLogs = !decryptLogs;
+
+            $("a.decrypt-link").html(decryptLogs ? locString.encrypt : locString.decrypt);
+
+            return false;
+        });
+            
+    function appendNewLogs(obj) {
+
+        totalPages = obj.pageInfo.totalPages;
+
+        var $newBody = $(document.createElement("TBODY"));
+
+        $("#tmpl_CacheLogRow").tmpl(obj.data,{ includeAvatars: includeAvatars }).appendTo($newBody);
+
+        $newBody.find("a.tb_images").each(function()
+        {
+            var $this = $(this);
+            $this.fancybox({
+                'type': 'image', 
+                'titlePosition': 'inside', 
+                'padding': 10,
+                titleFormat: function() { return $this.data('title'); } 
+            });
+        });
+
+        $("#cache_logs_table")
+            .append($newBody.children());
+
+        currentPageIdx = obj.pageInfo.idx + 1;
+        pageSize = obj.pageInfo.size;
+    }
+
+    var showScroll = false;
+
+    function CheckCoords() {
+        var latDirection = document.getElementById('ctl00_ContentBody_txtLatDirection').value;
+        var lonDirection = document.getElementById('ctl00_ContentBody_txtLongDirection').value;
+        var latDeg = document.getElementById('ctl00_ContentBody_txtLatitude').value;
+        var lonDeg = document.getElementById('ctl00_ContentBody_txtLongitude').value;
+        var latMin = document.getElementById('ctl00_ContentBody_txtLatMinutes').value;
+        var lonMin = document.getElementById('ctl00_ContentBody_txtLongMinutes').value;
+        var latMin2 = document.getElementById('ctl00_ContentBody_txtLatSeconds').value;
+        var lonMin2 = document.getElementById('ctl00_ContentBody_txtLongSeconds').value;
+
+        // check direction values
+        var textResult = $('#ctl00_ContentBody_checkCoordsResult');
+        if (latDirection.toUpperCase() !== "N" && latDirection.toUpperCase() !== "S") {
+            textResult.text("Latitude direction must be N or S");
+            textResult.css('color', 'red');
+            return false;
+        }
+
+        if (lonDirection.toUpperCase() !== "W" && lonDirection.toUpperCase() !== "E") {
+            textResult.text("Longitude direction must be E or W");
+            textResult.css('color', 'red');
+            return false;
+        }
+
+        //check if not null 
+        if (latDeg.length == 0 || lonDeg.length == 0 || latMin.length == 0 || lonMin.length == 0 
+            || latMin2.length == 0 || lonMin2.length == 0) {
+            textResult.text("All coordinate fields must be entered");
+            textResult.css('color', 'red');
+            return false;
+        }
+        
+        //check if numbers
+        if (!$.isNumeric(latDeg) || !$.isNumeric(lonDeg) || !$.isNumeric(latMin) || !$.isNumeric(lonMin)
+            || !$.isNumeric(latMin2) || !$.isNumeric(lonMin2)) {
+            textResult.text("Degrees and minutes must be numeric");
+            textResult.css('color', 'red');
+            return false;
+        }
+
+        var north = latDirection.toUpperCase() == "N";
+        var east = lonDirection.toUpperCase() == "E";
+
+        var recaptcha = document.getElementById('g-recaptcha-response').value;
+        var data = {'coord' : {
+            'LatDir' : latDirection, 'LonDir' : lonDirection, 'LatMin' : latMin + '.' + latMin2,
+            'LonMin' : lonMin + '.' + lonMin2, 'LatDeg' : latDeg, 'LonDeg' : lonDeg ,
+            'North' : north, "East" : east
+        }, 'recaptcha' : recaptcha, 'cacheGuid' : 'a9493b25-e4af-4677-81b3-4dd63d44caa4', 'userId' : '3829532'}
+
+        $.ajax({
+            type: "POST",
+            url: "/seek/cache_details.aspx/CheckCoordsButton",
+            data: JSON.stringify(data),
+            contentType: "application/json; charset=utf-8",
+            dataType: "json",
+            error: function (XMLHttpRequest, textStatus, errorThrown) {
+                var textResult = $('#ctl00_ContentBody_checkCoordsResult');
+                textResult.text("Coordinate checker failed. Please try again later.");
+            },
+            success: function(result) {
+                var response = JSON.parse(result.d);
+                var textResult = $('#ctl00_ContentBody_checkCoordsResult');
+                textResult.text(response.ResultText);
+
+                if (response.Success == false) {
+                    textResult.css('color', 'red');
+                    $('#update-cc-div').hide();
+                    if (response.ResultText.indexOf("Verification failed") >= 0) {
+                        $('#recaptcha-br').show();
+                        $('.g-recaptcha').show();
+                    } else {
+                        $('#recaptcha-br').hide();
+                        $('.g-recaptcha').hide();
+                    }
+                } else {
+                    textResult.css('color', 'green');
+                    $('#update-cc-div').show();
+                    $('.g-recaptcha').hide();
+                    $('#recaptcha-br').hide();
+
+                }
+
+                var s = "";
+                var counterLabel = $('#ctl00_ContentBody_lblCheckerCounter');
+                if (response.GuessCount > 1) {s = "s"}
+                var counter = "You have made "+ response.GuessCount +" attempt"+ s + " in 10 minutes";
+                counterLabel.css('color', 'black');
+                counterLabel.text(counter);
+
+                if (response.GuessCount > 10) {
+                    counterLabel.css('color', 'red');
+                    counterLabel.text("You cannot make more than 10 guesses in 10 minutes");
+                }
+            }
+        });
+    }
+
+    function callLogLoad(hideFooter) {
+        if (screen.width > 1090){
+            showScroll = true;
+        }
+        $.getJSON("/seek/geocache.logbook", { tkn: userToken, idx: currentPageIdx, num: pageSize, decrypt: decryptLogs },
+            function (response) {
+                if (response.status == "success") {
+                    if (response.data.length > 0) {
+                        $("#ctl00_ContentBody_lnkPrintFriendly5Logs").css('display', 'inline-block');
+                        $("#ctl00_ContentBody_lnkPrintFriendly10Logs").css('display', 'inline-block');
+                    }
+
+                    appendNewLogs(response);
+                    if( hideFooter || (totalPages < currentPageIdx) ) {
+                        $tfoot.hide();
+                    }
+                } else if (response.status == "error" && response.value == "1") {
+                    // reload the page since the data had expired.
+                    window.location.reload();
+                }
+                isBusy = false;
+            });
+    }
+
+    
+
+    $("#add_to_favorites").click(function () {
+
+        if (canUpdateFavoriteStatus) {
+            canUpdateFavoriteStatus = false;
+
+            var fv = parseInt($(".favorite-value").text());
+            fv++;
+            $(".favorite-value").text(fv);
+
+            var fr = parseInt($(".favorite-rank").text());
+            fr--;
+            $(".favorite-rank").text(fr);
+
+            $("#pnlNonfavoriteCache").fadeOut("fast", function () {
+                $("#pnlFavoriteCache").fadeIn("fast");
+            });
+
+            $.ajax({
+                type: "POST",
+                cache: false,
+                url: '/datastore/favorites.svc/update?u=' + userToken + '&f=true',
+                success: function () {
+                    canUpdateFavoriteStatus = true;
+                    gotScore = false;
+                    showFavoriteScore();
+                }
+            });
+
+            return false;
+        }
+    });
+
+    $("#remove_from_favorites").click(function () {
+
+        if (canUpdateFavoriteStatus) {
+            canUpdateFavoriteStatus = false;
+
+            var fv = parseInt($(".favorite-value").text());
+            fv--;
+            $(".favorite-value").text(fv);
+
+            var fr = parseInt($(".favorite-rank").text());
+            fr++;
+            $(".favorite-rank").text(fr);
+
+            $("#pnlFavoriteCache").fadeOut("fast", function () {
+                $("#pnlNonfavoriteCache").fadeIn("fast");
+            });
+
+            $.ajax({
+                type: "POST",
+                cache: false,
+                url: '/datastore/favorites.svc/update?u=' + userToken + '&f=false',
+                success: function () {
+                    canUpdateFavoriteStatus = true;
+                    gotScore = false;
+                    showFavoriteScore();
+                }
+            });
+
+            return false;
+        }
+    });
+
+    $(function () {
+
+        // CSP Section
+        if ($("#cspMessage").length) {
+                
+            var editLink = $('a[href*="report.aspx"]').attr('href');
+
+            $("#cspMessage").prepend('<P><strong>Already submitted this geocache?</strong> Please check below for the Reviewer’s notes and make any necessary changes before you resubmit. You can also respond by clicking "Log Your Visit" and posting a Reviewer Note.</P>');
+            $("#cspMessage").prepend('<P>Your geocache has not been published. Once your geocache is in place and all of the details have been entered, click "Submit for Review". A volunteer reviewer will begin the review process within about 7 days.</P>');
+                    
+            $("#cspGoBack").click(function (e) {
+                e.preventDefault();
+                window.location = editLink;
+                return false;
+            });
+                    
+            $("#cspSubmit").click(function (e) {
+                e.preventDefault();
+                $.pageMethod("/seek/cache_details.aspx/EnableCSPCache", JSON.stringify({ dto: { ut: userToken } }), function (r) {
+                    var r = JSON.parse(r.d);
+                    if (r.success == true) {
+                        window.location = '/seek/cache_details.aspx?guid=' + r.guid;
+                    } else {
+                        alert("There was an error enabling your cache.");
+                    }
+                });
+                return false;
+            });
+                    
+                
+        }
+
+
+        //override coords
+        if (typeof(userDefinedCoords) != "undefined") {
+            if (userDefinedCoords.status == "success" && userDefinedCoords.data.isUserDefined == true) {
+                mapLatLng = $.extend({}, mapLatLng, userDefinedCoords.data);
+                $("#uxLatLon")
+                    .data("isOverridden", true)
+                    .addClass("myLatLon");
+            } else if (userDefinedCoords.status == "success") {
+                mapLatLng = $.extend({}, mapLatLng, userDefinedCoords.data);
+            } else {
+                $("#uxLatLonLink").contents().unwrap();
+            }
+        } else {
+            $("#uxLatLonLink").contents().unwrap();
+        }
+            
+            
+        var cacheNoteText = {
+            DefaultText: 'Click to enter a note',
+                ErrorInSaving: 'There was an error saving page.  Please refresh the page and try again.',
+                SavingText: 'Please wait, saving your note...'
+            };
+
+        $("time.timeago").timeago();
+
+        $(".button").button();
+
+        var sn = Cookie.get('sn');
+
+        if ($('#trNotPM').length > 0) {
+            $('#trNotPM').toggle(!sn);
+        }
+
+        $("#cache_note").editInPlace({
+            cancel_button: "<input type='submit' class='inplace_cancel' value='Cancel'></input>",
+            save_button: "<input type='submit' class='inplace_save' value='Save'></input>",
+            callback: function (unused, enteredText) {
+                var me = $(this);
+
+                var et = $.trim(enteredText);
+                if (et.length > 2500 ) {
+                    et = et.substr(0, 2500);
+                }
+                $.pageMethod("/seek/cache_details.aspx/SetUserCacheNote", JSON.stringify({ dto: { et: et, ut: userToken} }), function (r) {
+                    var r = JSON.parse(r.d);
+                    if (r.success == true) {
+                        if ($.trim(r.note) == "") {
+                            $("#cache_note").text(cacheNoteText.DefaultText);
+                        } else {
+                            $("#cache_note").text(r.note);
+                        }
+
+                        me.effect('highlight', { color: '#ffb84c' }, 'slow');
+                    } else {
+                        alert(cacheNoteText.ErrorInSaving);
+                        $("#cache_note").text(cacheNoteText.DefaultText);
+                    }
+
+                });
+
+                return cacheNoteText.SavingText;
+            }
+                    , default_text: cacheNoteText.DefaultText
+                    , field_type: "textarea"
+                    , textarea_rows: "7"
+                    , textarea_cols: "65"
+                    , show_buttons: true
+                    , bg_over: "#dad7cb"
+            //, callback_skip_dom_reset: true
+
+        });
+
+        $("#lnk_slippyMap").click(function(e) {
+            e.preventDefault();
+            loadDynamicMap();
+            return false;
+        });
+
+        $(".inplace_field").live("focus", function () {
+            if ($(this).data("created") == null) {
+                $(this).data("created", true)
+                $(this).countable({
+                    maxLength: 2500
+                    });
+            }
+            });
+                
+        $("#pcn_help").qtip({ 
+            content: 'Enter your own notes here.  No other user will be able to access them.',
+                position: {
+                    my: 'top center',
+                    at: 'bottom center'
+                },
+                style: {
+                    classes: 'ui-tooltip-dark ui-tooltip-rounded pcn-tooltip'
+                },
+            });
+                    
+        $("a.decrypt-link").html(decryptLogs ? locString.encrypt : locString.decrypt);
+                        
+        if ($("#cache_logs_container").length > 0) {
+
+            appendNewLogs(initalLogs);
+
+            if (DetectMobileQuick()) {
+                $("#pnlButtonLoad")
+                    .show()
+                    .find("a.MobileButton")
+                    .click(function(e) {
+                        e.preventDefault();
+                        callLogLoad(false);
+                        return false;
+                    })
+                    .button();
+                if (!DetectTierTablet()) {
+                    $("a.MobileButton").addClass("Phone");
+                }
+            } else {
+                $("#pnlLazyLoad").show();
+
+                $(window).endlessScroll({
+                    fireOnce: true,
+                    fireDelay: 500,
+                    bottomPixels: ($(document).height() - $("#cache_logs_container").offset().top) + 50,
+                    ceaseFire: function() {
+                        // stop the scrolling if the last page is reached.
+                        return (isLoggedIn == false) || (totalPages < currentPageIdx);
+                    },
+                    callback: function() {
+                        if (!isBusy) {
+
+                            isBusy = true;
+                            $tfoot.show();
+                            callLogLoad(true);
+                        }
+                    }
+                });
+            }
+        }
+
+        if (!isLoggedIn) {
+            $("#cache_logs_table").find("tfoot").hide();
+        }
+
+        if (mapLatLng != null) {
+
+            $("#uxLatLonLink").qtip({
+                suppress:false,
+                content: buildCacheCoordMenu(),
+                position: {
+                    my: 'left top',
+                    at: 'right top',
+                    adjust: {
+                        x: 10, y: -10
+                    }
+                },
+                show: {
+                    ready: false,
+                    event: "click",
+                    solo: true
+                }, hide: {
+                    event: 'unfocus'
+                },
+                style: {
+                    tip: {
+                        corner: false
+                    },
+                    classes: 'ui-tooltip-widget'
+                },
+                events: {
+                    show: function () {
+                        if ($("#uxLatLon").data("isOverridden")) {
+                            $("a.ccu-restore").show();
+                        } else {
+                            $("a.ccu-restore").hide();
+                        }
+
+                        if (userDefinedCoords.status != "success") {
+                            $("div.ccu-update").hide();
+                        } else {
+                            $("div.ccu-update").show();
+                        }
+                    }
+                }
+            }).click(function (e) {
+                e.preventDefault();
+                return false;
+            });
+            
+            $("#ctl00_ContentBody_uxNotesAboutPrinting").fancybox({
+                    overlayShow: false
+                });
+                
+                setStaticMap();
+            }
+    });
+
+        function setStaticMap() {
+            
+            var mapLarge = L.map('map_canvas', {
+                center: [mapLatLng.lat, mapLatLng.lng],
+                zoom: 14,
+                doubleClickZoom: true,
+                dragging: true,
+                touchZoom: false,
+                scrollWheelZoom: false,
+                zoomControl: true,
+                attributionControl: false
+            })
+            .addControl(new L.Control.Attribution({ prefix: '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. <a href="/about/maps.aspx#leaflet" target="_blank">About our maps</a>' }))
+            .addControl(new L.Control.Scale());
+
+            addInternalMapTileLayer(mapLarge, function(layer) {
+                if (cmapAdditionalWaypoints != null && cmapAdditionalWaypoints.length > 0) {
+
+                    var llBounds = L.latLngBounds([mapLatLng.lat, mapLatLng.lng], [mapLatLng.lat, mapLatLng.lng]);
+
+                    for (var x = 0, len = cmapAdditionalWaypoints.length; x < len; x++) {
+
+                        var item = cmapAdditionalWaypoints[x],
+                            ll = [item.lat, item.lng];
+
+                        L.marker(ll, {
+                            icon:  L.icon({ iconUrl: '/images/wpttypes/pins/'+ item.type + '.png', iconSize: [20, 23], iconAnchor: [10, 23] }),
+                            title: item.name,
+                            clickable: false
+                        }).addTo(mapLarge);
+
+                        llBounds.extend(ll);
+                    }
+
+                    window.setTimeout(function () {
+                        mapLarge.fitBounds(llBounds.pad(.5));
+                    }, 100);
+                }
+
+                // Add posted coords last so they are prioritized on map
+                L.marker([mapLatLng.lat, mapLatLng.lng], {
+                    icon: L.icon({iconUrl: '/images/wpttypes/pins/' + mapLatLng.type + '.png', iconSize: [20, 23], iconAnchor: [10, 23]}),
+                    clickable: false,
+                    //zIndexOffset: 99,
+                    title: mapLatLng.name
+                }).addTo(mapLarge);
+            });
+        }
+
+        var lnkDH = $('#ctl00_ContentBody_lnkDH');
+        function dht() {
+            try {
+                $('#div_hint').html(convertROTStringWithBrackets($('#div_hint').html()));
+                var linkText = ((lnkDH.attr('title') == 'Decrypt') ? 'Encrypt' : 'Decrypt');
+                lnkDH
+                    .text(linkText)
+                    .attr('title', linkText);
+            } catch (e) {
+                alert(e);
+                return false;
+            }
+            return false;
+        } 
+
+        function buildCacheCoordMenu() {
+            var curLatLng = new LatLon(mapLatLng.lat, mapLatLng.lng)
+            $.template( "tmplCacheCoordinateUpdate_CoordItem", "<tr><td nowrap='nowrap'>${t}</td><td class='ccc-coord' nowrap='nowrap' dataum='${k}'>${v}</td></tr>" );
+
+            var $menu = $("<div></div>");
+
+            $( "#tmpl_CacheCoordinateUpdate" ).tmpl( {
+                ll: [mapLatLng.lat, mapLatLng.lng], 
+                ll_formatted: mapLatLng.oldLatLngDisplay
+            } ).appendTo( $menu );
+
+            $menu.find("button.ccu-button").button();
+
+            $menu.delegate("button.ccu-parse", "click", function (e) {
+                e.preventDefault();
+                var $this = $(e.target),
+                    $parse =$this.closest('dd').find(".cc-parse-text"),
+                    parseCoords = $.trim($parse.val());
+                    
+                if (parseCoords.length == 0) {
+                    alert('Please provide valid coordinates.');    
+                } else {
+                    $.getJSON("/api/geocode", { parse: parseCoords}, function (response) {
+                        if (response.status == "success") {
+                            var newLatLng = new LatLon(response.data.lat, response.data.lng);
+                                
+                            // update the displayed coords    
+                            var dist = curLatLng.rhumbDistanceTo(newLatLng);
+                            var bearingTo = curLatLng.rhumbBearingTo(newLatLng);
+                            var bearing = bearingTo >= 0 || bearingTo < 22.5 ? "N" : bearingTo >= 22.5 || bearingTo < 67.5 ? "NE" : bearingTo >= 67.5 || bearingTo < 112.5 ? "E" : bearingTo >= 112.5 || bearingTo < 157.5 ? "SE" : bearingTo >= 157.5 || bearingTo < 202.5 ? "S" : bearingTo >= 202.5 || bearingTo < 247.5 ? "SW" : bearingTo >= 247.5 || bearingTo < 292.5 ? "W" : bearingTo >= 292.5 || bearingTo < 337.5 ? "NW" : "N";
+                                
+                            var formats = response.data.formats;
+                            
+                            $menu
+                                .find("span.ccu-parseverify-coords").text(formats.DM).end()
+                                .find("dl.ccu-parse").hide().end()
+                                .find("dl.ccu-parseverify").show().end()
+                                .find("button.ccu-parseverify-accept")
+                                    .data("utm", '')
+                                    .data("dm", formats.DM)
+                                    .data("lat", response.data.lat)
+                                    .data("lng", response.data.lng)
+                                    .end();
+                        } else {
+                            alert("Sorry unable to parse the coordinates you entered.");
+                        }
+                    });
+                }
+                        
+                return false;
+            });
+
+
+            //$menu.delegate("button.btn-checkcoords", "click", function(e) {
+            //    e.preventDefault();
+            //    var $this = $(this);
+            //    $.pageMethod("/seek/cache_details.aspx/CheckCoordsButton",
+            //        "",
+            //        function(r) {
+
+            //        });
+            //});
+
+            $menu.delegate("button.ccu-parseverify-accept", "click", function (e) {
+                e.preventDefault();
+                var $this = $(this);
+                // update to webmethod
+                $.pageMethod("/seek/cache_details.aspx/SetUserCoordinate", 
+                    JSON.stringify({ dto: { data: {lat: $this.data("lat"), lng: $this.data("lng") }, ut: userToken } }), 
+                    function (r) {
+                    var r = JSON.parse(r.d);
+                    if (r.status == "success") {
+                        window.location.reload();
+                    } else {
+                        $("#uxLatLonLink").qtip('hide');
+                    }
+                    
+                });
+                
+                return false;
+            });
+
+            $menu.delegate("button.ccu-parseverify-cancel", "click", function (e) {
+                e.preventDefault();
+                $menu
+                    .find("input.cc-parse-text").val('').end()
+                    .find("dl.ccu-parse").show().end()
+                    .find("dl.ccu-parseverify").hide().end();
+                return false;
+            });
+
+            $menu.delegate("a.ccu-restore", "click", function (e) {
+                e.preventDefault();
+
+                $.pageMethod("/seek/cache_details.aspx/ResetUserCoordinate", JSON.stringify({ dto: { ut: userToken } }), function (r) {
+                    var r = JSON.parse(r.d);
+                    if (r.status == "success") {
+                        window.location.reload();
+                    }
+                });
+                
+                return false;
+            });
+
+            return $menu;
+        }
+
+        GSPK = window.GSPK || {};
+        GSPK.Selector = {};
+        GSPK.Selector.getSelected = function(){
+            var t = null;
+            if ( window.getSelection ){
+                t = window.getSelection();
+            }else if(document.getSelection){
+                t = document.getSelection();
+            }else if(document.selection){
+                t = document.selection.createRange().text;
+            }
+            return t;
+        }
+        //-->
+    </script>
+    <script id="loc_favPointsScoreDesc" type="text/html">
+        Favorites/Premium Logs
+    </script>
+    <script type="text/javascript" language="javascript">
+            <!--
+    var gotScore = false;
+    var favDropDown = $('.favorite-dropdown');
+    var favContainer = $('.favorite-container');
+
+    function showFavoriteScore() {
+        $.ajax({
+            type: "POST",
+            cache: false,
+            url: '/datastore/favorites.svc/score?u=' + userToken,
+            success: function (scoreResult) {
+                gotScore = true;
+
+                var score = 0;
+
+                if(scoreResult) {
+                    score = scoreResult;
+                }
+
+                if(score > 100) {
+                    score = 100;
+                }
+
+                $('.favorite-score').html((score < 1 ? "<1" : score) + '%' + $("#loc_favPointsScoreDesc").html());
+            }
+        });
+    }
+    var scrollId = false,
+        logTop = 0;
+
+    if (document.getElementById("cache_logs_container") != null){
+        logTop = $("#cache_logs_container").position().top;
+    }
+
+
+    $(window).on("scroll", function() {
+        if (scrollId != false) {
+            window.clearTimeout(scrollId);
+            scrollId = false;
+        }
+
+        scrollId = window.setTimeout(function() {
+            if (showScroll){
+                if ($(this).scrollTop()< logTop) {
+                    $("#topScroll").fadeOut();
+                } else {
+                    $("#topScroll").fadeIn();
+                }
+            }}, 250);
+    });
+
+    $(document).bind('mouseup', function (e) {
+        var $clicked = $(e.target);
+        if (!$clicked.parents().hasClass("favorite-dropdown") && !$clicked.parents().hasClass("FavoriteWidget")) {
+            favDropDown.hide(1, function () {
+                favContainer.addClass('favorite-container');
+                favContainer.removeClass('favorite-container-open');
+            });
+        }
+    });
+
+    $('#uxFavContainerLink').click(function () {
+        if ($(favDropDown).is(':visible')) {
+            favDropDown.hide(1, function(){
+                favContainer.addClass('favorite-container');
+                favContainer.removeClass('favorite-container-open');
+            });                
+        }
+        else {
+            if (!gotScore) {
+                showFavoriteScore();
+            }
+
+            favContainer.addClass('favorite-container-open');
+            favContainer.removeClass('favorite-container');
+            favDropDown.show(1);
+        }
+    });
+
+    $("#lnkMessageOwner").on("click", function (e) {
+        e.preventDefault();
+        var $self = $(this),
+            hasFired = false;
+        
+        var hitCallback = function() {
+            if (!hasFired) {
+                hasFired = true;
+                document.location = $self.attr('href');
+            }
+        }
+
+        ga('send', 'event', 'Message Center', 'Click', 'Message Owner - Cache Details', { 'hitCallback': hitCallback });
+
+        // just in case google analytics is having issues.
+        window.setTimeout(hitCallback, 3000);
+
+        return false;
+    });
+
+    $("body").on("click", ".LogText a", function(e) {
+        if (e.target.tagName.toLowerCase() === 'a') {
+            var url = $(e.target).attr("href");
+
+            var hostname = extractHostname(url);
+            if (isGeocachingDomain(hostname)) {
+                return true;
+            }
+        }
+        
+        if (window.confirm("Hey wait! You’re about to leave Geocaching.com. Are you sure you want to do that?")) {
+            return true;
+        } else {
+            return false;
+        }
+    });
+        
+    $(function() {
+        if($('.banner').length) {
+            //get access token
+            var accessTokenPromise = $.get('/account/oauth/token');
+            accessTokenPromise.done(function(result) {
+
+                var now = new Date();
+                var utcNow = new Date(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds());
+                utcNow.setSeconds(utcNow.getSeconds() - 5);
+                var checkCounter = 0;
+
+                function getSouvenirs() {
+                    checkCounter++;
+
+                    var getSouvenirsPromise = $.ajax({
+                        type: "GET",
+                        url: "/api/proxy/web/v1/souvenirs",
+                        dataType: 'json',
+                        headers: {
+                            "Authorization": "Bearer " + result.access_token
+                        },
+                        data: { minAwardDateUtc: utcNow.toISOString() }
+                    });
+
+                    getSouvenirsPromise.done(function(result) {
+                        if (result.length) {
+                            // show notification(s)
+                            for (var i = 0; i < result.length; i++) {
+                                (function(i) {
+                                    setTimeout(function() {
+                                        noty({
+                                            template: '<div class="noty_message">' +
+                                                    '<img src="' + result[i].icon + '"></img>' +
+                                                    '<div class="souvenir-info">' +
+                                                    '<h3>You earned a souvenir!</h3>' +
+                                                    '<div class="souvenir-title">' + result[i].title + '</div>' +
+                                                    '<a class="btn btn-primary" href="/souvenir?guid=' + result[i].guid + '">See souvenir</a>' +
+                                                    '</div>' +
+                                                    '</div>',
+                                            animation: {
+                                                open: 'animated slideInRight',
+                                                close: 'animated slideOutRight'
+                                            },
+                                            timeout: 3000 + (result.length - i) * 400,
+                                            maxVisible: false
+                                        });
+                                    }, 200 * i);
+                                }) (i);
+                            }
+                        } else if(checkCounter < 20) {
+                            setTimeout(getSouvenirs, 1000);
+                        }
+                    });
+                }
+
+                getSouvenirs();
+            });
+        }
+    });
+
+            //poll for souvenirs
+          /*  var checkCounter = 0;
+            var checkSouvenirInterval = setInterval(function() {
+                checkCounter++;
+
+                $.ajax({
+                    
+                });
+
+                if (checkCounter >= 20) {
+                    window.clearInterval(checkSouvenirInterval);
+                }
+            }, 1000);*/
+         
+
+        //  End -->
+    </script>
+
+
+    <script>
+        $(document).ready(function () {
+            $('#hlUpgrade').bind('click', function () {
+                var $self = $(this),
+                hasFired = false;
+
+                var hitCallback = function() {
+                    if (!hasFired) {
+                        hasFired = true;
+                        document.location = $self.attr('href');
+                    }
+                }
+
+                ga('send', 'event', 'Geocaching', 'Premium Upsell', 'Mini-profile Widget', { 'hitCallback': hitCallback });
+
+                // just in case google analytics is having issues.
+                window.setTimeout(hitCallback, 3000);
+
+                return false;
+            });
+
+            $('a[target="_blank"]').attr('rel', 'noopener noreferrer');
+        });
+
+        $(function () {
+            $("a.language").click(function (e) {
+                e.preventDefault();
+                window.location.replace(window.location.href + (window.location.search.indexOf("?") == -1 ? "?" : "&") + "lang=" + $(this).attr("lang"));
+            });
+        });
+    </script>
+
+    
+    <div id="Quantcast">
+        <script>
+            var _qevents = _qevents || [];
+
+            (function () {
+                var elem = document.createElement('script');
+
+                elem.src = (document.location.protocol == "https:" ? "https://secure" : "http://edge") + ".quantserve.com/quant.js";
+                elem.async = true;
+                elem.type = "text/javascript";
+                var scpt = document.getElementsByTagName('script')[0];
+                scpt.parentNode.insertBefore(elem, scpt);
+            })();
+        </script>
+        <script>
+            _qevents.push({ qacct: "p-f6VPrfmR4cujU" });
+        </script>
+        <noscript>
+            <div style="display: none;">
+                <img src="http://pixel.quantserve.com/pixel/p-f6VPrfmR4cujU.gif" height="1" width="1"
+                    alt="Quantcast" /></div>
+        </noscript>
+    </div>
+    
+
+    <!-- Server: WEB05; Build: release-20170821.4.Release_2439 
+ -->
+</body>
+</html>

--- a/tests/src/cgeo/geocaching/utils/AngleUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/AngleUtilsTest.java
@@ -1,32 +1,36 @@
 package cgeo.geocaching.utils;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class AngleUtilsTest extends TestCase {
+import static org.assertj.core.api.Java6Assertions.assertThat;
 
-    public static void testNormalize() {
-        assertEquals(AngleUtils.normalize(0), 0.0f, 0);
-        assertEquals(AngleUtils.normalize(-0.0f), 0.0f, 0);
-        assertEquals(AngleUtils.normalize(360), 0.0f, 0);
-        assertEquals(AngleUtils.normalize(720), 0.0f, 0);
-        assertEquals(AngleUtils.normalize(-360), 0.0f, 0);
-        assertEquals(AngleUtils.normalize(-720), 0.0f, 0);
-        assertEquals(AngleUtils.normalize(721), 1.0f, 0);
-        assertEquals(AngleUtils.normalize(-721), 359.0f, 0);
-        assertEquals(AngleUtils.normalize(-Float.MIN_VALUE), 0.0f, 0);
+public class AngleUtilsTest {
+
+    @Test
+    public void testNormalize() {
+        assertThat(AngleUtils.normalize(0)).isEqualTo(0.0f);
+        assertThat(AngleUtils.normalize(-0.0f)).isEqualTo(0.0f);
+        assertThat(AngleUtils.normalize(360)).isEqualTo(0.0f);
+        assertThat(AngleUtils.normalize(720)).isEqualTo(0.0f);
+        assertThat(AngleUtils.normalize(-360)).isEqualTo(0.0f);
+        assertThat(AngleUtils.normalize(-720)).isEqualTo(0.0f);
+        assertThat(AngleUtils.normalize(721)).isEqualTo(1.0f);
+        assertThat(AngleUtils.normalize(-721)).isEqualTo(359.0f);
+        assertThat(AngleUtils.normalize(-Float.MIN_VALUE)).isEqualTo(0.0f);
     }
 
-    public static void testDifference() {
-        assertEquals(AngleUtils.difference(12, 12), 0.0f, 0);
-        assertEquals(AngleUtils.difference(372, 12), 0.0f, 0);
-        assertEquals(AngleUtils.difference(12, 372), 0.0f, 0);
-        assertEquals(AngleUtils.difference(10, 20), 10.0f, 0);
-        assertEquals(AngleUtils.difference(355, 5), 10.0f, 0);
-        assertEquals(AngleUtils.difference(715, -715), 10.0f, 0);
-        assertEquals(AngleUtils.difference(20, 10), -10.0f, 0);
-        assertEquals(AngleUtils.difference(5, 355), -10.0f, 0);
-        assertEquals(AngleUtils.difference(-715, 715), -10.0f, 0);
-        assertEquals(AngleUtils.difference(-90, 90), -180.0f, 0);
-        assertEquals(AngleUtils.difference(90, -90), -180.0f, 0);
+    @Test
+    public void testDifference() {
+        assertThat(AngleUtils.difference(12, 12)).isEqualTo(0.0f);
+        assertThat(AngleUtils.difference(372, 12)).isEqualTo(0.0f);
+        assertThat(AngleUtils.difference(12, 372)).isEqualTo(0.0f);
+        assertThat(AngleUtils.difference(10, 20)).isEqualTo(10.0f);
+        assertThat(AngleUtils.difference(355, 5)).isEqualTo(10.0f);
+        assertThat(AngleUtils.difference(715, -715)).isEqualTo(10.0f);
+        assertThat(AngleUtils.difference(20, 10)).isEqualTo(-10.0f);
+        assertThat(AngleUtils.difference(5, 355)).isEqualTo(-10.0f);
+        assertThat(AngleUtils.difference(-715, 715)).isEqualTo(-10.0f);
+        assertThat(AngleUtils.difference(-90, 90)).isEqualTo(-180.0f);
+        assertThat(AngleUtils.difference(90, -90)).isEqualTo(-180.0f);
     }
 }

--- a/tests/src/cgeo/geocaching/utils/CalculationUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/CalculationUtilsTest.java
@@ -1,21 +1,26 @@
 package cgeo.geocaching.utils;
 
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 
-import junit.framework.TestCase;
 
-public class CalculationUtilsTest extends TestCase {
+public class CalculationUtilsTest {
 
-    public static void testEval() {
+    @Test
+    public void testEval() {
         assertThat(new CalculationUtils("-2.5 + 3 * (4-1) + 3^3").eval()).isEqualTo(33.5d);
     }
 
-    public static void testEvalSqrt() {
+    @Test
+    public void testEvalSqrt() {
         assertThat(new CalculationUtils("sqrt(9)").eval()).isEqualTo(3d);
     }
 
-    public static void testEvalUnknownOperator() {
+    @Test
+    public void testEvalUnknownOperator() {
         try {
             new CalculationUtils("2 & 5").eval();
             fail("should throw IllegalArgumentException on unknown operator");
@@ -24,7 +29,8 @@ public class CalculationUtilsTest extends TestCase {
         }
     }
 
-    public static void testEvalUnknownFunction() {
+    @Test
+    public void testEvalUnknownFunction() {
         try {
             new CalculationUtils("uknown(42)").eval();
             fail("should throw IllegalArgumentException on unknown function");
@@ -33,7 +39,8 @@ public class CalculationUtilsTest extends TestCase {
         }
     }
 
-    public static void testUnbalancedParentheses() {
+    @Test
+    public void testUnbalancedParentheses() {
         try {
             new CalculationUtils("3 * (2 + 4 * 2").eval();
             fail("should throw IllegalArgumentException on missing ')'");

--- a/tests/src/cgeo/geocaching/utils/CalendarUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/CalendarUtilsTest.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.utils;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.util.Calendar;
 
@@ -9,9 +9,10 @@ import cgeo.geocaching.enumerations.CacheType;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class CalendarUtilsTest extends TestCase {
+public class CalendarUtilsTest {
 
-    public static void testDaysSince() {
+    @Test
+    public void testDaysSince() {
         final Calendar start = Calendar.getInstance();
         for (int hour = 0; hour < 24; hour++) {
             start.set(Calendar.HOUR_OF_DAY, hour);
@@ -19,7 +20,8 @@ public class CalendarUtilsTest extends TestCase {
         }
     }
 
-    public static void testIsPastEvent() {
+    @Test
+    public void testIsPastEvent() {
         final Calendar start = Calendar.getInstance();
         start.set(Calendar.HOUR_OF_DAY, 0);
         start.set(Calendar.MINUTE, 10);
@@ -40,7 +42,8 @@ public class CalendarUtilsTest extends TestCase {
         assertThat(CalendarUtils.isPastEvent(cache)).isEqualTo(expectedPast);
     }
 
-    public static void testIsFuture() {
+    @Test
+    public void testIsFuture() {
         final Calendar date = Calendar.getInstance();
         assertThat(CalendarUtils.isFuture(date)).isFalse();
 

--- a/tests/src/cgeo/geocaching/utils/CryptUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/CryptUtilsTest.java
@@ -1,13 +1,14 @@
 package cgeo.geocaching.utils;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import cgeo.geocaching.connector.gc.GCConstants;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class CryptUtilsTest extends TestCase {
-    public static void testROT13() {
+public class CryptUtilsTest {
+    @Test
+    public void testROT13() {
         assertThat(CryptUtils.rot13("")).isEqualTo("");
         assertThat(CryptUtils.rot13((String) null)).isEqualTo("");
         assertThat(CryptUtils.rot13("Cache hint")).isEqualTo("Pnpur uvag");
@@ -16,17 +17,20 @@ public class CryptUtilsTest extends TestCase {
         assertThat(CryptUtils.rot13("123")).isEqualTo("123");
     }
 
-    public static void testConvertToGcBase31() {
+    @Test
+    public void testConvertToGcBase31() {
         assertThat(GCConstants.gccodeToGCId("GC1PKK9")).isEqualTo(1186660);
         assertThat(GCConstants.gccodeToGCId("GC1234")).isEqualTo(4660);
         assertThat(GCConstants.gccodeToGCId("GCF123")).isEqualTo(61731);
     }
 
-    public static void testIssue1902() {
+    @Test
+    public void testIssue1902() {
         assertThat(CryptUtils.rot13("ƖƖyƖƖƖƖ")).isEqualTo("ƖƖlƖƖƖƖ");
     }
 
-    public static void testMd5() {
+    @Test
+    public void testMd5() {
         assertThat(CryptUtils.md5("")).isEqualTo("d41d8cd98f00b204e9800998ecf8427e");
         // expected value taken from debugger. should assure every developer uses UTF-8
         assertThat(CryptUtils.md5("äöü")).isEqualTo("a7f4e3ec08f09be2ef7ecb4eea5f8981");

--- a/tests/src/cgeo/geocaching/utils/LazyInitializedListTest.java
+++ b/tests/src/cgeo/geocaching/utils/LazyInitializedListTest.java
@@ -1,13 +1,13 @@
 package cgeo.geocaching.utils;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.TestCase;
-
-public class LazyInitializedListTest extends TestCase {
+public class LazyInitializedListTest {
 
     private static final class MockedLazyInitializedList extends LazyInitializedList<String> {
         @Override
@@ -16,7 +16,8 @@ public class LazyInitializedListTest extends TestCase {
         }
     }
 
-    public static void testAccess() {
+    @Test
+    public void testAccess() {
         final LazyInitializedList<String> list = new MockedLazyInitializedList();
         assertThat(list).isEmpty();
         list.add("Test");

--- a/tests/src/cgeo/geocaching/utils/LeastRecentlyUsedMapTest.java
+++ b/tests/src/cgeo/geocaching/utils/LeastRecentlyUsedMapTest.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.utils;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.util.Map;
 
@@ -8,9 +8,10 @@ import cgeo.geocaching.models.Geocache;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class LeastRecentlyUsedMapTest extends TestCase {
+public class LeastRecentlyUsedMapTest {
 
-    public static void testLruMode() {
+    @Test
+    public void testLruMode() {
         final Map<String, String> map = new LeastRecentlyUsedMap.LruCache<>(4);
         map.put("one", "1");
         map.put("two", "2");
@@ -29,7 +30,8 @@ public class LeastRecentlyUsedMapTest extends TestCase {
         assertThat(map.keySet()).containsExactly("six", "one", "five", "seven");
     }
 
-    public static void testBoundedMode() {
+    @Test
+    public void testBoundedMode() {
         final Map<String, String> map = new LeastRecentlyUsedMap.Bounded<>(5);
         map.put("one", "1");
         map.put("two", "2");
@@ -48,7 +50,8 @@ public class LeastRecentlyUsedMapTest extends TestCase {
         assertThat(map.keySet()).containsExactly("four", "three", "five", "six", "seven");
     }
 
-    public static void testRemoveEldestEntry() {
+    @Test
+    public void testRemoveEldestEntry() {
         final LeastRecentlyUsedMap<String, Geocache> cache = new LeastRecentlyUsedMap.LruCache<>(10);
         final Geocache first = new Geocache();
         assertThat(cache.put("1", first)).isNull();

--- a/tests/src/cgeo/geocaching/utils/LeastRecentlyUsedSetTest.java
+++ b/tests/src/cgeo/geocaching/utils/LeastRecentlyUsedSetTest.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.utils;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.util.Set;
 
@@ -8,9 +8,10 @@ import cgeo.geocaching.models.Geocache;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class LeastRecentlyUsedSetTest extends TestCase {
+public class LeastRecentlyUsedSetTest {
 
-    public static void testLruMode() {
+    @Test
+    public void testLruMode() {
         final Set<String> set = new LeastRecentlyUsedSet<>(5);
         set.add("one");
         set.add("two");
@@ -29,7 +30,8 @@ public class LeastRecentlyUsedSetTest extends TestCase {
         assertThat(set).containsExactly("four", "three", "five", "six", "seven");
     }
 
-    public static void testRemoveEldestEntry() {
+    @Test
+    public void testRemoveEldestEntry() {
         final LeastRecentlyUsedSet<Geocache> caches = new LeastRecentlyUsedSet<>(10);
         final Geocache first = new Geocache();
         first.setGeocode("1");

--- a/tests/src/cgeo/geocaching/utils/RxUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/RxUtilsTest.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.utils;
 
+import org.junit.Test;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import java.util.concurrent.TimeUnit;
@@ -11,11 +13,11 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
-import junit.framework.TestCase;
 
-public class RxUtilsTest extends TestCase {
+public class RxUtilsTest {
 
-    public static void testRememberLast() {
+    @Test
+    public void testRememberLast() {
         final PublishSubject<String> rawObservable = PublishSubject.create();
         final Observable<String> observable = RxUtils.rememberLast(rawObservable, "initial");
 
@@ -36,7 +38,8 @@ public class RxUtilsTest extends TestCase {
         assertThat(observable.blockingFirst()).isEqualTo("first");
     }
 
-    public static void testObservableCache() {
+    @Test
+    public void testObservableCache() {
         final AtomicInteger counter = new AtomicInteger(0);
         final RxUtils.ObservableCache<String, Integer> cache = new RxUtils.ObservableCache<>(new Function<String, Observable<Integer>>() {
             @Override
@@ -57,7 +60,8 @@ public class RxUtilsTest extends TestCase {
         assertThat(counter.get()).isEqualTo(2);
     }
 
-    public static void testDelayedUnsubscription() {
+    @Test
+    public void testDelayedUnsubscription() {
         final AtomicBoolean unsubscribed = new AtomicBoolean(false);
         Observable.never().doOnDispose(new Action() {
             @Override

--- a/tests/src/cgeo/geocaching/utils/XmlUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/XmlUtilsTest.java
@@ -8,30 +8,32 @@ import java.io.IOException;
 import java.io.StringWriter;
 
 
-import junit.framework.TestCase;
 import org.apache.commons.lang3.CharEncoding;
+import org.junit.Before;
+import org.junit.Test;
 import org.xmlpull.v1.XmlSerializer;
 
-public class XmlUtilsTest extends TestCase {
+public class XmlUtilsTest {
 
     private XmlSerializer xml;
 
     private StringWriter stringWriter;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         stringWriter = new StringWriter();
         xml = new KXmlSerializer();
         xml.setOutput(stringWriter);
         xml.startDocument(CharEncoding.UTF_8, null);
     }
 
+    @Test
     public void testSimpleText() throws Exception {
         XmlUtils.simpleText(xml, "", "tag", "text");
         assertXmlEquals("<tag>text</tag>");
     }
 
+    @Test
     public void testSimpleTextWithPrefix() throws Exception {
         XmlUtils.simpleText(xml, "prefix", "tag", "text");
         assertXmlEquals("<n0:tag xmlns:n0=\"prefix\">text</n0:tag>");
@@ -43,11 +45,13 @@ public class XmlUtilsTest extends TestCase {
         assertThat(stringWriter.toString()).isEqualTo("<?xml version='1.0' encoding='UTF-8' ?>" + expected);
     }
 
+    @Test
     public void testMultipleTexts() throws Exception {
         XmlUtils.multipleTexts(xml, "", "tag1", "text1", "tag2", "text2");
         assertXmlEquals("<tag1>text1</tag1><tag2>text2</tag2>");
     }
 
+    @Test
     public void testSkipIllegalChars() throws Exception {
         XmlUtils.simpleText(xml, "", "tag", "Vom\u0001 Gasthaus\u000f zur \u000bPyramide\u0020aus \u0018Glas\u0009");
         assertXmlEquals("<tag>Vom Gasthaus zur Pyramide\u0020aus Glas\u0009</tag>");


### PR DESCRIPTION
Added contextmenu for copying of waypoints coordinates on longclick just as in the main cache page.