### PR TITLE
fix #6793 handling of scheme relative image urls

### DIFF
--- a/main/src/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/cgeo/geocaching/network/HtmlImage.java
@@ -381,12 +381,18 @@ public class HtmlImage implements Html.ImageGetter {
             return url;
         }
 
+        final String hostUrl = ConnectorFactory.getConnector(geocode).getHostUrl();
+
+        // special case for scheme relative URLs
+        if (StringUtils.startsWith(url, "//")) {
+            return StringUtils.isEmpty(hostUrl) ? "https:" + url : Uri.parse(hostUrl).getScheme() + ":" + url;
+        }
+
         if (!StringUtils.startsWith(url, "/")) {
             Log.w("unusable relative URL for geocache " + geocode + ": " + url);
             return null;
         }
 
-        final String hostUrl = ConnectorFactory.getConnector(geocode).getHostUrl();
         if (StringUtils.isEmpty(hostUrl)) {
             Log.w("unable to compute relative images URL for " + geocode);
             return null;


### PR DESCRIPTION
For scheme relative image URLs it takes the scheme of the geocache connector hostUrl.
If not exist it assumes "https".