### PR TITLE
support for null in coordsinputdialog

### DIFF
--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -459,6 +459,11 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         }
     }
 
+    @Override
+    public boolean supportsNullCoordinates() {
+        return true;
+    }
+
     private void setProjectionEnabled(final boolean enabled) {
         bearing.setEnabled(enabled);
         distanceView.setEnabled(enabled);

--- a/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
+++ b/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
@@ -296,6 +296,11 @@ public class NavigateAnyPointActivity extends AbstractActionBarActivity implemen
         changed = true;
     }
 
+    @Override
+    public boolean supportsNullCoordinates() {
+        return false;
+    }
+
     private static class ChangeDistanceUnit implements OnItemSelectedListener {
 
         private ChangeDistanceUnit(final NavigateAnyPointActivity unitView) {

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -1,25 +1,5 @@
 package cgeo.geocaching;
 
-import android.app.Activity;
-import android.app.SearchManager;
-import android.content.Intent;
-import android.content.res.Configuration;
-import android.os.Bundle;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.View.OnClickListener;
-import android.widget.AutoCompleteTextView;
-import android.widget.Button;
-
-import org.apache.commons.lang3.StringUtils;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-
-import java.util.Locale;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.address.AddressListActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
@@ -38,6 +18,27 @@ import cgeo.geocaching.ui.dialog.CoordinatesInputDialog;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.EditUtils;
 import cgeo.geocaching.utils.functions.Func1;
+
+import android.app.Activity;
+import android.app.SearchManager;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.AutoCompleteTextView;
+import android.widget.Button;
+
+import java.util.Locale;
+
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import org.apache.commons.lang3.StringUtils;
 
 public class SearchActivity extends AbstractActionBarActivity implements CoordinatesInputDialog.CoordinateUpdate {
 
@@ -313,6 +314,11 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     public void updateCoordinates(final Geopoint gp) {
         buttonLatitude.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
         buttonLongitude.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
+    }
+
+    @Override
+    public boolean supportsNullCoordinates() {
+        return false;
     }
 
     private void findByCoordsFn() {

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -425,6 +425,11 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
         geocache.setCoords(geopoint);
     }
 
+    @Override
+    public boolean supportsNullCoordinates() {
+        return false;
+    }
+
     private class DateListener implements View.OnClickListener {
 
         @Override

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -93,7 +93,7 @@ public class CoordinatesInputDialog extends DialogFragment {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         gp = getArguments().getParcelable(GEOPOINT_ARG);
-        if (gp == null) {
+        if (gp == null && !supportsNullCoordinates()) {
             gp = currentCoords();
         }
         cacheCoords = getArguments().getParcelable(CACHECOORDS_ARG);
@@ -101,6 +101,10 @@ public class CoordinatesInputDialog extends DialogFragment {
         if (savedInstanceState != null && savedInstanceState.getParcelable(GEOPOINT_ARG) != null) {
             gp = savedInstanceState.getParcelable(GEOPOINT_ARG);
         }
+    }
+
+    private boolean supportsNullCoordinates() {
+        return ((CoordinateUpdate)getActivity()).supportsNullCoordinates();
     }
 
     @Override
@@ -200,7 +204,7 @@ public class CoordinatesInputDialog extends DialogFragment {
         }
 
         final Button buttonClear = ButterKnife.findById(v, R.id.clear);
-        if (getActivity() instanceof CalculateState) {
+        if (supportsNullCoordinates()) {
             buttonClear.setOnClickListener(new ClearCoordinatesListener());
             buttonClear.setVisibility(View.VISIBLE);
         }
@@ -238,20 +242,23 @@ public class CoordinatesInputDialog extends DialogFragment {
     }
 
     private void updateGUI() {
-        if (gp == null) {
-            return;
+        if (gp != null) {
+            bLat.setText(String.valueOf(gp.getLatDir()));
+            bLon.setText(String.valueOf(gp.getLonDir()));
+        } else {
+            bLat.setText(String.valueOf(currentCoords().getLatDir()));
+            bLon.setText(String.valueOf(currentCoords().getLonDir()));
         }
-
-        bLat.setText(String.valueOf(gp.getLatDir()));
-        bLon.setText(String.valueOf(gp.getLonDir()));
 
         switch (currentFormat) {
             case Plain:
                 setVisible(R.id.coordTable, View.GONE);
                 eLat.setVisibility(View.VISIBLE);
                 eLon.setVisibility(View.VISIBLE);
-                eLat.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
-                eLon.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
+                if (gp != null) {
+                    eLat.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
+                    eLon.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
+                }
                 break;
             case Deg: // DDD.DDDDD°
                 setVisible(R.id.coordTable, View.VISIBLE);
@@ -269,12 +276,15 @@ public class CoordinatesInputDialog extends DialogFragment {
                 tLatSep2.setText("°");
                 tLonSep2.setText("°");
 
-                eLatDeg.setText(addZeros(gp.getLatDeg(), 2));
-                eLatMin.setText(addZeros(gp.getLatDegFrac(), 5));
                 eLatMin.setGravity(Gravity.NO_GRAVITY);
-                eLonDeg.setText(addZeros(gp.getLonDeg(), 3));
-                eLonMin.setText(addZeros(gp.getLonDegFrac(), 5));
                 eLonMin.setGravity(Gravity.NO_GRAVITY);
+
+                if (gp != null) {
+                    eLatDeg.setText(addZeros(gp.getLatDeg(), 2));
+                    eLatMin.setText(addZeros(gp.getLatDegFrac(), 5));
+                    eLonDeg.setText(addZeros(gp.getLonDeg(), 3));
+                    eLonMin.setText(addZeros(gp.getLonDegFrac(), 5));
+                }
                 break;
             case Min: // DDD° MM.MMM
                 setVisible(R.id.coordTable, View.VISIBLE);
@@ -294,14 +304,17 @@ public class CoordinatesInputDialog extends DialogFragment {
                 tLatSep3.setText("'");
                 tLonSep3.setText("'");
 
-                eLatDeg.setText(addZeros(gp.getLatDeg(), 2));
-                eLatMin.setText(addZeros(gp.getLatMin(), 2));
                 eLatMin.setGravity(Gravity.RIGHT);
-                eLatSec.setText(addZeros(gp.getLatMinFrac(), 3));
-                eLonDeg.setText(addZeros(gp.getLonDeg(), 3));
-                eLonMin.setText(addZeros(gp.getLonMin(), 2));
                 eLonMin.setGravity(Gravity.RIGHT);
-                eLonSec.setText(addZeros(gp.getLonMinFrac(), 3));
+
+                if (gp != null) {
+                    eLatDeg.setText(addZeros(gp.getLatDeg(), 2));
+                    eLatMin.setText(addZeros(gp.getLatMin(), 2));
+                    eLatSec.setText(addZeros(gp.getLatMinFrac(), 3));
+                    eLonDeg.setText(addZeros(gp.getLonDeg(), 3));
+                    eLonMin.setText(addZeros(gp.getLonMin(), 2));
+                    eLonSec.setText(addZeros(gp.getLonMinFrac(), 3));
+                }
                 break;
             case Sec: // DDD° MM SS.SSS
                 setVisible(R.id.coordTable, View.VISIBLE);
@@ -321,16 +334,19 @@ public class CoordinatesInputDialog extends DialogFragment {
                 tLatSep3.setText(".");
                 tLonSep3.setText(".");
 
-                eLatDeg.setText(addZeros(gp.getLatDeg(), 2));
-                eLatMin.setText(addZeros(gp.getLatMin(), 2));
                 eLatMin.setGravity(Gravity.RIGHT);
-                eLatSec.setText(addZeros(gp.getLatSec(), 2));
-                eLatSub.setText(addZeros(gp.getLatSecFrac(), 3));
-                eLonDeg.setText(addZeros(gp.getLonDeg(), 3));
-                eLonMin.setText(addZeros(gp.getLonMin(), 2));
                 eLonMin.setGravity(Gravity.RIGHT);
-                eLonSec.setText(addZeros(gp.getLonSec(), 2));
-                eLonSub.setText(addZeros(gp.getLonSecFrac(), 3));
+
+                if (gp != null) {
+                    eLatDeg.setText(addZeros(gp.getLatDeg(), 2));
+                    eLatMin.setText(addZeros(gp.getLatMin(), 2));
+                    eLatSec.setText(addZeros(gp.getLatSec(), 2));
+                    eLatSub.setText(addZeros(gp.getLatSecFrac(), 3));
+                    eLonDeg.setText(addZeros(gp.getLonDeg(), 3));
+                    eLonMin.setText(addZeros(gp.getLonMin(), 2));
+                    eLonSec.setText(addZeros(gp.getLonSec(), 2));
+                    eLonSub.setText(addZeros(gp.getLonSecFrac(), 3));
+                }
                 break;
         }
 
@@ -526,7 +542,7 @@ public class CoordinatesInputDialog extends DialogFragment {
 
                 // Start new format with an acceptable value: either the current one
                 // entered by the user, or our current position.
-                if (!areCurrentCoordinatesValid(false)) {
+                if (!areCurrentCoordinatesValid(false) && !supportsNullCoordinates()) {
                     gp = currentCoords();
                 }
             }
@@ -587,6 +603,7 @@ public class CoordinatesInputDialog extends DialogFragment {
                 calculateDialog.setTargetFragment(CoordinatesInputDialog.this, 1);
                 calculateDialog.setCancelable(true);
                 calculateDialog.show(myContext.getSupportFragmentManager(), "wpcalcdialog");
+                CoordinatesInputDialog.this.dismiss();
             }
         }
     }
@@ -634,6 +651,7 @@ public class CoordinatesInputDialog extends DialogFragment {
 
     public interface CoordinateUpdate {
         void updateCoordinates(final Geopoint gp);
+        boolean supportsNullCoordinates();
     }
 
     // Interface used by the coordinate calculator dialog too preserve its state in the waypoint itself.


### PR DESCRIPTION
Follow up from #6861.

The CoordinatesInputDialog doesn't show anymore the user location as default. Which was confusing if the calculation was (temporarily) invalid.

Still the CoordinatesInputDialog feels "in the way" if the waypoint is beeing calculated. To be addressed in some other issue.