### PR TITLE
set initial zoom level on cache map to include its waypoints (fix #7949)

### DIFF
--- a/main/src/cgeo/geocaching/location/Viewport.java
+++ b/main/src/cgeo/geocaching/location/Viewport.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.location;
 
+import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.ICoordinates;
+import cgeo.geocaching.models.Waypoint;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -33,6 +35,12 @@ public final class Viewport {
         final double lonHalfSpan = Math.abs(lonSpan) / 2;
         bottomLeft = new Geopoint(centerLat - latHalfSpan, centerLon - lonHalfSpan);
         topRight = new Geopoint(centerLat + latHalfSpan, centerLon + lonHalfSpan);
+    }
+
+    public Viewport(@NonNull final ICoordinates point) {
+        center = point.getCoords();
+        bottomLeft = point.getCoords();
+        topRight = point.getCoords();
     }
 
     public double getLatitudeMin() {
@@ -182,6 +190,49 @@ public final class Viewport {
                     latMax = Math.max(latMax, latitude);
                     lonMin = Math.min(lonMin, longitude);
                     lonMax = Math.max(lonMax, longitude);
+                }
+            }
+        }
+        if (!valid) {
+            return null;
+        }
+        return new Viewport(new Geopoint(latMin, lonMin), new Geopoint(latMax, lonMax));
+    }
+
+    @Nullable
+    public static Viewport containingCachesAndWaypoints(final Collection<Geocache> caches) {
+        boolean valid = false;
+        double latMin = Double.MAX_VALUE;
+        double latMax = -Double.MAX_VALUE;
+        double lonMin = Double.MAX_VALUE;
+        double lonMax = -Double.MAX_VALUE;
+        for (final Geocache cache : caches) {
+            if (cache != null) {
+                final Geopoint coords = cache.getCoords();
+                if (coords != null) {
+                    valid = true;
+                    final double latitude = coords.getLatitude();
+                    final double longitude = coords.getLongitude();
+                    latMin = Math.min(latMin, latitude);
+                    latMax = Math.max(latMax, latitude);
+                    lonMin = Math.min(lonMin, longitude);
+                    lonMax = Math.max(lonMax, longitude);
+                }
+                if (cache.hasWaypoints()) {
+                    for (final Waypoint waypoint : cache.getWaypoints()) {
+                        if (waypoint != null) {
+                            final Geopoint wpcoords = waypoint.getCoords();
+                            if (wpcoords != null) {
+                                valid = true;
+                                final double latitude = wpcoords.getLatitude();
+                                final double longitude = wpcoords.getLongitude();
+                                latMin = Math.min(latMin, latitude);
+                                latMax = Math.max(latMax, latitude);
+                                lonMin = Math.min(lonMin, longitude);
+                                lonMax = Math.max(lonMax, longitude);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -255,6 +255,12 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
     }
 
     @Override
+    public void zoomToBounds(final Viewport bounds, final GeoPointImpl center) {
+        mapController.zoomToSpan(bounds.topRight.getLatitudeE6() - bounds.bottomLeft.getLatitudeE6(), bounds.topRight.getLongitudeE6() - bounds.bottomLeft.getLongitudeE6());
+        mapController.animateTo(center);
+    };
+
+    @Override
     public void setMapSource() {
         if (googleMap == null) {
             return;

--- a/main/src/cgeo/geocaching/maps/interfaces/MapViewImpl.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapViewImpl.java
@@ -32,6 +32,8 @@ public interface MapViewImpl<T extends CachesOverlayItemImpl> {
 
     int getMapZoomLevel();
 
+    void zoomToBounds(Viewport bounds, GeoPointImpl center);
+
     float getBearing();
 
     int getWidth();

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -183,6 +183,12 @@ public class MapsforgeMapView extends MapView implements MapViewImpl<MapsforgeCa
         return getMapPosition().getZoomLevel() + 1;
     }
 
+    @Override
+    public void zoomToBounds(final Viewport bounds, final GeoPointImpl center) {
+        mapController.zoomToSpan(bounds.topRight.getLatitudeE6() - bounds.bottomLeft.getLatitudeE6(), bounds.topRight.getLongitudeE6() - bounds.bottomLeft.getLongitudeE6());
+        mapController.animateTo(center);
+    };
+
     /**
      * Mapsforge map does not have support for map rotation
      */

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -245,7 +245,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 postZoomToViewport(viewport);
             }
         } else if (StringUtils.isNotEmpty(mapOptions.geocode)) {
-            final Viewport viewport = DataStore.getBounds(mapOptions.geocode);
+            final Viewport viewport = DataStore.getBounds(mapOptions.geocode, true);
 
             if (viewport != null) {
                 postZoomToViewport(viewport);

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -1851,13 +1851,18 @@ public class DataStore {
     }
 
     @Nullable
-    public static Viewport getBounds(final Set<String> geocodes) {
+    public static Viewport getBounds(final Set<String> geocodes, final boolean withWaypoints) {
         if (CollectionUtils.isEmpty(geocodes)) {
             return null;
         }
 
         final Set<Geocache> caches = loadCaches(geocodes, LoadFlags.LOAD_CACHE_OR_DB);
-        return Viewport.containing(caches);
+        return withWaypoints ? Viewport.containingCachesAndWaypoints(caches) : Viewport.containing(caches);
+    }
+
+    @Nullable
+    public static Viewport getBounds(final Set<String> geocodes) {
+        return getBounds(geocodes, false);
     }
 
     /**
@@ -3612,12 +3617,17 @@ public class DataStore {
     }
 
     @Nullable
-    public static Viewport getBounds(final String geocode) {
+    public static Viewport getBounds(final String geocode, final boolean withWaypoints) {
         if (geocode == null) {
             return null;
         }
 
-        return getBounds(Collections.singleton(geocode));
+        return getBounds(Collections.singleton(geocode), withWaypoints);
+    }
+
+    @Nullable
+    public static Viewport getBounds(final String geocode) {
+        return getBounds(geocode, false);
     }
 
     public static void clearVisitDate(final Collection<String> selected) {


### PR DESCRIPTION
If a map gets opened from a single cache: Set initial zoom level on map to include all of cache's waypoints (fixes #7949)