### PR TITLE
show warning if not logged in yet (fix #7770)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -20,6 +20,22 @@
         tools:layout="@layout/status" />
     <!-- ** -->
 
+    <TextView
+        android:id="@+id/info_notloggedin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/helper_bcg"
+        android:layout_centerVertical="true"
+        android:layout_below="@+id/status"
+        android:layout_marginLeft="16dip"
+        android:layout_marginRight="16dip"
+        android:padding="4dip"
+        android:gravity="center"
+        android:textColor="@color/text_icon"
+        android:textIsSelectable="false"
+        android:textSize="14sp"
+        android:text="@string/warn_notloggedin" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -258,6 +258,7 @@
     <string name="warn_pocket_query_select">No Pocket query selected.</string>
     <string name="warn_no_pocket_query_found">No Pocket query found online.</string>
     <string name="warn_invalid_character">Character must be a LETTER or a DIGIT</string>
+    <string name="warn_notloggedin">Not logged in. Live map will only show caches stored locally.</string>
     <string name="err_read_pocket_query_list">Error reading Pocket query list.</string>
     <string name="info_log_posted">c:geo successfully submitted the log.</string>
     <string name="info_log_saved">c:geo successfully saved the log.</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -93,6 +93,7 @@ public class MainActivity extends AbstractActionBarActivity {
     @BindView(R.id.nav_location) protected TextView navLocation;
     @BindView(R.id.offline_count) protected TextView countBubble;
     @BindView(R.id.info_area) protected ListView infoArea;
+    @BindView(R.id.info_notloggedin) protected TextView notLoggedIn;
 
     /**
      * view of the action bar search
@@ -147,6 +148,7 @@ public class MainActivity extends AbstractActionBarActivity {
                                 userInfo.append(" (").append(conn.getCachesFound()).append(')');
                             }
                             userInfo.append(Formatter.SEPARATOR);
+                            activity.notLoggedIn.setVisibility(View.INVISIBLE);
                         }
                         userInfo.append(conn.getLoginStatusString());
 


### PR DESCRIPTION
Show a warning if not logged in yet. Message gets hidden automatically as soon as the first geocaching connector was able to log in.

![image](https://user-images.githubusercontent.com/3754370/66251041-77347200-e74b-11e9-86f4-34adcf2c53af.png)
