### PR TITLE
move 'additional lists' setting to preferences

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -113,10 +113,6 @@
                 android:enabled="false"
                 app:showAsAction="never|withText"/>
             <item
-                android:id="@+id/menu_toggle_listdisplay"
-                android:title="@string/caches_toggle_listdisplay"
-                app:showAsAction="ifRoom|withText"/>
-            <item
                 android:id="@+id/menu_set_listmarker"
                 android:title="@string/caches_set_listmarker"
                 app:showAsAction="never|withText">

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -410,7 +410,6 @@
     <string name="caches_clear_offlinelogs_message">Do you want to clear the offline logs?</string>
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
     <string name="caches_make_list_unique">Make list unique</string>
-    <string name="caches_toggle_listdisplay">Toggle display of additional lists</string>
     <string name="caches_set_listmarker">Set list marker</string>
     <string name="caches_listmarker_none">No marker</string>
     <string name="caches_listmarker_marker">Marker %d</string>
@@ -630,6 +629,7 @@
     <string name="init_summary_log_offline">Enable Offline Logging (Won\'t show online log screen when logging, won\'t upload logs)</string>
     <string name="init_choose_list">Ask for List</string>
     <string name="init_summary_choose_list">Ask which list to store caches in</string>
+    <string name="init_listdisplay">Show additional lists in cache list</string>
     <string name="init_livelist">Show Direction</string>
     <string name="init_summary_livelist">Show direction of caches in the list</string>
 

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -680,6 +680,10 @@
             android:key="@string/pref_choose_list"
             android:summary="@string/init_summary_choose_list"
             android:title="@string/init_choose_list" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/pref_showListsInCacheList"
+            android:title="@string/init_listdisplay" />
 
         <PreferenceCategory android:title="@string/settings_title_gpx"
             android:layout="@layout/preference_category" >

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -940,12 +940,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             case R.id.menu_rename_list:
                 renameList();
                 return true;
-            case R.id.menu_toggle_listdisplay:
-                final boolean showListsInCacheList = !Settings.showListsInCacheList();
-                Settings.setShowListsInCacheList(showListsInCacheList);
-                setAdapterStoredList();
-                updateAdapter();
-                return true;
             case R.id.menu_invert_selection:
                 adapter.invertSelection();
                 invalidateOptionsMenuCompatible();
@@ -1276,7 +1270,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         registerForContextMenu(listView);
 
         adapter = new CacheListAdapter(this, cacheList, type);
-        setAdapterStoredList();
+        adapter.setStoredLists(Settings.showListsInCacheList() ? StoredList.UserInterface.getMenuLists(true, PseudoList.NEW_LIST.id) : null);
         adapter.setFilter(currentFilter);
 
         if (listFooter == null) {
@@ -1290,10 +1284,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         adapter.setInverseSort(currentInverseSort);
         adapter.forceSort();
-    }
-
-    private void setAdapterStoredList() {
-        adapter.setStoredLists(Settings.showListsInCacheList() ? StoredList.UserInterface.getMenuLists(true, PseudoList.NEW_LIST.id) : null);
     }
 
     private void updateAdapter() {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -754,7 +754,7 @@ public class Settings {
     }
 
     public static boolean showListsInCacheList() {
-        return getBoolean(R.string.pref_showListsInCacheList, false);
+        return getBoolean(R.string.pref_showListsInCacheList, true);
     }
 
     public static void setShowListsInCacheList(final boolean showListsInCacheList) {


### PR DESCRIPTION
A followup to #7769:
- move "show additional lists" toggle from CacheList dot menu to preferences screen (offline data section)
- set default to true
