### PR TITLE
Create UDC for migrated 'go to' targets during migration (fix #8042, fix #8067)

### DIFF
--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.StatusCode;
-import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
@@ -155,7 +154,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
      * @param context   context in which this function gets called
      */
     public static void assertHistoryCacheExists(final Context context) {
-        assertCacheExists(context, ID_HISTORY_CACHE, context.getString(R.string.internal_goto_targets_title), context.getString(R.string.internal_goto_targets_description), null, PseudoList.UDC_LIST.id);
+        assertCacheExists(context, ID_HISTORY_CACHE, context.getString(R.string.internal_goto_targets_title), context.getString(R.string.internal_goto_targets_description), null, StoredList.STANDARD_LIST_ID);
     }
 
     /**

--- a/main/src/cgeo/geocaching/list/PseudoList.java
+++ b/main/src/cgeo/geocaching/list/PseudoList.java
@@ -42,22 +42,6 @@ public abstract class PseudoList extends AbstractList {
         }
     };
 
-    public static final int UDC_LIST_ID = 5;
-    /**
-     * pseudo list id for "go to target" UDC to be displayed in "all caches" only
-     */
-    public static final AbstractList UDC_LIST = new PseudoList(UDC_LIST_ID, R.string.user_defined_caches) {
-        @Override
-        public int getNumberOfCaches() {
-            return -1;
-        }
-
-        @Override
-        public boolean isConcrete() {
-            return true;
-        };
-    };
-
     /**
      * private constructor to have all instances as constants in the class
      */

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -934,6 +934,22 @@ public class DataStore {
                     // migrate "go to" history to waypoints of user defined cache (only the 5 most recent entries!) & delete old history table
                     if (oldVersion < 78) {
                         try {
+                            // check if history UDC already exists
+                            boolean zz0Exists = false;
+                            try (Cursor c = db.rawQuery("SELECT geocode FROM " + dbTableCaches + " WHERE geocode='" + InternalConnector.GEOCODE_HISTORY_CACHE + "'", null)) {
+                                if (c.moveToFirst()) {
+                                    zz0Exists = true;
+                                }
+                            }
+
+                            // if not: manually create history UDC stub
+                            if (!zz0Exists) {
+                                db.execSQL("INSERT INTO " + dbTableCaches + " (updated, detailed, detailedupdate, visiteddate, geocode, reason, cacheid, guid, type, name, owner, owner_real, hidden, hint, size, difficulty, terrain, location, direction, distance, latitude, longitude, reliable_latlon, personal_note, shortdesc, description, favourite_cnt, rating, votes, myvote)"
+                                        + " VALUES (datetime(), 1, 0, 0, '" + InternalConnector.GEOCODE_HISTORY_CACHE + "', 1, '', '', '" + CacheType.USER_DEFINED.id + "', '''Go to'' targets', 'You', '', 0, '', '" + CacheSize.UNKNOWN.id + "', 0.0, 0.0, '', NULL, NULL, NULL, NULL, 1, NULL, '', 'This cache stores your recent ''Go to'' targets', -1, 0.0, 0, 0.0)");
+                                db.execSQL("INSERT INTO " + dbTableCachesLists + " (list_id, geocode) VALUES (" + PseudoList.UDC_LIST.id + ",'" + InternalConnector.GEOCODE_HISTORY_CACHE + "')");
+                            }
+
+                            // migrate most recent history waypoints (up to 5)
                             final String sql = "INSERT INTO " + dbTableWaypoints + " (geocode, updated, type, prefix, lookup, name, latitude, longitude, note, own, visited, user_note, org_coords_empty, calc_state)"
                                     + " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
                             final SQLiteStatement statement = db.compileStatement(sql);

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -946,7 +946,7 @@ public class DataStore {
                             if (!zz0Exists) {
                                 db.execSQL("INSERT INTO " + dbTableCaches + " (updated, detailed, detailedupdate, visiteddate, geocode, reason, cacheid, guid, type, name, owner, owner_real, hidden, hint, size, difficulty, terrain, location, direction, distance, latitude, longitude, reliable_latlon, personal_note, shortdesc, description, favourite_cnt, rating, votes, myvote)"
                                         + " VALUES (datetime(), 1, 0, 0, '" + InternalConnector.GEOCODE_HISTORY_CACHE + "', 1, '', '', '" + CacheType.USER_DEFINED.id + "', '''Go to'' targets', 'You', '', 0, '', '" + CacheSize.UNKNOWN.id + "', 0.0, 0.0, '', NULL, NULL, NULL, NULL, 1, NULL, '', 'This cache stores your recent ''Go to'' targets', -1, 0.0, 0, 0.0)");
-                                db.execSQL("INSERT INTO " + dbTableCachesLists + " (list_id, geocode) VALUES (" + PseudoList.UDC_LIST.id + ",'" + InternalConnector.GEOCODE_HISTORY_CACHE + "')");
+                                db.execSQL("INSERT INTO " + dbTableCachesLists + " (list_id, geocode) VALUES (" + StoredList.STANDARD_LIST_ID + ",'" + InternalConnector.GEOCODE_HISTORY_CACHE + "')");
                             }
 
                             // migrate most recent history waypoints (up to 5)

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -945,7 +945,7 @@ public class DataStore {
                             // if not: manually create history UDC stub
                             if (!zz0Exists) {
                                 db.execSQL("INSERT INTO " + dbTableCaches + " (updated, detailed, detailedupdate, visiteddate, geocode, reason, cacheid, guid, type, name, owner, owner_real, hidden, hint, size, difficulty, terrain, location, direction, distance, latitude, longitude, reliable_latlon, personal_note, shortdesc, description, favourite_cnt, rating, votes, myvote)"
-                                        + " VALUES (datetime(), 1, 0, 0, '" + InternalConnector.GEOCODE_HISTORY_CACHE + "', 1, '', '', '" + CacheType.USER_DEFINED.id + "', '''Go to'' targets', 'You', '', 0, '', '" + CacheSize.UNKNOWN.id + "', 0.0, 0.0, '', NULL, NULL, NULL, NULL, 1, NULL, '', 'This cache stores your recent ''Go to'' targets', -1, 0.0, 0, 0.0)");
+                                        + " VALUES (" + System.currentTimeMillis() + ", 1, 0, 0, '" + InternalConnector.GEOCODE_HISTORY_CACHE + "', 1, '', '', '" + CacheType.USER_DEFINED.id + "', '''Go to'' targets', 'You', '', 0, '', '" + CacheSize.UNKNOWN.id + "', 0.0, 0.0, '', NULL, NULL, NULL, NULL, 1, NULL, '', 'This cache stores your recent ''Go to'' targets', -1, 0.0, 0, 0.0)");
                                 db.execSQL("INSERT INTO " + dbTableCachesLists + " (list_id, geocode) VALUES (" + StoredList.STANDARD_LIST_ID + ",'" + InternalConnector.GEOCODE_HISTORY_CACHE + "')");
                             }
 


### PR DESCRIPTION
- Create UDC for migrated 'go to' targets during migration
- UDC ZZ0 gets stored in standard list (instead of non visible virtual list)