### PR TITLE
skip validity check on pressing lat/lon buttons (fix #8254)

### DIFF
--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -412,9 +412,6 @@ public class CoordinatesInputDialog extends DialogFragment {
                 default:
                     break;
             }
-
-            // This will serve as a reminder to the user that the current coordinates might not be valid
-            areCurrentCoordinatesValid(true);
         }
     }
 


### PR DESCRIPTION
skip validity check on pressing lat/lon buttons in wp editor