### PR TITLE
#6259 reset cookies on GCLogin failure

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -76,6 +76,14 @@ public class GCLogin extends AbstractLogin {
     @Override
     @NonNull
     protected StatusCode login(final boolean retry, @NonNull final Credentials credentials) {
+        final StatusCode status = loginInternal(retry, credentials);
+        if (status != StatusCode.NO_ERROR) {
+            resetLoginStatus();
+        }
+        return status;
+    }
+
+    private StatusCode loginInternal(final boolean retry, @NonNull final Credentials credentials) {
         if (credentials.isInvalid()) {
             clearLoginInfo();
             Log.w("Login.login: No login information stored");


### PR DESCRIPTION
As discussed in #6259 this PR clears the cookies when a GCLogin failure is happening.

I don't know if this finally solves the issue because I cannot reproduce it myself. As users report that it is happening if c:geo wasn't used for quite some time. So we suspect stale session keys in the cookies.