### PR TITLE
temporaribly disable check for active trackable connectors due to #7617

### DIFF
--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -412,13 +412,16 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
             return;
         }
 
-        if (ConnectorFactory.anyTrackableConnectorActive()) {
+        // check temporaribly disabled due to #7617
+        // if (ConnectorFactory.anyTrackableConnectorActive()) {
             final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
             trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText.toUpperCase(Locale.US));
             startActivity(trackablesIntent);
+        /*
         } else {
             showToast(getString(R.string.warn_no_connector));
         }
+        */
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -59,11 +59,6 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     }
 
     @Override
-    public boolean isActive() {
-        return Settings.isGCConnectorActive();
-    }
-
-    @Override
     public boolean isRegistered() {
         return Settings.hasGCCredentials();
     }


### PR DESCRIPTION
Adding the `isActive()` function in `TravelBugConnector` needed for #7555 triggers side effects in `TravelBugConnector` due to an incomplete implementation of the connector, which leads to #7617.

Thus to be able to release I temporaribly disable the active trackable connector check for the search (which reopens #7555). Check for active geo connectors (#7554) is unharmed.