### PR TITLE
split border_straight and progressdialog styles into light and dark themes (fix #7492)

### DIFF
--- a/main/res/drawable/border_straight_light.xml
+++ b/main/res/drawable/border_straight_light.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <stroke android:width="1dp" android:color="#CCCCCC"/>
-    <solid android:color="?background_color" />
+    <solid android:color="@android:color/white" />
 </shape>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -383,4 +383,10 @@
         <item name="android:windowBackground">@drawable/border_straight</item>
         <item name="buttonBarButtonStyle">@style/button_borderless</item>
     </style>
+    <style name="cgeoProgressdialogTheme_light" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:textColorPrimary">?text_color</item>
+        <item name="android:textColor">?text_color</item>
+        <item name="android:windowBackground">@drawable/border_straight_light</item>
+        <item name="buttonBarButtonStyle">@style/button_borderless</item>
+    </style>
 </resources>

--- a/main/src/cgeo/geocaching/activity/Progress.java
+++ b/main/src/cgeo/geocaching/activity/Progress.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.activity;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.CustomProgressDialog;
 import cgeo.geocaching.utils.Log;
 
@@ -56,7 +57,7 @@ public class Progress {
     }
 
     private void createProgressDialog(final Context context, final String title, final String message, final Message cancelMessage) {
-        dialog = hideAbsolute ? new CustomProgressDialog(context) : new ProgressDialog(context, R.style.cgeoProgressdialogTheme);
+        dialog = hideAbsolute ? new CustomProgressDialog(context) : new ProgressDialog(context, Settings.isLightSkin() ? R.style.cgeoProgressdialogTheme_light : R.style.cgeoProgressdialogTheme);
         dialog.setTitle(title);
         dialog.setMessage(message);
         if (cancelMessage != null) {

--- a/main/src/cgeo/geocaching/ui/dialog/CustomProgressDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CustomProgressDialog.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.ui.dialog;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Log;
 
 import android.app.ProgressDialog;
@@ -17,7 +18,7 @@ import java.lang.reflect.Field;
 public class CustomProgressDialog extends ProgressDialog {
 
     public CustomProgressDialog(final Context context) {
-        super(context, R.style.cgeoProgressdialogTheme);
+        super(context, Settings.isLightSkin() ? R.style.cgeoProgressdialogTheme_light : R.style.cgeoProgressdialogTheme);
     }
 
     @Override


### PR DESCRIPTION
As I do need to create two xml files for themed drawables anyway, I can skip the parametrized drawable-v21 version.