### PR TITLE
upgrade LeakCanary

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -297,13 +297,8 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     // Leak Canary, memory leak detection
-    def leakCanaryVersion = '1.6.3'
+    def leakCanaryVersion = '2.1'
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
-    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
-    nightlyImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
-    rcImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
-    legacyImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
-    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
 
     // Locus Maps integration
     implementation "com.asamm:locus-api-android:0.3.17"

--- a/main/src/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/cgeo/geocaching/CgeoApplication.java
@@ -22,8 +22,6 @@ import androidx.annotation.NonNull;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import com.squareup.leakcanary.LeakCanary;
-
 public class CgeoApplication extends Application {
 
     private static CgeoApplication instance;
@@ -50,7 +48,6 @@ public class CgeoApplication extends Application {
             fixUserManagerMemoryLeak();
         }
 
-        LeakCanary.install(this);
         showOverflowMenu();
 
         initApplicationLocale();


### PR DESCRIPTION
Upgrade LeakCanary to version 2 (esp. 2.1).

LeakCanary 2 is a major rewrite. High level changes:

    New heap analyzer, reimplemented from scratch to use 10 times less memory (see Shark).
    APIs updated to simplify configuration and provide access to the new heap analyzer.
    Internals rewritten to 100% Kotlin.
    Multiple leaks detected in one analysis, grouped per leak type

The integration is now easier.
<strike>Additionally, the integration in instrumentation tests is activated.</strike>