### PR TITLE
allow jpg, png, gif for log foto uploads (fix #6955)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -206,6 +206,7 @@
     <string name="err_favorite_failed">Changing favorite status failed.</string>
     <string name="err_select_logimage_failed">Selecting an image for the log failed.</string>
     <string name="err_acquire_image_failed">Acquiring an image failed.</string>
+    <string name="err_unsupported_image_format">Unsupported image format.</string>
     <string name="err_tb_display">c:geo can\'t display the trackable you want. Is it really a trackable?</string>
     <string name="err_tb_details_open">c:geo can\'t open trackable details.</string>
     <string name="err_tb_not_loggable">This trackable isn\'t loggable.</string>

--- a/main/src/cgeo/geocaching/ImageSelectActivity.java
+++ b/main/src/cgeo/geocaching/ImageSelectActivity.java
@@ -239,7 +239,7 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
 
     private void selectImageFromStorage() {
         final Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.setType("image/jpeg");
+        intent.setType("image/*");
 
         startActivityForResult(Intent.createChooser(intent, "Select Image"), SELECT_STORED_IMAGE);
     }
@@ -264,6 +264,11 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
             final Uri selectedImage = data.getData();
             // In principal can selectedImage be null
             if (selectedImage != null) {
+                final String mimeType = getContentResolver().getType(selectedImage);
+                if (!("image/jpeg".equals(mimeType) || "image/png".equals(mimeType) || "image/gif".equals(mimeType))) {
+                    showToast(getString(R.string.err_unsupported_image_format));
+                    return;
+                }
                 if (Build.VERSION.SDK_INT < VERSION_CODES.KITKAT) {
                     final String[] filePathColumn = { MediaColumns.DATA };
 


### PR DESCRIPTION
instead of a fixed MIME filter of "image/jpeg" set intent filter to "image/*" and check the file chosen by the user for MIME types "image/jpeg", "image/png" and "image/gif" (which are uploadeable for both geocaching.com as well as opencaching.* platforms)