### PR TITLE
unify map rotation settings (related to #8097)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -93,15 +93,27 @@
                 android:title="@string/map_dot_mode"
                 app:showAsAction="ifRoom|withText">
             </item>
-            <item
-                android:id="@+id/menu_map_autorotate"
-                android:checkable="true"
-                android:icon="@drawable/ic_menu_rotate"
-                android:title="@string/map_autorotate"
-                android:visible="false"
-                app:showAsAction="ifRoom|withText">
-            </item>
-
+        </menu>
+    </item>
+    <item
+        android:id="@+id/menu_map_rotation"
+        android:title="@string/map_rotation"
+        android:visible="false"
+        app:showAsAction="ifRoom|withText">
+        <menu>
+            <group
+                android:id="@+id/menu_group_map_rotation"
+                android:checkableBehavior="single" >
+                <item
+                    android:id="@+id/menu_map_rotation_off"
+                    android:title="@string/switch_off" />
+                <item
+                    android:id="@+id/menu_map_rotation_manual"
+                    android:title="@string/switch_manual" />
+                <item
+                    android:id="@+id/menu_map_rotation_auto"
+                    android:title="@string/switch_auto" />
+            </group>
         </menu>
     </item>
     <item

--- a/main/res/values/arrays.xml
+++ b/main/res/values/arrays.xml
@@ -23,4 +23,16 @@
         <item>@string/pref_value_pn_text_only</item>
         <item>@string/pref_value_pn_tone_and_text</item>
     </string-array>
+
+    <string-array name="maprotation">
+        <item>@string/switch_off</item>
+        <item>@string/switch_manual</item>
+        <item>@string/switch_auto</item>
+    </string-array>
+
+    <string-array name="maprotationValues">
+        <item>@string/pref_maprotation_off</item>
+        <item>@string/pref_maprotation_manual</item>
+        <item>@string/pref_maprotation_auto</item>
+    </string-array>
 </resources>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -84,8 +84,7 @@
     <string translatable="false" name="pref_maplanguage">maplanguage</string>
     <string translatable="false" name="pref_mapDirectory">mapDirectory</string>
     <string translatable="false" name="pref_mapsforge_scale_text">mapsforgeScaleText</string>
-    <string translatable="false" name="pref_map_manualrotation_disabled">map_manualrotation_disabled</string>
-    <string translatable="false" name="pref_map_autorotation_disabled">map_autorotation_disabled</string>
+    <string translatable="false" name="pref_mapRotation">mapRotation</string>
     <string translatable="false" name="pref_renderthemepath">renderthemepath</string>
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_zoomincludingwaypoints">zoomincludingwaypoints</string>
@@ -246,4 +245,8 @@
     <string translatable="false" name="pref_value_blue">blue</string>
     <string translatable="false" name="pref_value_green">green</string>
     <string translatable="false" name="pref_value_grey">grey</string>
+
+    <string translatable="false" name="pref_maprotation_off">off</string>
+    <string translatable="false" name="pref_maprotation_manual">manual</string>
+    <string translatable="false" name="pref_maprotation_auto">auto</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -645,10 +645,6 @@
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="settings_title_scale_map_text">Scale Map Text</string>
     <string name="settings_summary_scale_map_text">Scale text labels on offline map according to device dpi</string>
-    <string name="settings_title_map_manualrotation_disabled">Disable manual map rotation</string>
-    <string name="settings_summary_map_manualrotation_disabled">Disable controls for manual map rotation</string>
-    <string name="settings_title_map_autorotation_disabled">Disable automatic map rotation</string>
-    <string name="settings_summary_map_autorotation_disabled">Disable automatic map rotation</string>
     <string name="init_map_directory_description">Directory with offline maps</string>
     <string name="init_gpx_exportdir">GPX Export Directory</string>
     <string name="init_gpx_importdir">GPX Import Directory</string>
@@ -1123,6 +1119,7 @@
     <string name="map_live">Live map</string>
     <string name="map_view_map">Map view</string>
     <string name="map_modes">Map settings</string>
+    <string name="map_rotation">Map rotation</string>
     <string name="map_hide">Hide</string>
     <string name="map_trail_show">Show trail</string>
     <string name="map_dot_mode">Use compact icons</string>
@@ -1687,4 +1684,8 @@
     <string name="unit_yd">yd</string>
     <string name="unit_mi">mi</string>
 
+    <!-- switch settings -->
+    <string name="switch_off">Off</string>
+    <string name="switch_manual">Manual</string>
+    <string name="switch_auto">Auto</string>
 </resources>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -571,20 +571,13 @@
                 android:key="@string/pref_mapsforge_scale_text"
                 android:summary="@string/settings_summary_scale_map_text"
                 android:title="@string/settings_title_scale_map_text" />
-        </PreferenceCategory>
-
-        <PreferenceCategory android:title="@string/settings_title_map_rotation"
-            android:layout="@layout/preference_category" >
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_map_manualrotation_disabled"
-                android:summary="@string/settings_summary_map_manualrotation_disabled"
-                android:title="@string/settings_title_map_manualrotation_disabled" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_map_autorotation_disabled"
-                android:summary="@string/settings_summary_map_autorotation_disabled"
-                android:title="@string/settings_title_map_autorotation_disabled" />
+            <ListPreference
+                android:title="@string/settings_title_map_rotation"
+                android:summary="%s"
+                android:key="@string/pref_mapRotation"
+                android:defaultValue="@string/pref_maprotation_manual"
+                android:entries="@array/maprotation"
+                android:entryValues="@array/maprotationValues" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/settings_title_waypoints"

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -782,10 +782,20 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null);
                 ActivityMixin.invalidateOptionsMenu(activity);
                 return true;
