### PR TITLE
Fix missing map update on icon switch

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -235,6 +235,9 @@ public class CachesBundle {
         if (liveOverlay != null) {
             liveOverlay.invalidateAll();
         }
+        if (wpOverlay != null) {
+            wpOverlay.invalidateAll();
+        }
     }
 
     public boolean isDownloading() {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesOverlay.java
@@ -62,10 +62,11 @@ public class CachesOverlay extends AbstractCachesOverlay {
             overlay.updating = true;
             try {
                 // Initially bring the main list in
-                if (overlay.firstRun) {
+                if (overlay.firstRun || overlay.isInvalidated()) {
                     final Set<Geocache> cachesToDisplay = overlay.search.getCachesFromSearchResult(LoadFlags.LOAD_WAYPOINTS);
                     overlay.display(cachesToDisplay);
                     overlay.firstRun = false;
+                    overlay.refreshed();
                 }
 
                 // get current viewport


### PR DESCRIPTION
Fixes #7799 

In addition, on non-live maps when icons were switched, the cache markers just vanished. Now they switch correctly.