### PR TITLE
lint resolving: remove unused strings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -103,7 +103,6 @@
     <string name="log_posting_generic_trackable">Posting %1$s %2$d/%3$d</string>
     <string name="log_clear">Clear</string>
     <string name="log_post_not_possible">Download of data in progress…\nPlease try again in a few seconds or check your internet connection.</string>
-    <string name="log_post_geocode_missing">Geocode missing…</string>
     <string name="log_date_future_not_allowed">Future log dates are not allowed.</string>
     <string name="log_add">Add</string>
     <string name="log_repeat">Repeat last log</string>
@@ -190,10 +189,7 @@
     <string name="err_detail_cache_find">c:geo can\'t find geocache</string>
     <string name="err_detail_cache_find_some">c:geo can\'t find that geocache.</string>
     <string name="err_detail_cache_find_any">c:geo can\'t find any geocaches.</string>
-    <string name="err_detail_google_maps_limit_reached">c:geo failed to download static maps. Maybe the Google Maps API limit was reached.</string>
     <string name="err_detail_no_spoiler">c:geo found no spoiler images for this cache.</string>
-    <string name="err_detail_no_map_static">c:geo found no static maps for this cache.</string>
-    <string name="err_detail_not_load_map_static">c:geo failed to load static maps.</string>
     <string name="err_detail_still_working">Still working on another task.</string>
     <string name="err_watchlist_still_managing">Still managing your watchlist.</string>
     <string name="err_watchlist_failed">Changing your watchlist failed.</string>
@@ -217,19 +213,15 @@
     <string name="err_tb_find_that">c:geo can\'t find that trackable.</string>
     <string name="err_waypoint_cache_unknown">c:geo doesn\'t know to which cache you want to add a waypoint for.</string>
     <string name="err_waypoint_add_failed">c:geo failed to add your waypoint.</string>
-    <string name="err_point_unknown_position">c:geo can\'t recognize where you are.</string>
     <string name="err_point_bear_and_dist_title">Need some help?</string>
     <string name="err_point_bear_and_dist">Fill both bearing and distance. Bearing is angle 0 to 360 degrees relative to north. Distance doesn\'t require units.</string>
     <string name="err_log_load_data">c:geo can\'t load data required to log visit.</string>
-    <string name="err_log_load_data_again">c:geo can\'t load data required to log visit. Trying again.</string>
-    <string name="err_log_load_data_still">c:geo is still loading data required to post log. Please wait a little while longer.</string>
     <string name="err_log_post_missing_tracking_code">Tracking code is missing.</string>
     <string name="err_log_post_missing_coordinates">Coordinates are missing.</string>
     <string name="err_log_post_failed">It seems that your log was not posted. Please check it on the cache originating website.</string>
     <string name="err_log_post_failed_ec">It seems that your log was not posted. Please check it on Extremcaching.com.</string>
     <string name="err_log_post_failed_gk">It seems that your log was not posted. Please check it on GeoKrety.org.</string>
     <string name="err_logimage_post_failed">It seems that your log image was not uploaded. Please check it on the cache originating website.</string>
-    <string name="err_search_address_forgot">c:geo forgot the address you tried to find.</string>
     <string name="err_parse_lat">c:geo can\'t parse latitude.</string>
     <string name="err_parse_lon">c:geo can\'t parse longitude.</string>
     <string name="err_parse_dist">c:geo can\'t parse distance.</string>
@@ -278,7 +270,6 @@
     <string name="err_trackable_no_preference_activity">Sorry, cannot find a suitable preference screen.</string>
     <string name="confirm_unsaved_changes_title">Unsaved changes</string>
     <string name="confirm_discard_wp_changes">Discard unsaved waypoint changes?</string>
-    <string name="warn_discard_changes">Unsaved waypoint changes discarded!</string>
     <string name="err_request_popup_info">c:geo failed to get cache popup info.</string>
     <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
     <string name="more_information">More information</string>
@@ -362,18 +353,8 @@
     <string name="caches_select_mode_exit">Exit select mode</string>
     <string name="caches_select_invert">Invert selection</string>
     <string name="caches_nearby">Nearby</string>
-    <string name="caches_manage">Manage</string>
     <string name="caches_remove_all">Remove all</string>
-    <plurals name="caches_remove_all_confirm">
-        <item quantity="one">Do you want to remove this cache from the current list?</item>
-        <item quantity="other">Do you want to remove all %d caches from the current list?</item>
-    </plurals>
     <string name="caches_remove_selected">Remove selected</string>
