### PR TITLE
fix String formatting

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1729,7 +1729,7 @@
     <string name="color_grey">Grey</string>
 
     <!-- number input -->
-    <string name="number_input_title">Enter a value between %s and %s</string>
+    <string name="number_input_title">Enter a value between %1$s and %2$s</string>
     <string name="number_input_err_boundarymin">Entered value is too small - reset to min value</string>
     <string name="number_input_err_boundarymax">Entered value is too large - reset to max value</string>
     <string name="number_input_err_format">Invalid number format</string>

--- a/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractSeekbarPreference.java
@@ -143,7 +143,7 @@ public abstract class AbstractSeekbarPreference extends Preference {
         valueView.setOnClickListener(v2 -> {
             final EditText editText = new EditText(context);
             editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | (hasDecimals ? InputType.TYPE_NUMBER_FLAG_DECIMAL : 0));
-            editText.setText(String.valueOf(valueToShownValue(progressToValue(seekBar.getProgress()))));
+            editText.setText(valueToShownValue(progressToValue(seekBar.getProgress())));
 
             new AlertDialog.Builder(context)
                 .setTitle(String.format(context.getString(R.string.number_input_title), valueToShownValue(progressToValue(minValue)), valueToShownValue(progressToValue(maxValue))))


### PR DESCRIPTION
If multiple format arguments are used, they need positions, otherwise there are new build warnings.