### PR TITLE
Revert "add horizontal progress spinner to maps (fix #7289)"

### DIFF
--- a/main/res/layout/map_google.xml
+++ b/main/res/layout/map_google.xml
@@ -38,9 +38,6 @@
             android:clickable="true"
             android:enabled="true"
             android:keepScreenOn="true" />
-
-        <include layout="@layout/map_progressbar" />
-
     </RelativeLayout>
 
 </LinearLayout>

--- a/main/res/layout/map_mapsforge.xml
+++ b/main/res/layout/map_mapsforge.xml
@@ -37,9 +37,6 @@
             android:clickable="true"
             android:enabled="true"
             android:keepScreenOn="true" />
-
-        <include layout="@layout/map_progressbar" />
-
     </RelativeLayout>
 
 </LinearLayout>

--- a/main/res/layout/map_mapsforge_v6.xml
+++ b/main/res/layout/map_mapsforge_v6.xml
@@ -60,9 +60,7 @@
             android:textSize="18sp"
             android:visibility="gone"
             android:maxLines="1" />
-
-        <include layout="@layout/map_progressbar" />
-
+        
     </RelativeLayout>
 
 </LinearLayout>

--- a/main/res/layout/map_progressbar.xml
+++ b/main/res/layout/map_progressbar.xml
@@ -1,9 +1,0 @@
-<ProgressBar
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:id="@+id/map_progressbar"
-	style="@style/map_progressbar"
-	android:layout_width="match_parent"
-	android:layout_height="wrap_content"
-	android:indeterminateOnly="true"
-	android:layout_alignParentTop="true"
-	/>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -389,12 +389,4 @@
         <item name="android:windowBackground">@drawable/border_straight_light</item>
         <item name="buttonBarButtonStyle">@style/button_borderless</item>
     </style>
-
-    <!-- map progressbar style -->
-    <style name="map_progressbar" parent="@style/Widget.AppCompat.ProgressBar.Horizontal">
-        <item name="android:height">8dp</item>
-        <item name="colorAccent">#007DD6</item>
-        <item name="android:padding">0dp</item>
-        <item name="android:layout_marginTop">-4dp</item>
-    </style>
 </resources>

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -6,9 +6,11 @@ import cgeo.geocaching.maps.routing.Routing;
 
 import android.app.Activity;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.Window;
 
 /**
  * Base class for the map activity. Delegates base class calls to the
@@ -32,6 +34,10 @@ public abstract class AbstractMap {
 
     public void onCreate(final Bundle savedInstanceState) {
         mapActivity.superOnCreate(savedInstanceState);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            mapActivity.getActivity().requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
+        }
+
         Routing.connect();
     }
 

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -162,7 +162,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
     private int detailTotal = 0;
     private int detailProgress = 0;
     private long detailProgressTime = 0L;
-    private ProgressBar spinner;
 
     // views
     private CheckBox myLocSwitch = null;
@@ -324,7 +323,13 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
             if (map == null) {
                 return;
             }
-            map.spinner.setVisibility(show ? View.VISIBLE : View.GONE);
+
+            final ProgressBar progress = ButterKnife.findById(map.activity, R.id.actionbar_progress);
+            if (progress != null) {
+                final int visibility = show ? View.VISIBLE : View.GONE;
+                progress.setVisibility(visibility);
+            }
+            map.activity.setProgressBarIndeterminateVisibility(show);
         }
 
     }
@@ -468,9 +473,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
             overlayPositionAndScale.setHistory(trailHistory);
         }
 
-        // prepare circular progress spinner
-        spinner = (ProgressBar) activity.findViewById(R.id.map_progressbar);
-        spinner.setVisibility(View.GONE);
 
         mapView.repaintRequired(null);
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -74,7 +74,6 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.ListAdapter;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import java.io.File;
@@ -137,7 +136,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
     private ProgressDialog waitDialog;
     private LoadDetails loadDetailsThread;
-    private ProgressBar spinner;
 
     private String themeSettingsPref = "";
 
@@ -200,10 +198,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
         setContentView(R.layout.map_mapsforge_v6);
         setTitle();
-
-        // prepare circular progress spinner
-        spinner = (ProgressBar) findViewById(R.id.map_progressbar);
-        spinner.setVisibility(View.GONE);
 
         // initialize map
         mapView = (MfMapView) findViewById(R.id.mfmapv5);
@@ -1146,7 +1140,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             if (map == null) {
                 return;
             }
-            map.spinner.setVisibility(show ? View.VISIBLE : View.GONE);
+            map.setProgressBarIndeterminateVisibility(show);
         }
 
     }


### PR DESCRIPTION
Reverts cgeo/cgeo#7639

Sorry, I reverted this as I was a bit fast with merging and overlooked, that it targeted the `release` branch.
While this is OK generally, I would like to have some more testing time with this one and rather like to have it on `master` only instead (also looking at the hopefully upcoming bugfix release for the OSM tile loading).

@moving-bits 
Can you target your PR to `master` please?
Sorry for the additional effort.