### PR TITLE
update the test environment in preparation of compileSdk 28 (fix #7866)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -323,9 +323,8 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.5'
 
     // Play Services
-    def playServicesVersion = '11.8.0'
-    implementation "com.google.android.gms:play-services-location:$playServicesVersion"
-    implementation "com.google.android.gms:play-services-maps:$playServicesVersion"
+    implementation 'com.google.android.gms:play-services-location:16.0.0'
+    implementation 'com.google.android.gms:play-services-maps:16.1.0'
     // somehow there is a transitive play service dependency which we don't want
     configurations.all*.exclude module: "play-services-measurement"
 

--- a/tests/AndroidManifest.xml
+++ b/tests/AndroidManifest.xml
@@ -5,8 +5,8 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="16"
+        android:targetSdkVersion="28" />
 
     <uses-feature
         android:name="android.hardware.screen.portrait"
@@ -19,8 +19,15 @@
     <application
         android:allowBackup="false"
         android:icon="@drawable/icon"
-        android:label="@string/app_name" >
-        <uses-library android:name="android.test.runner" />
+        android:label="@string/app_name">
+
+        <uses-library
+            android:name="android.test.base"
+            android:required="false" />
+
+        <uses-library
+            android:name="android.test.runner"
+            android:required="false" />
 
         <activity android:name="CgeoTestsActivity" >
             <intent-filter>


### PR DESCRIPTION
fix #7866 

- set minSdk/targetSdk for tests according to installation code
- use library android.test.runner /.base for tests
- update android.gms:play-services-location/play-services-maps
