### PR TITLE
Fix #6851 implement copy waypoint notes action

### DIFF
--- a/main/res/menu/waypoint_options.xml
+++ b/main/res/menu/waypoint_options.xml
@@ -19,6 +19,10 @@
         android:title="@string/waypoint_copy_coordinates">
     </item>
     <item
+        android:id="@+id/menu_waypoint_copy_notes"
+        android:title="Copy notes">
+    </item>
+    <item
         android:id="@+id/menu_waypoint_duplicate"
         android:title="@string/waypoint_duplicate">
     </item>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -605,8 +605,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     }
 
     private static String stripAndMergeNotes(Waypoint waypoint) {
-        String note = Html.fromHtml(StringUtils.trimToEmpty(waypoint.getNote())).toString();
-        String userNote = StringUtils.trimToEmpty(waypoint.getUserNote());
+        final String note = Html.fromHtml(StringUtils.trimToEmpty(waypoint.getNote())).toString();
+        final String userNote = StringUtils.trimToEmpty(waypoint.getUserNote());
         if (StringUtils.isBlank(note)) {
             return userNote;
         }

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -463,6 +463,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 menu.findItem(R.id.menu_waypoint_navigate).setVisible(hasCoords);
                 menu.findItem(R.id.menu_waypoint_caches_around).setVisible(hasCoords);
                 menu.findItem(R.id.menu_waypoint_copy_coordinates).setVisible(hasCoords);
+                final boolean notBlank = StringUtils.isNotBlank(stripAndMergeNotes(selectedWaypoint));
+                menu.findItem(R.id.menu_waypoint_copy_notes).setVisible(notBlank);
                 break;
             default:
                 if (imagesList != null) {
@@ -509,6 +511,15 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     if (coordinates != null) {
                         ClipboardUtils.copyToClipboard(
                                 GeopointFormatter.reformatForClipboard(coordinates.toString()));
+                        showToast(getString(R.string.clipboard_copy_ok));
+                    }
+                }
+                return true;
+            case R.id.menu_waypoint_copy_notes:
+                if (selectedWaypoint != null) {
+                    final String mergedNote = stripAndMergeNotes(selectedWaypoint);
+                    if (!mergedNote.isEmpty()) {
+                        ClipboardUtils.copyToClipboard(mergedNote);
                         showToast(getString(R.string.clipboard_copy_ok));
                     }
                 }
@@ -591,6 +602,18 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             return true;
         }
         return onOptionsItemSelected(item);
+    }
+
+    private static String stripAndMergeNotes(Waypoint waypoint) {
+        String note = Html.fromHtml(StringUtils.trimToEmpty(waypoint.getNote())).toString();
+        String userNote = StringUtils.trimToEmpty(waypoint.getUserNote());
+        if (StringUtils.isBlank(note)) {
+            return userNote;
+        }
+        if (StringUtils.isBlank(userNote)) {
+            return note;
+        }
+        return note + "\n" + userNote;
     }
 
     @Override


### PR DESCRIPTION
Changed behavior:
Open the waypoint context menu by long press:
- Waypoint without (server) note and user note -> no menu item "Copy notes" shown
- Waypoint with (server) note only or user note only -> menu item "Copy notes" shown and note is copied
- Waypoint with both notes -> menu item "Copy notes" shown, notes are concatenated as in "Duplicate Waypoint" and copied