### PR TITLE
extend waypoint filters to all map modes

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1306,12 +1306,14 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                     //All visible waypoints
                     final CacheType type = Settings.getCacheType();
                     final Set<Waypoint> waypointsInViewport = DataStore.loadWaypoints(mapView.getViewport(), excludeMine, excludeDisabled, excludeArchived, type);
-                    MapUtils.filter(waypointsInViewport);
+                    MapUtils.filter(waypointsInViewport, true);
                     waypoints.addAll(waypointsInViewport);
                 } else {
-                    //All waypoints from the viewed caches
+                    //All visible waypoints from the viewed caches
                     for (final Geocache c : caches.getAsList()) {
-                        waypoints.addAll(c.getWaypoints());
+                        final Set<Waypoint> filteredWaypoints = new HashSet<>(c.getWaypoints());
+                        MapUtils.filter(filteredWaypoints, false);
+                        waypoints.addAll(filteredWaypoints);
                     }
                 }
             }

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -19,8 +19,8 @@ public class MapUtils {
     }
 
     // filter waypoints from owned caches or certain wp types if requested.
-    public static void filter(final Set<Waypoint> waypoints) {
-        final boolean excludeMine = Settings.isExcludeMyCaches();
+    public static void filter(final Set<Waypoint> waypoints, final boolean checkOwnership) {
+        final boolean excludeMine = checkOwnership && Settings.isExcludeMyCaches();
         final boolean excludeWpOriginal = Settings.isExcludeWpOriginal();
         final boolean excludeWpParking = Settings.isExcludeWpParking();
         final boolean excludeWpVisited = Settings.isExcludeWpVisited();

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -219,6 +219,12 @@ public class CachesBundle {
         if (liveOverlay != null) {
             liveOverlay.invalidate();
         }
+        if (wpOverlay != null) {
+            wpOverlay.invalidate();
+        }
+        if (baseOverlay != null) {
+            baseOverlay.invalidate();
+        }
     }
 
     public void invalidate(final Collection<String> geocodes) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -35,7 +35,9 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         final Set<Geocache> baseCaches = DataStore.loadCaches(baseGeoCodes, LoadFlags.LOAD_WAYPOINTS);
 
         for (final Geocache cache : baseCaches) {
-            waypoints.addAll(cache.getWaypoints());
+            final Set<Waypoint> filteredWaypoints = new HashSet<>(cache.getWaypoints());
+            MapUtils.filter(filteredWaypoints, true);
+            waypoints.addAll(filteredWaypoints);
         }
 
         if (showStored) {
@@ -45,7 +47,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
             final CacheType type = Settings.getCacheType();
 
             final Set<Waypoint> waypointsInViewport = DataStore.loadWaypoints(getViewport(), excludeMine, excludeDisabled, excludeArchived, type);
-            MapUtils.filter(waypointsInViewport);
+            MapUtils.filter(waypointsInViewport, true);
             waypoints.addAll(waypointsInViewport);
         }
 


### PR DESCRIPTION
Following the discussion in #8125: Extend the "filter waypoints" options to all map modes (eg: cache map and list map).