### PR TITLE
Add option to clear the goto history (fix #8224)

### DIFF
--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -145,4 +145,9 @@
         app:showAsAction="ifRoom"
         android:visible="true">
     </item>
+    <item
+        android:id="@+id/menu_clear_goto_history"
+        android:title="@string/clear_goto_history_title"
+        android:visible="false">
+    </item>
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1005,6 +1005,8 @@
     <string name="init_longtap_udc">Long tap on map</string>
     <string name="init_summary_longtap_udc">Long tap on map to create a user defined cache</string>
     <string name="goto_targets_list">Internal caches</string>
+    <string name="clear_goto_history_title">Clear goto history</string>
+    <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>
 
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">degrees</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -18,6 +18,7 @@ import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.connector.capability.PgcChallengeCheckerCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.enumerations.CacheAttribute;
@@ -671,6 +672,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         menu.findItem(R.id.menu_gcvote).setVisible(cache != null && GCVote.isVotingPossible(cache));
         menu.findItem(R.id.menu_checker).setVisible(cache != null && StringUtils.isNotEmpty(CheckerUtils.getCheckerUrl(cache)));
         menu.findItem(R.id.menu_extract_waypoints).setVisible(cache != null);
+        menu.findItem(R.id.menu_clear_goto_history).setVisible(cache.isGotoHistoryUDC());
         menuItemToggleWaypointsFromNote = menu.findItem(R.id.menu_toggleWaypointsFromNote);
         menuItemToggleWaypointsFromNote.setVisible(cache != null);
         setMenuPreventWaypointsFromNote(cache != null && cache.isPreventWaypointsFromNote());
@@ -740,6 +742,14 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     }
                 }.execute();
 
+                return true;
+            case R.id.menu_clear_goto_history:
+                Dialogs.confirm(this, R.string.clear_goto_history_title, R.string.clear_goto_history, (dialog, which) -> {
+                    AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.clearGotoHistory(), () -> {
+                        cache = DataStore.loadCache(InternalConnector.GEOCODE_HISTORY_CACHE, LoadFlags.LOAD_ALL_DB_ONLY);
+                        notifyDataSetChanged();
+                    });
+                });
                 return true;
             case R.id.menu_export_gpx:
                 new GpxExport().export(Collections.singletonList(cache), this);

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.connector.gc.Tile;
 import cgeo.geocaching.connector.gc.UncertainProperty;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.su.SuConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.enumerations.CacheSize;
@@ -2010,5 +2011,9 @@ public class Geocache implements IWaypoint {
                 "\">" +
                 alternativeCode +
                 "</a><br /><br />";
+    }
+
+    public boolean isGotoHistoryUDC() {
+        return geocode.equals(InternalConnector.GEOCODE_HISTORY_CACHE);
     }
 }

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2310,6 +2310,28 @@ public class DataStore {
     }
 
     /**
+     * deletes all but the (up to) five most recent goto history entries
+     * @return true, if successful, false otherwise
+     */
+    public static boolean clearGotoHistory() {
+        init();
+        database.beginTransaction();
+        try {
+            final String sqlGetMostRecentHistoryWaypoints = "SELECT _id FROM " + dbTableWaypoints + " WHERE geocode='" + InternalConnector.GEOCODE_HISTORY_CACHE + "' ORDER BY _id DESC LIMIT 5";
+            final String sqlGetMinIdFromMostRecentHistoryWaypoints = "SELECT MIN(_id) minId FROM (" + sqlGetMostRecentHistoryWaypoints + ")";
+            final String sqlWhereDeleteOlderHistorywaypoints = "geocode='" + InternalConnector.GEOCODE_HISTORY_CACHE + "' AND _id < (" + sqlGetMinIdFromMostRecentHistoryWaypoints + ")";
+            database.delete(dbTableWaypoints, sqlWhereDeleteOlderHistorywaypoints, null);
+            database.setTransactionSuccessful();
+            return true;
+        } catch (final Exception e) {
+            Log.e("Unable to clear goto history", e);
+        } finally {
+            database.endTransaction();
+        }
+        return false;
+    }
+
+    /**
      * Loads the trail history from the database
      *
      * @return A list of previously trail points or an empty list.


### PR DESCRIPTION
- Deletes all but the five most recent goto history entries
- Menu option is only shown for the "goto history" UDC (ZZ0)
