### PR TITLE
lint: hard-coded package name

### DIFF
--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res/cgeo.geocaching"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:key="@string/preference_screen_main" >
 
     <PreferenceScreen


### PR DESCRIPTION
All resources should use the auto resolution namespace nowadays.