### PR TITLE
create access to gc.su account creation web site

### DIFF
--- a/main/src/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/cgeo/geocaching/connector/su/SuConnector.java
@@ -338,5 +338,14 @@ public class SuConnector extends AbstractConnector implements ISearchByCenter, I
         return geocode.substring(2);
     }
 
+    /**
+     * Returns the web address to create an account
+     *
+     * @return web address
+     */
+    @Override
+    public String getCreateAccountUrl() {
+        return StringUtils.join(getHostUrl(), "/?pn=14");
+    }
 
 }


### PR DESCRIPTION
fix #7535 (missing option to create account for geocaching.su)

@okainov Please be free to change it to api access if possible