### PR TITLE
update to and workaround for Gradle plugin 3.5.3 (fix #7858)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // un-mocking of portable Android classes
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.3'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -51,6 +51,16 @@ android {
 
         // include only those language resources from libraries which we actively maintain ourself in the translation project
         resConfigs "en","ca","ceb","cs","da","de","el","es","fi","fr","hu","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tr"
+
+        javaCompileOptions {
+            // workaround for build error "Could not find AndroidManifest.xml file using generation folder" when using Gradle plugin v3.5
+            // might be fixed with release of AndroidAnnotations 4.7 (see https://github.com/androidannotations/androidannotations/issues/2034)
+            annotationProcessorOptions {
+                arguments = [
+                        "androidManifestFile": "$projectDir/AndroidManifest.xml".toString()
+                ]
+            } // annotationProcessorOptions
+        } // javaCompileOptions
     }
 
     // signing is handled via private.properties

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -54,13 +54,13 @@ android {
 
         javaCompileOptions {
             // workaround for build error "Could not find AndroidManifest.xml file using generation folder" when using Gradle plugin v3.5
-            // might be fixed with release of AndroidAnnotations 4.7 (see https://github.com/androidannotations/androidannotations/issues/2034)
+            // will be fixed with release of AndroidAnnotations 4.7.0 (see https://github.com/androidannotations/androidannotations/issues/2229)
             annotationProcessorOptions {
                 arguments = [
                         "androidManifestFile": "$projectDir/AndroidManifest.xml".toString()
                 ]
-            } // annotationProcessorOptions
-        } // javaCompileOptions
+            }
+        }
     }
 
     // signing is handled via private.properties
@@ -257,6 +257,7 @@ android {
 
 dependencies {
     // AndroidAnnotations, https://github.com/excilys/androidannotations/wiki/building-project-gradle
+    // remove the android.defaultConfig.javaCompileOptions.annotationProcessorOptions on version 4.7.0
     def androidAnnotationsVersion = '4.6.0'
     annotationProcessor "org.androidannotations:androidannotations:$androidAnnotationsVersion"
     implementation "org.androidannotations:androidannotations-api:$androidAnnotationsVersion"


### PR DESCRIPTION
- activates Gradle plugin v3.5.3
- adds a workaround to avoid the "Could not find AndroidManifest.xml file using generation folder" error by pointing to AndroidManifext.xml file in gradle config (see https://github.com/androidannotations/androidannotations/issues/2034)
- please review first :-)