### PR TITLE
fix #6844 confirm discard wp changes

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -257,6 +257,8 @@
     <string name="warn_calculator_state_save">Be sure to save waypoint if you want to keep the calculator state.</string>
     <string name="err_trackable_log_not_anonymous">Logging %1$s from c:geo cannot be done anonymously. Do you want to open the settings to fill in your credentials from %2$s?</string>
     <string name="err_trackable_no_preference_activity">Sorry, cannot find a suitable preference screen.</string>
+    <string name="confirm_unsaved_changes_title">Unsaved changes</string>
+    <string name="confirm_discard_wp_changes">Discard unsaved waypoint changes?</string>
     <string name="warn_discard_changes">Unsaved waypoint changes discarded!</string>
     <string name="err_request_popup_info">c:geo failed to get cache popup info.</string>
 

--- a/main/src/cgeo/geocaching/location/Geopoint.java
+++ b/main/src/cgeo/geocaching/location/Geopoint.java
@@ -547,4 +547,16 @@ public final class Geopoint implements ICoordinates, Parcelable {
         return p1 == null ? p2 == null : p2 != null && p1.equals(p2);
     }
 
+    /**
+     * Check whether two geopoints represent the same String in the given format or are both <tt>null</tt>.
+     *
+     * @param p1 the first Geopoint, or <tt>null</tt>
+     * @param p2 the second Geopoint, or <tt>null</tt>
+     * @return <tt>true</tt> if both geopoints represent the same String in the given format or are both <tt>null</tt>,
+     *         <tt>false</tt> otherwise
+     */
+    public static boolean equalsFormatted(final Geopoint p1, final Geopoint p2, final GeopointFormatter.Format format) {
+        return p1 == null ? p2 == null : p2 != null && p1.format(format).equals(p2.format(format));
+    }
+
 }

--- a/main/src/cgeo/geocaching/models/CalcState.java
+++ b/main/src/cgeo/geocaching/models/CalcState.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.ui.CalculateButton;
 import cgeo.geocaching.ui.CalculatorVariable;
 import cgeo.geocaching.ui.JSONAble;
 import cgeo.geocaching.ui.JSONAbleFactory;
+import cgeo.geocaching.utils.Log;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -76,12 +77,17 @@ public class CalcState implements Serializable {
         return returnValue;
     }
 
-    public static CalcState fromJSON(final String json) throws JSONException {
+    public static CalcState fromJSON(final String json)  {
         if (json == null) {
             return null;
         }
 
-        return new CalcState(new JSONObject(json));
+        try {
+            return new CalcState(new JSONObject(json));
+        } catch (final JSONException e) {
+            Log.e("Unable to read calculator state information", e);
+        }
+        return null;
     }
 
     private JSONArray toJSON(final List<? extends JSONAble> items) throws JSONException {
@@ -94,18 +100,22 @@ public class CalcState implements Serializable {
         return returnValue;
     }
 
-    public JSONObject toJSON() throws JSONException {
+    public JSONObject toJSON() {
         final JSONObject returnValue = new JSONObject();
 
-        returnValue.put("format", format.ordinal());
-        returnValue.put("plainLat", plainLat);
-        returnValue.put("plainLon", plainLon);
-        returnValue.put("latHemisphere", latHemisphere);
-        returnValue.put("lonHemisphere", lonHemisphere);
-        returnValue.put("buttons", toJSON(buttons));
-        returnValue.put("equations", toJSON(equations));
-        returnValue.put("freeVariables", toJSON(freeVariables));
-        // "variableBank" intentionally left out.
+        try {
+            returnValue.put("format", format.ordinal());
+            returnValue.put("plainLat", plainLat);
+            returnValue.put("plainLon", plainLon);
+            returnValue.put("latHemisphere", latHemisphere);
+            returnValue.put("lonHemisphere", lonHemisphere);
+            returnValue.put("buttons", toJSON(buttons));
+            returnValue.put("equations", toJSON(equations));
+            returnValue.put("freeVariables", toJSON(freeVariables));
+            // "variableBank" intentionally left out.
+        } catch (final JSONException e) {
+            Log.e("Unable to write calculator state information", e);
+        }
 
         return returnValue;
     }

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -47,7 +47,7 @@ public class Waypoint implements IWaypoint {
     private boolean visited = false;
     private boolean originalCoordsEmpty = false;
 
-    private CalcState calculatorSaveState = null;
+    private String calcStateJson = null;
 
     /**
      * require name and type for every waypoint
@@ -91,8 +91,8 @@ public class Waypoint implements IWaypoint {
         if (StringUtils.equals(note, userNote)) {
             userNote = "";
         }
-        if (calculatorSaveState == null) {
-            calculatorSaveState = old.calculatorSaveState;
+        if (calcStateJson == null) {
+            calcStateJson = old.calcStateJson;
         }
         if (id < 0) {
             id = old.id;
@@ -344,12 +344,12 @@ public class Waypoint implements IWaypoint {
         this.originalCoordsEmpty = originalCoordsEmpty;
     }
 
-    public CalcState getCalculatorStoredState() {
-        return calculatorSaveState;
+    public String getCalcStateJson() {
+        return calcStateJson;
     }
 
-    public void setCalculatorStoredState(final CalcState calculatorStoredState) {
-        this.calculatorSaveState = calculatorStoredState;
+    public void setCalcStateJson(final String calcStateJson) {
+        this.calcStateJson = calcStateJson;
     }
 
     /*

--- a/tests/src/cgeo/geocaching/location/GeopointTest.java
+++ b/tests/src/cgeo/geocaching/location/GeopointTest.java
@@ -64,6 +64,14 @@ public class GeopointTest {
     }
 
     @Test
+    public void testEqualsFormatted() {
+        final Geopoint gp1 = new Geopoint(48.559984, 2.713871);
+        final Geopoint gp2 = new Geopoint(48.559981, 2.713873);
+        assertThat(Geopoint.equals(gp1, gp2)).isFalse();
+        assertThat(Geopoint.equalsFormatted(gp1, gp2, GeopointFormatter.Format.LAT_LON_DECMINUTE)).isTrue();
+    }
+
+    @Test
     public void testBearingDistance() {
         final Geopoint gp1 = new Geopoint(-30.4, -1.2);
         final Geopoint gp2 = new Geopoint(-30.1, -2.3);


### PR DESCRIPTION
Adding the confirmation dialog was not an issue. But I saw that the calculator state was not included in the detection of changes in `isWaypointChanged(currentState)`. Adding it was a bigger challenge. 
Long story short I decided to go with the json string to compare before and after. Otherwise I would have to implement a deep copy and compare of this object. 
@S-Bartfast: maybe you can give some feedback here. Better ideas are welcome.

Another issue is the prefill of the coordinates if they are NULL which we want to tackle in #6861. At the moment the user needs to confirm an unsaved change here, even if he didn't change anything on purpose.

Sometimes there is a rounding issue in the Geopoint(Parser) class which results in a failing equals test even if the coords haven't been changed and they look similar. In the database we have lat/lon as doubles convert them to a String for the buttons and parse them back.