### PR TITLE
Fix #7636 - Use https for send2cgeo

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -729,7 +729,7 @@
     <string name="init_sendToCgeo">Send to c:geo</string>
     <string name="settings_info_send2cgeo_title">Info on send2cgeo</string>
     <string name="init_sendToCgeo_name">Your device name</string>
-    <string name="init_sendToCgeo_description"><b>Send2cgeo</b> allows you to send caches to your Android device directly from geocaching.com using a special plugin for Firefox or Chrome. Before registering, please see <a href="http://send2.cgeo.org/">http://send2.cgeo.org/</a>. You only need to register if you want to use send2cgeo. c:geo will work normally without registering your device.</string>
+    <string name="init_sendToCgeo_description"><b>Send2cgeo</b> allows you to send caches to your Android device directly from geocaching.com using a special plugin for Firefox or Chrome. Before registering, please see <a href="https://send2.cgeo.org/">https://send2.cgeo.org/</a>. You only need to register if you want to use send2cgeo. c:geo will work normally without registering your device.</string>
     <string name="init_sendToCgeo_register">Request Registration</string>
     <string name="init_sendToCgeo_registering">Registering your device for send2cgeo…</string>
     <string name="init_sendToCgeo_register_ok">Registration successful. PIN code is %d. Use it on the c:geo website to connect this device to your browser.</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -29,8 +29,8 @@
     <string name="settings_gc_legal_note_url" translatable="false">https://www.geocaching.com/account/documents/termsofuse</string>
     <string name="settings_offline_maps_url" translatable="false">https://manual.cgeo.org/en/offline#offline_maps</string>
     <string name="settings_themes_url" translatable="false">https://manual.cgeo.org/en/offline#offline_maps</string>
-    <string name="settings_send2cgeo_url" translatable="false">http://send2.cgeo.org/</string>
-    <string name="settings_facebook_login_url" translatable="false">http://faq.cgeo.org/#facebook-login</string>
+    <string name="settings_send2cgeo_url" translatable="false">https://send2.cgeo.org/</string>
+    <string name="settings_facebook_login_url" translatable="false">https://faq.cgeo.org/#facebook-login</string>
 
     <!-- contributors -->
     <string name="contributors" translatable="false">

--- a/main/src/cgeo/geocaching/network/Send2CgeoDownloader.java
+++ b/main/src/cgeo/geocaching/network/Send2CgeoDownloader.java
@@ -42,7 +42,7 @@ public class Send2CgeoDownloader {
 
                 // Download new code
                 try {
-                    final Response responseFromWeb = Network.getRequest("http://send2.cgeo.org/read.html", params)
+                    final Response responseFromWeb = Network.getRequest("https://send2.cgeo.org/read.html", params)
                             .flatMap(Network.withSuccess).blockingGet();
 
                     final String response = Network.getResponseData(responseFromWeb);

--- a/main/src/cgeo/geocaching/settings/RegisterSend2CgeoPreference.java
+++ b/main/src/cgeo/geocaching/settings/RegisterSend2CgeoPreference.java
@@ -62,7 +62,7 @@ public class RegisterSend2CgeoPreference extends AbstractClickablePreference {
                         final Parameters params = new Parameters("name", nam, "code", cod);
 
                         try {
-                            final Response response = Network.getRequest("http://send2.cgeo.org/auth.html", params)
+                            final Response response = Network.getRequest("https://send2.cgeo.org/auth.html", params)
                                     .flatMap(Network.withSuccess).blockingGet();
 
                             final String[] strings = StringUtils.split(Network.getResponseData(response), ',');


### PR DESCRIPTION
I only changed the protocol, please double-check before merge if functional changes are needed, but I guess not.

Instead of adapting all translations I only changed the english string as I worked on the Github UI. Still this should invalidate the translations on Crowdin and trigger retranslation. 
If someone has a spare minute, feel free to change all other languages and push to the branch in my repo.
