### PR TITLE
add filtering for empty locations to country filter (fix #8258)

### DIFF
--- a/main/src/cgeo/geocaching/filter/CountryFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/CountryFilterFactory.java
@@ -52,7 +52,11 @@ public class CountryFilterFactory implements IFilterFactory {
         public boolean accepts(@NonNull final Geocache cache) {
             final @NonNull String location = cache.getLocation();
 
-            return location != null && location.endsWith(this.location);
+            if (this.location.isEmpty()) {
+                return null == location || location.isEmpty();
+            } else {
+                return null != location && location.endsWith(this.location);
+            }
         }
 
     }


### PR DESCRIPTION
Selecting the empty country filter line now means filtering for an empty/missing location info.