### PR TITLE
fix parsing of empty waypoint notes

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -778,8 +778,13 @@ public final class GCParser {
                         }
 
                         // waypoint note, cleanup via Jsoup
-                        final Document document = Jsoup.parse(TextUtils.getMatch(wpNote[3], GCConstants.PATTERN_WPNOTE, waypoint.getNote()));
-                        waypoint.setNote(document.outerHtml());
+                        final String noteText = TextUtils.getMatch(wpNote[3], GCConstants.PATTERN_WPNOTE, waypoint.getNote());
+                        if (StringUtils.isNotBlank(noteText)) {
+                            final Document document = Jsoup.parse(noteText);
+                            waypoint.setNote(document.outerHtml());
+                        } else {
+                            waypoint.setNote(StringUtils.EMPTY);
+                        }
                     }
 
                     cache.addOrChangeWaypoint(waypoint, false);


### PR DESCRIPTION
Many stored waypoints have an empty HTML document as note (e.g. opening and closing HTML, head, body tags), since the introduction of JSoup parsing for waypoint notes in commit 81d43038d9edc4a62291d42e596c1dc550a54247. The problem is that even for blank input JSoup returns an HTML document. Instead store an empty note when there is nothing to parse.

For reproduction of the bug, open any cache with a parking place waypoint (e.g. GC8406N) and use "Google Navigation (Driving)". In the upcoming selection dialog all the parking place waypoints have a description starting with "<html>...". The bad note is NOT visible in the waypoints list, however.