### PR TITLE
 supported language list

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -21,6 +21,10 @@ android {
         minSdkVersion 16
         //noinspection OldTargetApi
         targetSdkVersion 28
+
+        // include only those language resources from libraries which we actively maintain ourselves in the translation project
+        // not yet enough translations (~50%): "is","iw" (="he"),"zh"
+        resConfigs "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr"
     }
 
     sourceSets {

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -51,8 +51,9 @@ android {
         // this is necessary to move .google_measurement_service into a app-specific namespace (see https://github.com/kotmyrevich/analytics-issues/issues/784)
         applicationId = "cgeo.geocaching"
 
-        // include only those language resources from libraries which we actively maintain ourself in the translation project
-        resConfigs "en","ca","ceb","cs","da","de","el","es","fi","fr","hu","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tr"
+        // include only those language resources from libraries which we actively maintain ourselves in the translation project
+        // not yet enough translations (~50%): "is","iw" (="he"),"zh"
+        resConfigs "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr"
 
         javaCompileOptions {
             // workaround for build error "Could not find AndroidManifest.xml file using generation folder" when using Gradle plugin v3.5


### PR DESCRIPTION
After the crowdin work we need some adjustments.
- languages ar=Arabic, fil=Filipino and in=Indonesian are at >74% translated and will be activated
- add info for other included but not activated languages: is=Icelandic, iw=Hebrew, zh=Chinese Simplified

Configure the same for cgeo-contacts