### PR TITLE
add hint (+ toggle button for it) to cache popup (fix #7468)

### DIFF
--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -27,13 +27,30 @@
                 android:orientation="vertical" >
             </LinearLayout>
 
-            <Button
-                android:id="@+id/more_details"
-                style="@style/button_small"
-                android:layout_width="fill_parent"
-                android:layout_height="40dip"
-                android:layout_gravity="center_horizontal"
-                android:text="@string/popup_more" />
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <Button
+                    android:id="@+id/more_details"
+                    style="@style/button_small"
+                    android:layout_width="fill_parent"
+                    android:layout_height="40dip"
+                    android:layout_marginRight="51dip"
+                    android:layout_gravity="center_horizontal"
+                    android:text="@string/popup_more" />
+
+                <ImageButton
+                    android:id="@+id/offline_hint"
+                    style="@style/button_small"
+                    android:src="@drawable/ic_menu_hint"
+                    android:layout_width="40dip"
+                    android:layout_height="40dip"
+                    android:layout_alignParentRight="true"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+
+            </RelativeLayout>
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
 
@@ -42,7 +59,7 @@
 
             <RelativeLayout
                 android:layout_width="fill_parent"
-                android:layout_height="wrap_content" >
+                android:layout_height="wrap_content">
 
                 <TextView
                     android:id="@+id/offline_text"
@@ -104,6 +121,26 @@
                     android:layout_marginLeft="2dip"
                     android:layout_alignParentRight="true"/>
             </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/offline_hint_separator"
+                style="@style/separator_horizontal_layout"
+                android:visibility="gone" >
+                <View style="@style/separator_horizontal" />
+            </RelativeLayout>
+            <TextView
+                android:id="@+id/offline_hint_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:paddingRight="3dip"
+                android:textColor="?text_color"
+                android:textIsSelectable="false"
+                android:textSize="14sp"
+                android:visibility="gone"
+                tools:text="hint"/>
 
         </LinearLayout>
     </ScrollView>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2343,26 +2343,33 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (null != showHintClickListener) {
             final String hint = cache.getHint();
             if (!StringUtils.isEmpty(hint)) {
-                final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);
+                hintButtonEnabled = true;
+                final TextView offlineHintText = ButterKnife.findById(view, R.id.offline_hint_text);
+                offlineHintText.setText(hint);
+            }
+        }
+        // adjust right margin of "more details" button to whether a hint button is shown
+        final AppCompatButton moreButton = ButterKnife.findById(view, R.id.more_details);
+        if (null != moreButton) {
+            final float scale = view.getResources().getDisplayMetrics().density;
+            final int rightMargin = (int) (51 * scale + 0.5f);
+            final int otherMargin = (int) (4 * scale + 0.5f);
+            final ViewGroup.MarginLayoutParams lpt = (ViewGroup.MarginLayoutParams) moreButton.getLayoutParams();
+            lpt.setMargins(otherMargin, otherMargin, hintButtonEnabled ? rightMargin : otherMargin, otherMargin);
+            moreButton.setLayoutParams(lpt);
+        }
+
+        // show or remove clickable hint button
+        final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);
+        if (null != offlineHint) {
+            if (hintButtonEnabled) {
                 offlineHint.setVisibility(View.VISIBLE);
                 offlineHint.setClickable(true);
                 offlineHint.setOnClickListener(showHintClickListener);
-
-                final TextView offlineHintText = ButterKnife.findById(view, R.id.offline_hint_text);
-                offlineHintText.setText(hint);
-
-                hintButtonEnabled = true;
-            }
-        }
-        if (!hintButtonEnabled) {
-            // if no "hint" button is shown: expand "more details" button to full width
-            final AppCompatButton moreButton = ButterKnife.findById(view, R.id.more_details);
-            if (null != moreButton) {
-                final float scale = view.getResources().getDisplayMetrics().density;
-                final int px = (int) (4 * scale + 0.5f);
-                final ViewGroup.MarginLayoutParams lpt = (ViewGroup.MarginLayoutParams) moreButton.getLayoutParams();
-                lpt.setMargins(px, px, px, px);
-                moreButton.setLayoutParams(lpt);
+            } else {
+                offlineHint.setVisibility(View.GONE);
+                offlineHint.setClickable(false);
+                offlineHint.setOnClickListener(null);
             }
         }
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -104,6 +104,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.view.ActionMode;
+import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
 import android.text.Html;
@@ -1153,7 +1154,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             ButterKnife.findById(view, R.id.attributes_box).setVisibility(cache.getAttributes().isEmpty() ? View.GONE : View.VISIBLE);
 
             updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(),
-                    new StoreCacheClickListener(), new MoveCacheClickListener(), new StoreCacheClickListener());
+                    new StoreCacheClickListener(), null, new MoveCacheClickListener(), new StoreCacheClickListener());
 
             // list
             updateCacheLists(view, cache, res);
