### PR TITLE
Update coordinatescalculate_dialog.xml

### DIFF
--- a/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
+++ b/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
@@ -79,7 +79,7 @@
                     android:overScrollMode="always"
                     android:scrollbarStyle="insideInset"
                     android:scrollbars="vertical"
-                    android:inputType="textMultiLine"
+                    android:inputType="textMultiLine|textCapSentences"
                     android:hint="@string/waypointcalc_notes_prompt" />
             </LinearLayout>
         </LinearLayout>

--- a/main/res/layout/coordinatescalculate_dialog.xml
+++ b/main/res/layout/coordinatescalculate_dialog.xml
@@ -58,7 +58,7 @@
                 android:overScrollMode="always"
                 android:scrollbarStyle="insideInset"
                 android:scrollbars="vertical"
-                android:inputType="textMultiLine|textAutoCorrect"
+                android:inputType="textMultiLine|textCapSentences"
                 android:hint="@string/waypointcalc_notes_prompt" />
 
             <Button

--- a/main/res/layout/coordinatescalculate_dialog.xml
+++ b/main/res/layout/coordinatescalculate_dialog.xml
@@ -58,7 +58,7 @@
                 android:overScrollMode="always"
                 android:scrollbarStyle="insideInset"
                 android:scrollbars="vertical"
-                android:inputType="textMultiLine"
+                android:inputType="textMultiLine|textAutoCorrect"
                 android:hint="@string/waypointcalc_notes_prompt" />
 
             <Button


### PR DESCRIPTION
fixes #7710 

as discussed in #7711 - suggestion: the text from the coordinate calculator is copied in the user_note field of the editwaypoint_activity, which is defined in this way.

