### PR TITLE
copy waypoints between caches (fix #8155)

### DIFF
--- a/main/res/layout/cachedetail_waypoints_header.xml
+++ b/main/res/layout/cachedetail_waypoints_header.xml
@@ -19,4 +19,11 @@
         android:clickable="true"
         android:focusable="true"
         android:text="@string/cache_waypoints_add_currentLocation" />
+    <Button
+        android:id="@+id/add_waypoint_fromclipboard"
+        style="@style/button_full"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/cache_waypoints_add_fromclipboard"
+        android:visibility="gone" />
 </LinearLayout>

--- a/main/res/menu/waypoint_options.xml
+++ b/main/res/menu/waypoint_options.xml
@@ -27,6 +27,11 @@
         android:title="@string/waypoint_duplicate">
     </item>
     <item
+        android:id="@+id/menu_waypoint_toclipboard"
+        android:title="@string/waypoint_toclipboard"
+        android:visible="false">
+    </item>
+    <item
         android:id="@+id/menu_waypoint_delete"
         android:title="@string/waypoint_delete">
     </item>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -875,6 +875,8 @@
 
     <string name="cache_waypoints_add">Add Waypoint</string>
     <string name="cache_waypoints_add_currentLocation">Add current location</string>
+    <string name="cache_waypoints_add_fromclipboard">Add from clipboard</string>
+    <string name="cache_waypoints_remove_original_waypoint">Waypoint copied from clipboard to this cache.\n\nRemove original waypoint?</string>
     <string name="cache_hint">Hint</string>
     <string name="cache_hint_not_available">No hint available</string>
     <string name="cache_logs">Logbook</string>
@@ -1099,6 +1101,7 @@
     <string name="waypoint_coordinates_has_been_modified_on_website">Cache coordinates on website have been modified to: %s.</string>
     <string name="waypoint_done">Done</string>
     <string name="waypoint_duplicate">Duplicate waypoint</string>
+    <string name="waypoint_toclipboard">Copy waypoint to clipboard</string>
     <string name="waypoint_copy_of">Copy of</string>
     <string name="waypointcalc_notes_prompt">Enter notes here…</string>
     <string name="waypoint_coordinate_formats_plain">Plain</string>

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointParser;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.ClipboardUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -28,6 +29,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 public class Waypoint implements IWaypoint {
 
     public static final String PREFIX_OWN = "OWN";
+    public static final String CLIPBOARD_PREFIX = "c:geo:WAYPOINT:";
 
     private static final String WP_PREFIX_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     private static final int ORDER_UNDEFINED = -2;
@@ -403,4 +405,28 @@ public class Waypoint implements IWaypoint {
         return type.getL10n() + " " + (max + 1);
     }
 
+    /**
+     * returns a string with current waypoint's id to clipboard, preceeded by internal prefix
+     * this is to be pushed to clipboard
+     */
+    public CharSequence reformatForClipboard() {
+        return CLIPBOARD_PREFIX + getId();
+    }
+
+    /**
+     * tries to retrieve waypoint id from clipboard
+     * returns the id, or -1 if no waypoint (with internal prefix) found
+     */
+    public static int hasClipboardWaypoint() {
+        final int length = CLIPBOARD_PREFIX.length();
+        final String clip = StringUtils.defaultString(ClipboardUtils.getText());
+        if (clip.length() > length && clip.substring(0, length).equals(CLIPBOARD_PREFIX)) {
+            try {
+                return Integer.parseInt(clip.substring(CLIPBOARD_PREFIX.length()));
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
+    }
 }

--- a/main/src/cgeo/geocaching/utils/ClipboardUtils.java
+++ b/main/src/cgeo/geocaching/utils/ClipboardUtils.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
 
+import android.content.ClipboardManager;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
@@ -44,4 +45,15 @@ public final class ClipboardUtils {
         return text != null ? text.toString() : null;
     }
 
+    /**
+     * clear clipboard content
+     * (up to API level 28: replace with empty string)
+     */
+    public static void clearClipboard() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            ((ClipboardManager) CgeoApplication.getInstance().getSystemService(Context.CLIPBOARD_SERVICE)).clearPrimaryClip();
+        } else {
+            copyToClipboard("");
+        }
+    }
 }


### PR DESCRIPTION
- option to copy waypoint id to clipboard using longpress
- option to create new waypoint from waypoint id in clipboard
- optionally delete original waypoint after creating new one (only for user defined waypoints)

New popup menu option "Copy waypoint to clipboard":
![image](https://user-images.githubusercontent.com/3754370/79617352-8c7d5680-8107-11ea-9ae9-383808e11e1d.png)

If a waypoint id is available in the clipboard, waypoint list menu has an additional button "add from clipboard":
![image](https://user-images.githubusercontent.com/3754370/79617365-943cfb00-8107-11ea-9add-98160de4fe04.png)

If waypoint creation has been successful and the original waypoint is user-defined: show option to delete the original waypoint:
![image](https://user-images.githubusercontent.com/3754370/79617371-9b640900-8107-11ea-8def-d6b6f23656cd.png)
