### PR TITLE
fix #6995: use user name as display name when no specific one exists

### DIFF
--- a/main/src/cgeo/geocaching/log/CacheLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/CacheLogsViewCreator.java
@@ -137,7 +137,8 @@ public class CacheLogsViewCreator extends LogsViewCreator {
 
     @Override
     protected UserClickListener createUserActionsListener(final LogEntry log) {
-        return UserClickListener.forUser(getCache(), StringEscapeUtils.unescapeHtml4(log.author), StringUtils.EMPTY);
+        final String userName = StringEscapeUtils.unescapeHtml4(log.author);
+        return UserClickListener.forUser(getCache(), userName, userName);
     }
 
 }

--- a/main/src/cgeo/geocaching/ui/UserClickListener.java
+++ b/main/src/cgeo/geocaching/ui/UserClickListener.java
@@ -18,8 +18,6 @@ import android.view.View.OnClickListener;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-
 public abstract class UserClickListener implements View.OnClickListener {
 
     @NonNull private final Context user;
@@ -81,7 +79,7 @@ public abstract class UserClickListener implements View.OnClickListener {
     }
 
     public static OnClickListener forUser(final Trackable trackable, final String userName) {
-        return new UserClickListener(new Context(userName, StringUtils.EMPTY)) {
+        return new UserClickListener(new Context(userName, userName)) {
 
             @Override
             protected List<UserAction> createUserActions(final UserAction.Context user) {


### PR DESCRIPTION
This fixes the problem with username in cache logs, and takes care of
the one in trackable logs as well.