### PR TITLE
Fix #7359 - Raise minSDK to Android 4.1 (SDK16)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -29,7 +29,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 27
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)


### PR DESCRIPTION
Please doublecheck as described in #7359 whether this is the right file to change minSDK before merging.

I targeted this PR to `release` as I would like to have this change out asap. Android 4.0.x can no longer login and use online functions. A closeout warning has already been given to users since middle of last year.