### PR TITLE
map auto rotation for Google Maps v2

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -107,6 +107,14 @@
                 android:title="@string/map_dot_mode"
                 app:showAsAction="ifRoom|withText">
             </item>
+            <item
+                android:id="@+id/menu_map_autorotate"
+                android:checkable="true"
+                android:icon="@drawable/ic_menu_rotate"
+                android:title="@string/map_autorotate"
+                android:visible="false"
+                app:showAsAction="ifRoom|withText">
+            </item>
 
         </menu>
     </item>

--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -6,6 +6,7 @@
     · New: Ability to create user defined caches\n
     · New: Proximity notification messages as Android system notifications\n
     · New: Add support for geocheckers of geocache-planer.de and geotjek.dk\n
+    · New: Auto rotate for Google Maps\n
     · New: Option to disable Google Maps controls for manual screen rotation\n
     · Change: Use waypoints of a user defined cache in \"Go to\" menu\n
     · Change: Link from offline map \"More info\" page to the new offline map tutorial\n

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -80,6 +80,7 @@
     <string translatable="false" name="pref_mapDirectory">mapDirectory</string>
     <string translatable="false" name="pref_mapsforge_scale_text">mapsforgeScaleText</string>
     <string translatable="false" name="pref_map_manualrotation_disabled">map_manualrotation_disabled</string>
+    <string translatable="false" name="pref_map_autorotation_disabled">map_autorotation_disabled</string>
     <string translatable="false" name="pref_renderthemepath">renderthemepath</string>
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="settings_title_map">Map</string>
     <string name="settings_summary_map">Set map source, offline map settings and map details.</string>
     <string name="settings_title_map_data">Map Data</string>
+    <string name="settings_title_map_rotation">Map rotation (Google Maps)</string>
     <string name="settings_title_map_content">Map Content</string>
     <string name="settings_title_gpx">GPX</string>
 
@@ -682,8 +683,10 @@
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="settings_title_scale_map_text">Scale Map Text</string>
     <string name="settings_summary_scale_map_text">Scale text labels on offline map according to device dpi</string>
-    <string name="settings_title_map_manualrotation_disabled">Manual map rotation</string>
+    <string name="settings_title_map_manualrotation_disabled">Disable manual map rotation</string>
     <string name="settings_summary_map_manualrotation_disabled">Disable controls for manual map rotation</string>
+    <string name="settings_title_map_autorotation_disabled">Disable automatic map rotation</string>
+    <string name="settings_summary_map_autorotation_disabled">Disable automatic map rotation</string>
     <string name="init_map_directory_description">Directory with offline maps</string>
     <string name="init_gpx_exportdir">GPX Export Directory</string>
     <string name="init_gpx_importdir">GPX Import Directory</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1185,6 +1185,7 @@
     <string name="map_modes">Map settings</string>
     <string name="map_trail_show">Show trail</string>
     <string name="map_dot_mode">Use compact icons</string>
+    <string name="map_autorotate">Map autorotate</string>
     <string name="map_circles_show">Show circles</string>
     <string name="map_mycaches_hide">Hide own/found caches</string>
     <string name="map_disabled_hide">Hide disabled caches</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -561,11 +561,20 @@
                 android:key="@string/pref_mapsforge_scale_text"
                 android:summary="@string/settings_summary_scale_map_text"
                 android:title="@string/settings_title_scale_map_text" />
+        </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/settings_title_map_rotation"
+            android:layout="@layout/preference_category" >
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="@string/pref_map_manualrotation_disabled"
                 android:summary="@string/settings_summary_map_manualrotation_disabled"
                 android:title="@string/settings_title_map_manualrotation_disabled" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_map_autorotation_disabled"
+                android:summary="@string/settings_summary_map_autorotation_disabled"
+                android:title="@string/settings_title_map_autorotation_disabled" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/settings_title_map_content"

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -745,6 +745,11 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null);
                 ActivityMixin.invalidateOptionsMenu(activity);
                 return true;
+            case R.id.menu_map_autorotate:
+                Settings.setMapAutoRotationDisabled(!Settings.isMapAutoRotationDisabled());
+                overlayPositionAndScale.updateMapAutoRotation();
+                ActivityMixin.invalidateOptionsMenu(activity);
+                return true;
             case R.id.menu_direction_line:
                 Settings.setMapDirection(!Settings.isMapDirection());
                 mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null);

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -128,7 +128,9 @@ public class GoogleMapActivity extends Activity implements MapActivityImpl, Filt
 
     @Override
     public boolean superOnPrepareOptionsMenu(final Menu menu) {
-        return super.onPrepareOptionsMenu(menu);
+        final boolean result = super.onPrepareOptionsMenu(menu);
+        menu.findItem(R.id.menu_map_autorotate).setVisible(true).setChecked(!Settings.isMapAutoRotationDisabled());
+        return result;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -100,7 +100,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         }
         this.googleMap = googleMap;
         mapController.setGoogleMap(googleMap);
-        if (Settings.isManualRotationDisabled()) {
+        if (Settings.isMapManualRotationDisabled()) {
             googleMap.getUiSettings().setRotateGesturesEnabled(false);
         }
         cachesList = new GoogleCachesList(googleMap);

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -69,7 +69,7 @@ public class GooglePositionAndHistory implements PositionAndHistory {
         this.mapView = mapView;
         trailColor = Settings.getTrailColor();
         this.postRealDistance = postRealDistance;
-        this.isMapAutoRotationDisabled = Settings.isMapAutoRotationDisabled();
+        updateMapAutoRotation();
     }
 
     @Override
@@ -105,6 +105,10 @@ public class GooglePositionAndHistory implements PositionAndHistory {
                 }
             }
         }
+    }
+
+    public void updateMapAutoRotation() {
+        this.isMapAutoRotationDisabled = Settings.isMapAutoRotationDisabled();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
@@ -21,4 +21,6 @@ public interface PositionAndHistory {
     void setHistory(ArrayList<Location> history);
 
     void repaintRequired();
+
+    void updateMapAutoRotation();
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
@@ -110,4 +110,8 @@ public class MapsforgePositionAndHistory implements GeneralOverlay, PositionAndH
     public void repaintRequired() {
         ovlImpl.getMapViewImpl().repaintRequired(this);
     }
+
+    @Override
+    public void updateMapAutoRotation() {
+    }
 }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -604,6 +604,10 @@ public class Settings {
         return getBoolean(R.string.pref_map_autorotation_disabled, false);
     }
 
+    public static void setMapAutoRotationDisabled(final boolean disabled) {
+        putBoolean(R.string.pref_map_autorotation_disabled, disabled);
+    }
+
     public static CoordInputFormatEnum getCoordInputFormat() {
         return CoordInputFormatEnum.fromInt(getInt(R.string.pref_coordinputformat, CoordInputFormatEnum.DEFAULT_INT_VALUE));
     }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -596,8 +596,12 @@ public class Settings {
         return getBoolean(R.string.pref_mapsforge_scale_text, true);
     }
 
-    public static boolean isManualRotationDisabled() {
+    public static boolean isMapManualRotationDisabled() {
         return getBoolean(R.string.pref_map_manualrotation_disabled, false);
+    }
+
+    public static boolean isMapAutoRotationDisabled() {
+        return getBoolean(R.string.pref_map_autorotation_disabled, false);
     }
 
     public static CoordInputFormatEnum getCoordInputFormat() {


### PR DESCRIPTION
Fixes #7507

When bearing between last rotation point and current location reaches +/- 15° map rotates accordingly. Auto rotation is enabled per default, and can be disabled using settings - map - map rotation - disable automatic map rotation.