### PR TITLE
update libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // check for updates of gradle plugin dependencies
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.22.0'
 
         // Android gradle plugin
         classpath 'com.android.tools.build:gradle:3.4.2'
@@ -84,7 +84,7 @@ buildscript {
         classpath 'com.github.gfx.ribbonizer:ribbonizer-plugin:2.1.0'
 
         // gradle build script profiling
-        classpath 'com.gradle:build-scan-plugin:2.3'
+        classpath 'com.gradle:build-scan-plugin:2.4.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // check for updates of gradle plugin dependencies
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.22.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.24.0'
 
         // Android gradle plugin
         classpath 'com.android.tools.build:gradle:3.4.2'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -95,13 +95,13 @@ android {
 
     buildTypes.all { buildType ->
         // enable proguard and remove unused code
-        buildType.minifyEnabled true
+        minifyEnabled true
 
         // remove unused resources in addition to unused code
         shrinkResources true
 
         // proguard rules
-        buildType.proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
+        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
     }
 
     testBuildType "debug" //the default BuildType
@@ -248,8 +248,8 @@ dependencies {
     implementation "org.androidannotations:androidannotations-api:$androidAnnotationsVersion"
 
     // Apache Commons
-    implementation 'org.apache.commons:commons-collections4:4.3'
-    implementation 'org.apache.commons:commons-compress:1.18'
+    implementation 'org.apache.commons:commons-collections4:4.4'
+    implementation 'org.apache.commons:commons-compress:1.19'
     implementation 'commons-io:commons-io:2.5'
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.apache.commons:commons-text:1.1'
@@ -275,8 +275,9 @@ dependencies {
 
     // Jackson XML processing
     def jacksonVersion = '2.9.9'
+    def jacksonVersionPatch = '2.9.9.3'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersionPatch"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
 
     // Jsoup HTML parsing
@@ -299,7 +300,7 @@ dependencies {
 
     // Mapsforge old version
     implementation files('libs/mapsforge-map-0.3.0-jar-with-dependencies.jar')
-    implementation 'com.caverock:androidsvg:1.3'
+    implementation 'com.caverock:androidsvg:1.4'
 
     // Mapsforge new version
     def mapsforgeVersion = '0.11.0'
@@ -316,10 +317,10 @@ dependencies {
     implementation project(":mapswithme-api")
 
     // Metadata Extractor, EXIF location extraction from images
-    implementation 'com.drewnoakes:metadata-extractor:2.11.0'
+    implementation 'com.drewnoakes:metadata-extractor:2.12.0'
 
     // Okhttp network access. 3.12.x is API level < 21, 3.13 or better requires API 21
-    implementation 'com.squareup.okhttp3:okhttp:3.12.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.3'
 
     // Play Services
     implementation 'com.google.android.gms:play-services-location:11.8.0'
@@ -330,7 +331,7 @@ dependencies {
     implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation "io.reactivex.rxjava2:rxjava:2.2.8"
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.12'
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
 
     // Support Libraries. All com.android.support.* libraries must use the same version
@@ -354,7 +355,7 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:$supportLibraryVersion"
 
     // Testing Support Library. Android Studio recommended test runner, see https://developer.android.com/tools/testing-support-library/index.html#setup
-    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
 
     // Undo toast
     implementation 'com.github.jenzz.undobar:library:1.3:api8Release@aar'


### PR DESCRIPTION
Update used libraries compatible to the current supportLibraryVersion and compileSdkVersion
and minor syntax optimization.

List of updated libraries:
com.github.ben-manes:gradle-versions-plugin: 0.21.0 -> 0.24.0
com.gradle:build-scan-plugin: 2.3 -> 2.4.1
org.apache.commons:commons-collections4: 4.3 -> 4.4
org.apache.commons:commons-compress: 1.18 -> 1.19
com.fasterxml.jackson.core:jackson-databind: 2.9.9 -> 2.9.9.3
com.caverock:androidsvg: 1.3 -> 1.4
com.drewnoakes:metadata-extractor: 2.11.0 -> 2.12.0
com.squareup.okhttp3:okhttp: 3.12.2 -> 3.12.3
io.reactivex.rxjava2:rxjava: 2.2.8 -> 2.2.12
com.android.support.test:runner : 0.5 -> 1.0.1