### PR TITLE
add two attribute values to cgeo_gmap and cgeo_gmap_light themes to fix #7358

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -50,11 +50,17 @@
         <item name="android:indeterminateProgressStyle" tools:ignore="NewApi">@style/cgeo.Widget.AppCompat.Base.ProgressBar.Medium</item>
     </style>
 
-    <style name="cgeo_gmap" parent="@android:style/Theme.DeviceDefault" />
+    <style name="cgeo_gmap" parent="@android:style/Theme.DeviceDefault">
+        <item name="text_color">@color/text_dark</item>
+        <item name="button">@drawable/action_button_dark</item>
+    </style>
 
-    <style name="cgeo_gmap_light" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar" />
+    <style name="cgeo_gmap_light" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
+        <item name="text_color">@color/text_light</item>
+        <item name="button">@drawable/action_button_light</item>
+    </style>
 
-   <style name="cgeo.base" parent="@style/Theme.AppCompat">
+    <style name="cgeo.base" parent="@style/Theme.AppCompat">
 
        <!-- For some reason we get a different text-size here (bug in abc?), explicitly set text styles -->
        <item name="titleTextStyle">@style/TextAppearance.AppCompat.Widget.ActionMode.Title</item>


### PR DESCRIPTION
values for attributes "text_color" and "button" must be defined to inflate a layout which uses the "button" style (which is what gmap implementation does when creating an AlertDialog with its new styling)