### PR TITLE
restore button borders for search dialog (fix #7356)

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -11,6 +11,10 @@
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textColor">?text_color</item>
+        <item name="android:background">?button</item>
+    </style>
+
+    <style name="button_borderless" parent="button">
         <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -225,7 +225,7 @@
     </style>
 
     <style name="Dialog_Alert" parent="@style/Theme.AppCompat.Dialog.Alert">
-        <item name="buttonBarButtonStyle">@style/button</item>
+        <item name="buttonBarButtonStyle">@style/button_borderless</item>
         <item name="background">?android:attr/selectableItemBackground</item>
     </style>
 


### PR DESCRIPTION
- restore button borders for search dialog buttons
- but keep buttons on "save list" dialog borderless