### PR TITLE
allow max zoom on combined OSM map (fix #8263)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/MultiRendererLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/MultiRendererLayer.java
@@ -9,13 +9,14 @@ import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
 import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.reader.MapFile;
+import org.mapsforge.map.reader.header.MapFileInfo;
 
 
 public class MultiRendererLayer implements ITileLayer {
     private final MultiMapDataStore mapDataStore;
     private final TileRendererLayer tileLayer;
     private byte zoomLevelMin = 0;
-    private byte zoomLevelMax = 21;
+    private byte zoomLevelMax = 0;
 
 
     public MultiRendererLayer(final TileCache tileCache, final List<MapFile> mapFiles, final IMapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
@@ -23,8 +24,12 @@ public class MultiRendererLayer implements ITileLayer {
 
         for (MapFile f : mapFiles) {
             mapDataStore.addMapDataStore(f, false, false);
-            zoomLevelMin = (byte) Math.max(f.getMapFileHeader().getMapFileInfo().zoomLevelMin, zoomLevelMin);
-            zoomLevelMax = (byte) Math.min(f.getMapFileHeader().getMapFileInfo().zoomLevelMax, zoomLevelMax);
+            final MapFileInfo headerInfo = f.getMapFileHeader().getMapFileInfo();
+            zoomLevelMin = (byte) Math.max(headerInfo.zoomLevelMin, zoomLevelMin);
+            // intentionally return the max zoomLevelMax level any of the maps support
+            // to support combining maps with extremely different max zoom levels
+            // like a country map combined with world map
+            zoomLevelMax = (byte) Math.max(headerInfo.zoomLevelMax, zoomLevelMax);
         }
 
         tileLayer = new TileRendererLayer(tileCache, mapDataStore, mapViewPosition, isTransparent, renderLabels, cacheLabels, graphicFactory);


### PR DESCRIPTION
set maxZoom of a combined OSM offline map to the maximum of maxZoom values of the maps involved