### PR TITLE
Allow individual routes

### DIFF
--- a/main/res/layout/map_mapsforge_v6.xml
+++ b/main/res/layout/map_mapsforge_v6.xml
@@ -74,6 +74,14 @@
             android:layout_width="wrap_content"
             style="@style/map_distanceinfo" />
 
+        <TextView
+            android:id="@+id/routeDistance"
+            android:layout_marginTop="0dp"
+            android:layout_below="@id/distance2"
+            android:layout_alignParentRight="true"
+            android:layout_width="100dp"
+            style="@style/map_distanceinfo" />
+
         <include layout="@layout/map_progressbar" />
 
     </RelativeLayout>

--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -207,5 +207,9 @@
         android:id="@+id/menu_clear_trailhistory"
         android:title="@string/map_clear_trailhistory">
     </item>
+    <item
+        android:id="@+id/menu_clear_individual_route"
+        android:title="@string/map_clear_individual_route">
+    </item>
 
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1705,4 +1705,10 @@
     <string name="notification_channel_name">c:geo notifications</string>
     <string name="notification_channel_description">notifications from c:geo geocaching app</string>
     <string name="proximity_notification_title">c:geo proximity notification</string>
+
+    <!-- individual routes -->
+    <string name="individual_route_added">added to route</string>
+    <string name="individual_route_removed">removed from route</string>
+    <string name="individual_route_error_toggling_waypoint">error toggling waypoint</string>
+
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1710,5 +1710,7 @@
     <string name="individual_route_added">added to route</string>
     <string name="individual_route_removed">removed from route</string>
     <string name="individual_route_error_toggling_waypoint">error toggling waypoint</string>
+    <string name="map_clear_individual_route">Clear individual route</string>
+    <string name="map_individual_route_cleared">Individual route cleared</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -878,6 +878,11 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 ActivityMixin.showToast(activity, res.getString(R.string.map_trailhistory_cleared));
                 return true;
             }
