### PR TITLE
Update Okapi waypoint types

### DIFF
--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -721,6 +721,9 @@ final class OkapiClient {
             return WaypointType.FINAL;
         }
         if ("poi".equalsIgnoreCase(wptType)) {
+            return WaypointType.WAYPOINT;
+        }
+        if ("trailhead".equalsIgnoreCase(wptType)) {
             return WaypointType.TRAILHEAD;
         }
         return WaypointType.WAYPOINT;


### PR DESCRIPTION
poi = point of interest = intesting place; this is not a trailhead. Best mapping is "Reference point".

For trailheads, there is the new OC type "trailhead", e.g. in [OP6FEC](https://opencaching.pl/viewcache.php?cacheid=28657).