### PR TITLE
fix waypoint selection for proximity calculation (NewMap)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -278,7 +278,9 @@ public class CachesBundle {
             minDistance = Math.min(minDistance, liveOverlay.getClosestDistanceInM(coord));
         }
         if (wpOverlay != null) {
-            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(coord));
+            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(baseOverlay, coord));
+            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(storedOverlay, coord));
+            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(liveOverlay, coord));
         }
         return minDistance;
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -66,18 +66,19 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         syncLayers(removeCodes, newCodes);
     }
 
-    @Override
-    public int getClosestDistanceInM(final Geopoint coord) {
+    public int getClosestDistanceInM(final AbstractCachesOverlay baseOverlay, final Geopoint coord) {
         int minDistance = 50000000;
-        final Set<Geocache> baseCaches = DataStore.loadCaches(getCacheGeocodes(), LoadFlags.LOAD_WAYPOINTS);
-        final Set<Waypoint> waypoints = new HashSet<>();
-        for (final Geocache cache : baseCaches) {
-            waypoints.addAll(cache.getWaypoints());
-        }
-        for (final Waypoint waypoint : waypoints) {
-            final int distance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
-            if (distance > 0 && distance < minDistance) {
-                minDistance = distance;
+        if (null != baseOverlay) {
+            final Set<Geocache> baseCaches = DataStore.loadCaches(baseOverlay.getCacheGeocodes(), LoadFlags.LOAD_WAYPOINTS);
+            final Set<Waypoint> waypoints = new HashSet<>();
+            for (final Geocache cache : baseCaches) {
+                waypoints.addAll(cache.getWaypoints());
+            }
+            for (final Waypoint waypoint : waypoints) {
+                final int distance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
+                if (distance > 0 && distance < minDistance) {
+                    minDistance = distance;
+                }
             }
         }
         return minDistance;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -28,12 +28,8 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         syncLayers(removeCodes, newCodes);
     }
 
-    void showWaypoints(final Collection<String> baseGeoCodes, final boolean showStored) {
-        final Collection<String> removeCodes = getGeocodes();
-        final Collection<String> newCodes = new HashSet<>();
-
+    private Set<Waypoint> filterWaypoints(final Collection<String> baseGeoCodes, final boolean showStored) {
         final Set<Waypoint> waypoints = new HashSet<>();
-        final boolean isDotMode = Settings.isDotMode();
 
         final Set<Geocache> baseCaches = DataStore.loadCaches(baseGeoCodes, LoadFlags.LOAD_WAYPOINTS);
 
@@ -50,6 +46,17 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
             MapUtils.filter(waypointsInViewport);
             waypoints.addAll(waypointsInViewport);
         }
+
+        return waypoints;
+    }
+
+    void showWaypoints(final Collection<String> baseGeoCodes, final boolean showStored) {
+        final Collection<String> removeCodes = getGeocodes();
+        final Collection<String> newCodes = new HashSet<>();
+
+        final Set<Waypoint> waypoints = filterWaypoints(baseGeoCodes, showStored);
+        final boolean isDotMode = Settings.isDotMode();
+
         for (final Waypoint waypoint : waypoints) {
             if (waypoint == null || waypoint.getCoords() == null) {
                 continue;
@@ -69,11 +76,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
     public int getClosestDistanceInM(final AbstractCachesOverlay baseOverlay, final Geopoint coord) {
         int minDistance = 50000000;
         if (null != baseOverlay) {
-            final Set<Geocache> baseCaches = DataStore.loadCaches(baseOverlay.getCacheGeocodes(), LoadFlags.LOAD_WAYPOINTS);
-            final Set<Waypoint> waypoints = new HashSet<>();
-            for (final Geocache cache : baseCaches) {
-                waypoints.addAll(cache.getWaypoints());
-            }
+            final Set<Waypoint> waypoints = filterWaypoints(baseOverlay.getCacheGeocodes(), true);
             for (final Waypoint waypoint : waypoints) {
                 final int distance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
                 if (distance > 0 && distance < minDistance) {


### PR DESCRIPTION
getCacheGeocodes() always returned empty collection in wp.getClosestDistanceInM - needed to use getCacheGeocodes() on each overlay instead (base / stored / live overlay)