### PR TITLE
fix for broken GPX import dialog (fix #7261)

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -361,5 +361,13 @@
         <item name="android:stepSize">0.5</item>
         <item name="android:isIndicator">true</item>
     </style>
-    
+
+    <!-- progress dialog theme -->
+    <style name="cgeoProgressdialogTheme" parent="Theme.AppCompat.Dialog">
+        <item name="android:alertDialogStyle">@style/cgeoProgressdialogThemeStyle</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+    </style>
+    <style name="cgeoProgressdialogThemeStyle">
+        <item name="android:gravity">center</item>
+    </style>
 </resources>

--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.activity;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.ui.dialog.CustomProgressDialog;
 import cgeo.geocaching.utils.Log;
 
@@ -55,7 +56,7 @@ public class Progress {
     }
 
     private void createProgressDialog(final Context context, final String title, final String message, final Message cancelMessage) {
-        dialog = hideAbsolute ? new CustomProgressDialog(context) : new ProgressDialog(context);
+        dialog = hideAbsolute ? new CustomProgressDialog(context) : new ProgressDialog(context,R.style.cgeoProgressdialogTheme);
         dialog.setTitle(title);
         dialog.setMessage(message);
         if (cancelMessage != null) {

--- a/main/src/cgeo/geocaching/ui/dialog/CustomProgressDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CustomProgressDialog.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.ui.dialog;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.utils.Log;
 
@@ -17,7 +18,7 @@ import java.lang.reflect.Field;
 public class CustomProgressDialog extends ProgressDialog {
 
     public CustomProgressDialog(final Context context) {
-        super(context, ActivityMixin.getDialogTheme());
+        super(context, R.style.cgeoProgressdialogTheme);
     }
 
     @Override


### PR DESCRIPTION
fix for #7261 (GPX import dialog looks broken)
add styling to get gpx import dialog back to centered vertically + background non-transparent

It's not yet perfect - button styling differs from the rest of the program -, but at least import dialog works and is readable.