### PR TITLE
extend cache popup's hint view by personal note

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2341,10 +2341,13 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         boolean hintButtonEnabled = false;
         if (null != showHintClickListener) {
             final String hint = cache.getHint();
-            if (!StringUtils.isEmpty(hint)) {
+            final boolean hintGiven = !StringUtils.isEmpty(hint);
+            final String personalNote = cache.getPersonalNote();
+            final boolean personalNoteGiven = !StringUtils.isEmpty(personalNote);
+            if (hintGiven || personalNoteGiven) {
                 hintButtonEnabled = true;
                 final TextView offlineHintText = ButterKnife.findById(view, R.id.offline_hint_text);
-                offlineHintText.setText(hint);
+                offlineHintText.setText((hintGiven ? hint + (personalNoteGiven ? "\r\n" : "") : "") + (personalNoteGiven ? personalNote : ""));
             }
         }
         final ImageButton offlineHint = ButterKnife.findById(view, R.id.offline_hint);


### PR DESCRIPTION
When pressing the cache popup's hint button: Do show the personal note as well (if given), not just the hint.