### PR TITLE
optimize for last selected list when saving caches to lists (fix#7484)

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1355,7 +1355,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         if (Settings.getChooseList() && type != CacheListType.OFFLINE && type != CacheListType.HISTORY) {
             // let user select list to store cache in
-            new StoredList.UserInterface(this).promptForMultiListSelection(R.string.list_title,
+            new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title,
                     new Action1<Set<Integer>>() {
                         @Override
                         public void call(final Set<Integer> selectedListIds) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -779,7 +779,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
 
             if (Settings.getChooseList()) {
                 // let user select list to store cache in
-                new StoredList.UserInterface(activity).promptForMultiListSelection(R.string.list_title, new Action1<Set<Integer>>() {
+                new StoredList.UserInterface(activity).promptForMultiListSelection(R.string.lists_title, new Action1<Set<Integer>>() {
                     @Override
                     public void call(final Set<Integer> selectedListIds) {
                         storeCaches(geocodesInViewport, selectedListIds);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -482,12 +482,12 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
             if (Settings.getChooseList()) {
                 // let user select list to store cache in
-                new StoredList.UserInterface(this).promptForMultiListSelection(R.string.list_title, new Action1<Set<Integer>>() {
+                new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title, new Action1<Set<Integer>>() {
                     @Override
                     public void call(final Set<Integer> selectedListIds) {
                         storeCaches(geocodes, selectedListIds);
                     }
-                }, true, Collections.singleton(StoredList.TEMPORARY_LIST.id), false);
+                }, true, Collections.<Integer>emptySet(), false);
             } else {
                 storeCaches(geocodes, Collections.singleton(StoredList.STANDARD_LIST_ID));
             }


### PR DESCRIPTION
fix#7484 (Dialog "Store Unsaved" missing button "Last Selection")

- change headline to lists_title, when multi list selection is requestet
- let show "last selected" button (as implementedd in CGeoMap) for storing all or new caches to list(s) from map menu on NewMap