### PR TITLE
change abbreviation for geocaching.su to GC.SU

### DIFF
--- a/main/src/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/cgeo/geocaching/connector/su/SuConnector.java
@@ -119,7 +119,7 @@ public class SuConnector extends AbstractConnector implements ISearchByCenter, I
     @Override
     @NonNull
     public String getNameAbbreviated() {
-        return "GCSU";
+        return "GC.SU";
     }
 
     @Override


### PR DESCRIPTION
change abbreviation for geocaching.su to GC.SU (according other sites like OC.DE) from current GCSU