### PR TITLE
rename Google Maps key placeholder to maps_api2_key to avoid conflicts with other branches

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -80,7 +80,7 @@
             android:value="@integer/google_play_services_version" />
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/maps_api_key" />
+            android:value="@string/maps_api2_key" />
 
         <!-- support also very wide screen devices. https://developer.android.com/guide/practices/screens_support.html#MaxAspectRatio -->
         <meta-data

--- a/main/res/layout/map_google.xml
+++ b/main/res/layout/map_google.xml
@@ -34,7 +34,7 @@
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             class="cgeo.geocaching.maps.google.v2.GoogleMapView"
-            android:apiKey="@string/maps_api_key"
+            android:apiKey="@string/maps_api2_key"
             android:clickable="true"
             android:enabled="true"
             android:keepScreenOn="true" />

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -37,7 +37,7 @@ public class MapProviderFactory {
 
     public static boolean isGoogleMapsInstalled() {
         // Check if API key is available
-        final String mapsKey = CgeoApplication.getInstance().getString(R.string.maps_api_key);
+        final String mapsKey = CgeoApplication.getInstance().getString(R.string.maps_api2_key);
         if (StringUtils.length(mapsKey) < 30 || StringUtils.contains(mapsKey, "key")) {
             Log.w("No Google API key available.");
             return false;

--- a/main/templates/keys.xml
+++ b/main/templates/keys.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Google Maps -->
-    <string name="maps_api_key" translatable="false">@maps.api.key@</string>
+    <string name="maps_api2_key" translatable="false">@maps.api2.key@</string>
 
     <!-- Opencaching.de -->
     <string name="oc_de_okapi_consumer_key" translatable="false">@ocde.okapi.consumer.key@</string>


### PR DESCRIPTION
- making the key placeholder for v2 Google Maps unique allows parallel development for both versions
- also helps with setting up the CI (see #7449)