### PR TITLE
change testSearchByOwner to use Lineflyer's earth caches

### DIFF
--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -228,10 +228,10 @@ public class CgeoApplicationTest extends CGeoTestCase {
 
             @Override
             public void run() {
-                final SearchResult search = GCParser.searchByOwner("blafoo", CacheType.MYSTERY);
+                final SearchResult search = GCParser.searchByOwner("Lineflyer", CacheType.EARTH);
                 assertThat(search).isNotNull();
-                assertThat(search.getGeocodes()).hasSize(8);
-                assertThat(search.getGeocodes()).contains("GC36RT6");
+                assertThat(search.getGeocodes()).hasSize(5);
+                assertThat(search.getGeocodes()).contains("GC7J99X");
             }
         });
     }


### PR DESCRIPTION
In case blafoo starts a 24 day Adventskalender (which would break this test again and again): update testSearchByOwner to use Lineflyer's earthcaches instead (5 caches as of today, all non-PMO)