-    <plurals name="caches_remove_selected_confirm">
-        <item quantity="one">Do you want to remove this cache from your device?</item>
-        <item quantity="other">Do you want to remove the selected %d caches from your device?</item>
-    </plurals>
-    <string name="caches_remove_progress">Removing caches</string>
     <string name="caches_delete_events">Delete past events</string>
     <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>
     <string name="caches_upload_modifiedcoords_warning">Do you want to upload modified coordinates for all (selected) caches and overwrite the existing coordinates on the server? This cannot be undone.</string>
@@ -388,10 +369,6 @@
     <string name="caches_copy_all">Copy all</string>
     <string name="caches_map_locus">Locus</string>
     <string name="caches_map_locus_export">Export to Locus</string>
-    <string name="caches_recaptcha_title">reCAPTCHA</string>
-    <string name="caches_recaptcha_explanation">Please enter the text you see in the image. This enables downloading of cache coordinates, which can be disabled in Settings.</string>
-    <string name="caches_recaptcha_hint">Text from image</string>
-    <string name="caches_recaptcha_continue">Continue</string>
     <string name="caches_filter">Filter</string>
     <string name="caches_filter_title">Filter by</string>
     <string name="caches_filter_size">Size</string>
@@ -419,7 +396,6 @@
     <string name="caches_make_list_unique">Make list unique</string>
     <string name="caches_set_listmarker">Set list marker</string>
     <string name="caches_listmarker_none">No marker</string>
-    <string name="caches_listmarker_marker">Marker %d</string>
     <string name="caches_listmarker_selected">(selected)</string>
 
     <!-- caches lists -->
@@ -430,19 +406,15 @@
     <string name="list_menu_import">Import</string>
     <string name="list_title">Pick a list</string>
     <string name="lists_title">Pick the lists</string>
-    <string name="lists_remove_all">None</string>
     <string name="list_inbox">Stored</string>
     <string name="list_all_lists">All caches</string>
     <string name="list_dialog_create_title">New list</string>
     <string name="list_dialog_create">Create</string>
-    <string name="list_dialog_create_ok">A new list was created</string>
     <string name="list_dialog_create_err">c:geo failed to create the new list</string>
     <string name="list_dialog_remove_title">Remove list</string>
     <string name="list_dialog_remove_description">Do you want to remove the current list? All caches remaining in the list will be moved to \"Stored\".</string>
     <string name="list_dialog_remove_nowempty">List is empty. Do you want to remove the current list?</string>
     <string name="list_dialog_remove">Remove</string>
-    <string name="list_dialog_remove_ok">The list was removed</string>
-    <string name="list_dialog_remove_err">c:geo failed to remove the current list</string>
     <string name="list_dialog_rename_title">Rename list</string>
     <string name="list_dialog_rename">Rename</string>
     <string name="list_not_available">List no longer available, switching to standard list</string>
@@ -529,10 +501,8 @@
 
     <string name="settings_title_gc">Geocaching.com</string>
     <string name="settings_title_ec">Extremcaching.com</string>
-    <string name="settings_title_su">Geocaching.su</string>
     <string name="settings_activate_gc">Activate</string>
     <string name="settings_activate_ec">Activate</string>
-    <string name="settings_activate_ox">Activate</string>
     <string name="settings_gc_legal_note">With using the service of geocaching.com, you accept the Groundspeak Terms of Use.</string>
     <string name="settings_info_facebook_login_title">Facebook Login</string>
     <string name="settings_info_facebook_login">You can\'t make c:geo login to geocaching.com with your Facebook account. But there is a simple workaround…</string>
@@ -574,9 +544,6 @@
     <string name="gcvote_sent">Voting successfully sent</string>
     <string name="init_twitter">Twitter</string>
     <string name="settings_activate_twitter">Activate</string>
-    <string name="init_username">Username</string>
-    <string name="init_password">Password</string>
-    <string name="init_login">Check Login</string>
     <string name="init_login_popup">Login</string>
     <string name="init_login_popup_working">Logging in…</string>
     <string name="init_login_popup_ok">Login OK</string>
@@ -614,8 +581,6 @@
     <string name="init_summary_skin">Use light skin (Restart needed)</string>
     <string name="init_address">Show Address</string>
     <string name="init_summary_address">Show address instead of coordinates on main screen</string>
-    <string name="init_captcha">Show CAPTCHA</string>
-    <string name="init_summary_captcha">Show CAPTCHA if necessary (only Basic Member)</string>
     <string name="init_useenglish">Use English</string>
     <string name="init_summary_useenglish">Use English language for c:geo (Restart needed)</string>
     <string name="init_exclude">Exclude Own and Found</string>
