### PR TITLE
fix #6923 no update of save ts on new wp

### DIFF
--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -691,10 +691,6 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         }
         final Waypoint oldWaypoint = cache.getWaypointById(waypointId);
         if (cache.addOrChangeWaypoint(waypoint, true)) {
-            DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
-
-            LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(new Intent(Intents.INTENT_CACHE_CHANGED));
-
             if (!StaticMapsProvider.hasAllStaticMapsForWaypoint(geocode, waypoint)) {
                 StaticMapsProvider.removeWpStaticMaps(oldWaypoint, geocode);
                 if (Settings.isStoreOfflineWpMaps()) {


### PR DESCRIPTION
We ensure that the cache is saved already in the CacheDetailsActivity before going to the EditWaypointActivity. So this could be removed here.

But if the user selects to update the final coordinates of the cache we still update the save timestamp.