### PR TITLE
optimize GeokretyConnector

### DIFF
--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -145,7 +145,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
                     URL + "/export2.php" + "?gkid=" + gkid,
             };
             InputStream response = null;
-            for (String urlDetails : gkUlrs) {
+            for (final String urlDetails : gkUlrs) {
                 response = Network.getResponseStream(Network.getRequest(urlDetails));
                 if (response != null) {
                     break;
@@ -185,7 +185,7 @@ public class GeokretyConnector extends AbstractTrackableConnector {
                     URL +  "/export2.php?wpt=" + geocodeEncoded,
             };
             InputStream response = null;
-            for (String urlDetails : gkUlrs) {
+            for (final String urlDetails : gkUlrs) {
                 response = Network.getResponseStream(Network.getRequest(urlDetails));
                 if (response != null) {
                     break;

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -655,10 +655,6 @@ public class Settings {
         return getBoolean(R.string.pref_connectorGeokretyActive, false);
     }
 
-    public static boolean isGeokretyCacheActive() {
-        return true;
-    }
-
     static boolean hasGeokretyAuthorization() {
         return StringUtils.isNotBlank(getGeokretySecId());
     }

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyConnectorTest.java
@@ -38,6 +38,9 @@ public class GeokretyConnectorTest extends AbstractResourceInstrumentationTestCa
         assertThat(getConnector().getTrackableCodeFromUrl("https://www.geokrety.org/konkret.php?id=46464")).isEqualTo("GKB580");
         assertThat(getConnector().getTrackableCodeFromUrl("http://geokrety.org/konkret.php?id=46465")).isEqualTo("GKB581");
         assertThat(getConnector().getTrackableCodeFromUrl("https://geokrety.org/konkret.php?id=46465")).isEqualTo("GKB581");
+
+        assertThat(getConnector().getTrackableCodeFromUrl("https://api.geokrety.org/gk/46464")).isEqualTo("GKB580");
+        assertThat(getConnector().getTrackableCodeFromUrl("https://api.geokrety.org/gk/46464/details")).isEqualTo("GKB580");
     }
 
     public static void testGeocode() throws Exception {


### PR DESCRIPTION
fix #7615 (replace deprecated GKM endpoint by new one)

GeokretyConnector
- getUrlCache() removed
  - not more used
- searchTrackable()
  - add test
  - replace GKM export-details.php by new one
  - GK export-details.php as fallback
- searchTrackables()
  - replace GKM export2.php by new one
  - GK export2.php as fallback
- getTrackableCodeFromUrl()
  - finetuning the API call
- getGeocodeFromTrackingCode()
  - replace GKM nr2id.php by new one
- some comment add/change/remove

GeokretyConnectorTest
- add tests for getTrackableCodeFromUrl()

Settings
- remove isGeokretyCacheActive()
  - not more used
