### PR TITLE
add function to batch upload coords for all (selected) caches

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -74,6 +74,10 @@
                 android:title="@string/caches_upload_modifiedcoords"
                 app:showAsAction="ifRoom|withText"/>
             <item
+                android:id="@+id/menu_upload_allcoords"
+                android:title="@string/caches_upload_allcoords"
+                app:showAsAction="ifRoom|withText"/>
+            <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"
                 android:enabled="false"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -371,6 +371,8 @@
     <string name="caches_delete_events">Delete past events</string>
     <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>
     <string name="caches_upload_modifiedcoords_warning">Do you want to upload modified coordinates for all (selected) caches and overwrite the existing coordinates on the server? This cannot be undone.</string>
+    <string name="caches_upload_allcoords">Upload coordinates for all caches</string>
+    <string name="caches_upload_allcoords_warning">Do you want to upload coordinates for all (selected) caches and overwrite the existing coordinates on the server? This cannot be undone.</string>
     <string name="caches_refresh_selected">Refresh selected</string>
     <string name="caches_refresh_all">Refresh all</string>
     <string name="caches_move_selected">Move selected</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -960,7 +960,11 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 return true;
             case R.id.menu_upload_modifiedcoords:
                 final Activity that = this;
-                Dialogs.confirm(this, R.string.caches_upload_modifiedcoords, R.string.caches_upload_modifiedcoords_warning, (dialog, which) -> new BatchUploadModifiedCoordinates().export(adapter.getCheckedOrAllCaches(), that));
+                Dialogs.confirm(this, R.string.caches_upload_modifiedcoords, R.string.caches_upload_modifiedcoords_warning, (dialog, which) -> new BatchUploadModifiedCoordinates(true).export(adapter.getCheckedOrAllCaches(), that));
+                return true;
+            case R.id.menu_upload_allcoords:
+                final Activity that2 = this;
+                Dialogs.confirm(this, R.string.caches_upload_allcoords, R.string.caches_upload_allcoords_warning, (dialog, which) -> new BatchUploadModifiedCoordinates(false).export(adapter.getCheckedOrAllCaches(), that2));
                 return true;
             case R.id.menu_remove_from_history:
                 removeFromHistoryCheck();

--- a/main/src/cgeo/geocaching/export/BatchUploadModifiedCoordinates.java
+++ b/main/src/cgeo/geocaching/export/BatchUploadModifiedCoordinates.java
@@ -24,9 +24,11 @@ public class BatchUploadModifiedCoordinates extends AbstractExport {
     private int uploadProgress = 0;
     private int uploadOk = 0;
     private int uploadFailed = 0;
+    private boolean modifiedOnly = true;
 
-    public BatchUploadModifiedCoordinates() {
+    public BatchUploadModifiedCoordinates(final boolean modifiedOnly) {
         super(R.string.export_modifiedcoords);
+        this.modifiedOnly = modifiedOnly;
     }
 
     @Override
@@ -49,7 +51,7 @@ public class BatchUploadModifiedCoordinates extends AbstractExport {
                 IConnector con;
                 for (final Geocache cache : caches) {
                     publishProgress(++uploadProgress);
-                    if (cache.hasUserModifiedCoords()) {
+                    if (!modifiedOnly || cache.hasUserModifiedCoords()) {
                         con = ConnectorFactory.getConnector(cache);
                         if (con.supportsOwnCoordinates()) {
                             if (!con.uploadModifiedCoordinates(cache, cache.getCoords())) {
@@ -61,7 +63,7 @@ public class BatchUploadModifiedCoordinates extends AbstractExport {
                     }
                 }
             } catch (final Exception e) {
-                Log.e("BatchUploadModifiedCoordinates.ExportTask exception when uploading modified coords", e);
+                Log.e("BatchUploadModifiedCoordinates.ExportTask exception when uploading coords", e);
                 return false;
             }
             return true;


### PR DESCRIPTION
This is a follow up PR related to the recent discussion in #7028:

Our current method to batch upload coords for caches relies on the internal flag in c:geo for "modified coords", which gets set by either manually storing a waypoint's coords as new final coords in c:geo or by using a GPX import which has the needed GSAK extensions (and data).

This PR adds a separate menu entry to upload the current coords for all / all selected caches.

To upload caches of a GPX without the proper GSAK extensions you can simply import this GPX to a new list and use the new "upload coordinates for all caches" menu entry.