### PR TITLE
Allow creation of user defined caches

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -87,6 +87,10 @@
                 android:title="@string/cache_clear_history"
                 android:enabled="false"
                 app:showAsAction="never|withText"/>
+            <item
+                android:id="@+id/menu_create_internal_cache"
+                android:title="@string/create_internal_cache"
+                app:showAsAction="ifRoom|withText"/>
         </menu>
     </item>
     <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="gchqceleb">Geocaching HQ Celebration</string>
     <string name="gps">GPS Adventures Exhibit</string>
     <string name="block">Geocaching HQ Block Party</string>
+    <string name="userdefined">User defined cache</string>
     <string name="unknown">Unknown Type</string>
 
     <!-- cache sizes -->
@@ -1051,6 +1052,9 @@
     <string name="cache_listed_on">Listed on %s</string>
 
     <string name="create_internal_cache">Create user defined cache</string>
+    <string name="internal_cache_default_name">User defined cache #%1$d</string>
+    <string name="internal_cache_default_description">This is a user defined cache</string>
+    <string name="internal_cache_default_owner">You</string>
 
     <!-- editor dialog -->
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1017,6 +1017,8 @@
     <string name="cache_status_stored_morethanthirtydays">Before last thirty days</string>
     <string name="cache_geocode">Geo code</string>
     <string name="cache_name">Name</string>
+    <string name="cache_name_set">Set cachename</string>
+    <string name="cache_name_updated">Cachename updated</string>
     <string name="cache_type">Type</string>
     <string name="cache_size">Size</string>
     <string name="cache_distance">Distance</string>
@@ -1047,6 +1049,8 @@
     <string name="cache_share_field">Share</string>
     <string name="cache_time_full_hours">o\'clock</string>
     <string name="cache_listed_on">Listed on %s</string>
+
+    <string name="create_internal_cache">Create user defined cache</string>
 
     <!-- editor dialog -->
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1082,19 +1082,19 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             addContextMenu(cachename);
             if (cache.supportsNamechange()) {
                 cachename.setOnClickListener(v -> {
-                    Context context = parentView.getContext();
+                    final Context context = parentView.getContext();
                     final EditText editText = new EditText(context);
                     editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL);
                     editText.setText(cache.getName());
 
                     new AlertDialog.Builder(context)
-                        .setTitle("set cache title")
+                        .setTitle(R.string.cache_name_set)
                         .setView(editText)
                         .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
                             cachename.setText(editText.getText().toString());
                             cache.setName(editText.getText().toString());
                             DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
-                            Toast.makeText(context, "Cachename updated", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(context, R.string.cache_name_updated, Toast.LENGTH_SHORT).show();
                         })
                         .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })
                         .show()

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.command.MoveToListCommand;
 import cgeo.geocaching.command.RenameListCommand;
 import cgeo.geocaching.compatibility.Compatibility;
 import cgeo.geocaching.connector.gc.PocketQueryListActivity;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -983,6 +984,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             case R.id.menu_delete_events:
                 deletePastEvents();
                 invalidateOptionsMenuCompatible();
+                return true;
+            case R.id.menu_create_internal_cache:
+                InternalConnector.interactiveCreateCache(this, coords, StoredList.getConcreteList(listId));
                 return true;
             case R.id.menu_clear_offline_logs:
                 clearOfflineLogs();

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -114,5 +114,7 @@ public final class CacheMenuHandler extends AbstractUIFactory {
 
     public static void addMenuItems(final Activity activity, final Menu menu, final Geocache cache) {
         addMenuItems(activity.getMenuInflater(), menu, cache);
+        // some connectors don't support URL - we don't need "open in browser" for those caches
+        menu.findItem(R.id.menu_show_in_browser).setVisible(cache != null && cache.getCgeoUrl() != null);
     }
 }

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -100,6 +100,11 @@ public abstract class AbstractConnector implements IConnector {
         return new NoLoggingManager();
     }
 
