### PR TITLE
add support for locationless cache type (fix #8010)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="gchqceleb">Geocaching HQ Celebration</string>
     <string name="gps">GPS Adventures Exhibit</string>
     <string name="block">Geocaching HQ Block Party</string>
+    <string name="locationless">Locationless (Reverse) Cache</string>
     <string name="userdefined">User defined cache</string>
     <string name="unknown">Unknown Type</string>
 

--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -316,6 +316,8 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 return GeocachingData.CACHE_TYPE_GPS_ADVENTURE;
             case BLOCK_PARTY:
                 return GeocachingData.CACHE_TYPE_EVENT; // no special locus type
+            case LOCATIONLESS:
+                return GeocachingData.CACHE_TYPE_LOCATIONLESS;
             default:
                 return NO_LOCUS_ID;
         }

--- a/main/src/cgeo/geocaching/enumerations/CacheType.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheType.java
@@ -181,6 +181,6 @@ public enum CacheType {
     }
 
     public boolean isVirtual() {
-        return this == VIRTUAL || this == WEBCAM || this == EARTH;
+        return this == VIRTUAL || this == WEBCAM || this == EARTH || this == LOCATIONLESS;
     }
 }

--- a/main/src/cgeo/geocaching/enumerations/CacheType.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheType.java
@@ -35,6 +35,7 @@ public enum CacheType {
     GCHQ_CELEBRATION("gchqceleb", "Geocaching HQ Celebration", "af820035-787a-47af-b52b-becc8b0c0c88", R.string.gchqceleb, R.drawable.type_hq, "3774", R.drawable.dot_event), // icon missing
     GPS_EXHIBIT("gps", "GPS Adventures Exhibit", "72e69af2-7986-4990-afd9-bc16cbbb4ce3", R.string.gps, R.drawable.type_event, "1304", R.drawable.dot_event), // icon missing
     BLOCK_PARTY("block", "Geocaching HQ Block Party", "bc2f3df2-1aab-4601-b2ff-b5091f6c02e3", R.string.block, R.drawable.type_event, "4738", R.drawable.dot_event), // icon missing
+    LOCATIONLESS("locationless", "Locationless (Reverse) Cache", "8f6dd7bc-ff39-4997-bd2e-225a0d2adf9d", R.string.locationless, R.drawable.type_virtual, "12", R.drawable.dot_virtual), // icon missing
 
     // insert other official cache types before USER_DEFINED and UNKNOWN
     USER_DEFINED("userdefined", "User defined cache", "", R.string.userdefined, R.drawable.type_virtual, "", R.drawable.dot_virtual),

--- a/tests/src/cgeo/geocaching/enumerations/CacheTypeTest.java
+++ b/tests/src/cgeo/geocaching/enumerations/CacheTypeTest.java
@@ -24,6 +24,7 @@ public class CacheTypeTest {
         assertThat(CacheType.getByPattern(null)).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getByPattern("random garbage")).isEqualTo(CacheType.UNKNOWN);
         assertThat(CacheType.getByPattern("cache in trash out event")).isEqualTo(CacheType.CITO);
+        assertThat(CacheType.getByPattern("Locationless (Reverse) Cache")).isEqualTo(CacheType.LOCATIONLESS);
     }
 
     @Test
@@ -65,5 +66,6 @@ public class CacheTypeTest {
         assertThat(CacheType.GPS_EXHIBIT.isEvent()).isTrue();
         assertThat(CacheType.GCHQ_CELEBRATION.isEvent()).isTrue();
         assertThat(CacheType.TRADITIONAL.isEvent()).isFalse();
+        assertThat(CacheType.LOCATIONLESS.isEvent()).isFalse();
     }
 }


### PR DESCRIPTION
Fixes #8010

Add config to detect caches of the type "Locationless (Reverse) Cache" - the once only reintroduced cache type for GCFR0G. As it's probably only a single new cache, I did not created a new symbol for it but reused the "virtual cache" symbol.

![image](https://user-images.githubusercontent.com/3754370/71115111-831fc400-21d1-11ea-925f-b509ec437511.png)