@@ -2329,6 +2330,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final OnClickListener refreshCacheClickListener,
             final OnClickListener dropCacheClickListener,
             final OnClickListener storeCacheClickListener,
+            final OnClickListener showHintClickListener,
             final OnLongClickListener moveCacheListener,
             final OnLongClickListener storeCachePreselectedListener) {
         // offline use
@@ -2336,6 +2338,33 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         final ImageButton offlineRefresh = ButterKnife.findById(view, R.id.offline_refresh);
         final ImageButton offlineStoreDrop = ButterKnife.findById(view, R.id.offline_store_drop);
         final ImageButton offlineEdit = ButterKnife.findById(view, R.id.offline_edit);
+
+        boolean hintButtonEnabled = false;
+        if (null != showHintClickListener) {
+            final String hint = cache.getHint();
+            if (!StringUtils.isEmpty(hint)) {
+                final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);
+                offlineHint.setVisibility(View.VISIBLE);
+                offlineHint.setClickable(true);
+                offlineHint.setOnClickListener(showHintClickListener);
+
+                final TextView offlineHintText = ButterKnife.findById(view, R.id.offline_hint_text);
+                offlineHintText.setText(hint);
+
+                hintButtonEnabled = true;
+            }
+        }
+        if (!hintButtonEnabled) {
+            // if no "hint" button is shown: expand "more details" button to full width
+            final AppCompatButton moreButton = ButterKnife.findById(view, R.id.more_details);
+            if (null != moreButton) {
+                final float scale = view.getResources().getDisplayMetrics().density;
+                final int px = (int) (4 * scale + 0.5f);
+                final ViewGroup.MarginLayoutParams lpt = (ViewGroup.MarginLayoutParams) moreButton.getLayoutParams();
+                lpt.setMargins(px, px, px, px);
+                moreButton.setLayoutParams(lpt);
+            }
+        }
 
         offlineStoreDrop.setClickable(true);
         offlineStoreDrop.setOnClickListener(storeCacheClickListener);

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -128,7 +128,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
             addCacheDetails();
 
             // offline use
-            CacheDetailActivity.updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), null, new StoreCacheClickListener());
+            CacheDetailActivity.updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), new ShowHintClickListener(view), null, new StoreCacheClickListener());
 
             CacheDetailActivity.updateCacheLists(view, cache, res);
         } catch (final Exception e) {
@@ -200,7 +200,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
                 DataStore.saveLists(Collections.singletonList(cache), listIds);
                 CacheDetailActivity.updateOfflineBox(getView(), cache, res,
                         new RefreshCacheClickListener(), new DropCacheClickListener(),
-                        new StoreCacheClickListener(), null, new StoreCacheClickListener());
+                        new StoreCacheClickListener(), new ShowHintClickListener(getView()), null, new StoreCacheClickListener());
                 CacheDetailActivity.updateCacheLists(getView(), cache, res);
             } else {
                 final StoreCacheHandler storeCacheHandler = new StoreCacheHandler(CachePopupFragment.this, R.string.cache_dialog_offline_save_message);
@@ -219,7 +219,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
                         if (view != null) {
                             CacheDetailActivity.updateOfflineBox(view, cache, res,
                                     new RefreshCacheClickListener(), new DropCacheClickListener(),
-                                    new StoreCacheClickListener(), null, new StoreCacheClickListener());
+                                    new StoreCacheClickListener(), new ShowHintClickListener(view), null, new StoreCacheClickListener());
                             CacheDetailActivity.updateCacheLists(view, cache, res);
                         }
                     }
@@ -261,6 +261,26 @@ public class CachePopupFragment extends AbstractDialogFragment {
         }
     }
 
+    private class ShowHintClickListener implements View.OnClickListener {
+        private View anchorView;
+
+        ShowHintClickListener (final View view) {
+            anchorView = view;
+        }
+
+        @Override
+        public void onClick(final View view) {
+            final TextView offlineHintText = (TextView) anchorView.findViewById(R.id.offline_hint_text);
+            final View offlineHintSeparator = anchorView.findViewById(R.id.offline_hint_separator);
+            if (offlineHintText.getVisibility() == View.VISIBLE) {
+                offlineHintText.setVisibility(View.GONE);
+                offlineHintSeparator.setVisibility(View.GONE);
+            } else {
+                offlineHintText.setVisibility(View.VISIBLE);
+                offlineHintSeparator.setVisibility(View.VISIBLE);
+            }
+        }
+    }
 
     @Override
     public void navigateTo() {


### PR DESCRIPTION
non intrusive way to show hint on cache popup:
- hint is not shown initially, but activated by pressing the new hint button
- hint button gets shown only if hint is available
- hint button is a toggle