### PR TITLE
Don't restrict the tile size of mapsforge layers. Fixes #7750.

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -663,7 +663,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
         // Exchange layer
         if (newLayer != null) {
-            this.mapView.getModel().displayModel.setFixedTileSize(newLayer.getFixedTileSize());
             final MapZoomControls zoomControls = mapView.getMapZoomControls();
             zoomControls.setZoomLevelMax(newLayer.getZoomLevelMax());
             zoomControls.setZoomLevelMin(newLayer.getZoomLevelMin());


### PR DESCRIPTION
Fixes #7750 
