### PR TITLE
add layout captures directory of Android Studio to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,7 @@ main/gradle.properties
 !.idea/checkstyle-idea.xml
 *.iml
 
+# ignore AS layout captures
+captures/
+
 main/usage.txt


### PR DESCRIPTION
add "captures" directory to .gitignore
("captures" directory is used by Android Studio for the Layout Inspector)