### PR TITLE
Set cursor position to "start" (fixes #7254)

### DIFF
--- a/main/res/layout/fragment_edit_note.xml
+++ b/main/res/layout/fragment_edit_note.xml
@@ -13,6 +13,7 @@
         android:id="@+id/note"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        android:gravity="start"
         android:inputType="textMultiLine"
         android:lines="8" />
 


### PR DESCRIPTION
fixes #7254: Personal note dialog looks broken

Add "android:gravity="start"" to set the cursor to the first line
