### PR TITLE
api.geokretymap.org replaced by api.geokrety.org (fix #7638)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -657,23 +657,10 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="geokrety.org" />
+                <data android:host="api.geokrety.org" />
                 <data android:host="www.geokrety.org" />
                 <data android:pathPrefix="/konkret.php" />
                 <data android:pathPrefix="/m/qr.php" />
-            </intent-filter>
-
-            <!-- GeoKretyMap.org -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <data android:host="geokretymap.org" />
-                <data android:host="www.geokretymap.org" />
                 <data android:pathPrefix="/GK" />
                 <data android:pathPrefix="/gk" />
             </intent-filter>

--- a/main/res/values-ca/strings.xml
+++ b/main/res/values-ca/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Inici de sessió correcte</string>
     <string name="init_geokrety_register_fail">S\'ha produït un error a l\'accedir</string>
     <string name="init_geokrety_description">Autorizar c:geo a GeoKrety.org per registrar traçables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org proporciona dades als catxés per a GeoKrety trackables.\n Les dades contenent informació dels GeoKrety com \'Descripció\' o \'misió\'.\n\nLes Dades no són en directe! \nLa Posició: ~ 30 min. \nDescripcions: ~ 24 h.</string>
-    <string name="init_geokrety_cache">Utilitzar GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Usuari: %s</string>
     <string name="trackable_title_log_without_geocode">El Geocodi no es troba</string>
     <string name="trackable_log_without_geocode">Estàs a punt d\'enviar un registre sense un Geocodi. Voleu afegir-lo ara?</string>

--- a/main/res/values-ceb/strings.xml
+++ b/main/res/values-ceb/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Malamposon ang pag login</string>
     <string name="init_geokrety_register_fail">Napakyas ang pag login</string>
     <string name="init_geokrety_description">I-awtorisar ang c:geo uban ang GeoKrety.org para i-log ang GeoKrety na mga trackables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org kay maghatag og cached na mga datos para sa GeoKrety trackables.\n Ang mga datos kay mas daghan na sulod nga GeoKrety nga mga inpormasyon pareha sa \'diskripsyon\' o \'nawala\' nga estado.\n\nAng mga datos kay dili buhi!\nMga posisyon: ~30min.\nMga deskripsyon: ~24h.</string>
-    <string name="init_geokrety_cache">Gamita ang GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Id sa tagagamit: %s</string>
     <string name="trackable_title_log_without_geocode">Ang Geocode wala ma plastado</string>
     <string name="trackable_log_without_geocode">Ikaw paingon nga na mo padala og log nga walay Geocode. Gidasig na mag plastado og usa. Ganahan ba ka na magpuno karon?</string>

--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -1526,8 +1526,6 @@
     <string name="init_geokrety_register_ok">Přihlášení bylo úspěšné</string>
     <string name="init_geokrety_register_fail">Přihlášení selhalo</string>
     <string name="init_geokrety_description">Autorizovat c:geo pro logování sledovatelných předmětů služby Geokrety.org.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org poskytuje informace o sledovatelných předmětech služby Geokrety.\nDostupné informace jsou např. „popis“ a nebo „ztracený“ stav.\n\nData nemusí být aktuální!\nPozice: ~30 min\nPopisy: ~24 h</string>
-    <string name="init_geokrety_cache">Použít GeoKretyMap.org</string>
     <string name="init_geokrety_userid">ID uživatele: %s</string>
     <string name="trackable_title_log_without_geocode">Geokód nenastaven</string>
     <string name="trackable_log_without_geocode">Chystáš se odeslat log bez geokódu. Je doporučeno alespoň jeden nastavit, chceš ho nyní přidat?</string>

--- a/main/res/values-da/strings.xml
+++ b/main/res/values-da/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Login fuldført</string>
     <string name="init_geokrety_register_fail">Login fejlede</string>
     <string name="init_geokrety_description">Autorisér c:geo til at logge GeoKrety trackables på GeoKrety.org.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org leverer cachelagerede data for GeoKrety trackables.\nTilgængelige data indeholder flere GeoKrety informationer som \'beskrivelse\' eller \'mangler\' status.\n\nData er ikke live!\nPositioner: ~30min.\nBeskrivelser: ~24h.</string>
-    <string name="init_geokrety_cache">Brug GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Brugerid: %s</string>
     <string name="trackable_title_log_without_geocode">Geokode ikke sendt</string>
     <string name="trackable_log_without_geocode">Du er ved at sende en logbesked uden en geokode. Det anbefales at du inkluderer en geokode. Vil du tilføje en geokode?</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Anmeldung OK</string>
     <string name="init_geokrety_register_fail">Anmeldung fehlgeschlagen</string>
     <string name="init_geokrety_description">Autorisiere c:geo, auf GeoKrety.org zuzugreifen, um GeoKrety-Trackables zu loggen.</string>
-    <string name="init_geokrety_cache_description">GeoKretyMap.org stellt zwischengespeicherte Daten für GeoKrety Trackables zur Verfügung.\nDie Daten enthalten mehr Infos zu GeoKrets wie z. B. „Beschreibung“ oder „Vermisst“-Status.\n\nDie Daten sind nicht immer aktuell!\nPositionen: ~30min.\nBeschreibungen: ~24h.</string>
-    <string name="init_geokrety_cache">Benutze GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Nutzer-ID: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode nicht gesetzt</string>
     <string name="trackable_log_without_geocode">Du bist gerade dabei, ein Log ohne Geocode zu senden. Es wird empfohlen, immer einen Geocode anzugeben. Möchtest du einen hinzufügen?</string>

--- a/main/res/values-el/strings.xml
+++ b/main/res/values-el/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Επιτυχής σύνδεση</string>
     <string name="init_geokrety_register_fail">Αποτυχία σύνδεσης</string>
     <string name="init_geokrety_description">Εξουσιοδοτείστε το c:geo να καταγράφει τα ανιχνεύσιμα GeoKrety στο GeoKrety.org.</string>
-    <string name="init_geokrety_cache_description">Το GeokretyMap.org παρέχει κρυφές πληροφορίες για τα ανιχνεύσιμα GeoKrety.\nΤα διαθέσιμα GeoKrety περιλαμβάνουν περισσότερες πληροφορίες όπως \'περιγραφή\' ή \'χαμένο\'.\n\nΤα δεδομένα δεν είναι σε πραγματικό χρόνο!\nΘέσεις: ~30min.\nΠεριγραφές: ~24h.\n.</string>
-    <string name="init_geokrety_cache">Χρήση GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Ταυτότητα χρήστη: %s</string>
     <string name="trackable_title_log_without_geocode">Δεν έχει δοθεί ο κωδικός ανιχνεύσιμου</string>
     <string name="trackable_log_without_geocode">Πρόκειται να στείλετε μια καταγραφή χωρίς κωδικό ανιχνεύσιμου. Καλό είναι να ορίσετε έναν. Θέλετε να τον προσθέσετε τώρα;</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -1493,8 +1493,6 @@ Nombre de archivo:%2$s</string>
     <string name="init_geokrety_register_ok">Se ha iniciado sesión</string>
     <string name="init_geokrety_register_fail">Fallo al iniciar sesión</string>
     <string name="init_geokrety_description">Autorizar a c:geo en GeoKrety.org para registrar rastreables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org proporciona datos almacenados para rastreables GeoKrety.\nLos datos disponibles contienen más información sobre GeoKrety como \'descripción\' o estado \'desaparecido\'.\n\n¡Los datos no se actualizan en vivo!\nPosiciones: ~30min.\nDescripciones: ~24h.</string>
-    <string name="init_geokrety_cache">Usar GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Usuario: %s</string>
     <string name="trackable_title_log_without_geocode">Geocódigo no establecido</string>
     <string name="trackable_log_without_geocode">Estás a punto de enviar un registro sin Geocódigo. Recomendamos establecer uno. ¿Quieres añadirlo ahora?</string>

--- a/main/res/values-fi/strings.xml
+++ b/main/res/values-fi/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Kirjautuminen onnistui</string>
     <string name="init_geokrety_register_fail">Kirjautuminen epäonnistui</string>
     <string name="init_geokrety_description">Valtuuta c:geo sivulla GeoKrety.org lokataksesi GeoKrety-reissaajia.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org tarjoaa välimuistissa olevaa tietoa GeoKrety-reissaajille.\nAineisto sisältää enemmän tietoa GeoKretyistä kuin \'kuvaus\' tai kadonnut-tila.\n\nAineisto ei ole reaaliaikaista!\nSijainnit: ~ 30 min. \nKuvaukset: ~ 24 h.</string>
-    <string name="init_geokrety_cache">Käytä GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Käyttäjätunnus: %s</string>
     <string name="trackable_title_log_without_geocode">Koodi puuttuu</string>
     <string name="trackable_log_without_geocode">Yrität lähettää lokin ilman Geokoodia. On suositeltavaa antaa koodi. Haluatko lisätä sen nyt?</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Connexion réussie</string>
     <string name="init_geokrety_register_fail">Erreur de connexion</string>
     <string name="init_geokrety_description">Autoriser c:geo à ouvrir une session sur GeoKrety.org pour les objets voyageurs GeoKrets.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org fournit des données pour les objets voyageurs GeoKrets.\nCes données sont par exemple la Description, la Position ou le Statut de l\'objet (disparu…).\n\nATTENTION : il ne s\'agit pas de données temps réel :\n- Les positions sont actualisées toutes les ~30 min.\n- Les descriptions sont actualisées toutes les ~24 h.</string>
-    <string name="init_geokrety_cache">Utiliser GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Utilisateur : %s</string>
     <string name="trackable_title_log_without_geocode">Géocode non renseigné</string>
     <string name="trackable_log_without_geocode">Vous êtes sur le point d\'envoyer une visite sans géocode. Il est fortement recommandé d\'indiquer un géocode. Voulez-vous l\'ajouter maintenant ?</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Sikeres bejelentkezés</string>
     <string name="init_geokrety_register_fail">Sikertelen bejelentkezés</string>
     <string name="init_geokrety_description">A c:geo hitelesítése a geokrety.org-on GeoKrety tárgyak logolásához.</string>
-    <string name="init_geokrety_cache_description">A geokretymap.org a GeoKrety utazókhoz biztosít adatokat.\nAz elérhető adatok több információt tartalmaznak, mint pl. leírás vagy státuszadatok.\n\nNem élő adatok!\nPoziciók: ~30 perc.\nLeírások: ~24 óra.</string>
-    <string name="init_geokrety_cache">GeoKretyMap.org használata</string>
     <string name="init_geokrety_userid">Felhasználói azonosító: %s</string>
     <string name="trackable_title_log_without_geocode">A geokód nincs beállítva</string>
     <string name="trackable_log_without_geocode">Geokód nélkül akarsz logot küldeni. Kérlek, adj meg egyet! Hozzá akarsz adni egyet most?</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Login effettuato</string>
     <string name="init_geokrety_register_fail">Login fallito</string>
     <string name="init_geokrety_description">Autorizza c:geo su GeoKrety.org per loggare trackables GeoKrety.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org fornisce dati su GeoKrety trackables.\nI dati disponibili contengono ulteriori informazioni di GeoKrety come \'Descrizione\' o stato di \'mancante\'.\n\nI dati non sono live! \nPosizioni: ~30 min\nDescrizioni: ~24 h.</string>
-    <string name="init_geokrety_cache">Use GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Id utente: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode non impostato</string>
     <string name="trackable_log_without_geocode">Stai per inviare un log senza un Geocode. Si consiglia di impostarne uno. Desideri aggiungerlo ora?</string>

--- a/main/res/values-ja/strings.xml
+++ b/main/res/values-ja/strings.xml
@@ -1476,8 +1476,6 @@ Google翻訳アプリで各言語の辞書をダウンロードしておけば�
     <string name="init_geokrety_register_ok">ログインに成功しました</string>
     <string name="init_geokrety_register_fail">ログインに失敗しました</string>
     <string name="init_geokrety_description">GeoKrety.org で c:geo を認証して、GeoKrety トラッカブルをログに記録します。</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org は GeoKrety トラッカブルのキャッシュされたデータを提供します。\n利用可能なデータには \'説明\' または \'行方不明\' 状態のようなより多くの GeoKrety 情報が含まれています。\n\nデータはライブではありません!\n位置: ~30 分。\n説明: ~24時間。</string>
-    <string name="init_geokrety_cache">GeoKretyMap.org を使用する</string>
     <string name="init_geokrety_userid">ユーザID: %s</string>
     <string name="trackable_title_log_without_geocode">ジオコードが設定されていません</string>
     <string name="trackable_log_without_geocode">ジオコードのないログを送信しようとしています。それは設定することが奨励されています。今すぐ追加しますか?</string>

--- a/main/res/values-ko/strings.xml
+++ b/main/res/values-ko/strings.xml
@@ -1475,8 +1475,6 @@
     <string name="init_geokrety_register_ok">로그인 성공</string>
     <string name="init_geokrety_register_fail">로그인 실패!</string>
     <string name="init_geokrety_description">GeoKrety 추적아이템을 로그하려면 GeoKrety.org에서 c:geo를 인증하세요.</string>
-    <string name="init_geokrety_cache_description">GeoKretyMap.org에는 과거의 GeoKrety 추적아이템정보가 들어있습니다.\n\'설명\'이나 \'분실\'등의 GeoKrety 정보가 포함되어 있을 수 있습니다.\n\n데이터가 실시간정보가 아닙니다!\n위치 : ~30분.\n설명 : 약 24시간.</string>
-    <string name="init_geokrety_cache">GeoKretyMap.org 사용하기</string>
     <string name="init_geokrety_userid">사용자 ID : %s</string>
     <string name="trackable_title_log_without_geocode">지오코드 설정되지 않음</string>
     <string name="trackable_log_without_geocode">지오코드 없이 로그를 보낼 예정입니다. 지오코드가 있는게 좋습니다. 추가하시겠습니까?</string>

--- a/main/res/values-lt/strings.xml
+++ b/main/res/values-lt/strings.xml
@@ -1526,8 +1526,6 @@
     <string name="init_geokrety_register_ok">Prisijungimas sėkmingas</string>
     <string name="init_geokrety_register_fail">Nepavyko prisijungti</string>
     <string name="init_geokrety_description">Leiskite c:geo prisijungti prie GeoKrety.org tam, kad galėtumėt registruoti GeoKrety keliauninkus.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org suteikia duomenis apie GeoKrety keliauninkus.\nPrieinami duomenys turi daugiau GeoKrety informacijos kaip \"aprašymas\" arba \"dingusių\" būsena.\n\nDuomenys nėra patys naujausi! \nPadėtis: ~ 30 min. \nAprašymai: ~ 24 h.</string>
-    <string name="init_geokrety_cache">Naudoti GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Vartotojo Id: %s</string>
     <string name="trackable_title_log_without_geocode">Nenurodytas geokodas</string>
     <string name="trackable_log_without_geocode">Jūs ruošiatės siųsti įrašą be Geo kodo. Reikia nurodyti Geo kodą. Ar norite pridėti jį dabar?</string>

--- a/main/res/values-lv/strings.xml
+++ b/main/res/values-lv/strings.xml
@@ -1509,8 +1509,6 @@
     <string name="init_geokrety_register_ok">Pieteikšanās izdevās</string>
     <string name="init_geokrety_register_fail">Pieteikšanās neizdevās</string>
     <string name="init_geokrety_description">Autorizē c:geo ar GeoKrety.org, lai reģistrētu GeoKrety ceļotāju.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org sniedz informāciju par GeoKrety ceļotājiem.\nPieejamie dati satur vairāk GeoKrety informācijas, tādus kā \"apraksts\", vai \"pazudis\" statuss.\n\nDati nav reāllaika! \nVietas: ~ 30 min. \nApraksti: ~ 24 h.</string>
-    <string name="init_geokrety_cache">Izmantot GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Lietotāja ID: %s</string>
     <string name="trackable_title_log_without_geocode">Nav ievadīts Geokods</string>
     <string name="trackable_log_without_geocode">Tiks nosūtīts ieraksts bez Geokoda. Ieteicams to ievadīt. Vai pievienot kodu?</string>

--- a/main/res/values-nb/strings.xml
+++ b/main/res/values-nb/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Du er logget inn</string>
     <string name="init_geokrety_register_fail">Innlogging mislyktes</string>
     <string name="init_geokrety_description">Autorisere c:geo med GeoKrety.org å logge GeoKrety-sporbare.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org gir offline datasett for GeoKrety-sporbare .\nTilgjengelige datasett inneholder mer GeoKrety-informasjon som \"beskrivelse\"- eller \"mangler\"-status.\n\nDataene er ikke live! \nPosisjoner: ~ 30 min. \nBeskrivelser: ~ 24 timer.</string>
-    <string name="init_geokrety_cache">Bruk GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Brukernavn: %s</string>
     <string name="trackable_title_log_without_geocode">Geokode ikke angitt</string>
     <string name="trackable_log_without_geocode">Du prøver å sende en logg uten en Geokode. Du oppfordres til å angi en. Vil du legge til en Geokode nå?</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Inloggen succesvol</string>
     <string name="init_geokrety_register_fail">Inloggen mislukt</string>
     <string name="init_geokrety_description">C:geo autoriseren om op GeoKrety.org GeoKrety trackables te loggen.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org voorziet in de data van GeoKrety trackables.\nBeschikbare data bevat overige GeoKrety informatie zoals \'beschrijving\' of \'ontbreekt\' status.\n\nData is niet live! \nPosities: ~ 30 min. \nOmschrijvingen: ~ 24 h.</string>
-    <string name="init_geokrety_cache">Gebruik GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Gebruikers-id: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode niet ingesteld</string>
     <string name="trackable_log_without_geocode">Je gaat een log zonder Geocode verzenden. Het wordt aanbevolen een Geocode in te stellen. Wil je nu een Geocode toevoegen?</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -1526,8 +1526,6 @@
     <string name="init_geokrety_register_ok">Zalogowano</string>
     <string name="init_geokrety_register_fail">Logowanie nieudane</string>
     <string name="init_geokrety_description">Zezwól c:geo na logowanie GeoKretów na GeoKrety.org.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org dostarcza informacji o GeoKretach.\nDostępne dane zawierają więcej informacji o GeoKretach takich jak \'opis\' lub status \'zagubiony\' .\n\nDane nie są aktualizowane na bieżąco!\nPozycja: ~30min.\nOpis: ~24h.</string>
-    <string name="init_geokrety_cache">Używaj GeoKretyMap.org</string>
     <string name="init_geokrety_userid">ID użytkownika: %s</string>
     <string name="trackable_title_log_without_geocode">Geokod nie jest ustawiony</string>
     <string name="trackable_log_without_geocode">Masz zamiar wysłać wpis bez Geokodu, ale nie jest to rekomendowane. Czy chciałbyś go dodać teraz?</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Inicio de sessão com sucesso</string>
     <string name="init_geokrety_register_fail">Falha ao iniciar sessão</string>
     <string name="init_geokrety_description">Autorize c:geo com GeoKrety.org para registar GeoKrety trackables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org fornece dados em cache para GeoKrety trackables.\nDados disponíveis contém mais informações GeoKrety como estado \'descrição\' ou \'perdido\'.\n\nDados não são ao vivo! \nPositions: ~ 30 min. \nDescriptions: ~ 24 h.</string>
-    <string name="init_geokrety_cache">Use GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Id de utilizador: %s</string>
     <string name="trackable_title_log_without_geocode">Código GC não definido</string>
     <string name="trackable_log_without_geocode">Está prestes a enviar um registo sem um código GC. É aconselhado a definir um. Quer adiciona-lo agora?</string>

--- a/main/res/values-ro/strings.xml
+++ b/main/res/values-ro/strings.xml
@@ -1509,8 +1509,6 @@
     <string name="init_geokrety_register_ok">Autentificare reuşită</string>
     <string name="init_geokrety_register_fail">Autentificare eșuată</string>
     <string name="init_geokrety_description">Autorizează c:geo la GeoKrety.org pentru a însemna obiecte călătoare de tip GeoKrety.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org furnizează informaţii recente despre obiecte călătoare GeoKrety.\nDatele disponibile conţin informaţii despre \'descriere\' sau \'statut\'.\n\nDatele furnizate nu sunt în timp real!\nPoziţia: ~30min.\nDescrierea: ~24ore.</string>
-    <string name="init_geokrety_cache">Utilizează GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Id utilizator: %s</string>
     <string name="trackable_title_log_without_geocode">Lipseşte geocodul</string>
     <string name="trackable_log_without_geocode">Eşti pe cale să trimiţi o însemnare fără Geocod. Te încurajăm să setezi unul. Vrei să adaugi acum?</string>

--- a/main/res/values-ru/strings.xml
+++ b/main/res/values-ru/strings.xml
@@ -1526,8 +1526,6 @@
     <string name="init_geokrety_register_ok">Вход успешен</string>
     <string name="init_geokrety_register_fail">Ошибка при входе</string>
     <string name="init_geokrety_description">Авторизуйте c:geo на GeoKrety.org, чтобы отмечать ГеоКротов.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org обеспечивает кешированные данные о ГеоКротах.\nДоступные данные содержат больше информации о ГеоКротах, такой как \"описание\" или статус \"потерян\".\n\nДанные не обновляются в реальном времени!\nМестоположение: ~30 мин.\nОписания: ~24ч.</string>
-    <string name="init_geokrety_cache">Использовать GeoKretyMap</string>
     <string name="init_geokrety_userid">Пользователь: %s</string>
     <string name="trackable_title_log_without_geocode">Код трекабла не установлен</string>
     <string name="trackable_log_without_geocode">Вы собираетесь отправить запись без геокода. Необходимо указать геокод. Добавить его сейчас?</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -1526,8 +1526,6 @@
     <string name="init_geokrety_register_ok">Prihlásenie úspešné</string>
     <string name="init_geokrety_register_fail">Prihlásenie zlyhalo</string>
     <string name="init_geokrety_description">Autorizovať c:geo na GeoKrety.org, aby ste mohli zalogovať trasovateľné predmety GeoKrety.</string>
-    <string name="init_geokrety_cache_description">GeoKretyMap.org poskytuje kešované dáta pre trasovateľné predmety GeoKrety.\nDostupné dáta obsahujú napríklad \'popis\' alebo \'chýbajúci\' status.\n\nDáta nemusia byť aktuálne!\nSúradnice: ~30min.\nPopis: ~24hod.</string>
-    <string name="init_geokrety_cache">Použiť GeoKretyMap.org</string>
     <string name="init_geokrety_userid">ID používateľa: %s</string>
     <string name="trackable_title_log_without_geocode">Geokód nie je nastavený</string>
     <string name="trackable_log_without_geocode">Chystáte sa odoslať log bez geokódu. Neodporúčame to. Chcete ho teraz pridať?</string>

--- a/main/res/values-sl/strings.xml
+++ b/main/res/values-sl/strings.xml
@@ -1526,8 +1526,6 @@
     <string name="init_geokrety_register_ok">Login successful</string>
     <string name="init_geokrety_register_fail">Login failed</string>
     <string name="init_geokrety_description">Authorize c:geo with GeoKrety.org to log GeoKrety trackables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org provides cached datas for GeoKrety trackables.\nAvailable datas contains more GeoKrety informations like \'description\' or \'missing\' status.\n\nDatas are not live!\nPositions: ~30min.\nDescriptions: ~24h.</string>
-    <string name="init_geokrety_cache">Use GeoKretyMap.org</string>
     <string name="init_geokrety_userid">User Id: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode not set</string>
     <string name="trackable_log_without_geocode">You\'re about to send a log without a Geocode. It\'s encouraged to set one. Do you want to add it now?</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Inloggning lyckades</string>
     <string name="init_geokrety_register_fail">Inloggningen misslyckades</string>
     <string name="init_geokrety_description">Tillåt c:geo att kommunicera med GeoKrety.org för att logga GeoKrety trackables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org tillhandahåller lagrad data för GeoKrety trackables.\nTillgänglig data innehåller mer GeoKrety information som \'beskrivning\' eller \'saknad\' status.\n\nData är inte live!\nPositioner: ~30min.\nBeskrivningar: ~24h.</string>
-    <string name="init_geokrety_cache">Använd GeoKretyMap.org</string>
     <string name="init_geokrety_userid">Användarid: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode saknas</string>
     <string name="trackable_log_without_geocode">Du kommer nu att skicka en logg utan en Geocode. Det rekommenderas att ange en. Vill du lägga till det nu?</string>

--- a/main/res/values-tr/strings.xml
+++ b/main/res/values-tr/strings.xml
@@ -1492,8 +1492,6 @@
     <string name="init_geokrety_register_ok">Giriş başarılı</string>
     <string name="init_geokrety_register_fail">Giriş başarısız</string>
     <string name="init_geokrety_description">c:geo\'yu GeoKrety trackable\'larını kayıt edebilmek için GeoKrety.org ile yetkilendir.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org, GeoKrety trackableları verilerini izlemeyi sağlar.\nMevcut veriler \'açıklama\' veya \'kayıp\' durumu gibi daha fazla GeoKrety bilgisi içerir.\n\n Veriler anlık değildir!\n Konum: ~30dk.\n Açıklama: ~24sa.</string>
-    <string name="init_geokrety_cache">GeoKretyMap.org\'u kullanın</string>
     <string name="init_geokrety_userid">Kullanıcı adı:%s</string>
     <string name="trackable_title_log_without_geocode">Geocode ayarlanmadı</string>
     <string name="trackable_log_without_geocode">Geocode\'u olmayan kayıt göndermek üzeresiniz. Bir tane ayarlamanız tavsiye edilir. Şimdi eklemek ister misiniz?</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1586,8 +1586,8 @@
     <string name="init_geokrety_register_ok">Login successful</string>
     <string name="init_geokrety_register_fail">Login failed</string>
     <string name="init_geokrety_description">Authorize c:geo with GeoKrety.org to log GeoKrety trackables.</string>
-    <string name="init_geokrety_cache_description">GeokretyMap.org provides cached datas for GeoKrety trackables.\nAvailable datas contains more GeoKrety informations like \'description\' or \'missing\' status.\n\nDatas are not live!\nPositions: ~30min.\nDescriptions: ~24h.</string>
-    <string name="init_geokrety_cache">Use GeoKretyMap.org</string>
+    <string name="init_geokrety_cache">Use api.GeoKrety.org</string>
+    <string name="init_geokrety_cache_description">api.Geokrety.org provides cached data for GeoKrety trackables.\nAvailable data contains more GeoKrety informations like \'description\' or \'missing\' status.\n\nData is not live!\nPosition: ~30min.\nDescription: ~24h.</string>
     <string name="init_geokrety_userid">User Id: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode not set</string>
     <string name="trackable_log_without_geocode">You\'re about to send a log without a Geocode. It\'s encouraged to set one. Do you want to add it now?</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1586,8 +1586,6 @@
     <string name="init_geokrety_register_ok">Login successful</string>
     <string name="init_geokrety_register_fail">Login failed</string>
     <string name="init_geokrety_description">Authorize c:geo with GeoKrety.org to log GeoKrety trackables.</string>
-    <string name="init_geokrety_cache">Use api.GeoKrety.org</string>
-    <string name="init_geokrety_cache_description">api.Geokrety.org provides cached data for GeoKrety trackables.\nAvailable data contains more GeoKrety informations like \'description\' or \'missing\' status.\n\nData is not live!\nPosition: ~30min.\nDescription: ~24h.</string>
     <string name="init_geokrety_userid">User Id: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode not set</string>
     <string name="trackable_log_without_geocode">You\'re about to send a log without a Geocode. It\'s encouraged to set one. Do you want to add it now?</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -377,18 +377,6 @@
                         android:key="@string/pref_fakekey_geokrety_authorization" />
                 </PreferenceCategory>
 
-                <PreferenceCategory android:title="@string/settings_advanced"
-                    android:layout="@layout/preference_category" >
-                    <CheckBoxPreference
-                        android:dependency="@string/pref_connectorGeokretyActive"
-                        android:defaultValue="true"
-                        android:key="@string/pref_geokrety_cache"
-                        android:title="@string/init_geokrety_cache" />
-                    <cgeo.geocaching.settings.TextPreference
-                        android:layout="@layout/text_preference"
-                        android:text="@string/init_geokrety_cache_description" />
-                </PreferenceCategory>
-
                 <PreferenceCategory android:title="@string/settings_information"
                     android:layout="@layout/preference_category" >
                     <Preference

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -59,7 +59,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
     private static final Pattern PATTERN_GK_CODE_EXTENDED = Pattern.compile("(GK[0-9A-F]{4,})|([1-9A-NP-Z]{6})");
     private static final String HOST = "geokrety.org";
     public static final String URL = "https://" + HOST;
-    private static final String URLPROXY = "https://api.geokrety.org";
+    private static final String URLPROXY = "https://api." + HOST;
 
     @Override
     @NonNull

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -59,7 +59,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
     private static final Pattern PATTERN_GK_CODE_EXTENDED = Pattern.compile("(GK[0-9A-F]{4,})|([1-9A-NP-Z]{6})");
     private static final String HOST = "geokrety.org";
     public static final String URL = "https://" + HOST;
-    private static final String URLPROXY = "https://api.geokretymap.org";
+    private static final String URLPROXY = "https://api.geokrety.org";
 
     @Override
     @NonNull
@@ -258,13 +258,13 @@ public class GeokretyConnector extends AbstractTrackableConnector {
     @Override
     @Nullable
     public String getTrackableCodeFromUrl(@NonNull final String url) {
-        // http://geokrety.org/konkret.php?id=38545
+        // https://geokrety.org/konkret.php?id=38545
         final String gkId = StringUtils.substringAfterLast(url, "konkret.php?id=");
         if (StringUtils.isNumeric(gkId)) {
             return geocode(Integer.parseInt(gkId));
         }
-        // http://geokretymap.org/38545
-        final String gkmapId = StringUtils.substringAfterLast(url, "geokretymap.org/");
+        // https://api.geokrety.org/38545
+        final String gkmapId = StringUtils.substringAfterLast(url, "api.geokrety.org/");
         if (StringUtils.isNumeric(gkmapId)) {
             return geocode(Integer.parseInt(gkmapId));
         }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -656,7 +656,7 @@ public class Settings {
     }
 
     public static boolean isGeokretyCacheActive() {
-        return getBoolean(R.string.pref_geokrety_cache, true);
+        return true;
     }
 
     static boolean hasGeokretyAuthorization() {


### PR DESCRIPTION
fix #7638 (api.geokretymap.org replaced by api.geokrety.org)

- change the references to api.geokretymap.org with api.geokrety.org
- change the text on the geokrety settings page
- AndroidManifest: remove the references to geokretymap.org, integrate into geokrety.org