+    @NonNull
+    public boolean supportsNamechange() {
+        return false;
+    }
+
     @Override
     @NonNull
     public String getLicenseText(@NonNull final Geocache cache) {

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.connector.ec.ECConnector;
 import cgeo.geocaching.connector.ga.GeocachingAustraliaConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.ge.GeopeitusConnector;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.oc.OCApiConnector.ApiSupport;
 import cgeo.geocaching.connector.oc.OCApiLiveConnector;
 import cgeo.geocaching.connector.oc.OCCZConnector;
@@ -77,6 +78,7 @@ public final class ConnectorFactory {
             new TerraCachingConnector(),
             new WaymarkingConnector(),
             SuConnector.getInstance(),
+            new InternalConnector(),
             UNKNOWN_CONNECTOR // the unknown connector MUST be the last one
     ));
 

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -78,6 +78,12 @@ public interface IConnector {
     ILoggingManager getLoggingManager(@NonNull LogCacheActivity activity, @NonNull Geocache cache);
 
     /**
+     * enable/disable changing the name of a cache
+     *
+     */
+    boolean supportsNamechange();
+
+    /**
      * Get host name of the connector server for dynamic loading of data.
      *
      */

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -117,7 +117,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
         return search;
     }
 
-    protected static void assertCacheExists(final long id, @Nullable final String name, @Nullable final String description, @Nullable final Geopoint geopoint) {
+    protected static void assertCacheExists(final long id, @Nullable final String name, @Nullable final String description, @Nullable final Geopoint geopoint, final int listId) {
         final String geocode = geocodeFromId(id);
         // creates a new cache with the given id, if it does not exist yet
         if (DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB) == null) {
@@ -129,7 +129,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
             cache.setDetailed(true);
             cache.setType(CacheType.VIRTUAL);
             final Set<Integer> lists = new HashSet<>(1);
-            lists.add(StoredList.STANDARD_LIST_ID);
+            lists.add(StoredList.getConcreteList(listId));
             cache.setLists(lists);
             if (geopoint != null) {
                 cache.setCoords(geopoint);
@@ -145,25 +145,25 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
      * @param geopoint      cache's current location
      * @return String       geocode
      */
-    public static String createCache(@Nullable final String name, @Nullable final Geopoint geopoint) {
+    public static String createCache(@Nullable final String name, @Nullable final Geopoint geopoint, final int listId) {
         final long newId = DataStore.incSequenceInternalCache();
-        assertCacheExists(newId, name == null ? "User defined cache #" + newId : name, "This is a user defined cache", geopoint);
+        assertCacheExists(newId, name == null ? "User defined cache #" + newId : name, "This is a user defined cache", geopoint, listId);
         return geocodeFromId(newId);
     }
 
     /**
      * ask cache name and create new cache if entered
      */
-    public static void interactiveCreateCache(final Context context, final Geopoint geopoint) {
+    public static void interactiveCreateCache(final Context context, final Geopoint geopoint, final int listId) {
         final EditText editText = new EditText(context);
         editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL);
         editText.setText("");
 
         new AlertDialog.Builder(context)
-            .setTitle("Create new cache")
+            .setTitle(R.string.create_internal_cache)
             .setView(editText)
             .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
-                final String geocode = InternalConnector.createCache(editText.getText().toString(), geopoint);
+                final String geocode = InternalConnector.createCache(editText.getText().toString(), geopoint, listId);
                 CacheDetailActivity.startActivity(context, geocode);
             })
             .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -151,4 +151,23 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
         return geocodeFromId(newId);
     }
 
+    /**
+     * ask cache name and create new cache if entered
+     */
+    public static void interactiveCreateCache(final Context context, final Geopoint geopoint) {
+        final EditText editText = new EditText(context);
+        editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL);
+        editText.setText("");
+
+        new AlertDialog.Builder(context)
+            .setTitle("Create new cache")
+            .setView(editText)
+            .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
+                final String geocode = InternalConnector.createCache(editText.getText().toString(), geopoint);
+                CacheDetailActivity.startActivity(context, geocode);
+            })
+            .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })
+            .show()
+        ;
+    }
 }

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -1,0 +1,154 @@
+package cgeo.geocaching.connector.internal;
+
+import cgeo.geocaching.CacheDetailActivity;
+import cgeo.geocaching.R;
+import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.AbstractConnector;
+import cgeo.geocaching.connector.capability.ISearchByGeocode;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.enumerations.StatusCode;
+import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.Log;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.InputType;
+import android.widget.EditText;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class InternalConnector extends AbstractConnector implements ISearchByGeocode {
+
+    // prefix - must not contain regexp characters
+    public static final String PREFIX = "ZZ";
+
+    // predefined id (without prefix) and geocode (with prefix) for certain special caches:
+    public static final int ID_HISTORY_CACHE = 0;
+    public static final String GEOCODE_HISTORY_CACHE = geocodeFromId(ID_HISTORY_CACHE);
+
+    // pattern for internal caches id
+    @NonNull private static final Pattern PATTERN_GEOCODE = Pattern.compile("(" + PREFIX + ")[0-9A-Z]{1,4}", Pattern.CASE_INSENSITIVE);
+
+    public static String geocodeFromId (final long id) {
+        return PREFIX + id;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return "Internal";
+    }
+
+    @Override
+    @NonNull
+    public String getNameAbbreviated() {
+        return PREFIX;
+    }
+
+    @Override
+    @Nullable
+    public String getCacheUrl(@NonNull final Geocache cache) {
+        return null;
+    }
+
+    @Override
+    @NonNull
+    public String getHost() {
+        return StringUtils.EMPTY; // we have no host for these caches
+    }
+
+    @Override
+    public boolean getHttps() {
+        return false;
+    }
+
+    @Override
+    public boolean isOwner(@NonNull final Geocache cache) {
+        return false;
+    }
+
+    @Override
+    @NonNull
+    protected String getCacheUrlPrefix() {
+        return StringUtils.EMPTY; // we have no URL for these caches
+    }
+
+    @Override
+    public boolean canHandle(@NonNull final String geocode) {
+        return PATTERN_GEOCODE.matcher(geocode).matches();
+    }
+
+    @NonNull
+    public boolean supportsNamechange() {
+        // this connector supports changing the name of a geocache
+        return true;
+    }
+
+    @Override
+    public SearchResult searchByGeocode(@Nullable final String geocode, @Nullable final String guid, final DisposableHandler handler) {
+
+        DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_loadpage);
+
+        final SearchResult search = new SearchResult();
+        if (DataStore.isThere(geocode, guid, false)) {
+            if (StringUtils.isBlank(geocode) && StringUtils.isNotBlank(guid)) {
+                Log.i("Loading old cache from cache.");
+                search.addGeocode(DataStore.getGeocodeForGuid(guid));
+            } else {
+                search.addGeocode(geocode);
+            }
+            search.setError(StatusCode.NO_ERROR);
+            return search;
+        }
+
+        search.setError(StatusCode.CACHE_NOT_FOUND);
+        return search;
+    }
+
+    protected static void assertCacheExists(final long id, @Nullable final String name, @Nullable final String description, @Nullable final Geopoint geopoint) {
+        final String geocode = geocodeFromId(id);
+        // creates a new cache with the given id, if it does not exist yet
+        if (DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB) == null) {
+            final Geocache cache = new Geocache();
+            cache.setGeocode(geocode);
+            cache.setName(name == null ? "Internal cache " + id : name);
+            cache.setOwnerDisplayName("You");
+            cache.setDescription(description == null ? "user defined cache" : description);
+            cache.setDetailed(true);
+            cache.setType(CacheType.VIRTUAL);
+            final Set<Integer> lists = new HashSet<>(1);
+            lists.add(StoredList.STANDARD_LIST_ID);
+            cache.setLists(lists);
+            if (geopoint != null) {
+                cache.setCoords(geopoint);
+            }
+            // add more fields if needed
+
+            DataStore.saveCache(cache, EnumSet.of(LoadFlags.SaveFlag.DB));
+        }
+    }
+
+    /**
+     * creates a new cache for the internal connector
+     * @param geopoint      cache's current location
+     * @return String       geocode
+     */
+    public static String createCache(@Nullable final String name, @Nullable final Geopoint geopoint) {
+        final long newId = DataStore.incSequenceInternalCache();
+        assertCacheExists(newId, name == null ? "User defined cache #" + newId : name, "This is a user defined cache", geopoint);
+        return geocodeFromId(newId);
+    }
+
+}

