### PR TITLE
make trail history persistent (fix #2958)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -176,5 +176,9 @@
         android:icon="@drawable/ic_menu_agenda"
         android:title="@string/map_as_list">
     </item>
+    <item
+        android:id="@+id/menu_clear_trailhistory"
+        android:title="@string/map_clear_trailhistory">
+    </item>
 
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1099,6 +1099,8 @@
     <string name="map_static_loading">Loading static maps…</string>
     <string name="map_token_err">Since c:geo is only able to download partial data, coordinates of caches could be inaccurate.</string>
     <string name="map_as_list">Show as list</string>
+    <string name="map_clear_trailhistory">Clear trail history</string>
+    <string name="map_trailhistory_cleared">trail history cleared</string>
     <string name="map_strategy">Strategy</string>
     <string name="map_strategy_title">Live Map strategy</string>
     <string name="map_strategy_fastest">Fastest</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -636,6 +636,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
 
             menu.findItem(R.id.menu_as_list).setVisible(!isLoading() && caches.size() > 1);
 
+            menu.findItem(R.id.menu_clear_trailhistory).setVisible(Settings.isMapTrail());
+
             menu.findItem(R.id.submenu_strategy).setVisible(mapOptions.isLiveEnabled);
 
             switch (Settings.getLiveMapStrategy()) {
@@ -734,6 +736,13 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                 return true;
             case R.id.menu_as_list: {
                 CacheListActivity.startActivityMap(activity, new SearchResult(getGeocodesForCachesInViewport()));
+                return true;
+            }
+            case R.id.menu_clear_trailhistory: {
+                DataStore.clearTrailHistory();
+                overlayPositionAndScale.setHistory(new ArrayList<Location>());
+                mapView.repaintRequired(overlayPositionAndScale);
+                ActivityMixin.showToast(activity, res.getString(R.string.map_trailhistory_cleared));
                 return true;
             }
             case R.id.menu_strategy_fast: {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -312,6 +312,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
             menu.findItem(R.id.menu_as_list).setVisible(!caches.isDownloading() && caches.getVisibleCachesCount() > 1);
 
+            menu.findItem(R.id.menu_clear_trailhistory).setVisible(Settings.isMapTrail());
+
             menu.findItem(R.id.submenu_strategy).setVisible(mapOptions.isLiveEnabled);
 
             switch (Settings.getLiveMapStrategy()) {
@@ -425,6 +427,11 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 return true;
             case R.id.menu_as_list:
                 CacheListActivity.startActivityMap(this, new SearchResult(caches.getVisibleCacheGeocodes()));
+                return true;
+            case R.id.menu_clear_trailhistory:
+                this.historyLayer.reset();
+                this.historyLayer.requestRedraw();
+                showToast(res.getString(R.string.map_trailhistory_cleared));
                 return true;
             case R.id.menu_strategy_fast:
                 item.setChecked(true);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -30,6 +30,10 @@ public class HistoryLayer extends Layer {
         }
     }
 
+    public void reset() {
+        positionHistory.reset();
+    }
+
     @Override
     public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
         if (coordinates == null) {


### PR DESCRIPTION
- log trail history to database
- restore when recreating map (implemented for CGeoMap and NewMap)
- menu option to clear history (implemented for CGeoMap and NewMap)
- limit number of trail points in database automatically (cleanup on open db)