### PR TITLE
add list membership filter

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -401,6 +401,7 @@
     <string name="caches_filter_own_rating">With own rating</string>
     <string name="caches_filter_multi_listing">Multi listing with different state</string>
     <string name="caches_filter_own_waypoint">With user defined waypoints</string>
+    <string name="caches_filter_lists">Assigned to a list</string>
     <string name="caches_removing_from_history">Removing from History…</string>
     <string name="caches_clear_offlinelogs">Clear offline logs</string>
     <string name="caches_clear_offlinelogs_message">Do you want to clear the offline logs?</string>

--- a/main/src/cgeo/geocaching/filter/FilterRegistry.java
+++ b/main/src/cgeo/geocaching/filter/FilterRegistry.java
@@ -64,6 +64,7 @@ public class FilterRegistry {
         register(R.string.caches_filter_popularity, PopularityFilter.Factory.class);
         register(R.string.caches_filter_popularity_ratio, PopularityRatioFilter.Factory.class);
         register(R.string.caches_filter_personal_data, PersonalDataFilterFactory.class);
+        register(R.string.caches_filter_lists, ListFilterFactory.class);
     }
 
     public List<FactoryEntry> getFactories() {

--- a/main/src/cgeo/geocaching/filter/ListFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/ListFilterFactory.java
@@ -1,0 +1,61 @@
+package cgeo.geocaching.filter;
+
+import cgeo.geocaching.list.AbstractList;
+import cgeo.geocaching.list.PseudoList;
+import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.models.Geocache;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListFilterFactory implements IFilterFactory {
+    static class ListFilter extends AbstractFilter {
+        private int listId = 0;
+
+        public static final Creator<ListFilter> CREATOR
+                = new Parcelable.Creator<ListFilter>() {
+
+            @Override
+            public ListFilter createFromParcel(final Parcel in) {
+                return new ListFilter(in);
+            }
+
+            @Override
+            public ListFilter[] newArray(final int size) {
+                return new ListFilter[size];
+            }
+        };
+
+        ListFilter(final int listId, final String title) {
+            super(title);
+            this.listId = listId;
+        }
+
+        protected ListFilter(final Parcel in) {
+            super(in);
+            listId = in.readInt();
+        }
+
+        @Override
+        public boolean accepts(@NonNull final Geocache cache) {
+            return cache.getLists().contains(listId);
+        }
+
+    }
+
+    @Override
+    @NonNull
+    public List<IFilter> getFilters() {
+        final List<IFilter> filters = new ArrayList<>(6);
+        final List<AbstractList> storedLists = StoredList.UserInterface.getMenuLists(true, PseudoList.NEW_LIST.id);
+        for (final AbstractList temp : storedLists) {
+            filters.add(new ListFilter(temp.id, temp.title));
+        }
+        return filters;
+    }
+
+}

--- a/main/src/cgeo/geocaching/filter/ListFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/ListFilterFactory.java
@@ -41,6 +41,12 @@ public class ListFilterFactory implements IFilterFactory {
         }
 
         @Override
+        public void writeToParcel(final Parcel dest, final int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(listId);
+        }
+        
+        @Override
         public boolean accepts(@NonNull final Geocache cache) {
             return cache.getLists().contains(listId);
         }


### PR DESCRIPTION
Related to (but does not fully implement) #7761: Add a list membership filter to be able to use lists as tag replacement.

![grafik](https://user-images.githubusercontent.com/3754370/62618156-d0328600-b913-11e9-9d4c-5e837207d90b.png)
