### PR TITLE
allow http connections via AndroidManifest (fix #7889)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
         android:label="@string/app_name"
         android:theme="@style/cgeo"
         android:hardwareAccelerated="false"
+        android:usesCleartextTraffic="true"
         android:supportsRtl="true"
         android:largeHeap="true">
 


### PR DESCRIPTION
cleartextTraffic needs to be enabled explicitly as gc.com links uploaded listing images via http and OkHttp disables cleartext traffic by default in newer versions.