### PR TITLE
three colum mainscreen with up to two lines of text each (fix #6361)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -21,18 +21,19 @@
     <!-- ** -->
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:layout_marginTop="45dip"
         android:gravity="center"
-        android:orientation="vertical" >
+        android:orientation="vertical">
 
-        <LinearLayout style="@style/icon_mainscreen_row" >
+        <LinearLayout
+            style="@style/icon_mainscreen_row">
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoFindOnMap" >
+                android:onClick="cgeoFindOnMap">
 
                 <ImageView
                     android:id="@+id/map"
@@ -44,7 +45,8 @@
                     android:text="@string/live_map_button" />
             </LinearLayout>
 
-            <LinearLayout style="@style/icon_mainscreen_cell" >
+            <LinearLayout
+                style="@style/icon_mainscreen_cell">
 
                 <ImageView
                     android:id="@+id/nearest"
@@ -57,17 +59,19 @@
             </LinearLayout>
 
             <RelativeLayout
-                android:layout_width="74dip"
+                android:layout_width="0dip"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:layout_margin="4dip"
-                android:onClick="cgeoFindByOffline" >
+                android:orientation="vertical"
+                android:onClick="cgeoFindByOffline">
 
                 <TextView
                     android:id="@+id/offline_count"
                     style="@style/icon_mainscreen_count"
                     android:textIsSelectable="false" />
 
-                <LinearLayout style="@style/icon_mainscreen_cell_counter" >
+                <LinearLayout
+                    style="@style/icon_mainscreen_cell_counter">
 
                     <ImageView
                         android:id="@+id/search_offline"
@@ -81,11 +85,12 @@
             </RelativeLayout>
         </LinearLayout>
 
-        <LinearLayout style="@style/icon_mainscreen_row" >
+        <LinearLayout
+            style="@style/icon_mainscreen_row">
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoSearch" >
+                android:onClick="cgeoSearch">
 
                 <ImageView
                     android:id="@+id/advanced_button"
@@ -99,7 +104,7 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoPoint" >
+                android:onClick="cgeoPoint">
 
                 <ImageView
                     android:id="@+id/any_button"
@@ -113,7 +118,7 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoFilter" >
+                android:onClick="cgeoFilter">
 
                 <ImageView
                     android:id="@+id/filter_button"
@@ -124,7 +129,7 @@
                     android:id="@+id/filter_button_title"
                     style="@style/icon_mainscreen_text"
                     android:text="@null"
-                    tools:text="Filter"/>
+                    tools:text="Filter" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -166,8 +166,7 @@
         <item name="android:paddingBottom">1dip</item>
         <item name="android:paddingLeft">5dip</item>
         <item name="android:paddingRight">5dip</item>
-        <item name="android:singleLine">true</item>
-        <item name="android:lines">1</item>
+        <item name="android:maxLines">2</item>
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">13sp</item>
         <item name="android:textColor">@color/text_icon</item>
@@ -180,9 +179,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center_horizontal</item>
         <item name="android:layout_alignParentTop">true</item>
-        <item name="android:layout_alignParentRight">true</item>
-        <item name="android:layout_marginRight">4dip</item>
-        <item name="android:layout_marginLeft">4dip</item>
+        <item name="android:layout_centerHorizontal">true</item>
         <item name="android:gravity">center</item>
         <item name="android:paddingTop">2dip</item>
         <item name="android:paddingBottom">2dip</item>
@@ -197,16 +194,21 @@
         <item name="android:text"></item>
     </style>
     <style name="icon_mainscreen_cell_counter">
-        <item name="android:layout_width">74dip</item>
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:orientation">vertical</item>
     </style>
-    <style name="icon_mainscreen_cell" parent="icon_mainscreen_cell_counter">
-        <item name="android:layout_margin">4dip</item>
+    <style name="icon_mainscreen_cell">
+        <item name="android:layout_width">0dip</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:orientation">vertical</item>
     </style>
     <style name="icon_mainscreen_row">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">fill_parent</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_margin">4dip</item>
         <item name="android:gravity">center_horizontal</item>
         <item name="android:orientation">horizontal</item>


### PR DESCRIPTION
tweaked the layout settings for the mainscreen so that
- icons + text are set into three equally-wide columns
- text can be up to two lines long (but takes up space for only one line if short enough)