### PR TITLE
first installation: "Getting Started" page, deactivate geocaching.com (fix #7461)

### DIFF
--- a/main/res/layout/about_starting_page.xml
+++ b/main/res/layout/about_starting_page.xml
@@ -20,22 +20,92 @@
             android:layout_margin="7dip"
             android:paddingLeft="3dip"
             android:text="@string/about_starting_head"
-            android:textColor="?text_color"
+            android:textColor="?text_color_headline"
             android:textStyle="bold"
             android:textSize="16sp" />
 
         <TextView
-            android:id="@+id/about_starting_text"
+            android:id="@+id/about_starting_text_basics_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_basics_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_basics_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="left"
             android:layout_margin="7sp"
             android:autoLink="web"
             android:paddingLeft="3dip"
-            android:text="@string/about_starting_text"
+            android:text="@string/about_starting_text_basics_text"
             android:textColor="?text_color"
             android:textColorLink="?text_color_link"
             android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_device_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_device_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_device_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:autoLink="web"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_device_text"
+            android:textColor="?text_color"
+            android:textColorLink="?text_color_link"
+            android:textSize="12sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_first_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_first_head"
+            android:textColor="?text_color_headline"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text_first_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:autoLink="web"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text_first_text"
+            android:textColor="?text_color"
+            android:textColorLink="?text_color_link"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/about_starting_btn_services"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?text_color"
+            android:text="@string/open_services_page"
+            android:padding="12dp"  />
     </LinearLayout>
 
 </ScrollView>

--- a/main/res/layout/about_starting_page.xml
+++ b/main/res/layout/about_starting_page.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical"
+    android:padding="4dip"
+    tools:context=".AboutActivity$StartingViewCreator" >
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <TextView
+            android:id="@+id/about_starting_head"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_margin="7dip"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_head"
+            android:textColor="?text_color"
+            android:textStyle="bold"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/about_starting_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_margin="7sp"
+            android:autoLink="web"
+            android:paddingLeft="3dip"
+            android:text="@string/about_starting_text"
+            android:textColor="?text_color"
+            android:textColorLink="?text_color_link"
+            android:textSize="12sp" />
+    </LinearLayout>
+
+</ScrollView>

--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -2,7 +2,7 @@
 <resources>
   <!-- changelog for the release branch -->
   <string name="changelog_release" translatable="false">\n
-     <b>Next release:</b>\n
+     <b>2019.04.16:</b>\n
     · New: Show map icon on address search result to directly jump to the live map\n
     · New: Show cache status overlay icons also in title bar of cache details\n
     · New: Implement geocaching.su\n

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -442,33 +442,25 @@
     <string name="about_help">Help</string>
     <string name="about_starting">Getting Started</string>
     <string name="about_starting_head">Getting Started</string>
-    <string name="about_starting_text">
-<b><i>Geocaching basics</i></b>\n\n
-
+    <string name="about_starting_text_basics_head">Geocaching basics</string>
+    <string name="about_starting_text_basics_text">
 Geocaching is an outdoor game to search and find so-called \"caches\".\n
 This app helps you to play this game.\n\n
-
-Link to the full <b>c:geo basics</b> documentation: https://manual.cgeo.org/en/basicuse\n\n
-
-<b><i>c:geo device permissions</i></b>\n\n
-
-During the installation process you will be informed and need to agree, that c:geo needs certain permissions on your device: \n
-- Location:\t Of course c:geo needs access to the GPS on your device to locate your position and calculate distance and direction to geocaches.\n
-- Photos/Media/Files: c:geo will write data onto your phone storage or SD card as soon as you save geocaches for offline use. \n
-                      \tFurthermore c:geo will use your phone storage for import and export of files and reading of offline maps.\n
-                      \tIn case you attach a photo to a log, c:geo needs to use your device camera.\n\n
-
-Link to the full <b>c:geo permission</b> documentation: https://manual.cgeo.org/en/installation#permissions\n\n
-
-<b><i>First steps with c:geo</i></b>\n\n
-
-In order to use c:geo, you need an account of a geocaching platform of your choice.\n
-Select a platform you would like to use, and upfront create an user account on their web page (Basic accounts are normally free of charge).\n\n
-
-Then go to the c:geo settings => services page. There you have to choose the (before selected) platform and then activate and authorize it.\n\n
-
-Link to the full <b>c:geo First steps</b> documentation: https://manual.cgeo.org/en/firststeps\n\n
+Link to the full <b>c:geo basics</b> documentation: https://manual.cgeo.org/en/basicuse
     </string>
+    <string name="about_starting_text_device_head">c:geo device permissions</string>
+    <string name="about_starting_text_device_text">
+During the installation process you will be informed and need to agree, that c:geo needs certain permissions on your device: \n
+<b>Location</b> and <b>Photos/Media/Files</b>.\n\n
+Details are in the <b>c:geo permission</b> documentation: https://manual.cgeo.org/en/installation#permissions
+    </string>
+    <string name="about_starting_text_first_head">First steps with c:geo</string>
+    <string name="about_starting_text_first_text">
+In order to use c:geo, you need an account for a geocaching platform of your choice.\n
+You can configure it from our services page.\n\n
+Link to the full <b>c:geo First steps</b> documentation: https://manual.cgeo.org/en/firststeps
+    </string>
+    <string name="open_services_page">Open services page</string>
     <string name="about_system_include">Please include the following system information when sending a bug report or asking for more information about c:geo:</string>
     <string name="about_system_info_send_button">Send by mail…</string>
     <string name="about_system_info">c:geo system information</string>
@@ -510,7 +502,8 @@ Link to the full <b>c:geo First steps</b> documentation: https://manual.cgeo.org
     <string name="settings_title_navigation_menu">Navigation Menu</string>
 
     <string name="settings_category_browser">Browser</string>
-    <string name="settings_category_geocaching">Geocaching</string>
+    <string name="settings_category_geocaching_provider">Geocaching Provider</string>
+    <string name="settings_category_geocaching_additionals">Further services and addon</string>
     <string name="settings_category_social">Social media</string>
     <string name="settings_category_logging_other">Other Logging Options</string>
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -440,6 +440,35 @@
     <string name="about_license">License</string>
     <string name="about_apache_license"><a href="">Apache License, Version 2.0</a></string>
     <string name="about_help">Help</string>
+    <string name="about_starting">Getting Started</string>
+    <string name="about_starting_head">Getting Started</string>
+    <string name="about_starting_text">
+<b><i>Geocaching basics</i></b>\n\n
+
+Geocaching is an outdoor game to search and find so-called \"caches\".\n
+This app helps you to play this game.\n\n
+
+Link to the full <b>c:geo basics</b> documentation: https://manual.cgeo.org/en/basicuse\n\n
+
+<b><i>c:geo device permissions</i></b>\n\n
+
+During the installation process you will be informed and need to agree, that c:geo needs certain permissions on your device: \n
+- Location:\t Of course c:geo needs access to the GPS on your device to locate your position and calculate distance and direction to geocaches.\n
+- Photos/Media/Files: c:geo will write data onto your phone storage or SD card as soon as you save geocaches for offline use. \n
+                      \tFurthermore c:geo will use your phone storage for import and export of files and reading of offline maps.\n
+                      \tIn case you attach a photo to a log, c:geo needs to use your device camera.\n\n
+
+Link to the full <b>c:geo permission</b> documentation: https://manual.cgeo.org/en/installation#permissions\n\n
+
+<b><i>First steps with c:geo</i></b>\n\n
+
+In order to use c:geo, you need an account of a geocaching platform of your choice.\n
+Select a platform you would like to use, and upfront create an user account on their web page (Basic accounts are normally free of charge).\n\n
+
+Then go to the c:geo settings => services page. There you have to choose the (before selected) platform and then activate and authorize it.\n\n
+
+Link to the full <b>c:geo First steps</b> documentation: https://manual.cgeo.org/en/firststeps\n\n
+    </string>
     <string name="about_system_include">Please include the following system information when sending a bug report or asking for more information about c:geo:</string>
     <string name="about_system_info_send_button">Send by mail…</string>
     <string name="about_system_info">c:geo system information</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -8,7 +8,7 @@
         android:key="@string/preference_screen_services"
         android:summary="@string/settings_summary_services"
         android:title="@string/settings_title_services" >
-        <PreferenceCategory android:title="@string/settings_category_geocaching"
+        <PreferenceCategory android:title="@string/settings_category_geocaching_provider"
             android:layout="@layout/preference_category" >
 
             <PreferenceScreen
@@ -323,6 +323,10 @@
                         app:connector="SU" />
                 </PreferenceCategory>
             </PreferenceScreen>
+        </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/settings_category_geocaching_additionals"
+            android:layout="@layout/preference_category" >
 
             <PreferenceScreen
                 android:key="@string/preference_screen_gcvote"

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -18,7 +18,7 @@
                 <PreferenceCategory android:title="@string/settings_settings"
                     android:layout="@layout/preference_category" >
                     <cgeo.geocaching.settings.CheckBoxWithPopupPreference
-                        android:defaultValue="true"
+                        android:defaultValue="false"
                         android:key="@string/pref_connectorGCActive"
                         android:title="@string/settings_activate_gc"
                         app:text="@string/settings_gc_legal_note"
@@ -40,7 +40,7 @@
                         android:key="@string/preference_screen_basicmembers"
                         android:title="@string/settings_title_basicmembers" >
                         <CheckBoxPreference
-                            android:defaultValue="true"
+                            android:defaultValue="false"
                             android:key="@string/pref_loaddirectionimg"
                             android:summary="@string/init_summary_loaddirectionimg"
                             android:title="@string/init_loaddirectionimg" />

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -185,9 +185,20 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
 
     class StartingViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
 
+        @BindView(R.id.about_starting_btn_services) protected Button services;
+
         @Override
         public ScrollView getDispatchedView(final ViewGroup parentView) {
             final ScrollView view = (ScrollView) getLayoutInflater().inflate(R.layout.about_starting_page, parentView, false);
+            ButterKnife.bind(this, view);
+
+            services.setOnClickListener(new OnClickListener() {
+
+                @Override
+                public void onClick(final View v) {
+                    ;
+                }
+            });
             return view;
         }
 

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -183,6 +183,16 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
 
     }
 
