### PR TITLE
reorder menu entries for proximity notification configuration

### DIFF
--- a/main/res/layout/preference_seekbar.xml
+++ b/main/res/layout/preference_seekbar.xml
@@ -3,35 +3,49 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:paddingTop="8dp"
+    android:orientation="vertical"
     tools:context=".settings.SettingsActivity" >
 
     <TextView
         android:id="@+id/preference_seekbar_label_view"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="left"
+        android:visibility="gone"
         android:gravity="left"/>
 
-    <SeekBar
-        android:id="@+id/preference_seekbar"
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_weight="1"
-        android:paddingRight="4dp"
-        tools:progress="25"/>
+        android:paddingLeft="0dp"
+        android:paddingRight="0dp"
+        android:paddingTop="0dp"
+        android:orientation="horizontal">
 
-    <TextView
-        android:id="@+id/preference_seekbar_value_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="right"
-        android:layout_weight="5"
-        android:gravity="right"
-        tools:text="25"/>
+        <SeekBar
+            android:id="@+id/preference_seekbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_weight="1"
+            android:paddingLeft="0dp"
+            android:paddingRight="4dp"
+            tools:progress="25"/>
 
+        <TextView
+            android:id="@+id/preference_seekbar_value_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:layout_gravity="right"
+            android:layout_weight="5"
+            android:gravity="right"
+            tools:text="25"/>
+
+    </LinearLayout>
 </LinearLayout>
+

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -739,9 +739,11 @@
     <!-- proximity notification -->
     <string name="settings_title_proximityNotification">Proximity notification</string>
     <string name="init_proximityNotificationGeneral">General proximity notification</string>
-    <string name="init_summary_proximityNotificationGeneral">Play a single notification, if any cache or waypoint currently visible on the map is closer than distance 1.</string>
+    <string name="init_summary_proximityNotificationGeneral">Play a single notification, if any cache or waypoint currently visible on the map is closer than far distance or near distance. Uses different tones for the two distances.</string>
     <string name="init_proximityNotificationSpecific">Specific proximity notification</string>
-    <string name="init_summary_proximityNotificationSpecific">Play a notification, if the selected cache or waypoint is closer than distance 1 (farther away) or distance 2 (closer). Uses different tones for the two distances.</string>
+    <string name="init_summary_proximityNotificationSpecific">Play a repeated notification, if the selected cache or waypoint is closer than far distance or near distance. Uses different tones for the two distances.</string>
+    <string name="far_distance">far distance</string>
+    <string name="near_distance">near distance</string>
 
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -605,22 +605,22 @@
 
         <PreferenceCategory android:title="@string/settings_title_proximityNotification"
             android:layout="@layout/preference_category" >
+            <cgeo.geocaching.settings.ProximityFarPreference
+                android:key="@string/pref_proximityDistanceFar"
+                android:layout="@layout/preference_seekbar" />
+            <cgeo.geocaching.settings.ProximityNearPreference
+                android:key="@string/pref_proximityDistanceNear"
+                android:layout="@layout/preference_seekbar" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="@string/pref_proximityNotificationGeneral"
                 android:summary="@string/init_summary_proximityNotificationGeneral"
                 android:title="@string/init_proximityNotificationGeneral" />
-            <cgeo.geocaching.settings.ProximityFarPreference
-                android:key="@string/pref_proximityDistanceFar"
-                android:layout="@layout/preference_seekbar" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="@string/pref_proximityNotificationSpecific"
                 android:summary="@string/init_summary_proximityNotificationSpecific"
                 android:title="@string/init_proximityNotificationSpecific" />
-            <cgeo.geocaching.settings.ProximityNearPreference
-                android:key="@string/pref_proximityDistanceNear"
-                android:layout="@layout/preference_seekbar" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"

--- a/main/src/cgeo/geocaching/settings/AbstractProximityPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractProximityPreference.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.settings;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.location.IConversion;
 
 import android.content.Context;
@@ -47,7 +48,7 @@ public abstract class AbstractProximityPreference extends AbstractSeekbarPrefere
     @Override
     protected View onCreateView(final ViewGroup parent) {
         maxSeekbarLength = valueToProgressHelper(Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE);
-        configure(1, maxSeekbarLength, valueToProgress(Settings.getProximityNotificationThreshold(farDistance)), farDistance ? "1" : "2");
+        configure(1, maxSeekbarLength, valueToProgress(Settings.getProximityNotificationThreshold(farDistance)), farDistance ? getContext().getString(R.string.far_distance) : getContext().getString(R.string.near_distance));
         return super.onCreateView(parent);
     }
 }

--- a/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
@@ -82,6 +82,7 @@ public abstract class AbstractSeekbarPreference extends Preference {
         // set label (if given)
         if (null != labelValue && !labelValue.isEmpty()) {
             final TextView labelView = ButterKnife.findById(v, R.id.preference_seekbar_label_view);
+            labelView.setVisibility(View.VISIBLE);
             labelView.setText(labelValue);
         }
 


### PR DESCRIPTION
- move seekbar label to separate line
- move distances configuration above switches for general/specific proximity notifications
- change labels "1" and "2" to "far distance" and "near distance"

![image](https://user-images.githubusercontent.com/3754370/60756669-ab8b7b80-a000-11e9-835d-b6bc141462a3.png)
