### PR TITLE
Fix #7211 - PMO failure not detected

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -165,7 +165,7 @@ public final class GCConstants {
     static final Pattern PATTERN_SESSIONTOKEN = Pattern.compile("sessionToken:'([^']+)'");
 
     static final String STRING_PREMIUMONLY_2 = "Sorry, the owner of this listing has made it viewable to Premium Members only.";
-    static final String STRING_PREMIUMONLY_1 = "has marked it as Premium-Only.";
+    static final String STRING_PREMIUMONLY_1 = "class=\"illustration lock-icon\"";
     static final String STRING_UNPUBLISHED_OTHER = "you cannot view this cache listing until it has been published";
     static final String STRING_UNPUBLISHED_FROM_SEARCH = "class=\"UnpublishedCacheSearchWidget"; // do not include closing brace as the CSS can contain additional styles
     static final String STRING_UNKNOWN_ERROR = "An Error Has Occurred";


### PR DESCRIPTION
Seems the page shown to basic members when accessing a PMO cache has changed recently.
The used class item seems to be specific for this page, as I could not find it on other cache pages.

Change is not tested yet. Will test it with debug APK from CI.