### PR TITLE
adjust styling for API 21+ to fix progressdialog crash (fix #7533)

### DIFF
--- a/main/res/values-v1/styles.xml
+++ b/main/res/values-v1/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- progress dialog theme -->
+    <style name="cgeoProgressdialogTheme" parent="cgeoProgressdialogTheme_Base">
+        <item name="android:textColorPrimary">?text_color</item>
+        <item name="buttonBarButtonStyle">@style/button_borderless</item>
+    </style>
+    <style name="cgeoProgressdialogTheme_light" parent="cgeoProgressdialogTheme_light_Base">
+        <item name="android:textColorPrimary">?text_color</item>
+        <item name="buttonBarButtonStyle">@style/button_borderless</item>
+    </style>
+
+</resources>

--- a/main/res/values-v21/styles.xml
+++ b/main/res/values-v21/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- progress dialog theme -->
+    <style name="cgeoProgressdialogTheme" parent="cgeoProgressdialogTheme_Base">
+    </style>
+    <style name="cgeoProgressdialogTheme_light" parent="cgeoProgressdialogTheme_light_Base">
+    </style>
+
+</resources>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -377,17 +377,13 @@
     </style>
 
     <!-- progress dialog theme -->
-    <style name="cgeoProgressdialogTheme" parent="Theme.AppCompat.Dialog.Alert">
-        <item name="android:textColorPrimary">?text_color</item>
+    <style name="cgeoProgressdialogTheme_Base" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:textColor">?text_color</item>
         <item name="android:windowBackground">@drawable/border_straight</item>
-        <item name="buttonBarButtonStyle">@style/button_borderless</item>
     </style>
-    <style name="cgeoProgressdialogTheme_light" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="android:textColorPrimary">?text_color</item>
+    <style name="cgeoProgressdialogTheme_light_Base" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:textColor">?text_color</item>
         <item name="android:windowBackground">@drawable/border_straight_light</item>
-        <item name="buttonBarButtonStyle">@style/button_borderless</item>
     </style>
 
     <!-- map progressbar style -->


### PR DESCRIPTION
Leave out two attributes for `cgeoProgressdialogTheme` and `cgeoProgressdialogTheme_light` stylings and re-add them only for API level 1 to 20.

Needs some extra testing on different physical devices, see https://github.com/cgeo/cgeo/issues/7533#issuecomment-618023674