### PR TITLE
fix #6741 remove check of OC rcmd_max_pixels param

### DIFF
--- a/main/src/cgeo/geocaching/ImageSelectActivity.java
+++ b/main/src/cgeo/geocaching/ImageSelectActivity.java
@@ -51,7 +51,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
     private static final String SAVED_STATE_IMAGE = "cgeo.geocaching.saved_state_image";
     private static final String SAVED_STATE_IMAGE_SCALE = "cgeo.geocaching.saved_state_image_scale";
     private static final String SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE = "cgeo.geocaching.saved_state_max_image_upload_size";
-    private static final String SAVED_STATE_MAX_IMAGE_PIXELS = "cgeo.geocaching.saved_state_max_image_pixels";
 
     private static final int SELECT_NEW_IMAGE = 1;
     private static final int SELECT_STORED_IMAGE = 2;
@@ -59,7 +58,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
     // Data to be saved while reconfiguring
     private Image image;
     private int scaleChoiceIndex;
-    private long maxImagePixels;
     private long maxImageUploadSize;
 
     @Override
@@ -74,7 +72,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
         if (extras != null) {
             image = extras.getParcelable(Intents.EXTRA_IMAGE);
             scaleChoiceIndex = extras.getInt(Intents.EXTRA_SCALE, scaleChoiceIndex);
-            maxImagePixels = extras.getLong(Intents.EXTRA_MAX_IMAGE_PIXELS);
             maxImageUploadSize = extras.getLong(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE);
             final String geocode = extras.getString(Intents.EXTRA_GEOCODE);
             setCacheTitleBar(geocode);
@@ -85,7 +82,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
             image = savedInstanceState.getParcelable(SAVED_STATE_IMAGE);
             scaleChoiceIndex = savedInstanceState.getInt(SAVED_STATE_IMAGE_SCALE);
             maxImageUploadSize = savedInstanceState.getLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE);
-            maxImagePixels = savedInstanceState.getLong(SAVED_STATE_MAX_IMAGE_PIXELS);
         }
 
         if (image == null) {
@@ -157,7 +153,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
         outState.putParcelable(SAVED_STATE_IMAGE, image);
         outState.putInt(SAVED_STATE_IMAGE_SCALE, scaleChoiceIndex);
         outState.putLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
-        outState.putLong(SAVED_STATE_MAX_IMAGE_PIXELS, maxImagePixels);
     }
 
     public void saveImageInfo(final boolean saveInfo) {
@@ -174,11 +169,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
                         image = new Image.Builder().setUrl(scaleImageResult.getFilename()).build();
 
                         if (maxImageUploadSize > 0 && image.getFile().length() > maxImageUploadSize) {
-                            showToast(res.getString(R.string.err_select_logimage_upload_size));
-                            return;
-                        }
-
-                        if (maxImagePixels > 0 && scaleImageResult.getWidth() * scaleImageResult.getHeight() > maxImagePixels) {
                             showToast(res.getString(R.string.err_select_logimage_upload_size));
                             return;
                         }

--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -28,7 +28,6 @@ public class Intents {
     public static final String EXTRA_IMAGE = PREFIX + "image";
     public static final String EXTRA_IMAGES = PREFIX + "images";
     public static final String EXTRA_MAX_IMAGE_UPLOAD_SIZE = PREFIX + "max-image-upload-size";
-    public static final String EXTRA_MAX_IMAGE_PIXELS = PREFIX + "max-image-pixels";
     public static final String EXTRA_ID = PREFIX + "id";
     public static final String EXTRA_KEYWORD = PREFIX + "keyword";
     public static final String EXTRA_KEYWORD_SEARCH = PREFIX + "keyword_search";

--- a/main/src/cgeo/geocaching/connector/AbstractLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/AbstractLoggingManager.java
@@ -30,9 +30,4 @@ public abstract class AbstractLoggingManager implements ILoggingManager {
         return null;
     }
 
-    @Override
-    public Long getMaxImagePixels() {
-        return null;
-    }
-
 }

--- a/main/src/cgeo/geocaching/connector/ILoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/ILoggingManager.java
@@ -43,6 +43,4 @@ public interface ILoggingManager {
 
     Long getMaxImageUploadSize();
 
-    Long getMaxImagePixels();
-
 }

--- a/main/src/cgeo/geocaching/connector/oc/OkapiLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiLoggingManager.java
@@ -111,9 +111,4 @@ public class OkapiLoggingManager extends AbstractLoggingManager implements Loade
         return installationInformation != null ? installationInformation.imageMaxUploadSize : null;
     }
 
-    @Override
-    public Long getMaxImagePixels() {
-        return installationInformation != null ? installationInformation.imageRcmdMaxPixels : null;
-    }
-
 }

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -779,7 +779,6 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
         selectImageIntent.putExtra(Intents.EXTRA_IMAGE, image);
         selectImageIntent.putExtra(Intents.EXTRA_GEOCODE, cache.getGeocode());
         selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE, loggingManager.getMaxImageUploadSize());
-        selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_PIXELS, loggingManager.getMaxImagePixels());
 
         startActivityForResult(selectImageIntent, SELECT_IMAGE);
     }


### PR DESCRIPTION
Let's just remove this check. We don't warn about downscaling of images by GC either.