### PR TITLE
#7595 Caches of different events don't show favorite points

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -2,6 +2,7 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.gcvote.GCVote;
 import cgeo.geocaching.gcvote.GCVoteRating;
@@ -221,7 +222,9 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
             if (findsCount > 0) {
                 details.add(R.string.cache_favorite, res.getString(R.string.favorite_count_percent, favCount, (float) (favCount * 100) / findsCount));
             } else {
-                details.add(R.string.cache_favorite, res.getString(R.string.favorite_count, favCount));
+                if (!(cache.getType().isEvent())) {
+                    details.add(R.string.cache_favorite, res.getString(R.string.favorite_count, favCount));
+                }
             }
         }
 

--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -2,7 +2,6 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.gcvote.GCVote;
 import cgeo.geocaching.gcvote.GCVoteRating;
@@ -221,10 +220,9 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
             final int findsCount = cache.getFindsCount();
             if (findsCount > 0) {
                 details.add(R.string.cache_favorite, res.getString(R.string.favorite_count_percent, favCount, (float) (favCount * 100) / findsCount));
-            } else {
-                if (!(cache.getType().isEvent())) {
-                    details.add(R.string.cache_favorite, res.getString(R.string.favorite_count, favCount));
-                }
+            }
+            else if (!cache.isEventCache()) {
+                details.add(R.string.cache_favorite, res.getString(R.string.favorite_count, favCount));
             }
         }
 

--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -220,8 +220,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
             final int findsCount = cache.getFindsCount();
             if (findsCount > 0) {
                 details.add(R.string.cache_favorite, res.getString(R.string.favorite_count_percent, favCount, (float) (favCount * 100) / findsCount));
-            }
-            else if (!cache.isEventCache()) {
+            } else if (!cache.isEventCache()) {
                 details.add(R.string.cache_favorite, res.getString(R.string.favorite_count, favCount));
             }
         }

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1429,7 +1429,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         private void updateFavPointBox() {
             // Favorite counts
             final int favCount = cache.getFavoritePoints();
-            if (favCount >= 0 && !cache.getType().isEvent()) {
+            if (favCount >= 0 && !cache.isEventCache()) {
                 favoriteLine.left.setVisibility(View.VISIBLE);
 
                 final int findsCount = cache.getFindsCount();

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1429,7 +1429,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         private void updateFavPointBox() {
             // Favorite counts
             final int favCount = cache.getFavoritePoints();
-            if (favCount >= 0) {
+            if (favCount >= 0 && !cache.getType().isEvent()) {
                 favoriteLine.left.setVisibility(View.VISIBLE);
 
                 final int findsCount = cache.getFindsCount();


### PR DESCRIPTION
Fixes #7595


** Description of change: **
Caches that isn't able to have favorite points no longer shows the favorite points on cache details and cache popup. (As far as I know it's only caches of different event types.).

** Screenshot (if applicable): **
Caches with favorite points:

![Screenshot_20191006-212827_cgeo](https://user-images.githubusercontent.com/9050730/66274622-b6b0aa80-e880-11e9-859a-49a25244a353.jpg)
![Screenshot_20191006-212836_cgeo](https://user-images.githubusercontent.com/9050730/66274633-cd570180-e880-11e9-9dfa-7691ebf5f4b2.jpg)

Caches that can't have favorite points:

![Screenshot_20191006-212907_cgeo](https://user-images.githubusercontent.com/9050730/66274645-e8297600-e880-11e9-9ae1-9f1c7075b360.jpg)
![Screenshot_20191006-212915_cgeo](https://user-images.githubusercontent.com/9050730/66274646-ecee2a00-e880-11e9-8fc1-468b93f604b4.jpg)
