### PR TITLE
proximity notifications

### DIFF
--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -17,12 +17,6 @@
         app:showAsAction="ifRoom">
     </item>
     <item
-        android:id="@+id/menu_tts_toggle"
-        android:icon="@drawable/ic_menu_start_conversation"
-        android:title="@string/tts_toggle"
-        app:showAsAction="ifRoom">
-    </item>
-    <item
         android:id="@+id/menu_log_visit_offline"
         android:icon="@drawable/ic_menu_edit"
         android:title="@string/cache_menu_visit_offline"
@@ -34,6 +28,12 @@
         android:icon="@drawable/ic_menu_edit"
         android:title="@string/cache_menu_visit"
         android:visible="false"
+        app:showAsAction="ifRoom">
+    </item>
+    <item
+        android:id="@+id/menu_tts_toggle"
+        android:icon="@drawable/ic_menu_start_conversation"
+        android:title="@string/tts_toggle"
         app:showAsAction="ifRoom">
     </item>
     <item

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -81,6 +81,8 @@
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
     <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
+    <string translatable="false" name="pref_proximityNotificationGeneral">pref_proximityNotificationGeneral</string>
+    <string translatable="false" name="pref_proximityNotificationSpecific">pref_proximityNotificationSpecific</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -83,6 +83,8 @@
     <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
     <string translatable="false" name="pref_proximityNotificationGeneral">pref_proximityNotificationGeneral</string>
     <string translatable="false" name="pref_proximityNotificationSpecific">pref_proximityNotificationSpecific</string>
+    <string translatable="false" name="pref_proximityDistanceFar">pref_proximityDistanceFar</string>
+    <string translatable="false" name="pref_proximityDistanceNear">pref_proximityDistanceNear</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -728,7 +728,7 @@
     <string name="init_proximityNotificationGeneral">General proximity notification</string>
     <string name="init_summary_proximityNotificationGeneral">Play a single notification, if any cache or waypoint currently visible on the map is closer than distance 1.</string>
     <string name="init_proximityNotificationSpecific">Specific proximity notification</string>
-    <string name="init_summary_proximityNotificationSpecific">Play a notification, if the selected cache or waypoint is closer than distance 1 (farther away) or distance 2 (closer).</string>
+    <string name="init_summary_proximityNotificationSpecific">Play a notification, if the selected cache or waypoint is closer than distance 1 (farther away) or distance 2 (closer). Uses different tones for the two distances.</string>
 
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -723,6 +723,13 @@
     <string name="init_mfbeta">Mapsforge beta as default</string>
     <string name="init_mfbeta_description">The current release contains a beta version of our new Mapsforge map as an experimental feature. This new map can be activated here as default for the live and list maps.</string>
 
+    <!-- proximity notification -->
+    <string name="settings_title_proximityNotification">Proximity notification</string>
+    <string name="init_proximityNotificationGeneral">General proximity notification</string>
+    <string name="init_summary_proximityNotificationGeneral">Play a single notification, if any cache or waypoint currently visible on the map is closer than distance 1.</string>
+    <string name="init_proximityNotificationSpecific">Specific proximity notification</string>
+    <string name="init_summary_proximityNotificationSpecific">Play a notification, if the selected cache or waypoint is closer than distance 1 (farther away) or distance 2 (closer).</string>
+
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -596,6 +596,21 @@
                 android:title="@string/init_brouterShowBothDistances" />
         </PreferenceCategory>
 
+        <PreferenceCategory android:title="@string/settings_title_proximityNotification"
+            android:layout="@layout/preference_category" >
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_proximityNotificationGeneral"
+                android:summary="@string/init_summary_proximityNotificationGeneral"
+                android:title="@string/init_proximityNotificationGeneral" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_proximityNotificationSpecific"
+                android:summary="@string/init_summary_proximityNotificationSpecific"
+                android:title="@string/init_proximityNotificationSpecific" />
+            <!-- todo: seekbar preference for distances, currently using mockup -->
+        </PreferenceCategory>
+
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"
             android:layout="@layout/preference_category" >
             <cgeo.geocaching.settings.TextPreference

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -603,12 +603,17 @@
                 android:key="@string/pref_proximityNotificationGeneral"
                 android:summary="@string/init_summary_proximityNotificationGeneral"
                 android:title="@string/init_proximityNotificationGeneral" />
