### PR TITLE
localization scripts (folder) optimization

### DIFF
--- a/main/project/localization/findmissingtranslations.sh
+++ b/main/project/localization/findmissingtranslations.sh
@@ -26,7 +26,7 @@ usage() {
     exit 1
 }
 
-alllangs=`find ../../res/values-* -name "strings.xml" | sed "s/^.*values-\(..\).*$/    \1/"`
+alllangs=`find ../../res/values-* -name "strings.xml" | sed "s/^.*values-\(.*\)\/.*$/    \1/"`
 
 if [ $# -ne 1 ]; then
     usage

--- a/main/project/localization/readme.txt
+++ b/main/project/localization/readme.txt
@@ -1,0 +1,31 @@
+Checks for installed languages
+==============================
+
+These scripts are only relevant if you are not sure whether the crowdin translations are up-to-date.
+
+* findmissingtranslations.sh
+
+Search of missing translation strings in the language files other than English.
+Creates a file <lang>.missing for all checked languages in this directory.
+
+Parameter:
+  * all     check all languages
+  * <lang>  check a dedicated language
+
+
+* findextratranslations.sh
+
+Search of redundant strings in
+
+Parameter:
+  * -n      only display
+  * -f:     force unused strings removal
+
+Known false positives:
+* auth_connected:
+* settings_reauthorize:
+Both defined in SettingsActivity.java, but not covered by the regex because of ternary operator (?:) before
+Sample:
+   .setSummary(getString(hasToken
+       ? R.string.auth_connected
+       : R.string.auth_unconnected));


### PR DESCRIPTION
fix #8050

- add readme
- fix: findmissintraslations does not work with languages whose abbreviation is longer than 2 characters
- add as known false positives in readme (wont fix): findextratranslations finds 2 entries that are correct and therefore should not have been found
