### PR TITLE
6868 present disabled archived locked messages

### DIFF
--- a/main/res/drawable/alert_border.xml
+++ b/main/res/drawable/alert_border.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="3dip" android:color="#ff0000"/>
+</shape>

--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -16,7 +16,7 @@
             android:id="@+id/alert_message"
             android:autoLink="web|map"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="@dimen/cache_details_alert_height"
             android:focusable="false"
             android:textColor="?text_color"
             android:textSize="14sp"

--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -12,21 +12,28 @@
         android:orientation="vertical"
         android:padding="4dip" >
 
-        <TextView
-            android:id="@+id/alert_message"
-            android:autoLink="web|map"
-            android:layout_width="fill_parent"
+        <!-- the scroll view doesn't scroll, it is just there to do the fade out at the bottom -->
+        <ScrollView
+            android:layout_width="match_parent"
             android:layout_height="@dimen/cache_details_alert_height"
-            android:focusable="false"
-            android:textColor="?text_color"
-            android:textSize="14sp"
+            android:requiresFadingEdge="vertical"
+            android:fadingEdgeLength="40dp"
             android:background="@drawable/alert_border"
-            android:visibility="gone"
             android:paddingTop="10dp"
             android:paddingStart="10dp"
             android:paddingEnd="10dp"
-            tools:visiblity="visible"
-            tools:text="Disabled Message"/>
+            android:visibility="gone"
+            tools:visiblity="visible">
+            <TextView
+                android:id="@+id/alert_message"
+                android:autoLink="web|map"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:focusable="false"
+                android:textColor="?text_color"
+                android:textSize="14sp"
+                tools:text="Disabled Message"/>
+        </ScrollView>
 
         <!-- Details list -->
 

--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -12,6 +12,22 @@
         android:orientation="vertical"
         android:padding="4dip" >
 
+        <TextView
+            android:id="@+id/alert_message"
+            android:autoLink="web|map"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:focusable="false"
+            android:textColor="?text_color"
+            android:textSize="14sp"
+            android:background="@drawable/alert_border"
+            android:visibility="gone"
+            android:paddingTop="10dp"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            tools:visiblity="visible"
+            tools:text="Disabled Message"/>
+
         <!-- Details list -->
 
         <LinearLayout

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -11,4 +11,5 @@
 
     <dimen name="equation_name_width">40dip</dimen>
 
+    <dimen name="cache_details_alert_height">70dp</dimen>
 </resources>

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -11,5 +11,5 @@
 
     <dimen name="equation_name_width">40dip</dimen>
 
-    <dimen name="cache_details_alert_height">70dp</dimen>
+    <dimen name="cache_details_alert_height">90dp</dimen>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1607,5 +1607,8 @@
     <string name="err_logimage_caption_required">A caption is required for the image</string>
     <string name="waypoint_latitude_null">N/S --° --.---</string>
     <string name="waypoint_longitude_null">E/W --° --.---</string>
+    <string name="DISABLED_CACHE">This cache is temporarily unavailable</string>
+    <string name="ARCHIVED_CACHE">This cache has been archived</string>
+    <string name="LOCKED_CACHE">This cache has been locked, but it is available for viewing</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1107,6 +1107,19 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     });
 
             alertMessage = ButterKnife.findById(view, R.id.alert_message);
+            alertMessage.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(final View v) {
+                    final int defaultHeight =  getResources().getDimensionPixelSize(R.dimen.cache_details_alert_height);
+                    final ViewGroup.LayoutParams layoutParams = alertMessage.getLayoutParams();
+                    if (layoutParams.height == defaultHeight) {
+                        alertMessage.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+                    } else {
+                        layoutParams.height = defaultHeight;
+                        alertMessage.setLayoutParams(layoutParams);
+                    }
+                }
+            });
             if (StringUtils.isNotBlank(cache.getAlertMessage())) {
                 alertMessage.setText(Html.fromHtml(cache.getAlertMessage()));
                 alertMessage.setVisibility(View.VISIBLE);

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1080,6 +1080,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     public class DetailsViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
         // Reference to the details list and favorite line, so that the helper-method can access them without an additional argument
         private LinearLayout detailsList;
+        private TextView alertMessage;
         private ImmutablePair<RelativeLayout, TextView> favoriteLine;
 
         @Override
@@ -1104,6 +1105,12 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                             }
                         }
                     });
