### PR TITLE
Reactivate the contacts plugin (fix #7193)

### DIFF
--- a/cgeo-contacts/AndroidManifest.xml
+++ b/cgeo-contacts/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="cgeo.contacts"
-    android:versionCode="6"
-    android:versionName="1.6" >
+    android:versionCode="7"
+    android:versionName="1.7" >
 
     <uses-permission android:name="android.permission.READ_CONTACTS" />
 

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -7,6 +7,11 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 28
 
+    // signing is handled via private.properties
+    signingConfigs {
+        release
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -33,6 +38,12 @@ android {
         // abort release builds in case of FATAL errors
         checkReleaseBuilds true
     }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
 }
 
 
@@ -41,6 +52,29 @@ dependencies {
     implementation 'commons-io:commons-io:2.5'
     implementation 'org.apache.commons:commons-lang3:3.5'
 
+    // Support Library AppCompat
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+
     // Android annotations
     implementation "com.android.support:support-annotations:$supportLibraryVersion"
+}
+
+/*
+ * signing of release APK, use a properties file like in templates/private.properties
+ */
+
+// dynamically load the signing values from private.properties
+File privatePropertiesFile = rootProject.file('private.properties')
+if (privatePropertiesFile.exists()) {
+    Properties properties = new Properties()
+    properties.load(new FileInputStream(privatePropertiesFile))
+    android.signingConfigs {
+        release {
+            storeFile file(properties.getProperty('key.store'))
+            storePassword properties.getProperty('key.store.password')
+            keyAlias properties.getProperty('key.alias')
+            keyPassword properties.getProperty('key.alias.password')
+        }
+    }
+    android.buildTypes.release.signingConfig android.signingConfigs.release
 }

--- a/cgeo-contacts/res/values/strings.xml
+++ b/cgeo-contacts/res/values/strings.xml
@@ -4,5 +4,11 @@
     <string name="app_name">c:geo - contacts (add-on)</string>
     <string name="contact_not_found">Contact with alias/nickname %s not found. Add it in your contacts app first.</string>
     <string name="multiple_matches">Multiple matches</string>
-    
+
+    <!-- permission handling -->
+    <string name="ask_again">Ask me again</string>
+    <string name="close">Close</string>
+    <string name="contacts_permission_request_denied">You must give \"c:geo - contacts\" read permission for your address books to search the cacher name there.</string>
+    <string name="contacts_permission_request_explanation">\"c:geo - contacts\" can find the user in your address book by searching the cacher name. To do this, you must authorize the application for reading.</string>
+
 </resources>

--- a/cgeo-contacts/res/values/strings.xml
+++ b/cgeo-contacts/res/values/strings.xml
@@ -8,6 +8,7 @@
     <!-- permission handling -->
     <string name="ask_again">Ask me again</string>
     <string name="close">Close</string>
+    <string name="goto_app_details">Open Application Info</string>
     <string name="contacts_permission_request_denied">You must give \"c:geo - contacts\" read permission for your address books to search the cacher name there.</string>
     <string name="contacts_permission_request_explanation">\"c:geo - contacts\" can find the user in your address book by searching the cacher name. To do this, you must authorize the application for reading.</string>
 

--- a/cgeo-contacts/src/cgeo/contacts/ContactsActivity.java
+++ b/cgeo-contacts/src/cgeo/contacts/ContactsActivity.java
@@ -1,11 +1,11 @@
 package cgeo.contacts;
 
+import cgeo.contacts.permission.PermissionHandler;
+
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnCancelListener;
-import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -25,9 +25,10 @@ import java.util.List;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
 
-
 public final class ContactsActivity extends Activity {
     static final String LOG_TAG = "cgeo.contacts";
+
+    private String nickName;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -39,12 +40,31 @@ public final class ContactsActivity extends Activity {
             return;
         }
 
-        final String nickName = getParameter(uri, IContacts.PARAM_NAME);
+        nickName = getParameter(uri, IContacts.PARAM_NAME);
         if (StringUtils.isEmpty(nickName)) {
             finish();
             return;
         }
 
+        final boolean hasPermission = PermissionHandler.requestContactsPermission(this);
+        if (hasPermission) {
+            searchUser();
+        }
+        // else -> onRequestPermissionsResult()
+    }
+
+    @Override
+    public void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+        if (grantResults.length > 0) {
+            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                searchUser();
+            } else if (grantResults[0] == PackageManager.PERMISSION_DENIED) {
+                PermissionHandler.askAgainFor(this, requestCode);
+            }
+        }
+    }
+
+    public void searchUser() {
         // search by nickname, exact
         List<Pair<Integer, String>> contacts = getContacts(nickName, ContactsContract.Data.CONTENT_URI, ContactsContract.Data.CONTACT_ID, ContactsContract.CommonDataKinds.Nickname.NAME, false);
 
@@ -78,25 +98,17 @@ public final class ContactsActivity extends Activity {
         for (final Pair<Integer, String> p : contacts) {
             list.add(p.second);
         }
-        final CharSequence[] items = list.toArray(new CharSequence[list.size()]);
+        final CharSequence[] items = list.toArray(new CharSequence[0]);
         new AlertDialog.Builder(this)
                 .setTitle(R.string.multiple_matches)
-                .setItems(items, new OnClickListener() {
-
-                    @Override
-                    public void onClick(final DialogInterface dialog, final int which) {
-                        final int contactId = contacts.get(which).first;
-                        dialog.dismiss();
-                        openContactAndFinish(contactId);
-                    }
+                .setItems(items, (dialog, which) -> {
+                    final int contactId = contacts.get(which).first;
+                    dialog.dismiss();
+                    openContactAndFinish(contactId);
                 })
-                .setOnCancelListener(new OnCancelListener() {
-
-                    @Override
-                    public void onCancel(final DialogInterface dialog) {
-                        dialog.dismiss();
-                        finish();
-                    }
+                .setOnCancelListener(dialog -> {
+                    dialog.dismiss();
+                    finish();
                 })
                 .create().show();
     }
@@ -114,11 +126,9 @@ public final class ContactsActivity extends Activity {
         final String[] projection = { idColumnName, selectionColumnName, ContactsContract.Contacts.DISPLAY_NAME };
         final String selection = selectionColumnName + (like ? " LIKE" : " =") + " ? COLLATE NOCASE";
         final String[] selectionArgs = { like ? "%" + searchName + "%" : searchName };
-        Cursor cursor = null;
 
         final List<Pair<Integer, String>> result = new ArrayList<>();
-        try {
-            cursor = getContentResolver().query(uri, projection, selection, selectionArgs, null);
+        try (Cursor cursor = getContentResolver().query(uri, projection, selection, selectionArgs, null)) {
             while (cursor != null && cursor.moveToNext()) {
                 final int foundId = cursor.getInt(0);
                 final String foundName = cursor.getString(1);
@@ -127,12 +137,9 @@ public final class ContactsActivity extends Activity {
                         !StringUtils.equalsIgnoreCase(foundName, displayName) ? foundName + " (" + displayName + ")" : foundName));
             }
         } catch (final Exception e) {
-            Log.e(LOG_TAG, "ContactsActivity.getContactId", e);
-        } finally {
-            if (cursor != null) {
-                cursor.close(); // no Closable Cursor below sdk 16
-            }
+            Log.e(LOG_TAG, "ContactsActivity.getContacts", e);
         }
+        // no Closable Cursor below sdk 16
         return result;
     }
 

--- a/cgeo-contacts/src/cgeo/contacts/permission/PermissionHandler.java
+++ b/cgeo-contacts/src/cgeo/contacts/permission/PermissionHandler.java
@@ -5,8 +5,11 @@ import cgeo.contacts.R;
 import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
+import android.provider.Settings;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 
@@ -77,7 +80,15 @@ public class PermissionHandler {
             new AlertDialog.Builder(activity)
                     .setMessage(perm.getDeniedResource())
                     .setCancelable(false)
-                    .setNeutralButton(R.string.close, (dialog, which) -> activity.finish())
+                    .setNegativeButton(R.string.close, (dialog, which) -> activity.finish())
+                    .setPositiveButton(R.string.goto_app_details, (dialog, which) -> {
+                                final Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                        Uri.fromParts("package", activity.getPackageName(), null));
+                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                                activity.startActivity(intent);
+                                activity.finish();
+                            }
+                    )
                     .create()
                     .show();
         }

--- a/cgeo-contacts/src/cgeo/contacts/permission/PermissionHandler.java
+++ b/cgeo-contacts/src/cgeo/contacts/permission/PermissionHandler.java
@@ -1,0 +1,100 @@
+package cgeo.contacts.permission;
+
+import cgeo.contacts.R;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+
+public class PermissionHandler {
+
+    private static final String contactsPermission = Manifest.permission.READ_CONTACTS;
+
+    private PermissionHandler() {
+        // Utility class should not be instantiated externally
+    }
+
+    /*
+     * Check if version is marshmallow and above.
+     * Used in deciding to ask runtime permission
+     * */
+    private static boolean notNeedAskForPermission() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M;
+    }
+
+    public static boolean requestContactsPermission(final Activity activity) {
+
+        final PermissionRequestContext perm = PermissionRequestContext.ContactsActivity;
+        return requestPermission(activity, contactsPermission, perm);
+    }
+
+    private static boolean requestPermission(final Activity activity, final String permission, final PermissionRequestContext perm) {
+
+        if (notNeedAskForPermission()) {
+            return true;
+        }
+
+        if (hasPermission(activity, permission)) {
+            return true;
+        }
+
+        askFor(activity, permission, perm);
+        return false;
+    }
+
+    private static void askFor(final Activity activity, final String permission, final PermissionRequestContext perm) {
+        askFor(activity, new String[] {permission}, perm);
+    }
+
+    private static void askFor(final Activity activity, final String[] permissions, final PermissionRequestContext perm) {
+        ActivityCompat.requestPermissions(activity, permissions, perm.getRequestCode());
+    }
+
+    public static void askAgainFor(final Activity activity, final int requestCode) {
+        if (requestCode == PermissionRequestContext.ContactsActivity.getRequestCode()) {
+            askAgainForContacts(activity);
+        }
+    }
+
+    private static void askAgainForContacts(final Activity activity) {
+        final boolean currShouldShowStatus = ActivityCompat.shouldShowRequestPermissionRationale(activity, contactsPermission);
+        final PermissionRequestContext perm = PermissionRequestContext.ContactsActivity;
+        if (currShouldShowStatus) {
+            // Show permission explanation dialog...
+            new AlertDialog.Builder(activity)
+                    .setMessage(perm.getAskAgainResource())
+                    .setCancelable(false)
+                    .setNeutralButton(R.string.ask_again, (dialog, which) -> askFor(activity, new String[] {contactsPermission}, perm))
+                    .create()
+                    .show();
+        } else {
+            // Never ask again selected, or device policy prohibits the app from having that permission.
+            // So, disable that feature, or fall back to another situation...
+            new AlertDialog.Builder(activity)
+                    .setMessage(perm.getDeniedResource())
+                    .setCancelable(false)
+                    .setNeutralButton(R.string.close, (dialog, which) -> activity.finish())
+                    .create()
+                    .show();
+        }
+    }
+
+    private static boolean hasPermission(final Activity activity, final String permission) {
+        return hasPermission(activity, new String[] {permission});
+    }
+
+    private static boolean hasPermission(final Activity activity, final String[] permissions) {
+        boolean hasPermission = true;
+        for (String permission: permissions) {
+            if (ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+                hasPermission = false;
+            }
+        }
+
+        return hasPermission;
+    }
+}

--- a/cgeo-contacts/src/cgeo/contacts/permission/PermissionRequestContext.java
+++ b/cgeo-contacts/src/cgeo/contacts/permission/PermissionRequestContext.java
@@ -1,0 +1,40 @@
+package cgeo.contacts.permission;
+
+import cgeo.contacts.R;
+
+public enum PermissionRequestContext {
+
+    ContactsActivity(1114, R.string.contacts_permission_request_explanation, R.string.contacts_permission_request_denied);
+
+    private final int requestCode;
+    private final int askAgainResource;
+    private final int deniedResource;
+
+    PermissionRequestContext(final int requestCode, final int askAgainResource, final int deniedResource) {
+        this.requestCode = requestCode;
+        this.askAgainResource = askAgainResource;
+        this.deniedResource = deniedResource;
+    }
+
+    public int getRequestCode() {
+        return requestCode;
+    }
+
+    public int getAskAgainResource() {
+        return askAgainResource;
+    }
+
+    public int getDeniedResource() {
+        return deniedResource;
+    }
+
+    public static PermissionRequestContext fromRequestCode(final int requestCode) {
+        for (final PermissionRequestContext perm : PermissionRequestContext.values()) {
+            if (perm.requestCode == requestCode) {
+                return perm;
+            }
+        }
+
+        throw new IndexOutOfBoundsException("Unknown request code " + requestCode);
+    }
+}

--- a/main/src/cgeo/geocaching/permission/PermissionRequestContext.java
+++ b/main/src/cgeo/geocaching/permission/PermissionRequestContext.java
@@ -7,6 +7,8 @@ public enum PermissionRequestContext {
     MainActivityOnCreate(1111, R.string.location_permission_request_explanation),
     MainActivityOnResume(1112, R.string.location_permission_request_explanation),
     MainActivityStorage(1113, R.string.storage_permission_request_explanation),
+    // placeholder, see contacts addon
+    // ContactsActivity(1114, R.string.contacts_permission_request_explanation, R.string.contacts_permission_request_denied);
     TrackableActivity(2221, R.string.location_permission_request_explanation),
     CacheDetailActivity(2222, R.string.location_permission_request_explanation),
     CacheListActivity(2223, R.string.location_permission_request_explanation),


### PR DESCRIPTION
It was stated in https://github.com/cgeo/cgeo/issues/7582#issuecomment-487609065:
	As long as we support Api versions without permission requests, we IMO cannot integrate it
	into the main app based on the same arguments we had for the separation initially.
My internal test showed that this is correct.

fixes #7193 (Raise Target SDK to 26 for contacts plugin (or reintegrate into main app))
fixes #7582 (Remove contacts plugin from useful apps list)
 -> not remove, but reactivate

- build.gradle based on PR #7236
- adapt PermissionHandler and PermissionRequestContext from main for the contacts need
- inplement contacts permission handling in ContactsActivity
- minor code optimizations (Checkstyle suggestions) in selectContact and getContacts

tested on Android 4.3, 7.0 and 9

The *.apk is located at
https://ci.cgeo.org/view/All%20jobs/job/cgeo-contacts%20release/8/