### PR TITLE
Allow the user to display a combination of all available offline map files

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -755,6 +755,7 @@
     <string name="map_source_google_satellite">Google: Satellite</string>
     <string name="map_source_osm_mapnik">OSM: Map</string>
     <string name="map_source_osm_offline">Offline</string>
+    <string name="map_source_osm_offline_combined">Combined (Offline)</string>
     <string name="init_sendToCgeo">Send to c:geo</string>
     <string name="settings_info_send2cgeo_title">Info on send2cgeo</string>
     <string name="init_sendToCgeo_name">Your device name</string>

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -116,7 +116,7 @@ public class MapProviderFactory {
     public static void deleteOfflineMapSources() {
         final List<MapSource> deletion = new ArrayList<>();
         for (final MapSource mapSource : mapSources) {
-            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource) {
+            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource || mapSource instanceof MapsforgeMapProvider.OfflineMultiMapSource) {
                 deletion.add(mapSource);
             }
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/MultiRendererLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/MultiRendererLayer.java
@@ -1,0 +1,67 @@
+package cgeo.geocaching.maps.mapsforge.v6.layers;
+
+import java.util.List;
+
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.map.datastore.MultiMapDataStore;
+import org.mapsforge.map.layer.Layer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.renderer.TileRendererLayer;
+import org.mapsforge.map.model.IMapViewPosition;
+import org.mapsforge.map.reader.MapFile;
+
+
+public class MultiRendererLayer implements ITileLayer {
+    private final MultiMapDataStore mapDataStore;
+    private final TileRendererLayer tileLayer;
+    private byte zoomLevelMin = 0;
+    private byte zoomLevelMax = 21;
+
+
+    public MultiRendererLayer(final TileCache tileCache, final List<MapFile> mapFiles, final IMapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
+        this.mapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
+
+        for (MapFile f : mapFiles) {
+            mapDataStore.addMapDataStore(f, false, false);
+            zoomLevelMin = (byte) Math.max(f.getMapFileHeader().getMapFileInfo().zoomLevelMin, zoomLevelMin);
+            zoomLevelMax = (byte) Math.min(f.getMapFileHeader().getMapFileInfo().zoomLevelMax, zoomLevelMax);
+        }
+
+        tileLayer = new TileRendererLayer(tileCache, mapDataStore, mapViewPosition, isTransparent, renderLabels, cacheLabels, graphicFactory);
+    }
+
+    @Override
+    public Layer getTileLayer() {
+        return tileLayer;
+    }
+
+    @Override
+    public boolean hasThemes() {
+        return true;
+    }
+
+    @Override
+    public void onResume() {
+
+    }
+
+    @Override
+    public void onPause() {
+
+    }
+
+    @Override
+    public int getFixedTileSize() {
+        return 0;
+    }
+
+    @Override
+    public byte getZoomLevelMin() {
+        return zoomLevelMin;
+    }
+
+    @Override
+    public byte getZoomLevelMax() {
+        return zoomLevelMax;
+    }
+}


### PR DESCRIPTION
Added a new map source that displays a combination of all map files available in the map file directory. This allows users to download less map data if they just need several states or a few countries combined.

The screenshot shows my LiveMap with a map from Denmark and Germany showing simultaneously.

`OfflineMultiMapSource.getFileName()` is a bit rough but there don't seem to be any downsides to just returning the first map files name.

![photo5256059635884993639](https://user-images.githubusercontent.com/6485387/72340920-5fb14180-36c9-11ea-8853-819c26b8a8cf.jpg)
