### PR TITLE
put goto target user defined cache into its own list

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1053,6 +1053,7 @@
     <string name="cache_time_full_hours">o\'clock</string>
     <string name="cache_listed_on">Listed on %s</string>
 
+    <string name="user_defined_caches">User defined caches</string>
     <string name="create_internal_cache">Create user defined cache</string>
     <string name="internal_cache_default_name">User defined cache #%1$d</string>
     <string name="internal_cache_default_description">This is a user defined cache</string>

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.StatusCode;
+import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
@@ -153,7 +154,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
      * @param context   context in which this function gets called
      */
     public static void assertHistoryCacheExists(final Context context) {
-        assertCacheExists(context, ID_HISTORY_CACHE, context.getString(R.string.internal_goto_targets_title), context.getString(R.string.internal_goto_targets_description), null, StoredList.STANDARD_LIST_ID);
+        assertCacheExists(context, ID_HISTORY_CACHE, context.getString(R.string.internal_goto_targets_title), context.getString(R.string.internal_goto_targets_description), null, PseudoList.UDC_LIST.id);
     }
 
     /**

--- a/main/src/cgeo/geocaching/list/PseudoList.java
+++ b/main/src/cgeo/geocaching/list/PseudoList.java
@@ -42,6 +42,22 @@ public abstract class PseudoList extends AbstractList {
         }
     };
 
+    public static final int UDC_LIST_ID = 5;
+    /**
+     * pseudo list id for "go to target" UDC to be displayed in "all caches" only
+     */
+    public static final AbstractList UDC_LIST = new PseudoList(UDC_LIST_ID, R.string.user_defined_caches) {
+        @Override
+        public int getNumberOfCaches() {
+            return -1;
+        }
+
+        @Override
+        public boolean isConcrete() {
+            return true;
+        };
+    };
+
     /**
      * private constructor to have all instances as constants in the class
      */


### PR DESCRIPTION
part of #7952: Put the pseudo cache created for "goto targets" into its own list instead of standard list. Cache will only be shown if you chose "All caches".

Other user defined caches behave unchanged, will get stored to either the current list (if available) or the standard list.
