### PR TITLE
fix #6715 merge WP userNotes with Calculator notes

### DIFF
--- a/main/res/layout/coordinatesinput_dialog.xml
+++ b/main/res/layout/coordinatesinput_dialog.xml
@@ -34,7 +34,8 @@
             style="@style/button_full"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:text="@string/waypoint_calculate_coordinates" />
+            android:text="@string/waypoint_calculate_coordinates"
+            android:visibility="gone" />
 
         <Button
             android:id="@+id/clipboard"

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -468,11 +468,12 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
     @Override
     public void saveCalculatorState(final CalcState calcState) {
         this.calcState = calcState;
+        this.userNote.setText(calcState.notes);
     }
 
     @Override
     public CalcState fetchCalculatorState() {
-        return calcState;
+        return new CalcState(calcState, userNote.getText().toString());
     }
 
     /**

--- a/main/src/cgeo/geocaching/models/CalcState.java
+++ b/main/src/cgeo/geocaching/models/CalcState.java
@@ -58,6 +58,11 @@ public class CalcState implements Serializable {
         this.notes = notes;
     }
 
+    public CalcState(final CalcState calcState, final String notes) {
+        this(calcState.format, calcState.plainLat, calcState.plainLon, calcState.latHemisphere, calcState.lonHemisphere,
+                calcState.buttons, calcState.equations, calcState.freeVariables, calcState.variableBank, notes);
+    }
+
     private CalcState(final JSONObject json) {
         format = CoordInputFormatEnum.values()[json.optInt("format", 2)];
         plainLat = json.optString("plainLat");
@@ -68,7 +73,7 @@ public class CalcState implements Serializable {
         equations     = createJSONAbleList(json.optJSONArray("equations"),     new CalculatorVariable.VariableDataFactory());
         freeVariables = createJSONAbleList(json.optJSONArray("freeVariables"), new CalculatorVariable.VariableDataFactory());
         variableBank = new ArrayList<>(); // "variableBank" intentionally not loaded.
-        notes = json.optString("notes");
+        notes = ""; // "notes" is read from "user_note" db column, not this json
     }
 
     private static <T extends JSONAble> ArrayList<T> createJSONAbleList(final JSONArray json, final JSONAbleFactory<T> factory) {
@@ -112,7 +117,7 @@ public class CalcState implements Serializable {
         returnValue.put("equations", toJSON(equations));
         returnValue.put("freeVariables", toJSON(freeVariables));
         // "variableBank" intentionally left out.
-        returnValue.put("notes", notes);
+        // "notes" is written to another db column
 
         return returnValue;
     }

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.ui.dialog;
 import static cgeo.geocaching.R.id.PlainFormat;
 import static cgeo.geocaching.R.id.coordTable;
 import static cgeo.geocaching.models.CalcState.ERROR_CHAR;
+import static cgeo.geocaching.ui.dialog.CoordinatesInputDialog.GEOPOINT_ARG;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
@@ -66,6 +67,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
     private static final String SYMBOL_MIN = "'";
     private static final String SYMBOL_SEC = "\"";
     private static final String SYMBOL_POINT = ".";
+    public static final String CALC_STATE = "calc_state";
 
     private ImageButton doneButton;
     private boolean stateSaved = false;
@@ -116,8 +118,6 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
     private List<View> secButtons;
     private List<CalculateButton> pointLowButtons;
     private List<TextView> lastUnits;
-
-    private static final String GEOPOINT_ARG = "GEOPOINT";
 
     /**
      * Class used for checking that a value is with in a given range.
@@ -304,7 +304,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
     }
 
     /**
-     * @param gp Geopoint representing the coordinates from the CoordinateInputDialog
+     * @param gp               Geopoint representing the coordinates from the CoordinateInputDialog
      * @param calculationState State to set the calculator to when created
      */
     public static CoordinatesCalculateDialog getInstance(final Geopoint gp, final CalcState calculationState) {
@@ -336,7 +336,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
                 gp = savedInstanceState.getParcelable(GEOPOINT_ARG);
             }
 
-            final byte[] bytes = savedInstanceState.getByteArray("calc_state");
+            final byte[] bytes = savedInstanceState.getByteArray(CALC_STATE);
             if (bytes != null) {
                 setSavedState((CalcState) SerializationUtils.deserialize(bytes));
             }
@@ -528,7 +528,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
     @Override
     public void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putByteArray("calc_state", SerializationUtils.serialize(getCurrentState()));
+        outState.putByteArray(CALC_STATE, SerializationUtils.serialize(getCurrentState()));
     }
 
     private void displayToast(final int message) {

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -62,7 +62,7 @@ public class CoordinatesInputDialog extends DialogFragment {
     private CoordInputFormatEnum currentFormat = null;
     private List<EditText> orderedInputs;
 
-    private static final String GEOPOINT_ARG = "GEOPOINT";
+    public static final String GEOPOINT_ARG = "GEOPOINT";
     private static final String CACHECOORDS_ARG = "CACHECOORDS";
 
     private FragmentActivity myContext;
@@ -194,7 +194,10 @@ public class CoordinatesInputDialog extends DialogFragment {
             buttonCache.setVisibility(View.GONE);
         }
         final Button buttonCalculate = ButterKnife.findById(v, R.id.calculate);
-        buttonCalculate.setOnClickListener(new CalculateListener());
+        if (getActivity() instanceof CalculateState) {
+            buttonCalculate.setOnClickListener(new CalculateListener());
+            buttonCalculate.setVisibility(View.VISIBLE);
+        }
 
         if (hasClipboardCoordinates()) {
             final Button buttonClipboard = ButterKnife.findById(v, R.id.clipboard);
@@ -570,12 +573,15 @@ public class CoordinatesInputDialog extends DialogFragment {
 
         @Override
         public void onClick(final View v) {
-            final CalcState newState = ((CalculateState) getActivity()).fetchCalculatorState();
-            final CoordinatesCalculateDialog calculateDialog = CoordinatesCalculateDialog.getInstance(gp, newState);
-             // Assign this fragment as the target fragment so the calculate dialog can automatically close this one on completion
-            calculateDialog.setTargetFragment(CoordinatesInputDialog.this, 1);
-            calculateDialog.setCancelable(true);
-            calculateDialog.show(myContext.getSupportFragmentManager(), "wpcalcdialog");
+            if (getActivity() instanceof  CalculateState) {
+                final CalculateState calculateState = (CalculateState) getActivity();
+                final CalcState newState = calculateState.fetchCalculatorState();
+                final CoordinatesCalculateDialog calculateDialog = CoordinatesCalculateDialog.getInstance(gp, newState);
+                // Assign this fragment as the target fragment so the calculate dialog can automatically close this one on completion
+                calculateDialog.setTargetFragment(CoordinatesInputDialog.this, 1);
+                calculateDialog.setCancelable(true);
+                calculateDialog.show(myContext.getSupportFragmentManager(), "wpcalcdialog");
+            }
         }
     }
 


### PR DESCRIPTION
Current data in the calculator notes is simply ignored. Possible data loss for nightly build users! But the calculator variables are still available, so the loss might not be too hard.

It also removes the calculate button from CoordinatesInputDialog when called from NavigateAnyPointActivity, SearchActivity and LogTrackableActivity. That caused a crash.