### PR TITLE
Allow solid background (fix #1361)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -59,6 +59,7 @@
     <string translatable="false" name="pref_webDeviceName">webDeviceName</string>
     <string translatable="false" name="pref_nativeUa">nativeUa</string>
     <string translatable="false" name="pref_skin">skin</string>
+    <string translatable="false" name="pref_transparentBackground">transparentBackground</string>
     <string translatable="false" name="pref_showaddress">showaddress</string>
     <string translatable="false" name="pref_useenglish">useenglish</string>
     <string translatable="false" name="pref_units_imperial">units</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -580,7 +580,9 @@
     <string name="init_openlastdetailspage">Last Details Page</string>
     <string name="init_summary_openlastdetailspage">Open details with last used page</string>
     <string name="init_skin">Light Skin</string>
-    <string name="init_summary_skin">Use light skin (Restart needed)</string>
+    <string name="init_summary_skin">Use light skin (restart required)</string>
+    <string name="init_transparentBackground">Transparent background</string>
+    <string name="init_summary_transparentBackground">Use transparent background (restart required)</string>
     <string name="init_address">Show Address</string>
     <string name="init_summary_address">Show address instead of coordinates on main screen</string>
     <string name="init_useenglish">Use English</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -477,6 +477,11 @@
             android:title="@string/init_skin" />
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="@string/pref_transparentBackground"
+            android:summary="@string/init_summary_transparentBackground"
+            android:title="@string/init_transparentBackground" />
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="@string/pref_showaddress"
             android:summary="@string/init_summary_address"
             android:title="@string/init_address" />

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -262,6 +262,10 @@ public class MainActivity extends AbstractActionBarActivity {
         }
 
         setContentView(R.layout.main_activity);
+        if (!Settings.isTransparentBackground()) {
+            final View mainscreen = findViewById(R.id.mainscreen);
+            mainscreen.setBackgroundColor(getResources().getColor(Settings.isLightSkin() ? R.color.background_light_notice : R.color.background_dark_notice));
+        }
         ButterKnife.bind(this);
 
         if ((getIntent().getFlags() & Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -976,6 +976,10 @@ public class Settings {
         return getBoolean(R.string.pref_skin, false);
     }
 
+    public static boolean isTransparentBackground() {
+        return getBoolean(R.string.pref_transparentBackground, true);
+    }
+
     @NonNull
     public static String getTwitterKeyConsumerPublic() {
         return TWITTER_KEY_CONSUMER_PUBLIC;


### PR DESCRIPTION
Add a toggle under settings - appearance to switch between transparent and solid background for mainscreen. Color of solid background is determined by c:geo's skin.