### PR TITLE
lint resolving: add missing calls to super methods

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -73,7 +73,7 @@ public class CompassActivity extends AbstractActionBarActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        onCreate(savedInstanceState, R.layout.compass_activity);
+        super.onCreate(savedInstanceState, R.layout.compass_activity);
         ButterKnife.bind(this);
 
         // get parameters

--- a/main/src/cgeo/geocaching/ImageSelectActivity.java
+++ b/main/src/cgeo/geocaching/ImageSelectActivity.java
@@ -230,6 +230,7 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
 
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);  // call super to make lint happy
         if (resultCode == RESULT_CANCELED) {
             // User cancelled the image capture
             showToast(getString(R.string.info_select_logimage_cancelled));

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -508,6 +508,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
+        super.onActivityResult(requestCode, resultCode, intent);  // call super to make lint happy
         if (requestCode == Intents.SETTINGS_ACTIVITY_REQUEST_CODE) {
             if (resultCode == SettingsActivity.RESTART_NEEDED) {
                 ProcessPhoenix.triggerRebirth(this);

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -672,6 +672,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);  // call super to make lint happy
         // Refresh the logs view after coming back from logging a trackable
         if (requestCode == LogTrackableActivity.LOG_TRACKABLE && resultCode == RESULT_OK) {
             refreshTrackable(StringUtils.defaultIfBlank(trackable.getName(), trackable.getGeocode()));

--- a/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
@@ -175,6 +175,7 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
 
     @Override
     public void onNewIntent(final Intent intent) {
+        super.onNewIntent(intent);   // call super to make lint happy
         setIntent(intent);
     }
 

--- a/main/src/cgeo/geocaching/activity/TokenAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/activity/TokenAuthorizationActivity.java
@@ -127,6 +127,7 @@ public abstract class TokenAuthorizationActivity extends AbstractActivity {
 
     @Override
     public void onNewIntent(final Intent intent) {
+        super.onNewIntent(intent);  // call super to make lint happy
         setIntent(intent);
     }
 

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -880,6 +880,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
 
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);  // call super to make lint happy
         if (requestCode == SELECT_IMAGE) {
             if (resultCode == RESULT_OK) {
                 image = data.getParcelableExtra(Intents.EXTRA_IMAGE);

--- a/main/src/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
@@ -83,6 +83,7 @@ public abstract class AbstractCredentialsAuthorizationActivity extends AbstractA
 
     @Override
     public void onNewIntent(final Intent intent) {
+        super.onNewIntent(intent);  // call super to make lint happy
         setIntent(intent);
     }
 

--- a/main/src/cgeo/geocaching/settings/InfoPreference.java
+++ b/main/src/cgeo/geocaching/settings/InfoPreference.java
@@ -74,6 +74,7 @@ public class InfoPreference extends AbstractAttributeBasedPreference {
 
     @Override
     protected View onCreateView(final ViewGroup parent) {
+        super.onCreateView(parent);   // call super to make lint happy
 
         // show popup when clicked
         setOnPreferenceClickListener(new OnPreferenceClickListener() {

--- a/main/src/cgeo/geocaching/ui/CompassView.java
+++ b/main/src/cgeo/geocaching/ui/CompassView.java
@@ -97,6 +97,7 @@ public class CompassView extends View {
 
     @Override
     public void onAttachedToWindow() {
+        super.onAttachedToWindow();  // call super to make lint happy
         final Resources res = context.getResources();
         compassUnderlay = BitmapFactory.decodeResource(res, R.drawable.compass_underlay);
         compassRose = BitmapFactory.decodeResource(res, R.drawable.compass_rose);


### PR DESCRIPTION
Fix a couple of lint issues by adding missing call to super functions of overriden methods.