### PR TITLE
Fix #4697: TB selections and GC vote lost when returning

### DIFF
--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -223,7 +223,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
                     trackable.action = LogTypeTrackable.VISITED;
                 }
             } else { // refresh view
-                Integer tbStateId = trackableState.getInt(trackable.trackCode);
+                final Integer tbStateId = trackableState.getInt(trackable.trackCode);
                 if (tbStateId > 0) { // found in saved list
                     trackable.action = LogTypeTrackable.getById(tbStateId);
                 } else { // not found

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -133,6 +133,13 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
      * Hook called at the beginning of onLoadFinished().
      */
     public void onLoadFinished() {
+
+        // return from trackables detail view
+        if (!trackables.isEmpty()) {
+            showProgress(false);
+            return;
+        }
+
         if (loggingManager.hasLoaderError()) {
             showErrorLoadingData();
             return;
@@ -404,6 +411,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
         updateTweetBox(typeSelected);
         updateLogPasswordBox(typeSelected);
 
+ /*
         // Load Generic Trackables
         AndroidRxUtils.bindActivity(this,
             // Obtain the actives connectors
@@ -429,7 +437,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
                 updateTrackablesList();
             }
         });
-
+*/
         requestKeyboardForLogging();
     }
 

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -79,6 +79,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
     private static final String SAVED_STATE_IMAGE = "cgeo.geocaching.saved_state_image";
     private static final String SAVED_STATE_FAVPOINTS = "cgeo.geocaching.saved_state_favpoints";
     private static final String SAVED_STATE_PROBLEM = "cgeo.geocaching.saved_state_problem";
+    private static final String SAVED_STATE_TRACKABLES = "cgeo.geocaching.saved_state_trackables";
 
     private static final int SELECT_IMAGE = 101;
 
@@ -108,6 +109,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
     private int premFavPoints;
     private ReportProblemType reportProblemSelected = ReportProblemType.NO_PROBLEM;
     private LogEntry oldLog;
+    private Bundle trackableState;
 
     private SaveMode saveMode = SaveMode.SMART;
 
@@ -215,9 +217,20 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
     }
 
     private void initializeTrackablesAction() {
-        if (Settings.isTrackableAutoVisit()) {
-            for (final TrackableLog trackable : trackables) {
-                trackable.action = LogTypeTrackable.VISITED;
+        for (final TrackableLog trackable : trackables) {
+            if (trackableState == null) { // initial call
+                if (Settings.isTrackableAutoVisit()) {
+                    trackable.action = LogTypeTrackable.VISITED;
+                }
+            } else { // refresh view
+                Integer tbStateId = trackableState.getInt(trackable.trackCode);
+                if (tbStateId > 0) { // found in saved list
+                    trackable.action = LogTypeTrackable.getById(tbStateId);
+                } else { // not found
+                    if (Settings.isTrackableAutoVisit()) {
+                        trackable.action = LogTypeTrackable.VISITED;
+                    }
+                }
             }
         }
     }
@@ -353,6 +366,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
             image = savedInstanceState.getParcelable(SAVED_STATE_IMAGE);
             premFavPoints = savedInstanceState.getInt(SAVED_STATE_FAVPOINTS);
             reportProblemSelected = ReportProblemType.findByCode(savedInstanceState.getString(SAVED_STATE_PROBLEM));
+            trackableState = savedInstanceState.getBundle(SAVED_STATE_TRACKABLES);
         } else {
             // If log had been previously saved, load it now, otherwise initialize signature as needed
             loadLogFromDatabase();
@@ -512,6 +526,12 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
         outState.putParcelable(SAVED_STATE_IMAGE, image);
         outState.putInt(SAVED_STATE_FAVPOINTS, premFavPoints);
         outState.putString(SAVED_STATE_PROBLEM, reportProblemSelected.code);
+        // save state of trackables
+        final Bundle outTrackables = new Bundle();
+        for (final TrackableLog trackable : trackables) {
+            outTrackables.putInt(trackable.trackCode, trackable.action.id);
+        }
+        outState.putBundle(SAVED_STATE_TRACKABLES, outTrackables);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -1012,7 +1012,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         int id = startId;
 
         // If 'freeVariables' are to be displayed include a border around the tables
-        // such that it becomes apparent that their is a second table which may be off teh screen.
+        // such that it becomes apparent that their is a second table which may be off the screen.
         if (freeVariables.isEmpty()) {
             variablesScrollableContent.setBackgroundResource(0);
             variableDivider.setVisibility(View.GONE);


### PR DESCRIPTION
This Fixes #4697: TB selections and GC vote lost when returning to logging activity

After returning from TB detail view - do not reload the log data when already TB data exist.
This is a little bit dirty, but I think we call this only in this situation.

Extra: deactivate generating the activity in onCreate, ist seems not really useful