### PR TITLE
Fix #7676 - Reenable oc.us tests

### DIFF
--- a/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
@@ -16,24 +16,22 @@ import java.util.Locale;
 public class OkapiClientTest extends CGeoTestCase {
 
     public static void testGetOCCache() {
-        // temporarily disable oc.us
-
-//        final String geoCode = "OU0331";
-//        Geocache cache = OkapiClient.getCache(geoCode);
-//        assertThat(cache).as("Cache from OKAPI").isNotNull();
-//        assert cache != null; // eclipse null analysis
-//        assertThat(cache.getGeocode()).isEqualTo(geoCode);
-//        assertThat(cache.getName()).isEqualTo("Oshkosh Municipal Tank");
-//        assertThat(cache.isDetailed()).isTrue();
-//        // cache should be stored to DB (to listID 0) when loaded above
-//        cache = DataStore.loadCache(geoCode, LoadFlags.LOAD_ALL_DB_ONLY);
-//        assert cache != null;
-//        assertThat(cache).isNotNull();
-//        assertThat(cache.getGeocode()).isEqualTo(geoCode);
-//        assertThat(cache.getName()).isEqualTo("Oshkosh Municipal Tank");
-//        assertThat(cache.isDetailed()).isTrue();
-//        assertThat(cache.getOwnerDisplayName()).isEqualTo("glorkar");
-//        assertThat(cache.getOwnerUserId()).isEqualTo("19");
+        final String geoCode = "OU0331";
+        Geocache cache = OkapiClient.getCache(geoCode);
+        assertThat(cache).as("Cache from OKAPI").isNotNull();
+        assert cache != null; // eclipse null analysis
+        assertThat(cache.getGeocode()).isEqualTo(geoCode);
+        assertThat(cache.getName()).isEqualTo("Oshkosh Municipal Tank");
+        assertThat(cache.isDetailed()).isTrue();
+        // cache should be stored to DB (to listID 0) when loaded above
+        cache = DataStore.loadCache(geoCode, LoadFlags.LOAD_ALL_DB_ONLY);
+        assert cache != null;
+        assertThat(cache).isNotNull();
+        assertThat(cache.getGeocode()).isEqualTo(geoCode);
+        assertThat(cache.getName()).isEqualTo("Oshkosh Municipal Tank");
+        assertThat(cache.isDetailed()).isTrue();
+        assertThat(cache.getOwnerDisplayName()).isEqualTo("glorkar");
+        assertThat(cache.getOwnerUserId()).isEqualTo("19");
     }
 
     public static void testOCSearchMustWorkWithoutOAuthAccessTokens() {

--- a/tests/src-android/cgeo/watchdog/WatchdogTest.java
+++ b/tests/src-android/cgeo/watchdog/WatchdogTest.java
@@ -70,13 +70,7 @@ public class WatchdogTest extends CGeoTestCase {
         assertThat(geocache.getGeocode()).isEqualTo(geocode);
     }
 
-    private static void checkWebsite(final String connectorName, final String url) {
-        
-        // temporarily disable opencaching.us website check, see issue #7676
-        if (connectorName.equalsIgnoreCase("geocaching website opencaching.us")) {
-            return;
-        }
-        
+    private static void checkWebsite(final String connectorName, final String url) {       
         final String page = Network.getResponseData(Network.getRequest(url));
         assertThat(page).overridingErrorMessage("Failed to get response from " + connectorName).isNotEmpty();
     }

--- a/tests/src-android/cgeo/watchdog/WatchdogTest.java
+++ b/tests/src-android/cgeo/watchdog/WatchdogTest.java
@@ -53,8 +53,7 @@ public class WatchdogTest extends CGeoTestCase {
 
     @NotForIntegrationTests
     public static void testOpenCachingUS() {
-        // temporarily disable opencaching.us cache download check, see issue #7676
-        // downloadOpenCaching("OU0331");
+        downloadOpenCaching("OU0331");
     }
 
     private static void downloadOpenCaching(final String geocode) {


### PR DESCRIPTION
Enable watchdog tests and integration tests for opencaching.us
The website should be in normal working state again

To be merged to `release` and upwards to `master` to have watchdog enabled for both branches on CI.