### PR TITLE
enable cgeo checkstyle in IDEA

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA">
+    <option name="configuration">
+      <map>
+        <entry key="active-configuration" value="PROJECT_RELATIVE:$PRJ_DIR$/checkstyle.xml:cgeo" />
+        <entry key="checkstyle-version" value="8.8" />
+        <entry key="copy-libs" value="true" />
+        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
+        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
+        <entry key="location-2" value="PROJECT_RELATIVE:$PRJ_DIR$/checkstyle.xml:cgeo" />
+        <entry key="scan-before-checkin" value="true" />
+        <entry key="scanscope" value="JavaOnly" />
+        <entry key="suppress-errors" value="false" />
+      </map>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
This should enable a common checkstyle configuration for all users of Android Studio.