### PR TITLE
adjust alignment and sizes for useful apps view (fix #7258)

### DIFF
--- a/main/res/layout/usefulapps_item.xml
+++ b/main/res/layout/usefulapps_item.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/app_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:layout_marginBottom="10dip"
     android:descendantFocusability="blocksDescendants"
     android:orientation="vertical"
@@ -20,8 +20,8 @@
     </RelativeLayout>
 
     <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="5dip"
         android:layout_marginLeft="10dip"
         android:layout_marginRight="10dip"


### PR DESCRIPTION
adjust alignment and sizes for useful apps view to not use a full screen's height for each program entry