### PR TITLE
proximity notification for map cache and waypoint popups (fix #417)

### DIFF
--- a/main/res/layout/preference_seekbar.xml
+++ b/main/res/layout/preference_seekbar.xml
@@ -9,22 +9,29 @@
     android:paddingTop="8dp"
     tools:context=".settings.SettingsActivity" >
 
+    <TextView
+        android:id="@+id/preference_seekbar_label_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:gravity="left"/>
+
     <SeekBar
         android:id="@+id/preference_seekbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_weight="1"
-        android:paddingRight="8dp"
+        android:paddingRight="4dp"
         tools:progress="25"/>
 
     <TextView
         android:id="@+id/preference_seekbar_value_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_gravity="right"
         android:layout_weight="5"
-        android:gravity="center"
+        android:gravity="right"
         tools:text="25"/>
 
 </LinearLayout>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -80,6 +80,9 @@
     <string translatable="false" name="pref_renderthemepath">renderthemepath</string>
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
+    <string translatable="false" name="pref_distanceBeep">distanceBeep</string>
+    <string translatable="false" name="pref_distanceBeep1">distanceBeep1</string>
+    <string translatable="false" name="pref_distanceBeep2">distanceBeep2</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -596,6 +596,8 @@
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_brouterThreshold">Calculate route</string>
     <string name="init_brouterThreshold_description">Maximum distance up to which brouter helper app (if installed) will calculate a route.</string>
+    <string name="init_distanceBeep">Distance beep</string>
+    <string name="init_summary_distanceBeep">Play one or two beeps when coming close to the active cache.</string>
     <string name="init_disabled">Exclude Disabled</string>
     <string name="init_summary_disabled">Exclude disabled caches</string>
     <string name="init_save_log_img">Save Images</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -596,8 +596,8 @@
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_brouterThreshold">Calculate route</string>
     <string name="init_brouterThreshold_description">Maximum distance up to which brouter helper app (if installed) will calculate a route.</string>
-    <string name="init_distanceBeep">Distance beep</string>
-    <string name="init_summary_distanceBeep">Play one or two beeps when coming close to the active cache.</string>
+    <string name="init_distanceBeep">Proximity notification</string>
+    <string name="init_summary_distanceBeep">Play one or two signalling tones when approaching the active cache. Works from cache or waypoint popup in map view. Adjust slider "1" to set the distance for the single tone signal and slider "2" for the double tone signal.</string>
     <string name="init_disabled">Exclude Disabled</string>
     <string name="init_summary_disabled">Exclude disabled caches</string>
     <string name="init_save_log_img">Save Images</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -601,6 +601,17 @@
             <cgeo.geocaching.settings.BrouterThresholdPreference
                 android:key="@string/pref_brouterDistanceThreshold"
                 android:layout="@layout/preference_seekbar" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_distanceBeep"
+                android:summary="@string/init_summary_distanceBeep"
+                android:title="@string/init_distanceBeep" />
+            <cgeo.geocaching.settings.DistanceBeepPreference1
+                android:key="@string/pref_distanceBeep1"
+                android:layout="@layout/preference_seekbar" />
+            <cgeo.geocaching.settings.DistanceBeepPreference2
+                android:key="@string/pref_distanceBeep2"
+            android:layout="@layout/preference_seekbar" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"

--- a/main/src/cgeo/geocaching/AbstractDialogFragmentWithBeep.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragmentWithBeep.java
@@ -22,8 +22,9 @@ public abstract class AbstractDialogFragmentWithBeep extends AbstractDialogFragm
     // minimum increase in distance, before distance gets reset
     protected static final long MIN_DISTANCE_DELTA = 10;
 
-    // repeat tone every x ms (if still close enough)
-    protected static final long MIN_TIME_DELTA = 10000;
+    // repeat tone 1/2 every x ms (if still close enough)
+    protected static final long MIN_TIME_DELTA1 = 10000;
+    protected static final long MIN_TIME_DELTA2 = 5000;
 
     // distance beep activated?
     protected boolean distanceBeep = false;
@@ -53,17 +54,17 @@ public abstract class AbstractDialogFragmentWithBeep extends AbstractDialogFragm
             final long currentTimestamp = System.currentTimeMillis();
 
             int playTone = TONE_NONE;
-            if (distanceInM > (lastDistanceInM + MIN_DISTANCE_DELTA) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA)) {
+            if (distanceInM > (lastDistanceInM + MIN_DISTANCE_DELTA)) {
                 lastDistanceInM = DISTANCE_RESET;
             }
-            if ((distanceInM <= distanceDoubleBeep) && (lastDistanceInM > distanceDoubleBeep)) {
+            if ((distanceInM <= distanceDoubleBeep) && ((lastDistanceInM > distanceDoubleBeep) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA2))) {
                 playTone = ToneGenerator.TONE_PROP_BEEP2;
-            } else if ((distanceInM <= distanceSingleBeep) && (lastDistanceInM > distanceSingleBeep)) {
+            } else if ((distanceInM <= distanceSingleBeep) && ((lastDistanceInM > distanceSingleBeep) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA1))) {
                 playTone = ToneGenerator.TONE_PROP_BEEP;
             }
             lastDistanceInM = distanceInM;
             if (playTone != TONE_NONE) {
-                final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, 100);
+                final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, ToneGenerator.MAX_VOLUME);
                 toneG.startTone(playTone);
                 lastTimestamp = currentTimestamp;
                 final Handler handler = new Handler(Looper.getMainLooper());

