### PR TITLE
set circle state on GMv2 startup according to settings, if no mapstate is available

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -470,6 +470,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         if (mapOptions.mapState == null) {
             followMyLocation = followMyLocation && (mapOptions.mapMode == MapMode.LIVE);
+            mapView.setCircles(Settings.getCircles());
         } else {
             followMyLocation = mapOptions.mapState.followsMyLocation();
             if (mapView.getCircles() != mapOptions.mapState.showsCircles()) {


### PR DESCRIPTION
Fixes #7843
