### PR TITLE
set compileSdk to 28 / support library  to 28.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,8 +121,6 @@ allprojects {
                         }
                     }
                 }
-                // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
-                force 'com.google.guava:guava:26.0-jre'
             }
         }
     }
@@ -155,7 +153,7 @@ buildScan {
  */
 
 ext {
-    supportLibraryVersion = '27.0.2'
+    supportLibraryVersion = '28.0.0'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,8 @@ allprojects {
                         }
                     }
                 }
+                // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
+                force 'com.google.guava:guava:26.0-jre'
             }
         }
     }

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -18,7 +18,7 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     buildToolsVersion "28.0.3"
 
@@ -239,6 +239,10 @@ android {
         }
         // debug and release builds have offset zero, no special handling here
     }
+
+    // tests rely on JUnit-based classes
+    useLibrary 'android.test.runner'
+    useLibrary 'android.test.base'
 }
 
 dependencies {
@@ -323,9 +327,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.5'
 
     // Play Services
-    def playServicesVersion = '11.8.0'
-    implementation "com.google.android.gms:play-services-location:$playServicesVersion"
-    implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
+    implementation 'com.google.android.gms:play-services-location:16.0.0'
+    implementation 'com.google.android.gms:play-services-maps:16.1.0'
     // somehow there is a transitive play service dependency which we don't want
     configurations.all*.exclude module: "play-services-measurement"
 
@@ -357,7 +360,7 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:$supportLibraryVersion"
 
     // Testing Support Library. Android Studio recommended test runner, see https://developer.android.com/tools/testing-support-library/index.html#setup
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
 
     // Undo toast
     implementation 'com.github.jenzz.undobar:library:1.3:api8Release@aar'

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'android-library'
 android {
 
   // Define these properties in the gradle.properties file in the root project folder
-  compileSdkVersion 27
+  compileSdkVersion 28
 
   defaultConfig {
     minSdkVersion 16

--- a/tests/AndroidManifest.xml
+++ b/tests/AndroidManifest.xml
@@ -5,8 +5,8 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="16"
+        android:targetSdkVersion="28" />
 
     <uses-feature
         android:name="android.hardware.screen.portrait"
@@ -19,8 +19,15 @@
     <application
         android:allowBackup="false"
         android:icon="@drawable/icon"
-        android:label="@string/app_name" >
-        <uses-library android:name="android.test.runner" />
+        android:label="@string/app_name">
+
+        <uses-library
+            android:name="android.test.base"
+            android:required="false" />
+
+        <uses-library
+            android:name="android.test.runner"
+            android:required="false" />
 
         <activity android:name="CgeoTestsActivity" >
             <intent-filter>


### PR DESCRIPTION
fix #7866

- set compileSdk to 28 for all projects
- set minSdk/targetSdk for tests according to installation code
- set support library to 28.0.0
- use library android.test.runner /.base in code and test
- update android.gms:play-services-location/play-services-maps
- update support.test:runner