### PR TITLE
align more details and hint button to each other

### DIFF
--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -36,7 +36,7 @@
                     style="@style/button_small"
                     android:layout_width="fill_parent"
                     android:layout_height="40dip"
-                    android:layout_marginRight="51dip"
+                    android:layout_toLeftOf="@id/offline_hint"
                     android:layout_gravity="center_horizontal"
                     android:text="@string/popup_more" />
 
@@ -47,6 +47,7 @@
                     android:layout_width="40dip"
                     android:layout_height="40dip"
                     android:layout_alignParentRight="true"
+                    android:layout_marginLeft="0dp"
                     android:visibility="gone"
                     tools:visibility="visible"/>
 
@@ -94,7 +95,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentLeft="true"
                     android:layout_marginLeft="6dip"
-                    android:layout_marginRight="100dip"
+                    android:layout_toLeftOf="@id/offline_edit"
                     android:paddingRight="3dip"
                     android:textColor="?text_color"
                     android:textIsSelectable="false"
@@ -107,8 +108,8 @@
                     android:src="@drawable/ic_menu_edit"
                     android:layout_width="40dip"
                     android:layout_height="40dip"
-                    android:layout_alignParentRight="true"
-                    android:layout_marginRight="51dip"
+                    android:layout_toLeftOf="@id/offline_store_drop"
+                    android:layout_marginLeft="0dp"
                     android:visibility="gone"
                     tools:visibility="visible"/>
 
@@ -118,7 +119,7 @@
                     android:src="@drawable/ic_menu_save"
                     android:layout_width="40dip"
                     android:layout_height="40dip"
-                    android:layout_marginLeft="2dip"
+                    android:layout_marginLeft="0dp"
                     android:layout_alignParentRight="true"/>
             </RelativeLayout>
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -104,7 +104,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.view.ActionMode;
-import android.support.v7.widget.AppCompatButton;
 import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
 import android.text.Html;
@@ -1970,7 +1969,6 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 return null;
             }
 
-
             view = (RecyclerView) getLayoutInflater().inflate(R.layout.cachedetail_inventory_page, parentView, false);
             final RecyclerView recyclerView = ButterKnife.findById(view, R.id.list);
 
@@ -2213,7 +2211,6 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 }
             }
         }
-
     }
 
     private void resetCoords(final Geocache cache, final Handler handler, final Waypoint wpt, final boolean local, final boolean remote, final ProgressDialog progress) {
@@ -2339,6 +2336,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         final ImageButton offlineStoreDrop = ButterKnife.findById(view, R.id.offline_store_drop);
         final ImageButton offlineEdit = ButterKnife.findById(view, R.id.offline_edit);
 
+        // check if hint is available and set onClickListener and hint button visibility accordingly
         boolean hintButtonEnabled = false;
         if (null != showHintClickListener) {
             final String hint = cache.getHint();
@@ -2348,27 +2346,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 offlineHintText.setText(hint);
             }
         }
-
-        // retrieve margins of hint button to make sure moreButton aligns visually
         final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);
-        final ViewGroup.MarginLayoutParams lptHint = (ViewGroup.MarginLayoutParams) offlineHint.getLayoutParams();
-
-        // adjust right margin of "more details" button to whether a hint button is shown
-        final AppCompatButton moreButton = ButterKnife.findById(view, R.id.more_details);
-        if (null != moreButton) {
-            final float scale = view.getResources().getDisplayMetrics().density;
-            final int rightMargin = (int) (51 * scale + 0.5f);
-            final ViewGroup.MarginLayoutParams lpt = (ViewGroup.MarginLayoutParams) moreButton.getLayoutParams();
-            if (null != offlineHint) {
-                lpt.setMargins(lptHint.rightMargin, lptHint.topMargin, hintButtonEnabled ? rightMargin : lptHint.rightMargin, lptHint.bottomMargin);
-            } else {
-                final int otherMargin = (int) (4 * scale + 0.5f);
-                lpt.setMargins(otherMargin, otherMargin, hintButtonEnabled ? rightMargin : otherMargin, otherMargin);
-            }
-            moreButton.setLayoutParams(lpt);
-        }
-
-        // show or remove clickable hint button
         if (null != offlineHint) {
             if (hintButtonEnabled) {
                 offlineHint.setVisibility(View.VISIBLE);
@@ -2409,7 +2387,6 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
             offlineEdit.setVisibility(View.GONE);
         }
-
     }
 
     static void updateCacheLists(final View view, final Geocache cache, final Resources res) {

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2348,19 +2348,27 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 offlineHintText.setText(hint);
             }
         }
+
+        // retrieve margins of hint button to make sure moreButton aligns visually
+        final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);
+        final ViewGroup.MarginLayoutParams lptHint = (ViewGroup.MarginLayoutParams) offlineHint.getLayoutParams();
+
         // adjust right margin of "more details" button to whether a hint button is shown
         final AppCompatButton moreButton = ButterKnife.findById(view, R.id.more_details);
         if (null != moreButton) {
             final float scale = view.getResources().getDisplayMetrics().density;
             final int rightMargin = (int) (51 * scale + 0.5f);
-            final int otherMargin = (int) (4 * scale + 0.5f);
             final ViewGroup.MarginLayoutParams lpt = (ViewGroup.MarginLayoutParams) moreButton.getLayoutParams();
-            lpt.setMargins(otherMargin, otherMargin, hintButtonEnabled ? rightMargin : otherMargin, otherMargin);
+            if (null != offlineHint) {
+                lpt.setMargins(lptHint.rightMargin, lptHint.topMargin, hintButtonEnabled ? rightMargin : lptHint.rightMargin, lptHint.bottomMargin);
+            } else {
+                final int otherMargin = (int) (4 * scale + 0.5f);
+                lpt.setMargins(otherMargin, otherMargin, hintButtonEnabled ? rightMargin : otherMargin, otherMargin);
+            }
             moreButton.setLayoutParams(lpt);
         }
 
         // show or remove clickable hint button
-        final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);
         if (null != offlineHint) {
             if (hintButtonEnabled) {
                 offlineHint.setVisibility(View.VISIBLE);


### PR DESCRIPTION
"more details" and "hint" buttons in cache popup were slightly misaligned, so lets reuse "hint" button's margin settings and apply them mirroredly to the "more details" button