### PR TITLE
change CacheNumber on testSearchByOwner

### DIFF
--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -230,7 +230,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
             public void run() {
                 final SearchResult search = GCParser.searchByOwner("blafoo", CacheType.MYSTERY);
                 assertThat(search).isNotNull();
-                assertThat(search.getGeocodes()).hasSize(8);
+                assertThat(search.getGeocodes()).hasSize(9);
                 assertThat(search.getGeocodes()).contains("GC36RT6");
             }
         });


### PR DESCRIPTION
Test error:
~~~
V/InstrumentationResultParser: There was 1 failure:
V/InstrumentationResultParser: 1) testSearchByOwner(cgeo.geocaching.CgeoApplicationTest)
V/InstrumentationResultParser: java.lang.AssertionError:
V/InstrumentationResultParser: Expected size:<8> but was:<9> in:
~~~

Reason:
New mystery cache now by blafoo (GC8G0X7) from 15.11.19.