### PR TITLE
disable longclick on map to create UDC by default

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -109,6 +109,7 @@
     <string translatable="false" name="pref_debug">debug</string>
     <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
     <string translatable="false" name="pref_old_mapsforge_api">pref_old_mapsforge_api</string>
+    <string translatable="false" name="pref_longTapCreateUDC">pref_longTapCreateUDC</string>
     <!-- preferences used internally -->
     <string translatable="false" name="pref_temp_twitter_token_secret">temp-token-secret</string>
     <string translatable="false" name="pref_temp_twitter_token_public">temp-token-public</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1053,12 +1053,15 @@
     <string name="cache_time_full_hours">o\'clock</string>
     <string name="cache_listed_on">Listed on %s</string>
 
+    <string name="user_defined_caches">User defined caches</string>
     <string name="create_internal_cache">Create user defined cache</string>
     <string name="internal_cache_default_name">User defined cache #%1$d</string>
     <string name="internal_cache_default_description">This is a user defined cache</string>
     <string name="internal_cache_default_owner">You</string>
     <string name="internal_goto_targets_title">\'Go to\' targets</string>
     <string name="internal_goto_targets_description">This cache stores your recent \'Go to\' targets</string>
+    <string name="init_longtap_udc">Long tap on map</string>
+    <string name="init_summary_longtap_udc">Long tap on map to create a user defined cache</string>
 
     <!-- editor dialog -->
 

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -624,6 +624,15 @@
                 android:title="@string/init_proximityNotificationSpecific" />
         </PreferenceCategory>
 
+        <PreferenceCategory android:title="@string/user_defined_caches"
+            android:layout="@layout/preference_category" >
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_longTapCreateUDC"
+                android:summary="@string/init_summary_longtap_udc"
+                android:title="@string/init_longtap_udc" />
+        </PreferenceCategory>
+
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"
             android:layout="@layout/preference_category" >
             <cgeo.geocaching.settings.TextPreference

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -99,7 +99,9 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
                 return true;
             }
         });
-        googleMap.setOnMapLongClickListener(tapLatLong -> InternalConnector.interactiveCreateCache(this.getContext(), new Geopoint(tapLatLong.latitude, tapLatLong.longitude), StoredList.STANDARD_LIST_ID));
+        if (Settings.isLongTapCreateUDC()) {
+            googleMap.setOnMapLongClickListener(tapLatLong -> InternalConnector.interactiveCreateCache(this.getContext(), new Geopoint(tapLatLong.latitude, tapLatLong.longitude), StoredList.STANDARD_LIST_ID));
+        }
         if (mapReadyCallback != null) {
             mapReadyCallback.mapReady();
             mapReadyCallback = null;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -943,7 +943,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         final Geocache cache = getCurrentTargetCache();
         if (cache != null) {
             EditWaypointActivity.startActivityAddWaypoint(this, cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
-        } else {
+        } else if (Settings.isLongTapCreateUDC()) {
             InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), StoredList.STANDARD_LIST_ID);
         }
     }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1021,6 +1021,10 @@ public class Settings {
         putInt(farDistance ? R.string.pref_proximityDistanceFar : R.string.pref_proximityDistanceNear, distance);
     }
 
+    public static boolean isLongTapCreateUDC() {
+        return getBoolean(R.string.pref_longTapCreateUDC, false);
+    }
+
     public static boolean isUseTwitter() {
         return getBoolean(R.string.pref_twitter, false);
     }


### PR DESCRIPTION
Part of #7952:
Longclick on map to create a user defined cache is disabled by default.
Go to settings - map - user defined caches to change this setting.