+            case R.id.menu_clear_individual_route: {
+                route.clearRoute(overlayPositionAndScale);
+                ActivityMixin.showToast(activity, res.getString(R.string.map_individual_route_cleared));
+                return true;
+            }
             case R.id.menu_routing_straight: {
                 item.setChecked(true);
                 Settings.setRoutingMode(RoutingMode.STRAIGHT);

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -33,6 +33,8 @@ import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
+import cgeo.geocaching.maps.routing.Route;
+import cgeo.geocaching.maps.routing.RouteItem;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
 import cgeo.geocaching.models.Geocache;
@@ -131,6 +133,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private static final String BUNDLE_LIVE_ENABLED = "liveEnabled";
     private static final String BUNDLE_TRAIL_HISTORY = "trailHistory";
     private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
+    private static final String BUNDLE_ROUTE = "route";
 
     // Those are initialized in onCreate() and will never be null afterwards
     private Resources res;
@@ -144,6 +147,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     private final GeoDirHandler geoDirUpdate = new UpdateLoc(this);
     private ProximityNotification proximityNotification;
+    private Route route;
+
     // status data
     /**
      * Last search result used for displaying header
@@ -416,6 +421,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         if (proximityNotification != null) {
             outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
         }
+        if (route != null) {
+            outState.putParcelable(BUNDLE_ROUTE, route);
+        }
     }
 
     @Override
@@ -521,6 +529,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             mapOptions.isLiveEnabled = savedInstanceState.getBoolean(BUNDLE_LIVE_ENABLED, false);
             trailHistory = savedInstanceState.getParcelableArrayList(BUNDLE_TRAIL_HISTORY);
             proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
+            route = savedInstanceState.getParcelable(BUNDLE_ROUTE);
         } else {
             currentSourceId = Settings.getMapSource().getNumericalId();
             proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
@@ -565,6 +574,17 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         prepareFilterBar();
 
         AndroidBeam.disable(activity);
+    }
+
+    public void toggleRouteItem(final IWaypoint item) {
+        if (item == null || StringUtils.isEmpty(item.getGeocode())) {
+            return;
+        }
+        if (route == null) {
+            route = new Route();
+        }
+        route.toggleItem(this.mapView.getContext(), new RouteItem(item), overlayPositionAndScale);
+        overlayPositionAndScale.repaintRequired();
     }
 
     private void initMyLocationSwitchButton(final CheckBox locSwitch) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -477,6 +477,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         if (trailHistory != null) {
             overlayPositionAndScale.setHistory(trailHistory);
         }
+        if (route != null) {
+            route.updateRoute(overlayPositionAndScale);
+        }
 
         // prepare circular progress spinner
         spinner = (ProgressBar) activity.findViewById(R.id.map_progressbar);
@@ -533,6 +536,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         } else {
             currentSourceId = Settings.getMapSource().getNumericalId();
             proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
+            route = new Route();
+            route.loadRoute();
             trailHistory = null;
         }
         if (null != proximityNotification) {

--- a/main/src/cgeo/geocaching/maps/DistanceDrawer.java
+++ b/main/src/cgeo/geocaching/maps/DistanceDrawer.java
@@ -33,6 +33,9 @@ public class DistanceDrawer {
     private float distance = 0.0f;
     private float realDistance = 0.0f;
     private boolean showBothDistances = false;
+    private float routeDistance = 0.0f;
+
+    private int nextLine = 0;
 
     private static final char STRAIGHT_LINE_SYMBOL = (char) 0x007C;
     private static final char WAVY_LINE_SYMBOL = (char) 0x2307;
@@ -76,7 +79,11 @@ public class DistanceDrawer {
         this.realDistance = realDistance;
     }
 
-    private void setText(final Canvas canvas, final boolean firstLine, final char symbol, final String text) {
+    public void setRouteDistance(final float routeDistance) {
+        this.routeDistance = routeDistance;
+    }
+
+    private void setText(final Canvas canvas, final char symbol, final String text) {
         if (text == null) {
             return;
         }
@@ -119,7 +126,7 @@ public class DistanceDrawer {
 
         final float textX = (boxWidth - 3 * boxPadding - textBounds.width()) / 2 + boxX + 2 * boxPadding;
         final float textY = (boxHeight + textBounds.height()) / 2 + boxY;
-        final float yDelta = firstLine ? 0 : boxY + boxHeight + boxCornerRadius;
+        final float yDelta = nextLine++ * (boxY + boxHeight + boxCornerRadius);
 
         /* Paint background box */
         canvas.drawRoundRect(
@@ -147,11 +154,15 @@ public class DistanceDrawer {
     }
 
     public void drawDistance(final Canvas canvas) {
+        nextLine = 0;
         if (showBothDistances && realDistance != 0.0f && distance != realDistance) {
-            setText(canvas, true, STRAIGHT_LINE_SYMBOL, distanceText);
-            setText(canvas, false, WAVY_LINE_SYMBOL, Units.getDistanceFromKilometers(realDistance));
+            setText(canvas, STRAIGHT_LINE_SYMBOL, distanceText);
+            setText(canvas, WAVY_LINE_SYMBOL, Units.getDistanceFromKilometers(realDistance));
         } else {
-            setText(canvas, true, ' ', realDistance != 0.0f && distance != realDistance ? Units.getDistanceFromKilometers(realDistance) : distanceText);
+            setText(canvas, ' ', realDistance != 0.0f && distance != realDistance ? Units.getDistanceFromKilometers(realDistance) : distanceText);
+        }
+        if (routeDistance != 0.0f) {
+            setText(canvas, ' ', Units.getDistanceFromKilometers(routeDistance));
         }
     }
 }

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleOverlay.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleOverlay.java
@@ -14,9 +14,9 @@ public class GoogleOverlay implements OverlayImpl {
     private GooglePositionAndHistory overlayBase = null;
     private final Lock lock = new ReentrantLock();
 
-    public GoogleOverlay(final GoogleMap googleMap, final GoogleMapView mapView, final GoogleMapView.PostRealDistance postRealDistance) {
+    public GoogleOverlay(final GoogleMap googleMap, final GoogleMapView mapView, final GoogleMapView.PostRealDistance postRealDistance, final GoogleMapView.PostRealDistance postRouteDistance) {
         this.mapView = mapView;
-        overlayBase = new GooglePositionAndHistory(googleMap, mapView, postRealDistance);
+        overlayBase = new GooglePositionAndHistory(googleMap, mapView, postRealDistance, postRouteDistance);
     }
 
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -66,7 +66,6 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     private static Bitmap locationIcon;
 
     private ArrayList<LatLng> route = null;
-    private float distance = 0.0f;
 
 
     public GooglePositionAndHistory(final GoogleMap googleMap, final GoogleMapView mapView, final GoogleMapView.PostRealDistance postRealDistance, final GoogleMapView.PostRealDistance postRouteDistance) {
@@ -156,7 +155,6 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         for (int i = 0; i < route.size(); i++) {
             this.route.add(new LatLng(route.get(i).getLatitude(), route.get(i).getLongitude()));
         }
-        this.distance = distance;
 
         if (postRouteDistance != null) {
             postRouteDistance.postRealDistance(distance);

--- a/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
@@ -1,11 +1,13 @@
 package cgeo.geocaching.maps.interfaces;
 
 
+import cgeo.geocaching.maps.routing.Route;
+
 import android.location.Location;
 
 import java.util.ArrayList;
 
-public interface PositionAndHistory {
+public interface PositionAndHistory extends Route.RouteUpdater {
 
 
     void setCoordinates(Location coordinatesIn);

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
@@ -68,6 +68,12 @@ public class MapsforgePositionAndHistory implements GeneralOverlay, PositionAndH
     }
 
     @Override
+    public void updateRoute(final ArrayList<Geopoint> route, final float distance) {
+        // do nothing - functionality not implemented for old Mapsforge map
+    }
+
+
+    @Override
     public void drawOverlayBitmap(final Canvas canvas, final Point drawPosition,
             final MapProjectionImpl projection, final byte drawZoomLevel) {
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
@@ -15,6 +15,7 @@ public class DistanceView {
     private Geopoint destinationCoords;
     private float realDistance = 0.0f;
     private boolean showBothDistances = false;
+    private float routeDistance = 0.0f;
 
     private static final String STRAIGHT_LINE_SYMBOL = Character.toString((char) 0x007C);
     private static final String WAVY_LINE_SYMBOL = Character.toString((char) 0x2307);
@@ -23,13 +24,15 @@ public class DistanceView {
     @BindView(R.id.distance1) protected TextView distance1View;
     @BindView(R.id.distance2info) protected TextView distance2InfoView;
     @BindView(R.id.distance2) protected TextView distance2View;
+    @BindView(R.id.routeDistance) protected TextView routeDistanceView;
 
-    public DistanceView(final Geopoint destinationCoords, final TextView distance1InfoView, final TextView distance1View, final TextView distance2InfoView, final TextView distance2View, final boolean showBothDistances) {
+    public DistanceView(final Geopoint destinationCoords, final TextView distance1InfoView, final TextView distance1View, final TextView distance2InfoView, final TextView distance2View, final boolean showBothDistances, final TextView routeDistanceView) {
         this.distance1InfoView = distance1InfoView;
         this.distance1View = distance1View;
         this.distance2InfoView = distance2InfoView;
         this.distance2View = distance2View;
         this.showBothDistances = showBothDistances;
+        this.routeDistanceView = routeDistanceView;
 
         setDestination(destinationCoords);
     }
@@ -63,6 +66,18 @@ public class DistanceView {
             distance2View.setText(Units.getDistanceFromKilometers(realDistance));
         } else {
             distance1View.setText(Units.getDistanceFromKilometers(realDistance != 0.0f && distance != realDistance ? realDistance : distance));
+        }
+    }
+
+
+    public void setRouteDistance(final float routeDistance) {
+        this.routeDistance = routeDistance;
+    }
+
+    public void showRouteDistance() {
+        routeDistanceView.setVisibility(routeDistance != 0.0f ? View.VISIBLE : View.GONE);
+        if (routeDistance != 0.0f) {
+            routeDistanceView.setText(Units.getDistanceFromKilometers(routeDistance));
         }
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -480,6 +480,10 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 this.historyLayer.requestRedraw();
                 showToast(res.getString(R.string.map_trailhistory_cleared));
                 return true;
+            case R.id.menu_clear_individual_route:
+                route.clearRoute(routeLayer);
+                showToast(res.getString(R.string.map_individual_route_cleared));
+                return true;
             case R.id.menu_routing_straight:
                 item.setChecked(true);
                 Settings.setRoutingMode(RoutingMode.STRAIGHT);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -38,6 +38,7 @@ import cgeo.geocaching.maps.mapsforge.v6.layers.PositionLayer;
 import cgeo.geocaching.maps.mapsforge.v6.layers.RouteLayer;
 import cgeo.geocaching.maps.mapsforge.v6.layers.TapHandlerLayer;
 import cgeo.geocaching.maps.routing.Route;
+import cgeo.geocaching.maps.routing.RouteItem;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
 import cgeo.geocaching.models.Geocache;
@@ -1525,7 +1526,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         if (route == null) {
             route = new Route();
         }
-        route.toggleItem(this, item, routeLayer);
+        route.toggleItem(this, new RouteItem(item), routeLayer);
         distanceView.showRouteDistance();
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -204,6 +204,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             route = savedInstanceState.getParcelable(BUNDLE_ROUTE);
             followMyLocation = mapOptions.mapState.followsMyLocation();
         } else {
+            route = new Route();
+            route.loadRoute();
             followMyLocation = followMyLocation && mapOptions.mapMode == MapMode.LIVE;
             proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/TapHandler.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/TapHandler.java
@@ -13,9 +13,17 @@ public class TapHandler {
 
     private final WeakReference<NewMap> map;
     private final Set<GeoitemRef> hitItems = new HashSet<>();
+    private boolean longPressMode = false;
 
     public TapHandler(final NewMap map) {
         this.map = new WeakReference<>(map);
+    }
+
+    public synchronized void setMode(final boolean longPressMode) {
+        if (this.longPressMode != longPressMode) {
+            this.hitItems.clear();
+            this.longPressMode = longPressMode;
+        }
     }
 
     public synchronized void setHit(final GeoitemRef item) {
@@ -28,7 +36,7 @@ public class TapHandler {
 
         // show popup
         if (map != null) {
-            map.showSelection(new ArrayList<>(hitItems));
+            map.showSelection(new ArrayList<>(hitItems), longPressMode);
         }
 
         hitItems.clear();
@@ -39,7 +47,7 @@ public class TapHandler {
         final NewMap map = this.map.get();
 
         // show popup
-        if (map != null) {
+        if (map != null && hitItems.isEmpty()) {
             map.showAddWaypoint(tapLatLong);
         }
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
@@ -84,10 +84,20 @@ public class GeoitemLayer extends Marker {
 
     @Override
     public boolean onTap(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
+        tapHandler.setMode(false);
         if (isHit(layerXY, tapXY)) {
             tapHandler.setHit(item);
         }
         return super.onTap(tapLatLong, layerXY, tapXY);
+    }
+
+    @Override
+    public boolean onLongPress(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
+        tapHandler.setMode(true);
+        if (isHit(layerXY, tapXY)) {
+            tapHandler.setHit(item);
+        }
+        return super.onLongPress(tapLatLong, layerXY, tapXY);
     }
 
     private boolean isHit(final Point layerXY, final Point tapXY) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
@@ -3,11 +3,14 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.utils.TextUtils;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.util.Comparator;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class GeoitemRef {
+public class GeoitemRef implements Parcelable {
 
     public static final Comparator<? super GeoitemRef> NAME_COMPARATOR = (Comparator<GeoitemRef>) (left, right) -> TextUtils.COLLATOR.compare(left.getName(), right.getName());
 
@@ -75,4 +78,43 @@ public class GeoitemRef {
     public int getMarkerId() {
         return markerId;
     }
+
+
+    // Parcelable functions
+
+    public static final Parcelable.Creator<GeoitemRef> CREATOR =
+            new Parcelable.Creator<GeoitemRef>() {
+                @Override
+                public GeoitemRef createFromParcel(final Parcel in) {
+                    final String itemCode = in.readString();
+                    final CoordinatesType type = CoordinatesType.values()[in.readInt()];
+                    final String geocode = in.readString();
+                    final int id = in.readInt();
+                    final String name = in.readString();
+                    final int markerId = in.readInt();
+                    final GeoitemRef l = new GeoitemRef(itemCode, type, geocode, id, name, markerId);
+                    return l;
+                }
+
+                @Override
+                public GeoitemRef[] newArray(final int size) {
+                    return new GeoitemRef[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel parcel, final int flags) {
+        parcel.writeString(itemCode);
+        parcel.writeInt(type.ordinal());
+        parcel.writeString(geocode);
+        parcel.writeInt(id);
+        parcel.writeString(name);
+        parcel.writeInt(markerId);
+    }
+
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.maps.routing.Route;
 
 import android.content.Context;
 import android.util.DisplayMetrics;
@@ -20,7 +21,7 @@ import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
 
-public class RouteLayer extends Layer {
+public class RouteLayer extends Layer implements Route.RouteUpdater {
 
     private final float width;
     private Paint line = null;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -33,11 +33,6 @@ public class RouteLayer extends Layer implements Route.RouteUpdater {
     private ArrayList<Pair<Integer, Integer>> pixelRoute = null;
     private long mapSize = 0;
 
-
-    public void draw(final Canvas canvas, final Paint line, final Point topLeftPoint) {
-
-    }
-
     public interface PostRealDistance {
         void postRealDistance (float realDistance);
     }
@@ -64,30 +59,22 @@ public class RouteLayer extends Layer implements Route.RouteUpdater {
 
     @Override
     public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+        // no route or route too short?
         if (this.route == null || this.route.size() < 2) {
-            return; // no route or route too short
+            return;
         }
 
+        // still building cache?
         if (this.pixelRoute == null && this.mapSize > 0) {
-            return; // building cache
+            return;
         }
 
         final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
         if (this.pixelRoute == null || this.mapSize != mapSize) {
-            this.mapSize = mapSize;
-            this.pixelRoute = new ArrayList<Pair<Integer, Integer>>();
-            for (int i = 0; i < route.size(); i++) {
-                pixelRoute.add(translateToPixels(mapSize, this.route.get(i)));
-            }
+            translateRouteToPixels(mapSize);
         }
 
-        if (line == null) {
-            line = AndroidGraphicFactory.INSTANCE.createPaint();
-            line.setStrokeWidth(width);
-            line.setStyle(Style.STROKE);
-            line.setColor(0xD00000A0);
-            line.setTextSize(20);
-        }
+        prepareLine();
         for (int i = 1; i < pixelRoute.size(); i++) {
             final Pair<Integer, Integer> source = pixelRoute.get(i - 1);
             final Pair<Integer, Integer> destination = pixelRoute.get(i);
@@ -97,7 +84,24 @@ public class RouteLayer extends Layer implements Route.RouteUpdater {
         if (postRealRouteDistance != null) {
             postRealRouteDistance.postRealDistance(distance);
         }
+    }
 
+    private void translateRouteToPixels(final long mapSize) {
+        this.mapSize = mapSize;
+        this.pixelRoute = new ArrayList<Pair<Integer, Integer>>();
+        for (int i = 0; i < route.size(); i++) {
+            pixelRoute.add(translateToPixels(mapSize, this.route.get(i)));
+        }
+    }
+
+    private void prepareLine() {
+        if (line == null) {
+            line = AndroidGraphicFactory.INSTANCE.createPaint();
+            line.setStrokeWidth(width);
+            line.setStyle(Style.STROKE);
+            line.setColor(0xD00000A0);
+            line.setTextSize(20);
+        }
     }
 
     private static Pair<Integer, Integer> translateToPixels(final long mapSize, final Geopoint coords) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -1,0 +1,107 @@
+package cgeo.geocaching.maps.mapsforge.v6.layers;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.location.Geopoint;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
+import androidx.core.util.Pair;
+
+import java.util.ArrayList;
+
+import org.mapsforge.core.graphics.Canvas;
+import org.mapsforge.core.graphics.Paint;
+import org.mapsforge.core.graphics.Style;
+import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.Point;
+import org.mapsforge.core.util.MercatorProjection;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.layer.Layer;
+
+public class RouteLayer extends Layer {
+
+    private final float width;
+    private Paint line = null;
+    private PostRealDistance postRealRouteDistance = null;
+
+    // used for caching
+    private ArrayList<Geopoint> route = null;
+    private float distance = 0.0f;
+    private ArrayList<Pair<Integer, Integer>> pixelRoute = null;
+    private long mapSize = 0;
+
+
+    public void draw(final Canvas canvas, final Paint line, final Point topLeftPoint) {
+
+    }
+
+    public interface PostRealDistance {
+        void postRealDistance (float realDistance);
+    }
+
+    public RouteLayer(final PostRealDistance postRealRouteDistance) {
+        this.postRealRouteDistance = postRealRouteDistance;
+
+        final DisplayMetrics metrics = new DisplayMetrics();
+        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
+        windowManager.getDefaultDisplay().getMetrics(metrics);
+        width = 8f * metrics.density;
+    }
+
+    public void updateRoute(final ArrayList<Geopoint> route, final float distance) {
+        this.route = new ArrayList<Geopoint>(route);
+        this.distance = distance;
+        this.pixelRoute = null;
+        this.mapSize = 0;
+
+        if (postRealRouteDistance != null) {
+            postRealRouteDistance.postRealDistance(distance);
+        }
+    }
+
+    @Override
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+        if (this.route == null || this.route.size() < 2) {
+            return; // no route or route too short
+        }
+
+        if (this.pixelRoute == null && this.mapSize > 0) {
+            return; // building cache
+        }
+
+        final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
+        if (this.pixelRoute == null || this.mapSize != mapSize) {
+            this.mapSize = mapSize;
+            this.pixelRoute = new ArrayList<Pair<Integer, Integer>>();
+            for (int i = 0; i < route.size(); i++) {
+                pixelRoute.add(translateToPixels(mapSize, this.route.get(i)));
+            }
+        }
+
+        if (line == null) {
+            line = AndroidGraphicFactory.INSTANCE.createPaint();
+            line.setStrokeWidth(width);
+            line.setStyle(Style.STROKE);
+            line.setColor(0xD00000A0);
+            line.setTextSize(20);
+        }
+        for (int i = 1; i < pixelRoute.size(); i++) {
+            final Pair<Integer, Integer> source = pixelRoute.get(i - 1);
+            final Pair<Integer, Integer> destination = pixelRoute.get(i);
+            canvas.drawLine(source.first - (int) topLeftPoint.x, source.second - (int) topLeftPoint.y, destination.first - (int) topLeftPoint.x, destination.second - (int) topLeftPoint.y, line);
+        }
+
+        if (postRealRouteDistance != null) {
+            postRealRouteDistance.postRealDistance(distance);
+        }
+
+    }
+
+    private static Pair<Integer, Integer> translateToPixels(final long mapSize, final Geopoint coords) {
+        final int posX = (int) (MercatorProjection.longitudeToPixelX(coords.getLongitude(), mapSize));
+        final int posY = (int) (MercatorProjection.latitudeToPixelY(coords.getLatitude(), mapSize));
+        return new Pair<>(posX, posY);
+    }
+}

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
@@ -33,6 +33,7 @@ public class TapHandlerLayer extends Layer {
     public boolean onLongPress(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
 
         tapHandler.onLongPress(tapLatLong);
+        tapHandler.finished();
 
         return true;
     }

--- a/main/src/cgeo/geocaching/maps/routing/Route.java
+++ b/main/src/cgeo/geocaching/maps/routing/Route.java
@@ -1,0 +1,189 @@
+package cgeo.geocaching.maps.routing;
+
+import cgeo.geocaching.enumerations.CoordinatesType;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
+import cgeo.geocaching.maps.mapsforge.v6.layers.RouteLayer;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.storage.DataStore;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.widget.Toast;
+
+import java.util.ArrayList;
+
+public class Route implements Parcelable {
+
+    private static class RouteSegment implements Parcelable {
+        GeoitemRef ref = null;
+        Geopoint point = null;
+        ArrayList<Geopoint> points = null;
+        float distance = 0.0f;
+
+        RouteSegment(final GeoitemRef item) {
+            ref = item;
+
+            point = null;
+            if (item.getType() == CoordinatesType.CACHE) {
+                final Geocache cache = DataStore.loadCache(item.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);
+                if (cache != null) {
+                    point = cache.getCoords();
+                }
+            } else if (item.getType() == CoordinatesType.WAYPOINT && item.getId() >= 0) {
+                final Waypoint waypoint = DataStore.loadWaypoint(item.getId());
+                if (waypoint != null) {
+                    point = waypoint.getCoords();
+                }
+            }
+
+            points = null;
+            distance = 0.0f;
+        }
+
+        public static final Creator<RouteSegment> CREATOR = new Creator<RouteSegment>() {
+
+            @Override
+            public RouteSegment createFromParcel(final Parcel source) {
+                return new RouteSegment(source);
+            }
+
+            @Override
+            public RouteSegment[] newArray(final int size) {
+                return new RouteSegment[size];
+            }
+
+        };
+
+        RouteSegment (final Parcel parcel) {
+            ref = parcel.readParcelable(null);
+            point = parcel.readParcelable(null);
+            points = parcel.readArrayList(null);
+            distance = parcel.readFloat();
+        }
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(final Parcel dest, final int flags) {
+            dest.writeParcelable(ref, flags);
+            dest.writeParcelable(point, flags);
+            dest.writeList(points);
+            dest.writeFloat(distance);
+        }
+
+    }
+
+    private ArrayList<RouteSegment> segments = null;
+
+    public Route() {
+    }
+
+    public void toggleItem(final Context context, final GeoitemRef item, final RouteLayer routeLayer) {
+        if (segments == null) {
+            segments = new ArrayList<RouteSegment>();
+        }
+        final int pos = pos(item);
+        if (pos == -1) {
+            segments.add(new RouteSegment(item));
+            calculate(segments.size() - 1);
+            Toast.makeText(context, "added to route", Toast.LENGTH_SHORT).show();
+        } else {
+            segments.remove(pos);
+            calculate(pos);
+            if (pos < segments.size()) {
+                calculate(pos + 1);
+            }
+            Toast.makeText(context, "removed from route", Toast.LENGTH_SHORT).show();
+        }
+        updateRoute(routeLayer);
+    }
+
+    public void updateRoute(final RouteLayer routeLayer) {
+        final ArrayList<Geopoint> route = new ArrayList<>();
+        float distance = 0.0f;
+        if (segments != null) {
+            for (int i = 0; i < segments.size(); i++) {
+                final RouteSegment segment = segments.get(i);
+                if (segment.points != null) {
+                    for (int j = 0; j < segment.points.size(); j++) {
+                        route.add(segment.points.get(j));
+                    }
+                }
+                distance += segment.distance;
+            }
+        }
+        routeLayer.updateRoute(route, distance);
+        routeLayer.requestRedraw();
+    }
+
+    private int pos(final GeoitemRef ref) {
+        if (segments == null || segments.size() == 0) {
+            return -1;
+        }
+
+        for (int i = 0; i < segments.size(); i++) {
+            if (segments.get(i).ref.getItemCode() == ref.getItemCode()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void calculate (final int pos) {
+        if (segments != null && pos < segments.size()) {
+            // clear info for current segment
+            final RouteSegment segment = segments.get(pos);
+            segment.points = new ArrayList<>();
+            segment.distance = 0.0f;
+            // calculate route for segment between current point and its predecessor
+            if (pos > 0) {
+                // save points and calculate distance
+                final Geopoint[] temp = Routing.getTrackNoCaching(segments.get(pos - 1).point, segment.point);
+                if (temp != null && temp.length > 0) {
+                    for (int tempPos = 0; tempPos < temp.length; tempPos++) {
+                        segment.points.add(temp[tempPos]);
+                        if (tempPos > 0) {
+                            segment.distance += temp[tempPos - 1].distanceTo(temp[tempPos]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public static final Creator<Route> CREATOR = new Creator<Route>() {
+
+        @Override
+        public Route createFromParcel(final Parcel source) {
+            return new Route(source);
+        }
+
+        @Override
+        public Route[] newArray(final int size) {
+            return new Route[size];
+        }
+
+    };
+
+    Route (final Parcel parcel) {
+        segments = parcel.readArrayList(null);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeList(segments);
+    }
+}
+

--- a/main/src/cgeo/geocaching/maps/routing/Route.java
+++ b/main/src/cgeo/geocaching/maps/routing/Route.java
@@ -143,6 +143,12 @@ public class Route implements Parcelable {
         routeUpdater.updateRoute(route, distance);
     }
 
+    public void clearRoute(final RouteUpdater routeUpdater) {
+        Schedulers.io().scheduleDirect(() -> DataStore.clearRoute());
+        segments = null;
+        routeUpdater.updateRoute(new ArrayList<>(), 0);
+    }
+
     public void loadRoute() {
         if (loadingRoute) {
             return;

--- a/main/src/cgeo/geocaching/maps/routing/Route.java
+++ b/main/src/cgeo/geocaching/maps/routing/Route.java
@@ -19,15 +19,24 @@ import io.reactivex.schedulers.Schedulers;
 
 public class Route implements Parcelable {
 
+    private enum ToggleItemState {
+        ADDED,
+        REMOVED,
+        ERROR_NO_POINT
+    }
+
+    private ArrayList<RouteSegment> segments = null;
+    private boolean loadingRoute = false;
+
     public interface RouteUpdater {
         void updateRoute(ArrayList<Geopoint> route, float distance);
     }
 
     private static class RouteSegment implements Parcelable {
-        RouteItem item = null;
-        Geopoint point = null;
-        ArrayList<Geopoint> points = null;
-        float distance = 0.0f;
+        private RouteItem item = null;
+        private Geopoint point = null;
+        private ArrayList<Geopoint> points = null;
+        private float distance = 0.0f;
 
         RouteSegment(final RouteItem item) {
             this.item = item;
@@ -91,15 +100,6 @@ public class Route implements Parcelable {
 
     }
 
-    private enum ToggleItemState {
-        ADDED,
-        REMOVED,
-        ERROR_NO_POINT
-    }
-
-    private ArrayList<RouteSegment> segments = null;
-    private boolean loadingRoute = false;
-
     public Route() {
     }
 
@@ -117,6 +117,7 @@ public class Route implements Parcelable {
                 break;
             default:
                 Toast.makeText(context, R.string.individual_route_error_toggling_waypoint, Toast.LENGTH_SHORT).show();
+                break;
         }
         updateRoute(routeUpdater);
         saveRoute();

--- a/main/src/cgeo/geocaching/maps/routing/RouteItem.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteItem.java
@@ -50,7 +50,7 @@ public class RouteItem implements Parcelable {
 
     // parcelable methods
 
-    private RouteItem (final CoordinatesType type, final String geocode, final int id) {
+    public RouteItem (final CoordinatesType type, final String geocode, final int id) {
         this.type = type;
         this.geocode = geocode;
         this.id = id;

--- a/main/src/cgeo/geocaching/maps/routing/RouteItem.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteItem.java
@@ -1,0 +1,87 @@
+package cgeo.geocaching.maps.routing;
+
+import cgeo.geocaching.enumerations.CoordinatesType;
+import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.IWaypoint;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class RouteItem implements Parcelable {
+    private CoordinatesType type = CoordinatesType.CACHE;
+    private String geocode = "";         // cache code for type=cache
+    private int id = 0;                  // numeric id for type=waypoint
+
+    public RouteItem (final GeoitemRef ref) {
+        this.type = ref.getType();
+        if (this.type == CoordinatesType.CACHE) {
+            this.geocode = ref.getGeocode();
+            this.id = 0;
+        } else {
+            this.id = ref.getId();
+            this.geocode = "WP" + this.id;
+        }
+    }
+
+    public RouteItem (final IWaypoint item) {
+        if (item instanceof Geocache) {
+            this.type = CoordinatesType.CACHE;
+            this.geocode = item.getGeocode();
+            this.id = 0;
+        } else {
+            this.type = CoordinatesType.WAYPOINT;
+            this.id = item.getId();
+            this.geocode = "WP" + this.id;
+        }
+    }
+
+    public CoordinatesType getType() {
+        return this.type;
+    }
+
+    public String getGeocode() {
+        return geocode;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    // parcelable methods
+
+    private RouteItem (final CoordinatesType type, final String geocode, final int id) {
+        this.type = type;
+        this.geocode = geocode;
+        this.id = id;
+    }
+
+    public static final Parcelable.Creator<RouteItem> CREATOR =
+            new Parcelable.Creator<RouteItem>() {
+                @Override
+                public RouteItem createFromParcel(final Parcel in) {
+                    final CoordinatesType type = CoordinatesType.values()[in.readInt()];
+                    final String geocode = in.readString();
+                    final int id = in.readInt();
+                    return new RouteItem(type, geocode, id);
+                }
+
+                @Override
+                public RouteItem[] newArray(final int size) {
+                    return new RouteItem[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel parcel, final int flags) {
+        parcel.writeInt(type.ordinal());
+        parcel.writeString(geocode);
+        parcel.writeInt(id);
+    }
+
+}

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2395,6 +2395,19 @@ public class DataStore {
         }
     }
 
+    public static void clearRoute() {
+        init();
+
+        database.beginTransaction();
+        try {
+            database.execSQL("DELETE FROM " + dbTableRoute);
+            database.setTransactionSuccessful();
+        } catch (final Exception e) {
+            Log.e("Clearing route failed", e);
+        } finally {
+            database.endTransaction();
+        }
+    }
 
 
     /**


### PR DESCRIPTION
This is a no frills implementation for the basics of #8020 (and includes a fix #7914):
- create individual routes by selecting multiple geoitems (waypoints and/or caches)
- calculate the route length and display the calculated distance
- make the route persistent
- only menu entry is for clearing a route
- implemented for Google Maps v2 and NewMap

Use cases (among others):
- visualize a planned day tour (and clear visited geoitems along the tour)
- calculate distance between two or more geoitems
  (even if not having your current position at one of the geoitems)

Details:
- Add or remove a waypoint/cache from the route by long pressing on the waypoint/cache icon in the map. Added geoitems are appended at the end. No reordering or sorting.
- If the route consists of at least two geoitems, distance gets calculated (using brouter if available). The calculated route gets shown on the map in blue.
- Routing is done for the segments involved only. Calculated segments are cached.
- The route info (type, geocode/id, precedence of geoitems) gets saved to a new table automatically, and reloaded when opening the map. Currently only one route can be saved.
- Minimal UI impact: no additional views etc., just long press interaction on the icons and a single menu entry for clearing a route.

Example:

![image](https://user-images.githubusercontent.com/3754370/77833392-4a32ac00-713d-11ea-9e9a-ee3182ac78e6.png)

The red line and the upper distance info (25.6 mi) is the routing info from current position to the marked cache (as available today already). Starting from that cache there is an individual route linking several virtual caches, marked by a blue line and the distance info in the second line (92.2 mi).