### PR TITLE
show 'clear individual route' menu entry only when non-empty route is available (fix #8259)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -221,7 +221,8 @@
     </item>
     <item
         android:id="@+id/menu_clear_individual_route"
-        android:title="@string/map_clear_individual_route">
+        android:title="@string/map_clear_individual_route"
+        android:visible="false">
     </item>
 
 </menu>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -589,6 +589,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             route = new Route();
         }
         route.toggleItem(this.mapView.getContext(), new RouteItem(item), overlayPositionAndScale);
+        ActivityMixin.invalidateOptionsMenu(activity);
         overlayPositionAndScale.repaintRequired();
     }
 
@@ -700,6 +701,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         myLocSwitch.setButtonDrawable(R.drawable.ic_menu_myposition);
         item.setActionView(myLocSwitch);
         initMyLocationSwitchButton(myLocSwitch);
+        menu.findItem(R.id.menu_clear_individual_route).setVisible(route != null && !route.isEmpty());
         return true;
     }
 
@@ -880,6 +882,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             }
             case R.id.menu_clear_individual_route: {
                 route.clearRoute(overlayPositionAndScale);
+                ActivityMixin.invalidateOptionsMenu(activity);
                 ActivityMixin.showToast(activity, res.getString(R.string.map_individual_route_cleared));
                 return true;
             }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -290,6 +290,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         myLocSwitch.setButtonDrawable(R.drawable.ic_menu_myposition);
         item.setActionView(myLocSwitch);
         initMyLocationSwitchButton(myLocSwitch);
+        menu.findItem(R.id.menu_clear_individual_route).setVisible(route != null && !route.isEmpty());
 
         return result;
     }
@@ -483,6 +484,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 return true;
             case R.id.menu_clear_individual_route:
                 route.clearRoute(routeLayer);
+                ActivityMixin.invalidateOptionsMenu(this);
                 showToast(res.getString(R.string.map_individual_route_cleared));
                 return true;
             case R.id.menu_routing_straight:
@@ -1553,6 +1555,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         }
         route.toggleItem(this, new RouteItem(item), routeLayer);
         distanceView.showRouteDistance();
+        ActivityMixin.invalidateOptionsMenu(this);
     }
 
     @Nullable

--- a/main/src/cgeo/geocaching/maps/routing/Route.java
+++ b/main/src/cgeo/geocaching/maps/routing/Route.java
@@ -157,6 +157,10 @@ public class Route implements Parcelable {
         Schedulers.io().scheduleDirect(() -> loadRouteInternal());
     }
 
+    public boolean isEmpty() {
+        return segments == null || segments.size() < 1;
+    }
+
     private synchronized void loadRouteInternal() {
         loadingRoute = true;
         final ArrayList<RouteItem> routeItems = DataStore.loadRoute();


### PR DESCRIPTION
show 'clear individual route' menu entry only when non-empty individual route is available
(fix #8259)