+            <cgeo.geocaching.settings.ProximityFarPreference
+                android:key="@string/pref_proximityDistanceFar"
+                android:layout="@layout/preference_seekbar" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="@string/pref_proximityNotificationSpecific"
                 android:summary="@string/init_summary_proximityNotificationSpecific"
                 android:title="@string/init_proximityNotificationSpecific" />
-            <!-- todo: seekbar preference for distances, currently using mockup -->
+            <cgeo.geocaching.settings.ProximityNearPreference
+                android:key="@string/pref_proximityDistanceNear"
+                android:layout="@layout/preference_seekbar" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"

--- a/main/src/cgeo/geocaching/AbstractDialogFragmentWithProximityNotification.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragmentWithProximityNotification.java
@@ -1,0 +1,24 @@
+package cgeo.geocaching;
+
+import cgeo.geocaching.location.ProximityNotificationByCoords;
+import cgeo.geocaching.sensors.GeoData;
+
+import android.os.Bundle;
+
+public abstract class AbstractDialogFragmentWithProximityNotification extends AbstractDialogFragment {
+    protected ProximityNotificationByCoords proximityNotification = null;
+
+    @Override
+    protected void onUpdateGeoData(final GeoData geo) {
+        super.onUpdateGeoData(geo);
+        if (null != proximityNotification) {
+            proximityNotification.onUpdateGeoData(geo);
+        }
+    }
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        proximityNotification = new ProximityNotificationByCoords();
+    }
+}

--- a/main/src/cgeo/geocaching/AbstractDialogFragmentWithProximityNotification.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragmentWithProximityNotification.java
@@ -2,6 +2,7 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.location.ProximityNotificationByCoords;
 import cgeo.geocaching.sensors.GeoData;
+import cgeo.geocaching.settings.Settings;
 
 import android.os.Bundle;
 
@@ -19,6 +20,6 @@ public abstract class AbstractDialogFragmentWithProximityNotification extends Ab
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        proximityNotification = new ProximityNotificationByCoords();
+        proximityNotification = Settings.isSpecificProximityNotificationActive() ? new ProximityNotificationByCoords() : null;
     }
 }

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -37,7 +37,7 @@ import butterknife.ButterKnife;
 import io.reactivex.schedulers.Schedulers;
 import org.apache.commons.lang3.StringUtils;
 
