### PR TITLE
update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // check for updates of gradle plugin dependencies
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.25.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.27.0'
 
         // Android gradle plugin
         classpath 'com.android.tools.build:gradle:3.4.2'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -275,11 +275,11 @@ dependencies {
     }
 
     // GeographicLib
-    implementation "net.sf.geographiclib:GeographicLib-Java:1.49"
+    implementation 'net.sf.geographiclib:GeographicLib-Java:1.50'
 
     // Jackson XML processing
-    def jacksonVersion = '2.9.9'
-    def jacksonVersionPatch = '2.9.9.3'
+    def jacksonVersion = '2.9.10'
+    def jacksonVersionPatch = '2.9.10.1'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersionPatch"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
@@ -324,7 +324,7 @@ dependencies {
     implementation 'com.drewnoakes:metadata-extractor:2.12.0'
 
     // Okhttp network access. 3.12.x is API level < 21, 3.13 or better requires API 21
-    implementation 'com.squareup.okhttp3:okhttp:3.12.5'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.6'
 
     // Play Services
     implementation 'com.google.android.gms:play-services-location:16.0.0'
@@ -336,7 +336,7 @@ dependencies {
     implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.12'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.14'
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
 
     // Support Libraries. All com.android.support.* libraries must use the same version
@@ -361,7 +361,7 @@ dependencies {
 
     // Testing Support Libraries
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
 
     // Undo toast
     implementation 'com.github.jenzz.undobar:library:1.3:api8Release@aar'


### PR DESCRIPTION
- com.github.ben-manes:gradle-versions-plugin:0.25.0 zu 0.27.0
- net.sf.geographiclib:GeographicLib-Java:1.49 zu 1.50
- com.fasterxml.jackson.core:jackson-core/jackson-annotations:2.9.9 zu 2.9.10
- com.fasterxml.jackson.core:jackson-databind:2.9.9.3 zu 2.9.10.1
- com.squareup.okhttp3:okhttp:3.12.5 zu 3.12.6
- io.reactivex.rxjava2:rxjava:2.2.12 zu 2.2.14
- com.android.support.test.espresso:espresso-core:3.0.1 zu 3.0.1