### PR TITLE
restrict brouter threshold setting to a minimum of one km (fix #7239)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -583,7 +583,7 @@
     <string name="init_showwaypoints">Show Waypoints</string>
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_brouterThreshold">Calculate route</string>
-    <string name="init_brouterThreshold_description">Maximum distance up to which brouter helper app (if installed) will calculate a route. (0 = disable)</string>
+    <string name="init_brouterThreshold_description">Maximum distance up to which brouter helper app (if installed) will calculate a route.</string>
     <string name="init_disabled">Exclude Disabled</string>
     <string name="init_summary_disabled">Exclude disabled caches</string>
     <string name="init_offline">Static Maps</string>

--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -87,7 +87,7 @@ public final class Routing {
     public static Geopoint[] getTrack(final Geopoint start, final Geopoint destination) {
         final int maxThresholdKm = Settings.getBrouterThreshold();
 
-        if (brouter == null || Settings.getRoutingMode() == RoutingMode.STRAIGHT || maxThresholdKm == 0) {
+        if (brouter == null || Settings.getRoutingMode() == RoutingMode.STRAIGHT) {
             return defaultTrack(start, destination);
         }
 

--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -85,8 +85,6 @@ public final class Routing {
      */
     @NonNull
     public static Geopoint[] getTrack(final Geopoint start, final Geopoint destination) {
-        final int maxThresholdKm = Settings.getBrouterThreshold();
-
         if (brouter == null || Settings.getRoutingMode() == RoutingMode.STRAIGHT) {
             return defaultTrack(start, destination);
         }
@@ -98,6 +96,7 @@ public final class Routing {
         }
 
         // Disable routing for huge distances
+        final int maxThresholdKm = Settings.getBrouterThreshold();
         final float targetDistance = start.distanceTo(destination);
         if (targetDistance > maxThresholdKm) {
             return defaultTrack(start, destination);

--- a/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
+++ b/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
@@ -46,6 +46,14 @@ public class BrouterThresholdPreference extends Preference {
         ;
     }
 
+    private boolean atLeastOne(final SeekBar seekBar, final int progress) {
+        if (progress < 1) {
+            seekBar.setProgress(1);
+            return false;
+        }
+        return true;
+    }
+
     @Override
     protected View onCreateView(final ViewGroup parent) {
         final View v = super.onCreateView(parent);
@@ -66,7 +74,9 @@ public class BrouterThresholdPreference extends Preference {
             @Override
             public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
                 if (fromUser) {
-                    valueView.setText(getValueString(progress));
+                    if (atLeastOne(seekBar, progress)) {
+                        valueView.setText(getValueString(progress));
+                    }
                 }
             }
             @Override
@@ -75,7 +85,9 @@ public class BrouterThresholdPreference extends Preference {
             }
             @Override
             public void onStopTrackingTouch(final SeekBar seekBar) {
-                Settings.setBrouterThreshold(seekBar.getProgress());
+                if (atLeastOne(seekBar, seekBar.getProgress())) {
+                    Settings.setBrouterThreshold(seekBar.getProgress());
+                }
             }
         });
 

--- a/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
+++ b/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
@@ -73,10 +73,8 @@ public class BrouterThresholdPreference extends Preference {
         seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-                if (fromUser) {
-                    if (atLeastOne(seekBar, progress)) {
-                        valueView.setText(getValueString(progress));
-                    }
+                if (fromUser && atLeastOne(seekBar, progress)) {
+                    valueView.setText(getValueString(progress));
                 }
             }
             @Override


### PR DESCRIPTION
- restrict brouter threshold setting slider to a minimum of one km
- removed the check for zero value in routing routine
- remove mention of "0=disable" in settings string