### PR TITLE
replace go to menu by user defined cache and waypoint page

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1057,6 +1057,8 @@
     <string name="internal_cache_default_name">User defined cache #%1$d</string>
     <string name="internal_cache_default_description">This is a user defined cache</string>
     <string name="internal_cache_default_owner">You</string>
+    <string name="internal_goto_targets_title">\'Go to\' targets</string>
+    <string name="internal_goto_targets_description">This cache stores your recent \'Go to\' targets</string>
 
     <!-- editor dialog -->
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -174,6 +174,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     private static final int MESSAGE_FAILED = -1;
     private static final int MESSAGE_SUCCEEDED = 1;
 
+    private static final String EXTRA_FORCE_WAYPOINTSPAGE = "cgeo.geocaching.extra.cachedetail.forceWaypointsPage";
+
     /**
      * Minimal contrast ratio. If description:background contrast ratio is less than this value
      * for some string, foreground color will be removed and gray background will be used
@@ -229,11 +231,13 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         // try to get data from extras
         String name = null;
         String guid = null;
+        boolean forceWaypointsPage = false;
 
         if (extras != null) {
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
             name = extras.getString(Intents.EXTRA_NAME);
             guid = extras.getString(Intents.EXTRA_GUID);
+            forceWaypointsPage = extras.getBoolean(EXTRA_FORCE_WAYPOINTSPAGE);
         }
 
         // When clicking a cache in MapsWithMe, we get back a PendingIntent
@@ -303,7 +307,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             // nothing, we lost the window
         }
 
-        final int pageToOpen = savedInstanceState != null ?
+        final int pageToOpen = forceWaypointsPage ? getPageIndex(Page.WAYPOINTS) :
+            savedInstanceState != null ?
                 savedInstanceState.getInt(STATE_PAGE_INDEX, 0) :
                 Settings.isOpenLastDetailsPage() ? Settings.getLastDetailsPage() : 1;
         createViewPager(pageToOpen, new OnPageSelectedListener() {
@@ -938,10 +943,15 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         createDisposables.add(imagesList.loadImages(imageView, cache.getNonStaticImages()));
     }
 
-    public static void startActivity(final Context context, final String geocode) {
+    public static void startActivity(final Context context, final String geocode, final boolean forceWaypointsPage) {
         final Intent detailIntent = new Intent(context, CacheDetailActivity.class);
         detailIntent.putExtra(Intents.EXTRA_GEOCODE, geocode);
+        detailIntent.putExtra(EXTRA_FORCE_WAYPOINTSPAGE, forceWaypointsPage);
         context.startActivity(detailIntent);
+    }
+
+    public static void startActivity(final Context context, final String geocode) {
+        startActivity(context, geocode, false);
     }
 
     /**

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.PocketQueryListActivity;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.helper.UsefulAppsActivity;
@@ -717,7 +718,8 @@ public class MainActivity extends AbstractActionBarActivity {
      */
     public void cgeoPoint(final View v) {
         any.setPressed(true);
-        startActivity(new Intent(this, NavigateAnyPointActivity.class));
+        InternalConnector.assertHistoryCacheExists(this);
+        CacheDetailActivity.startActivity(this, InternalConnector.GEOCODE_HISTORY_CACHE, true);
     }
 
     /**

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -149,6 +149,14 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     /**
+     * makes sure that the pseudo cache storing the "go to" targets exists
+     * @param context   context in which this function gets called
+     */
+    public static void assertHistoryCacheExists(final Context context) {
+        assertCacheExists(context, ID_HISTORY_CACHE, context.getString(R.string.internal_goto_targets_title), context.getString(R.string.internal_goto_targets_description), null, StoredList.STANDARD_LIST_ID);
+    }
+
+    /**
      * creates a new cache for the internal connector
      * @param context       context in which this function gets called
      * @param name          cache's name (or null for default name)


### PR DESCRIPTION
Issue #3288 proposes replacing the "go to" menu by a waypoint view. With introduction of the internal connector and user defined caches with #7918 this can be implemented easily now.

Here are some screenshots:

a) After pressing "go to" button on mainscreen a waypoint view of the automatically created user defined cache opens:

![image](https://user-images.githubusercontent.com/3754370/68618987-d31cb400-04ca-11ea-8e84-96e69c898e8e.png)

(There is only one user defined cache created for all "go to" targets, so if you press "go to" again you will be directed to the same cache. If you delete this cache (which you are perfectly allowed to do) it will be recreated on next run.)

b) Waypoint handling is the same as you're used to:

![image](https://user-images.githubusercontent.com/3754370/68619102-0e1ee780-04cb-11ea-85ee-ff5efc2df020.png)

c) And you may open the compass from waypoint view directly:

![image](https://user-images.githubusercontent.com/3754370/68619136-20992100-04cb-11ea-9158-be2bb60d81f9.png)

(And as this is a regular cache you may swipe to the cache's main page and open navigation and much more.)

Current state of this PR is fully functional, but not yet cleaned up. It shows how replacing the "go to" menu by a automatically created user defined cache would look and work, but does not yet remove the current implementation or migrate any history data - the latter would have to be discussed later.