### PR TITLE
fix "lint:unchecked" warnings

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -529,7 +529,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         setTitle();
 
         // initialize map
-        mapView = activity.findViewById(mapProvider.getMapViewId());
+        mapView = (MapViewImpl) activity.findViewById(mapProvider.getMapViewId());
 
         // added keys must be removed before passing bundle to google's mapView, otherwise this will be thrown:
         // ClassNotFoundException: Didn't find class "cgeo.geocaching.sensors.GeoData"

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -529,7 +529,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         setTitle();
 
         // initialize map
-        mapView = (MapViewImpl) activity.findViewById(mapProvider.getMapViewId());
+        mapView = activity.findViewById(mapProvider.getMapViewId());
 
         // added keys must be removed before passing bundle to google's mapView, otherwise this will be thrown:
         // ClassNotFoundException: Didn't find class "cgeo.geocaching.sensors.GeoData"

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -291,7 +291,7 @@ public class CachesBundle {
 
     public void handleWaypoints() {
         if (getVisibleCachesCount() < Settings.getWayPointsThreshold()) {
-            Collection<String> baseGeocodes = Collections.<String>emptyList();
+            Collection<String> baseGeocodes = Collections.emptyList();
             if (baseOverlay != null) {
                 baseGeocodes = baseOverlay.getCacheGeocodes();
             }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -291,7 +291,7 @@ public class CachesBundle {
 
     public void handleWaypoints() {
         if (getVisibleCachesCount() < Settings.getWayPointsThreshold()) {
-            Collection<String> baseGeocodes = Collections.EMPTY_LIST;
+            Collection<String> baseGeocodes = Collections.<String>emptyList();
             if (baseOverlay != null) {
                 baseGeocodes = baseOverlay.getCacheGeocodes();
             }

--- a/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
@@ -75,7 +75,7 @@ public class SharedPrefsBackupUtils extends Activity {
     private void backupInternal(final Boolean fullBackup, final Runnable runAfterwards) {
         final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), MODE_PRIVATE);
         final Map<String, ?> keys = prefs.getAll();
-        final HashSet<String> ignoreKeys = new HashSet<String>();
+        final HashSet<String> ignoreKeys = new HashSet<>();
 
         // if a backup without account data is requested add all account related preference keys to the ignore set
         if (!fullBackup) {

--- a/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
@@ -75,7 +75,7 @@ public class SharedPrefsBackupUtils extends Activity {
     private void backupInternal(final Boolean fullBackup, final Runnable runAfterwards) {
         final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), MODE_PRIVATE);
         final Map<String, ?> keys = prefs.getAll();
-        final HashSet<String> ignoreKeys = new HashSet();
+        final HashSet<String> ignoreKeys = new HashSet<String>();
 
         // if a backup without account data is requested add all account related preference keys to the ignore set
         if (!fullBackup) {


### PR DESCRIPTION
Fix these 3 warnings:

~~~
\cgeo\main\src\cgeo\geocaching\maps\CGeoMap.java:532: warning: [unchecked] unchecked conversion
        mapView = (MapViewImpl) activity.findViewById(mapProvider.getMapViewId());
                  ^
  required: MapViewImpl<CachesOverlayItemImpl>
  found:    MapViewImpl

\cgeo\main\src\cgeo\geocaching\maps\mapsforge\v6\caches\CachesBundle.java:294: warning: [unchecked] unchecked conversion
            Collection<String> baseGeocodes = Collections.EMPTY_LIST;
                                                         ^
  required: Collection<String>
  found:    List

\cgeo\main\src\cgeo\geocaching\utils\SharedPrefsBackupUtils.java:78: warning: [unchecked] unchecked conversion
        final HashSet<String> ignoreKeys = new HashSet();
                                           ^
  required: HashSet<String>
  found:    HashSet
~~~