### PR TITLE
fix general proximity notification for Google Maps v2 (fix #7844)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1067,11 +1067,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                             map.overlayPositionAndScale.setCoordinates(currentLocation);
                             map.overlayPositionAndScale.repaintRequired();
 
-                            /*
                             if (map.proximityNotification != null) {
-                                map.proximityNotification.checkDistance(map.overlayCaches.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
+                                map.proximityNotification.checkDistance(map.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
                             }
-                            */
                         } else if (needsRepaintForHeading) {
                             final float mapBearing = map.mapView.getBearing();
                             map.overlayPositionAndScale.setHeading(currentHeading + mapBearing);
@@ -1710,6 +1708,25 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
 
         progress.dismiss();
+    }
+
+    public int getClosestDistanceInM(final Geopoint coord) {
+        int minDistance = 50000000;
+        // check caches
+        for (final Geocache item : caches) {
+            final int distance = (int) (1000 * coord.distanceTo(item.getCoords()));
+            if (distance > 0) {
+                minDistance = Math.min(minDistance, distance);
+            }
+        }
+        // check waypoints
+        for (final Waypoint item : waypoints) {
+            final int distance = (int) (1000 * coord.distanceTo(item.getCoords()));
+            if (distance > 0) {
+                minDistance = Math.min(minDistance, distance);
+            }
+        }
+        return minDistance;
     }
 
     private class RequestDetailsThread extends Thread {


### PR DESCRIPTION
After the removal of `maps/CachesOverlay.java` during the move from GMv1 to GMv2 general proximity notification did not work for Google Maps any longer. This PR fixes this by adding implementation of and call to `getClosestDistanceInM()`.