-public class CachePopupFragment extends AbstractDialogFragment {
+public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotification {
     private final Progress progress = new Progress();
 
     public static DialogFragment newInstance(final String geocode) {
@@ -110,6 +110,7 @@ public class CachePopupFragment extends AbstractDialogFragment {
     @Override
     protected void init() {
         super.init();
+        proximityNotification.setReferencePoint(cache.getCoords());
 
         try {
             if (StringUtils.isNotBlank(cache.getName())) {

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -110,7 +110,9 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
     @Override
     protected void init() {
         super.init();
-        proximityNotification.setReferencePoint(cache.getCoords());
+        if (null != proximityNotification) {
+            proximityNotification.setReferencePoint(cache.getCoords());
+        }
 
         try {
             if (StringUtils.isNotBlank(cache.getName())) {

--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.ProximityNotificationByCoords;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.maps.DefaultMap;
@@ -67,6 +68,7 @@ public class CompassActivity extends AbstractActionBarActivity {
     private Geopoint dstCoords = null;
     private float cacheHeading = 0;
     private String description;
+    private ProximityNotificationByCoords proximityNotification = null;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -79,6 +81,9 @@ public class CompassActivity extends AbstractActionBarActivity {
             finish();
             return;
         }
+
+        // prepare proximity notification
+        proximityNotification = new ProximityNotificationByCoords();
 
         // cache must exist, except for "any point navigation"
         final String geocode = extras.getString(Intents.EXTRA_GEOCODE);
@@ -261,6 +266,9 @@ public class CompassActivity extends AbstractActionBarActivity {
 
     private void setDestCoords(final Geopoint coords) {
         dstCoords = coords;
+        if (null != proximityNotification) {
+            proximityNotification.setReferencePoint(coords);
+        }
         if (dstCoords == null) {
             return;
         }
@@ -316,6 +324,10 @@ public class CompassActivity extends AbstractActionBarActivity {
                 updateDistanceInfo(geo);
 
                 updateNorthHeading(AngleUtils.getDirectionNow(dir));
+
+                if (null != proximityNotification) {
+                    proximityNotification.onUpdateGeoData(geo);
+                }
             } catch (final RuntimeException e) {
                 Log.w("Failed to update location", e);
             }

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -27,7 +27,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import org.apache.commons.lang3.StringUtils;
 
-public class WaypointPopupFragment extends AbstractDialogFragment {
+public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNotification {
     @BindView(R.id.actionbar_title) protected TextView actionBarTitle;
     @BindView(R.id.waypoint_details_list) protected LinearLayout waypointDetailsLayout;
     @BindView(R.id.edit) protected Button buttonEdit;
@@ -54,6 +54,7 @@ public class WaypointPopupFragment extends AbstractDialogFragment {
 
     @Override
     protected void onUpdateGeoData(final GeoData geo) {
+        super.onUpdateGeoData(geo);
         if (waypoint != null) {
             final Geopoint coordinates = waypoint.getCoords();
             if (coordinates != null) {
@@ -68,6 +69,7 @@ public class WaypointPopupFragment extends AbstractDialogFragment {
         super.init();
 
         waypoint = DataStore.loadWaypoint(waypointId);
+        proximityNotification.setReferencePoint(waypoint.getCoords());
 
         if (waypoint == null) {
             Log.e("WaypointPopupFragment.init: unable to get waypoint " + waypointId);

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -69,7 +69,9 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
         super.init();
 
         waypoint = DataStore.loadWaypoint(waypointId);
-        proximityNotification.setReferencePoint(waypoint.getCoords());
+        if (null != proximityNotification) {
+            proximityNotification.setReferencePoint(waypoint.getCoords());
+        }
 
         if (waypoint == null) {
             Log.e("WaypointPopupFragment.init: unable to get waypoint " + waypointId);

--- a/main/src/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotification.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.location;
 
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.Log;
 
 import android.media.AudioManager;
 import android.media.ToneGenerator;
@@ -54,8 +53,6 @@ public class ProximityNotification {
     }
 
     public void checkDistance (final int distance) {
-        int tone = TONE_NONE;
-
         // no precise distances
         if (distance > Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE) {
             return;
@@ -72,15 +69,14 @@ public class ProximityNotification {
         }
 
         // check if tone needs to be played
+        int tone = TONE_NONE;
         final long currentTimestamp = System.currentTimeMillis();
         if (twoDistances && distance <= distanceNear) {
             if ((lastTone != TONE_NEAR) || (repeatedSignal && (currentTimestamp - lastTimestamp) > MIN_TIME_DELTA_NEAR)) {
                 tone = TONE_NEAR;
             }
-        } else if (distance <= distanceFar) {
-            if ((lastTone != TONE_FAR) || (repeatedSignal && (currentTimestamp - lastTimestamp) > MIN_TIME_DELTA_FAR)) {
-                tone = TONE_FAR;
-            }
+        } else if (distance <= distanceFar && ((lastTone != TONE_FAR) || (repeatedSignal && (currentTimestamp - lastTimestamp) > MIN_TIME_DELTA_FAR))) {
+            tone = TONE_FAR;
         }
 
         // play tone if necessary

--- a/main/src/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotification.java
@@ -1,0 +1,99 @@
+package cgeo.geocaching.location;
+
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.Log;
+
+import android.media.AudioManager;
+import android.media.ToneGenerator;
+import android.os.Handler;
+import android.os.Looper;
+
+public class ProximityNotification {
+
+    // tones
+    protected static final int TONE_NONE = 0;
+    protected static final int TONE_FAR = ToneGenerator.TONE_PROP_BEEP;
+    protected static final int TONE_NEAR = ToneGenerator.TONE_PROP_BEEP2;
+
+    // minimum increase in distance before distance gets reset
+    protected static final long MIN_DISTANCE_DELTA = 10;
+
+    // minimum time diff in ms (if repeatedSignal is enabled)
+    protected static final long MIN_TIME_DELTA_FAR = 10000;
+    protected static final long MIN_TIME_DELTA_NEAR = 5000;
+
+    // config options - get initialized in constructor
+    protected int distanceFar;
+    protected int distanceNear;
+    protected boolean twoDistances;
+    protected boolean repeatedSignal;
+
+    // temp values - get initialized in resetValues()
+    protected int lastDistance;
+    protected long lastTimestamp;
+    protected int lastTone;
+
+    public ProximityNotification(final boolean twoDistances, final boolean repeatedSignal) {
+        distanceFar = Settings.getProximityNotificationThreshold(true);
+        if (distanceFar < 1) {
+            distanceFar = Settings.PROXIMITY_NOTIFICATION_DISTANCE_FAR;
+        }
+        distanceNear = Settings.getProximityNotificationThreshold(false);
+        if (distanceNear < 1) {
+            distanceNear = Settings.PROXIMITY_NOTIFICATION_DISTANCE_NEAR;
+        }
+        this.twoDistances = twoDistances;
+        this.repeatedSignal = repeatedSignal;
+        resetValues();
+    }
+
+    private void resetValues() {
+        lastDistance = Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE + 1;
+        lastTimestamp = System.currentTimeMillis();
+        lastTone = TONE_NONE;
+    }
+
+    public void checkDistance (final int distance) {
+        int tone = TONE_NONE;
+
+        // no precise distances
+        if (distance > Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE) {
+            return;
+        }
+        if (lastDistance > Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE) {
+            lastDistance = distance;
+        }
+
+        // are we disapproaching our target?
+        if (distance - lastDistance > MIN_DISTANCE_DELTA) {
+            resetValues();
+            lastDistance = distance;
+            return;
+        }
+
+        // check if tone needs to be played
+        final long currentTimestamp = System.currentTimeMillis();
+        if (twoDistances && distance <= distanceNear) {
+            if ((lastTone != TONE_NEAR) || (repeatedSignal && (currentTimestamp - lastTimestamp) > MIN_TIME_DELTA_NEAR)) {
+                tone = TONE_NEAR;
+            }
+        } else if (distance <= distanceFar) {
+            if ((lastTone != TONE_FAR) || (repeatedSignal && (currentTimestamp - lastTimestamp) > MIN_TIME_DELTA_FAR)) {
+                tone = TONE_FAR;
+            }
+        }
+
+        // play tone if necessary
+        if (tone != TONE_NONE) {
+            final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, ToneGenerator.MAX_VOLUME);
+            toneG.startTone(tone);
+            lastTimestamp = currentTimestamp;
+            lastDistance = distance;
+            lastTone = tone;
+            final Handler handler = new Handler(Looper.getMainLooper());
+            handler.postDelayed(() -> {
+                toneG.release();
+            }, 350);
+        }
+    }
+}

--- a/main/src/cgeo/geocaching/location/ProximityNotificationByCoords.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotificationByCoords.java
@@ -17,7 +17,7 @@ public class ProximityNotificationByCoords extends ProximityNotification {
     }
 
     public void onUpdateGeoData(final GeoData geo) {
-        if (referencePoint != null) {
+        if (null != referencePoint) {
             checkDistance((int) (1000f * referencePoint.distanceTo(geo.getCoords())));
         }
     }

--- a/main/src/cgeo/geocaching/location/ProximityNotificationByCoords.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotificationByCoords.java
@@ -1,0 +1,25 @@
+package cgeo.geocaching.location;
+
+import cgeo.geocaching.sensors.GeoData;
+
+public class ProximityNotificationByCoords extends ProximityNotification {
+
+    // reference point to calculate distance to
+    // needs to be set by calling setReferencePoint()
+    private Geopoint referencePoint = null;
+
+    public ProximityNotificationByCoords() {
+        super(true, true);
+    }
+
+    public void setReferencePoint(final Geopoint referencePoint) {
+        this.referencePoint = referencePoint;
+    }
+
+    public void onUpdateGeoData(final GeoData geo) {
+        if (referencePoint != null) {
+            checkDistance((int) (1000f * referencePoint.distanceTo(geo.getCoords())));
+        }
+    }
+
+}

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -14,6 +14,7 @@ import cgeo.geocaching.enumerations.LoadFlags.RemoveFlag;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.interfaces.CachesOverlayItemImpl;
 import cgeo.geocaching.maps.interfaces.GeoPointImpl;
@@ -129,6 +130,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
     private PositionAndScaleOverlay overlayPositionAndScale;
 
     private final GeoDirHandler geoDirUpdate = new UpdateLoc(this);
+    private ProximityNotification proximityNotification;
     // status data
     /**
      * Last search result used for displaying header
@@ -534,6 +536,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                         resumeDisposables.addAll(geoDirUpdate.start(GeoDirHandler.UPDATE_GEODIR), startTimer());
                     }
                 });
+        proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(false, false) : null;
 
         final List<String> toRefresh;
         synchronized (dirtyCaches) {
@@ -983,6 +986,10 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                             map.overlayPositionAndScale.setCoordinates(currentLocation);
                             map.overlayPositionAndScale.setHeading(currentHeading);
                             map.mapView.repaintRequired(map.overlayPositionAndScale);
+
+                            if (null != map.proximityNotification) {
+                                map.proximityNotification.checkDistance(map.overlayCaches.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
+                            }
                         }
                     }
                 } catch (final RuntimeException e) {

--- a/main/src/cgeo/geocaching/maps/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/CachesOverlay.java
@@ -314,7 +314,6 @@ public class CachesOverlay extends AbstractItemizedOverlay {
                 minDistance = Math.min(minDistance, distance);
             }
         }
-        Log.e("minDistance=" + minDistance);
         return minDistance;
     }
 }

--- a/main/src/cgeo/geocaching/maps/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/CachesOverlay.java
@@ -306,4 +306,15 @@ public class CachesOverlay extends AbstractItemizedOverlay {
         }
     }
 
+    public int getClosestDistanceInM(final Geopoint coord) {
+        int minDistance = 50000000;
+        for (final CachesOverlayItemImpl item : items) {
+            final int distance = (int) (1000 * coord.distanceTo(item.getCoord()));
+            if (distance > 0) {
+                minDistance = Math.min(minDistance, distance);
+            }
+        }
+        Log.e("minDistance=" + minDistance);
+        return minDistance;
+    }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.MapMode;
 import cgeo.geocaching.maps.MapOptions;
@@ -145,6 +146,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
     /**
      * initialization with an empty subscription to make static code analysis tools more happy
      */
+    private ProximityNotification proximityNotification;
     private final CompositeDisposable resumeDisposables = new CompositeDisposable();
     private CheckBox myLocSwitch;
     private MapOptions mapOptions;
@@ -706,6 +708,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         Log.d("NewMap: onResume");
 
         resumeTileLayer();
+        proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(false, false) : null;
     }
 
     @Override
@@ -1271,6 +1274,10 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                             map.positionLayer.setCoordinates(currentLocation);
                             map.positionLayer.setHeading(currentHeading);
                             map.positionLayer.requestRedraw();
+
+                            if (map.proximityNotification != null) {
+                                map.proximityNotification.checkDistance(map.caches.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
+                            }
                         }
                     }
                 } catch (final RuntimeException e) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1275,7 +1275,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                             map.positionLayer.setHeading(currentHeading);
                             map.positionLayer.requestRedraw();
 
-                            if (map.proximityNotification != null) {
+                            if (null != map.proximityNotification) {
                                 map.proximityNotification.checkDistance(map.caches.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
                             }
                         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -312,4 +312,16 @@ public abstract class AbstractCachesOverlay {
 
         return null;
     }
+
+    public int getClosestDistanceInM(final Geopoint coord) {
+        int minDistance = 50000000;
+        final Set<Geocache> caches = DataStore.loadCaches(getCacheGeocodes(), LoadFlags.LOAD_CACHE_OR_DB);
+        for (Geocache cache : caches) {
+            final int distance = (int) (1000f * cache.getCoords().distanceTo(coord));
+            if (distance > 0 && distance < minDistance) {
+                minDistance = distance;
+            }
+        }
+        return minDistance;
+    }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -316,7 +316,7 @@ public abstract class AbstractCachesOverlay {
     public int getClosestDistanceInM(final Geopoint coord) {
         int minDistance = 50000000;
         final Set<Geocache> caches = DataStore.loadCaches(getCacheGeocodes(), LoadFlags.LOAD_CACHE_OR_DB);
-        for (Geocache cache : caches) {
+        for (final Geocache cache : caches) {
             final int distance = (int) (1000f * cache.getCoords().distanceTo(coord));
             if (distance > 0 && distance < minDistance) {
                 minDistance = distance;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -265,4 +265,21 @@ public class CachesBundle {
             wpOverlay.hideWaypoints();
         }
     }
+
+    public int getClosestDistanceInM(final Geopoint coord) {
+        int minDistance = 50000000;
+        if (baseOverlay != null) {
+            minDistance = Math.min(minDistance, baseOverlay.getClosestDistanceInM(coord));
+        }
+        if (storedOverlay != null) {
+            minDistance = Math.min(minDistance, storedOverlay.getClosestDistanceInM(coord));
+        }
+        if (liveOverlay != null) {
+            minDistance = Math.min(minDistance, liveOverlay.getClosestDistanceInM(coord));
+        }
+        if (wpOverlay != null) {
+            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(coord));
+        }
+        return minDistance;
+    }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
 import cgeo.geocaching.models.Geocache;
@@ -64,4 +65,20 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
 
         syncLayers(removeCodes, newCodes);
     }
-}
+
+    @Override
+    public int getClosestDistanceInM(final Geopoint coord) {
+        int minDistance = 50000000;
+        final Set<Geocache> baseCaches = DataStore.loadCaches(getCacheGeocodes(), LoadFlags.LOAD_WAYPOINTS);
+        final Set<Waypoint> waypoints = new HashSet<>();
+        for (final Geocache cache : baseCaches) {
+            waypoints.addAll(cache.getWaypoints());
+        }
+        for (Waypoint waypoint : waypoints) {
+            final int distance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
+            if (distance > 0 && distance < minDistance) {
+                minDistance = distance;
+            }
+        }
+        return minDistance;
+    }}

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -74,11 +74,12 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         for (final Geocache cache : baseCaches) {
             waypoints.addAll(cache.getWaypoints());
         }
-        for (Waypoint waypoint : waypoints) {
+        for (final Waypoint waypoint : waypoints) {
             final int distance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
             if (distance > 0 && distance < minDistance) {
                 minDistance = distance;
             }
         }
         return minDistance;
-    }}
+    }
+}

--- a/main/src/cgeo/geocaching/settings/AbstractProximityPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractProximityPreference.java
@@ -1,0 +1,53 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.location.IConversion;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.Locale;
+
+public abstract class AbstractProximityPreference extends AbstractSeekbarPreference {
+    private int maxSeekbarLength = 0;   // initialized in onCreateView
+    private boolean farDistance = true;
+
+    public AbstractProximityPreference(final Context context, final AttributeSet attrs, final boolean farDistance) {
+        super(context, attrs);
+        this.farDistance = farDistance;
+    }
+
+    private int valueToProgressHelper(final int value) {
+        return (int) Math.round(25.0 * Math.log10(value + 1));
+    }
+
+    private int valueToProgress(final int value) {
+        final int progress = valueToProgressHelper(value);
+        return progress < 0 ? 0 : progress > maxSeekbarLength ? maxSeekbarLength : progress;
+    }
+
+    private int progressToValue(final int progress) {
+        final int value = (int) Math.pow(10, Double.valueOf(progress) / 25.0) - 1;
+        return value < 0 ? 0 : value > Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE ? Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE : value;
+    }
+
+    protected String getValueString(final int progress) {
+        final int value = progressToValue(progress);
+        return Settings.useImperialUnits()
+            ? String.format(Locale.US, "%.2f mi", value / (1000 * IConversion.MILES_TO_KILOMETER))
+            : value + " m"
+        ;
+    }
+
+    protected void saveSetting(final int progress) {
+        Settings.setProximityNotificationThreshold(farDistance, progressToValue(progress));
+    }
+
+    @Override
+    protected View onCreateView(final ViewGroup parent) {
+        maxSeekbarLength = valueToProgressHelper(Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE);
+        configure(1, maxSeekbarLength, valueToProgress(Settings.getProximityNotificationThreshold(farDistance)), farDistance ? "1" : "2");
+        return super.onCreateView(parent);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/ProximityFarPreference.java
+++ b/main/src/cgeo/geocaching/settings/ProximityFarPreference.java
@@ -1,0 +1,10 @@
+package cgeo.geocaching.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class ProximityFarPreference extends AbstractProximityPreference {
+    public ProximityFarPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs, true);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/ProximityNearPreference.java
+++ b/main/src/cgeo/geocaching/settings/ProximityNearPreference.java
@@ -1,0 +1,10 @@
+package cgeo.geocaching.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class ProximityNearPreference extends AbstractProximityPreference {
+    public ProximityNearPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs, false);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -990,8 +990,11 @@ public class Settings {
     }
 
     public static int getProximityNotificationThreshold(final boolean farDistance) {
-        // mockup only so far
-        return farDistance ? PROXIMITY_NOTIFICATION_DISTANCE_FAR : PROXIMITY_NOTIFICATION_DISTANCE_NEAR;
+        return getInt(farDistance ? R.string.pref_proximityDistanceFar : R.string.pref_proximityDistanceNear, farDistance ? PROXIMITY_NOTIFICATION_DISTANCE_FAR : PROXIMITY_NOTIFICATION_DISTANCE_NEAR);
+    }
+
+    public static void setProximityNotificationThreshold(final boolean farDistance, final int distance) {
+        putInt(farDistance ? R.string.pref_proximityDistanceFar : R.string.pref_proximityDistanceNear, distance);
     }
 
     public static boolean isUseTwitter() {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -74,6 +74,11 @@ public class Settings {
     public static final int SHOW_WP_THRESHOLD_MAX = 200;
     private static final int BROUTER_THRESHOLD_DEFAULT = 10;
     public static final int BROUTER_THRESHOLD_MAX = 120;
+
+    public static final int PROXIMITY_NOTIFICATION_MAX_DISTANCE = 1000;
+    public static final int PROXIMITY_NOTIFICATION_DISTANCE_FAR = 60;
+    public static final int PROXIMITY_NOTIFICATION_DISTANCE_NEAR = 20;
+
     private static final int MAP_SOURCE_DEFAULT = GoogleMapProvider.GOOGLE_MAP_ID.hashCode();
 
     private static final String PHONE_MODEL_AND_SDK = Build.MODEL + "/" + Build.VERSION.SDK_INT;
@@ -970,6 +975,23 @@ public class Settings {
 
     static void setBrouterShowBothDistances(final boolean show) {
         putBoolean(R.string.pref_brouterShowBothDistances, show);
+    }
+
+    /**
+     * Proximity notification settings
+     */
+
+    public static boolean isGeneralProximityNotificationActive() {
+        return getBoolean(R.string.pref_proximityNotificationGeneral, false);
+    }
+
+    public static boolean isSpecificProximityNotificationActive() {
+        return getBoolean(R.string.pref_proximityNotificationSpecific, false);
+    }
+
+    public static int getProximityNotificationThreshold(final boolean farDistance) {
+        // mockup only so far
+        return farDistance ? PROXIMITY_NOTIFICATION_DISTANCE_FAR : PROXIMITY_NOTIFICATION_DISTANCE_NEAR;
     }
 
     public static boolean isUseTwitter() {


### PR DESCRIPTION
adds two types of proximity notifications:

a) general proximity notification
- available in map view
- checks distance to closest waypoint or cache
- beeps once when closest distance is below threshold (no repeats)
- is reset when distance > threshold

(a) is the "Garmin like" notification variant.)

b) specific proximity notification
- available in compass view and in map popups for cache or waypoint
- checks distance to currently active geopoint (cache / waypoint)
- supports two notification signals, bound to two different distances (far / near)
- sound is repeated after 10s (far) / 5s (near)
- is reset when distance > far threshold

Settings are on Settings => Map => Proximity notification:
- enable / disable general proximity notification
- enable / disable specific proximity notification
- set far and near distances

Implemented for
- NewMap and CGeoMap (general notification)
- cache popup, waypoint popup and compass view (specific notification)