-            case R.id.menu_map_autorotate:
-                Settings.setMapAutoRotationDisabled(!Settings.isMapAutoRotationDisabled());
-                overlayPositionAndScale.updateMapAutoRotation();
-                ActivityMixin.invalidateOptionsMenu(activity);
+            case R.id.menu_map_rotation_off:
+                Settings.setMapRotation(Settings.MAPROTATION_OFF);
+                overlayPositionAndScale.updateMapRotation();
+                item.setChecked(true);
+                return true;
+            case R.id.menu_map_rotation_manual:
+                Settings.setMapRotation(Settings.MAPROTATION_MANUAL);
+                overlayPositionAndScale.updateMapRotation();
+                item.setChecked(true);
+                return true;
+            case R.id.menu_map_rotation_auto:
+                Settings.setMapRotation(Settings.MAPROTATION_AUTO);
+                overlayPositionAndScale.updateMapRotation();
+                item.setChecked(true);
                 return true;
             case R.id.menu_direction_line:
                 Settings.setMapDirection(!Settings.isMapDirection());

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -7,6 +7,9 @@ import cgeo.geocaching.maps.AbstractMap;
 import cgeo.geocaching.maps.CGeoMap;
 import cgeo.geocaching.maps.interfaces.MapActivityImpl;
 import cgeo.geocaching.settings.Settings;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_OFF;
 
 import android.app.Activity;
 import android.os.Bundle;
@@ -129,7 +132,24 @@ public class GoogleMapActivity extends Activity implements MapActivityImpl, Filt
     @Override
     public boolean superOnPrepareOptionsMenu(final Menu menu) {
         final boolean result = super.onPrepareOptionsMenu(menu);
-        menu.findItem(R.id.menu_map_autorotate).setVisible(true).setChecked(!Settings.isMapAutoRotationDisabled());
+
+        menu.findItem(R.id.menu_map_rotation).setVisible(true);
+
+        final int mapRotation = Settings.getMapRotation();
+        switch (mapRotation) {
+            case MAPROTATION_OFF:
+                menu.findItem(R.id.menu_map_rotation_off).setChecked(true);
+                break;
+            case MAPROTATION_MANUAL:
+                menu.findItem(R.id.menu_map_rotation_manual).setChecked(true);
+                break;
+            case MAPROTATION_AUTO:
+                menu.findItem(R.id.menu_map_rotation_auto).setChecked(true);
+                break;
+            default:
+                break;
+        }
+
         return result;
     }
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -100,9 +100,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         }
         this.googleMap = googleMap;
         mapController.setGoogleMap(googleMap);
-        if (Settings.isMapManualRotationDisabled()) {
-            googleMap.getUiSettings().setRotateGesturesEnabled(false);
-        }
+
         cachesList = new GoogleCachesList(googleMap);
         googleMap.setOnCameraMoveListener(() -> recognizePositionChange());
         googleMap.setOnCameraIdleListener(() -> recognizePositionChange());

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -9,6 +9,8 @@ import cgeo.geocaching.maps.routing.Route;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AngleUtils;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -50,7 +52,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
 
     // settings for map auto rotation
     private Location lastBearingCoordinates = null;
-    private boolean isMapAutoRotationDisabled = false;
+    private int mapRotation = MAPROTATION_MANUAL;
 
     private static final int MAX_HISTORY_POINTS = 230; // TODO add alpha, make changeable in constructor?
 
