### PR TITLE
switch off indoor mode for Google Maps in standard mode (fix #7984)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -261,6 +261,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         }
         final boolean satellite = GoogleMapProvider.isSatelliteSource(Settings.getMapSource());
         googleMap.setMapType(satellite ? GoogleMap.MAP_TYPE_HYBRID : GoogleMap.MAP_TYPE_NORMAL);
+        googleMap.setIndoorEnabled(!satellite);
     }
 
     @Override


### PR DESCRIPTION
Indoor mode is set according to Google Maps mode:
- standard mode / map mode: on
- satellite mode: off
