### PR TITLE
Make lint for mapswithme happy

### DIFF
--- a/mapswithme-api/lint.xml
+++ b/mapswithme-api/lint.xml
@@ -6,7 +6,6 @@
     <issue id="AddJavascriptInterface" severity="ignore" />
     <issue id="AllowBackup" severity="ignore" />
     <issue id="AlwaysShowAction" severity="ignore" />
-    <issue id="AndroidGradlePluginVersion" severity="ignore" />
     <issue id="AppCompatMethod" severity="ignore" />
     <issue id="AppCompatResource" severity="ignore" />
     <issue id="Assert" severity="ignore" />
@@ -49,6 +48,7 @@
     <issue id="GradleIdeError" severity="ignore" />
     <issue id="GradleOverrides" severity="ignore" />
     <issue id="GradlePath" severity="ignore" />
+    <issue id="GradlePluginVersion" severity="ignore" />
     <issue id="GrantAllUris" severity="ignore" />
     <issue id="GridLayout" severity="ignore" />
     <issue id="HandlerLeak" severity="ignore" />
@@ -68,7 +68,6 @@
     <issue id="IconXmlAndPng" severity="ignore" />
     <issue id="IllegalResourceRef" severity="ignore" />
     <issue id="ImpliedQuantity" severity="ignore" />
-    <issue id="ImproperProjectLevelStatement" severity="ignore" />
     <issue id="InOrMmUsage" severity="ignore" />
     <issue id="IncludeLayoutParam" severity="ignore" />
     <issue id="InconsistentArrays" severity="ignore" />
@@ -90,7 +89,6 @@
     <issue id="ManifestTypo" severity="ignore" />
     <issue id="MenuTitle" severity="ignore" />
     <issue id="MergeRootFrame" severity="ignore" />
-    <issue id="MisplacedStatement" severity="ignore" />
     <issue id="MissingApplicationIcon" severity="ignore" />
     <issue id="MissingId" severity="ignore" />
     <issue id="MissingPrefix" severity="ignore" />


### PR DESCRIPTION
* Task :mapswithme-api:lint FAILED
   Ran lint on variant debug: 3 issues found
   Ran lint on variant release: 3 issues found
   Wrote XML report to file:///C:/StudioProjects/cgeo/mapswithme-api/build/reports/lint-results.xml

* In the xml:
<issue id="LintError" severity="Error" message="Unknown issue id "AndroidGradlePluginVersion", found in C:\StudioProjects\cgeo\mapswithme-api\lint.xml" category="Lint" priority="10" summary="Lint Failure" explanation="This issue type represents a problem running lint itself. Examples include failure to find bytecode for source files (which means certain detectors could not be run), parsing errors in lint configuration files, etc.

 These errors are not errors in your own code, but they are shown to make it clear that some checks were not completed.">
</issue>
<issue id="LintError" severity="Error" message="Unknown issue id "ImproperProjectLevelStatement", found in C:\StudioProjects\cgeo\mapswithme-api\lint.xml" category="Lint" priority="10" summary="Lint Failure" explanation="This issue type represents a problem running lint itself. Examples include failure to find bytecode for source files (which means certain detectors could not be run), parsing errors in lint configuration files, etc.

 These errors are not errors in your own code, but they are shown to make it clear that some checks were not completed.">
</issue>
<issue id="LintError" severity="Error" message="Unknown issue id "MisplacedStatement", found in C:\StudioProjects\cgeo\mapswithme-api\lint.xml" category="Lint" priority="10" summary="Lint Failure" explanation="This issue type represents a problem running lint itself. Examples include failure to find bytecode for source files (which means certain detectors could not be run), parsing errors in lint configuration files, etc.

 These errors are not errors in your own code, but they are shown to make it clear that some checks were not completed.">
</issue>

* checked against lint --list

* resolved by:
  - changed:
	- AndroidGradlePluginVersion to GradlePluginVersion (rearranged)
  - removed:
	- ImproperProjectLevelStatement
	- MisplacedStatement