### PR TITLE
add button 'add current location' to waypoint list (fix #8114)

### DIFF
--- a/main/res/layout/cachedetail_waypoints_header.xml
+++ b/main/res/layout/cachedetail_waypoints_header.xml
@@ -1,11 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Button xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/add_waypoint"
-    style="@style/button_full"
-    android:layout_margin="10dip"
-    android:clickable="true"
-    android:focusable="true"
-    android:padding="10dip"
-    android:text="@string/cache_waypoints_add"
-    tools:context=".CacheDetailActivity$WaypointsViewCreator" />
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_margin="0dp"
+    android:padding="0dp">
+    <Button
+        android:id="@+id/add_waypoint"
+        style="@style/button_full"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/cache_waypoints_add"
+        tools:context=".CacheDetailActivity$WaypointsViewCreator" />
+    <Button
+        android:id="@+id/add_waypoint_currentlocation"
+        style="@style/button_full"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/cache_waypoints_add_currentLocation" />
+</LinearLayout>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -888,6 +888,7 @@
     </plurals>
 
     <string name="cache_waypoints_add">Add Waypoint</string>
+    <string name="cache_waypoints_add_currentLocation">Add current location</string>
     <string name="cache_hint">Hint</string>
     <string name="cache_hint_not_available">No hint available</string>
     <string name="cache_logs">Logbook</string>

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -29,6 +29,7 @@ import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.UnknownTagsHandler;
+import static cgeo.geocaching.models.Waypoint.getDefaultWaypointName;
 
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -325,11 +326,11 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         waypointTypeSelector.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(final AdapterView<?> parent, final View v, final int pos, final long id) {
-                final String oldDefaultName = waypointTypeSelectorPosition >= 0 ? getDefaultWaypointName(POSSIBLE_WAYPOINT_TYPES.get(waypointTypeSelectorPosition)) : StringUtils.EMPTY;
+                final String oldDefaultName = waypointTypeSelectorPosition >= 0 ? getDefaultWaypointName(cache, POSSIBLE_WAYPOINT_TYPES.get(waypointTypeSelectorPosition)) : StringUtils.EMPTY;
                 waypointTypeSelectorPosition = pos;
                 final String currentName = waypointName.getText().toString().trim();
                 if (StringUtils.isBlank(currentName) || oldDefaultName.equals(currentName)) {
-                    waypointName.setText(getDefaultWaypointName(getSelectedWaypointType()));
+                    waypointName.setText(getDefaultWaypointName(cache, getSelectedWaypointType()));
                 }
             }
 
@@ -498,32 +499,6 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         outState.putString(CALC_STATE_JSON, calcStateJson);
     }
 
-    /**
-     * Suffix the waypoint type with a running number to get a default name.
-     *
-     * @param type
-     *            type to create a new default name for
-     *
-     */
-    private String getDefaultWaypointName(final WaypointType type) {
-        final ArrayList<String> wpNames = new ArrayList<>();
-        for (final Waypoint waypoint : cache.getWaypoints()) {
-            wpNames.add(waypoint.getName());
-        }
-        // try final and trailhead without index
-        if ((type == WaypointType.FINAL || type == WaypointType.TRAILHEAD) && !wpNames.contains(type.getL10n())) {
-            return type.getL10n();
-        }
-        // for other types add an index by default, which is highest found index + 1
-        int max = 0;
-        for (int i = 0; i < 30; i++) {
-            if (wpNames.contains(type.getL10n() + " " + i)) {
-                max = i;
-            }
-        }
-        return type.getL10n() + " " + (max + 1);
-    }
-
     private WaypointType getSelectedWaypointType() {
         final int selectedTypeIndex = waypointTypeSelector.getSelectedItemPosition();
         return selectedTypeIndex >= 0 ? POSSIBLE_WAYPOINT_TYPES.get(selectedTypeIndex) : waypoint.getWaypointType();
@@ -591,7 +566,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         currentState.coords = coords;
 
         final String givenName = waypointName.getText().toString().trim();
-        currentState.name = StringUtils.defaultIfBlank(givenName, getDefaultWaypointName(getSelectedWaypointType()));
+        currentState.name = StringUtils.defaultIfBlank(givenName, getDefaultWaypointName(cache, getSelectedWaypointType()));
         if (own) {
             currentState.noteText = "";
         } else { // keep original note

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.storage.DataStore;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -374,6 +375,32 @@ public class Waypoint implements IWaypoint {
         }
 
         throw new IllegalStateException("too many waypoints, unable to assign unique prefix");
+    }
+
+    /**
+     * Suffix the waypoint type with a running number to get a default name.
+     *
+     * @param type
+     *            type to create a new default name for
+     *
+     */
+    public static String getDefaultWaypointName(final Geocache cache, final WaypointType type) {
+        final ArrayList<String> wpNames = new ArrayList<>();
+        for (final Waypoint waypoint : cache.getWaypoints()) {
+            wpNames.add(waypoint.getName());
+        }
+        // try final and trailhead without index
+        if ((type == WaypointType.FINAL || type == WaypointType.TRAILHEAD) && !wpNames.contains(type.getL10n())) {
+            return type.getL10n();
+        }
+        // for other types add an index by default, which is highest found index + 1
+        int max = 0;
+        for (int i = 0; i < 30; i++) {
+            if (wpNames.contains(type.getL10n() + " " + i)) {
+                max = i;
+            }
+        }
+        return type.getL10n() + " " + (max + 1);
     }
 
 }


### PR DESCRIPTION
Add a button "add current location" to create a new waypoint with current coordinates, standard waypoint type and title.

![image](https://user-images.githubusercontent.com/3754370/73599198-33a71480-4541-11ea-8d81-adb342664295.png)

Also moves method `getDefaultWaypointName()` from `EditWaypointActivity` private method to `Waypoint` public static method to make it reusable.