### PR TITLE
 Add Icon to address search result list to directly jump to map (fix #6400)

### DIFF
--- a/main/res/layout/addresslist_item.xml
+++ b/main/res/layout/addresslist_item.xml
@@ -1,42 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/button_map"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="3dip"
     android:background="?background_color"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:paddingBottom="7dip"
     android:paddingLeft="5dip"
     android:paddingRight="5dip"
     android:paddingTop="7dip"
     tools:context=".address.AddressListAdapter" >
 
-    <TextView
-        android:id="@+id/label"
-        android:layout_width="fill_parent"
+    <LinearLayout
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:ellipsize="end"
-        android:gravity="left"
-        android:scrollHorizontally="true"
-        android:textColor="?text_color"
-        android:textIsSelectable="false"
-        android:textSize="22sp"
-        tools:text="Address of place\nwith multiple lines"/>
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/distance"
-        android:layout_width="fill_parent"
+        <TextView
+            android:id="@+id/label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:gravity="left"
+            android:scrollHorizontally="true"
+            android:textColor="?text_color"
+            android:textIsSelectable="false"
+            android:textSize="22sp"
+            tools:text="Address of place\nwith multiple lines"/>
+
+        <TextView
+            android:id="@+id/distance"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:gravity="left"
+            android:lines="1"
+            android:scrollHorizontally="true"
+            android:textColor="?text_color"
+            android:textIsSelectable="false"
+            android:textSize="12sp"
+            tools:text="distance"
+            android:maxLines="1" />
+
+    </LinearLayout>
+    <ImageView
+        android:id="@+id/mapIcon"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:ellipsize="end"
-        android:gravity="left"
-        android:lines="1"
+        android:layout_gravity="right"
+        android:gravity="right"
         android:scrollHorizontally="true"
-        android:textColor="?text_color"
-        android:textIsSelectable="false"
-        android:textSize="12sp"
-        tools:text="distance"
-        android:maxLines="1" />
-
-</LinearLayout>
+        tools:text="place holder for jump to map"
+        android:src="@drawable/ic_menu_mapmode"
+        android:layout_alignParentRight="true" />
+</RelativeLayout>

--- a/main/src/cgeo/geocaching/address/AddressClickListener.java
+++ b/main/src/cgeo/geocaching/address/AddressClickListener.java
@@ -5,4 +5,5 @@ import android.support.annotation.NonNull;
 
 interface AddressClickListener {
     void onClickAddress(@NonNull Address address);
+    void onClickMapIcon(@NonNull Address address);
 }

--- a/main/src/cgeo/geocaching/address/AddressListActivity.java
+++ b/main/src/cgeo/geocaching/address/AddressListActivity.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.maps.DefaultMap;
 import cgeo.geocaching.ui.recyclerview.RecyclerViewProvider;
 import cgeo.geocaching.utils.AndroidRxUtils;
 
@@ -66,4 +67,9 @@ public class AddressListActivity extends AbstractActionBarActivity implements Ad
         finish();
     }
 
+    @Override
+    public void onClickMapIcon(final Address address) {
+        DefaultMap.startActivityGeoCode(this, new Geopoint(address.getLatitude(), address.getLongitude()));
+        finish();
+    }
 }

--- a/main/src/cgeo/geocaching/address/AddressListAdapter.java
+++ b/main/src/cgeo/geocaching/address/AddressListAdapter.java
@@ -13,6 +13,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import java.util.ArrayList;
@@ -31,11 +32,11 @@ class AddressListAdapter extends RecyclerView.Adapter<AddressListAdapter.Address
 
         @BindView(R.id.label) TextView label;
         @BindView(R.id.distance) TextView distance;
+        @BindView(R.id.mapIcon) ImageView mapIcon;
 
         AddressListHolder(final View itemView) {
             super(itemView);
         }
-
     }
 
     AddressListAdapter(@NonNull final List<Address> addresses, @NonNull final AddressClickListener addressClickListener) {
@@ -54,10 +55,15 @@ class AddressListAdapter extends RecyclerView.Adapter<AddressListAdapter.Address
         final View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.addresslist_item, parent, false);
         final AddressListHolder viewHolder = new AddressListHolder(view);
         viewHolder.itemView.setOnClickListener(new OnClickListener() {
-
             @Override
             public void onClick(final View view) {
                 clickListener.onClickAddress(addresses.get(viewHolder.getAdapterPosition()));
+            }
+        });
+        viewHolder.mapIcon.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(final View v) {
+                clickListener.onClickMapIcon(addresses.get(viewHolder.getAdapterPosition()));
             }
         });
         return viewHolder;

--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -27,12 +27,20 @@ public final class DefaultMap {
         return getLiveMapIntent(fromActivity, getDefaultMapClass());
     }
 
+    public static Intent getLiveMapIntent(final Activity fromActivity, final Geopoint coords) {
+        return new MapOptions(coords).newIntent(fromActivity, getDefaultMapClass());
+    }
+
     public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Geopoint coords, final WaypointType type, final String title) {
         new MapOptions(coords, type, title).startIntent(fromActivity, cls);
     }
 
     public static void startActivityCoords(final Activity fromActivity, final Geopoint coords, final WaypointType type, final String title) {
         startActivityCoords(fromActivity, getDefaultMapClass(), coords, type, title);
+    }
+
+    public static void startActivityGeoCode(final Context fromActivity, final Geopoint coords) {
+        new MapOptions(coords).startIntent(fromActivity, getDefaultMapClass());
     }
 
     public static void startActivityGeoCode(final Context fromActivity, final Class<?> cls, final String geocode) {

--- a/main/src/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/cgeo/geocaching/maps/MapOptions.java
@@ -60,6 +60,13 @@ public class MapOptions {
         isLiveEnabled = Settings.isLiveMap();
     }
 
+    public MapOptions(final Geopoint coords) {
+        mapMode = MapMode.COORDS;
+        this.coords = coords;
+        isStoredEnabled = true;
+        isLiveEnabled = Settings.isLiveMap();
+    }
+
     public MapOptions(final Geopoint coords, final WaypointType type, final String title) {
         this.coords = coords;
         this.waypointType = type;


### PR DESCRIPTION
Extends mainscreen's "search for address" functionality by adding a map icon to the result list. Clicking on this map icon directly leads to a map view, centered at the coordinates given by the clicked search result.