### PR TITLE
set target SDK to 28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ buildScan {
  */
 
 ext {
-    supportLibraryVersion = '27.1.1'
+    supportLibraryVersion = '28.0.0'
 }
 
 subprojects {

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
     }
 
     sourceSets {

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -82,6 +82,9 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/maps_api2_key" />
 
+        <!-- required by Google Maps SDK version 16 and below if targeted to SDK 28 or above -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
+
         <!-- support also very wide screen devices. https://developer.android.com/guide/practices/screens_support.html#MaxAspectRatio -->
         <meta-data
             android:name="android.max_aspect"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -30,7 +30,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -18,7 +18,7 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     buildToolsVersion "28.0.3"
 

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -7,7 +7,7 @@ android {
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 27
+    targetSdkVersion 28
   }
 
   sourceSets.main {

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'android-library'
 android {
 
   // Define these properties in the gradle.properties file in the root project folder
-  compileSdkVersion 27
+  compileSdkVersion 28
 
   defaultConfig {
     minSdkVersion 16


### PR DESCRIPTION
Play store requires all existing apps to target SDK 28 to be still upgradeable beginning November 19 so let's start testing