### PR TITLE
trackable log list: move gc info to main column to give it more space

### DIFF
--- a/main/res/layout/logs_item.xml
+++ b/main/res/layout/logs_item.xml
@@ -1,85 +1,90 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
+<LinearLayout
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="3dip"
-    android:paddingTop="3dip"
-    tools:context=".log.LogsViewCreator$1" >
+    android:orientation="vertical"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <TextView
         android:id="@+id/author"
-        style="@style/logitem_author"
-        tools:text="author"/>
+        style="@style/logitem_author"/>
 
-    <LinearLayout
-        android:id="@+id/detail_box"
-        android:layout_width="102dip"
+    <RelativeLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_below="@id/author"
-        android:layout_gravity="left|top"
-        android:orientation="horizontal" >
+        android:orientation="horizontal">
 
         <LinearLayout
-            android:layout_width="100dip"
+            android:id="@+id/detail_box"
+            android:layout_width="102dip"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|top"
-            android:orientation="vertical"
-            android:padding="3dip" >
+            android:layout_alignParentLeft="true"
+            android:layout_gravity="left|top"
+            android:orientation="horizontal" >
 
-            <TextView
-                android:id="@+id/added"
-                style="@style/logitem_property"
-                tools:text="date"/>
+            <LinearLayout
+                android:layout_width="100dip"
+                android:layout_height="wrap_content"
+                android:layout_gravity="right|top"
+                android:orientation="vertical"
+                android:padding="3dip" >
 
-            <TextView
-                android:id="@+id/type"
-                style="@style/logitem_property"
-                tools:text="type"/>
+                <TextView
+                    android:id="@+id/added"
+                    style="@style/logitem_property"/>
 
-            <TextView
-                android:id="@+id/count_or_location"
-                style="@style/logitem_property"
-                tools:text="count"/>
+                <TextView
+                    android:id="@+id/type"
+                    style="@style/logitem_property"/>
+
+                <TextView
+                    android:id="@+id/count_or_location"
+                    style="@style/logitem_property"/>
+            </LinearLayout>
+
+            <ImageView
+                android:id="@+id/log_mark"
+                style="@style/logitem_mark" />
         </LinearLayout>
 
-        <ImageView
-            android:id="@+id/log_mark"
-            style="@style/logitem_mark" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/log_layout"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/detail_box"
-        android:orientation="vertical"
-        android:paddingLeft="3dip"
-        android:textSize="14sp" >
-
-        <TextView
-            android:id="@+id/log"
+        <LinearLayout
+            android:id="@+id/log_layout"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="left"
-            android:layout_marginTop="22dip"
-            android:gravity="left"
-            android:textColor="?text_color"
-            android:textSize="14sp"
-            tools:text="log text"/>
+            android:layout_toRightOf="@id/detail_box"
+            android:orientation="vertical"
+            android:paddingTop="3dip"
+            android:paddingLeft="3dip"
+            android:textSize="14sp" >
 
-        <TextView
-            android:id="@+id/log_images"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|top"
-            android:layout_marginTop="3dip"
-            android:drawableLeft="?log_img_icon"
-            android:drawablePadding="3dip"
-            android:textColor="?text_color"
-            android:textSize="14sp"
-            tools:text="log images"/>
-    </LinearLayout>
+            <TextView
+                android:id="@+id/gcinfo"
+                style="@style/logitem_property"
+                android:visibility="gone"
+                android:gravity="left"
+                android:layout_gravity="left"/>
 
-</RelativeLayout>
+            <TextView
+                android:id="@+id/log"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="left"
+                android:gravity="left"
+                android:textColor="?text_color"
+                android:textSize="14sp"/>
+
+            <TextView
+                android:id="@+id/log_images"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="left|top"
+                android:layout_marginTop="3dip"
+                android:drawableLeft="?log_img_icon"
+                android:drawablePadding="3dip"
+                android:textColor="?text_color"
+                android:textSize="14sp"/>
+        </LinearLayout>
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/main/src/cgeo/geocaching/log/LogViewHolder.java
+++ b/main/src/cgeo/geocaching/log/LogViewHolder.java
@@ -14,6 +14,7 @@ public class LogViewHolder extends AbstractViewHolder {
     @BindView(R.id.type) protected TextView type;
     @BindView(R.id.author) protected TextView author;
     @BindView(R.id.count_or_location) protected TextView countOrLocation;
+    @BindView(R.id.gcinfo) protected TextView gcinfo;
     @BindView(R.id.log) protected TextView text;
     @BindView(R.id.log_images) protected TextView images;
     @BindView(R.id.log_mark) protected ImageView marker;

--- a/main/src/cgeo/geocaching/log/TrackableLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/TrackableLogsViewCreator.java
@@ -47,11 +47,11 @@ public class TrackableLogsViewCreator extends LogsViewCreator {
     @Override
     protected void fillCountOrLocation(final LogViewHolder holder, final LogEntry log) {
         if (StringUtils.isNotBlank(log.cacheName)) {
-            holder.countOrLocation.setText(Html.fromHtml(log.cacheName));
-            holder.countOrLocation.setVisibility(View.VISIBLE);
+            holder.gcinfo.setText(Html.fromHtml(log.cacheName));
+            holder.gcinfo.setVisibility(View.VISIBLE);
             final String cacheGuid = log.cacheGuid;
             final String cacheName = log.cacheName;
-            holder.countOrLocation.setOnClickListener(arg0 -> {
+            holder.gcinfo.setOnClickListener(arg0 -> {
                 if (StringUtils.isNotBlank(cacheGuid)) {
                     CacheDetailActivity.startActivityGuid(activity, cacheGuid, TextUtils.stripHtml(cacheName));
                 } else {
@@ -62,8 +62,11 @@ public class TrackableLogsViewCreator extends LogsViewCreator {
                     }
                 }
             });
+            holder.countOrLocation.setVisibility(View.GONE);
+            holder.gcinfo.setVisibility(View.VISIBLE);
         } else {
             holder.countOrLocation.setVisibility(View.GONE);
+            holder.gcinfo.setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
Currently the cache name info of trackable logs get cut off, only a small portion is shown. This PR moves the cache information in trackable log list to the main column to give it more space. Cache log list remains unchanged.

![grafik](https://user-images.githubusercontent.com/3754370/62736068-db2d0980-ba2c-11e9-9797-49cb9d7c80d8.png)

currently the list looks like this:
_(see the cache name "TB - Schlosshotel Rasthof Stillhorn" in the log of "michaundkaro" which got cut off to "TB - Schlossh.")_
![grafik](https://user-images.githubusercontent.com/3754370/62736920-e123ea00-ba2e-11e9-84b7-7bebe79255d1.png)
