### PR TITLE
avoid gradle warning about root project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+// Make the root project name independent of the directory name where we checked out the repository.
+// This can avoid problems with directory names like "cgeo pull request" containing blanks on CI.
+rootProject.name = "cgeo"
+
+// included sub projects
 include ':mapswithme-api'
 include ':main'
 include ':cgeo-contacts'


### PR DESCRIPTION
Since some builds we see warnings when building a PR, since the
directory is named "cgeo pull request" automatically by Jenkins, which is
now an invalid name in gradle.