### PR TITLE
Disable gradle welcome message

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ org.gradle.caching=true
 
 # Avoid printing release notes after gradle version upgrades. See https://github.com/gradle/gradle/issues/5213
 org.gradle.internal.launcher.welcomeMessageEnabled=false
+systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false


### PR DESCRIPTION
When experimenting with gradle updates I still saw the welcome message on first build with new version. Therefore add a second variant of the property, as found on the Internet.