### PR TITLE
downgrade support library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ buildScan {
  */
 
 ext {
-    supportLibraryVersion = '27.1.1'
+    supportLibraryVersion = '27.0.2'
 }
 
 subprojects {


### PR DESCRIPTION
to fix #7860

The app crash was caused by upgrading the Support Library to the latest 27.x version. (27.1.0)
The last version without this problem is 27.0.2.