@@ -742,9 +707,7 @@
     <string name="init_hardware_acceleration_title">Hardware accelerated rendering</string>
     <string name="init_hardware_acceleration_note">Hardware acceleration renders graphical elements faster on the screen. However on some devices the Android operating system contains bugs and some text may appear blurred (notably bold characters). Disable hardware acceleration if this happens to you.</string>
     <string name="init_hardware_acceleration">Enable hardware acceleration</string>
-    <string name="settings_create_account">Create account</string>
     <string name="settings_open_website">Open website</string>
-    <string name="settings_open_geokrety_register">Open GeoKrety.org registration page</string>
     <string name="settings_open_geokretymap_website">Open GeoKretyMap.org website</string>
     <string name="settings_settings">Settings</string>
     <string name="settings_information">Information</string>
@@ -755,7 +718,6 @@
     <string name="settings_ec_icons_other">Own style</string>
     <string name="settings_ec_icons_oc">Like OC</string>
     <string name="settings_features">Supported Features</string>
-    <string name="feature_description">The following <b>online</b> features of this website are supported in c:geo (in addition to the offline features):</string>
     <string name="feature_personal_notes">Personal note</string>
     <string name="feature_online_logging">Online logging</string>
     <string name="feature_log_images">Attach images to logs</string>
@@ -770,9 +732,6 @@
     <string name="init_mapsforge_api_title">Mapsforge API</string>
     <string name="init_mfold_api">Old Mapsforge V3</string>
     <string name="init_mfold_api_description">We are using a new version of the Mapsforge map by default. If you miss some features or encounter issues you can go back to the old version here.</string>
-    <string name="init_experimental_title">Experimental features</string>
-    <string name="init_mfbeta">Mapsforge beta as default</string>
-    <string name="init_mfbeta_description">The current release contains a beta version of our new Mapsforge map as an experimental feature. This new map can be activated here as default for the live and list maps.</string>
 
     <!-- proximity notification -->
     <string name="settings_title_proximityNotification">Proximity notification</string>
@@ -825,7 +784,6 @@
     <string name="auth_credentials_explain_long">Filling your credentials and pressing the \"Check authentication\" button will start the process. This process will connect to %s and validate your credentials. That\'s all.</string>
 
     <!-- auth token -->
-    <string name="auth_token_register">Create an account</string>
     <string name="auth_token_explain_short">The following process will allow <b>c:geo</b> to access %s.</string>
     <string name="auth_token_explain_long">Filling your credential and pressing the \"authorize c:geo\" button will start the process. This process will connect to %s and retrieve an authentication token. That\'s all.</string>
 
@@ -866,12 +824,8 @@
     <string name="cache_offline_refresh">Refresh</string>
     <string name="cache_offline_drop">Remove</string>
     <string name="cache_offline_store">Store</string>
-    <string name="cache_offline_manage">Manage</string>
-    <string name="cache_offline_store_in_list">Store in list</string>
     <string name="cache_offline_stored">Stored in device</string>
     <string name="cache_offline_not_ready">Not available offline</string>
-    <string name="cache_offline_time_about">about</string>
-    <string name="cache_offline_time_mins">minutes ago</string>
     <string name="cache_offline_time_mins_few">a few minutes ago</string>
     <plurals name="cache_offline_about_time_mins">
 		<item quantity="one">about %d minute ago</item>
@@ -890,9 +844,6 @@
         <item quantity="other">about %d months ago</item>
     </plurals>
     <string name="cache_offline_about_time_year">over a year ago</string>
-    <string name="cache_offline_time_hour">one hour ago</string>
-    <string name="cache_offline_time_hours">hours ago</string>
-    <string name="cache_offline_time_days">days ago</string>
     <string name="cache_premium">Premium</string>
     <string name="cache_attributes">Attributes</string>
     <string name="cache_inventory">Inventory</string>
@@ -908,7 +859,6 @@
     <string name="cache_personal_note_upload_error">Error uploading personal note</string>
     <string name="cache_personal_note_upload_cancelled">Personal note upload cancelled</string>
     <string name="cache_description">Description</string>
-    <string name="cache_description_long">Long Description</string>
     <string name="cache_description_table_note">Description contains table formatting which may need to be viewed at %s to be seen correctly.</string>
     <string name="cache_area_description">Area Description</string>
     <string name="cache_cache_description">Cache Description</string>
@@ -919,15 +869,8 @@
     <string name="cache_watchlist_on_extra">This cache is on your watchlist (Watchers: %1d).</string>
     <string name="cache_watchlist_not_on">This cache is not on your watchlist.</string>
     <string name="cache_watchlist_not_on_extra">This cache is not on your watchlist (Watchers: %1d).</string>
