### PR TITLE
POC: show status message on main screen, if no live connector is active

### DIFF
--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -167,6 +167,15 @@ public final class ConnectorFactory {
         return liveConns.toArray(new ILogin[liveConns.size()]);
     }
 
+    public static boolean anyLiveConnectorActive() {
+        for (final IConnector conn : CONNECTORS) {
+            if (conn instanceof ILogin && conn.isActive()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @NonNull
     public static List<IConnector> getActiveConnectors() {
         final List<IConnector> activeConnectors = new ArrayList<>();


### PR DESCRIPTION
Use status updater to display a warning message on the main screen, if no live connector is active. ("live connector active" = connector must be active and support login, which requires validated authentication data)

POC only - there is a lot missing for now, eg:
- setting to disable this warning message (for "offline only" use)
- update this message after a connector was changed
- click on the message should lead to services authentification page
- strings to be put in resources + wordings adapted to "non technical view"
(and maybe more)

For now I would like to get feedback
- if this approach would be reasonable at all
- how to update the status window after a (relevant) change to the connectors
- how to start the authentication intent

![image](https://user-images.githubusercontent.com/3754370/62901328-c4542300-bd5c-11e9-8e6a-c4224f93fc62.png)
