### PR TITLE
for locus integration - change doc ref to kotlin code

### DIFF
--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -277,7 +277,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
         return p;
     }
 
-    // https://github.com/asamm/locus-api/blob/master/locus-api-core/src/main/java/locus/api/objects/geocaching/GeocachingData.java
+    // https://github.com/asamm/locus-api/blob/master/locus-api-core/src/main/java/locus/api/objects/geocaching/GeocachingData.kt
     private static int toLocusType(final CacheType ct) {
         switch (ct) {
             case TRADITIONAL:


### PR DESCRIPTION
Locus is now written in kontlin, therefore chage from
https://github.com/asamm/locus-api/blob/master/locus-api-core/src/main/java/locus/api/objects/geocaching/GeocachingData.java
to
https://github.com/asamm/locus-api/blob/master/locus-api-core/src/main/java/locus/api/objects/geocaching/GeocachingData.kt