### PR TITLE
remove false code line (Fix #7558)

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -794,13 +794,12 @@ public class MainActivity extends AbstractActionBarActivity {
             final long checksum = TextUtils.checksum(getString(R.string.changelog_master) + getString(R.string.changelog_release));
             Settings.setLastChangelogChecksum(checksum);
 
-            // show starting page after install
-            AboutActivity.showChangeLog(this);
             if (lastChecksum == 0) {
+                // show starting page after install
                 AboutActivity.showStarting(this);
             } else {
-                // show change log page after update
                 if (lastChecksum != checksum) {
+                    // show change log page after update
                     AboutActivity.showChangeLog(this);
                 }
             }


### PR DESCRIPTION
Fix #7558 (About c:geo: "Back Arrow" displays release notes only)

remove false code line (copy/paste errror)
adjust comments