### PR TITLE
update gc-apps.com geochecker url

### DIFF
--- a/main/src/cgeo/geocaching/utils/CheckerUtils.java
+++ b/main/src/cgeo/geocaching/utils/CheckerUtils.java
@@ -16,7 +16,7 @@ import org.apache.commons.text.StringEscapeUtils;
 public final class CheckerUtils {
     private static final String[] CHECKERS = {
             "certitudes.org/certitude?",
-            "gc-apps.com/geochecker",
+            "gc-apps.com/checker/",
             "gccounter.com/gcchecker.php?",
             "geocheck.org/geo_inputchkcoord.php?",
             "geochecker.com/index.php?",


### PR DESCRIPTION
Geochecker URL of gc-apps.com has either changed or never worked with "geochecker" path (receiving a 404 error now), but works with "checker" path, so updated it in c:geo utils class.