### PR TITLE
change alert dialog styling (fix #7342)

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -11,7 +11,7 @@
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textColor">?text_color</item>
-        <item name="android:background">?button</item>
+        <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
     <style name="edittext" parent="@android:style/Widget.EditText">
@@ -373,9 +373,10 @@
     </style>
 
     <!-- progress dialog theme -->
-    <style name="cgeoProgressdialogTheme" parent="Theme.AppCompat.Dialog">
+    <style name="cgeoProgressdialogTheme" parent="Dialog_Alert">
         <item name="android:alertDialogStyle">@style/cgeoProgressdialogThemeStyle</item>
         <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="buttonBarButtonStyle">@style/button</item>
     </style>
     <style name="cgeoProgressdialogThemeStyle">
         <item name="android:gravity">center</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -224,4 +224,9 @@
         <item name="settings_info_icon">@drawable/settings_info_icon_black</item>
     </style>
 
+    <style name="Dialog_Alert" parent="@style/Theme.AppCompat.Dialog.Alert">
+        <item name="buttonBarButtonStyle">@style/button</item>
+        <item name="background">?android:attr/selectableItemBackground</item>
+    </style>
+
 </resources>

--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -9,11 +9,11 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Application;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
 import android.view.View;
 import android.widget.ListView;
 
@@ -108,7 +108,7 @@ public final class StoredList extends AbstractList {
             }
 
             final Activity activity = activityRef.get();
-            final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+            final AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.Dialog_Alert);
             builder.setTitle(res.getString(titleId));
             builder.setMultiChoiceItems(listTitles, selectedItems, new MultiChoiceClickListener(lists, selectedListIds));
             builder.setPositiveButton(android.R.string.ok, new OnOkClickListener(selectedListIds, runAfterwards, listNameMemento));


### PR DESCRIPTION
- add theming/styling for AlertDialogs to get c:geo standard buttons as defined in styles
- use this theme for manually created AlertDialogs in StoredList (fix #7342)
- also restores white button text color for other AlertDialog popups (like GPX import, which got changed by fix for #7261)