### PR TITLE
make map trail color configurable (fix #7660)

### DIFF
--- a/main/res/values/arrays.xml
+++ b/main/res/values/arrays.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="trailcolors">
+        <item>@string/color_grey</item>
+        <item>@string/color_blue</item>
+        <item>@string/color_green</item>
+    </string-array>
+
+    <string-array name="trailcolorValues">
+        <item>@string/pref_value_grey</item>
+        <item>@string/pref_value_blue</item>
+        <item>@string/pref_value_green</item>
+    </string-array>
+
+</resources>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -82,6 +82,7 @@
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
     <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
+    <string translatable="false" name="pref_trailcolor">trailcolor</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>
     <string translatable="false" name="pref_defaultNavigationTool2">defaultNavigationTool2</string>
@@ -220,4 +221,8 @@
     <string translatable="false" name="pref_map_direction">map_direction</string>
     <string translatable="false" name="pref_map_routing">map_routing</string>
     <string translatable="false" name="pref_theme_menu">theme_menu</string>
+
+    <string translatable="false" name="pref_value_blue">blue</string>
+    <string translatable="false" name="pref_value_green">green</string>
+    <string translatable="false" name="pref_value_grey">grey</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1660,4 +1660,9 @@
     <string name="ask_again">Ask me again</string>
     <string name="location_permission_request_explanation">c:geo needs access to the GPS on your device to locate your position and calculate distance and direction to geocaches. It cannot be used without this permission.</string>
     <string name="storage_permission_request_explanation">c:geo will write data onto your phone storage or SD card as soon as you save geocaches for offline use. Furthermore c:geo will use your phone storage for import and export of files and reading of offline maps. It cannot be used without this permission.</string>
+
+    <!-- colors -->
+    <string name="color_blue">blue</string>
+    <string name="color_green">green</string>
+    <string name="color_grey">grey</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1662,7 +1662,7 @@
     <string name="storage_permission_request_explanation">c:geo will write data onto your phone storage or SD card as soon as you save geocaches for offline use. Furthermore c:geo will use your phone storage for import and export of files and reading of offline maps. It cannot be used without this permission.</string>
 
     <!-- colors -->
-    <string name="color_blue">blue</string>
-    <string name="color_green">green</string>
-    <string name="color_grey">grey</string>
+    <string name="color_blue">Blue</string>
+    <string name="color_green">Green</string>
+    <string name="color_grey">Grey</string>
 </resources>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -582,6 +582,13 @@
                 android:key="@string/pref_maptrail"
                 android:summary="@string/init_summary_maptrail"
                 android:title="@string/init_maptrail" />
+            <ListPreference
+                android:title="Trail color"
+                android:summary="%s"
+                android:key="@string/pref_trailcolor"
+                android:defaultValue="@string/pref_value_grey"
+                android:entries="@array/trailcolors"
+                android:entryValues="@array/trailcolorValues" />
             <Preference
                 android:selectable="false"
                 android:summary="@string/init_brouterThreshold_description"

--- a/main/src/cgeo/geocaching/maps/PositionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/PositionDrawer.java
@@ -33,6 +33,7 @@ public class PositionDrawer {
     private Paint accuracyCircle = null;
     private Paint historyLine = null;
     private Paint historyLineShadow = null;
+    private final int trailColor;
     private final Point center = new Point();
     private final Point left = new Point();
     private Bitmap arrow = null;
@@ -45,6 +46,7 @@ public class PositionDrawer {
 
     public PositionDrawer() {
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
+        trailColor = Settings.getTrailColor();
     }
 
     void drawPosition(final Canvas canvas, final MapProjectionImpl projection) {
@@ -69,7 +71,7 @@ public class PositionDrawer {
             historyLineShadow = new Paint();
             historyLineShadow.setAntiAlias(true);
             historyLineShadow.setStrokeWidth(7.0f);
-            historyLineShadow.setColor(0x66000000);
+            historyLineShadow.setColor(trailColor);
         }
 
         if (setfil == null) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -27,12 +27,14 @@ public class HistoryLayer extends Layer {
     private Location coordinates;
     private Paint historyLine;
     private Paint historyLineShadow;
+    private final int trailColor;
 
     public HistoryLayer(final ArrayList<Location> locationHistory) {
         super();
         if (locationHistory != null) {
             positionHistory.setHistory(locationHistory);
         }
+        trailColor = Settings.getTrailColor();
     }
 
     public void reset() {
@@ -54,7 +56,7 @@ public class HistoryLayer extends Layer {
         if (historyLineShadow == null) {
             historyLineShadow = AndroidGraphicFactory.INSTANCE.createPaint();
             historyLineShadow.setStrokeWidth(7.0f);
-            historyLineShadow.setColor(0x66000000);
+            historyLineShadow.setColor(trailColor);
         }
 
         positionHistory.rememberTrailPosition(coordinates);

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -748,6 +748,19 @@ public class Settings {
         putBoolean(R.string.pref_maptrail, showTrail);
     }
 
+    public static int getTrailColor() {
+        final Context baseContext = CgeoApplication.getInstance().getBaseContext();
+        final String defaultValue = baseContext.getString(R.string.pref_value_grey);
+        final String trailColor = getString(R.string.pref_trailcolor, defaultValue);
+        if (trailColor.equals(baseContext.getString(R.string.pref_value_blue))) {
+            return 0xff0000dd;
+        } else if (trailColor.equals(baseContext.getString(R.string.pref_value_green))) {
+            return 0xff006b00;
+        } else {
+            return 0x66000000;
+        }
+    }
+
     public static boolean isDotMode() {
         return getBoolean(R.string.pref_dot_mode, false);
     }


### PR DESCRIPTION
make map trail color configurable (fix #7660)

map view:
![image](https://user-images.githubusercontent.com/3754370/59824544-b6bc8700-9331-11e9-987e-18c2d20fc288.png)

settings menu: (Map => trail color)
![image](https://user-images.githubusercontent.com/3754370/59824565-ca67ed80-9331-11e9-8c1d-92104f047426.png)

select one of the predefined colors: (grey is default)
![image](https://user-images.githubusercontent.com/3754370/59824581-d81d7300-9331-11e9-9060-465e368ff2d6.png)
