### PR TITLE
WIP/testing only: set viewport factor to 3.0 on map search

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1395,7 +1395,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         try {
             showProgressHandler.sendEmptyMessage(SHOW_PROGRESS); // show progress
 
-            final SearchResult searchResult = ConnectorFactory.searchByViewport(mapView.getViewport().resize(0.8));
+            final SearchResult searchResult = ConnectorFactory.searchByViewport(mapView.getViewport().resize(3.0));
             downloaded = true;
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
@@ -94,7 +94,7 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
         try {
             showProgress();
 
-            final SearchResult searchResult = ConnectorFactory.searchByViewport(getViewport().resize(1.2));
+            final SearchResult searchResult = ConnectorFactory.searchByViewport(getViewport().resize(3.0));
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);
             MapUtils.filter(result);


### PR DESCRIPTION
alternative to #8227, only setting the viewport factors to 3.0 on calls to `searchByViewport()`

(note: in contrast to #8227 without additional debug info)