### PR TITLE
reenable Google Maps on Android 10

### DIFF
--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -36,12 +36,6 @@ public class MapProviderFactory {
     }
 
     public static boolean isGoogleMapsInstalled() {
-        // Check if running on Android 10 or higher, as our current Google Maps v1 implementation is no longer supported on Q or higher
-        // @todo: check needs to be removed as soon as Google Maps v2 implementation is merged
-        if (android.os.Build.VERSION.SDK_INT >= 29) {
-            return false;
-        }
-
         // Check if API key is available
         final String mapsKey = CgeoApplication.getInstance().getString(R.string.maps_api2_key);
         if (StringUtils.length(mapsKey) < 30 || StringUtils.contains(mapsKey, "key")) {


### PR DESCRIPTION
We can re-enable Google Maps for Android 10 since the new Google Maps v2 API branch has been merged.