### PR TITLE
fixed build warning about generated id for ext. pkg. android (fix #7269)

### DIFF
--- a/main/res/drawable/star_rating.xml
+++ b/main/res/drawable/star_rating.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:id="@+android:id/background"
+    <item android:id="@android:id/background"
           android:drawable="@drawable/star_off" />
-    <item android:id="@+android:id/secondaryProgress"
+    <item android:id="@android:id/secondaryProgress"
           android:drawable="@drawable/star_off" />
-    <item android:id="@+android:id/progress"
+    <item android:id="@android:id/progress"
           android:drawable="@drawable/star_on" />
 </layer-list>


### PR DESCRIPTION
fixed build warning about generated id for external package android (fix #7269)