### PR TITLE
adjust styling of settings' subheadings (fix #8176)

### DIFF
--- a/main/res/layout/preference_category.xml
+++ b/main/res/layout/preference_category.xml
@@ -7,7 +7,9 @@
     <TextView android:id="@android:id/title"
         style="?android:attr/listSeparatorTextViewStyle"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:paddingTop="30dp"
+        android:textSize="18sp" />
     <TextView android:id="@android:id/summary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Make settings subheadings a little larger and give them some top padding:

![image](https://user-images.githubusercontent.com/3754370/78458207-d0a43c00-76af-11ea-8844-0220fb0d2919.png)
