### PR TITLE
rebase settings using seekbar on new AbstractSeekbarPreference

### DIFF
--- a/main/res/layout/preference_seekbar.xml
+++ b/main/res/layout/preference_seekbar.xml
@@ -9,22 +9,29 @@
     android:paddingTop="8dp"
     tools:context=".settings.SettingsActivity" >
 
+    <TextView
+        android:id="@+id/preference_seekbar_label_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:gravity="left"/>
+
     <SeekBar
         android:id="@+id/preference_seekbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_weight="1"
-        android:paddingRight="8dp"
+        android:paddingRight="4dp"
         tools:progress="25"/>
 
     <TextView
         android:id="@+id/preference_seekbar_value_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_gravity="right"
         android:layout_weight="5"
-        android:gravity="center"
+        android:gravity="right"
         tools:text="25"/>
 
 </LinearLayout>

--- a/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
@@ -1,0 +1,109 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.TextView;
+
+import butterknife.ButterKnife;
+
+public abstract class AbstractSeekbarPreference extends Preference {
+
+    private TextView valueView;
+    private int minValue = 0;
+    private int maxValue = 100;
+    private int startValue = 0;
+    private String labelValue = "";
+
+    public AbstractSeekbarPreference(final Context context) {
+        super(context);
+        init();
+    }
+
+    public AbstractSeekbarPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public AbstractSeekbarPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+    }
+
+    protected void init() {
+        setPersistent(false);
+    }
+
+    protected String getValueString(final int progress) {
+        return String.valueOf(progress);
+    }
+
+    private boolean atLeastMin(final SeekBar seekBar, final int progress) {
+        if (progress < minValue) {
+            seekBar.setProgress(minValue);
+            return false;
+        }
+        return true;
+    }
+
+    // sets boundaries and initial value for seekbar
+    protected void configure(final int minValue, final int maxValue, final int startValue, final String labelValue) {
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.startValue = startValue;
+        this.labelValue = labelValue;
+    }
+
+    // method to store the final value
+    protected abstract void saveSetting(int progress);
+
+    @Override
+    protected View onCreateView(final ViewGroup parent) {
+        final View v = super.onCreateView(parent);
+
+        // get views
+        final SeekBar seekBar = ButterKnife.findById(v, R.id.preference_seekbar);
+        valueView = ButterKnife.findById(v, R.id.preference_seekbar_value_view);
+
+        // init seekbar
+        seekBar.setMax(maxValue);
+
+        // set initial value
+        final int threshold = startValue;
+        valueView.setText(getValueString(threshold));
+        seekBar.setProgress(threshold);
+
+        // set label (if given)
+        if (null != labelValue && !labelValue.isEmpty()) {
+            final TextView labelView = ButterKnife.findById(v, R.id.preference_seekbar_label_view);
+            labelView.setText(labelValue);
+        }
+
+        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
+                if (fromUser && atLeastMin(seekBar, progress)) {
+                    valueView.setText(getValueString(progress));
+                }
+            }
+            @Override
+            public void onStartTrackingTouch(final SeekBar seekBar) {
+                // abstract method needs to be implemented, but is not used here
+            }
+            @Override
+            public void onStopTrackingTouch(final SeekBar seekBar) {
+                if (atLeastMin(seekBar, seekBar.getProgress())) {
+                    saveSetting(seekBar.getProgress());
+                }
+            }
+        });
+
+        return v;
+    }
+}

--- a/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
+++ b/main/src/cgeo/geocaching/settings/BrouterThresholdPreference.java
@@ -1,94 +1,35 @@
 package cgeo.geocaching.settings;
 
-import cgeo.geocaching.R;
 import cgeo.geocaching.location.IConversion;
 
 import android.content.Context;
-import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
-import android.widget.TextView;
 
 import java.util.Locale;
 
