### PR TITLE
invalidate base overlay on wp popup from single cache map

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -228,6 +228,9 @@ public class CachesBundle {
         if (wpOverlay != null) {
             wpOverlay.invalidateWaypoints(geocodes);
         }
+        if (baseOverlay != null) {
+            baseOverlay.invalidate(geocodes);
+        }
     }
 
     /**


### PR DESCRIPTION
Triggers repaint of base overlay and related waypoints, if coming from waypoint popup on a single cache map. Fixes #7812