### PR TITLE
update LeakCanary dependency

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -291,7 +291,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Leak Canary, memory leak detection
-    def leakCanaryVersion = '1.5.4'
+    def leakCanaryVersion = '1.6.3'
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
     nightlyImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"

--- a/tests/src-android/cgeo/CGeoTestCase.java
+++ b/tests/src-android/cgeo/CGeoTestCase.java
@@ -19,7 +19,6 @@ public abstract class CGeoTestCase extends ApplicationTestCase<CgeoApplication> 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        createApplication();
     }
 
     /** Remove cache from DB and cache to ensure that the cache is not loaded from the database */


### PR DESCRIPTION
- from 1.5.4 to 1.6.3
- remove call "createApplication();" from CGeoTestCase.setUp()
  reason:
	java.lang.UnsupportedOperationException: buildAndInstall() should only be called once.
	at com.squareup.leakcanary.AndroidRefWatcherBuilder.buildAndInstall(AndroidRefWatcherBuilder.java:89)
	at com.squareup.leakcanary.LeakCanary.install(LeakCanary.java:43)
	at cgeo.geocaching.CgeoApplication.onCreate(CgeoApplication.java:52)
	at android.test.ApplicationTestCase.createApplication(ApplicationTestCase.java:126)
	at cgeo.CGeoTestCase.setUp(CGeoTestCase.java:22)
	at junit.framework.TestCase.runBare(TestCase.java:132)
	at junit.framework.TestResult$1.protect(TestResult.java:115)