### PR TITLE
adjust coordinate input dialog to preserve lat/lon buttons (fix #8255)

### DIFF
--- a/main/res/layout/coordinates_input.xml
+++ b/main/res/layout/coordinates_input.xml
@@ -18,7 +18,7 @@
         android:layout_width="fill_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:shrinkColumns="0,1,3,5,7"
+        android:shrinkColumns="1,3,5,7"
         android:stretchColumns="0,1,3,5,7" >
 
         <TableRow android:id="@+id/latRow" >

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -108,11 +108,12 @@
 
     <!-- button: letter -->
     <style name="button_letter" parent="button">
-        <item name="android:layout_width">40sp</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:minWidth">40sp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">22sp</item>
-        <item name="android:layout_marginLeft">10dip</item>
-        <item name="android:layout_marginRight">10dip</item>
+        <item name="android:layout_marginLeft">5dip</item>
+        <item name="android:layout_marginRight">5dip</item>
         <item name="android:layout_marginBottom">5dip</item>
     </style>
 


### PR DESCRIPTION
adjust coordinate input dialog's styling to preserve lat/lon buttons (fix #8255)
- set button min width, reduce margin
- do not allow shrinking of the first table column (where the buttons are in)