### PR TITLE
Fix Icon size in lists different with/without overlay (fix #5193)

### DIFF
--- a/main/res/drawable/mark_transparent.xml
+++ b/main/res/drawable/mark_transparent.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" >
+
+    <solid android:color="#00000000" />
+
+</shape>

--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -32,8 +32,8 @@
         android:layout_marginRight="4dip"
         android:layout_toRightOf="@id/checkbox"
         android:scaleType="fitXY"
-        android:src="@drawable/mark_green"
-        android:visibility="gone"
+        android:src="@drawable/mark_transparent"
+        android:visibility="visible"
         tools:visibility="visible"/>
 
     <!-- cache name and icon -->

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -372,15 +372,12 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> {
     public static void updateViewHolder(final ViewHolder holder, final Geocache cache, final Resources res) {
         if (cache.isFound() && cache.isLogOffline()) {
             holder.logStatusMark.setImageResource(R.drawable.mark_green_orange);
-            holder.logStatusMark.setVisibility(View.VISIBLE);
         } else if (cache.isFound()) {
             holder.logStatusMark.setImageResource(R.drawable.mark_green_more);
-            holder.logStatusMark.setVisibility(View.VISIBLE);
         } else if (cache.isLogOffline()) {
             holder.logStatusMark.setImageResource(R.drawable.mark_orange);
-            holder.logStatusMark.setVisibility(View.VISIBLE);
         } else {
-            holder.logStatusMark.setVisibility(View.GONE);
+            holder.logStatusMark.setImageResource(R.drawable.mark_transparent);
         }
         holder.text.setCompoundDrawablesWithIntrinsicBounds(MapMarkerUtils.getCacheMarker(res, cache, holder.cacheListType), null, null, null);
     }


### PR DESCRIPTION
Fixes the two causes for ragged display in cache list:
- fix different icon sizes (by calculating inset padding at runtime to respect the actual scaling)
- always reserve space for offline marker in cache list (show transparent marker if needed)

This fix is also a prerequisite for PR #7577.