### PR TITLE
add "Plain (single line)" format to coordinates input dialog

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1018,6 +1018,7 @@
     <string name="init_summary_longtap_udc">Long tap on map to create a user defined cache</string>
 
     <!-- coordinate calculator hints -->
+    <string name="cc_hint_latlon">latitude longitude</string>
     <string name="cc_hint_degrees">degrees</string>
     <string name="cc_hint_minutes">minutes</string>
     <string name="cc_hint_seconds">seconds</string>
@@ -1113,6 +1114,7 @@
     <string name="waypoint_copy_of">Copy of</string>
     <string name="waypointcalc_notes_prompt">Enter notes here…</string>
     <string name="waypoint_coordinate_formats_plain">Plain</string>
+    <string name="waypoint_coordinate_formats_plain_singleline">Plain (single line)</string>
     <string name="from_clipboard">From clipboard</string>
     <string name="copy_to_clipboard">Copy to clipboard</string>
 

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- coordinate input formats - order must be the same as in Settings.CoordInputFormatEnum -->
     <string-array name="waypoint_coordinate_formats" translatable="false">
         <item>@string/waypoint_coordinate_formats_plain</item>
+        <item>@string/waypoint_coordinate_formats_plain_singleline</item>
         <item>DDD.DDDDD°</item>
         <item>DDD°MM.MMM\'</item>
         <item>DDD°MM\'SS.SSS\"</item>

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -92,6 +92,7 @@ public class Settings {
 
     public enum CoordInputFormatEnum {
         Plain,
+        Plain_Singleline,
         Deg,
         Min,
         Sec;

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -41,6 +41,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.gridlayout.widget.GridLayout;
@@ -265,7 +266,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
                 shot = true;
             }
 
-            currentFormat = Settings.CoordInputFormatEnum.fromInt(pos);
+            currentFormat = Settings.CoordInputFormatEnum.fromInt(((SpinnerItem) parent.getItemAtPosition(pos)).id);
             Settings.setCoordInputFormat(currentFormat);
             setFormat();
 
@@ -354,6 +355,23 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         }
     }
 
+    // minimum helper class for workaround until Plain_SingleLine gets supported by coordinates calculator
+    private class SpinnerItem {
+        public int id;
+        public String text;
+
+        SpinnerItem (final int id, final String text) {
+            this.id = id;
+            this.text = text;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return text;
+        }
+    }
+
     @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
         final Dialog dialog = getDialog();
@@ -383,10 +401,22 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         }
 
         spinner = v.findViewById(R.id.spinnerCoordinateFormats);
+        /*
         final ArrayAdapter<CharSequence> adapter =
                 ArrayAdapter.createFromResource(getActivity(),
                         R.array.waypoint_coordinate_formats,
                         android.R.layout.simple_spinner_item);
+        */
+        // workaround until Plain_SingleLine format is supported in CoordinatesCalculator:
+        final String[] formats = getResources().getStringArray(R.array.waypoint_coordinate_formats);
+        final String leaveOut = getString(R.string.waypoint_coordinate_formats_plain_singleline);
+        final ArrayAdapter<SpinnerItem> adapter = new ArrayAdapter<SpinnerItem>(getActivity(), android.R.layout.simple_spinner_item);
+        for (int i = 0; i < formats.length; i++) {
+            if (!formats[i].equals(leaveOut)) {
+                adapter.add(new SpinnerItem(i, formats[i]));
+            }
+        }
+
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinner.setAdapter(adapter);
         spinner.setOnItemSelectedListener(new CoordinateFormatListener());

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -250,6 +250,8 @@ public class CoordinatesInputDialog extends DialogFragment {
             bLon.setText(String.valueOf(currentCoords().getLonDir()));
         }
 
+        eLat.setHint(R.string.latitude);
+
         switch (currentFormat) {
             case Plain:
                 setVisible(R.id.coordTable, View.GONE);
@@ -258,6 +260,15 @@ public class CoordinatesInputDialog extends DialogFragment {
                 if (gp != null) {
                     eLat.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
                     eLon.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
+                }
+                break;
+            case Plain_Singleline:
+                setVisible(R.id.coordTable, View.GONE);
+                eLat.setVisibility(View.VISIBLE);
+                eLon.setVisibility(View.GONE);
+                eLat.setHint(R.string.cc_hint_latlon);
+                if (gp != null) {
+                    eLat.setText(gp.format(GeopointFormatter.Format.LAT_LON_DECMINUTE));
                 }
                 break;
             case Deg: // DDD.DDDDD°
@@ -488,6 +499,9 @@ public class CoordinatesInputDialog extends DialogFragment {
                     break;
                 case Plain:
                     current = new Geopoint(eLat.getText().toString(), eLon.getText().toString());
+                    break;
+                case Plain_Singleline:
+                    current = new Geopoint(eLat.getText().toString());
                     break;
                 default:
                     throw new IllegalStateException("can never happen, keep tools happy");


### PR DESCRIPTION
Depending on the data I have I frequently wished to have a single line input field in the coordinates input dialog. (eg: https://coord.info/GC8FG9B has coordinates in plain format in the listing)

So here we are:

![image](https://user-images.githubusercontent.com/3754370/71595591-8fded900-2b3c-11ea-9575-4928edc8ba9e.png)

![image](https://user-images.githubusercontent.com/3754370/71595605-9bca9b00-2b3c-11ea-8ef9-e8d75b190ddf.png)

For now it's the input dialog only, not yet the coordinates calculator (format is deactivated there). Need to figure out how to reliably detect the longitude hemisphere letter in the different formats first...