### PR TITLE
fix #7068 increase trackables shown

### DIFF
--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -2,6 +2,9 @@
 <resources>
   <!-- changelog for the release branch -->
   <string name="changelog_release" translatable="false">\n
+    <b>Next bugfix release:</b>\n
+    · Fix: only 20 trackables where shown when logging a cache (increased to 50)\n
+    \n
     <b>2018.06.26:</b>\n
     · New: New mapsforge library (former beta version) now used by default for OSM and offline maps\n
            Known regressions we are still working on (click for info):\n

--- a/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -389,10 +389,10 @@ class GCWebAPI {
     }
 
     /**
-     * https://www.geocaching.com/api/proxy/trackables?inCollection=false&skip=0&take=20
+     * https://www.geocaching.com/api/proxy/trackables?inCollection=false&skip=0&take=50
      */
     static Single<TrackableInventoryEntry[]> getTrackableInventory() {
-        return getAPI("/trackables?inCollection=false&skip=0&take=20", TrackableInventoryEntry[].class);
+        return getAPI("/trackables?inCollection=false&skip=0&take=50", TrackableInventoryEntry[].class);
     }
 
     /**


### PR DESCRIPTION
Still not all trackables are shown in LogCacheActivity, but the maximum is increased from 20 to 50.