### PR TITLE
update the locus connector

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -295,8 +295,7 @@ dependencies {
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
 
     // Locus Maps integration
-    implementation "com.asamm:locus-api:0.2.25"
-    implementation "com.asamm:locus-api-android:0.2.15"
+    implementation "com.asamm:locus-api-android:0.3.17"
 
     // Mapsforge old version
     implementation files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1700,6 +1700,7 @@
     <string name="ask_again">Ask me again</string>
     <string name="location_permission_request_explanation">c:geo needs access to the GPS on your device to locate your position and calculate distance and direction to geocaches. It cannot be used without this permission.</string>
     <string name="storage_permission_request_explanation">c:geo will write data onto your phone storage or SD card as soon as you save geocaches for offline use. Furthermore c:geo will use your phone storage for import and export of files and reading of offline maps. It cannot be used without this permission.</string>
+    <string name="storage_permission_needed">This function is not possible without storage permission.</string>
 
     <!-- colors -->
     <string name="color_blue">Blue</string>

--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.apps;
 
 import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.WaypointType;
@@ -8,10 +10,15 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.Log;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.FileProvider;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -21,11 +28,11 @@ import java.util.List;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import locus.api.android.ActionDisplay;
 import locus.api.android.ActionDisplayPoints;
-import locus.api.android.objects.PackWaypoints;
+import locus.api.android.objects.PackPoints;
 import locus.api.android.utils.LocusUtils;
 import locus.api.android.utils.exceptions.RequiredVersionMissingException;
 import locus.api.objects.extra.Location;
-import locus.api.objects.extra.Waypoint;
+import locus.api.objects.extra.Point;
 import locus.api.objects.geocaching.GeocachingData;
 import locus.api.objects.geocaching.GeocachingWaypoint;
 import org.apache.commons.collections4.CollectionUtils;
@@ -34,23 +41,29 @@ import org.apache.commons.collections4.CollectionUtils;
  * for the Locus API:
  *
  * @see <a href="http://docs.locusmap.eu/doku.php?id=manual:advanced:locus_api:installation">Locus API</a>
- * @see <a href="https://bitbucket.org/asamm/locus-api-android-sample/src/1fad202e6166239b6e424f03bac79f0000f8eb6d/src/main/java/menion/android/locus/api/utils/SampleCalls.java?at=default&fileviewer=file-view-default">Sample Calls</a>
+ * @see <a href="https://github.com/asamm/locus-api/blob/master/locus-api-android-sample/src/main/java/com/asamm/locus/api/sample/utils/SampleCalls.kt">Sample Calls</a>
  */
 public abstract class AbstractLocusApp extends AbstractApp {
+
+    private static final int NO_LOCUS_ID = -1;
+    /**
+     * Locus Version
+     */
+    private final LocusUtils.LocusVersion lv;
 
     @SuppressFBWarnings("NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION")
     protected AbstractLocusApp(@NonNull final String text, @NonNull final String intent) {
         super(text, intent);
+
+        lv = LocusUtils.getActiveVersion(CgeoApplication.getInstance());
+        if (lv == null) { // locus not installed
+            Log.w("Couldn't get active Locus version");
+        }
     }
 
     @Override
     public boolean isInstalled() {
-        try {
-            return LocusUtils.getActiveVersion(CgeoApplication.getInstance()) != null;
-        } catch (final Exception ignored) {
-            Log.w("Couldn't get active Locus version", ignored);
-        }
-        return false;
+        return lv != null;
     }
 
     /**
@@ -61,16 +74,20 @@ public abstract class AbstractLocusApp extends AbstractApp {
      * @param withCacheWaypoints
      *            Whether to give waypoints of caches to Locus or not
      */
-    protected static void showInLocus(final List<?> objectsToShow, final boolean withCacheWaypoints, final boolean export,
-            final Context context) {
+    protected void showInLocus(final List<?> objectsToShow, final boolean withCacheWaypoints, final boolean export,
+                               final Context context) {
         if (CollectionUtils.isEmpty(objectsToShow)) {
             return;
         }
 
+        if (!isInstalled()) {
+            return;
+        }
+
         final boolean withCacheDetails = objectsToShow.size() < 200;
-        final PackWaypoints pd = new PackWaypoints("c:geo");
+        final PackPoints pd = new PackPoints("c:geo");
         for (final Object o : objectsToShow) {
-            Waypoint p = null;
+            Point p = null;
             // get icon and Point
             if (o instanceof Geocache) {
                 p = getCachePoint((Geocache) o, withCacheWaypoints, withCacheDetails);
@@ -78,20 +95,19 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 p = getWaypointPoint((cgeo.geocaching.models.Waypoint) o);
             }
             if (p != null) {
-                pd.addWaypoint(p);
+                pd.addPoint(p);
             }
         }
 
-        if (pd.getWaypoints().isEmpty()) {
+        if (pd.getPoints().length == 0) {
             return;
         }
 
-        if (pd.getWaypoints().size() <= 1000) {
+        if (pd.getPoints().length <= 1000) {
             try {
-                ActionDisplayPoints.sendPack(context, pd, export ? ActionDisplay.ExtraAction.IMPORT : ActionDisplay.ExtraAction.CENTER);
+                ActionDisplayPoints.INSTANCE.sendPack(context, pd, export ? ActionDisplay.ExtraAction.IMPORT : ActionDisplay.ExtraAction.CENTER);
             } catch (final RequiredVersionMissingException e) {
                 Log.e("AbstractLocusApp.showInLocus: problem in sendPack", e);
-                return;
             }
         } else {
             final File externalDir = Environment.getExternalStorageDirectory();
@@ -105,15 +121,26 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 filePath += "/";
             }
             filePath += "Android/data/menion.android.locus.api/files/showIn.locus";
+            final File file = new File(filePath);
 
-            final ArrayList<PackWaypoints> data = new ArrayList<>();
+            final ArrayList<PackPoints> data = new ArrayList<>();
             data.add(pd);
 
             try {
-                ActionDisplayPoints.sendPacksFile(context, data, filePath, export ? ActionDisplay.ExtraAction.IMPORT : ActionDisplay.ExtraAction.CENTER);
+                if (lv.isVersionValid(LocusUtils.VersionCode.UPDATE_15)) {
+                    // send file via FileProvider, you don't need WRITE_EXTERNAL_STORAGE permission for this
+                    final Uri uri = FileProvider.getUriForFile(context, context.getString(R.string.file_provider_authority), file);
+                    ActionDisplayPoints.INSTANCE.sendPacksFile(context, lv, data, file, uri, export ? ActionDisplay.ExtraAction.IMPORT : ActionDisplay.ExtraAction.CENTER);
+                } else {
+                    // send file old way, you need WRITE_EXTERNAL_STORAGE permission for this
+                    if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+                        ActionDisplayPoints.INSTANCE.sendPacksFile(context, lv, data, file.getAbsolutePath(), ActionDisplay.ExtraAction.CENTER);
+                    } else {
+                        ActivityMixin.showToast(context, getString(R.string.storage_permission_needed));
+                    }
+                }
             } catch (final RequiredVersionMissingException e) {
                 Log.e("AbstractLocusApp.showInLocus: problem in sendPacksFile", e);
-                return;
             }
         }
     }
@@ -129,17 +156,18 @@ public abstract class AbstractLocusApp extends AbstractApp {
      * @return null, when the {@code Point} could not be constructed
      */
     @Nullable
-    private static Waypoint getCachePoint(final Geocache cache, final boolean withWaypoints, final boolean withCacheDetails) {
+    private static Point getCachePoint(final Geocache cache, final boolean withWaypoints, final boolean withCacheDetails) {
         if (cache == null || cache.getCoords() == null) {
             return null;
         }
 
         // create one simple point with location
-        final Location loc = new Location("cgeo");
+        final Location loc = new Location();
+        loc.setProvider("cgeo");
         loc.setLatitude(cache.getCoords().getLatitude());
         loc.setLongitude(cache.getCoords().getLongitude());
 
-        final Waypoint wpt = new Waypoint(cache.getName(), loc);
+        final Point wpt = new Point(cache.getName(), loc);
         // generate new data
         final GeocachingData gcData = new GeocachingData();
 
@@ -222,7 +250,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
      * @return null, when the {@code Point} could not be constructed
      */
     @Nullable
-    private static Waypoint getWaypointPoint(final cgeo.geocaching.models.Waypoint waypoint) {
+    private static Point getWaypointPoint(final cgeo.geocaching.models.Waypoint waypoint) {
         if (waypoint == null) {
             return null;
         }
@@ -232,18 +260,21 @@ public abstract class AbstractLocusApp extends AbstractApp {
         }
 
         // create one simple point with location
-        final Location loc = new Location("cgeo");
+        final Location loc = new Location();
+        loc.setProvider("cgeo");
         loc.setLatitude(coordinates.getLatitude());
         loc.setLongitude(coordinates.getLongitude());
 
-        final Waypoint p = new Waypoint(waypoint.getName(), loc);
-        //TODO: not supported by new Locus API (or I haven't found it yet, pstorch)
-        //p.setDescription("<a href=\"" + waypoint.getUrl() + "\">" + waypoint.getGeocode() + "</a>");
+        final Point p = new Point(waypoint.getName(), loc);
+        p.setParameterDescription(
+                "Name: " + waypoint.getName() +
+                        "<br />Note: " + waypoint.getNote() +
+                        "<br />UserNote: " + waypoint.getUserNote() +
+                        "<br /><br /> <a href=\"" + waypoint.getUrl() + "\">" + waypoint.getGeocode() + "</a>"
+        );
 
         return p;
     }
-
-    private static final int NO_LOCUS_ID = -1;
 
     // https://github.com/asamm/locus-api/blob/master/locus-api-core/src/main/java/locus/api/objects/geocaching/GeocachingData.java
     private static int toLocusType(final CacheType ct) {
@@ -276,8 +307,14 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 return GeocachingData.CACHE_TYPE_LF_EVENT;
             case PROJECT_APE:
                 return GeocachingData.CACHE_TYPE_PROJECT_APE;
+            case GCHQ:
+                return GeocachingData.CACHE_TYPE_GROUNDSPEAK;
+            case GCHQ_CELEBRATION:
+                return GeocachingData.CACHE_TYPE_LF_CELEBRATION;
             case GPS_EXHIBIT:
                 return GeocachingData.CACHE_TYPE_GPS_ADVENTURE;
+            case BLOCK_PARTY:
+                return GeocachingData.CACHE_TYPE_EVENT; // no special locus type
             default:
                 return NO_LOCUS_ID;
         }
@@ -285,6 +322,8 @@ public abstract class AbstractLocusApp extends AbstractApp {
 
     private static int toLocusSize(final CacheSize cs) {
         switch (cs) {
+            case NANO:
+                return GeocachingData.CACHE_SIZE_MICRO; // used by OC only
             case MICRO:
                 return GeocachingData.CACHE_SIZE_MICRO;
             case SMALL:
@@ -293,6 +332,8 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 return GeocachingData.CACHE_SIZE_REGULAR;
             case LARGE:
                 return GeocachingData.CACHE_SIZE_LARGE;
+            case VERY_LARGE:
+                return GeocachingData.CACHE_SIZE_HUGE; // used by OC only
             case NOT_CHOSEN:
                 return GeocachingData.CACHE_SIZE_NOT_CHOSEN;
             case OTHER:


### PR DESCRIPTION
fix #7721

build.gradle
- update to locus-api-android:0.3.17 (=latest)
- locus-api is no more a direct prereq, removed

AbstractLocusApp
- Update links
- chage code to make locus-api-android:0.3.17 happy
  - Waypoint to Point
  - PackWaypoints to PackPoints
  - some changes for locus code changes (some java code is now kotlin, minor API changes)
  - use the new method sendPacksFile without external storage permission for Locus version greater UPDATE_15
  - implement permission checks for older locus installation
  - add some Description for Waypoints
  - add some c:geo to locus cache type migrations
  - add some c:geo to locus (OC) cache size migrations
- sort some parameter

strings.xml
- add text for storage permission message
