### PR TITLE
improve Mapfsforge map version error handling (fix #7801)

### DIFF
--- a/main/res/values-ca/strings.xml
+++ b/main/res/values-ca/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Introduïu un text per al vostre registre.</string>
     <string name="warn_load_images">El c:geo no ha pogut carregar les imatges.</string>
     <string name="warn_invalid_mapfile">El fitxer de mapa seleccionat no és un fitxer vàlid de mapa mapsforge versió 0.3.0 . \nEls mapes fora de línia no estan disponibles.</string>
-    <string name="warn_deprecated_mapfile">Esteu utilitzant una versió obsoleta del fitxer de mapes (0.2.4).\nConsidereu canviar a una versió de mapa 0.3.0. \nDeixarem de donar suport a la versió 0.2.4 en la propera versió.</string>
     <string name="warn_nonexistant_mapfile">No existeix el fitxer de mapa seleccionat. \nNo estan disponibles els mapes fora línia.</string>
     <string name="warn_rendertheme_missing">No s\'ha trobat l\'esquema de colors del mapa.</string>
     <string name="warn_pocket_query_select">No hi ha cap pocket query seleccionada.</string>

--- a/main/res/values-ceb/strings.xml
+++ b/main/res/values-ceb/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Palihug sa pag-input ug pipila ka mga teksto para sa imong log.</string>
     <string name="warn_load_images">c:geo napakyas sa pag-load ug mga larawan.</string>
     <string name="warn_invalid_mapfile">Ang napili na mapa na papeles kay dili balido nga mapsforge bersyon 0.3.0 nga papeles.\nOffline nga mapa kay dili puwede.</string>
-    <string name="warn_deprecated_mapfile">Ikaw nag gamit og dili angay nga bersyon sa mapa nga papeles (0.2.4).\nPaghatag og pagtugot og pag-ilis sa bersyon na 0.3.0 mapa.\n. Mohatag mi og suporta sa bersyon 0.2.4 sa sunod na pagpagawas.</string>
     <string name="warn_nonexistant_mapfile">Ang napili nga mapa na papeles kay wala makita.\nOffline na mapa kay dili puwede makuha o magamit.</string>
     <string name="warn_rendertheme_missing">Ang mapa nga tema kay wala makit-an.</string>
     <string name="warn_pocket_query_select">Walay gipili na bulsa na query.</string>

--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Prosím, napiš nějaký text do logu.</string>
     <string name="warn_load_images">c:geo nedokázalo načíst obrázky.</string>
     <string name="warn_invalid_mapfile">Vybraný mapový soubor není platným mapovým podkladem verze 0.3.0 mapového souboru.\nOffline mapy nejsou dostupné.</string>
-    <string name="warn_deprecated_mapfile">Používáš zastaralou verzi 0.2.4 mapového souboru.\nZvaž přepnutí na mapovou verzi 0.3.0.\nV příštím vydání již nebude verze 0.2.4 podporována.</string>
     <string name="warn_nonexistant_mapfile">Zvolený soubor map neexistuje.\nOffline mapy nejsou dostupné.</string>
     <string name="warn_rendertheme_missing">Téma pro mapu není k dispozici.</string>
     <string name="warn_pocket_query_select">Nevybrána žádná Pocket Query.</string>

--- a/main/res/values-da/strings.xml
+++ b/main/res/values-da/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Indtast tekst til din logbesked.</string>
     <string name="warn_load_images">c:geo kunne ikke indlæse billeder.</string>
     <string name="warn_invalid_mapfile">Den valgte kortfil er ikke en gyldig mapsforge version 0.3.0 kortfil.\nOffline kort vil ikke være tilgængelige.</string>
-    <string name="warn_deprecated_mapfile">Du bruger en kortfil med et forældet format (version 0.2.4).\nOvervej at skifte til kort med version 0.3.0.\nNæste udgave af c:geo vil ikke understøtte version 0.2.4.</string>
     <string name="warn_nonexistant_mapfile">Den valgte kortfil eksisterer ikke.\nOffline kort vil ikke være tilgængelige.</string>
     <string name="warn_rendertheme_missing">Korttema ikke fundet.</string>
     <string name="warn_pocket_query_select">Ingen Pocket Query valgt.</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -241,8 +241,7 @@
     <string name="warn_search_help_tb">Code des Trackables eingeben, z. B. „TB29QMZ“.</string>
     <string name="warn_log_text_fill">Bitte Text einfügen.</string>
     <string name="warn_load_images">c:geo konnte die Bilder nicht laden.</string>
-    <string name="warn_invalid_mapfile">Die gewählte Datei ist keine gültige Mapsforge-Karte in der Version 0.3.0.\nOffline Karte ist nicht verfügbar.</string>
-    <string name="warn_deprecated_mapfile">Es wird eine veraltete Offline-Karte v0.2.4 verwendet.\nBitte zukünftig Offline-Karten in der Version 0.3.0 verwenden.\nDer Support für die alte Version wird im nächsten Release eingestellt.</string>
+    <string name="warn_invalid_mapfile">Die gewählte Datei ist keine gültige Mapsforge-Karte oder verwendet eine nicht unterstützte Version.\n(c:geo unterstützt aktuell v3 bis v5 / nur v3, falls \"Alte Mapsforge V3\" aktiv ist.)\n\nOffline Karte ist nicht verfügbar.</string>
     <string name="warn_nonexistant_mapfile">Die gewählte Datei existiert nicht.\nOffline-Karte ist nicht verfügbar.</string>
     <string name="warn_rendertheme_missing">Das gewählte Karten-Theme wurde nicht gefunden.</string>
     <string name="warn_pocket_query_select">Kein Pocket-Query ausgewählt.</string>

--- a/main/res/values-el/strings.xml
+++ b/main/res/values-el/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Παρακαλώ εισάγετε κάποιο κείμενο για το αρχείο καταγραφής.</string>
     <string name="warn_load_images">Απέτυχε η φόρτωση εικόνων στο c:geo.</string>
     <string name="warn_invalid_mapfile">Το επιλεγμένο αρχείο χάρτη δεν είναι ένα έγκυρο αρχείο mapsforge έκδοση 0.3.0. \n Οι χάρτες δεν θα είναι διαθέσιμοι εκτός σύνδεσης.</string>
-    <string name="warn_deprecated_mapfile">Χρησιμοποιείτε ένα παλαιότερης έκδοσης αρχείο map (0.2.4).\nΚατεβάστε ένα χάρτη σε έκδοση 0.3.0. \nΟι χάρτες γενεάς 0.2.4 δεν θα υποστηρίζονται στην επόμενη έκδοση.</string>
     <string name="warn_nonexistant_mapfile">Δεν υπάρχει το αρχείο χάρτη που επιλέξατε.\nΟι χάρτες δεν είναι διαθέσιμοι εκτός σύνδεσης.</string>
     <string name="warn_rendertheme_missing">Το θέμα δεν βρέθηκε.</string>
     <string name="warn_pocket_query_select">Δεν έχει επιλεγεί καμία Προσωπική Αναζήτηση.</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Escribe algún texto de registro.</string>
     <string name="warn_load_images">Error al cargar las imágenes.</string>
     <string name="warn_invalid_mapfile">El archivo de mapa seleccionado no es un archivo de mapsforge versión 0.3.0 válido.\nLos mapas sin conexión no están disponibles.</string>
-    <string name="warn_deprecated_mapfile">Está usando una versión obsoleta del fichero de mapa (0.2.4)\nConsidere cambiar a un archivo versión 0.3.0.\nc:geo no será compatible con mapas versión 0.2.4 en nuestra siguiente versión.</string>
     <string name="warn_nonexistant_mapfile">El archivo de mapa seleccionado no existe.\nLos mapas sin conexión no están disponibles.</string>
     <string name="warn_rendertheme_missing">No se ha encontrado el esquema de colores del mapa.</string>
     <string name="warn_pocket_query_select">No ha seleccionado ninguna Pocket Query.</string>

--- a/main/res/values-fi/strings.xml
+++ b/main/res/values-fi/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Ole hyvä ja syötä jotain tekstiä lokiisi.</string>
     <string name="warn_load_images">c:geo epäonnistui kuvien latauksessa.</string>
     <string name="warn_invalid_mapfile">Valittu karttatiedosto ei ole kelvollinen mapsforge 0.3.0 version karttatiedosto.\nKartat eivät ole saatavilla offline-tilassa.</string>
-    <string name="warn_deprecated_mapfile">Käytät vanhentunutta versiota karttatiedostosta (0.2.4).\nHarkitse siirtymistä kartan 0.3.0 versioon.\nPoistamme tuen 0.2.4 versioon seuraavassa versiossa.</string>
     <string name="warn_nonexistant_mapfile">Valittua karttatiedostoa ei ole.\nOffline-kartat eivät ole saatavilla.</string>
     <string name="warn_rendertheme_missing">Karttateemaa ei löytynyt.</string>
     <string name="warn_pocket_query_select">Ei pocket queryja valittuna.</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Merci de saisir un texte pour votre visite.</string>
     <string name="warn_load_images">c:geo n\'a pas pu charger les images.</string>
     <string name="warn_invalid_mapfile">Le fichier sélectionné n\'est pas un fichier de carte mapsforge version 0.3.0.\nLes cartes hors-lignes ne sont pas disponibles.</string>
-    <string name="warn_deprecated_mapfile">Vous utilisez un fichier de carte obsolète de version 0.2.4.\nVous devriez charger sans tarder une carte version 0.3.\nLe support des cartes 0.2.4 disparaîtra dans une prochaine version de c:geo.</string>
     <string name="warn_nonexistant_mapfile">Le fichier de carte spécifié n\'existe pas.\nLes cartes hors ligne ne sont pas disponibles.</string>
     <string name="warn_rendertheme_missing">Le thème de la carte n\'a pas été trouvé.</string>
     <string name="warn_pocket_query_select">Aucune Pocket Query sélectionnée.</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Kérlek, írj szöveget a bejegyzéshez!</string>
     <string name="warn_load_images">Sajnáljuk, a c:geo nem tudta betölteni a képeket.</string>
     <string name="warn_invalid_mapfile">A kiválasztott térképfájl nem felel meg a mapsforge v0.3.0 formátumnak.\nAz offline térképek nem elérhetőék.</string>
-    <string name="warn_deprecated_mapfile">0.2.4-es verziójú térképfájlt használsz.\nFontold meg a váltást 0.3.0-ás verzióra.\nA következő kiadás már nem támogatja a 0.2.4-es verziót.</string>
     <string name="warn_nonexistant_mapfile">A kiválasztott térképfájl nem létezik.\nAz offline térképek nem elérhetőék.</string>
     <string name="warn_rendertheme_missing">Nem található térképstílus</string>
     <string name="warn_pocket_query_select">Nincs pocket lekérdezés kiválasztva.</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Prego, inserire del testo nel log.</string>
     <string name="warn_load_images">c:geo non riesce a caricare immagini.</string>
     <string name="warn_invalid_mapfile">La mappa selezionata non è mapsforge versione 0.3.0.\nMappa offline non disponibile.</string>
-    <string name="warn_deprecated_mapfile">Stai usando una vecchia mappa 0.2.4.\nAggiornala alla 0.3.0 appena puoi.\nIl supporto alla 0.2.4 sarà rimosso nella prossima versione.</string>
     <string name="warn_nonexistant_mapfile">La mappa selezionata non esiste.\nMappa offline non disponibile.</string>
     <string name="warn_rendertheme_missing">Tema mappa non trovato.</string>
     <string name="warn_pocket_query_select">Nessuna Pocket query selezionata.</string>

--- a/main/res/values-ja/strings.xml
+++ b/main/res/values-ja/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">ログの本文を入力してください。</string>
     <string name="warn_load_images">画像をロードすることができませんでした。</string>
     <string name="warn_invalid_mapfile">選択した地図ファイルはMapsforge version 0.3.0フォーマットの地図ファイルではありません。\nオフライン地図は利用できません。</string>
-    <string name="warn_deprecated_mapfile">Mapsforge version 0.2.4フォーマットの地図ファイルは非推奨です。\nMapsforge version 0.3.0フォーマットに変更した方がいいでしょう。次のリリースでversion 0.2.4はサポートされなくなります。</string>
     <string name="warn_nonexistant_mapfile">選択した地図ファイルは存在しません。\nオフライン地図は利用できません。</string>
     <string name="warn_rendertheme_missing">地図のテーマファイルが見つかりません。</string>
     <string name="warn_pocket_query_select">ポケット・クエリが選択されていません。</string>

--- a/main/res/values-ko/strings.xml
+++ b/main/res/values-ko/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">로그에 내용을 입력해 주세요.</string>
     <string name="warn_load_images">이미지를 불러오지 못했습니다.</string>
     <string name="warn_invalid_mapfile">선택한 지도파일은 mapsforge 버전 0.3.0 맵파일이 아닙니다.\n오프라인 지도를 사용할 수 없습니다.</string>
-    <string name="warn_deprecated_mapfile">지원하지 않을 예정인 지도파일(0.2.4)입니다.\n0.3.0 버전으로 바꿔주세요.\n다음 버전에서는 0.2.4를 지원하지 않을 계획입니다.</string>
     <string name="warn_nonexistant_mapfile">선택한 지도파일이 존재하지 않습니다.\n오프라인 지도를 사용할 수 없습니다.</string>
     <string name="warn_rendertheme_missing">지도 테마를 찾을 수 없습니다.</string>
     <string name="warn_pocket_query_select">포켓쿼리를 선택하지 않았습니다.</string>

--- a/main/res/values-lt/strings.xml
+++ b/main/res/values-lt/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Prašome įrašyti įrašo tekstą.</string>
     <string name="warn_load_images">c:geo nepavyko įkelti nuotraukų.</string>
     <string name="warn_invalid_mapfile">Pasirinktas žemėlapio failas nėra mapsforge 0.3.0 versijos failas.\nIšsaugoti žemėlapiai yra nepasiekiami.</string>
-    <string name="warn_deprecated_mapfile">Jūs naudojate pasenusią žemėlapio versiją (0.2.4).\nSiūlome atsinaujinti žemėlapį į 0.3.0 versiją.\nNuo sekančio leidimo versija 0.2.4 nebebus palaikoma.</string>
     <string name="warn_nonexistant_mapfile">Pasirinktas žemėlapio failas neegzistuoja.\nIšsaugoti žemėlapiai yra nepasiekiami.</string>
     <string name="warn_rendertheme_missing">Nerasta žemėlapio tema.</string>
     <string name="warn_pocket_query_select">Nepasirinktas joks Pocket query.</string>

--- a/main/res/values-lv/strings.xml
+++ b/main/res/values-lv/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Lūdzu, ievadi tekstu savam apmeklējuma ierakstam.</string>
     <string name="warn_load_images">c:geo neizdevās ielādēt attēlus.</string>
     <string name="warn_invalid_mapfile">Izvēlētais kartes fails nav derīgs mapsforge versijai 0.3.0 map file.\nBezsaistes kartes nav piejamas.</string>
-    <string name="warn_deprecated_mapfile">Jūs izmantojat novecojušu kartes faila versiju (0.2.4).\nApsveriet pāriet uz  0.3.0 versijas karti.\nMēs izbeigsim versijas 0.2.4 nākamajā atjauninājumā.</string>
     <string name="warn_nonexistant_mapfile">Izvēlētais kartes fails nepastāv. \nBezsaistes kartes nav pieejamas.</string>
     <string name="warn_rendertheme_missing">Kartes tēma nav atrasta.</string>
     <string name="warn_pocket_query_select">Nav atlasīta Slēpņu atlase (PQ).</string>

--- a/main/res/values-nb/strings.xml
+++ b/main/res/values-nb/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Vennligst skriv en logg-tekst.</string>
     <string name="warn_load_images">c:geo kunne ikke laste bilder.</string>
     <string name="warn_invalid_mapfile">Den valgte kartfilen er ikke et gyldig mapsforge-kart versjon 0.3.0. \nOffline-kartene er ikke tilgjengelig.</string>
-    <string name="warn_deprecated_mapfile">Du bruker en utgått versjon av kartfilen (0.2.4).\nDu bør bytte til versjon 0.3.0,\nC:geo vil ikke støtte versjon 0.2.4 i neste utgivelse.</string>
     <string name="warn_nonexistant_mapfile">Den valgte kartfilen finnes ikke. \nOffline-kartene er ikke tilgjengelige.</string>
     <string name="warn_rendertheme_missing">Karttema ikke funnet.</string>
     <string name="warn_pocket_query_select">Ingen pocket query er valgt.</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Voer s.v.p. een logtekst in.</string>
     <string name="warn_load_images">Sorry, c:geo kon de afbeeldingen niet laden.</string>
     <string name="warn_invalid_mapfile">Het geselecteerde mapbestand is geen correct mapforge 0.3.0 mapbestand.\nOffline kaarten zijn niet beschikbaar.</string>
-    <string name="warn_deprecated_mapfile">Je gebruikt een verouderd 0.2.4 mapbestand.\nJe word aangeraden naar een 0.3.0 mapbestand over te schakelen.\nOndersteuning voor de 0.2.4 versie zal in de volgende versie verdwijnen.</string>
     <string name="warn_nonexistant_mapfile">Het geselecteerde mapbestand bestaat niet.\nOffline kaarten zijn niet beschikbaar.</string>
     <string name="warn_rendertheme_missing">Map thema niet gevonden.</string>
     <string name="warn_pocket_query_select">Geen Pocket query geselecteerd.</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Proszę uzupełnij tekst wpisu.</string>
     <string name="warn_load_images">c:geo nie był w stanie załadować obrazów.</string>
     <string name="warn_invalid_mapfile">Wybrany plik mapy nie jest poprawnym plikiem mapsforge wersji 0.3.0.\nMapy offline są niedostępne.</string>
-    <string name="warn_deprecated_mapfile">Używasz przestarzałego pliku mapy w wersji 0.2.4.\nRozważ przejście na wersję mapy 0.3.0.\nNiedługo c:geo przestanie wspierać wersję 0.2.4.</string>
     <string name="warn_nonexistant_mapfile">Wybrany plik z mapą nie istnieje.\nMapy offline są niedostępne.</string>
     <string name="warn_rendertheme_missing">Nie znaleziono tematu mapy.</string>
     <string name="warn_pocket_query_select">Nie wybrano Pocket query.</string>

--- a/main/res/values-pt/strings.xml
+++ b/main/res/values-pt/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Por favor, preencha algum texto para o registo.</string>
     <string name="warn_load_images">O c:geo falhou o carregamento de imagens.</string>
     <string name="warn_invalid_mapfile">O ficheiro de mapa seleccionado não é suportado pela versão mapsforge 0.3.0.\nOs mapas offline não estão disponíveis.</string>
-    <string name="warn_deprecated_mapfile">Está a utilizar um ficheiro de mapa de uma versão obsoleta.\nConsidere mudar o mapa para a versão 0.3.0.\nNa próxima versão vamos deixar de suportar a 0.2.4.</string>
     <string name="warn_nonexistant_mapfile">O ficheiro de mapa seleccionado não existe.\nOs mapas offline não estão disponíveis.</string>
     <string name="warn_rendertheme_missing">Tema de mapa não encontrado.</string>
     <string name="warn_pocket_query_select">Nenhuma Pocket query seleccionada.</string>

--- a/main/res/values-ro/strings.xml
+++ b/main/res/values-ro/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Te rog introdu ceva text pentru această însemnare.</string>
     <string name="warn_load_images">c:geo nu a putut încărca imaginile.</string>
     <string name="warn_invalid_mapfile">Harta aleasă nu este în formatul mapsforge versiunea 0.3.0.\nHarta salvată nu este disponibilă.</string>
-    <string name="warn_deprecated_mapfile">Foloseşti o hartă într-un format prea vechi (mapsforge 0.2.4).\nAr fi bine să schimbi pe hărţi versiunea 0.3.0.\nNu va mai exista suport pentru hărţi versiunea 0.2.4 în urmatoarea versiune de c:geo.</string>
     <string name="warn_nonexistant_mapfile">Fişierul cu harta aleasă nu există.\nHarta salvată nu este disponibilă.</string>
     <string name="warn_rendertheme_missing">Stilul hărţii nu a fost găsit.</string>
     <string name="warn_pocket_query_select">Nu a fost selectat nici un \"Pocket Query\".</string>

--- a/main/res/values-ru/strings.xml
+++ b/main/res/values-ru/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Пожалуйста, введите текст записи.</string>
     <string name="warn_load_images">c:geo не удалось загрузить изображения.</string>
     <string name="warn_invalid_mapfile">Выбранный файл карты не является файлом карты Mapsforge 0.3.0\nОффлайновые карты недоступны.</string>
-    <string name="warn_deprecated_mapfile">Вы используете устаревшую версию файла карт (0.2.4).\nМы планируем убрать поддержку 0.2.4 в следующей версии.\nОбновите вашу карту до версии 0.3.0.</string>
     <string name="warn_nonexistant_mapfile">Выбранный файл карты не существует.\nОффлайн карты недоступны.</string>
     <string name="warn_rendertheme_missing">Тема карты не найдена.</string>
     <string name="warn_pocket_query_select">Не выбрана выборка.</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Prosím, vyplňte nejaký text do logu.</string>
     <string name="warn_load_images">Prepáčte, c:geo sa nepodarilo načítať obrázky.</string>
     <string name="warn_invalid_mapfile">Vybraná mapa nemá platný formát mapsforge verzie 0.3.0.\nOffline mapy nie sú dostupné.</string>
-    <string name="warn_deprecated_mapfile">Používate zastaralý formát mapových súborov verzie 0.2.4.\nZvážte prechod na mapy verzie 0.3.0.\nV budúcnosti prestane byť verzia 0.2.4 podporovaná.</string>
     <string name="warn_nonexistant_mapfile">Vybraný mapový súbor neexistuje.\nOffline mapy nie sú dostupné.</string>
     <string name="warn_rendertheme_missing">Téma mapy nebola nájdená.</string>
     <string name="warn_pocket_query_select">Najprv vyber pocket query.</string>

--- a/main/res/values-sl/strings.xml
+++ b/main/res/values-sl/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Vnesite besedilo zapisa.</string>
     <string name="warn_load_images">c:geo ni uspel naložiti slik.</string>
     <string name="warn_invalid_mapfile">Izbrana datoteka ni veljaven mapsforge 0.3.0 zemljevid. Zemljevidi brez povezave niso na voljo.</string>
-    <string name="warn_deprecated_mapfile">Uporabljate različico zemljevidov 0.2.4. Prosimo uporabite različico 0.3.0. V naslednji izdaji bomo prekinili podporo za različico 0.2.4.</string>
     <string name="warn_nonexistant_mapfile">Datoteka z zemljevidi ne obstaja.\nZemljevidi brez povezave niso na voljo.</string>
     <string name="warn_rendertheme_missing">Tema zemljevidov ni na voljo.</string>
     <string name="warn_pocket_query_select">Noben Pocket Query ni bil izbran.</string>

--- a/main/res/values-sv/strings.xml
+++ b/main/res/values-sv/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Vänligen skriv någon text i loggen.</string>
     <string name="warn_load_images">Tyvärr misslyckades c:geo att ladda ner bilder.</string>
     <string name="warn_invalid_mapfile">Den valda kartfilen är inte en korrekt Mapsforge version 0.3.0 kartfil.\nOffline-kartan är inte tillgänglig.</string>
-    <string name="warn_deprecated_mapfile">Den kartfil du använder är av en gammal version (0.2.4).\nVi rekommenderar att byta till en kartfil med version 0.3.0.\nNästa version av c:geo kommer inte hantera version 0.2.4.</string>
     <string name="warn_nonexistant_mapfile">Den angivna kartfilen finns inte.\nOffline-kartor kommer inte att vara tillgängliga.</string>
     <string name="warn_rendertheme_missing">Karttema kunde inte hittas.</string>
     <string name="warn_pocket_query_select">Ingen Pocket query vald.</string>

--- a/main/res/values-tr/strings.xml
+++ b/main/res/values-tr/strings.xml
@@ -242,7 +242,6 @@
     <string name="warn_log_text_fill">Lütfen kaydınız için metin girin.</string>
     <string name="warn_load_images">c:geo görüntüleri yükleyemedi.</string>
     <string name="warn_invalid_mapfile">Seçilen harita dosyası geçerli bir mapsforge version 0.3.0 harita dosyası değildir. \nÇevrimdışı haritalar kullanılabilir değildir.</string>
-    <string name="warn_deprecated_mapfile">Harita dosyasının kullanımdan kaldırılmış bir versiyonunu kullanıyorsunuz (0.2.4.).\nHarita versiyonu 0.3.0\'e geçmeyi düşünün.\nBir sonraki sürümde versiyon 0.2.4\'ü destekleyemeyeceğiz.</string>
     <string name="warn_nonexistant_mapfile">Seçtiğiniz harita dosyası artık yok. \nÇevrimdışı haritalar kullanılabilir değildir.</string>
     <string name="warn_rendertheme_missing">Harita teması bulunamadı.</string>
     <string name="warn_pocket_query_select">Sorgulama kaydı seçilmedi.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="warn_discard_changes">Unsaved waypoint changes discarded!</string>
     <string name="err_request_popup_info">c:geo failed to get cache popup info.</string>
     <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
+    <string name="more_information">More information</string>
 
     <string name="warn_gm_not_available">Google Maps not available.</string>
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -250,8 +250,7 @@
     <string name="warn_search_help_tb">Enter the code for a trackable. For example \"TB29QMZ\".</string>
     <string name="warn_log_text_fill">Please input some text for your log.</string>
     <string name="warn_load_images">c:geo failed to load images.</string>
-    <string name="warn_invalid_mapfile">The selected map file is not a valid mapsforge version 0.3.0 map file.\nOffline maps are not available.</string>
-    <string name="warn_deprecated_mapfile">You are using a deprecated version of map file (0.2.4).\nConsider switching to a version 0.3.0 map.\nWe will drop support for version 0.2.4 in the next release.</string>
+    <string name="warn_invalid_mapfile">The selected map file is not a valid mapsforge map file or uses an unsupported version.\n(c:geo currently supports v3 to v5 / v3 only if you are using \"Old Mapfsforge V3\" setting.)\n\nOffline maps are not available.</string>
     <string name="warn_nonexistant_mapfile">The selected map file does not exist.\nOffline maps are not available.</string>
     <string name="warn_rendertheme_missing">Map theme not found.</string>
     <string name="warn_pocket_query_select">No Pocket query selected.</string>

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -14,8 +14,10 @@ import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.Log;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.os.Bundle;
@@ -231,11 +233,7 @@ public class MapsforgeMapView extends MapView implements MapViewImpl<MapsforgeCa
             }
             setMapFile(new File(Settings.getMapFile()));
             if (!Settings.isValidMapFile(Settings.getMapFile())) {
-                Toast.makeText(
-                        getContext(),
-                        getContext().getString(R.string.warn_invalid_mapfile),
-                        Toast.LENGTH_LONG)
-                        .show();
+                Dialogs.message((Activity) getContext(), R.string.warn_invalid_mapfile);
             }
         }
         if (hasMapThemes()) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.maps.mapsforge;
 
+import static cgeo.geocaching.utils.MapUtils.showInvalidMapfileMessage;
+
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
@@ -14,10 +16,8 @@ import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.Log;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.os.Bundle;
@@ -233,7 +233,7 @@ public class MapsforgeMapView extends MapView implements MapViewImpl<MapsforgeCa
             }
             setMapFile(new File(Settings.getMapFile()));
             if (!Settings.isValidMapFile(Settings.getMapFile())) {
-                Dialogs.message((Activity) getContext(), R.string.warn_invalid_mapfile);
+                showInvalidMapfileMessage(getContext());
             }
         }
         if (hasMapThemes()) {

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.settings;
 
+import static cgeo.geocaching.utils.MapUtils.showInvalidMapfileMessage;
+
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
@@ -719,7 +721,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                     if (!file.isDirectory()) {
                         Settings.setMapFile(mapFile);
                         if (!Settings.isValidMapFile(Settings.getMapFile())) {
-                            Dialogs.message(this, R.string.warn_invalid_mapfile);
+                            showInvalidMapfileMessage(this);
                         } else {
                             // Ensure map source preference is updated accordingly.
                             // TODO: There should be a better way to find and select the map source for a map file

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SelectMapfileActivity;
-import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
 import cgeo.geocaching.apps.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.connector.ConnectorFactory;
@@ -720,7 +719,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                     if (!file.isDirectory()) {
                         Settings.setMapFile(mapFile);
                         if (!Settings.isValidMapFile(Settings.getMapFile())) {
-                            ActivityMixin.showToast(this, R.string.warn_invalid_mapfile);
+                            Dialogs.message(this, R.string.warn_invalid_mapfile);
                         } else {
                             // Ensure map source preference is updated accordingly.
                             // TODO: There should be a better way to find and select the map source for a map file

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -432,6 +432,29 @@ public final class Dialogs {
     }
 
     /**
+     * Standard message box + additional neutral button.
+     *
+     * @param context
+     *            activity hosting the dialog
+     * @param msg
+     *            dialog message
+     * @param neutralTextButton
+     *            Text for the neutral button
+     * @param neutralListener
+     *            listener of the neutral button
+     */
+    public static AlertDialog.Builder messageNeutral(final Activity context, final String msg, final int neutralTextButton, final OnClickListener neutralListener) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog dialog = builder.setMessage(msg)
+                .setPositiveButton(android.R.string.ok, null)
+                .setNeutralButton(neutralTextButton, neutralListener)
+                .create();
+        dialog.setOwnerActivity(context);
+        dialog.show();
+        return builder;
+    }
+
+    /**
      * Show a message dialog for input from the user. The okay button is only enabled on non empty input.
      *
      * @param context

--- a/main/src/cgeo/geocaching/utils/MapUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapUtils.java
@@ -1,0 +1,25 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.ui.dialog.Dialogs;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+public final class MapUtils {
+
+    private MapUtils() {
+        // utility class
+    }
+
+    public static void showInvalidMapfileMessage(final Context context) {
+        Dialogs.messageNeutral((Activity) context, context.getString(R.string.warn_invalid_mapfile), R.string.more_information, (dialog, which) -> {
+            final Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.addCategory(Intent.CATEGORY_BROWSABLE);
+            intent.setDataAndType(Uri.parse(context.getString(R.string.settings_offline_maps_url)), "text/html");
+            context.startActivity(intent);
+        });
+    }
+}


### PR DESCRIPTION
improve Mapfsforge map version error handling (fix #7801)
- add supported map versions to map loading error message
- display error message as dialog instead of toast
- remove unused "deprecated mf 2.4 version" message

![image](https://user-images.githubusercontent.com/3754370/69907043-d7ebce00-13cd-11ea-9a97-303df9f300ea.png)
