### PR TITLE
Add support for multilingual OSM maps (fix #8185)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -199,6 +199,18 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
+        android:id="@+id/menu_select_language"
+        android:title="@string/map_language"
+        android:visible="false"
+        app:showAsAction="ifRoom|withText">
+        <menu>
+            <group
+                android:id="@+id/menu_group_map_languages"
+                android:checkableBehavior="single" >
+            </group>
+        </menu>
+    </item>
+    <item
         android:id="@+id/menu_as_list"
         android:icon="@drawable/ic_menu_agenda"
         android:title="@string/map_as_list">

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -81,6 +81,7 @@
     <string translatable="false" name="pref_logimages">logimages</string>
     <string translatable="false" name="pref_choose_list">choose_list</string>
     <string translatable="false" name="pref_mapsource">mapsource</string>
+    <string translatable="false" name="pref_maplanguage">maplanguage</string>
     <string translatable="false" name="pref_mapDirectory">mapDirectory</string>
     <string translatable="false" name="pref_mapsforge_scale_text">mapsforgeScaleText</string>
     <string translatable="false" name="pref_map_manualrotation_disabled">map_manualrotation_disabled</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1155,6 +1155,7 @@
     <string name="map_theme_builtin">Default</string>
     <string name="map_theme_select">Select map theme</string>
     <string name="map_theme_options">Theme Options</string>
+    <string name="map_language">Map language</string>
     <string name="map_live_enable">Enable live</string>
     <string name="map_live_disable">Disable live</string>
     <string name="map_as_list">Show as list</string>

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Log;
 
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.SubMenu;
 
 import androidx.annotation.NonNull;
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 public class MapProviderFactory {
 
     private static final ArrayList<MapSource> mapSources = new ArrayList<>();
+    private static String[] languages;
 
     static {
         // add GoogleMapProvider only if google api is available in order to support x86 android emulator
@@ -108,6 +110,50 @@ public class MapProviderFactory {
 
     public static MapSource getDefaultSource() {
         return mapSources.get(0);
+    }
+
+    /**
+     * Fills the "Map language" submenu with the languages provided by the current map
+     * Makes menu visible if more than one language is available, invisible if not
+     *
+     * @param menu
+     */
+    public static void addMapViewLanguageMenuItems(final Menu menu) {
+        final MenuItem parentMenu = menu.findItem(R.id.menu_select_language);
+        if (languages != null) {
+            final int currentLanguage = Settings.getMapLanguage();
+            final SubMenu subMenu = parentMenu.getSubMenu();
+            for (int i = 0; i < languages.length; i++) {
+                final int languageId = languages[i].hashCode();
+                subMenu.add(R.id.menu_group_map_languages, languageId, i, languages[i]).setCheckable(true).setChecked(languageId == currentLanguage);
+            }
+            subMenu.setGroupCheckable(R.id.menu_group_map_languages, true, true);
+            parentMenu.setVisible(languages.length > 1);
+        } else {
+            parentMenu.setVisible(false);
+        }
+    }
+
+    /**
+     * Return a language by id.
+     *
+     * @param id the language id
+     * @return the language, or <tt>null</tt> if <tt>id</tt> does not correspond to a registered language
+     */
+    @Nullable
+    public static String getLanguage(final int id) {
+        if (languages != null) {
+            for (final String language : languages) {
+                if (language.hashCode() == id) {
+                    return language;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static void setLanguages (final String[] newLanguages) {
+        languages = newLanguages;
     }
 
     /**

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -151,7 +151,9 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
             final File mapFile = new File(fileName);
             if (mapFile.exists()) {
-                return new RendererLayer(tileCache, new MapFile(mapFile), mapViewPosition, false, true, false, AndroidGraphicFactory.INSTANCE);
+                final MapFile mf = new MapFile(mapFile, MapProviderFactory.getLanguage(Settings.getMapLanguage()));
+                MapProviderFactory.setLanguages(mf.getMapLanguages());
+                return new RendererLayer(tileCache, mf, mapViewPosition, false, true, false, AndroidGraphicFactory.INSTANCE);
             }
             return null;
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -283,6 +283,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         getMenuInflater().inflate(R.menu.map_activity, menu);
 
         MapProviderFactory.addMapviewMenuItems(menu);
+        MapProviderFactory.addMapViewLanguageMenuItems(menu);
 
         final MenuItem item = menu.findItem(R.id.menu_toggle_mypos);
         myLocSwitch = new CheckBox(this);
@@ -511,11 +512,18 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 menuCompass();
                 return true;
             default:
-                final MapSource mapSource = MapProviderFactory.getMapSource(id);
-                if (mapSource != null) {
+                final String language = MapProviderFactory.getLanguage(id);
+                if (language != null) {
                     item.setChecked(true);
-                    changeMapSource(mapSource);
+                    changeLanguage(id);
                     return true;
+                } else {
+                    final MapSource mapSource = MapProviderFactory.getMapSource(id);
+                    if (mapSource != null) {
+                        item.setChecked(true);
+                        changeMapSource(mapSource);
+                        return true;
+                    }
                 }
         }
         return false;
@@ -676,6 +684,11 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         }
     }
 
+    private void changeLanguage(final int languageId) {
+        Settings.setMapLanguage(languageId);
+        mapRestart();
+    }
+
     /**
      * Restart the current activity with the default map source.
      */
@@ -705,6 +718,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         if (newSource instanceof MapsforgeMapSource) {
             newLayer = ((MapsforgeMapSource) newSource).createTileLayer(tileCache, this.mapView.getModel().mapViewPosition);
         }
+        ActivityMixin.invalidateOptionsMenu(this);
 
         // Exchange layer
         if (newLayer != null) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -949,6 +949,14 @@ public class Settings {
         mapSource = newMapSource;
     }
 
+    public static void setMapLanguage(final int languageId) {
+        putInt(R.string.pref_maplanguage, languageId);
+    }
+
+    public static int getMapLanguage() {
+        return getInt(R.string.pref_maplanguage, 0);
+    }
+
     public static void setAnyCoordinates(final Geopoint coords) {
         if (coords != null) {
             putFloat(R.string.pref_anylatitude, (float) coords.getLatitude());


### PR DESCRIPTION
If the opened OSM offline map file supports multiple languages, a new menu entry "Map language" gets added to the map's menu, having the supported languages as entries of the sub menu.

![image](https://user-images.githubusercontent.com/3754370/78981898-3fa2ea00-7b21-11ea-8a6c-9f839c5a4662.png)

Selecting one of those languages restarts the map, setting labels accordingly to the set language, if available:

Language set to "fr":
![image](https://user-images.githubusercontent.com/3754370/78982403-5bf35680-7b22-11ea-85d4-b130c843265c.png)
(The red box is just for better visualization in this info, it's not part of the actual map rendering!)

Language set to "de":
![image](https://user-images.githubusercontent.com/3754370/78982447-6e6d9000-7b22-11ea-8cc4-6ef9bc382336.png)

Selected language gets saved to preferences.
If the map does not support the language set in preferences, it switches to default language.
If a map does not support any languages, the menu entry "Map language" is not shown.
