### PR TITLE
option added to prevent NewMap rotation on device rotation (fix #7565)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -108,7 +108,13 @@
                 android:visible="false"
                 app:showAsAction="ifRoom|withText">
             </item>
-
+            <item
+                android:id="@+id/menu_map_rotation_locked"
+                android:checkable="true"
+                android:title="@string/map_rotation_lock"
+                android:visible="false"
+                app:showAsAction="ifRoom|withText">
+            </item>
         </menu>
     </item>
     <item

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -82,6 +82,7 @@
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
+    <string translatable="false" name="pref_map_rotation_locked">map_rotation_locked</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>
     <string translatable="false" name="pref_defaultNavigationTool2">defaultNavigationTool2</string>
     <string translatable="false" name="pref_gpxExportDir">gpxExportDir</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1111,6 +1111,7 @@ You can read more about <b>c:geo First steps</b> in our user guide: https://manu
     <string name="map_modes">Map settings</string>
     <string name="map_trail_show">Show trail</string>
     <string name="map_dot_mode">Use compact icons</string>
+    <string name="map_rotation_lock">Lock map rotation</string>
     <string name="map_circles_show">Show circles</string>
     <string name="map_mycaches_hide">Hide own/found caches</string>
     <string name="map_disabled_hide">Hide disabled caches</string>

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -761,6 +761,17 @@ public class Settings {
     }
 
     /**
+     * whether automatic rotation of map on rotating the device is locked
+     */
+    public static boolean isMapRotationLocked() {
+        return getBoolean(R.string.pref_map_rotation_locked, false);
+    }
+
+    public static void setMapRotationLocked(final boolean rotationLocked) {
+        putBoolean(R.string.pref_map_rotation_locked, rotationLocked);
+    }
+
+    /**
      * whether to show a direction line on the map
      */
     public static boolean isMapDirection() {


### PR DESCRIPTION
- option added to prevent NewMap rotation on device rotation (fix #7565)
- requires API 18 minimum, useful for API 27 maximum (as API 28+ offeres a system built-in function for this) - checking current API level and offering the menu entry only for API 18-27
