### PR TITLE
optionally calculate and display route length on map (fix #6017)

### DIFF
--- a/main/res/layout/map_mapsforge_v6.xml
+++ b/main/res/layout/map_mapsforge_v6.xml
@@ -43,23 +43,35 @@
             android:maxLines="1" />
         
         <TextView
-            android:id="@+id/distance"
+            android:id="@+id/distance1"
+            android:layout_marginTop="-8dp"
             android:layout_alignParentTop="true"
             android:layout_alignParentRight="true"
-            android:layout_marginTop="-8dp"
-            android:layout_marginRight="-8dp"
-            android:paddingTop="4dp"
             android:layout_width="100dp"
-            android:layout_height="30dp"
-            android:background="@drawable/icon_bcg"
-            android:ellipsize="end"
-            android:gravity="center_horizontal"
-            android:lines="1"
-            android:textColor="@color/text_icon"
-            android:textStyle="bold"
-            android:textSize="18sp"
-            android:visibility="gone"
-            android:maxLines="1" />
+            style="@style/map_distanceinfo" />
+
+        <TextView
+            android:id="@+id/distance1info"
+            android:layout_marginTop="-8dp"
+            android:layout_toLeftOf="@id/distance1"
+            android:layout_width="wrap_content"
+            style="@style/map_distanceinfo" />
+
+        <TextView
+            android:id="@+id/distance2"
+            android:layout_marginTop="0dp"
+            android:layout_below="@id/distance1"
+            android:layout_alignParentRight="true"
+            android:layout_width="100dp"
+            style="@style/map_distanceinfo" />
+
+        <TextView
+            android:id="@+id/distance2info"
+            android:layout_marginTop="0dp"
+            android:layout_below="@id/distance1info"
+            android:layout_toLeftOf="@id/distance2"
+            android:layout_width="wrap_content"
+            style="@style/map_distanceinfo" />
 
         <include layout="@layout/map_progressbar" />
 

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -80,6 +80,7 @@
     <string translatable="false" name="pref_renderthemepath">renderthemepath</string>
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
+    <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -596,6 +596,8 @@
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_brouterThreshold">Calculate route</string>
     <string name="init_brouterThreshold_description">Maximum distance up to which brouter helper app (if installed) will calculate a route.</string>
+    <string name="init_brouterShowBothDistances">Show straight distance</string>
+    <string name="init_summary_brouterShowBothDistances">If routing is active: Show the straight distance in addition to the calculated route length.</string>
     <string name="init_disabled">Exclude Disabled</string>
     <string name="init_summary_disabled">Exclude disabled caches</string>
     <string name="init_save_log_img">Save Images</string>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -397,4 +397,20 @@
         <item name="android:padding">0dp</item>
         <item name="android:layout_marginTop">-4dp</item>
     </style>
+
+    <!-- map distance info style -->
+    <style name="map_distanceinfo">
+        <item name="android:layout_marginRight">-8dp</item>
+        <item name="android:paddingTop">4dp</item>
+        <item name="android:layout_height">30dp</item>
+        <item name="android:background">@drawable/icon_bcg</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:gravity">center_horizontal</item>
+        <item name="android:lines">1</item>
+        <item name="android:textColor">@color/text_icon</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:visibility">gone</item>
+        <item name="android:maxLines">1</item>
+    </style>
 </resources>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -589,6 +589,11 @@
             <cgeo.geocaching.settings.BrouterThresholdPreference
                 android:key="@string/pref_brouterDistanceThreshold"
                 android:layout="@layout/preference_seekbar" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_brouterShowBothDistances"
+                android:summary="@string/init_summary_brouterShowBothDistances"
+                android:title="@string/init_brouterShowBothDistances" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"

--- a/main/src/cgeo/geocaching/maps/DirectionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/DirectionDrawer.java
@@ -19,16 +19,23 @@ import android.view.WindowManager;
 import java.util.ArrayList;
 
 public class DirectionDrawer {
+
     private Geopoint currentCoords;
     private final Geopoint destinationCoords;
     private final MapItemFactory mapItemFactory;
     private final float width;
 
     private Paint linePaint = null;
+    private PostRealDistance postRealDistance = null;
 
-    public DirectionDrawer(final Geopoint coords) {
+    public interface PostRealDistance {
+        void postRealDistance (float realDistance);
+    }
+
+    public DirectionDrawer(final Geopoint coords, final PostRealDistance postRealDistance) {
         this.destinationCoords = coords;
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
+        this.postRealDistance = postRealDistance;
 
         final DisplayMetrics metrics = new DisplayMetrics();
         final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
@@ -67,6 +74,15 @@ public class DirectionDrawer {
         }
 
         CanvasUtils.drawPath(pixelPoints, canvas, linePaint);
+
+        // calculate distance
+        if (null != postRealDistance && routingPoints.length > 1) {
+            float distance = 0.0f;
+            for (int i = 1; i < routingPoints.length; i++) {
+                distance += routingPoints[i - 1].distanceTo(routingPoints[i]);
+            }
+            postRealDistance.postRealDistance(distance);
+        }
     }
 
     private Point translateToPixels(final MapProjectionImpl projection, final Geopoint geopoint) {

--- a/main/src/cgeo/geocaching/maps/DistanceDrawer.java
+++ b/main/src/cgeo/geocaching/maps/DistanceDrawer.java
@@ -136,7 +136,9 @@ public class DistanceDrawer {
         );
 
         /* Paint distance */
-        canvas.drawText(Character.toString(symbol), boxX + 2 * boxPadding, textY + yDelta, paintText);
+        if (symbol != ' ') {
+            canvas.drawText(Character.toString(symbol), boxX + 2 * boxPadding, textY + yDelta, paintText);
+        }
         canvas.drawText(text, textX + 5 * boxPadding, textY + yDelta, paintText);
     }
 
@@ -144,10 +146,8 @@ public class DistanceDrawer {
         if (showBothDistances && realDistance != 0.0f && distance != realDistance) {
             setText(canvas, true, STRAIGHT_LINE_SYMBOL, distanceText);
             setText(canvas, false, WAVY_LINE_SYMBOL, Units.getDistanceFromKilometers(realDistance));
-        } else if (realDistance != 0.0f && distance != realDistance) {
-            setText(canvas, true, (char) WAVY_LINE_SYMBOL, Units.getDistanceFromKilometers(realDistance));
         } else {
-            setText(canvas, true, (char) STRAIGHT_LINE_SYMBOL, distanceText);
+            setText(canvas, true, ' ', realDistance != 0.0f && distance != realDistance ? Units.getDistanceFromKilometers(realDistance) : distanceText);
         }
     }
 }

--- a/main/src/cgeo/geocaching/maps/PositionAndScaleOverlay.java
+++ b/main/src/cgeo/geocaching/maps/PositionAndScaleOverlay.java
@@ -22,19 +22,19 @@ public class PositionAndScaleOverlay implements GeneralOverlay {
     DirectionDrawer directionDrawer = null;
     DistanceDrawer distanceDrawer = null;
 
-    public PositionAndScaleOverlay(final OverlayImpl ovlImpl, final MapViewImpl mapView, final Geopoint coords, final String geocode) {
+    public PositionAndScaleOverlay(final OverlayImpl ovlImpl, final MapViewImpl mapView, final Geopoint coords, final String geocode, final boolean showBothDistances) {
         this.ovlImpl = ovlImpl;
         positionDrawer = new PositionDrawer();
         scaleDrawer = new ScaleDrawer();
 
         if (coords != null) {
-            directionDrawer = new DirectionDrawer(coords);
-            distanceDrawer = new DistanceDrawer(mapView, coords);
+            directionDrawer = new DirectionDrawer(coords, realDistance -> distanceDrawer.setRealDistance(realDistance));
+            distanceDrawer = new DistanceDrawer(mapView, coords, showBothDistances);
         } else if (geocode != null) {
             final Viewport bounds = DataStore.getBounds(geocode);
             if (bounds != null) {
-                directionDrawer = new DirectionDrawer(bounds.center);
-                distanceDrawer = new DistanceDrawer(mapView, bounds.center);
+                directionDrawer = new DirectionDrawer(bounds.center, realDistance -> distanceDrawer.setRealDistance(realDistance));
+                distanceDrawer = new DistanceDrawer(mapView, bounds.center, showBothDistances);
             }
         }
     }

--- a/main/src/cgeo/geocaching/maps/google/v1/GoogleOverlay.java
+++ b/main/src/cgeo/geocaching/maps/google/v1/GoogleOverlay.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.maps.PositionAndScaleOverlay;
 import cgeo.geocaching.maps.interfaces.GeneralOverlay;
 import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OverlayImpl;
+import cgeo.geocaching.settings.Settings;
 
 import android.graphics.Canvas;
 
@@ -20,7 +21,7 @@ public class GoogleOverlay extends Overlay implements OverlayImpl {
     private final Lock lock = new ReentrantLock();
 
     public GoogleOverlay(final MapViewImpl mapView, final Geopoint coords, final String geocode) {
-        overlayBase = new PositionAndScaleOverlay(this, mapView, coords, geocode);
+        overlayBase = new PositionAndScaleOverlay(this, mapView, coords, geocode, Settings.isBrouterShowBothDistances());
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeOverlay.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.maps.PositionAndScaleOverlay;
 import cgeo.geocaching.maps.interfaces.GeneralOverlay;
 import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OverlayImpl;
+import cgeo.geocaching.settings.Settings;
 
 import android.graphics.Canvas;
 import android.graphics.Point;
@@ -21,7 +22,7 @@ public class MapsforgeOverlay extends Overlay implements OverlayImpl {
     private final Lock lock = new ReentrantLock();
 
     public MapsforgeOverlay(final MapViewImpl mapView, final Geopoint coords, final String geocode) {
-        overlayBase = new PositionAndScaleOverlay(this, mapView, coords, geocode);
+        overlayBase = new PositionAndScaleOverlay(this, mapView, coords, geocode, Settings.isBrouterShowBothDistances());
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
@@ -13,19 +13,36 @@ import butterknife.BindView;
 public class DistanceView {
 
     private Geopoint destinationCoords;
+    private float realDistance = 0.0f;
+    private boolean showBothDistances = false;
 
-    @BindView(R.id.distance) protected TextView distanceView;
+    private static final String STRAIGHT_LINE_SYMBOL = Character.toString((char) 0x007C);
+    private static final String WAVY_LINE_SYMBOL = Character.toString((char) 0x2307);
 
-    public DistanceView(final Geopoint destinationCoords, final TextView distanceView) {
+    @BindView(R.id.distance1info) protected TextView distance1InfoView;
+    @BindView(R.id.distance1) protected TextView distance1View;
+    @BindView(R.id.distance2info) protected TextView distance2InfoView;
+    @BindView(R.id.distance2) protected TextView distance2View;
 
-        this.distanceView = distanceView;
+    public DistanceView(final Geopoint destinationCoords, final TextView distance1InfoView, final TextView distance1View, final TextView distance2InfoView, final TextView distance2View, final boolean showBothDistances) {
+        this.distance1InfoView = distance1InfoView;
+        this.distance1View = distance1View;
+        this.distance2InfoView = distance2InfoView;
+        this.distance2View = distance2View;
+        this.showBothDistances = showBothDistances;
 
         setDestination(destinationCoords);
     }
 
     public void setDestination(final Geopoint coords) {
         destinationCoords = coords;
-        this.distanceView.setVisibility(destinationCoords != null ? View.VISIBLE : View.GONE);
+        realDistance = 0.0f;
+        this.distance1InfoView.setVisibility(destinationCoords != null ? View.VISIBLE : View.GONE);
+        this.distance1View.setVisibility(destinationCoords != null ? View.VISIBLE : View.GONE);
+    }
+
+    public void setRealDistance(final float realDistance) {
+        this.realDistance = realDistance;
     }
 
     public void setCoordinates(final Location coordinatesIn) {
@@ -34,8 +51,22 @@ public class DistanceView {
         }
 
         final Geopoint currentCoords = new Geopoint(coordinatesIn);
-
         final float distance = currentCoords.distanceTo(destinationCoords);
-        distanceView.setText(Units.getDistanceFromKilometers(distance));
+
+        final boolean bothViewsNeeded = showBothDistances && realDistance != 0.0f && distance != realDistance;
+        distance2InfoView.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
+        distance2View.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
+        if (bothViewsNeeded) {
+            distance1InfoView.setText(STRAIGHT_LINE_SYMBOL);
+            distance1View.setText(Units.getDistanceFromKilometers(distance));
+            distance2InfoView.setText(WAVY_LINE_SYMBOL);
+            distance2View.setText(Units.getDistanceFromKilometers(realDistance));
+        } else if (realDistance != 0.0f && distance != realDistance) {
+            distance1InfoView.setText(WAVY_LINE_SYMBOL);
+            distance1View.setText(Units.getDistanceFromKilometers(realDistance));
+        } else {
+            distance1InfoView.setText(STRAIGHT_LINE_SYMBOL);
+            distance1View.setText(Units.getDistanceFromKilometers(distance));
+        }
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
@@ -37,7 +37,6 @@ public class DistanceView {
     public void setDestination(final Geopoint coords) {
         destinationCoords = coords;
         realDistance = 0.0f;
-        this.distance1InfoView.setVisibility(destinationCoords != null ? View.VISIBLE : View.GONE);
         this.distance1View.setVisibility(destinationCoords != null ? View.VISIBLE : View.GONE);
     }
 
@@ -54,6 +53,7 @@ public class DistanceView {
         final float distance = currentCoords.distanceTo(destinationCoords);
 
         final boolean bothViewsNeeded = showBothDistances && realDistance != 0.0f && distance != realDistance;
+        distance1InfoView.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
         distance2InfoView.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
         distance2View.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
         if (bothViewsNeeded) {
@@ -61,12 +61,8 @@ public class DistanceView {
             distance1View.setText(Units.getDistanceFromKilometers(distance));
             distance2InfoView.setText(WAVY_LINE_SYMBOL);
             distance2View.setText(Units.getDistanceFromKilometers(realDistance));
-        } else if (realDistance != 0.0f && distance != realDistance) {
-            distance1InfoView.setText(WAVY_LINE_SYMBOL);
-            distance1View.setText(Units.getDistanceFromKilometers(realDistance));
         } else {
-            distance1InfoView.setText(STRAIGHT_LINE_SYMBOL);
-            distance1View.setText(Units.getDistanceFromKilometers(distance));
+            distance1View.setText(Units.getDistanceFromKilometers(realDistance != 0.0f && distance != realDistance ? realDistance : distance));
         }
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -735,7 +735,11 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 }
             }
         }
-        this.navigationLayer = new NavigationLayer(navTarget);
+        this.navigationLayer = new NavigationLayer(navTarget, realDistance -> {
+            if (null != this.distanceView) {
+                this.distanceView.setRealDistance(realDistance);
+            }
+        });
         this.mapView.getLayerManager().getLayers().add(this.navigationLayer);
 
         // TapHandler
@@ -763,7 +767,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         this.mapView.getLayerManager().getLayers().add(positionLayer);
 
         //Distance view
-        this.distanceView = new DistanceView(navTarget, (TextView) findViewById(R.id.distance));
+        this.distanceView = new DistanceView(navTarget, (TextView) findViewById(R.id.distance1info), (TextView) findViewById(R.id.distance1), (TextView) findViewById(R.id.distance2info), (TextView) findViewById(R.id.distance2), Settings.isBrouterShowBothDistances());
 
         //Target view
         this.targetView = new TargetView((TextView) findViewById(R.id.target), StringUtils.EMPTY, StringUtils.EMPTY);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -29,10 +29,16 @@ public class NavigationLayer extends Layer {
     private final float width;
 
     private Paint line = null;
+    private PostRealDistance postRealDistance = null;
 
-    public NavigationLayer(final Geopoint coords) {
+    public interface PostRealDistance {
+        void postRealDistance (float realDistance);
+    }
+
+    public NavigationLayer(final Geopoint coords, final PostRealDistance postRealDistance) {
 
         this.destinationCoords = coords;
+        this.postRealDistance = postRealDistance;
 
         final DisplayMetrics metrics = new DisplayMetrics();
         final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
@@ -60,6 +66,7 @@ public class NavigationLayer extends Layer {
             line.setStrokeWidth(width);
             line.setStyle(Style.STROKE);
             line.setColor(0xD0EB391E);
+            line.setTextSize(20);
         }
         final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
 
@@ -75,6 +82,15 @@ public class NavigationLayer extends Layer {
             final Pair<Integer, Integer> source = pixelPoints.get(i - 1);
             final Pair<Integer, Integer> destination = pixelPoints.get(i);
             canvas.drawLine(source.first, source.second, destination.first, destination.second, line);
+        }
+
+        // calculate distance
+        if (null != postRealDistance && routingPoints.length > 1) {
+            float distance = 0.0f;
+            for (int i = 1; i < routingPoints.length; i++) {
+                distance += routingPoints[i - 1].distanceTo(routingPoints[i]);
+            }
+            postRealDistance.postRealDistance(distance);
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -968,6 +968,14 @@ public class Settings {
         putInt(R.string.pref_brouterDistanceThreshold, threshold);
     }
 
+    public static boolean isBrouterShowBothDistances() {
+        return getBoolean(R.string.pref_brouterShowBothDistances, false);
+    }
+
+    static void setBrouterShowBothDistances(final boolean show) {
+        putBoolean(R.string.pref_brouterShowBothDistances, show);
+    }
+
     public static boolean isUseTwitter() {
         return getBoolean(R.string.pref_twitter, false);
     }


### PR DESCRIPTION
- calculate and display route length on map (in addition to direct distance) (optional) (fix #6017)
- add settings to enable/disable route length calculation and display

(implemented for GoogleMaps v1, Mapsforge v0.3 and NewMap)
