### PR TITLE
fix #6922 stored months/year ago

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -783,6 +783,11 @@
 		<item quantity="one">about %d day ago</item>
 		<item quantity="other">about %d days ago</item>
     </plurals>
+    <plurals name="cache_offline_about_time_months">
+        <item quantity="one">about %d month ago</item>
+        <item quantity="other">about %d months ago</item>
+    </plurals>
+    <string name="cache_offline_about_time_year">over a year ago</string>
     <string name="cache_offline_time_hour">one hour ago</string>
     <string name="cache_offline_time_hours">hours ago</string>
     <string name="cache_offline_time_days">days ago</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2392,17 +2392,25 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         offlineRefresh.setOnClickListener(refreshCacheClickListener);
 
         if (cache.isOffline()) {
-            final long diff = (System.currentTimeMillis() / (60 * 1000)) - (cache.getUpdated() / (60 * 1000)); // minutes
+            final long minutes = (System.currentTimeMillis() - cache.getUpdated()) / (60 * 1000);
+            final long days = minutes / (24 * 60);
+            final float daysPerMonth = 365F / 12; // on average
 
             final String ago;
-            if (diff < 15) {
+            if (cache.getUpdated() == 0L) {
+                ago = "";
+            } else if (minutes < 15) {
                 ago = res.getString(R.string.cache_offline_time_mins_few);
-            } else if (diff < 50) {
-                ago = res.getQuantityString(R.plurals.cache_offline_about_time_mins, (int) diff, (int) diff);
-            } else if (diff < (48 * 60)) {
-                ago = res.getQuantityString(R.plurals.cache_offline_about_time_hours, (int) (diff / 60), (int) (diff / 60));
+            } else if (minutes < 60) {
+                ago = res.getQuantityString(R.plurals.cache_offline_about_time_mins, (int) minutes, (int) minutes);
+            } else if (days < 2) {
+                ago = res.getQuantityString(R.plurals.cache_offline_about_time_hours, (int) (minutes / 60), (int) (minutes / 60));
+            } else if (days < daysPerMonth) {
+                ago = res.getQuantityString(R.plurals.cache_offline_about_time_days, (int) days, (int) days);
+            } else if (days < 365) {
+                ago = res.getQuantityString(R.plurals.cache_offline_about_time_months, (int) (days / daysPerMonth), (int) (days / daysPerMonth));
             } else {
-                ago = res.getQuantityString(R.plurals.cache_offline_about_time_days, (int) (diff / (24 * 60)), (int) (diff / (24 * 60)));
+                ago = res.getString(R.string.cache_offline_about_time_year);
             }
 
             offlineText.setText(res.getString(R.string.cache_offline_stored) + "\n" + ago);


### PR DESCRIPTION
Adds the following cases:
- "about 1 month ago"
- "about %d months ago" (from 2-11 months)
- "over a year ago" (if more than 365 days ago)