-    <string name="cache_watchlist_add">Add to Watchlist</string>
-    <string name="cache_watchlist_remove">Remove from Watchlist</string>
     <string name="cache_favpoint_on">This cache is one of your favorites.</string>
     <string name="cache_favpoint_not_on">This cache is not one of your favorites.</string>
-    <string name="cache_favpoint_add">Add</string>
-    <string name="cache_favpoint_remove">Remove</string>
-    <string name="cache_list_text">List:</string>
-    <string name="cache_list_change">Move</string>
-    <string name="cache_list_unknown">Not in a list</string>
     <string name="cache_list_select_last">Last Selection</string>
     <string name="cache_images">Images</string>
     <string name="cache_waypoints">Waypoints</string>
@@ -998,7 +941,6 @@
     <string name="cache_menu_oruxmaps_online">OruxMaps (Online)</string>
     <string name="cache_menu_oruxmaps_offline">OruxMaps (Offline)</string>
     <string name="cache_menu_pebble">Pebble</string>
-    <string name="cache_menu_android_wear">Android Wear</string>
     <string name="cache_menu_vote">Vote</string>
     <string name="cache_menu_checker">Open Geochecker</string>
     <string name="cache_menu_challenge_checker">Search challenge checker</string>
@@ -1086,14 +1028,10 @@
     <string name="simple_dir_chooser_invalid_path">Invalid Path</string>
 
     <!-- gpx -->
-    <string name="gpx_import_loading_caches">Loading caches from .gpx file</string>
     <string name="gpx_import_loading_caches_with_filename">Loading caches from %1$s</string>
-    <string name="gpx_import_loading_waypoints">Loading waypoints file</string>
     <string name="gpx_import_loading_waypoints_with_filename">Loading waypoints from %1$s</string>
-    <string name="gpx_import_caches_imported">caches imported</string>
     <string name="gpx_import_caches_imported_with_filename">%1$d caches imported from %2$s</string>
     <string name="gpx_import_static_maps_skipped">Download of static maps aborted</string>
-    <string name="gpx_import_title_static_maps">Store static maps</string>
     <string name="gpx_import_title_reading_file">Reading file</string>
     <string name="gpx_import_title">Import GPX</string>
     <string name="gpx_import_title_caches_imported">Result</string>
@@ -1101,7 +1039,6 @@
     <string name="gpx_import_error_io">Can\'t read file</string>
     <string name="gpx_import_error_parser">Bad File format</string>
     <string name="gpx_import_error_unexpected">Unexpected error</string>
-    <string name="gpx_import_canceled">GPX import was canceled</string>
     <string name="gpx_import_canceled_with_filename">GPX import from %1$s was canceled</string>
     <string name="gpx_import_delete_title">Delete file</string>
     <string name="gpx_import_delete_message">Do you want to delete %s?</string>
@@ -1158,14 +1095,11 @@
     <string name="waypoint_reset">Reset</string>
     <string name="waypoint_localy_reset_cache_coords">Reset in c:geo</string>
     <string name="waypoint_reset_local_and_remote_cache_coords">Reset in c:geo and on website</string>
-    <string name="waypoint_being_saved">Waypoint is being saved…</string>
     <string name="waypoint_coordinates_couldnt_be_modified_on_website">Website doesn\'t support modifying cache coordinates.</string>
     <string name="waypoint_coordinates_upload_error">Error occurred while modifying coordinates on website.</string>
-    <string name="waypoint_coordinates_uploading_to_website">Uploading coordinates %s to website.</string>
     <string name="waypoint_coordinates_has_been_modified_on_website">Cache coordinates on website have been modified to: %s.</string>
     <string name="waypoint_done">Done</string>
     <string name="waypoint_duplicate">Duplicate waypoint</string>
-    <string name="waypoint_duplicated">Waypoint duplicated</string>
     <string name="waypoint_copy_of">Copy of</string>
     <string name="waypointcalc_notes_prompt">Enter notes here…</string>
     <string name="waypoint_coordinate_formats_plain">Plain</string>
@@ -1190,9 +1124,6 @@
     <string name="map_theme_options">Theme Options</string>
     <string name="map_live_enable">Enable live</string>
     <string name="map_live_disable">Disable live</string>
-    <string name="map_static_title">Static maps</string>
-    <string name="map_static_loading">Loading static maps…</string>
-    <string name="map_token_err">Since c:geo is only able to download partial data, coordinates of caches could be inaccurate.</string>
     <string name="map_as_list">Show as list</string>
     <string name="map_clear_trailhistory">Clear trail history</string>
     <string name="map_trailhistory_cleared">trail history cleared</string>
