### PR TITLE
read child waypoint types from GPX <type>

### DIFF
--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -99,10 +99,15 @@ public enum WaypointType {
         return this == FINAL || this == STAGE;
     }
 
-    public static WaypointType fromGPXString(@NonNull final String sym) {
+    public static WaypointType fromGPXString(@NonNull final String sym, final String subtype) {
         // first check the somewhat "official" sym types
         for (final WaypointType waypointType : WaypointType.values()) {
             if (waypointType.gpx.equalsIgnoreCase(sym)) {
+                return waypointType;
+            }
+            // Maybe the <sym> element was used for a Garmin symbol (e.g. Opencaching GPX).
+            // Try the sybtype instead.
+            if (subtype != null && waypointType.gpx.equalsIgnoreCase(subtype)) {
                 return waypointType;
             }
         }

--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -99,6 +99,10 @@ public enum WaypointType {
         return this == FINAL || this == STAGE;
     }
 
+    public static WaypointType fromGPXString(@NonNull final String sym) {
+        return fromGPXString(sym, null);
+    }
+
     public static WaypointType fromGPXString(@NonNull final String sym, final String subtype) {
         // first check the somewhat "official" sym types
         for (final WaypointType waypointType : WaypointType.values()) {
@@ -106,8 +110,8 @@ public enum WaypointType {
                 return waypointType;
             }
             // Maybe the <sym> element was used for a Garmin symbol (e.g. Opencaching GPX).
-            // Try the sybtype instead.
-            if (subtype != null && waypointType.gpx.equalsIgnoreCase(subtype)) {
+            // Try the subtype instead if defined
+            if (waypointType.gpx.equalsIgnoreCase(subtype)) {
                 return waypointType;
             }
         }

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -117,6 +117,7 @@ abstract class GPXParser extends FileParser {
     private LogEntry.Builder logBuilder = null;
 
     private String type = null;
+    private String subtype = null;
     private String sym = null;
     private String name = null;
     private String cmt = null;
@@ -307,7 +308,7 @@ abstract class GPXParser extends FileParser {
 
                     final Geocache cacheForWaypoint = findParentCache();
                     if (cacheForWaypoint != null) {
-                        final Waypoint waypoint = new Waypoint(cache.getShortDescription(), WaypointType.fromGPXString(sym), false);
+                        final Waypoint waypoint = new Waypoint(cache.getShortDescription(), WaypointType.fromGPXString(sym, subtype), false);
                         if (wptUserDefined) {
                             waypoint.setUserDefined();
                         }
@@ -396,6 +397,9 @@ abstract class GPXParser extends FileParser {
                 final String[] content = StringUtils.split(body, '|');
                 if (content.length > 0) {
                     type = content[0].toLowerCase(Locale.US).trim();
+                    if (content.length > 1) {
+                        subtype = content[1].toLowerCase(Locale.US).trim();
+                    }
                 }
             }
         });
@@ -1152,6 +1156,7 @@ abstract class GPXParser extends FileParser {
      */
     private void resetCache() {
         type = null;
+        subtype = null;
         sym = null;
         name = null;
         desc = null;
@@ -1217,7 +1222,7 @@ abstract class GPXParser extends FileParser {
         if (cache.getCoords() == null) {
             return false;
         }
-        final boolean valid = (type == null && sym == null)
+        final boolean valid = (type == null && subtype == null && sym == null)
                 || StringUtils.contains(type, "geocache")
                 || StringUtils.contains(sym, "geocache")
                 || StringUtils.containsIgnoreCase(sym, "waymark")

--- a/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
+++ b/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
@@ -24,6 +24,9 @@ public class WaypointTypeTest extends AndroidTestCase {
         // new names of multi and mystery stages
         assertThat(WaypointType.fromGPXString("Physical Stage")).isEqualTo(WaypointType.STAGE);
         assertThat(WaypointType.fromGPXString("Virtual Stage")).isEqualTo(WaypointType.PUZZLE);
+
+        // subtype form
+        assertThat(WaypointType.fromGPXString("xxx", "unknown sym")).isEqualTo(WaypointType.WAYPOINT);
     }
 
 }

--- a/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
+++ b/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
@@ -26,7 +26,7 @@ public class WaypointTypeTest extends AndroidTestCase {
         assertThat(WaypointType.fromGPXString("Virtual Stage")).isEqualTo(WaypointType.PUZZLE);
 
         // subtype form
-        assertThat(WaypointType.fromGPXString("xxx", "unknown sym")).isEqualTo(WaypointType.WAYPOINT);
+        assertThat(WaypointType.fromGPXString("unknown sym", "Virtual Stage")).isEqualTo(WaypointType.PUZZLE);
     }
 
 }

--- a/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
+++ b/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
@@ -25,7 +25,8 @@ public class WaypointTypeTest extends AndroidTestCase {
         assertThat(WaypointType.fromGPXString("Physical Stage")).isEqualTo(WaypointType.STAGE);
         assertThat(WaypointType.fromGPXString("Virtual Stage")).isEqualTo(WaypointType.PUZZLE);
 
-        // subtype form
+        // subtype forms
+        assertThat(WaypointType.fromGPXString("Parking Area", "Parking Area")).isEqualTo(WaypointType.PARKING);
         assertThat(WaypointType.fromGPXString("unknown sym", "Virtual Stage")).isEqualTo(WaypointType.PUZZLE);
     }
 


### PR DESCRIPTION
This is dry-written code; I have no c:geo development environment (yet).

It allows to have the type of GPX child waypoints only in the `<type>` element, instead of redundantly in `<type>` and `<sym>`. Then Garmin and Groundspeak waypoint IDs can coexist in the same file.

(`<sym>` is an original Garmin GPX element, while Groundspeak added the `<type>`.)

Example:
```
    <wpt lat="51.11847" lon="17.06827">
        ...
        <sym>Trail Head</sym>
        <type>Waypoint|Trailhead</type>
...
    </wpt>
```

(Garmin "Trail Head" = Groundspeak "Trailhead")

Such GPX files are now produced by OKAPI at Opencaching.PL/NL/US/RO. Example:

https://opencaching.pl/okapi/services/caches/formatters/gpx?consumer_key=YourConsumerKey&cache_codes=OP601F&alt_wpts=true&ns_ground=true

(Insert your OC.PL consumer key, that you received via [OKAPI signup](https://opencaching.pl/okapi/signup.html)).