### PR TITLE
fix #6826 remove superfluous waypoint note

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1890,11 +1890,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             if (StringUtils.isNotBlank(wpt.getUserNote()) && !StringUtils.equals(wpt.getNote(), wpt.getUserNote())) {
                 userNoteView.setOnClickListener(new DecryptTextClickListener(userNoteView));
                 userNoteView.setVisibility(View.VISIBLE);
-                if (TextUtils.containsHtml(wpt.getUserNote())) {
-                    userNoteView.setText(Html.fromHtml(wpt.getUserNote(), new SmileyImage(cache.getGeocode(), userNoteView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
-                } else {
-                    userNoteView.setText(wpt.getUserNote());
-                }
+                userNoteView.setText(wpt.getUserNote());
             } else {
                 userNoteView.setVisibility(View.GONE);
             }


### PR DESCRIPTION
For user defined waypoints, the note is merged with the userNote and the original note be emptied.

Empty note fields get hidden, even for server defined waypoints.

For server defined notes gets preserved. They are not editable but we stripped html. Now html can be preserved.

Html in userNotes is not supported and "<" characters escaped.

This might solve #6791 as well.