--- a/main/src/cgeo/geocaching/AbstractDialogFragmentWithBeep.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragmentWithBeep.java
@@ -1,0 +1,89 @@
+package cgeo.geocaching;
+
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.sensors.GeoData;
+import cgeo.geocaching.settings.Settings;
+
+import android.media.AudioManager;
+import android.media.ToneGenerator;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+
+// like AbstractDialogFragment, but plays beeps if close enough to reference point
+public abstract class AbstractDialogFragmentWithBeep extends AbstractDialogFragment {
+
+    // marker: don't play a tone
+    protected static final int TONE_NONE = 0;
+
+    // marker: no last distance set
+    protected static final long DISTANCE_RESET = Settings.DISTANCE_BEEP_MAX + 1;
+
+    // minimum increase in distance, before distance gets reset
+    protected static final long MIN_DISTANCE_DELTA = 10;
+
+    // repeat tone every x ms (if still close enough)
+    protected static final long MIN_TIME_DELTA = 10000;
+
+    // distance beep activated?
+    protected boolean distanceBeep = false;
+
+    // max distances for single or double beep
+    protected long distanceSingleBeep = 200;
+    protected long distanceDoubleBeep = 50;
+
+    // last distance / last timestamp
+    protected long lastDistanceInM = DISTANCE_RESET;
+    protected long lastTimestamp = 0;
+
+    // reference point to calculate distance to
+    // needs to be set by inheriting class
+    protected Geopoint referencePointForBeep = null;
+
+    /**
+     * @param geo
+     *            location
+     */
+    protected void onUpdateGeoData(final GeoData geo) {
+        super.onUpdateGeoData(geo);
+
+        // send acoustic signal depending on distance (if activated)
+        if (distanceBeep) {
+            final long distanceInM = (long) (1000 * geo.getCoords().distanceTo(referencePointForBeep));
+            final long currentTimestamp = System.currentTimeMillis();
+
+            int playTone = TONE_NONE;
+            if (distanceInM > (lastDistanceInM + MIN_DISTANCE_DELTA) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA)) {
+                lastDistanceInM = DISTANCE_RESET;
+            }
+            if ((distanceInM <= distanceDoubleBeep) && (lastDistanceInM > distanceDoubleBeep)) {
+                playTone = ToneGenerator.TONE_PROP_BEEP2;
+            } else if ((distanceInM <= distanceSingleBeep) && (lastDistanceInM > distanceSingleBeep)) {
+                playTone = ToneGenerator.TONE_PROP_BEEP;
+            }
+            lastDistanceInM = distanceInM;
+            if (playTone != TONE_NONE) {
+                final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, 100);
+                toneG.startTone(playTone);
+                lastTimestamp = currentTimestamp;
+                final Handler handler = new Handler(Looper.getMainLooper());
+                handler.postDelayed(() -> {
+                    toneG.release();
+                }, 350);
+            }
+        }
+    }
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // init distance beep checker
+        distanceBeep = Settings.getDistanceBeep();
+        if (distanceBeep) {
+            distanceSingleBeep = Settings.getDistanceBeepThreshold(true);
+            distanceDoubleBeep = Settings.getDistanceBeepThreshold(false);
+            distanceBeep &= (distanceSingleBeep > 0) && (distanceDoubleBeep > 0);
+        }
+    }
+}

