### PR TITLE
fix #6890 npe in coordsinput landscape

### DIFF
--- a/main/res/layout-land/coordinatesinput_dialog.xml
+++ b/main/res/layout-land/coordinatesinput_dialog.xml
@@ -14,41 +14,51 @@
         <include layout="@layout/dialog_title_ok_cancel" />
         <include layout="@layout/coordinates_input" />
 
-        <LinearLayout
-            android:id="@+id/linearLayout2"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content" >
-
+        <LinearLayout android:id="@+id/botton_row_one"
+                      android:layout_width="fill_parent"
+                      android:layout_height="wrap_content"
+                      android:orientation="horizontal">
             <Button
                 android:id="@+id/current"
                 style="@style/button_full"
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/waypoint_my_coordinates" />
-
             <Button
                 android:id="@+id/cache"
                 style="@style/button_full"
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="@string/waypoint_cache_coordinates" />
-
-            <Button
-                android:id="@+id/calculate"
-                style="@style/button_full"
-                android:layout_width="fill_parent"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:text="@string/waypoint_calculate_coordinates" />
-
             <Button
                 android:id="@+id/clipboard"
                 style="@style/button_full"
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/from_clipboard"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <LinearLayout android:id="@+id/botton_row_two"
+                      android:layout_width="fill_parent"
+                      android:layout_height="wrap_content"
+                      android:orientation="horizontal">
+            <Button
+                android:id="@+id/calculate"
+                style="@style/button_full"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/waypoint_calculate_coordinates"
+                android:visibility="gone"/>
+            <Button
+                android:id="@+id/clear"
+                style="@style/button_full"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/waypoint_clear_coordinates"
                 android:visibility="gone" />
         </LinearLayout>
 

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -200,7 +200,7 @@ public class CoordinatesInputDialog extends DialogFragment {
         }
 
         final Button buttonClear = ButterKnife.findById(v, R.id.clear);
-        if (getActivity() instanceof CoordinateUpdate) {
+        if (getActivity() instanceof CalculateState) {
             buttonClear.setOnClickListener(new ClearCoordinatesListener());
             buttonClear.setVisibility(View.VISIBLE);
         }


### PR DESCRIPTION
Simply added the 4th button `Clear coordinates` to the coordinates input landscape layout.

![screenshot_20171219-215120](https://user-images.githubusercontent.com/5598124/34178740-8a6bb910-e508-11e7-9dae-0212b28c1182.png)

The button texts get more and more truncated now. Anyone with a better idea? A second button row maybe?