### PR TITLE
switch to Mapsforge map provider if Google Play services are too old

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -283,6 +283,10 @@
     <string name="err_request_popup_info">c:geo failed to get cache popup info.</string>
     <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
 
+    <string name="warn_gm_not_available">Google Maps not available.</string>
+    <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>
+    <string name="switched_to_mf">Default map switched to Mapsforge map provider. Restart your map now.</string>
+
     <!-- location service -->
     <string name="loc_last">Last known</string>
     <string name="loc_net">Network</string>

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -272,6 +272,54 @@ public final class Dialogs {
      *
      * @param context
      *            activity owning the dialog
+     * @param msg
+     *            message dialog content
+     * @param positiveButton
+     *            label for positive button
+     */
+    public static AlertDialog.Builder message(final Activity context, final String title, final String msg, final String positiveButton, final OnClickListener okayListener) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog dialog = builder.setTitle(title)
+                .setCancelable(true)
+                .setMessage(msg)
+                .setPositiveButton(positiveButton, okayListener)
+                .create();
+        dialog.setOwnerActivity(context);
+        dialog.show();
+        return builder;
+    }
+
+    /**
+     * Show a message dialog with a single "OK" button.
+     *
+     * @param context
+     *            activity owning the dialog
+     * @param msg
+     *            message dialog content
+     * @param positiveButton
+     *            label for positive button
+     */
+    public static AlertDialog.Builder message(final Activity context, final int title, final int msg, final int positiveButton, final OnClickListener okayListener) {
+        return message(context, getString(title), getString(msg), getString(positiveButton), okayListener);
+    }
+
+    /**
+     * Show a message dialog with a single "OK" button.
+     *
+     * @param context
+     *            activity owning the dialog
+     * @param msg
+     *            message dialog content
+     */
+    public static AlertDialog.Builder message(final Activity context, final int title, final int msg, final OnClickListener okayListener) {
+        return message(context, getString(title), getString(msg), getString(android.R.string.ok), okayListener);
+    }
+
+    /**
+     * Show a message dialog with a single "OK" button.
+     *
+     * @param context
+     *            activity owning the dialog
      * @param message
      *            message dialog content
      */


### PR DESCRIPTION
Quick solution if Google Play services are too old to support current Google Maps implementation: Inform the user about version conflict and offer to switch the default map to Mapsforge map provider. User has to manually restart the map activity then.
If user cancelled the info box, she/he can update the Play Services instead.
(fixes #7975)

![image](https://user-images.githubusercontent.com/3754370/69898428-d54f9100-1359-11ea-8287-4b966138ced6.png)

![image](https://user-images.githubusercontent.com/3754370/69898431-e3051680-1359-11ea-87ad-3a7a72cb7505.png)
