### PR TITLE
invalidateOptionsMenu(Activity activity) is deprecated (#7903)

### DIFF
--- a/main/src/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/cgeo/geocaching/activity/ActivityMixin.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.NavUtils;
 import android.support.v4.app.TaskStackBuilder;
 import android.support.v7.app.ActionBar;
@@ -160,7 +159,7 @@ public final class ActivityMixin {
         if (activity instanceof AppCompatActivity) {
             ((AppCompatActivity) activity).supportInvalidateOptionsMenu();
         } else {
-            ActivityCompat.invalidateOptionsMenu(activity);
+            activity.invalidateOptionsMenu();
         }
     }
 


### PR DESCRIPTION
(restores 8dca18817c30e / #7903 on branch master)

from documentation:
static boolean 	invalidateOptionsMenu(Activity activity)
This method was deprecated in API level 27.1.0. Use invalidateOptionsMenu() directly.
