### PR TITLE
extend compact icon mode to Google Maps v2 (fix #7847)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -105,7 +105,6 @@
                 android:checkable="true"
                 android:icon="@drawable/ic_menu_dot_mode"
                 android:title="@string/map_dot_mode"
-                android:visible="false"
                 app:showAsAction="ifRoom|withText">
             </item>
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -312,7 +312,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             menu.findItem(R.id.menu_direction_line).setChecked(Settings.isMapDirection());
             menu.findItem(R.id.menu_circle_mode).setChecked(Settings.getCircles());
             menu.findItem(R.id.menu_trail_mode).setChecked(Settings.isMapTrail());
-            menu.findItem(R.id.menu_dot_mode).setVisible(true);
             menu.findItem(R.id.menu_dot_mode).setChecked(Settings.isDotMode());
 
             menu.findItem(R.id.menu_theme_mode).setVisible(tileLayerHasThemes());


### PR DESCRIPTION
So far compact icon mode has been available to NewMap only. After merging Google Maps v2 this can be extended to Google Maps as well.