### PR TITLE
check if viewport is only a dot before zoomToBounds (fix #8068)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -463,7 +463,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         mapView.repaintRequired(null);
 
-        if (mapOptions.geocode != null) {
+        if (mapOptions.geocode != null && !viewport.topRight.equals(viewport.bottomLeft)) {
             mapView.zoomToBounds(viewport, mapItemFactory.getGeoPointBase(viewport.center));
         } else {
             setZoom(Settings.getMapZoom(mapOptions.mapMode));


### PR DESCRIPTION
If a cache has no waypoints, the viewport spanned by this cache is just a dot (upper left corner identical to bottom right corner), which leads GMv2 to use world view on `zoomToBounds()`. Precheck for this condition and use the previous zoom instead of `zoomToBounds()` in this condition.