### PR TITLE
Fix #6802: Use exact matching when parsing latitude/longitude

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/cgeo/geocaching/location/GeopointParser.java
@@ -514,17 +514,16 @@ public class GeopointParser {
      */
     @Nullable
     private static ResultWrapper parseHelper(@NonNull final String text, @NonNull final LatLon latlon) {
-        final String withoutSpaceAfterComma = removeAllSpaceAfterComma(text);
+        final String withoutSpaceAfterComma = removeAllSpaceAfterComma(text.trim());
 
-        ResultWrapper best = null;
         for (final AbstractParser parser : parsers) {
             final ResultWrapper wrapper = parser.parse(withoutSpaceAfterComma, latlon);
-            if (wrapper != null && (best == null || wrapper.matcherLength > best.matcherLength)) {
-                best = wrapper;
+            if (wrapper != null && wrapper.matcherLength == withoutSpaceAfterComma.length()) {
+                return wrapper;
             }
         }
 
-        return best;
+        return null;
     }
 
     /**
@@ -609,6 +608,8 @@ public class GeopointParser {
     /**
      * Parses latitude out of the given string.
      *
+     * The parsing fails if the string contains additional characters (except whitespaces).
+     *
      * @see #parse(String)
      * @param text
      *            the string to be parsed
@@ -629,6 +630,8 @@ public class GeopointParser {
 
     /**
      * Parses longitude out of the given string.
+     *
+     * The parsing fails if the string contains additional characters (except whitespaces).
      *
      * @see #parse(String)
      * @param text

--- a/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
@@ -299,4 +299,20 @@ public class GeoPointParserTest {
         assertGeopointEquals(gp3, ref, 1e-4f);
     }
 
+    @Test
+    public void test6802() {
+        try {
+            GeopointParser.parseLatitude("N 1.1.1.1.1.1.1");
+            failBecauseExceptionWasNotThrown(Geopoint.ParseException.class);
+        } catch (final Geopoint.ParseException e) {
+            // expected
+        }
+        try {
+            GeopointParser.parseLongitude("E 99?++?9.93@#$%&-+777");
+            failBecauseExceptionWasNotThrown(Geopoint.ParseException.class);
+        } catch (final Geopoint.ParseException e) {
+            // expected
+        }
+    }
+
 }


### PR DESCRIPTION
I'm not up to date whether this PR should be against master or release, so I picked the same base as #6848.