### PR TITLE
Fix NPE onResume in AbstractDialogFragment, #7466

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -9,6 +9,9 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.permission.PermissionHandler;
+import cgeo.geocaching.permission.PermissionRequestContext;
+import cgeo.geocaching.permission.RestartLocationPermissionGrantedCallback;
 import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.settings.Settings;
@@ -168,7 +171,15 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
     @Override
     public void onResume() {
         super.onResume();
-        resumeDisposables.add(geoUpdate.start(GeoDirHandler.UPDATE_GEODATA));
+        // resume location access
+        PermissionHandler.executeIfLocationPermissionGranted(getActivity(),
+                new RestartLocationPermissionGrantedCallback(PermissionRequestContext.AbstractDialogFragment) {
+
+            @Override
+            public void executeAfter() {
+                resumeDisposables.add(geoUpdate.start(GeoDirHandler.UPDATE_GEODATA));
+            }
+        });
         init();
     }
 

--- a/main/src/cgeo/geocaching/permission/PermissionRequestContext.java
+++ b/main/src/cgeo/geocaching/permission/PermissionRequestContext.java
@@ -7,14 +7,15 @@ public enum PermissionRequestContext {
     MainActivityOnCreate(1111, R.string.location_permission_request_explanation),
     MainActivityOnResume(1112, R.string.location_permission_request_explanation),
     MainActivityStorage(1113, R.string.storage_permission_request_explanation),
-    TrackableActivity(2222, R.string.location_permission_request_explanation),
-    CacheDetailActivity(3333, R.string.location_permission_request_explanation),
-    CacheListActivity(4444, R.string.location_permission_request_explanation),
-    CGeoMap(5555, R.string.location_permission_request_explanation),
-    NewMap(6666, R.string.location_permission_request_explanation),
-    EditWaypointActivity(7777, R.string.location_permission_request_explanation),
-    CompassActivity(8888, R.string.location_permission_request_explanation),
-    NavigateAnyPointActivity(9999, R.string.location_permission_request_explanation);
+    TrackableActivity(2221, R.string.location_permission_request_explanation),
+    CacheDetailActivity(2222, R.string.location_permission_request_explanation),
+    CacheListActivity(2223, R.string.location_permission_request_explanation),
+    CGeoMap(2224, R.string.location_permission_request_explanation),
+    NewMap(2225, R.string.location_permission_request_explanation),
+    EditWaypointActivity(2226, R.string.location_permission_request_explanation),
+    CompassActivity(2227, R.string.location_permission_request_explanation),
+    AbstractDialogFragment(2228, R.string.location_permission_request_explanation),
+    NavigateAnyPointActivity(2229, R.string.location_permission_request_explanation);
 
     private final int requestCode;
     private final int askAgainResource;


### PR DESCRIPTION
Insert RestartLocationPermissionHandler
Re-assign callback id numbers

This is going to be tricky to test, as there is no direct venue into this code like calling the map from a shortcut. It is used e.g. in cache and waypoint popups