### PR TITLE
6870 destroy initial loader when load more caches

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1556,9 +1556,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             showFooterLoadingCaches();
 
             getSupportLoaderManager().restartLoader(CacheListLoaderType.NEXT_PAGE.getLoaderId(), null, CacheListActivity.this);
-            if (type == CacheListType.NEAREST) {
-                getSupportLoaderManager().destroyLoader(CacheListType.NEAREST.getLoaderId());
-            }
+            // the loader for subsequent pages takes over - therefore the initial loader needs to be destroyed
+            getSupportLoaderManager().destroyLoader(type.getLoaderId());
         }
     }
 


### PR DESCRIPTION
Fix the issue by destroying the initial loader unconditionally.
This listener method is only entered for the CacheListTypes that show the above issue.

Test steps
- Open a cache list of type NEARBY, ADDRESS, POCKET, OWNER, FINDER, KEYWORD, COORDINATE
- "Load more caches" twice to get 60 entries
- Select one of the caches in this list
- Optionally: to make the test deterministic place a breakpoint at the begin of AbstractSearchLoader.loadInBackground(). This makes sure that the two concurrent loaders always execute in the same order (before the fix).
- Leave the selected cache with the "Back" button
Without the fix:
- The breakpoint above hits twice for two different "ModernAsyncTask" threads
- The list shows 40 entries. If no breakpoinnt is used a few retries might be needed to get this behavior.
With the fix:
- The breakpoint above hits only once in a "ModernAsyncTask" thread
- The list still shows 60 entries. This can be only proven with an active breakpoint

NEARBY ok.
COORDINATE ok.
ADDRESS ok
KEYWORD ok
FINDER ok
OWNER ok
POCKET @pstorch can you give it a try?

Verified that MAP, OFFLINE and HISTORY work as before.