### PR TITLE
GMv2: repaint overlay after clearing individual route (fix #8267)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -882,6 +882,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             }
             case R.id.menu_clear_individual_route: {
                 route.clearRoute(overlayPositionAndScale);
+                overlayPositionAndScale.repaintRequired();
                 ActivityMixin.invalidateOptionsMenu(activity);
                 ActivityMixin.showToast(activity, res.getString(R.string.map_individual_route_cleared));
                 return true;


### PR DESCRIPTION
trigger a repaint of the overlay involved after clearing the individual route