### PR TITLE
use task avoidance gradle API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,9 @@
 
 defaultTasks 'cgeoHelp'
 
-task cgeoHelp {
+tasks.register('cgeoHelp') {
+    group = 'cgeo'
+    description = 'Displays help for building cgeo.'
     doLast {
         println ''
         println 'These are some of the available commands for building cgeo.'
@@ -42,11 +44,6 @@ task cgeoHelp {
         println 'Available build types are: debug, nightly (requires an env var named NB), ' +
                 'rc (requires an env var named RC), release.'
     }
-}
-
-configure(cgeoHelp) {
-    group = 'cgeo'
-    description = 'Displays help for building cgeo.'
 }
 
 /*
@@ -183,14 +180,14 @@ subprojects {
 /*
  * Make sure that we use the source distribution when updating the wrapper from the command line.
  */
-wrapper {
+tasks.named('wrapper') {
     distributionType = Wrapper.DistributionType.ALL
 }
 
 /*
  * Configuration for dependencyUpdates, see https://github.com/ben-manes/gradle-versions-plugin
  */
-dependencyUpdates {
+tasks.named('dependencyUpdates') {
     checkForGradleUpdate = true
     revision = "release"
     gradleReleaseChannel = "current"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -390,7 +390,9 @@ project.afterEvaluate{
     preBuild.dependsOn("verifyCgeoKeys")
 }
 
-task verifyCgeoKeys {
+tasks.register('verifyCgeoKeys') {
+    group = 'verification'
+    description = 'Checks for the existence of keys.xml to successfully compile cgeo.'
     doFirst {
         def keysFile = file("res/values/keys.xml")
         if (!keysFile.exists()) {
@@ -413,11 +415,6 @@ task verifyCgeoKeys {
             throw new InvalidUserDataException("You must provide API keys for c:geo to compile successfully. Please read the 'API keys' section in the README.md file for further details.")
         }
     }
-}
-
-configure (verifyCgeoKeys) {
-    group = 'verification'
-    description = 'Checks for the existence of keys.xml to successfully compile cgeo.'
 }
 
 
@@ -471,9 +468,10 @@ static def isContinuousIntegrationServer() {
  */
 android.applicationVariants.all { variant ->
     if (variant.installProvider) {
-        tasks.create(name: "run${variant.name.capitalize()}", dependsOn: variant.installProvider.get()) {
+        tasks.register("run${variant.name.capitalize()}") {
             group 'cgeo'
             description "Installs the ${variant.description} and runs the main activity. Depends on 'adb' being on the PATH."
+            dependsOn tasks.named(variant.installProvider.name)
 
             doFirst {
                 def classpath = variant.applicationId
@@ -497,6 +495,7 @@ android.applicationVariants.all { variant ->
 }
 
 // run device and non device tests together with one task. also fixes the bug that gradle optimizes tests away in repeated runs
+// FIXME: This uses eager task creation API. Found no way to configure a set of dependsOn with the new API.
 tasks.create(name: "testDebug", dependsOn: [ "testBasicDebugUnitTest", "connectedBasicDebugAndroidTest" ]) {
     group 'cgeo'
     description "Tests the debug build both with device-dependent and device-independent tests."
@@ -523,7 +522,7 @@ if (privatePropertiesFile.exists()) {
 }
 
 // check existence of private properties, show an error message
-task verifyPrivateProperties {
+tasks.register('verifyPrivateProperties') {
     doLast {
         if (!rootProject.file('private.properties').exists()) {
             throw new InvalidUserDataException("For signing the release build you must provide a file private.properties in the root directory. Copy templates/private.properties and change the values.")
@@ -532,7 +531,8 @@ task verifyPrivateProperties {
 }
 
 // copy preferences containing user and password to the device
-task copyDefaultPreferencesToAndroid(dependsOn: 'installBasicDebug') {
+tasks.register('copyDefaultPreferencesToAndroid') {
+    dependsOn 'installBasicDebug'
     doFirst {
         def preferences = file('cgeo.geocaching_preferences.xml')
         if (preferences.exists()) {
@@ -579,15 +579,18 @@ tasks.whenTaskAdded { theTask ->
 
 apply plugin: 'checkstyle'
 
-check.dependsOn 'checkstyle'
-
-task checkstyle(type: Checkstyle) {
+tasks.register('checkstyle', Checkstyle) {
     configFile file("${project.rootDir}/checkstyle.xml")
     source 'src'
     include '**/*.java'
 
     classpath = files()
 }
+
+tasks.named('check') {
+    dependsOn tasks.named('checkstyle')
+}
+
 
 /*
  * Ribbonizer, adds ribbons to launcher icon of debug builds


### PR DESCRIPTION
Gradle is changing from immediate to lazy task creation and
configuration for better performance. This requires new API to be used
in build scripts.

This change converts some of our tasks. Unfortunately, most of the
Android plugins tasks are still created eagerly, so we only avoid a
small number of tasks to be created.