### PR TITLE
fix #6811 copy/move caches from history

### DIFF
--- a/main/src/cgeo/geocaching/command/MoveToListAndRemoveFromOthersCommand.java
+++ b/main/src/cgeo/geocaching/command/MoveToListAndRemoveFromOthersCommand.java
@@ -3,32 +3,44 @@ package cgeo.geocaching.command;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 
-import android.app.Activity;
-
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class MoveToListAndRemoveFromOthersCommand extends MoveToListCommand {
 
-    private final Geocache cache;
-    private HashSet<Integer> oldLists;
+    private final Map<String, Set<Integer>> oldLists = new HashMap<>();
 
     protected MoveToListAndRemoveFromOthersCommand(@NonNull final Activity context, @NonNull final Geocache cache) {
-        super(context, Collections.singleton(cache), -1);
-        this.cache = cache;
+        this(context, Collections.singleton(cache));
+    }
+
+    protected MoveToListAndRemoveFromOthersCommand(@NonNull final Activity context, @NonNull final Collection<Geocache> caches) {
+        super(context, caches, -1);
     }
 
     @Override
     protected void doCommand() {
-        oldLists = new HashSet<>(cache.getLists());
+        for (final Geocache cache : getCaches()) {
+            oldLists.put(cache.getGeocode(), new HashSet<>(cache.getLists()));
+        }
         DataStore.saveLists(getCaches(), Collections.singleton(getNewListId()));
     }
 
     @Override
     protected void undoCommand() {
-        DataStore.saveLists(getCaches(), oldLists);
+        for (final Geocache cache : getCaches()) {
+            final Set<Integer> listIds = oldLists.get(cache.getGeocode());
+            if (listIds != null) {
+                DataStore.saveLists(getCaches(), listIds);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
I've enabled the copy and move caches menu item for history. 
Now it is possible to copy caches from the History to any concrete list.
Move is a bit special, I decided to remove from all other lists and store it on the new list. You cannot remove it this way from History, because they have still the recent found status or the offline log. But I think it is usefull: imagine you want to move all found caches to a found list. 