+
+            alertMessage = ButterKnife.findById(view, R.id.alert_message);
+            if (StringUtils.isNotBlank(cache.getAlertMessage())) {
+                alertMessage.setText(Html.fromHtml(cache.getAlertMessage()));
+                alertMessage.setVisibility(View.VISIBLE);
+            }
 
             detailsList = ButterKnife.findById(view, R.id.details_list);
             final CacheDetailsCreator details = new CacheDetailsCreator(CacheDetailActivity.this, detailsList);

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1107,22 +1107,23 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     });
 
             alertMessage = ButterKnife.findById(view, R.id.alert_message);
-            alertMessage.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(final View v) {
-                    final int defaultHeight =  getResources().getDimensionPixelSize(R.dimen.cache_details_alert_height);
-                    final ViewGroup.LayoutParams layoutParams = alertMessage.getLayoutParams();
-                    if (layoutParams.height == defaultHeight) {
-                        alertMessage.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
-                    } else {
-                        layoutParams.height = defaultHeight;
-                        alertMessage.setLayoutParams(layoutParams);
-                    }
-                }
-            });
             if (StringUtils.isNotBlank(cache.getAlertMessage())) {
                 alertMessage.setText(Html.fromHtml(cache.getAlertMessage()));
-                alertMessage.setVisibility(View.VISIBLE);
+                final ScrollView scrollView = (ScrollView) alertMessage.getParent();
+                scrollView.setVisibility(View.VISIBLE);
+                alertMessage.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(final View v) {
+                        final float defaultHeight = getResources().getDimension(R.dimen.cache_details_alert_height);
+                        final ViewGroup.LayoutParams layoutParams = scrollView.getLayoutParams();
+                        if (layoutParams.height == (int)defaultHeight) {
+                            layoutParams.height = alertMessage.getLayoutParams().height;
+                        } else {
+                            layoutParams.height = (int)defaultHeight;
+                        }
+                        scrollView.setLayoutParams(layoutParams);
+                    }
+                });
             }
 
             detailsList = ButterKnife.findById(view, R.id.details_list);