--- a/main/src/cgeo/geocaching/connector/internal/package-info.java
+++ b/main/src/cgeo/geocaching/connector/internal/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implements an c:geo internal connector for user defined "caches" and waypoints
+ */
+package cgeo.geocaching.connector.internal;

--- a/main/src/cgeo/geocaching/enumerations/CacheType.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheType.java
@@ -35,6 +35,9 @@ public enum CacheType {
     GCHQ_CELEBRATION("gchqceleb", "Geocaching HQ Celebration", "af820035-787a-47af-b52b-becc8b0c0c88", R.string.gchqceleb, R.drawable.type_hq, "3774", R.drawable.dot_event), // icon missing
     GPS_EXHIBIT("gps", "GPS Adventures Exhibit", "72e69af2-7986-4990-afd9-bc16cbbb4ce3", R.string.gps, R.drawable.type_event, "1304", R.drawable.dot_event), // icon missing
     BLOCK_PARTY("block", "Geocaching HQ Block Party", "bc2f3df2-1aab-4601-b2ff-b5091f6c02e3", R.string.block, R.drawable.type_event, "4738", R.drawable.dot_event), // icon missing
+
+    // insert other official cache types before USER_DEFINED and UNKNOWN
+    USER_DEFINED("userdefined", "User defined cache", "", R.string.userdefined, R.drawable.type_virtual, "", R.drawable.dot_virtual),
     UNKNOWN("unknown", "unknown", "", R.string.unknown, R.drawable.type_unknown, "", R.drawable.dot_unknown),
     /** No real cache type -> filter */
     ALL("all", "display all caches", "9a79e6ce-3344-409c-bbe9-496530baf758", R.string.all_types, R.drawable.type_unknown, "", R.drawable.dot_unknown);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -944,7 +944,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         if (cache != null) {
             EditWaypointActivity.startActivityAddWaypoint(this, cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
         } else {
-            InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
+            InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), StoredList.STANDARD_LIST_ID);
         }
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -14,6 +14,7 @@ import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.connector.gc.GCMap;
 import cgeo.geocaching.connector.gc.Tile;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -942,6 +943,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         final Geocache cache = getCurrentTargetCache();
         if (cache != null) {
             EditWaypointActivity.startActivityAddWaypoint(this, cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
+        } else {
+            InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
         }
     }
 

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -753,6 +753,10 @@ public class Geocache implements IWaypoint {
         return getConnector() instanceof ISearchByCenter;
     }
 
