### PR TITLE
check for active connectors before geocode or trackable search (fix #7554) (fix #7555)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -248,7 +248,6 @@
     <string name="warn_search_help_keyword">Enter all or part of a geocache\'s name. For example \"Night Cache\".</string>
     <string name="warn_search_help_user">Enter a username from Geocaching.com.</string>
     <string name="warn_search_help_tb">Enter the code for a trackable. For example \"TB29QMZ\".</string>
-    <string name="warn_search_no_active_connectors">No active connectors found for this search</string>
     <string name="warn_log_text_fill">Please input some text for your log.</string>
     <string name="warn_load_images">c:geo failed to load images.</string>
     <string name="warn_invalid_mapfile">The selected map file is not a valid mapsforge version 0.3.0 map file.\nOffline maps are not available.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="warn_search_help_keyword">Enter all or part of a geocache\'s name. For example \"Night Cache\".</string>
     <string name="warn_search_help_user">Enter a username from Geocaching.com.</string>
     <string name="warn_search_help_tb">Enter the code for a trackable. For example \"TB29QMZ\".</string>
+    <string name="warn_search_no_active_connectors">No active connectors found for this search</string>
     <string name="warn_log_text_fill">Please input some text for your log.</string>
     <string name="warn_load_images">c:geo failed to load images.</string>
     <string name="warn_invalid_mapfile">The selected map file is not a valid mapsforge version 0.3.0 map file.\nOffline maps are not available.</string>

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -400,7 +400,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
         if (ConnectorFactory.anyConnectorActive()) {
             CacheDetailActivity.startActivity(this, geocodeText.toUpperCase(Locale.US));
         } else {
-            showToast(getString(R.string.warn_search_no_active_connectors));
+            showToast(getString(R.string.warn_no_connector));
         }
     }
 
@@ -417,7 +417,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
             trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText.toUpperCase(Locale.US));
             startActivity(trackablesIntent);
         } else {
-            showToast(getString(R.string.warn_search_no_active_connectors));
+            showToast(getString(R.string.warn_no_connector));
         }
     }
 

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -397,7 +397,11 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
             return;
         }
 
-        CacheDetailActivity.startActivity(this, geocodeText.toUpperCase(Locale.US));
+        if (ConnectorFactory.anyConnectorActive()) {
+            CacheDetailActivity.startActivity(this, geocodeText.toUpperCase(Locale.US));
+        } else {
+            showToast(getString(R.string.warn_search_no_active_connectors));
+        }
     }
 
     private void findTrackableFn() {
@@ -408,9 +412,13 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
             return;
         }
 
-        final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
-        trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText.toUpperCase(Locale.US));
-        startActivity(trackablesIntent);
+        if (ConnectorFactory.anyTrackableConnectorActive()) {
+            final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
+            trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText.toUpperCase(Locale.US));
+            startActivity(trackablesIntent);
+        } else {
+            showToast(getString(R.string.warn_search_no_active_connectors));
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -179,6 +179,24 @@ public final class ConnectorFactory {
         return activeConnectors;
     }
 
+    public static boolean anyConnectorActive() {
+        for (final IConnector conn : CONNECTORS) {
+            if (conn.isActive()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean anyTrackableConnectorActive() {
+        for (final TrackableConnector conn : TRACKABLE_CONNECTORS) {
+            if (conn.isActive()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean canHandle(@Nullable final String geocode) {
         if (geocode == null) {
             return false;


### PR DESCRIPTION
- checks for any active connector before conducting a search for geocode (fix #7554)
- checks for any active trackable connector before conducting a search for trackables (fix #7555)
and shows a toast after pressing the search button, if none fitting active connector found