### PR TITLE
set cache data to active during tests, if it is online disabled (#7886)

### DIFF
--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -303,6 +303,11 @@ public class CgeoApplicationTest extends CGeoTestCase {
             try {
                 mockedCache.setMockedDataUser(Settings.getUserName());
                 final Geocache parsedCache = CgeoApplicationTest.testSearchByGeocode(mockedCache.getGeocode());
+
+                // enable here if cache is disabled (see #7886)
+                if (parsedCache.isDisabled()) {
+                    parsedCache.setDisabled(false);
+                }
                 Compare.assertCompareCaches(mockedCache, parsedCache, true);
             } finally {
                 mockedCache.setMockedDataUser(oldUser);

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCBaseTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCBaseTest.java
@@ -23,6 +23,10 @@ public class GCBaseTest extends TestCase {
         final SearchResult result = GCMap.searchByGeocodes(geocodes);
         final Geocache parsedCache = result.getFirstCacheFromResult(LoadFlags.LOAD_CACHE_ONLY);
 
+        // enable here if cache is disabled (see #7886)
+        if (parsedCache.isDisabled()) {
+            parsedCache.setDisabled(false);
+        }
         Compare.assertCompareCaches(mockedCache, parsedCache, false);
     }
 


### PR DESCRIPTION
fix #7886 Tests with live caches fail if they are disabled
