### PR TITLE
gradle plugin update 3.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ buildscript {
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // un-mocking of portable Android classes
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.3'


### PR DESCRIPTION
Update the gradle plugin according to AS 3.4.1

Info: Please let the experimental feature "Only sync the active vatiant" disabled.