### PR TITLE
fix some lint warnings

### DIFF
--- a/cgeo-contacts/lint.xml
+++ b/cgeo-contacts/lint.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <!-- we cannot use App Indexing with the GC website -->
+    <issue id="AppLinkUrlError" severity="ignore" />
+
+    <!-- we cannot use App Indexing with the GC website -->
+    <issue id="GoogleAppIndexingWarning" severity="ignore" />
+
+    <!-- many plain Java libraries cannot be upgraded further -->
+    <issue id="GradleDependency" severity="ignore" />
+
     <issue id="IconMissingDensityFolder" severity="ignore" />
     <issue id="MissingTranslation" severity="ignore" />
 </lint>

--- a/main/lint.xml
+++ b/main/lint.xml
@@ -1,30 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <issue id="AppCompatResource" severity="ignore" />
+
+    <!-- we cannot use App Indexing with the GC website -->
+    <issue id="AppLinkUrlError" severity="ignore" />
+
     <issue id="ContentDescription" severity="ignore" />
+
+    <!-- false positives for return values of RxJava subscribe() calls -->
+    <issue id="CheckResult" severity="ignore" />
+
     <issue id="DuplicateIds" severity="error" />
     <issue id="DuplicateIncludedIds" severity="error" />
     <issue id="ExportedContentProvider" severity="ignore" />
+
+    <!-- we cannot use App Indexing with the GC website -->
+    <issue id="GoogleAppIndexingWarning" severity="ignore" />
+
+    <!-- many plain Java libraries cannot be upgraded further -->
+    <issue id="GradleDependency" severity="ignore" />
+
     <issue id="GradleOverrides" severity="ignore" />
     <issue id="IconDensities" severity="ignore" />
     <issue id="ImpliedQuantity" severity="ignore" />
     <issue id="InvalidPackage" severity="ignore" />
+
+    <!-- do not care about incomplete translations -->
     <issue id="MissingQuantity">
         <ignore path="res/values-pl/strings.xml" />
         <ignore path="res/values-ru/strings.xml" />
     </issue>
+
+    <!-- unfinished localizations are okay since we always have English as fallback -->
     <issue id="MissingTranslation" severity="ignore" />
+
     <issue id="Registered" severity="ignore" />
     <issue id="RtlHardcoded" severity="ignore" />
     <issue id="RtlSymmetry" severity="ignore" />
-    <issue id="TypographyDashes">
-        <ignore path="res/values/strings.xml" />
-    </issue>
+
+    <!-- all false positives in coordinate input -->
+    <issue id="TypographyDashes" severity="ignore" />
+
+    <!-- many false positives due to our many supported languages -->
     <issue id="Typos" severity="ignore" />
+
     <issue id="UnusedAttribute" severity="ignore" />
+
+    <!-- let translators create more plural strings than needed -->
     <issue id="UnusedQuantity">
+        <ignore path="res/values-cs/strings.xml" />
+        <ignore path="res/values-lt/strings.xml" />
         <ignore path="res/values-ru/strings.xml" />
+        <ignore path="res/values-sk/strings.xml" />
     </issue>
+
+    <!-- resources loaded by dynamic name lookup -->
     <issue id="UnusedResources">
         <ignore path="res/drawable-mdpi/attribute_maintenance.png" />
         <ignore path="res/values/vpi__colors.xml" />

--- a/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
+++ b/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
@@ -79,7 +79,7 @@
                     android:overScrollMode="always"
                     android:scrollbarStyle="insideInset"
                     android:scrollbars="vertical"
-
+                    android:inputType="textAutoCorrect"
                     android:hint="@string/waypointcalc_notes_prompt" />
             </LinearLayout>
         </LinearLayout>

--- a/main/res/layout/authorization_credentials_activity.xml
+++ b/main/res/layout/authorization_credentials_activity.xml
@@ -41,6 +41,7 @@
 
         <EditText
             android:id="@+id/username"
+            android:inputType="textPersonName"
             style="@style/edittext_full"
             android:hint="@string/init_authorization_credential_username"
             android:layout_margin="7dip" />

--- a/main/res/layout/authorization_token_activity.xml
+++ b/main/res/layout/authorization_token_activity.xml
@@ -41,6 +41,7 @@
 
         <EditText
             android:id="@+id/username"
+            android:inputType="textPersonName"
             style="@style/edittext_full"
             android:hint="@string/init_authorization_credential_username"
             android:layout_margin="7dip" />

--- a/main/res/layout/coordinates_input.xml
+++ b/main/res/layout/coordinates_input.xml
@@ -158,6 +158,7 @@
         style="@style/edittext_full"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        android:inputType="textNoSuggestions"
         android:hint="@string/latitude" />
 
     <EditText
@@ -165,6 +166,7 @@
         style="@style/edittext_full"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
+        android:inputType="textNoSuggestions"
         android:hint="@string/longitude" />
 
 </merge>

--- a/main/res/layout/coordinatescalculate_dialog.xml
+++ b/main/res/layout/coordinatescalculate_dialog.xml
@@ -58,7 +58,7 @@
                 android:overScrollMode="always"
                 android:scrollbarStyle="insideInset"
                 android:scrollbars="vertical"
-
+                android:inputType="textAutoCorrect"
                 android:hint="@string/waypointcalc_notes_prompt" />
 
             <Button


### PR DESCRIPTION
* silence warnings around unused plural versions depending on language (since our translators will do that anyway)
* silence all app indexing warnings, we cannot use app indexing on the geocaching web site
* silence gradle library upgrade warnings in lint, many of those cannot be upgraded with our current target
* add inputtype attributes to text fields