### PR TITLE
add default resource entry for string "cache_menu_navigon"

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -915,6 +915,7 @@
     <string name="cache_menu_whereyougo">WhereYouGo</string>
     <string name="cache_menu_oruxmaps_online">OruxMaps (Online)</string>
     <string name="cache_menu_oruxmaps_offline">OruxMaps (Offline)</string>
+    <string name="cache_menu_navigon">Navigon</string>
     <string name="cache_menu_pebble">Pebble</string>
     <string name="cache_menu_android_wear">Android Wear</string>
     <string name="cache_menu_vote">Vote</string>


### PR DESCRIPTION
Add the default string for value "cache_menu_navigon" 

-> see the compiler warning/error 

00:32:06  /srv/jenkins/jobs/cgeo nightly/workspace/main/res/values-ca/strings.xml:880: Error: "cache_menu_navigon" is translated here but not found in default locale [ExtraTranslation]
00:32:06    <string name="cache_menu_navigon">Navigon</string>