### PR TITLE
throttle distance calculation to prevent NewMap ANR (fix #7923)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeCachesList.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeCachesList.java
@@ -234,16 +234,4 @@ public class MapsforgeCachesList extends AbstractItemizedOverlay {
     public int size() {
         return items.size();
     }
-
-
-    public int getClosestDistanceInM(final Geopoint coord) {
-        int minDistance = 50000000;
-        for (final CachesOverlayItemImpl item : items) {
-            final int distance = (int) (1000 * coord.distanceTo(item.getCoord()));
-            if (distance > 0) {
-                minDistance = Math.min(minDistance, distance);
-            }
-        }
-        return minDistance;
-    }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1230,6 +1230,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         float currentHeading;
 
         private long timeLastPositionOverlayCalculation = 0;
+        private long timeLastDistanceCheck = 0;
         /**
          * weak reference to the outer class
          */
@@ -1257,7 +1258,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
          */
         void repaintPositionOverlay() {
             final long currentTimeMillis = System.currentTimeMillis();
-            if (currentTimeMillis > timeLastPositionOverlayCalculation + MIN_UPDATE_INTERVAL) {
+            if (currentTimeMillis > (timeLastPositionOverlayCalculation + MIN_UPDATE_INTERVAL)) {
                 timeLastPositionOverlayCalculation = currentTimeMillis;
 
                 try {
@@ -1279,8 +1280,9 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                             map.positionLayer.setHeading(currentHeading);
                             map.positionLayer.requestRedraw();
 
-                            if (null != map.proximityNotification) {
+                            if (null != map.proximityNotification && (timeLastDistanceCheck == 0 || currentTimeMillis > (timeLastDistanceCheck + MIN_UPDATE_INTERVAL))) {
                                 map.proximityNotification.checkDistance(map.caches.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
+                                timeLastDistanceCheck = System.currentTimeMillis();
                             }
                         }
                     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.utils.MapMarkerUtils;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -375,6 +376,13 @@ public abstract class AbstractCachesOverlay {
             final int distance = (int) (1000f * cache.getCoords().distanceTo(coord));
             if (distance > 0 && distance < minDistance) {
                 minDistance = distance;
+            }
+            final List<Waypoint> waypoints = cache.getWaypoints();
+            for (final Waypoint waypoint : waypoints) {
+                final int wpDistance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
+                if (wpDistance > 0 && wpDistance < minDistance) {
+                    minDistance = wpDistance;
+                }
             }
         }
         return minDistance;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -313,11 +313,6 @@ public class CachesBundle {
         if (liveOverlay != null) {
             minDistance = Math.min(minDistance, liveOverlay.getClosestDistanceInM(coord));
         }
-        if (wpOverlay != null) {
-            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(baseOverlay, coord));
-            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(storedOverlay, coord));
-            minDistance = Math.min(minDistance, wpOverlay.getClosestDistanceInM(liveOverlay, coord));
-        }
         return minDistance;
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
-import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
 import cgeo.geocaching.models.Geocache;
@@ -91,17 +90,4 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         invalidate(invalidWpCodes);
     }
 
-    public int getClosestDistanceInM(final AbstractCachesOverlay baseOverlay, final Geopoint coord) {
-        int minDistance = 50000000;
-        if (null != baseOverlay) {
-            final Set<Waypoint> waypoints = filterWaypoints(baseOverlay.getCacheGeocodes(), true);
-            for (final Waypoint waypoint : waypoints) {
-                final int distance = (int) (1000f * waypoint.getCoords().distanceTo(coord));
-                if (distance > 0 && distance < minDistance) {
-                    minDistance = distance;
-                }
-            }
-        }
-        return minDistance;
-    }
 }


### PR DESCRIPTION
throttle distance calculation to prevent NewMap ANR (fix #7923)
on large caches/waypoints lists with activated proximity notification

- uses faster implementation of calculating min distance
- ensures a minimum timespan between two calculations