### PR TITLE
shorten 'not logged in' info + add dialog to configure services

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -20,22 +20,6 @@
         tools:layout="@layout/status" />
     <!-- ** -->
 
-    <TextView
-        android:id="@+id/info_notloggedin"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@drawable/helper_bcg"
-        android:layout_centerVertical="true"
-        android:layout_below="@+id/status"
-        android:layout_marginLeft="16dip"
-        android:layout_marginRight="16dip"
-        android:padding="4dip"
-        android:gravity="center"
-        android:textColor="@color/text_icon"
-        android:textIsSelectable="false"
-        android:textSize="14sp"
-        android:text="@string/warn_notloggedin" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -151,7 +135,44 @@
     </LinearLayout>
     <!-- ** -->
 
+    <RelativeLayout
+        android:id="@+id/info_notloggedin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/helper_bcg"
+        android:layout_centerVertical="true"
+        android:layout_above="@+id/connector_area"
+        android:layout_marginLeft="16dip"
+        android:layout_marginRight="16dip"
+        android:layout_marginBottom="16dip"
+        android:padding="4dip" >
+
+        <ImageView
+            android:id="@+id/info_notloggedin_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:layout_margin="4dip"
+            android:src="@drawable/ic_menu_info_details"/>
+
+        <TextView
+            android:id="@+id/info_notloggedin_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toRightOf="@id/info_notloggedin_icon"
+            android:gravity="center"
+            android:textColor="@color/text_icon"
+            android:textIsSelectable="false"
+            android:textSize="14sp"
+            android:text="@string/warn_notloggedin_short" />
+
+    </RelativeLayout>
+    <!-- ** -->
+
     <LinearLayout
+        android:id="@+id/connector_area"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -258,7 +258,9 @@
     <string name="warn_pocket_query_select">No Pocket query selected.</string>
     <string name="warn_no_pocket_query_found">No Pocket query found online.</string>
     <string name="warn_invalid_character">Character must be a LETTER or a DIGIT</string>
-    <string name="warn_notloggedin">Not logged in yet. Live map will only show caches stored locally and online functions will not work.\n Either there is no network connection, a server problem or you have to configure your account by tapping on this message.</string>
+    <string name="warn_notloggedin_title">Offline mode</string>
+    <string name="warn_notloggedin_short">Not logged in. Live map will only show caches stored locally.</string>
+    <string name="warn_notloggedin_long">Not logged in (yet). Live map will only show caches stored locally and online functions will not work.\n\nEither there is no network connection, a server problem or you have to (re)configure your geocaching services.\n\nDo you want to configure services now?</string>
     <string name="err_read_pocket_query_list">Error reading Pocket query list.</string>
     <string name="info_log_posted">c:geo successfully submitted the log.</string>
     <string name="info_log_saved">c:geo successfully saved the log.</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -93,7 +93,7 @@ public class MainActivity extends AbstractActionBarActivity {
     @BindView(R.id.nav_location) protected TextView navLocation;
     @BindView(R.id.offline_count) protected TextView countBubble;
     @BindView(R.id.info_area) protected ListView infoArea;
-    @BindView(R.id.info_notloggedin) protected TextView notLoggedIn;
+    @BindView(R.id.info_notloggedin) protected View notLoggedIn;
 
     /**
      * view of the action bar search
@@ -286,7 +286,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
         confirmDebug();
 
-        notLoggedIn.setOnClickListener(v -> SettingsActivity.openForScreen(R.string.preference_screen_services, this));
+        notLoggedIn.setOnClickListener(v -> Dialogs.confirmYesNo(this, R.string.warn_notloggedin_title, R.string.warn_notloggedin_long, (dialog, which) -> SettingsActivity.openForScreen(R.string.preference_screen_services, this)));
     }
 
     @Override


### PR DESCRIPTION
in regard to #7909:
- shorten "not logged in" warning on main screen to make it less obstructive
- tap on this message opens dialog with detailed info; "OK" on dialog leads to service configuration, "cancel" back to main screen


info message if not (yet) logged in:

![image](https://user-images.githubusercontent.com/3754370/67642310-c4e76900-f90a-11e9-92a2-3529b1ea72a8.png)

dialog after tapping on above message:

![image](https://user-images.githubusercontent.com/3754370/67642318-d3358500-f90a-11e9-99e6-6663951b0a40.png)