+    public boolean supportsNamechange() {
+        return getConnector().supportsNamechange();
+    }
+
     public void shareCache(@NonNull final Activity fromActivity, final Resources res) {
         final Intent intent = getShareIntent();
 

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -1090,6 +1090,10 @@ public class DataStore {
         }
     }
 
+    public static synchronized long incSequenceInternalCache () {
+        return incSequence(SEQUENCE_INTERNAL_CACHE, 1000);
+    }
+
     /**
      * Remove obsolete cache directories in c:geo private storage.
      */


### PR DESCRIPTION
This PR introduces an internal geocache connector which allows the user to create their own caches.

- create new cache by long clicking on map (or using the menu entry "manage cache" -> "create user defined cache")
- caches are created with "ZZ" prefix and a consecutive number
- cache type is "user defined cache"
- cache name is editable (for this connector only)
- certain fields are empty (eg: attributes, d/t rating, favorite points)
- cache location is set to map's location you've tapped on (or none, if created via menu)
- cache is assigned to current list (if applicable) or standard list on first saving (can be changed later on)
- further cache handling is similar to regular caches - you can show it on the map,
  create waypoints, change coordinates etc.
- cache is completely offline, so no logging, no listing under "services" section or on c:geo start page

Besides being a long time wish from myself (I currently use manually created GPX files to manage user defined caches) this is for feature requests like #7901, #6214, #132 (and maybe others).
It also can be used as base for replacing the "go to" menu with an internal cache, so that waypoint handling is the same as for any other cache (eg: #924, #3288). (I've already prepared a basic implementation for this, but it's not included in this PR intentionally.)

current limitation:
- implemented for NewMap only so far (I'm struggling with getting OnLongClick to run on Google Maps)

Some screenshots:
- creating a new cache by long tapping on map:
![image](https://user-images.githubusercontent.com/3754370/67624829-55a04500-f836-11e9-9e7c-8f0ecd02132b.png)
- some base data gets created with the new cache:
![image](https://user-images.githubusercontent.com/3754370/67624841-77013100-f836-11e9-8caa-66fece7059e8.png)
(cache type is outdated in this screenshot - it's "User defined cache" now)