### PR TITLE
Reverse migration create order

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -3780,24 +3780,26 @@ public class DataStore {
         final SQLiteStatement statement = database.compileStatement(sql);
 
         try (Cursor cursor = database.query(dbTableSearchDestinationHistory, new String[]{"_id", "date", "latitude", "longitude"}, null, null, null, null, "_id DESC", "5")) {
-            int sequence = cursor.getCount();
-            while (cursor.moveToNext()) {
-                statement.bindString    (1, InternalConnector.GEOCODE_HISTORY_CACHE);  // geocode
-                statement.bindLong      (2, cursor.getLong(cursor.getColumnIndex("date")));  // updated
-                statement.bindString    (3, "waypoint");                         // type
-                statement.bindString    (4, "00");                               // prefix
-                statement.bindString    (5, "---");                              // lookup
-                statement.bindString    (6, context.getString(R.string.wp_waypoint) + " " + sequence);     // name
-                statement.bindDouble    (7, cursor.getDouble(cursor.getColumnIndex("latitude")));
-                statement.bindDouble    (8, cursor.getDouble(cursor.getColumnIndex("longitude")));
-                statement.bindString    (9, "");                                 // note
-                statement.bindLong      (10, 1);                                 // own
-                statement.bindLong      (11, 0);                                 // visited
-                statement.bindString    (12, "");                                // user note
-                statement.bindLong      (13, 0);                                 // org_coords_empty
-                statement.bindNull      (14);                                          // calc_state
-                statement.executeInsert();
-                sequence--;
+            int sequence = 1;
+            if (cursor.moveToLast()) {
+                do {
+                    statement.bindString    (1, InternalConnector.GEOCODE_HISTORY_CACHE);  // geocode
+                    statement.bindLong      (2, cursor.getLong(cursor.getColumnIndex("date")));  // updated
+                    statement.bindString    (3, "waypoint");                         // type
+                    statement.bindString    (4, "00");                               // prefix
+                    statement.bindString    (5, "---");                              // lookup
+                    statement.bindString    (6, context.getString(R.string.wp_waypoint) + " " + sequence);     // name
+                    statement.bindDouble    (7, cursor.getDouble(cursor.getColumnIndex("latitude")));
+                    statement.bindDouble    (8, cursor.getDouble(cursor.getColumnIndex("longitude")));
+                    statement.bindString    (9, "");                                 // note
+                    statement.bindLong      (10, 1);                                 // own
+                    statement.bindLong      (11, 0);                                 // visited
+                    statement.bindString    (12, "");                                // user note
+                    statement.bindLong      (13, 0);                                 // org_coords_empty
+                    statement.bindNull      (14);                                          // calc_state
+                    statement.executeInsert();
+                    sequence++;
+                } while (cursor.moveToPrevious());
             }
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/cgeo/cgeo/issues/8114#issuecomment-581035299 the migrated waypoints are saved in a chronological order newest to oldest. But as new waypoints are always added at the end and waypoint page currently does not sort by age, waypoint page lists them as 5 - 4 - 3 - 2 - 1 - 6 - 7 ...

This PR reverses the saving order for the migrated goto targets, so that the oldest migrated element gets saved first, then the second oldest and so forth.