### PR TITLE
Update Mapsforge to 0.11.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -303,7 +303,7 @@ dependencies {
     implementation 'com.caverock:androidsvg:1.3'
 
     // Mapsforge new version
-    def mapsforgeVersion = '0.9.1'
+    def mapsforgeVersion = '0.11.0'
     implementation "org.mapsforge:mapsforge-core:$mapsforgeVersion"
     implementation "org.mapsforge:mapsforge-map:$mapsforgeVersion"
     implementation "org.mapsforge:mapsforge-map-android:$mapsforgeVersion"

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.cache.TileCache;
-import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.reader.header.MapFileException;
 import org.mapsforge.v3.android.maps.mapgenerator.MapGeneratorInternal;
@@ -147,7 +147,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
          * Create new render layer, if mapfile exists
          */
         @Override
-        public ITileLayer createTileLayer(final TileCache tileCache, final MapViewPosition mapViewPosition) {
+        public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
             final File mapFile = new File(fileName);
             if (mapFile.exists()) {
                 return new RendererLayer(tileCache, new MapFile(mapFile), mapViewPosition, false, true, false, AndroidGraphicFactory.INSTANCE);

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapSource.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapSource.java
@@ -10,7 +10,7 @@ import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
 import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
-import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.v3.android.maps.mapgenerator.MapGeneratorInternal;
 
 public class MapsforgeMapSource extends AbstractMapSource {
@@ -28,7 +28,7 @@ public class MapsforgeMapSource extends AbstractMapSource {
         return generator;
     }
 
-    public ITileLayer createTileLayer(final TileCache tileCache, final MapViewPosition mapViewPosition) {
+    public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
         final AbstractTileSource source = OpenStreetMapMapnik.INSTANCE;
         source.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA);
         return new DownloadLayer(tileCache, mapViewPosition, source, AndroidGraphicFactory.INSTANCE);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -184,6 +184,9 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         // some tiles are rather big, see https://github.com/mapsforge/mapsforge/issues/868
         Parameters.MAXIMUM_BUFFER_SIZE = 6500000;
 
+        // Use fast parent tile rendering to increase performance when zooming in
+        Parameters.PARENT_TILES_RENDERING = Parameters.ParentTilesRendering.SPEED;
+
         // Get parameters from the intent
         mapOptions = new MapOptions(this, getIntent().getExtras());
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/DownloadLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/DownloadLayer.java
@@ -5,7 +5,7 @@ import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.download.TileDownloadLayer;
 import org.mapsforge.map.layer.download.tilesource.TileSource;
-import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.model.IMapViewPosition;
 
 public class DownloadLayer implements ITileLayer {
 
@@ -13,7 +13,7 @@ public class DownloadLayer implements ITileLayer {
 
     private final TileSource tileSource;
 
-    public DownloadLayer(final TileCache tileCache, final MapViewPosition mapViewPosition, final TileSource tileSource, final GraphicFactory graphicFactory) {
+    public DownloadLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition, final TileSource tileSource, final GraphicFactory graphicFactory) {
         this.tileSource = tileSource;
         tileLayer = new TileDownloadLayer(tileCache, mapViewPosition, tileSource, graphicFactory);
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RendererLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RendererLayer.java
@@ -4,7 +4,7 @@ import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
-import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 
 public class RendererLayer implements ITileLayer {
@@ -13,7 +13,7 @@ public class RendererLayer implements ITileLayer {
 
     private final MapFile mapDataStore;
 
-    public RendererLayer(final TileCache tileCache, final MapFile mapDataStore, final MapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
+    public RendererLayer(final TileCache tileCache, final MapFile mapDataStore, final IMapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
         this.mapDataStore = mapDataStore;
         tileLayer = new TileRendererLayer(tileCache, mapDataStore, mapViewPosition, isTransparent, renderLabels, cacheLabels, graphicFactory);
     }


### PR DESCRIPTION
Fixes #7494 


Upgrade Mapsforge to 0.11.0.
Mapsforge 0.9.1 fails on Android 9 with targetSdk 28.

See https://github.com/mapsforge/mapsforge/commit/b7b07619a6389886734acd5bcb8ae9b14dfce8c2 for reference.
