### PR TITLE
adjust input hints to available input formats (fix #8037)

### DIFF
--- a/main/res/layout/coordinates_input.xml
+++ b/main/res/layout/coordinates_input.xml
@@ -84,7 +84,7 @@
                 android:layout_marginLeft="2dp"
                 android:layout_marginRight="2dp"
                 android:inputType="number"
-                android:hint="@string/cc_hint_secfractions"
+                android:hint="@string/cc_hint_fraction"
                 android:selectAllOnFocus="true" />
             <TextView
                 android:id="@+id/LatPaddingRight"
@@ -157,7 +157,7 @@
                 android:layout_marginLeft="2dp"
                 android:layout_marginRight="2dp"
                 android:inputType="number"
-                android:hint="@string/cc_hint_secfractions"
+                android:hint="@string/cc_hint_fraction"
                 android:selectAllOnFocus="true" />
         </TableRow>
     </TableLayout>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1021,7 +1021,7 @@
     <string name="cc_hint_degrees">degrees</string>
     <string name="cc_hint_minutes">minutes</string>
     <string name="cc_hint_seconds">seconds</string>
-    <string name="cc_hint_secfractions">fraction of seconds</string>
+    <string name="cc_hint_fraction">fraction</string>
 
     <!-- editor dialog -->
 

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -271,6 +271,9 @@ public class CoordinatesInputDialog extends DialogFragment {
                 eLatSub.setVisibility(View.GONE);
                 eLonSub.setVisibility(View.GONE);
 
+                eLatMin.setHint(R.string.cc_hint_fraction);
+                eLonMin.setHint(R.string.cc_hint_fraction);
+
                 tLatSep1.setText(".");
                 tLonSep1.setText(".");
                 tLatSep2.setText("°");
@@ -296,6 +299,11 @@ public class CoordinatesInputDialog extends DialogFragment {
                 tLonSep3.setVisibility(View.VISIBLE);
                 eLatSub.setVisibility(View.GONE);
                 eLonSub.setVisibility(View.GONE);
+
+                eLatMin.setHint(R.string.cc_hint_minutes);
+                eLatSec.setHint(R.string.cc_hint_fraction);
+                eLonMin.setHint(R.string.cc_hint_minutes);
+                eLonSec.setHint(R.string.cc_hint_fraction);
 
                 tLatSep1.setText("°");
                 tLonSep1.setText("°");
@@ -326,6 +334,13 @@ public class CoordinatesInputDialog extends DialogFragment {
                 tLonSep3.setVisibility(View.VISIBLE);
                 eLatSub.setVisibility(View.VISIBLE);
                 eLonSub.setVisibility(View.VISIBLE);
+
+                eLatMin.setHint(R.string.cc_hint_minutes);
+                eLatSec.setHint(R.string.cc_hint_seconds);
+                eLatSub.setHint(R.string.cc_hint_fraction);
+                eLonMin.setHint(R.string.cc_hint_minutes);
+                eLonSec.setHint(R.string.cc_hint_seconds);
+                eLonSub.setHint(R.string.cc_hint_fraction);
 
                 tLatSep1.setText("°");
                 tLonSep1.setText("°");


### PR DESCRIPTION
adjust input hints to available input formats:

![image](https://user-images.githubusercontent.com/3754370/71588755-f35c0d00-2b22-11ea-8acb-a534e84f13bb.png)

![image](https://user-images.githubusercontent.com/3754370/71588768-fc4cde80-2b22-11ea-8062-331e402c49ef.png)

![image](https://user-images.githubusercontent.com/3754370/71588779-02db5600-2b23-11ea-9660-9c11bfd0801f.png)

![image](https://user-images.githubusercontent.com/3754370/71588790-0a026400-2b23-11ea-8127-e1aa1718cb92.png)
