### PR TITLE
fix some trail history issues (fix #7830)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -44,6 +44,7 @@ public class GooglePositionAndHistory implements PositionAndHistory {
     private GoogleMapObjects positionObjs;
     private GoogleMapObjects historyObjs;
     private GoogleMapView mapView;
+    private final int trailColor;
 
     private static Bitmap locationIcon;
 
@@ -52,6 +53,7 @@ public class GooglePositionAndHistory implements PositionAndHistory {
         positionObjs = new GoogleMapObjects(googleMap);
         historyObjs = new GoogleMapObjects(googleMap);
         this.mapView = mapView;
+        trailColor = Settings.getTrailColor();
     }
 
     @Override
@@ -202,7 +204,7 @@ public class GooglePositionAndHistory implements PositionAndHistory {
         // history line shadow
         historyObjs.addPolyline(new PolylineOptions()
                 .addAll(points)
-                .color(0x000000 | ((int) (alpha * 0x66) << 24))
+                .color(trailColor)
                 .width(7)
                 .zIndex(ZINDEX_HISTORY_SHADOW)
         );

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -70,7 +70,7 @@ public class HistoryLayer extends Layer {
             if (size > 1) {
                 final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
 
-                final Location prev = paintHistory.get(0);
+                Location prev = paintHistory.get(0);
                 Point pointPrevious = MercatorProjection.getPixelRelative(new LatLong(prev.getLatitude(), prev.getLongitude()), mapSize, topLeftPoint);
 
                 for (int cnt = 1; cnt < size; cnt++) {
@@ -83,6 +83,7 @@ public class HistoryLayer extends Layer {
                         canvas.drawLine((int) pointPrevious.x, (int) pointPrevious.y, (int) pointNow.x, (int) pointNow.y, historyLine);
                     }
 
+                    prev = now;
                     pointPrevious = pointNow;
                 }
             }


### PR DESCRIPTION
Fixes the following regressions and missing pieces for trail history:
- error in trail history routines of our Mapsforge map implementation, which prevented a correct distance calculation and also caused the current position to be connected with the beginning of the trail history
- trail history routines of Google Maps v2 implementation did not respect the maximum distance at all (as well as ignored the trail color setting)

