### PR TITLE
WIP/testing only: reduce calls to online map search

### DIFF
--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -337,10 +337,15 @@ public final class ConnectorFactory {
         return StringUtils.isBlank(geocode) || !Character.isLetterOrDigit(geocode.charAt(0));
     }
 
-    /** @see ISearchByViewPort#searchByViewport */
+    /**
+     * @see ISearchByViewPort#searchByViewport
+     * @param forceByZoomlevel: reset cache if true and cached searchResult >= 400 results and requested viewport changed
+     *  */
     @NonNull
-    public static SearchResult searchByViewport(@NonNull final Viewport viewport) {
-        if (null != lastViewportUsed && lastViewportUsed.includes(viewport)) {
+    public static SearchResult searchByViewport(@NonNull final Viewport viewport, final boolean forceByZoomlevel) {
+        final boolean viewportChanged = (null == lastViewportUsed) || !viewport.equals(lastViewportUsed);
+        final boolean skipCache = forceByZoomlevel && null != lastSearchResult && lastSearchResult.getCount() >= 400 && viewportChanged;
+        if (null != lastViewportUsed && lastViewportUsed.includes(viewport) && !skipCache) {
             Log.d("searchByViewport: saved searchResult reused");            // @todo delete this line after testing
             return lastSearchResult;
         }

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1395,7 +1395,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         try {
             showProgressHandler.sendEmptyMessage(SHOW_PROGRESS); // show progress
 
-            final SearchResult searchResult = ConnectorFactory.searchByViewport(mapView.getViewport());
+            final SearchResult searchResult = ConnectorFactory.searchByViewport(mapView.getViewport(), mapView.getMapZoomLevel() <= 11);
             downloaded = true;
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1395,7 +1395,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         try {
             showProgressHandler.sendEmptyMessage(SHOW_PROGRESS); // show progress
 
-            final SearchResult searchResult = ConnectorFactory.searchByViewport(mapView.getViewport().resize(0.8));
+            final SearchResult searchResult = ConnectorFactory.searchByViewport(mapView.getViewport());
             downloaded = true;
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
@@ -94,7 +94,7 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
         try {
             showProgress();
 
-            final SearchResult searchResult = ConnectorFactory.searchByViewport(getViewport().resize(1.2));
+            final SearchResult searchResult = ConnectorFactory.searchByViewport(getViewport());
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);
             MapUtils.filter(result);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
@@ -94,7 +94,7 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
         try {
             showProgress();
 
-            final SearchResult searchResult = ConnectorFactory.searchByViewport(getViewport());
+            final SearchResult searchResult = ConnectorFactory.searchByViewport(getViewport(), getMapZoomLevel() <= 14);
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);
             MapUtils.filter(result);

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -257,7 +257,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
                 final Viewport viewport = new Viewport(mockedCache, 0.003, 0.003);
 
                 // check coords
-                final SearchResult search = ConnectorFactory.searchByViewport(viewport);
+                final SearchResult search = ConnectorFactory.searchByViewport(viewport, false);
                 assertThat(search).isNotNull();
                 assertThat(search.getGeocodes()).contains(mockedCache.getGeocode());
                 final Geocache parsedCache = DataStore.loadCache(mockedCache.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);


### PR DESCRIPTION
- caching of map search results
- use factor 3 bounding box for viewport being searched

If you activate debug mode in c:geo you'll see messages for each call to searchByViewport with info whether a cached result could be reused or a new call has been issued.