### PR TITLE
Rename "OSM: Map" to "OpenStreetMap Standard" (fix #8181)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -760,7 +760,7 @@
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>
-    <string name="map_source_osm_mapnik">OSM: Map</string>
+    <string name="map_source_osm_mapnik">OpenStreetMap</string>
     <string name="map_source_osm_offline">Offline</string>
     <string name="map_source_osm_offline_combined">Combined (Offline)</string>
     <string name="init_sendToCgeo">Send to c:geo</string>


### PR DESCRIPTION
per request of OSM operations team, see https://github.com/openstreetmap/operations/issues/371#issuecomment-598016057