### PR TITLE
general proximity notification changes (followup to #7699)

### DIFF
--- a/main/src/cgeo/geocaching/location/ProximityNotificationByCoords.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotificationByCoords.java
@@ -2,6 +2,9 @@ package cgeo.geocaching.location;
 
 import cgeo.geocaching.sensors.GeoData;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 public class ProximityNotificationByCoords extends ProximityNotification {
 
     // reference point to calculate distance to
@@ -20,6 +23,29 @@ public class ProximityNotificationByCoords extends ProximityNotification {
         if (null != referencePoint) {
             checkDistance((int) (1000f * referencePoint.distanceTo(geo.getCoords())));
         }
+    }
+
+    // extend parcelable functions
+
+    public void writeToParcel(final Parcel out, final int flags) {
+        super.writeToParcel(out, flags);
+        referencePoint.writeToParcel(out, flags);
+    }
+
+    public static final Parcelable.Creator<ProximityNotificationByCoords> CREATOR
+            = new Parcelable.Creator<ProximityNotificationByCoords>() {
+        public ProximityNotificationByCoords createFromParcel(final Parcel in) {
+            return new ProximityNotificationByCoords(in);
+        }
+
+        public ProximityNotificationByCoords[] newArray(final int size) {
+            return new ProximityNotificationByCoords[size];
+        }
+    };
+
+    private ProximityNotificationByCoords(final Parcel in) {
+        super(in);
+        referencePoint = new Geopoint(in);
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -119,6 +119,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
     private static final String BUNDLE_MAP_STATE = "mapState";
     private static final String BUNDLE_LIVE_ENABLED = "liveEnabled";
     private static final String BUNDLE_TRAIL_HISTORY = "trailHistory";
+    private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
 
     // Those are initialized in onCreate() and will never be null afterwards
     private Resources res;
@@ -398,6 +399,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
         outState.putParcelable(BUNDLE_MAP_STATE, currentMapState());
         outState.putBoolean(BUNDLE_LIVE_ENABLED, mapOptions.isLiveEnabled);
         outState.putParcelableArrayList(BUNDLE_TRAIL_HISTORY, overlayPositionAndScale.getHistory());
+        if (proximityNotification != null) {
+            outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
+        }
     }
 
     @Override
@@ -423,8 +427,10 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
             mapOptions.mapState = savedInstanceState.getParcelable(BUNDLE_MAP_STATE);
             mapOptions.isLiveEnabled = savedInstanceState.getBoolean(BUNDLE_LIVE_ENABLED, false);
             trailHistory = savedInstanceState.getParcelableArrayList(BUNDLE_TRAIL_HISTORY);
+            proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
         } else {
             currentSourceId = Settings.getMapSource().getNumericalId();
+            proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
         }
 
         // If recreating from an obsolete map source, we may need a restart
@@ -536,7 +542,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory {
                         resumeDisposables.addAll(geoDirUpdate.start(GeoDirHandler.UPDATE_GEODIR), startTimer());
                     }
                 });
-        proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(false, false) : null;
 
         final List<String> toRefresh;
         synchronized (dirtyCaches) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -156,6 +156,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
     private static final String BUNDLE_MAP_STATE = "mapState";
     private static final String BUNDLE_TRAIL_HISTORY = "trailHistory";
+    private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
 
     // Handler messages
     // DisplayHandler
@@ -190,9 +191,11 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         if (savedInstanceState != null) {
             mapOptions.mapState = savedInstanceState.getParcelable(BUNDLE_MAP_STATE);
             trailHistory = savedInstanceState.getParcelableArrayList(BUNDLE_TRAIL_HISTORY);
+            proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
             followMyLocation = mapOptions.mapState.followsMyLocation();
         } else {
             followMyLocation = followMyLocation && mapOptions.mapMode == MapMode.LIVE;
+            proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
         }
 
         ActivityMixin.onCreate(this, true);
@@ -708,7 +711,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         Log.d("NewMap: onResume");
 
         resumeTileLayer();
-        proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(false, false) : null;
     }
 
     @Override
@@ -895,6 +897,9 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         if (historyLayer != null) {
             trailHistory = historyLayer.getHistory();
             outState.putParcelableArrayList(BUNDLE_TRAIL_HISTORY, trailHistory);
+        }
+        if (proximityNotification != null) {
+            outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
         }
     }
 


### PR DESCRIPTION
general proximity notification changes:
- make general proximity notification parcelable
- ignore one time distance peaks
- use two different distances to play two different tones
