### PR TITLE
Fix #7161: Move test class into Android-specific test directory

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -87,8 +87,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
 
         try {
             final MapFile mapFile = new MapFile(mapFileIn);
-            if (mapFile.getMapFileInfo().fileVersion > 3 && Settings.useOldMapsforgeAPI()) return false;
-            return true;
+            return mapFile.getMapFileInfo().fileVersion <= 3 || !Settings.useOldMapsforgeAPI();
         } catch (MapFileException ex){
             Log.w(String.format("Exception reading mapfile '%s'", mapFileIn), ex);
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -30,8 +30,6 @@ import org.mapsforge.map.model.MapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.reader.header.MapFileException;
 import org.mapsforge.v3.android.maps.mapgenerator.MapGeneratorInternal;
-import org.mapsforge.v3.map.reader.MapDatabase;
-import org.mapsforge.v3.map.reader.header.FileOpenResult;
 
 public final class MapsforgeMapProvider extends AbstractMapProvider {
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -88,7 +88,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         try {
             final MapFile mapFile = new MapFile(mapFileIn);
             return mapFile.getMapFileInfo().fileVersion <= 3 || !Settings.useOldMapsforgeAPI();
-        } catch (MapFileException ex){
+        } catch (MapFileException ex) {
             Log.w(String.format("Exception reading mapfile '%s'", mapFileIn), ex);
         }
         return false;

--- a/tests/src-android/cgeo/geocaching/connector/su/SUParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/su/SUParserTest.java
@@ -8,8 +8,9 @@ import org.junit.Test;
 import java.io.InputStream;
 
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.test.AbstractResourceInstrumentationTestCase;
 
-public class SUParserTest {
+public class SUParserTest extends AbstractResourceInstrumentationTestCase {
 
     @Test
     public void testCanHandle() throws Exception {


### PR DESCRIPTION
Also use an appropriate base class for parser tests.