### PR TITLE
implement isActive() for TravelBugConnector (fix #7592)

### DIFF
--- a/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -59,6 +59,11 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     }
 
     @Override
+    public boolean isActive() {
+        return Settings.isGCConnectorActive();
+    }
+
+    @Override
     public boolean isRegistered() {
         return Settings.hasGCCredentials();
     }


### PR DESCRIPTION
Implement `isActive()` for TravelBugConnector (fix #7592) Without implementing this function the connector always was counted as inactive.