### PR TITLE
lint resolving: use sp instead of dp in layout

### DIFF
--- a/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
+++ b/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
@@ -74,7 +74,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     style="@style/edittext_full"
-                    android:textSize="16dp"
+                    android:textSize="16sp"
                     android:singleLine="false"
                     android:overScrollMode="always"
                     android:scrollbarStyle="insideInset"


### PR DESCRIPTION
Resolve a lint issue by replacing "dp"  with "sp" in layout definition of text field.