### PR TITLE
lint resolving: switch TextView to AppCompatTextView

### DIFF
--- a/main/src/cgeo/geocaching/ui/DistanceView.java
+++ b/main/src/cgeo/geocaching/ui/DistanceView.java
@@ -5,11 +5,11 @@ import cgeo.geocaching.location.Units;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatTextView;
 
-public class DistanceView extends TextView {
+public class DistanceView extends AppCompatTextView {
     private Geopoint cacheCoords = null;
 
     public DistanceView(final Context context) {

--- a/main/src/cgeo/geocaching/ui/IndexOutOfBoundsAvoidingTextView.java
+++ b/main/src/cgeo/geocaching/ui/IndexOutOfBoundsAvoidingTextView.java
@@ -2,7 +2,8 @@ package cgeo.geocaching.ui;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.TextView;
+
+import androidx.appcompat.widget.AppCompatTextView;
 
 /**
  * Jelly beans can crash when calculating the layout of a textview.
@@ -10,7 +11,7 @@ import android.widget.TextView;
  * https://code.google.com/p/android/issues/detail?id=35466
  *
  */
-public class IndexOutOfBoundsAvoidingTextView extends TextView {
+public class IndexOutOfBoundsAvoidingTextView extends AppCompatTextView {
 
     private boolean shouldWindowFocusWait;
 


### PR DESCRIPTION
Fixes two lint issues by switching from TextView to AppCompatTextView.