### PR TITLE
output warning when restore database failed due to corrupt database

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -638,6 +638,7 @@
     <string name="backup_confirm_overwrite">Do you want to overwrite the existing backup from %s?</string>
     <string name="restore_confirm_overwrite">Do you want to overwrite %s on your device with the backup?</string>
     <string name="init_restore_success">Restoration completed.</string>
+    <string name="init_restore_failed_dbrecreated">Restoration failed: Backup file corrupt, database had to be recreated.</string>
     <string name="init_restore_failed">Restoration failed.</string>
     <string name="init_restore_running">Restoring cache database…</string>
     <string name="init_restore_confirm">Database is empty. Do you want to restore the database backup?</string>

--- a/main/src/cgeo/geocaching/utils/DatabaseBackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/DatabaseBackupUtils.java
@@ -13,7 +13,7 @@ import android.support.annotation.Nullable;
 
 import java.io.File;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.functions.Consumer;
 import io.reactivex.schedulers.Schedulers;
@@ -49,11 +49,14 @@ public class DatabaseBackupUtils {
     private static void restoreDatabaseInternal(final Activity activity) {
         final Resources res = activity.getResources();
         final ProgressDialog dialog = ProgressDialog.show(activity, res.getString(R.string.init_backup_restore), res.getString(R.string.init_restore_running), true, false);
-        final AtomicBoolean restoreSuccessful = new AtomicBoolean(false);
+        final AtomicInteger restoreSuccessful = new AtomicInteger(DataStore.RESTORE_FAILED_GENERAL);
         AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> restoreSuccessful.set(DataStore.restoreDatabaseInternal()), () -> {
             dialog.dismiss();
-            final boolean restored = restoreSuccessful.get();
-            final String message = restored ? res.getString(R.string.init_restore_success) : res.getString(R.string.init_restore_failed);
+            final int restored = restoreSuccessful.get();
+            final String message =
+                    restored == DataStore.RESTORE_SUCCESSFUL ? res.getString(R.string.init_restore_success) :
+                    restored == DataStore.RESTORE_FAILED_DBRECREATED ? res.getString(R.string.init_restore_failed_dbrecreated) :
+                    res.getString(R.string.init_restore_failed);
             Dialogs.message(activity, R.string.init_backup_restore, message);
             if (activity instanceof MainActivity) {
                 ((MainActivity) activity).updateCacheCounter();


### PR DESCRIPTION
Currently c:geo silently fails when restoring a corrupt database. It even displays "restore successful", which, in this case, only means that copying the backup database file has been successful.

This PR changes this behaviour to perform a check after initializing the freshly copied backup file whether the `newlyCreatedDatabase` flag is set, and outputting a warning message if so.