### PR TITLE
reduce search for trackable on active connectors

### DIFF
--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -316,16 +316,13 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
             return;
         }
 
-        // check temporaribly disabled due to #7617
-        // if (ConnectorFactory.anyTrackableConnectorActive()) {
+        if (ConnectorFactory.anyTrackableConnectorActive()) {
             final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
             trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText.toUpperCase(Locale.US));
             startActivity(trackablesIntent);
-        /*
         } else {
             showToast(getString(R.string.warn_no_connector));
         }
-        */
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -178,6 +178,17 @@ public final class ConnectorFactory {
         return activeConnectors;
     }
 
+    @NonNull
+    public static Collection<TrackableConnector> getActiveTrackableConnectors() {
+        final Collection<TrackableConnector> activeConnectors = new ArrayList<>();
+        for (final TrackableConnector conn : TRACKABLE_CONNECTORS) {
+            if (conn.isActive()) {
+                activeConnectors.add(conn);
+            }
+        }
+        return activeConnectors;
+    }
+
     public static boolean anyConnectorActive() {
         for (final IConnector conn : CONNECTORS) {
             if (conn.isActive()) {
@@ -250,7 +261,7 @@ public final class ConnectorFactory {
 
     @NonNull
     public static TrackableConnector getTrackableConnector(final String geocode, final TrackableBrand brand) {
-        for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
+        for (final TrackableConnector connector : getActiveTrackableConnectors()) {
             if (connector.canHandleTrackable(geocode, brand)) {
                 return connector;
             }
@@ -431,7 +442,7 @@ public final class ConnectorFactory {
         }
 
         final Observable<Trackable> fromNetwork =
-                Observable.fromIterable(getTrackableConnectors()).filter(new Predicate<TrackableConnector>() {
+                Observable.fromIterable(getActiveTrackableConnectors()).filter(new Predicate<TrackableConnector>() {
                     @Override
                     public boolean test(final TrackableConnector trackableConnector) {
                         return trackableConnector.canHandleTrackable(geocode, brand);

--- a/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -59,6 +59,16 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     }
 
     @Override
+    public boolean isGenericLoggable() {
+        return false;
+    }
+
+    @Override
+    public boolean isActive() {
+        return Settings.isGCConnectorActive();
+    }
+
+    @Override
     public boolean isRegistered() {
         return Settings.hasGCCredentials();
     }


### PR DESCRIPTION
fix #7555 (Search for trackable code working without active connectors)
fix #7617 (TB inventory is blank after isActive() has been implemented in TravelBugConnector)

SearchActivity
- reactivate the anyTrackableConnectorActive filter

ConnectorFactory:
- implement getActiveTrackableConnectors
  => generate the list of active trackable connectors
- 2x use getActiveTrackableConnectors, replace the full trackable connectors list

TravelBugConnector
- implement isGenericLoggable (only for better readability)
- implement isActive