--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -181,6 +181,7 @@ public final class GCConstants {
     static final String STRING_UNKNOWN_ERROR = "An Error Has Occurred";
     static final String STRING_STATUS_DISABLED = "<div id=\"ctl00_ContentBody_uxDisabledMessageBody\"";
     static final String STRING_STATUS_ARCHIVED = "<div id=\"ctl00_ContentBody_archivedMessage\"";
+    static final String STRING_STATUS_LOCKED = "<div id=\"ctl00_ContentBody_lockedMessage\"";
     static final String STRING_CACHEDETAILS = "id=\"cacheDetails\"";
 
     // Pages with such title seem to be returned with a 200 code instead of 404

--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -179,9 +179,11 @@ public final class GCConstants {
     static final String STRING_UNPUBLISHED_OTHER = "you cannot view this cache listing until it has been published";
     static final String STRING_UNPUBLISHED_FROM_SEARCH = "class=\"UnpublishedCacheSearchWidget"; // do not include closing brace as the CSS can contain additional styles
     static final String STRING_UNKNOWN_ERROR = "An Error Has Occurred";
-    static final String STRING_STATUS_DISABLED = "<div id=\"ctl00_ContentBody_uxDisabledMessageBody\"";
+    static final String STRING_STATUS_DISABLED = "<div id=\"ctl00_ContentBody_disabledMessage\"";
     static final String STRING_STATUS_ARCHIVED = "<div id=\"ctl00_ContentBody_archivedMessage\"";
     static final String STRING_STATUS_LOCKED = "<div id=\"ctl00_ContentBody_lockedMessage\"";
+    static final Pattern PATTERN_DISABLED_MESSAGE = Pattern.compile("<div id=\"ctl00_ContentBody_uxDisabledMessageBody\"[^>]*>(.*?)</div>");
+    static final Pattern PATTERN_ARCHIVED_MESSAGE = Pattern.compile("<div id=\"ctl00_ContentBody_uxArchivedMessageBody\"[^>]*>(.*?)</div>");
     static final String STRING_CACHEDETAILS = "id=\"cacheDetails\"";
 
     // Pages with such title seem to be returned with a 200 code instead of 404

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -420,18 +420,18 @@ public final class GCParser {
         final Geocache cache = new Geocache();
         cache.setDisabled(page.contains(GCConstants.STRING_STATUS_DISABLED));
         if (cache.isDisabled()) {
-            cache.setAlertMessage("<h5>" + CgeoApplication.getInstance().getString(R.string.DISABLED_CACHE) + "</h5>"
+            cache.setAlertMessage("<b>" + CgeoApplication.getInstance().getString(R.string.DISABLED_CACHE) + "</b>"
                     + TextUtils.getMatch(page, GCConstants.PATTERN_DISABLED_MESSAGE, true, ""));
         }
 
         if (page.contains(GCConstants.STRING_STATUS_ARCHIVED)) {
-            cache.setAlertMessage("<h5>" + CgeoApplication.getInstance().getString(R.string.ARCHIVED_CACHE) + "</h5>"
+            cache.setAlertMessage("<b>" + CgeoApplication.getInstance().getString(R.string.ARCHIVED_CACHE) + "</b>"
                     + TextUtils.getMatch(page, GCConstants.PATTERN_ARCHIVED_MESSAGE, true, ""));
             cache.setArchived(true);
         }
 
         if (page.contains(GCConstants.STRING_STATUS_LOCKED)) {
-            cache.setAlertMessage("<h5>" + CgeoApplication.getInstance().getString(R.string.LOCKED_CACHE) + "</h5>");
+            cache.setAlertMessage("<b>" + CgeoApplication.getInstance().getString(R.string.LOCKED_CACHE) + "</b>");
             cache.setArchived(true);
         }
 

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -419,8 +419,21 @@ public final class GCParser {
 
         final Geocache cache = new Geocache();
         cache.setDisabled(page.contains(GCConstants.STRING_STATUS_DISABLED));
-        cache.setArchived(page.contains(GCConstants.STRING_STATUS_ARCHIVED)
-                        || page.contains(GCConstants.STRING_STATUS_LOCKED));
+        if (cache.isDisabled()) {
+            cache.setAlertMessage("<h5>" + CgeoApplication.getInstance().getString(R.string.DISABLED_CACHE) + "</h5>"
+                    + TextUtils.getMatch(page, GCConstants.PATTERN_DISABLED_MESSAGE, true, ""));
+        }
+
+        if (page.contains(GCConstants.STRING_STATUS_ARCHIVED)) {
+            cache.setAlertMessage("<h5>" + CgeoApplication.getInstance().getString(R.string.ARCHIVED_CACHE) + "</h5>"
+                    + TextUtils.getMatch(page, GCConstants.PATTERN_ARCHIVED_MESSAGE, true, ""));
+            cache.setArchived(true);
+        }
+
+        if (page.contains(GCConstants.STRING_STATUS_LOCKED)) {
+            cache.setAlertMessage("<h5>" + CgeoApplication.getInstance().getString(R.string.LOCKED_CACHE) + "</h5>");
+            cache.setArchived(true);
+        }
 
         cache.setPremiumMembersOnly(TextUtils.matches(page, GCConstants.PATTERN_PREMIUMMEMBERS));
 

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -419,7 +419,8 @@ public final class GCParser {
 
         final Geocache cache = new Geocache();
         cache.setDisabled(page.contains(GCConstants.STRING_STATUS_DISABLED));
-        cache.setArchived(page.contains(GCConstants.STRING_STATUS_ARCHIVED));
+        cache.setArchived(page.contains(GCConstants.STRING_STATUS_ARCHIVED)
+                        || page.contains(GCConstants.STRING_STATUS_LOCKED));
 
         cache.setPremiumMembersOnly(TextUtils.matches(page, GCConstants.PATTERN_PREMIUMMEMBERS));
 

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -174,6 +174,7 @@ public class Geocache implements IWaypoint {
     private Handler changeNotificationHandler = null;
 
     private static final List<Pattern> EVENT_TIME_PATTERNS = new ArrayList<>();
+    private String alertMessage;
 
     public void setChangeNotificationHandler(final Handler newNotificationHandler) {
         changeNotificationHandler = newNotificationHandler;
@@ -2039,4 +2040,13 @@ public class Geocache implements IWaypoint {
                 .append(alternativeCode)
                 .append("</a><br /><br />").toString();
     }
+
+    public void setAlertMessage(final String alertMessage) {
+        this.alertMessage = alertMessage;
+    }
+
+    public String getAlertMessage() {
+        return alertMessage;
+    }
+
 }

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -155,7 +155,8 @@ public class DataStore {
                     "cg_caches.inventorycoins,"      +   // 39
                     "cg_caches.inventorytags,"       +   // 40
                     "cg_caches.logPasswordRequired," +   // 41
-                    "cg_caches.watchlistCount";          // 42
+                    "cg_caches.watchlistCount,"      +   // 42
+                    "cg_caches.alertMessage";            // 43
 
     /** The list of fields needed for mapping. */
     private static final String[] WAYPOINT_COLUMNS = { "_id", "geocode", "updated", "type", "prefix", "lookup", "name", "latitude", "longitude", "note", "own", "visited", "user_note", "org_coords_empty", "calc_state" };
@@ -168,7 +169,7 @@ public class DataStore {
      */
     private static final CacheCache cacheCache = new CacheCache();
     private static volatile SQLiteDatabase database = null;
-    private static final int dbVersion = 73;
+    private static final int dbVersion = 74;
     public static final int customListIdOffset = 10;
 
     @NonNull private static final String dbTableCaches = "cg_caches";
@@ -228,7 +229,8 @@ public class DataStore {
             + "coordsChanged INTEGER DEFAULT 0, "
             + "finalDefined INTEGER DEFAULT 0, "
             + "logPasswordRequired INTEGER DEFAULT 0,"
-            + "watchlistCount INTEGER DEFAULT -1"
+            + "watchlistCount INTEGER DEFAULT -1,"
+            + "alertMessage TEXT"
             + "); ";
     private static final String dbCreateLists = ""
             + "CREATE TABLE " + dbTableLists + " ("
@@ -880,6 +882,15 @@ public class DataStore {
                             Log.e("Failed to upgrade to ver. 73", e);
                         }
                     }
+                    // Introduces alertMessage
+                    if (oldVersion < 74) {
+                        try {
+                            db.execSQL("ALTER TABLE " + dbTableCaches + " ADD COLUMN alertMessage TEXT");
+                        } catch (final Exception e) {
+                            Log.e("Failed to upgrade to ver. 70", e);
+                        }
+                    }
+
                 }
 
                 db.setTransactionSuccessful();
@@ -1258,6 +1269,7 @@ public class DataStore {
         values.put("finalDefined", cache.hasFinalDefined() ? 1 : 0);
         values.put("logPasswordRequired", cache.isLogPasswordRequired() ? 1 : 0);
         values.put("watchlistCount", cache.getWatchlistCount());
+        values.put("alertMessage", cache.getAlertMessage());
 
         init();
 
@@ -1874,6 +1886,7 @@ public class DataStore {
         cache.setFinalDefined(cursor.getInt(37) > 0);
         cache.setLogPasswordRequired(cursor.getInt(41) > 0);
         cache.setWatchlistCount(cursor.getInt(42));
+        cache.setAlertMessage(cursor.getString(43));
 
         Log.d("Loading " + cache.toString() + " from DB");
 


### PR DESCRIPTION
Here is now a coded version of the idea on how to present disabled, archived and locked messages in the cache details.

I've added `Do not merge`, because it is not ready yet. It is also based on #6893 which is not merged.

The messages can get quite long. The website is truncating them. I have no solution for it yet.

Here are some example screenshots:

![screenshot_20171222-215614](https://user-images.githubusercontent.com/5598124/34313062-e52064b6-e768-11e7-94cc-03db1663a517.png)
![screenshot_20171222-215857](https://user-images.githubusercontent.com/5598124/34313064-e538e914-e768-11e7-8ced-bc0624b2be2c.png)
![screenshot_20171222-220427](https://user-images.githubusercontent.com/5598124/34313065-e551515c-e768-11e7-8ed0-b2f47a0d0d7b.png)
![screenshot_20171222-220641](https://user-images.githubusercontent.com/5598124/34313066-e569e104-e768-11e7-9c9e-021208e8b220.png)
![screenshot_20171222-221531](https://user-images.githubusercontent.com/5598124/34313067-e5823696-e768-11e7-8f97-ae34dc4dcbeb.png)


Should we go on with this? What do you think?

If you want to try it yourself: beware that it changes the DB schema!