### PR TITLE
Hide Opencaching 0/0 waypoint coords

### DIFF
--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -616,6 +616,7 @@ final class OkapiClient {
     @Nullable
     private static List<Waypoint> parseWaypoints(final ArrayNode wptsJson) {
         List<Waypoint> result = null;
+        pt0 = new Geopoint(0, 0);
         for (final JsonNode wptResponse: wptsJson) {
             try {
                 final Waypoint wpt = new Waypoint(wptResponse.get(WPT_NAME).asText(),
@@ -623,7 +624,7 @@ final class OkapiClient {
                         false);
                 wpt.setNote(wptResponse.get(WPT_DESCRIPTION).asText());
                 final Geopoint pt = parseCoords(wptResponse.get(WPT_LOCATION).asText());
-                if (pt != null) {
+                if (pt != null && !pt.equals(pt0)) {
                     wpt.setCoords(pt);
                 } else {
                     wpt.setOriginalCoordsEmpty(true);


### PR DESCRIPTION
For OC.PL based sites, OKAPI now exposes cache waypoints with hidden coordinates. To have them backward compatible in existing apps, they are returned with "0|0" location. So c:geo needs to hide the 0|0 WP coordinates.

Example: [OP8J43](https://opencaching.pl/viewcache.php?cacheid=52510) has six waypoints, two of them with hidden coordinates.

Again, this is dry-written code, because I don't yet have a c:geo development environment.