### PR TITLE
remove cache list - show on map - Mapsforge Beta menu entry (fix #7963)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -968,7 +968,6 @@
     <string name="cache_menu_sygic_drive">Sygic (Driving)</string>
     <string name="cache_menu_radar">Radar</string>
     <string name="cache_menu_map">Map</string>
-    <string name="cache_menu_mfbeta">Mapsforge Beta</string>
     <string name="cache_menu_rmaps">Rmaps</string>
     <string name="cache_menu_map_ext">Other external apps</string>
     <string name="cache_menu_streetview">Street View</string>

--- a/main/src/cgeo/geocaching/apps/cachelist/CacheListApps.java
+++ b/main/src/cgeo/geocaching/apps/cachelist/CacheListApps.java
@@ -1,15 +1,11 @@
 package cgeo.geocaching.apps.cachelist;
 
-import cgeo.geocaching.R;
-import cgeo.geocaching.maps.mapsforge.v6.NewMap;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public enum CacheListApps {
 
     INTERNAL(new InternalCacheListMap()),
-    INTERNAL_NEW(new InternalCacheListMap(NewMap.class, R.string.cache_menu_mfbeta)),
     LOCUS_SHOW(new LocusShowCacheListApp()),
     LOCUS_EXPORT(new LocusExportCacheListApp()),
     MAPS_ME(new MapsMeCacheListApp());


### PR DESCRIPTION
Fixes #7963
removes menu entry cache list - show on map - Mapsforge Beta
