### PR TITLE
GMv2: disable autorotation on tap on compass rose

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1156,6 +1156,8 @@
     <string name="map_routing_walk">Walk</string>
     <string name="map_routing_bike">Bicycle</string>
     <string name="map_routing_car">Car</string>
+    <string name="map_gm_autorotation">Map auto rotation</string>
+    <string name="map_gm_autorotation_disable">Disable map auto rotation?\n\nYou can enable it again using the Map rotation menu</string>
 
     <!-- search -->
     <string name="search_bar_hint">Search for caches</string>

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -56,10 +56,6 @@ import com.google.android.gms.maps.model.VisibleRegion;
 
 public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOverlayItem>, OnMapReadyCallback {
 
-    public interface PostRealDistance {
-        void postRealDistance (float realDistance);
-    }
-
     private OnMapDragListener onDragListener;
     private final GoogleMapController mapController = new GoogleMapController();
     private GoogleMap googleMap;
@@ -81,6 +77,10 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
 
     private final ScaleDrawer scaleDrawer = new ScaleDrawer();
     private DistanceDrawer distanceDrawer;
+
+    public interface PostRealDistance {
+        void postRealDistance (float realDistance);
+    }
 
     public GoogleMapView(final Context context, final AttributeSet attrs) {
         super(context, attrs);

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -146,13 +146,13 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
             final float bearing = cameraPosition.bearing;
             if (canDisableAutoRotate && bearing == 0.0f && Settings.getMapRotation() == Settings.MAPROTATION_AUTO) {
                 canDisableAutoRotate = false;
-                Dialogs.confirm((Activity) getContext(), "Disable map auto rotation?", "Disable map auto rotation?\n\nYou can enable it again using the Map rotation menu", (dialog, which) -> {
+                Dialogs.confirm((Activity) getContext(), R.string.map_gm_autorotation, R.string.map_gm_autorotation_disable, (dialog, which) -> {
                     Settings.setMapRotation(Settings.MAPROTATION_MANUAL);
                 });
             } else if (bearing != 0.0f) {
                 canDisableAutoRotate = true;
             }
-            Log.e("bearing=" + cameraPosition.bearing + ", tilt=" + cameraPosition.tilt + ", canDisable=" + canDisableAutoRotate);
+            Log.d("bearing=" + cameraPosition.bearing + ", tilt=" + cameraPosition.tilt + ", canDisable=" + canDisableAutoRotate);
         });
         if (mapReadyCallback != null) {
             mapReadyCallback.mapReady();


### PR DESCRIPTION
This is a proposal to get a grip on the auto rotation UI:
It catches a tap on the compass rose (if rotation mode is set to `AUTO` only) and ask the user if he/she wants to disable auto rotation.

This is a WIP only - @Lineflyer  Do you have a chance to test it?

Note: Currently it asks every time the user presses the compass rose (if rotation mode is set to `AUTO`) - we should sort of damp this, like only asking once or twice each session. - To be figured out yet what could work.