### PR TITLE
Allow Java 1.8 to be used in cgeo

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -24,8 +24,8 @@ android {
 
     compileOptions {
         // use the diamond operator and some other goodies in Android
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/tests/src-android/cgeo/geocaching/location/GeopointAndroidTest.java
+++ b/tests/src-android/cgeo/geocaching/location/GeopointAndroidTest.java
@@ -13,7 +13,7 @@ public class GeopointAndroidTest extends TestCase {
         final String key = "geopoint";
         final Bundle bundle = new Bundle();
         bundle.putParcelable(key, gp);
-        assertThat(bundle.getParcelable(key)).isEqualTo(gp);
+        assertThat(bundle.<Geopoint>getParcelable(key)).isEqualTo(gp);
     }
 
 }


### PR DESCRIPTION
This enables features such as lambda expressions.