### PR TITLE
Fix #7130 - Change Twitter callback URL

### DIFF
--- a/main/src/cgeo/geocaching/twitter/TwitterAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/twitter/TwitterAuthorizationActivity.java
@@ -18,7 +18,7 @@ public class TwitterAuthorizationActivity extends OAuthAuthorizationActivity {
             true,
             Settings.getTwitterKeyConsumerPublic(),
             Settings.getTwitterKeyConsumerSecret(),
-            "callback://www.cgeo.org/twitter/");
+            "http://www.cgeo.org/twitter/");
 
     @Override
     protected String getCreateAccountUrl() {


### PR DESCRIPTION
as the current prefix is not allowed to be configured at Twitter.

Please doublecheck if this is the only place, which needs changes and if we might run into problems using `http` instead of `callback`