+    class StartingViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
+
+        @Override
+        public ScrollView getDispatchedView(final ViewGroup parentView) {
+            final ScrollView view = (ScrollView) getLayoutInflater().inflate(R.layout.about_starting_page, parentView, false);
+            return view;
+        }
+
+    }
+
     class VersionViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
 
         @BindView(R.id.about_version_string) protected TextView version;
@@ -206,6 +216,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     enum Page {
         VERSION(R.string.about_version),
         HELP(R.string.about_help),
+        STARTING(R.string.about_starting),
         CHANGELOG(R.string.about_changelog),
         SYSTEM(R.string.about_system),
         CONTRIBUTORS(R.string.about_contributors),
@@ -253,6 +264,8 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
                 return new VersionViewCreator();
             case HELP:
                 return new HelpViewCreator();
+            case STARTING:
+                return new StartingViewCreator();
             case CHANGELOG:
                 return new ChangeLogViewCreator();
             case SYSTEM:
@@ -279,6 +292,12 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     public static void showChangeLog(final Activity fromActivity) {
         final Intent intent = new Intent(fromActivity, AboutActivity.class);
         intent.putExtra(EXTRA_ABOUT_STARTPAGE, Page.CHANGELOG.ordinal());
+        fromActivity.startActivity(intent);
+    }
+
+    public static void showStarting(final Activity fromActivity) {
+        final Intent intent = new Intent(fromActivity, AboutActivity.class);
+        intent.putExtra(EXTRA_ABOUT_STARTPAGE, Page.STARTING.ordinal());
         fromActivity.startActivity(intent);
     }
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -283,7 +283,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
         init();
 
-        checkShowChangelog();
+        checkChangedInstall();
 
         LocalStorage.initGeocacheDataDir();
         if (LocalStorage.isRunningLowOnDiskSpace()) {
@@ -786,16 +786,22 @@ public class MainActivity extends AbstractActionBarActivity {
         startActivity(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS));
     }
 
-    private void checkShowChangelog() {
+    private void checkChangedInstall() {
         // temporary workaround for #4143
         //TODO: understand and avoid if possible
         try {
             final long lastChecksum = Settings.getLastChangelogChecksum();
             final long checksum = TextUtils.checksum(getString(R.string.changelog_master) + getString(R.string.changelog_release));
             Settings.setLastChangelogChecksum(checksum);
-            // don't show change log after new install...
-            if (lastChecksum > 0 && lastChecksum != checksum) {
-                AboutActivity.showChangeLog(this);
+
+            // show starting page after install
+            if (lastChecksum == 0) {
+                AboutActivity.showStarting(this);
+            } else {
+                // show change log page after update
+                if (lastChecksum != checksum) {
+                    AboutActivity.showChangeLog(this);
+                }
             }
         } catch (final Exception ex) {
             Log.e("Error checking/showing changelog!", ex);

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -423,7 +423,7 @@ public class Settings {
     }
 
     public static boolean isGCConnectorActive() {
-        return getBoolean(R.string.pref_connectorGCActive, true);
+        return getBoolean(R.string.pref_connectorGCActive, false);
     }
 
     public static boolean isECConnectorActive() {


### PR DESCRIPTION
Created a "Getting Started" page to display on first installation, deactivated geocaching.com on start.

fix #7461

I have created a "Getting Started" page that is displayed to the user the first time they start after installation. An initial text is defined. Of course, this is a first idea now. I think that there may be additional links in other languages, e.g. in German language to https://www.cachewiki.de/wiki/Hauptseite.

The page is presented before the permissions questions (on map access). 

@Lineflyer:
The text is contained in the strings.xml file. Can/should it be separated into an additional file, would something need to be configured for crowdin translation?
Please test it with different screen sizes and android versions. Feel free to change the text.
By the way, the documentation for the first steps in manual.cgeo.org is out of date.

@okainov: 
Is this behavior fine for users who only use geocaching.ru?
I think that in the Russian translation a link to this page would be fine.