### PR TITLE
workaround for missing progress indicator on live map: show toast after loading is finished

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1116,6 +1116,7 @@
     <string name="map_routing_walk">Walk</string>
     <string name="map_routing_bike">Bicycle</string>
     <string name="map_routing_car">Car</string>
+    <string name="map_loading_finished">loading finished</string>
 
     <!-- search -->
     <string name="search_bar_hint">Search for caches</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -114,6 +114,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
      */
     private static final int HIDE_PROGRESS = 0;
     private static final int SHOW_PROGRESS = 1;
+    private static final int HIDE_PROGRESS_WITH_TOAST = 2;   // used for workaround for missing progress indicator only, can be removed after switching to AppCompat.Toolbar instead of ActionBar
     private static final int UPDATE_TITLE = 0;
     private static final int INVALIDATE_MAP = 1;
     private static final int UPDATE_PROGRESS = 0;
@@ -319,7 +320,15 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                 counter++;
             } else if (what == HIDE_PROGRESS && --counter == 0) {
                 showProgress(false);
+            // workaround for missing progress indicator: show a short toast after loading of caches is finished
+            } else if (what == HIDE_PROGRESS_WITH_TOAST && --counter == 0) {
+                final CGeoMap map = mapRef.get();
+                if (null != map) {
+                    ActivityMixin.showShortToast(map.activity, map.res.getString(R.string.map_loading_finished));
+                }
+                showProgress(false);
             }
+            // end workaround
         }
 
         private void showProgress(final boolean show) {
@@ -1337,7 +1346,12 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
 
             updateMapTitle();
         } finally {
-            showProgressHandler.sendEmptyMessage(HIDE_PROGRESS);
+            // used for workaround for missing progress indicator only, can be removed after switching to AppCompat.Toolbar instead of ActionBar, otherwise HIDE_PROGRESS variant would be enough
+            if (mapOptions.mapMode == MapMode.LIVE) {
+                showProgressHandler.sendEmptyMessage(HIDE_PROGRESS_WITH_TOAST);
+            } else {
+                showProgressHandler.sendEmptyMessage(HIDE_PROGRESS);
+            }
         }
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -161,6 +161,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
     // ShowProgressHandler
     public static final int HIDE_PROGRESS = 0;
     public static final int SHOW_PROGRESS = 1;
+    public static final int HIDE_PROGRESS_WITH_TOAST = 2;   // used for workaround for missing progress indicator only, can be removed after switching to AppCompat.Toolbar instead of ActionBar
     // LoadDetailsHandler
     public static final int UPDATE_PROGRESS = 0;
     public static final int FINISHED_LOADING_DETAILS = 1;
@@ -1159,7 +1160,15 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             } else if (what == SHOW_PROGRESS) {
                 showProgress(true);
                 counter++;
+            // workaround for missing progress indicator: show a short toast after loading of caches is finished
+            } else if (what == HIDE_PROGRESS_WITH_TOAST && --counter == 0) {
+                final NewMap map = mapRef.get();
+                if (null != map) {
+                    map.showShortToast(map.res.getString(R.string.map_loading_finished));
+                }
+                showProgress(false);
             }
+            // end workaround
         }
 
         private void showProgress(final boolean show) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -253,6 +253,10 @@ public abstract class AbstractCachesOverlay {
         mapHandlers.sendEmptyProgressMessage(NewMap.HIDE_PROGRESS);
     }
 
+    protected void hideProgressWithToast() {
+        mapHandlers.sendEmptyProgressMessage(NewMap.HIDE_PROGRESS_WITH_TOAST);
+    }
+
     protected void updateTitle() {
         mapHandlers.sendEmptyDisplayMessage(NewMap.UPDATE_TITLE);
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
@@ -125,7 +125,7 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
             update(result);
 
         } finally {
-            hideProgress();
+            hideProgressWithToast();
         }
     }
 


### PR DESCRIPTION
- does not solve #7289, is just a workaround to give some progress indication
- workaround can be removed after switching from ActionBar to AppCompat.Toolbar (refactoring)
- workaround is for live map only (NewMap and CGeoMap)