### PR TITLE
fix #6861 support null coords in waypoints

### DIFF
--- a/main/res/layout/coordinatesinput_dialog.xml
+++ b/main/res/layout/coordinatesinput_dialog.xml
@@ -46,6 +46,14 @@
             android:visibility="gone" />
 
         <Button
+            android:id="@+id/clear"
+            style="@style/button_full"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/waypoint_clear_coordinates"
+            android:visibility="gone" />
+
+        <Button
             android:id="@+id/done"
             style="@style/button_full"
             android:layout_width="fill_parent"

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -34,7 +34,8 @@
                 android:id="@+id/bearing"
                 style="@style/edittext_full"
                 android:hint="@string/waypoint_bearing"
-                android:inputType="numberDecimal" />
+                android:inputType="numberDecimal"
+                android:enabled="false"/>
 
             <LinearLayout
                 android:layout_width="fill_parent"
@@ -47,14 +48,16 @@
                     android:layout_width="0dip"
                     android:layout_weight="1"
                     android:hint="@string/waypoint_distance"
-                    android:inputType="numberDecimal" />
+                    android:inputType="numberDecimal"
+                    android:enabled="false"/>
 
                 <Spinner
                     android:id="@+id/distanceUnit"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:entries="@array/distance_units"
-                    tools:listitem="@android:layout/simple_spinner_item" />
+                    tools:listitem="@android:layout/simple_spinner_item"
+                    android:enabled="false"/>
 
             </LinearLayout>
         </LinearLayout>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1603,5 +1603,7 @@
     <string name="list_confirm_debug_message">The debug mode causes instabilities! Do you want to deactivate the debug mode?</string>
     <string name="err_select_logimage_upload_size">Image too big, please select a smaller scale.</string>
     <string name="err_logimage_caption_required">A caption is required for the image</string>
+    <string name="waypoint_latitude_null">N/S --° --.---</string>
+    <string name="waypoint_longitude_null">E/W --° --.---</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -181,15 +181,13 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
             ((CoordinatesInputDialog.CalculateState) getActivity()).saveCalculatorState(currentState);
             ((EditWaypointActivity) getActivity()).getUserNotes().setText(notes.getText());
 
-            if (!areCurrentCoordinatesValid()) {
-                return;
-            }
 
-            if (gp != null) {
+            if (areCurrentCoordinatesValid()) {
                 ((CoordinatesInputDialog.CoordinateUpdate) getActivity()).updateCoordinates(gp);
+                close();
+            } else {
+                ((CoordinatesInputDialog.CoordinateUpdate) getActivity()).updateCoordinates(null);
             }
-
-            close();
         }
     }
 

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -199,6 +199,12 @@ public class CoordinatesInputDialog extends DialogFragment {
             buttonCalculate.setVisibility(View.VISIBLE);
         }
 
+        final Button buttonClear = ButterKnife.findById(v, R.id.clear);
+        if (getActivity() instanceof CoordinateUpdate) {
+            buttonClear.setOnClickListener(new ClearCoordinatesListener());
+            buttonClear.setVisibility(View.VISIBLE);
+        }
+
         if (hasClipboardCoordinates()) {
             final Button buttonClipboard = ButterKnife.findById(v, R.id.clipboard);
             buttonClipboard.setOnClickListener(new ClipboardListener());
@@ -604,9 +610,16 @@ public class CoordinatesInputDialog extends DialogFragment {
             if (!areCurrentCoordinatesValid(true)) {
                 return;
             }
-            if (gp != null) {
-                ((CoordinateUpdate) getActivity()).updateCoordinates(gp);
-            }
+            ((CoordinateUpdate) getActivity()).updateCoordinates(gp);
+            dismiss();
+        }
+    }
+
+    private class ClearCoordinatesListener implements View.OnClickListener {
+
+        @Override
+        public void onClick(final View v) {
+            ((CoordinateUpdate) getActivity()).updateCoordinates(null);
             dismiss();
         }
     }


### PR DESCRIPTION
The EditWaypointActivity is not anymore prefilled with the users location. Placeholders are visible on the latitude and longitude buttons.
If the user just wants to have the current location he has to open the CoordsInputDialog once and confirm.
The projection is only enabled if coordinates are set on the waypoint. Otherwise the projection fields are disabled. We can't do a projection from null coordinates.
I've also added a "Clear Coordinates" button on the CoordsInputDialog for convenience.
Invalid coordinates from the Calculator are now forwarded as null to the waypoint. No longer the users location is used in the meantime. This solves #6697 for me. I don't know if someone needs more visual clue.

Unfortunately the "simple" usecases like recording my current position as waypoint or a simple projection from my location needs two more clicks now.

What gets more apparent now is the fact that the CoordsInputDialog is in between the EditWaypointActivity and the Calculator. You can have null coordinates now in the EditWaypointActivity because of an invalid calculation, but when you navigate through the CoordsInputDialog you see your current location as coordinates but don't use it.

Maybe a future refactoring for e.g. #6833 can simplify the dialog(s).

Null coordinates with placeholder text on the lat/lon buttons:
![image](https://user-images.githubusercontent.com/5598124/33909470-0e3a265a-df8c-11e7-97cc-4f6518b698bc.png)

CoordsInputDialog:
![image](https://user-images.githubusercontent.com/5598124/33909505-2b848a16-df8c-11e7-9542-564e47a6d6e4.png)
