### PR TITLE
Fix #7491, Crash when trying to store cache list (Android 4.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,10 @@ allprojects {
                         if (selection.candidate.group == 'commons-io' && selection.candidate.module == 'commons-io' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 25) {
                             selection.reject("Apache Commons IO 2.6 calls methods not available in the Android runtime.")
                         }
+                        // Apache Commons lang3 3.6+ fails in StringUtils.join() for API < 19
+                        if (selection.candidate.group == 'org.apache.commons' && selection.candidate.module == 'commons-lang3' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 35) {
+                            selection.reject("Apache Commons lang3 3.6+ calls methods not available in the Android runtime.")
+                        }
                     }
                 }
             }

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -39,7 +39,7 @@ android {
 dependencies {
     // Apache Commons
     implementation 'commons-io:commons-io:2.5'
-    implementation 'org.apache.commons:commons-lang3:3.8.1'
+    implementation 'org.apache.commons:commons-lang3:3.5'
 
     // Android annotations
     implementation 'com.android.support:support-annotations:24.2.1'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -251,8 +251,8 @@ dependencies {
     implementation 'org.apache.commons:commons-collections4:4.3'
     implementation 'org.apache.commons:commons-compress:1.18'
     implementation 'commons-io:commons-io:2.5'
-    implementation 'org.apache.commons:commons-lang3:3.8.1'
-    implementation 'org.apache.commons:commons-text:1.6'
+    implementation 'org.apache.commons:commons-lang3:3.5'
+    implementation 'org.apache.commons:commons-text:1.1'
 
     // AssertJ for testing, needed both for local unit tests and Android instrumentation tests
     def assertJVersion = '2.9.1'


### PR DESCRIPTION
Downgrade commons-lang3 back to 3.5 to satisify API < 19 constraints
Requires downgrade of commons-text to 1.1 as well, as higher versions
depend on commons-lang3:3.6+