### PR TITLE
Fix #7108 - Use short string for donate button

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -432,7 +432,7 @@
     <string name="about_changelog">Changelog</string>
     <string name="about_system">System</string>
     <string name="about_donate">Support us</string>
-    <string name="about_donation_more">Support c:geo development\nMore info on our website</string>
+    <string name="about_donation_more">Visit website for info</string>
     <string name="about_contributors">Contributors</string>
     <string name="about_license">License</string>
     <string name="about_apache_license"><a href="">Apache License, Version 2.0</a></string>


### PR DESCRIPTION
Instead of any UI changes, that is possibly the the easy solution.