### PR TITLE
receive notification on waypoint creation from map (fix #8292)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -369,6 +369,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         // If we have a newer Android device setup Android Beam for easy cache sharing
         AndroidBeam.enable(this, this);
+
+        // get notified on cache changes (e.g.: waypoint creation from map)
+        LocalBroadcastManager.getInstance(this).registerReceiver(updateReceiver, new IntentFilter(Intents.INTENT_CACHE_CHANGED));
     }
 
     @Override
@@ -394,13 +397,6 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (start) {
             geoDataDisposable.add(locationUpdater.start(GeoDirHandler.UPDATE_GEODATA));
         }
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-
-        LocalBroadcastManager.getInstance(this).registerReceiver(updateReceiver, new IntentFilter(Intents.INTENT_CACHE_CHANGED));
     }
 
     @Override
@@ -432,16 +428,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     public void onDestroy() {
         createDisposables.clear();
         SpeechService.stopService(this);
-        super.onDestroy();
-    }
-
-    @Override
-    public void onStop() {
         if (cache != null) {
             cache.setChangeNotificationHandler(null);
         }
         LocalBroadcastManager.getInstance(this).unregisterReceiver(updateReceiver);
-        super.onStop();
+        super.onDestroy();
     }
 
     @Override


### PR DESCRIPTION
Make sure the cache change receiver is still available when creating a new waypoint from cache map. For this move the change notification setter from `onStart` to `onCreate`, and the receiver from `onStop` to `onDestroy`.
