### PR TITLE
fix gradle warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,6 @@ org.gradle.configureondemand=true
 
 # activate build caching
 org.gradle.caching=true
+
+# Avoid printing release notes after gradle version upgrades. See https://github.com/gradle/gradle/issues/5213
+org.gradle.internal.launcher.welcomeMessageEnabled=false

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -470,8 +470,8 @@ static def isContinuousIntegrationServer() {
  * have a run task for our builds to launch the app directly from gradle
  */
 android.applicationVariants.all { variant ->
-    if (variant.install) {
-        tasks.create(name: "run${variant.name.capitalize()}", dependsOn: variant.install) {
+    if (variant.installProvider) {
+        tasks.create(name: "run${variant.name.capitalize()}", dependsOn: variant.installProvider.get()) {
             group 'cgeo'
             description "Installs the ${variant.description} and runs the main activity. Depends on 'adb' being on the PATH."
 


### PR DESCRIPTION
* tasks of type wrapper are deprecated (this is only shown with
--warning-mode all)
* variant.install() is deprecated. This is shown in every build. We can
silence the warning by adding one more indirection towards the new
installProvider()

The compile scope warning is still there and not fixed with this change.