-import butterknife.ButterKnife;
-
-public class BrouterThresholdPreference extends Preference {
-
-    private TextView valueView;
-
-    public BrouterThresholdPreference(final Context context) {
-        super(context);
-        init();
-    }
+public class BrouterThresholdPreference extends AbstractSeekbarPreference {
 
     public BrouterThresholdPreference(final Context context, final AttributeSet attrs) {
         super(context, attrs);
         init();
     }
 
-    public BrouterThresholdPreference(final Context context, final AttributeSet attrs, final int defStyle) {
-        super(context, attrs, defStyle);
-        init();
-    }
-
-    private void init() {
-        setPersistent(false);
-    }
-
-    private String getValueString(final int progress) {
+    protected String getValueString(final int progress) {
         return Settings.useImperialUnits()
             ? String.format(Locale.US, "%.1f mi", progress / IConversion.MILES_TO_KILOMETER)
-            : String.valueOf(progress) + " km"
+            : progress + " km"
         ;
     }
 
-    private boolean atLeastOne(final SeekBar seekBar, final int progress) {
-        if (progress < 1) {
-            seekBar.setProgress(1);
-            return false;
-        }
-        return true;
+    protected void saveSetting(final int progress) {
+        Settings.setBrouterThreshold(progress);
     }
 
     @Override
     protected View onCreateView(final ViewGroup parent) {
-        final View v = super.onCreateView(parent);
-
-        // get views
-        final SeekBar seekBar = ButterKnife.findById(v, R.id.preference_seekbar);
-        valueView = ButterKnife.findById(v, R.id.preference_seekbar_value_view);
-
-        // init seekbar
-        seekBar.setMax(Settings.BROUTER_THRESHOLD_MAX);
-
-        // set initial value
-        final int threshold = Settings.getBrouterThreshold();
-        valueView.setText(getValueString(threshold));
-        seekBar.setProgress(threshold);
-
-        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-                if (fromUser && atLeastOne(seekBar, progress)) {
-                    valueView.setText(getValueString(progress));
-                }
-            }
-            @Override
-            public void onStartTrackingTouch(final SeekBar seekBar) {
-                // abstract method needs to be implemented, but is not used here
-            }
-            @Override
-            public void onStopTrackingTouch(final SeekBar seekBar) {
-                if (atLeastOne(seekBar, seekBar.getProgress())) {
-                    Settings.setBrouterThreshold(seekBar.getProgress());
-                }
-            }
-        });
-
-        return v;
+        configure(1, Settings.BROUTER_THRESHOLD_MAX, Settings.getBrouterThreshold(), null);
+        return super.onCreateView(parent);
     }
 }

--- a/main/src/cgeo/geocaching/settings/WpThresholdPreference.java
+++ b/main/src/cgeo/geocaching/settings/WpThresholdPreference.java
@@ -1,74 +1,23 @@
 package cgeo.geocaching.settings;
 
-import cgeo.geocaching.R;
-
 import android.content.Context;
-import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
-import android.widget.TextView;
 
-import butterknife.ButterKnife;
-
-public class WpThresholdPreference extends Preference {
-
-    private TextView valueView;
-
-    public WpThresholdPreference(final Context context) {
-        super(context);
-        init();
-    }
+public class WpThresholdPreference extends AbstractSeekbarPreference {
 
     public WpThresholdPreference(final Context context, final AttributeSet attrs) {
         super(context, attrs);
-        init();
     }
 
-    public WpThresholdPreference(final Context context, final AttributeSet attrs, final int defStyle) {
-        super(context, attrs, defStyle);
-        init();
-    }
-
-    private void init() {
-        setPersistent(false);
+    protected void saveSetting(final int progress) {
+        Settings.setShowWaypointsThreshold(progress);
     }
 
     @Override
     protected View onCreateView(final ViewGroup parent) {
-        final View v = super.onCreateView(parent);
-
-        // get views
-        final SeekBar seekBar = ButterKnife.findById(v, R.id.preference_seekbar);
-        valueView = ButterKnife.findById(v, R.id.preference_seekbar_value_view);
-
-        // init seekbar
-        seekBar.setMax(Settings.SHOW_WP_THRESHOLD_MAX);
-
-        // set initial value
-        final int threshold = Settings.getWayPointsThreshold();
-        valueView.setText(String.valueOf(threshold));
-        seekBar.setProgress(threshold);
-
-        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-                if (fromUser) {
-                    valueView.setText(String.valueOf(progress));
-                }
-            }
-            @Override
-            public void onStartTrackingTouch(final SeekBar seekBar) {
-                // abstract method needs to be implemented, but is not used here
-            }
-            @Override
-            public void onStopTrackingTouch(final SeekBar seekBar) {
-                Settings.setShowWaypointsThreshold(seekBar.getProgress());
-            }
-        });
-
-        return v;
+        configure(0, Settings.SHOW_WP_THRESHOLD_MAX, Settings.getWayPointsThreshold(), null);
+        return super.onCreateView(parent);
     }
 }


### PR DESCRIPTION
Extract common functions of BrouterThresholdPreference and WpThresholdPreference to a new AbstractSeekbarPreference and rebase the two on it.

This was actually part of PR 7625, in which a new nonlinear seekbar based on AbstractSeekbarPreference was introduced. Pushing this as separate change, as it is not necessarily bound to PR 7625 and PR 7625 needs to be rethought.