### PR TITLE
Fix #5964, Support new map-themes with overlays/stylemenus in new map

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -829,7 +829,8 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="cgeo.geocaching.MainActivity" />
         </activity>
-        
+        <activity android:name=".maps.mapsforge.v6.RenderThemeSettings" />
+
     </application>
 
 </manifest>

--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -140,6 +140,14 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
+        android:id="@+id/menu_theme_options"
+        android:icon="@drawable/ic_menu_preferences"
+        android:showAsAction="ifRoom|withText"
+        android:title="@string/map_theme_options"
+        android:visible="false"
+        app:showAsAction="ifRoom|withText">
+    </item>
+    <item
         android:id="@+id/submenu_strategy"
         android:icon="@drawable/ic_menu_preferences"
         android:title="@string/map_strategy"

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -216,4 +216,5 @@
     <string translatable="false" name="pref_home_location">home_location</string>
     <string translatable="false" name="pref_map_direction">map_direction</string>
     <string translatable="false" name="pref_map_routing">map_routing</string>
+    <string translatable="false" name="pref_theme_menu">theme_menu</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1087,6 +1087,7 @@
     <string name="map_disabled_hide">Hide disabled caches</string>
     <string name="map_theme_builtin">Default</string>
     <string name="map_theme_select">Select map theme</string>
+    <string name="map_theme_options">Theme Options</string>
     <string name="map_live_enable">Enable live</string>
     <string name="map_live_disable">Disable live</string>
     <string name="map_static_title">Static maps</string>

--- a/main/res/xml/theme_prefs.xml
+++ b/main/res/xml/theme_prefs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="Map Style">
+    <PreferenceCategory
+        android:key="@string/pref_theme_menu"
+        android:title="@string/map_theme_options" />
+</PreferenceScreen>

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettings.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettings.java
@@ -1,0 +1,159 @@
+package cgeo.geocaching.maps.mapsforge.v6;
+
+import android.app.ActionBar;
+import android.os.Bundle;
+import android.preference.CheckBoxPreference;
+import android.preference.ListPreference;
+import android.preference.PreferenceActivity;
+import android.content.SharedPreferences;
+import android.preference.PreferenceCategory;
+import android.preference.PreferenceManager;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleMenu;
+
+import java.util.Locale;
+import java.util.Map;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+
+public class RenderThemeSettings extends PreferenceActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
+    public static final String RENDERTHEME_MENU = "renderthememenu";
+
+    ListPreference baseLayerPreference;
+    SharedPreferences prefs;
+    XmlRenderThemeStyleMenu renderthemeOptions;
+    PreferenceCategory renderthemeMenu;
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return false;
+    }
+    @Override
+    public void onSharedPreferenceChanged(final SharedPreferences preferences,
+                                          final String key) {
+        if (this.renderthemeOptions != null && this.renderthemeOptions.getId().equals(key)) {
+            createRenderthemeMenu();
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        setTheme(Settings.isLightSkin() ? R.style.settings_light : R.style.settings);
+        super.onCreate(savedInstanceState);
+
+        final ActionBar actionBar = getActionBar();
+        if (actionBar != null) {
+            // Show the Up button in the action bar.
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        this.prefs = PreferenceManager.getDefaultSharedPreferences(this);
+
+        addPreferencesFromResource(R.xml.theme_prefs);
+
+        // if the render theme has a style menu, its data is delivered via the intent
+        renderthemeOptions = (XmlRenderThemeStyleMenu) getIntent().getSerializableExtra(RENDERTHEME_MENU);
+        if (renderthemeOptions != null) {
+
+            // the preference category serves as the hook to add a list preference to allow users to select a style
+            this.renderthemeMenu = (PreferenceCategory) findPreference(getString(R.string.pref_theme_menu));
+
+            createRenderthemeMenu();
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        this.prefs.unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        this.prefs.registerOnSharedPreferenceChangeListener(this);
+    }
+
+
+    @SuppressWarnings("deprecation")
+    private void createRenderthemeMenu() {
+        this.renderthemeMenu.removeAll();
+
+        this.baseLayerPreference = new ListPreference(this);
+
+        // the id of the setting is the id of the stylemenu, that allows this
+        // app to store different settings for different render themes.
+        baseLayerPreference.setKey(this.renderthemeOptions.getId());
+
+        baseLayerPreference.setTitle("Map style");
+
+        // this is the user language for the app, in 'en', 'de' etc format
+        // no dialects are supported at the moment
+        final String language = Locale.getDefault().getLanguage();
+
+        // build data structure for the ListPreference
+        final Map<String, XmlRenderThemeStyleLayer> baseLayers = renderthemeOptions.getLayers();
+
+        int visibleStyles = 0;
+        for (final XmlRenderThemeStyleLayer baseLayer : baseLayers.values()) {
+            if (baseLayer.isVisible()) {
+                ++visibleStyles;
+            }
+        }
+
+        final CharSequence[] entries = new CharSequence[visibleStyles];
+        final CharSequence[] values = new CharSequence[visibleStyles];
+        int i = 0;
+        for (final XmlRenderThemeStyleLayer baseLayer : baseLayers.values()) {
+            if (baseLayer.isVisible()) {
+                // build up the entries in the list
+                entries[i] = baseLayer.getTitle(language);
+                values[i] = baseLayer.getId();
+                ++i;
+            }
+        }
+
+        baseLayerPreference.setEntries(entries);
+        baseLayerPreference.setEntryValues(values);
+        baseLayerPreference.setEnabled(true);
+        baseLayerPreference.setPersistent(true);
+        baseLayerPreference.setDefaultValue(renderthemeOptions.getDefaultValue());
+
+        renderthemeMenu.addPreference(baseLayerPreference);
+
+        String selection = baseLayerPreference.getValue();
+        // need to check that the selection stored is actually a valid getLayer in the current
+        // rendertheme.
+        if (selection == null || !renderthemeOptions.getLayers().containsKey(selection)) {
+            selection = renderthemeOptions.getLayer(renderthemeOptions.getDefaultValue()).getId();
+        }
+        // the new Android style is to display information here, not instruction
+        baseLayerPreference.setSummary(renderthemeOptions.getLayer(selection).getTitle(language));
+
+        for (final XmlRenderThemeStyleLayer overlay : this.renderthemeOptions.getLayer(selection).getOverlays()) {
+            final CheckBoxPreference checkbox = new CheckBoxPreference(this);
+            checkbox.setKey(overlay.getId());
+            checkbox.setPersistent(true);
+            checkbox.setTitle(overlay.getTitle(language));
+            if (findPreference(overlay.getId()) == null) {
+                // value has never been set, so set from default
+                checkbox.setChecked(overlay.isEnabled());
+            }
+            this.renderthemeMenu.addPreference(checkbox);
+        }
+    }
+}


### PR DESCRIPTION
Implement style menus for appropriate render themes
mainly according to mapsforge sample implementation.