### PR TITLE
show user note on waypoint popup (fix #8290)

### DIFF
--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -100,7 +100,14 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             //Waypoint geocode
             details.add(R.string.cache_geocode, waypoint.getPrefix() + waypoint.getGeocode().substring(2));
             waypointDistance = details.addDistance(waypoint, waypointDistance);
-            details.addHtml(R.string.waypoint_note, waypoint.getNote(), waypoint.getGeocode());
+            final String note = waypoint.getNote();
+            if (StringUtils.isNotBlank(note)) {
+                details.addHtml(R.string.waypoint_note, note, waypoint.getGeocode());
+            }
+            final String userNote = waypoint.getUserNote();
+            if (StringUtils.isNotBlank(userNote)) {
+                details.addHtml(R.string.waypoint_user_note, userNote, waypoint.getGeocode());
+            }
 
             toggleVisited.setChecked(waypoint.isVisited());
             toggleVisited.setOnClickListener(arg1 -> {


### PR DESCRIPTION
Shows the user note on waypoint popup:

![image](https://user-images.githubusercontent.com/3754370/80873220-3daeef80-8cb7-11ea-8ad1-0f6bedceabaf.png)

If user note is empty, no user note field will be shown:

![image](https://user-images.githubusercontent.com/3754370/80873235-5b7c5480-8cb7-11ea-9653-585c627bf208.png)