@@ -1225,13 +1156,11 @@
     <string name="search_tb_hint">Trackable identification</string>
     <string name="search_tb_button">Search for trackable</string>
     <string name="search_destination">Destination</string>
-    <string name="search_direction_rel">From this position</string>
     <string name="search_address_started">Searching for places</string>
     <string name="search_address_result">Found places</string>
     <string name="search_own_caches">Search my caches</string>
 	<string name="search_pocket_title">Pocket Query</string>
 	<string name="search_pocket_loading">Loading a list of Pocket Queries</string>
-	<string name="search_pocket_select">Choose Pocket Query</string>
 
     <!-- trackable -->
     <string name="trackable">Trackable</string>
@@ -1287,8 +1216,6 @@
     <string name="use_compass">GPS and Magnetic Compass used</string>
     <string name="destination_select">Select destination</string>
     <string name="navigation_direct_navigation">Direct Navigation</string>
-    <string name="navigation_target">Target</string>
-    <string name="err_nav_no_coordinates">Cannot start navigation with no coordinates</string>
     <string name="osmand_marker_cgeo">Marker from c:geo</string>
 
     <!-- license -->
@@ -1317,16 +1244,10 @@
     <string name="helper_pocketquery_description">Allows easy creation and download of Pocket Queries centred on your current position or a point selected from a map. Requires a Premium Geocaching.com account.</string>
     <string name="helper_google_translate_title">Google Translate</string>
     <string name="helper_google_translate_description">If you download translation packages in the Google Translate app, then you can easily translate cache descriptions in c:geo by a long tap on the cache description text (without an Internet connection).</string>
-    <string name="helper_wear_title">c:geo Wear</string>
-    <string name="helper_wear_description">c:geo Wear is a plugin for c:geo that lets you navigate to geocaches using your Android Wear smartwatch.</string>
     <string name="helper_where_you_go_title">WhereYouGo</string>
     <string name="helper_where_you_go_description">WhereYouGo allows playing and searching geocaches of type Wherigo. c:geo can automatically trigger the download of cartridges within this app.</string>
     <string name="helper_brouter_title">BRouter Offline Navigation</string>
     <string name="helper_brouter_description">BRouter provides offline routing. If it is installed and has the necessary files downloaded, c:geo will automatically show a route to the cache on the internal map.</string>
-
-    <!-- add-ons -->
-    <string name="addon_missing_title">Missing plugin</string>
-    <string name="addon_download_prompt">Get it now from Google Play.</string>
 
     <!-- export -->
     <string name="export">Export</string>
@@ -1662,11 +1583,7 @@
     <!-- Geokrety -->
     <string name="settings_activate_geokrety">Activate</string>
     <string name="init_geokrety">GeoKrety.org</string>
-    <string name="init_connectorGeokretyActive">Geokrety Trackables</string>
     <string name="init_summary_geokrety">Enable trackables from GeoKrety.org</string>
-    <string name="init_summary_geokrety_account">No account configured.</string>
-    <string name="init_geokrety_register_ok">Login successful</string>
-    <string name="init_geokrety_register_fail">Login failed</string>
     <string name="init_geokrety_description">Authorize c:geo with GeoKrety.org to log GeoKrety trackables.</string>
     <string name="init_geokrety_userid">User Id: %s</string>
     <string name="trackable_title_log_without_geocode">Geocode not set</string>
@@ -1708,16 +1625,10 @@
     <string name="unit_yd">yd</string>
     <string name="unit_mi">mi</string>
 
-    <string name="pq_available_for_download">Pocket query available for download</string>
-    <string name="pq_available_for_download_description">This Pocket query is available for download as one file (gpx). Do you want to download and import it or view the caches as list?</string>
-    <string name="pq_as_cache_list">View cache list</string>
     <string name="pq_download_and_import">Import Pocket query</string>
-    <string name="pq_my_finds">My finds</string>
     <string name="caches_refresh_all_warning">This action may lead to high network traffic. Are you sure you want to batch refresh all caches?</string>
 
-    <string name="cache_list_remove_from">Remove from list</string>
     <string name="list_list_headline">Lists:</string>
-    <string name="cache_store_list">Store in list</string>
     <plurals name="extract_waypoints_result">
         <item quantity="one">%d waypoint extracted</item>
         <item quantity="other">%d waypoints extracted</item>


### PR DESCRIPTION
resolve some lint issues by removing unused strings in default locale
(unused strings in other locales will be removed automatically during the next crowdin cycle)