--- a/main/src/cgeo/geocaching/AbstractDialogFragmentWithBeep.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragmentWithBeep.java
@@ -1,45 +1,13 @@
 package cgeo.geocaching;
 
-import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.sensors.GeoData;
-import cgeo.geocaching.settings.Settings;
 
-import android.media.AudioManager;
-import android.media.ToneGenerator;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 
 // like AbstractDialogFragment, but plays beeps if close enough to reference point
 public abstract class AbstractDialogFragmentWithBeep extends AbstractDialogFragment {
-
-    // marker: don't play a tone
-    protected static final int TONE_NONE = 0;
-
-    // marker: no last distance set
-    protected static final long DISTANCE_RESET = Settings.DISTANCE_BEEP_MAX + 1;
-
-    // minimum increase in distance, before distance gets reset
-    protected static final long MIN_DISTANCE_DELTA = 10;
-
-    // repeat tone 1/2 every x ms (if still close enough)
-    protected static final long MIN_TIME_DELTA1 = 10000;
-    protected static final long MIN_TIME_DELTA2 = 5000;
-
-    // distance beep activated?
-    protected boolean distanceBeep = false;
-
-    // max distances for single or double beep
-    protected long distanceSingleBeep = 200;
-    protected long distanceDoubleBeep = 50;
-
-    // last distance / last timestamp
-    protected long lastDistanceInM = DISTANCE_RESET;
-    protected long lastTimestamp = 0;
-
-    // reference point to calculate distance to
-    // needs to be set by inheriting class
-    protected Geopoint referencePointForBeep = null;
+    protected ProximityNotification proximityNotification = null;
 
     /**
      * @param geo
@@ -47,44 +15,14 @@ public abstract class AbstractDialogFragmentWithBeep extends AbstractDialogFragm
      */
     protected void onUpdateGeoData(final GeoData geo) {
         super.onUpdateGeoData(geo);
-
-        // send acoustic signal depending on distance (if activated)
-        if (distanceBeep) {
-            final long distanceInM = (long) (1000 * geo.getCoords().distanceTo(referencePointForBeep));
-            final long currentTimestamp = System.currentTimeMillis();
-
-            int playTone = TONE_NONE;
-            if (distanceInM > (lastDistanceInM + MIN_DISTANCE_DELTA)) {
-                lastDistanceInM = DISTANCE_RESET;
-            }
-            if ((distanceInM <= distanceDoubleBeep) && ((lastDistanceInM > distanceDoubleBeep) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA2))) {
-                playTone = ToneGenerator.TONE_PROP_BEEP2;
-            } else if ((distanceInM <= distanceSingleBeep) && ((lastDistanceInM > distanceSingleBeep) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA1))) {
-                playTone = ToneGenerator.TONE_PROP_BEEP;
-            }
-            lastDistanceInM = distanceInM;
-            if (playTone != TONE_NONE) {
-                final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, ToneGenerator.MAX_VOLUME);
-                toneG.startTone(playTone);
-                lastTimestamp = currentTimestamp;
-                final Handler handler = new Handler(Looper.getMainLooper());
-                handler.postDelayed(() -> {
-                    toneG.release();
-                }, 350);
-            }
+        if (null != proximityNotification) {
+            proximityNotification.onUpdateGeoData(geo);
         }
     }
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        // init distance beep checker
-        distanceBeep = Settings.getDistanceBeep();
-        if (distanceBeep) {
-            distanceSingleBeep = Settings.getDistanceBeepThreshold(true);
-            distanceDoubleBeep = Settings.getDistanceBeepThreshold(false);
-            distanceBeep &= (distanceSingleBeep > 0) && (distanceDoubleBeep > 0);
-        }
+        proximityNotification = new ProximityNotification();
     }
 }

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -109,7 +109,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithBeep {
     @Override
     protected void init() {
         super.init();
-        referencePointForBeep = cache.getCoords();
+        proximityNotification.setReferencePoint(cache.getCoords());
 
         try {
             if (StringUtils.isNotBlank(cache.getName())) {

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -36,7 +36,7 @@ import butterknife.ButterKnife;
 import io.reactivex.schedulers.Schedulers;
 import org.apache.commons.lang3.StringUtils;
 
-public class CachePopupFragment extends AbstractDialogFragment {
+public class CachePopupFragment extends AbstractDialogFragmentWithBeep {
     private final Progress progress = new Progress();
 
     public static DialogFragment newInstance(final String geocode) {
@@ -109,6 +109,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
     @Override
     protected void init() {
         super.init();
+        referencePointForBeep = cache.getCoords();
 
         try {
             if (StringUtils.isNotBlank(cache.getName())) {

--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.maps.DefaultMap;
@@ -68,6 +69,7 @@ public class CompassActivity extends AbstractActionBarActivity {
     private Geopoint dstCoords = null;
     private float cacheHeading = 0;
     private String description;
+    private ProximityNotification proximityNotification = null;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -80,6 +82,9 @@ public class CompassActivity extends AbstractActionBarActivity {
             finish();
             return;
         }
+
+        // prepare promity notification
+        proximityNotification = new ProximityNotification();
 
         // cache must exist, except for "any point navigation"
         final String geocode = extras.getString(Intents.EXTRA_GEOCODE);
@@ -267,6 +272,9 @@ public class CompassActivity extends AbstractActionBarActivity {
 
     private void setDestCoords(final Geopoint coords) {
         dstCoords = coords;
+        if (null != proximityNotification) {
+            proximityNotification.setReferencePoint(coords);
+        }
         if (dstCoords == null) {
             return;
         }
@@ -322,6 +330,10 @@ public class CompassActivity extends AbstractActionBarActivity {
                 updateDistanceInfo(geo);
 
                 updateNorthHeading(AngleUtils.getDirectionNow(dir));
+
+                if (null != proximityNotification) {
+                    proximityNotification.onUpdateGeoData(geo);
+                }
             } catch (final RuntimeException e) {
                 Log.w("Failed to update location", e);
             }

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -68,7 +68,7 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithBeep {
         super.init();
 
         waypoint = DataStore.loadWaypoint(waypointId);
-        referencePointForBeep = waypoint.getCoords();
+        proximityNotification.setReferencePoint(waypoint.getCoords());
 
         if (waypoint == null) {
             Log.e("WaypointPopupFragment.init: unable to get waypoint " + waypointId);

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -26,7 +26,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import org.apache.commons.lang3.StringUtils;
 
-public class WaypointPopupFragment extends AbstractDialogFragment {
+public class WaypointPopupFragment extends AbstractDialogFragmentWithBeep {
     @BindView(R.id.actionbar_title) protected TextView actionBarTitle;
     @BindView(R.id.waypoint_details_list) protected LinearLayout waypointDetailsLayout;
     @BindView(R.id.edit) protected Button buttonEdit;
@@ -53,6 +53,7 @@ public class WaypointPopupFragment extends AbstractDialogFragment {
 
     @Override
     protected void onUpdateGeoData(final GeoData geo) {
+        super.onUpdateGeoData(geo);
         if (waypoint != null) {
             final Geopoint coordinates = waypoint.getCoords();
             if (coordinates != null) {
@@ -67,6 +68,7 @@ public class WaypointPopupFragment extends AbstractDialogFragment {
         super.init();
 
         waypoint = DataStore.loadWaypoint(waypointId);
+        referencePointForBeep = waypoint.getCoords();
 
         if (waypoint == null) {
             Log.e("WaypointPopupFragment.init: unable to get waypoint " + waypointId);

--- a/main/src/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotification.java
@@ -1,0 +1,78 @@
+package cgeo.geocaching.location;
+
+import cgeo.geocaching.sensors.GeoData;
+import cgeo.geocaching.settings.Settings;
+
+import android.media.AudioManager;
+import android.media.ToneGenerator;
+import android.os.Handler;
+import android.os.Looper;
+
+public class ProximityNotification {
+    // marker: don't play a tone
+    protected static final int TONE_NONE = 0;
+
+    // marker: no last distance set
+    protected static final long DISTANCE_RESET = Settings.DISTANCE_BEEP_MAX + 1;
+
+    // minimum increase in distance, before distance gets reset
+    protected static final long MIN_DISTANCE_DELTA = 10;
+
+    // repeat tone 1/2 every x ms (if still close enough)
+    protected static final long MIN_TIME_DELTA1 = 10000;
+    protected static final long MIN_TIME_DELTA2 = 5000;
+
+    // distance beep activated?
+    protected boolean distanceBeep = false;
+
+    // max distances for single or double beep
+    protected long distanceSingleBeep = 200;
+    protected long distanceDoubleBeep = 50;
+
+    // last distance / last timestamp
+    protected long lastDistanceInM = DISTANCE_RESET;
+    protected long lastTimestamp = 0;
+
+    // reference point to calculate distance to
+    // needs to be set by inheriting class by calling setReferencePoint()
+    private Geopoint referencePointForBeep = null;
+
+    public ProximityNotification() {
+        distanceSingleBeep = Settings.getDistanceBeepThreshold(true);
+        distanceDoubleBeep = Settings.getDistanceBeepThreshold(false);
+        distanceBeep = Settings.getDistanceBeep() & (distanceSingleBeep > 0) && (distanceDoubleBeep > 0);
+    }
+
+    public void setReferencePoint(final Geopoint referencePoint) {
+        referencePointForBeep = referencePoint;
+    }
+
+    public void onUpdateGeoData(final GeoData geo) {
+        // send acoustic signal depending on distance (if activated)
+        if (distanceBeep && null != referencePointForBeep) {
+            final long distanceInM = (long) (1000 * geo.getCoords().distanceTo(referencePointForBeep));
+            final long currentTimestamp = System.currentTimeMillis();
+
+            int playTone = TONE_NONE;
+            if (distanceInM > (lastDistanceInM + MIN_DISTANCE_DELTA)) {
+                lastDistanceInM = DISTANCE_RESET;
+            }
+            if ((distanceInM <= distanceDoubleBeep) && ((lastDistanceInM > distanceDoubleBeep) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA2))) {
+                playTone = ToneGenerator.TONE_PROP_BEEP2;
+            } else if ((distanceInM <= distanceSingleBeep) && ((lastDistanceInM > distanceSingleBeep) || ((currentTimestamp - lastTimestamp) > MIN_TIME_DELTA1))) {
+                playTone = ToneGenerator.TONE_PROP_BEEP;
+            }
+            lastDistanceInM = distanceInM;
+            if (playTone != TONE_NONE) {
+                final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, ToneGenerator.MAX_VOLUME);
+                toneG.startTone(playTone);
+                lastTimestamp = currentTimestamp;
+                final Handler handler = new Handler(Looper.getMainLooper());
+                handler.postDelayed(() -> {
+                    toneG.release();
+                }, 350);
+            }
+        }
+    }
+
+}

--- a/main/src/cgeo/geocaching/settings/AbstractDistanceBeepPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractDistanceBeepPreference.java
@@ -1,0 +1,53 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.location.IConversion;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.Locale;
+
+public abstract class AbstractDistanceBeepPreference extends AbstractSeekbarPreference {
+    private int maxSeekbarLength = 0;   // initialized in onCreateView
+    private boolean first = true;
+
+    public AbstractDistanceBeepPreference(final Context context, final AttributeSet attrs, final boolean first) {
+        super(context, attrs);
+        this.first = first;
+    }
+
+    private int valueToProgressHelper(final int value) {
+        return (int) Math.round(25.0 * Math.log10(value + 1));
+    }
+
+    private int valueToProgress(final int value) {
+        final int progress = valueToProgressHelper(value);
+        return progress < 0 ? 0 : progress > maxSeekbarLength ? maxSeekbarLength : progress;
+    }
+
+    private int progressToValue(final int progress) {
+        final int value = (int) Math.pow(10, Double.valueOf(progress) / 25.0) - 1;
+        return value < 0 ? 0 : value > Settings.DISTANCE_BEEP_MAX ? Settings.DISTANCE_BEEP_MAX : value;
+    }
+
+    protected String getValueString(final int progress) {
+        final int value = progressToValue(progress);
+        return Settings.useImperialUnits()
+            ? String.format(Locale.US, "%.2f mi", value / (1000 * IConversion.MILES_TO_KILOMETER))
+            : value + " m"
+        ;
+    }
+
+    protected void saveSetting(final int progress) {
+        Settings.setDistanceBeepThreshold(first, progressToValue(progress));
+    }
+
+    @Override
+    protected View onCreateView(final ViewGroup parent) {
+        maxSeekbarLength = valueToProgressHelper(Settings.DISTANCE_BEEP_MAX);
+        configure(1, maxSeekbarLength, valueToProgress(Settings.getDistanceBeepThreshold(first)), first ? "1" : "2");
+        return super.onCreateView(parent);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
@@ -1,0 +1,109 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.TextView;
+
+import butterknife.ButterKnife;
+
+public abstract class AbstractSeekbarPreference extends Preference {
+
+    private TextView valueView;
+    private int minValue = 0;
+    private int maxValue = 100;
+    private int startValue = 0;
+    private String labelValue = "";
+
+    public AbstractSeekbarPreference(final Context context) {
+        super(context);
+        init();
+    }
+
+    public AbstractSeekbarPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public AbstractSeekbarPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+    }
+
+    protected void init() {
+        setPersistent(false);
+    }
+
+    protected String getValueString(final int progress) {
+        return String.valueOf(progress);
+    }
+
+    private boolean atLeastMin(final SeekBar seekBar, final int progress) {
+        if (progress < minValue) {
+            seekBar.setProgress(minValue);
+            return false;
+        }
+        return true;
+    }
+
+    // sets boundaries and initial value for seekbar
+    protected void configure(final int minValue, final int maxValue, final int startValue, final String labelValue) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.startValue = startValue;
+        this.labelValue = labelValue;
+    }
+
+    // method to store the final value
+    protected abstract void saveSetting(int progress);
+
+    @Override
+    protected View onCreateView(final ViewGroup parent) {
+        final View v = super.onCreateView(parent);
+
+        // get views
+        final SeekBar seekBar = ButterKnife.findById(v, R.id.preference_seekbar);
+        valueView = ButterKnife.findById(v, R.id.preference_seekbar_value_view);
+
+        // init seekbar
+        seekBar.setMax(maxValue);
+
+        // set initial value
+        final int threshold = startValue;
+        valueView.setText(getValueString(threshold));
+        seekBar.setProgress(threshold);
+
+        // set label (if given)
+        if (null != labelValue && !labelValue.isEmpty()) {
+            final TextView labelView = ButterKnife.findById(v, R.id.preference_seekbar_label_view);
+            labelView.setText(labelValue);
+        }
+
+        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
+                if (fromUser && atLeastMin(seekBar, progress)) {
+                    valueView.setText(getValueString(progress));
+                }
+            }
+            @Override
+            public void onStartTrackingTouch(final SeekBar seekBar) {
+                // abstract method needs to be implemented, but is not used here
+            }
+            @Override
+            public void onStopTrackingTouch(final SeekBar seekBar) {
+                if (atLeastMin(seekBar, seekBar.getProgress())) {
+                    saveSetting(seekBar.getProgress());
+                }
+            }
+        });
+
+        return v;
+    }
+}

--- a/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
+++ b/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
@@ -1,94 +1,35 @@
 package cgeo.geocaching.settings;
 
-import cgeo.geocaching.R;
 import cgeo.geocaching.location.IConversion;
 
 import android.content.Context;
-import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
-import android.widget.TextView;
 
 import java.util.Locale;
 
-import butterknife.ButterKnife;
-
-public class BrouterThresholdPreference extends Preference {
-
-    private TextView valueView;
-
-    public BrouterThresholdPreference(final Context context) {
-        super(context);
-        init();
-    }
+public class BrouterThresholdPreference extends AbstractSeekbarPreference {
 
     public BrouterThresholdPreference(final Context context, final AttributeSet attrs) {
         super(context, attrs);
         init();
     }
 
-    public BrouterThresholdPreference(final Context context, final AttributeSet attrs, final int defStyle) {
-        super(context, attrs, defStyle);
-        init();
-    }
-
-    private void init() {
-        setPersistent(false);
-    }
-
-    private String getValueString(final int progress) {
+    protected String getValueString(final int progress) {
         return Settings.useImperialUnits()
             ? String.format(Locale.US, "%.1f mi", progress / IConversion.MILES_TO_KILOMETER)
-            : String.valueOf(progress) + " km"
+            : progress + " km"
         ;
     }
 
-    private boolean atLeastOne(final SeekBar seekBar, final int progress) {
-        if (progress < 1) {
-            seekBar.setProgress(1);
-            return false;
-        }
-        return true;
+    protected void saveSetting(final int progress) {
+        Settings.setBrouterThreshold(progress);
     }
 
     @Override
     protected View onCreateView(final ViewGroup parent) {
-        final View v = super.onCreateView(parent);
-
-        // get views
-        final SeekBar seekBar = ButterKnife.findById(v, R.id.preference_seekbar);
-        valueView = ButterKnife.findById(v, R.id.preference_seekbar_value_view);
-
-        // init seekbar
-        seekBar.setMax(Settings.BROUTER_THRESHOLD_MAX);
-
-        // set initial value
-        final int threshold = Settings.getBrouterThreshold();
-        valueView.setText(getValueString(threshold));
-        seekBar.setProgress(threshold);
-
-        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-                if (fromUser && atLeastOne(seekBar, progress)) {
-                    valueView.setText(getValueString(progress));
-                }
-            }
-            @Override
-            public void onStartTrackingTouch(final SeekBar seekBar) {
-                // abstract method needs to be implemented, but is not used here
-            }
-            @Override
-            public void onStopTrackingTouch(final SeekBar seekBar) {
-                if (atLeastOne(seekBar, seekBar.getProgress())) {
-                    Settings.setBrouterThreshold(seekBar.getProgress());
-                }
-            }
-        });
-
-        return v;
+        configure(1, Settings.BROUTER_THRESHOLD_MAX, Settings.getBrouterThreshold(), null);
+        return super.onCreateView(parent);
     }
 }

--- a/main/src/cgeo/geocaching/settings/DistanceBeepPreference1.java
+++ b/main/src/cgeo/geocaching/settings/DistanceBeepPreference1.java
@@ -1,0 +1,10 @@
+package cgeo.geocaching.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class DistanceBeepPreference1 extends AbstractDistanceBeepPreference {
+    public DistanceBeepPreference1(final Context context, final AttributeSet attrs) {
+        super(context, attrs, true);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/DistanceBeepPreference2.java
+++ b/main/src/cgeo/geocaching/settings/DistanceBeepPreference2.java
@@ -1,0 +1,10 @@
+package cgeo.geocaching.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class DistanceBeepPreference2 extends AbstractDistanceBeepPreference {
+    public DistanceBeepPreference2(final Context context, final AttributeSet attrs) {
+        super(context, attrs, false);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -74,6 +74,8 @@ public class Settings {
     public static final int SHOW_WP_THRESHOLD_MAX = 200;
     private static final int BROUTER_THRESHOLD_DEFAULT = 10;
     public static final int BROUTER_THRESHOLD_MAX = 120;
+    private static final int DISTANCE_BEEP_DEFAULT = 0;
+    public static final int DISTANCE_BEEP_MAX = 1000;
     private static final int MAP_SOURCE_DEFAULT = GoogleMapProvider.GOOGLE_MAP_ID.hashCode();
 
     private static final String PHONE_MODEL_AND_SDK = Build.MODEL + "/" + Build.VERSION.SDK_INT;
@@ -966,6 +968,21 @@ public class Settings {
 
     static void setBrouterThreshold(final int threshold) {
         putInt(R.string.pref_brouterDistanceThreshold, threshold);
+    }
+
+    /**
+     * The Threshold for distance beeps
+     */
+    public static boolean getDistanceBeep() {
+        return getBoolean(R.string.pref_distanceBeep, false);
+    }
+
+    public static int getDistanceBeepThreshold(final boolean first) {
+        return getInt(first ? R.string.pref_distanceBeep1 : R.string.pref_distanceBeep2, DISTANCE_BEEP_DEFAULT);
+    }
+
+    static void setDistanceBeepThreshold(final boolean first, final int value) {
+        putInt(first ? R.string.pref_distanceBeep1 : R.string.pref_distanceBeep2, value);
     }
 
     public static boolean isUseTwitter() {

--- a/main/src/cgeo/geocaching/settings/WpThresholdPreference.java
+++ b/main/src/cgeo/geocaching/settings/WpThresholdPreference.java
@@ -1,74 +1,23 @@
 package cgeo.geocaching.settings;
 
-import cgeo.geocaching.R;
-
 import android.content.Context;
-import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
-import android.widget.TextView;
 
-import butterknife.ButterKnife;
-
-public class WpThresholdPreference extends Preference {
-
-    private TextView valueView;
-
-    public WpThresholdPreference(final Context context) {
-        super(context);
-        init();
-    }
+public class WpThresholdPreference extends AbstractSeekbarPreference {
 
     public WpThresholdPreference(final Context context, final AttributeSet attrs) {
         super(context, attrs);
-        init();
     }
 
-    public WpThresholdPreference(final Context context, final AttributeSet attrs, final int defStyle) {
-        super(context, attrs, defStyle);
-        init();
-    }
-
-    private void init() {
-        setPersistent(false);
+    protected void saveSetting(final int progress) {
+        Settings.setShowWaypointsThreshold(progress);
     }
 
     @Override
     protected View onCreateView(final ViewGroup parent) {
-        final View v = super.onCreateView(parent);
-
-        // get views
-        final SeekBar seekBar = ButterKnife.findById(v, R.id.preference_seekbar);
-        valueView = ButterKnife.findById(v, R.id.preference_seekbar_value_view);
-
-        // init seekbar
-        seekBar.setMax(Settings.SHOW_WP_THRESHOLD_MAX);
-
-        // set initial value
-        final int threshold = Settings.getWayPointsThreshold();
-        valueView.setText(String.valueOf(threshold));
-        seekBar.setProgress(threshold);
-
-        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-                if (fromUser) {
-                    valueView.setText(String.valueOf(progress));
-                }
-            }
-            @Override
-            public void onStartTrackingTouch(final SeekBar seekBar) {
-                // abstract method needs to be implemented, but is not used here
-            }
-            @Override
-            public void onStopTrackingTouch(final SeekBar seekBar) {
-                Settings.setShowWaypointsThreshold(seekBar.getProgress());
-            }
-        });
-
-        return v;
+        configure(0, Settings.SHOW_WP_THRESHOLD_MAX, Settings.getWayPointsThreshold(), null);
+        return super.onCreateView(parent);
     }
 }


### PR DESCRIPTION
Adds a notification sound when approaching the cache or waypoint currently show in the map popup.
There are two distances configurable: One for single beep, one for double beep.

add distance beep feature to map cache and waypoint popups (AbstractDialogFragmentWithBeep)
add configuration settings, strings and preference keys
add AbstractSeekbarPreference
refactor existing BroutherThresholdPreference and WpThresholdPreference to use it
