### PR TITLE
Add an AppShortcut to directly launch the Live-Map

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -109,6 +109,8 @@
                 <!-- ProcessPhoenix uses the default flag to recognize which activity to use after restart -->
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+
+            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".SearchActivity"

--- a/main/res/xml/shortcuts.xml
+++ b/main/res/xml/shortcuts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="live_map"
+        android:enabled="true"
+        android:icon="@drawable/main_live"
+        android:shortcutShortLabel="@string/live_map_button">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="cgeo.geocaching"
+            android:targetClass="cgeo.geocaching.maps.MapActivity" />
+    </shortcut>
+</shortcuts>

--- a/main/res/xml/shortcuts.xml
+++ b/main/res/xml/shortcuts.xml
@@ -10,4 +10,39 @@
             android:targetPackage="cgeo.geocaching"
             android:targetClass="cgeo.geocaching.maps.MapActivity" />
     </shortcut>
+    <shortcut
+        android:shortcutId="nearby"
+        android:enabled="true"
+        android:icon="@drawable/main_nearby"
+        android:shortcutShortLabel="@string/caches_nearby_button">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="cgeo.geocaching"
+            android:targetClass="cgeo.geocaching.CacheListActivity">
+            <extra android:name="cgeo.geocaching.intent.extra.list_type" android:value="NEAREST" />
+        </intent>
+    </shortcut>
+    <shortcut
+        android:shortcutId="stored"
+        android:enabled="true"
+        android:icon="@drawable/main_stored"
+        android:shortcutShortLabel="@string/stored_caches_button">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="cgeo.geocaching"
+            android:targetClass="cgeo.geocaching.CacheListActivity">
+            <extra android:name="cgeo.geocaching.intent.extra.list_type" android:value="OFFLINE" />
+        </intent>
+    </shortcut>
+    <shortcut
+        android:shortcutId="search"
+        android:enabled="true"
+        android:icon="@drawable/main_search"
+        android:shortcutShortLabel="@string/advanced_search_button">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="cgeo.geocaching"
+            android:targetClass="cgeo.geocaching.SearchActivity">
+        </intent>
+    </shortcut>
 </shortcuts>


### PR DESCRIPTION
Let the user go straight to the Live-Map from their app drawer or home screen.

![photo5256059635884993642](https://user-images.githubusercontent.com/6485387/72342026-fc74de80-36cb-11ea-826d-4942279c73de.jpg)
