### PR TITLE
Support other OSM based online map sources (fix #8148)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -760,7 +760,9 @@
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>
-    <string name="map_source_osm_mapnik">OpenStreetMap</string>
+    <string name="map_source_osm_mapnik">OpenStreetMap.org</string>
+    <string name="map_source_osm_osmde">OpenStreetMap.de</string>
+    <string name="map_source_osm_cyclosm">CyclOSM</string>
     <string name="map_source_osm_offline">Offline</string>
     <string name="map_source_osm_offline_combined">Combined (Offline)</string>
     <string name="init_sendToCgeo">Send to c:geo</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -104,6 +104,7 @@
     · <a href="http://www.openstreetmap.org/">Geocoding data from OpenStreetMap</a>\n
     · The <a href="http://tango.freedesktop.org/Tango_Desktop_Project">Tango! Desktop Project</a> (Public Domain)\n
     · OpenStreetMap cartography (OSM:Mapnik) © OpenStreetMap contributors. Map tile data <a href="http://www.openstreetmap.org/copyright/en">licensed</a> under Creative Commons 2.0 BY-SA.\n
+    · More maps based on OpenStreetMap cartography: © <a href="https://www.openstreetmap.de/">openstreetmap.de</a> and © <a href="https://www.cyclosm.org/">cyclosm.org</a>.\n
 	</string>
 
     <!-- cache details -->

--- a/main/src/cgeo/geocaching/maps/mapsforge/TileSourceCyclosm.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/TileSourceCyclosm.java
@@ -1,0 +1,52 @@
+package cgeo.geocaching.maps.mapsforge;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
+
+public class TileSourceCyclosm extends AbstractTileSource {
+    /**
+     * A tile source which fetches cyclosm tiles from OpenStreetMap.fr.
+     * Requires a valid HTTP User-Agent identifying application: https://operations.osmfoundation.org/policies/tiles/
+     */
+    public static final TileSourceCyclosm INSTANCE = new TileSourceCyclosm(new String[]{
+            "a.tile-cyclosm.openstreetmap.fr", "b.tile-cyclosm.openstreetmap.fr", "c.tile-cyclosm.openstreetmap.fr"}, 443);
+    private static final int PARALLEL_REQUESTS_LIMIT = 8;
+    private static final String PROTOCOL = "https";
+    private static final int ZOOM_LEVEL_MAX = 18;
+    private static final int ZOOM_LEVEL_MIN = 0;
+
+    public TileSourceCyclosm(final String[] hostNames, final int port) {
+        super(hostNames, port);
+        /* Default TTL: 8279 seconds (the TTL currently set by the OSM server). */
+        defaultTimeToLive = 8279000;
+    }
+
+    @Override
+    public int getParallelRequestsLimit() {
+        return PARALLEL_REQUESTS_LIMIT;
+    }
+
+    @Override
+    public URL getTileUrl(final Tile tile) throws MalformedURLException {
+        return new URL(PROTOCOL, getHostName(), this.port, "/cyclosm/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png");
+    }
+
+    @Override
+    public byte getZoomLevelMax() {
+        return ZOOM_LEVEL_MAX;
+    }
+
+    @Override
+    public byte getZoomLevelMin() {
+        return ZOOM_LEVEL_MIN;
+    }
+
+    @Override
+    public boolean hasAlpha() {
+        return false;
+    }
+
+}

--- a/main/src/cgeo/geocaching/maps/mapsforge/TileSourceOsmde.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/TileSourceOsmde.java
@@ -1,0 +1,52 @@
+package cgeo.geocaching.maps.mapsforge;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
+
+public class TileSourceOsmde extends AbstractTileSource {
+    /**
+     * A tile source which fetches cyclosm tiles from OpenStreetMap.fr.
+     * Requires a valid HTTP User-Agent identifying application: https://operations.osmfoundation.org/policies/tiles/
+     */
+    public static final TileSourceOsmde INSTANCE = new TileSourceOsmde(new String[]{
+            "a.tile.openstreetmap.de", "b.tile.openstreetmap.de", "c.tile.openstreetmap.de"}, 443);
+    private static final int PARALLEL_REQUESTS_LIMIT = 8;
+    private static final String PROTOCOL = "https";
+    private static final int ZOOM_LEVEL_MAX = 18;
+    private static final int ZOOM_LEVEL_MIN = 0;
+
+    public TileSourceOsmde(final String[] hostNames, final int port) {
+        super(hostNames, port);
+        /* Default TTL: 8279 seconds (the TTL currently set by the OSM server). */
+        defaultTimeToLive = 8279000;
+    }
+
+    @Override
+    public int getParallelRequestsLimit() {
+        return PARALLEL_REQUESTS_LIMIT;
+    }
+
+    @Override
+    public URL getTileUrl(final Tile tile) throws MalformedURLException {
+        return new URL(PROTOCOL, getHostName(), this.port, "/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png");
+    }
+
+    @Override
+    public byte getZoomLevelMax() {
+        return ZOOM_LEVEL_MAX;
+    }
+
+    @Override
+    public byte getZoomLevelMin() {
+        return ZOOM_LEVEL_MIN;
+    }
+
+    @Override
+    public boolean hasAlpha() {
+        return false;
+    }
+
+}

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -720,6 +720,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             layers.add(index, newLayer.getTileLayer());
             this.tileLayer = newLayer;
             this.setMapTheme();
+            this.tileLayer.onResume();
         } else {
             this.tileLayer = null;
         }


### PR DESCRIPTION
Extend our supported OSM based online maps by
- openstreetmap.de and
- cyclosm.org

Avaialble for NewMap only.
Also renamed "OpenStreetMap" to "OpenStreetMap.org" to distinguish from "OpenStreetMap.de".


Example screen shots:

OpenStreetMap.org (aka "OSM:Mapnik")
![image](https://user-images.githubusercontent.com/3754370/79054749-da95e400-7c47-11ea-904f-7035fc951351.png)

OpenStreetMap.de:
![image](https://user-images.githubusercontent.com/3754370/79054753-e5507900-7c47-11ea-9d39-5067b303e274.png)

CyclOSM.org:
![image](https://user-images.githubusercontent.com/3754370/79054759-ee414a80-7c47-11ea-9968-1d6d37c77e0e.png)
