### PR TITLE
update & activate closeout message for Android < 5.0 (fix #8246)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1523,7 +1523,7 @@
     <string name="status_geocaching_change" tools:ignore="UnusedResources">Recent changes on geocaching.com broke c:geo.\nWe are working on it, check again soon.</string>
     <string name="status_geocaching_livemap" tools:ignore="UnusedResources">Recent changes on geocaching.com broke the live map feature.\nWe are working on it, check again soon.</string>
     <string name="status_geocaching_maintenance" tools:ignore="UnusedResources">geocaching.com is under maintenance.\nYou might run into various issues.</string>
-    <string name="status_closeout_warning_41" tools:ignore="UnusedResources">You appear to be using a version of Android older than 4.1. Future releases of c:geo might no longer be available for your device.</string>
+    <string name="status_closeout_warning" tools:ignore="UnusedResources">You appear to be using an older version of Android. Future releases of c:geo might no longer be available for your device.\nTap on this message for further information.</string>
 
     <!-- text-to-speech for compass view -->
     <string name="tts_service">Talking compass</string>

--- a/main/src/cgeo/geocaching/network/StatusUpdater.java
+++ b/main/src/cgeo/geocaching/network/StatusUpdater.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Version;
 
 import android.app.Application;
+import android.os.Build;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -37,7 +38,7 @@ public class StatusUpdater {
 
         public static final Status NO_STATUS = new Status(null, null, null, null);
         static final Status CLOSEOUT_STATUS =
-            new Status("", "status_closeout_warning_41", "attribute_abandonedbuilding", "https://www.cgeo.org/faq#legacy");
+            new Status("", "status_closeout_warning", "attribute_abandonedbuilding", "https://www.cgeo.org/faq#legacy");
 
         public final String message;
         public final String messageId;
@@ -63,7 +64,7 @@ public class StatusUpdater {
             if (upToDate != null && upToDate.message != null) {
                 return upToDate;
             }
-            return NO_STATUS;
+            return Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? CLOSEOUT_STATUS : NO_STATUS;
         }
     }
 


### PR DESCRIPTION
- updated closeout message (and made it version independent)
- activate closeout message for systems running Android < 5.0

![image](https://user-images.githubusercontent.com/3754370/80280843-25633180-8707-11ea-8377-6c1bfff8e616.png)
