### PR TITLE
upgrade butterknife

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -260,7 +260,7 @@ dependencies {
     androidTestImplementation "org.assertj:assertj-core:$assertJVersion"
 
     // ButterKnife view injection, https://github.com/JakeWharton/butterknife
-    def butterKnifeVersion = '8.4.0'
+    def butterKnifeVersion = '8.8.1'
     implementation "com.jakewharton:butterknife:$butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
 


### PR DESCRIPTION
We can upgrade the minor version of butterknife. 9.0.0 would require a
higher target however.