### PR TITLE
Issue 7122

### DIFF
--- a/main/res/values-el/strings.xml
+++ b/main/res/values-el/strings.xml
@@ -736,9 +736,8 @@
   <string name="err_auth_geokrety_unknown">%1$s επέστρεψε: %2$s.</string>
   <!-- cache -->
   <plurals name="cache_counts">
-    <item quantity="one">Μία κρύπτη
-%€1d κρύπτες</item>
-    <item quantity="other">%€1d κρύπτες</item>
+    <item quantity="one">Μία κρύπτη</item>
+    <item quantity="other">%1$d κρύπτες</item>
   </plurals>
   <!-- days remaining -->
   <plurals name="days_remaining">
@@ -1189,7 +1188,7 @@
   <string name="export_persnotes_uploading">Φόρτωση προσωπικής σημείωσης %1$d</string>
   <plurals name="export_persnotes_upload_success">
     <item quantity="one">Επιτυχημένη φόρτωση μιας σημείωσης</item>
-    <item quantity="other">Επιτυχημένη φόρτωση %€1d σημειώσεων</item>
+    <item quantity="other">Επιτυχημένη φόρτωση %1$d σημειώσεων</item>
   </plurals>
   <!-- GC attributes -->
   <string name="attribute_dogs_yes">Επιτρέπονται οι σκύλοι</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -265,7 +265,7 @@
     <string name="info_log_cleared">Log was cleared.</string>
     <string name="info_waypoint_coordinates_cleared">Coordinates cleared.</string>
     <string name="info_log_type_changed">Type of log has been changed!</string>
-    <string name="info_log_report_problem_changed">Report problem has changed!</string>
+    <string name="info_log_report_problem_changed">Available problem reports have changed!</string>
     <string name="info_select_logimage_cancelled">Image selection or capture was cancelled.</string>
     <string name="info_stored_image">New image saved to:</string>
     <string name="info_storing_static_maps">Trying to store static maps</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -277,6 +277,7 @@
     <string name="confirm_discard_wp_changes">Discard unsaved waypoint changes?</string>
     <string name="warn_discard_changes">Unsaved waypoint changes discarded!</string>
     <string name="err_request_popup_info">c:geo failed to get cache popup info.</string>
+    <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
 
     <!-- location service -->
     <string name="loc_last">Last known</string>

--- a/main/src/cgeo/geocaching/connector/AbstractLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/AbstractLoggingManager.java
@@ -17,6 +17,16 @@ public abstract class AbstractLoggingManager implements ILoggingManager {
     }
 
     @Override
+    public boolean hasTrackableLoadError() {
+        return false;
+    }
+
+    @Override
+    public boolean hasFavPointLoadError() {
+        return false;
+    }
+
+    @Override
     @NonNull
     public List<TrackableLog> getTrackables() {
         return Collections.emptyList();

--- a/main/src/cgeo/geocaching/connector/ILoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/ILoggingManager.java
@@ -51,4 +51,7 @@ public interface ILoggingManager {
     @NonNull
     List<ReportProblemType> getReportProblemTypes(@NonNull Geocache geocache);
 
+    boolean hasTrackableLoadError();
+
+    boolean hasFavPointLoadError();
 }

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -125,9 +125,18 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
             return;
         }
 
-        trackables.addAll(loggingManager.getTrackables());
+        if (!loggingManager.hasTrackableLoadError()) {
+            trackables.addAll(loggingManager.getTrackables());
+        } else {
+            showErrorLoadingAdditionalData();
+        }
+        if (!loggingManager.hasFavPointLoadError()) {
+            premFavPoints = loggingManager.getPremFavoritePoints();
+        } else {
+            showErrorLoadingAdditionalData();
+        }
+
         possibleLogTypes = loggingManager.getPossibleLogTypes();
-        premFavPoints = loggingManager.getPremFavoritePoints();
 
         if (possibleLogTypes.isEmpty()) {
             showErrorLoadingData();
@@ -188,6 +197,10 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
     private void showErrorLoadingData() {
         showToast(res.getString(R.string.err_log_load_data));
         showProgress(false);
+    }
+
+    private void showErrorLoadingAdditionalData() {
+        showToast(res.getString(R.string.warn_log_load_additional_data));
     }
 
     private void initializeTrackablesAction() {


### PR DESCRIPTION
Added error handling for trackable and favpoint download when logging.
Those have previously been taken from the log page and are now independent network requests which can fail as well.

Has been based on release (for being able to merge back) but first proposed for master (for testing).

To make this scheme work (again), merge has to be enabled in the project settings as suggested in #7113