### PR TITLE
reinit description page only after personal note update (fix #8324)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2542,7 +2542,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (personalNoteView != null) {
             setPersonalNote(personalNoteView, note);
         } else {
-            reinitializeViewPager();
+            reinitializePage(Page.DESCRIPTION);
         }
 
         Schedulers.io().scheduleDirect(() -> DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB)));

--- a/main/src/cgeo/geocaching/activity/AbstractViewPagerActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractViewPagerActivity.java
@@ -265,6 +265,12 @@ public abstract class AbstractViewPagerActivity<Page extends Enum<Page>> extends
      */
     protected abstract String getTitle(Page page);
 
+    protected final void reinitializePage(final Page page) {
+        final PageViewCreator detailsCreator = getViewCreator(page);
+        detailsCreator.notifyDataSetChanged();
+        viewPagerAdapter.notifyDataSetChanged();
+    }
+
     protected final void reinitializeViewPager() {
 
         // notify all creators that the data has changed


### PR DESCRIPTION
reinitialize only the description page after update of personal note, instead of reinitializing the whole view pager.