### PR TITLE
for straight_border drawable distinguish between API 21 and earlier (fix #7473)

### DIFF
--- a/main/res/drawable-v21/border_straight.xml
+++ b/main/res/drawable-v21/border_straight.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <stroke android:width="1dp" android:color="#CCCCCC"/>
-    <solid android:color="@android:color/black" />
+    <solid android:color="?background_color" />
 </shape>


### PR DESCRIPTION
API < 21 get fixed color black background, API 22+ background is colored according to ?background_color