### PR TITLE
upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ allprojects {
                         if (selection.candidate.group == 'com.google.code.findbugs' && selection.candidate.module == 'annotations' && selection.candidate.version == '3.0.1') {
                             selection.reject("3.0.1 is not an upgrade of 3.0.1u2")
                         }
+                        // Apache Commons IO 2.6 fails in FileUtils.deleteDirectory()
+                        if (selection.candidate.group == 'commons-io' && selection.candidate.module == 'commons-io' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 25) {
+                            selection.reject("Apache Commons IO 2.6 calls methods not available in the Android runtime.")
+                        }
                     }
                 }
             }

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -38,8 +38,8 @@ android {
 
 dependencies {
     // Apache Commons
-    implementation 'commons-io:commons-io:2.5'
-    implementation 'org.apache.commons:commons-lang3:3.5'
+    implementation 'commons-io:commons-io:2.6'
+    implementation 'org.apache.commons:commons-lang3:3.8.1'
 
     // Android annotations
     implementation 'com.android.support:support-annotations:24.2.1'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     implementation "org.androidannotations:androidannotations-api:$androidAnnotationsVersion"
 
     // Apache Commons
-    implementation 'org.apache.commons:commons-collections4:4.2'
+    implementation 'org.apache.commons:commons-collections4:4.3'
     implementation 'org.apache.commons:commons-compress:1.18'
     implementation 'commons-io:commons-io:2.5'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
@@ -294,12 +294,12 @@ dependencies {
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
 
     // Locus Maps integration
-    implementation "com.asamm:locus-api:0.2.15"
+    implementation "com.asamm:locus-api:0.2.25"
     implementation "com.asamm:locus-api-android:0.2.15"
 
     // Mapsforge old version
     implementation files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
-    implementation 'com.caverock:androidsvg:1.2.2-beta-1'
+    implementation 'com.caverock:androidsvg:1.3'
 
     // Mapsforge new version
     def mapsforgeVersion = '0.9.1'
@@ -318,7 +318,7 @@ dependencies {
     // Metadata Extractor, EXIF location extraction from images
     implementation 'com.drewnoakes:metadata-extractor:2.11.0'
 
-    // Okhttp network access
+    // Okhttp network access. 3.12.x is API level < 21, 3.13 or better requires API 21
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
 
     // Play Services
@@ -332,7 +332,7 @@ dependencies {
     implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation "io.reactivex.rxjava2:rxjava:2.2.7"
+    implementation "io.reactivex.rxjava2:rxjava:2.2.8"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
 
     // Support Library. Appcompat

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -100,8 +100,10 @@
 
 # OkHttp references unused classes
 -dontwarn java.nio.file.*
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
-# ignore reflection warnings
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+-dontwarn okhttp3.OkHttpClient$Builder
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontnote okhttp3.internal.platform.**
 
 # Play Services -----------------------------------------------------------------------------------


### PR DESCRIPTION
Since the switch to gradle 5.x and Java 8 we can again upgrade more
dependencies.