### PR TITLE
batch upload modified coords (fix #7028)

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -70,6 +70,10 @@
                 android:enabled="false"
                 app:showAsAction="never|withText"/>
             <item
+                android:id="@+id/menu_upload_modifiedcoords"
+                android:title="@string/caches_upload_modifiedcoords"
+                app:showAsAction="ifRoom|withText"/>
+            <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"
                 android:enabled="false"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -368,6 +368,7 @@
     </plurals>
     <string name="caches_remove_progress">Removing caches</string>
     <string name="caches_delete_events">Delete past events</string>
+    <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>
     <string name="caches_refresh_selected">Refresh selected</string>
     <string name="caches_refresh_all">Refresh all</string>
     <string name="caches_move_selected">Move selected</string>
@@ -1259,6 +1260,11 @@
         <item quantity="one">Uploaded one note successfully</item>
         <item quantity="other">Uploaded %1$d notes successfully</item>
     </plurals>
+    <string name="export_modifiedcoords">Modified coordinates</string>
+    <string name="export_modifiedcoords_uploading">Uploading %1$d</string>
+    <string name="export_modifiedcoords_success">Upload successful</string>
+    <string name="export_modifiedcoords_result">Upload finished: %1$d failed / %2$d ok</string>
+    <string name="export_modifiedcoords_error">Upload failed</string>
 
     <!-- GC attributes -->
     <string name="attribute_dogs_yes">Dogs allowed</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -23,6 +23,7 @@ import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.StatusCode;
+import cgeo.geocaching.export.BatchUploadModifiedCoordinates;
 import cgeo.geocaching.export.FieldNoteExport;
 import cgeo.geocaching.export.GpxExport;
 import cgeo.geocaching.export.PersonalNoteExport;
@@ -897,6 +898,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 return true;
             case R.id.menu_export_persnotes:
                 new PersonalNoteExport().export(adapter.getCheckedOrAllCaches(), this);
+                return true;
+            case R.id.menu_upload_modifiedcoords:
+                new BatchUploadModifiedCoordinates().export(adapter.getCheckedOrAllCaches(), this);
                 return true;
             case R.id.menu_remove_from_history:
                 removeFromHistoryCheck();

--- a/main/src/cgeo/geocaching/export/BatchUploadModifiedCoordinates.java
+++ b/main/src/cgeo/geocaching/export/BatchUploadModifiedCoordinates.java
@@ -1,0 +1,93 @@
+package cgeo.geocaching.export;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.AsyncTaskWithProgress;
+import cgeo.geocaching.utils.Log;
+
+import android.app.Activity;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.List;
+
+
+/**
+ * Batch upload modified coords
+ */
+public class BatchUploadModifiedCoordinates extends AbstractExport {
+    private int uploadProgress = 0;
+    private int uploadOk = 0;
+    private int uploadFailed = 0;
+
+    public BatchUploadModifiedCoordinates() {
+        super(R.string.export_modifiedcoords);
+    }
+
+    @Override
+    public void export(@NonNull final List<Geocache> cachesList, @Nullable final Activity activity) {
+        final Geocache[] caches = cachesList.toArray(new Geocache[cachesList.size()]);
+        new ExportTask(activity).execute(caches);
+    }
+
+    private class ExportTask extends AsyncTaskWithProgress<Geocache, Boolean> {
+        /**
+         * Instantiates and configures the task for uploading modified cache coords.
+         */
+        ExportTask(@Nullable final Activity activity) {
+            super(activity, getProgressTitle(), CgeoApplication.getInstance().getString(R.string.export_modifiedcoords));
+        }
+
+        @Override
+        protected Boolean doInBackgroundInternal(final Geocache[] caches) {
+            try {
+                IConnector con;
+                for (final Geocache cache : caches) {
+                    publishProgress(++uploadProgress);
+                    if (cache.hasUserModifiedCoords()) {
+                        con = ConnectorFactory.getConnector(cache);
+                        if (con.supportsOwnCoordinates()) {
+                            if (!con.uploadModifiedCoordinates(cache, cache.getCoords())) {
+                                uploadFailed++;
+                            } else {
+                                uploadOk++;
+                            }
+                        }
+                    }
+                }
+            } catch (final Exception e) {
+                Log.e("BatchUploadModifiedCoordinates.ExportTask exception when uploading modified coords", e);
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        protected void onPostExecuteInternal(final Boolean result) {
+            if (activity != null) {
+                final Context nonNullActivity = activity;
+                if (result) {
+                    ActivityMixin.showToast(activity, uploadFailed == 0
+                            ? nonNullActivity.getString(R.string.export_modifiedcoords_success)
+                            : nonNullActivity.getString(R.string.export_modifiedcoords_result, uploadFailed, uploadOk));
+                } else {
+                    ActivityMixin.showToast(activity, nonNullActivity.getString(R.string.export_modifiedcoords_error));
+                }
+                Log.d("upload finished: ok=" + uploadOk + " / failed=" + uploadFailed + " / total=" + uploadProgress);
+            }
+        }
+
+        @Override
+        protected void onProgressUpdateInternal(final Integer status) {
+            if (activity != null) {
+                setMessage(activity.getString(R.string.export_modifiedcoords_uploading, uploadProgress));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
add menu entry on cache list activity to batch upload all modified coords (if connector allows)