### PR TITLE
Changed string osm:mapnik to osm:default

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -716,7 +716,7 @@
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>
-    <string name="map_source_osm_mapnik">OSM: Mapnik</string>
+    <string name="map_source_osm_mapnik">OSM: Default</string>
     <string name="map_source_osm_cyclemap">OSM: Cyclemap</string>
     <string name="map_source_osm_offline">Offline</string>
     <string name="init_sendToCgeo">Send to c:geo</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -716,7 +716,7 @@
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>
-    <string name="map_source_osm_mapnik">OSM: Default</string>
+    <string name="map_source_osm_mapnik">OSM: Map</string>
     <string name="map_source_osm_cyclemap">OSM: Cyclemap</string>
     <string name="map_source_osm_offline">Offline</string>
     <string name="init_sendToCgeo">Send to c:geo</string>


### PR DESCRIPTION
Mapnik is the rendering software, not the style name

The internal names should be adapted, too. But this is not so important.

https://wiki.openstreetmap.org/wiki/Mapnik
Another possible name would be 
Osm:Carto
https://wiki.openstreetmap.org/wiki/Standard_tile_layer
But this would be confusing imo