### PR TITLE
make 'not logged in' warning clickable (fix #7897)

### DIFF
--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -248,7 +248,7 @@
     <string name="warn_pocket_query_select">Kein Pocket-Query ausgewählt.</string>
     <string name="warn_no_pocket_query_found">Kein Pocket-Query online gefunden.</string>
     <string name="warn_invalid_character">Das Zeichen muss ein BUCHSTABE oder eine ZIFFER sein</string>
-    <string name="warn_notloggedin">Nicht angemeldet. Die Live-Karte wird nur lokal gespeicherte Caches anzeigen.</string>
+    <string name="warn_notloggedin">Nicht angemeldet. Die Live-Karte wird nur lokal gespeicherte Caches anzeigen und Onlinefunktionen werden nicht funktionieren.\n Entweder steht kein Netz zur Verfügung, es gibt ein Serverproblem, oder Du musst erst einen Service konfigurieren, indem Du auf diese Nachricht tippst.</string>
     <string name="err_read_pocket_query_list">Fehler beim Lesen der Pocket Queries.</string>
     <string name="info_log_posted">Log erfolgreich gesendet.</string>
     <string name="info_log_saved">Log erfolgreich gespeichert.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -258,7 +258,7 @@
     <string name="warn_pocket_query_select">No Pocket query selected.</string>
     <string name="warn_no_pocket_query_found">No Pocket query found online.</string>
     <string name="warn_invalid_character">Character must be a LETTER or a DIGIT</string>
-    <string name="warn_notloggedin">Not logged in. Live map will only show caches stored locally.</string>
+    <string name="warn_notloggedin">Not logged in yet. Live map will only show caches stored locally and online functions will not work.\n Either there is no network connection, a server problem or you have to configure your account by tapping on this message.</string>
     <string name="err_read_pocket_query_list">Error reading Pocket query list.</string>
     <string name="info_log_posted">c:geo successfully submitted the log.</string>
     <string name="info_log_saved">c:geo successfully saved the log.</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -285,6 +285,8 @@ public class MainActivity extends AbstractActionBarActivity {
         }
 
         confirmDebug();
+
+        notLoggedIn.setOnClickListener(v -> SettingsActivity.openForScreen(R.string.preference_screen_services, this));
     }
 
     @Override


### PR DESCRIPTION
make 'not logged in' warning clickable (fix #7897)
