### PR TITLE
disable individual route toggle in single waypoint mode (fix #8309)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1676,6 +1676,7 @@
     <string name="individual_route_added">added to route</string>
     <string name="individual_route_removed">removed from route</string>
     <string name="individual_route_error_toggling_waypoint">error toggling waypoint</string>
+    <string name="individual_route_error_single_waypoint_mode">Not available in single waypoint mode</string>
     <string name="map_clear_individual_route">Clear individual route</string>
     <string name="map_individual_route_cleared">Individual route cleared</string>
 

--- a/main/src/cgeo/geocaching/maps/routing/Route.java
+++ b/main/src/cgeo/geocaching/maps/routing/Route.java
@@ -108,6 +108,11 @@ public class Route implements Parcelable {
             return;
         }
 
+        if (item.getType() == CoordinatesType.WAYPOINT && item.getId() == -1) {
+            Toast.makeText(context, R.string.individual_route_error_single_waypoint_mode, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         switch (toggleItemInternal(item)) {
             case ADDED:
                 Toast.makeText(context, R.string.individual_route_added, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
In single waypoint map mode we don't have the information available which is necessary for waypoint toggling in individual routes, therefore disable in this case.