### PR TITLE
avoid NPE during map initialization (fix #8328)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -255,6 +255,10 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
 
 
     private synchronized void drawHistory() {
+        if (null == coordinates) {
+            return;
+        }
+
         historyObjs.removeAll();
 
         // always add current position to drawn history to have a closed connection


### PR DESCRIPTION
Due to the changes necessary for #8303 and #8304 the overlay gets repainted earlier, in this case at a time where we do not have a current position, which leads to an NPE in drawing the history trail. Therefore check if we have a current position, and refrain from repainting the overlay if not.