### PR TITLE
add option to disable controls for manual map rotation on GMv2

### DIFF
--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -5,6 +5,7 @@
     <b>Next feature release:</b>\n
     · New: Ability to create user defined caches\n
     · New: Add support for geocheckers of geocache-planer.de and geotjek.dk\n
+    · New: Option to disable Google Maps controls for manual screen rotation\n
     · Change: Use waypoints of a user defined cache in \"Go to\" menu\n
     · Change: Link from offline map \"More info\" page to the new offline map tutorial\n
     · Fix: Support for geochecker gc-apps.com\n

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -79,6 +79,7 @@
     <string translatable="false" name="pref_mapsource">mapsource</string>
     <string translatable="false" name="pref_mapDirectory">mapDirectory</string>
     <string translatable="false" name="pref_mapsforge_scale_text">mapsforgeScaleText</string>
+    <string translatable="false" name="pref_map_manualrotation_disabled">map_manualrotation_disabled</string>
     <string translatable="false" name="pref_renderthemepath">renderthemepath</string>
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -682,6 +682,8 @@
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="settings_title_scale_map_text">Scale Map Text</string>
     <string name="settings_summary_scale_map_text">Scale text labels on offline map according to device dpi</string>
+    <string name="settings_title_map_manualrotation_disabled">Manual map rotation</string>
+    <string name="settings_summary_map_manualrotation_disabled">Disable controls for manual map rotation</string>
     <string name="init_map_directory_description">Directory with offline maps</string>
     <string name="init_gpx_exportdir">GPX Export Directory</string>
     <string name="init_gpx_importdir">GPX Import Directory</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -561,6 +561,11 @@
                 android:key="@string/pref_mapsforge_scale_text"
                 android:summary="@string/settings_summary_scale_map_text"
                 android:title="@string/settings_title_scale_map_text" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_map_manualrotation_disabled"
+                android:summary="@string/settings_summary_map_manualrotation_disabled"
+                android:title="@string/settings_title_map_manualrotation_disabled" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/settings_title_map_content"

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -99,6 +99,9 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         }
         this.googleMap = googleMap;
         mapController.setGoogleMap(googleMap);
+        if (Settings.isManualRotationDisabled()) {
+            googleMap.getUiSettings().setRotateGesturesEnabled(false);
+        }
         cachesList = new GoogleCachesList(googleMap);
         googleMap.setOnCameraMoveListener(() -> recognizePositionChange());
         googleMap.setOnCameraIdleListener(() -> recognizePositionChange());

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -595,6 +595,10 @@ public class Settings {
         return getBoolean(R.string.pref_mapsforge_scale_text, true);
     }
 
+    public static boolean isManualRotationDisabled() {
+        return getBoolean(R.string.pref_map_manualrotation_disabled, false);
+    }
+
     public static CoordInputFormatEnum getCoordInputFormat() {
         return CoordInputFormatEnum.fromInt(getInt(R.string.pref_coordinputformat, CoordInputFormatEnum.DEFAULT_INT_VALUE));
     }


### PR DESCRIPTION
fixes #7986

Adds menu option "Settings" - "Map" - "Manual rotation" to disable controls for manual rotation of map. (Currently only available for Google Maps v2, as our OSM implementation does not allow rotation at all.)