### PR TITLE
additional FileProvider path to support external SD card (fix #7255)

### DIFF
--- a/main/res/xml/file_provider_paths.xml
+++ b/main/res/xml/file_provider_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="external_files" path="." />
+    <root-path name="external_files" path="/storage/" />
 </paths>


### PR DESCRIPTION
add root /storage/ to support access to SD card for FileProvider (fix #7255, part two)