### PR TITLE
fix #6889 treat locked caches as archived

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -181,6 +181,7 @@ public final class GCConstants {
     static final String STRING_UNKNOWN_ERROR = "An Error Has Occurred";
     static final String STRING_STATUS_DISABLED = "<div id=\"ctl00_ContentBody_uxDisabledMessageBody\"";
     static final String STRING_STATUS_ARCHIVED = "<div id=\"ctl00_ContentBody_archivedMessage\"";
+    static final String STRING_STATUS_LOCKED = "<div id=\"ctl00_ContentBody_lockedMessage\"";
     static final String STRING_CACHEDETAILS = "id=\"cacheDetails\"";
 
     // Pages with such title seem to be returned with a 200 code instead of 404

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -419,7 +419,8 @@ public final class GCParser {
 
         final Geocache cache = new Geocache();
         cache.setDisabled(page.contains(GCConstants.STRING_STATUS_DISABLED));
-        cache.setArchived(page.contains(GCConstants.STRING_STATUS_ARCHIVED));
+        cache.setArchived(page.contains(GCConstants.STRING_STATUS_ARCHIVED)
+                        || page.contains(GCConstants.STRING_STATUS_LOCKED));
 
         cache.setPremiumMembersOnly(TextUtils.matches(page, GCConstants.PATTERN_PREMIUMMEMBERS));
 


### PR DESCRIPTION
As c:geo doesn't know locked status and this is rather seldom I would propose to treat it like archived. Most of the time it superseeds archived anyway (like in the example of this issue). There are exceptions though.