### PR TITLE
add visit state toggle button to map's waypoint popup (fix #2592)

### DIFF
--- a/main/res/layout/waypoint_popup.xml
+++ b/main/res/layout/waypoint_popup.xml
@@ -30,14 +30,21 @@
 
             <LinearLayout
                 android:id="@+id/edit_box"
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="vertical" >
+                android:layout_gravity="right"
+                android:orientation="horizontal" >
+
+                <Button
+                    android:id="@+id/toggle_visited"
+                    style="@style/button_small"
+                    android:text="toggle visited" />
 
                 <Button
                     android:id="@+id/edit"
                     style="@style/button_small"
                     android:text="@string/waypoint_edit" />
+
             </LinearLayout>
 
             <RelativeLayout style="@style/separator_horizontal_layout" >

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1105,6 +1105,8 @@
     <string name="waypoint_note">Note</string>
     <string name="waypoint_user_note">User note</string>
     <string name="waypoint_visited">Visited</string>
+    <string name="waypoint_set_visited">Set visited</string>
+    <string name="waypoint_unset_visited">Unset visited</string>
     <string name="waypoint_save">Save</string>
     <string name="waypoint_cancel_edit">Cancel</string>
     <string name="waypoint_loading">Loading waypoint…</string>

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNotification {
     @BindView(R.id.actionbar_title) protected TextView actionBarTitle;
     @BindView(R.id.waypoint_details_list) protected LinearLayout waypointDetailsLayout;
+    @BindView(R.id.toggle_visited) protected Button buttonToggle;
     @BindView(R.id.edit) protected Button buttonEdit;
     @BindView(R.id.details_list) protected LinearLayout cacheDetailsLayout;
 
@@ -97,6 +98,13 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             details.add(R.string.cache_geocode, waypoint.getPrefix() + waypoint.getGeocode().substring(2));
             waypointDistance = details.addDistance(waypoint, waypointDistance);
             details.addHtml(R.string.waypoint_note, waypoint.getNote(), waypoint.getGeocode());
+
+            buttonToggle.setText(waypoint.isVisited() ? R.string.waypoint_unset_visited : R.string.waypoint_set_visited);
+            buttonToggle.setOnClickListener(arg1 -> {
+                waypoint.setVisited(!waypoint.isVisited());
+                DataStore.saveWaypoint(waypoint.getId(), waypoint.getGeocode(), waypoint);
+                buttonToggle.setText(waypoint.isVisited() ? R.string.waypoint_unset_visited : R.string.waypoint_set_visited);
+            });
 
             buttonEdit.setOnClickListener(arg0 -> {
                 EditWaypointActivity.startActivityEditWaypoint(getActivity(), cache, waypoint.getId());


### PR DESCRIPTION
added a toggle button to the map's waypoint popup:

![image](https://user-images.githubusercontent.com/3754370/63193509-f7085f00-c06d-11e9-8a78-ef8e0e8213a6.png)

(label switches from "set visited" to "unset visited" according to current state)