@@ -77,7 +79,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         trailColor = Settings.getTrailColor();
         this.postRealDistance = postRealDistance;
         this.postRouteDistance = postRouteDistance;
-        updateMapAutoRotation();
+        updateMapRotation();
     }
 
     @Override
@@ -88,7 +90,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
             history.rememberTrailPosition(coordinates);
             mapView.setCoordinates(coordinates);
 
-            if (!isMapAutoRotationDisabled) {
+            if (mapRotation == MAPROTATION_AUTO) {
                 if (null != lastBearingCoordinates) {
                     final GoogleMap map = mapRef.get();
                     if (null != map) {
@@ -116,8 +118,12 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         }
     }
 
-    public void updateMapAutoRotation() {
-        this.isMapAutoRotationDisabled = Settings.isMapAutoRotationDisabled();
+    public void updateMapRotation() {
+        this.mapRotation = Settings.getMapRotation();
+        final GoogleMap map = mapRef.get();
+        if (null != map) {
+            map.getUiSettings().setRotateGesturesEnabled(mapRotation == MAPROTATION_MANUAL);
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
@@ -24,5 +24,5 @@ public interface PositionAndHistory extends Route.RouteUpdater {
 
     void repaintRequired();
 
-    void updateMapAutoRotation();
+    void updateMapRotation();
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
@@ -118,6 +118,6 @@ public class MapsforgePositionAndHistory implements GeneralOverlay, PositionAndH
     }
 
     @Override
-    public void updateMapAutoRotation() {
+    public void updateMapRotation() {
     }
 }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -80,6 +80,10 @@ public class Settings {
     public static final int PROXIMITY_NOTIFICATION_DISTANCE_FAR = 60;
     public static final int PROXIMITY_NOTIFICATION_DISTANCE_NEAR = 20;
 
+    public static final int MAPROTATION_OFF = 0;
+    public static final int MAPROTATION_MANUAL = 1;
+    public static final int MAPROTATION_AUTO = 2;
+
     private static final int MAP_SOURCE_DEFAULT = GoogleMapProvider.GOOGLE_MAP_ID.hashCode();
 
     private static final String PHONE_MODEL_AND_SDK = Build.MODEL + "/" + Build.VERSION.SDK_INT;
@@ -603,16 +607,31 @@ public class Settings {
         return getBoolean(R.string.pref_mapsforge_scale_text, true);
     }
 
-    public static boolean isMapManualRotationDisabled() {
-        return getBoolean(R.string.pref_map_manualrotation_disabled, false);
+    public static int getMapRotation() {
+        final String prefValue = getString(R.string.pref_mapRotation, "");
+        if (prefValue.equals(getKey(R.string.pref_maprotation_off))) {
+            return MAPROTATION_OFF;
+        } else if (prefValue.equals(getKey(R.string.pref_maprotation_auto))) {
+            return MAPROTATION_AUTO;
+        }
+        return MAPROTATION_MANUAL;
     }
 
-    public static boolean isMapAutoRotationDisabled() {
-        return getBoolean(R.string.pref_map_autorotation_disabled, true);
-    }
-
-    public static void setMapAutoRotationDisabled(final boolean disabled) {
-        putBoolean(R.string.pref_map_autorotation_disabled, disabled);
+    public static void setMapRotation(final int mapRotation) {
+        switch (mapRotation) {
+            case MAPROTATION_OFF:
+                putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_off));
+                break;
+            case MAPROTATION_MANUAL:
+                putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_manual));
+                break;
+            case MAPROTATION_AUTO:
+                putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_auto));
+                break;
+            default:
+                // do nothing except satisfy static code analysis
+                break;
+        }
     }
 
     public static CoordInputFormatEnum getCoordInputFormat() {


### PR DESCRIPTION
Unify map rotation settings:
- There is a single setting & preference, which can be either "off", "manual" or "auto"
- Setting can be changed via Settings -> Map -> Map rotation
- or via the new menu entry "Map rotation"

![image](https://user-images.githubusercontent.com/3754370/80644269-a99c1880-8a69-11ea-8aac-67873536edb8.png)

![image](https://user-images.githubusercontent.com/3754370/80644294-b4ef4400-8a69-11ea-963f-6a2595b46de1.png)

Today's separate settings for "disable manual map rotation" and "disable auto map rotation" are NOT migrated. (Should be noted in release notes.)

Default value is "manual rotation".