### PR TITLE
set target SDK to 28

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
     }
 
     sourceSets {

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -83,7 +83,9 @@
             android:value="@string/maps_api2_key" />
 
         <!-- required by Google Maps SDK version 16 and below if targeted to SDK 28 or above -->
-        <uses-library android:name="org.apache.http.legacy" android:required="false" />
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
 
         <!-- support also very wide screen devices. https://developer.android.com/guide/practices/screens_support.html#MaxAspectRatio -->
         <meta-data

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -82,6 +82,9 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/maps_api2_key" />
 
+        <!-- required by Google Maps SDK version 16 and below if targeted to SDK 28 or above -->
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
+
         <!-- support also very wide screen devices. https://developer.android.com/guide/practices/screens_support.html#MaxAspectRatio -->
         <meta-data
             android:name="android.max_aspect"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -30,7 +30,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 

--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -2,5 +2,13 @@
 <resources>
   <!-- changelog for the master branch -->
   <string name="changelog_master" translatable="false">
+<b>Nightly version:</b>\n
+· New: Set targetSDK to 28 to comply with upcoming Play Store requirements.\n
+· Please add project \"targetSDK28\" when reporting any issues at \"https://github.com/cgeo/cgeo/issues\".\n
+· Known issues for targetSDK28 can be found at \"https://github.com/cgeo/cgeo/projects/10\".\n 
+\n 
+· New: Updated Google Maps API to v2.\n
+· Please add project \"Google Maps V2\" when reporting any issues at \"https://github.com/cgeo/cgeo/issues\".\n
+· Known issues for Google Maps v2 can be found at \"https://github.com/cgeo/cgeo/projects/8\".\n 
   </string>
 </resources>

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -7,7 +7,7 @@ android {
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 27
+    targetSdkVersion 28
   }
 
   sourceSets.main {


### PR DESCRIPTION
changes target SDK to 28 and adds "uses-library org.apache.http.legacy" to make it compilable with Google Maps

does NOT increase compileSDK to 28 as this requires a couple of further changes