### PR TITLE
adjust heading pointer to map's bearing (fix #8021)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -210,7 +210,7 @@ public class GooglePositionAndHistory implements PositionAndHistory {
         positionObjs.addMarker(new MarkerOptions()
                 .icon(BitmapDescriptorFactory.fromBitmap(getLocationIcon()))
                 .position(latLng)
-                .rotation(heading)
+                .rotation(mapRef.get().getCameraPosition().bearing)
                 .anchor(0.5f, 0.5f)
                 .flat(true)
                 .zIndex(ZINDEX_POSITION)


### PR DESCRIPTION
set rotation of heading marker according to current map's bearing
