### PR TITLE
add logcat function to about-system screen (fix #8331)

### DIFF
--- a/main/res/layout/about_system_page.xml
+++ b/main/res/layout/about_system_page.xml
@@ -49,6 +49,12 @@
             android:textIsSelectable="true"
             android:textSize="12sp"
             tools:text="long list of system properties"/>
+
+        <Button android:id="@+id/logcat"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/about_system_write_logcat"
+            android:padding="12dp" />
     </LinearLayout>
 
 </ScrollView>

--- a/main/res/layout/about_version_page.xml
+++ b/main/res/layout/about_version_page.xml
@@ -263,7 +263,7 @@
                     android:clickable="true"
                     android:focusable="true"
                     android:linksClickable="false"
-                    android:text="@string/support_link"
+                    android:text="@string/support_mail"
                     android:textColor="?text_color"
                     android:textColorLink="?text_color_link"
                     android:textSize="14sp" />

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -230,6 +230,7 @@
     <string translatable="false" name="pref_twitter_trackable_message">twitter_trackable_message</string>
     <string translatable="false" name="pref_ec_icons">ec_icons</string>
     <string translatable="false" name="pref_memory_dump">memory_dump</string>
+    <string translatable="false" name="pref_generate_logcat">generate_logcat</string>
     <string translatable="false" name="pref_appearance">pref_appearance</string>
     <string translatable="false" name="pref_changelog_last_checksum">changelog_last_checksum</string>
     <string translatable="false" name="pref_caches_history">caches_history</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -443,6 +443,9 @@
     <string name="about_system_info_send_button">Send by mail…</string>
     <string name="about_system_info">c:geo system information</string>
     <string name="about_system_info_send_chooser">Send system information</string>
+    <string name="about_system_write_logcat">Generate logfile</string>
+    <string name="about_system_write_logcat_success">Logfile written to \"%1$s\" in \"%2$s\" dir</string>
+    <string name="about_system_write_logcat_error">Error writing logfile</string>
     <string name="changelog_github">List of all changes</string>
     <string name="about_nutshellmanual">Online manual</string>
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -445,6 +445,7 @@
     <string name="about_system_info_send_chooser">Send system information</string>
     <string name="about_system_write_logcat">Generate logfile</string>
     <string name="about_system_write_logcat_success">Logfile written to \"%1$s\" in \"%2$s\" dir</string>
+    <string name="about_system_write_logcat_empty">Logfile is empty</string>
     <string name="about_system_write_logcat_error">Error writing logfile</string>
     <string name="changelog_github">List of all changes</string>
     <string name="about_nutshellmanual">Online manual</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -118,7 +118,7 @@
     <string translatable="false" name="faq_link"><a href="">faq.cgeo.org</a></string>
     <string translatable="false" name="website_link"><a href="">cgeo.org</a></string>
     <string translatable="false" name="twitter_link"><a href="">@android_GC</a></string>
-    <string translatable="false" name="support_link"><a href="">support@cgeo.org</a></string>
+    <string translatable="false" name="support_mail"><a href="">support@cgeo.org</a></string>
     <string translatable="false" name="manual_link"><a href="">manual.cgeo.org</a></string>
 
     <string translatable="false" name="ellipsis">…</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -969,6 +969,9 @@
                 android:key="@string/pref_debug"
                 android:title="@string/init_debug" />
             <Preference
+                android:key="@string/pref_generate_logcat"
+                android:title="@string/about_system_write_logcat" />
+            <Preference
                 android:key="@string/pref_memory_dump"
                 android:title="@string/init_create_memory_dump" />
         </PreferenceCategory>

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -5,7 +5,9 @@ import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.ui.AbstractCachingPageViewCreator;
 import cgeo.geocaching.ui.AnchorAwareLinkMovementMethod;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.ProcessUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.SystemInformation;
 import cgeo.geocaching.utils.Version;
 
@@ -181,6 +183,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
         @BindView(R.id.system) protected TextView system;
         @BindView(R.id.copy) protected Button copy;
         @BindView(R.id.share) protected Button share;
+        @BindView(R.id.logcat) protected Button logcat;
 
         @Override
         public ScrollView getDispatchedView(final ViewGroup parentView) {
@@ -194,14 +197,9 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
                 ClipboardUtils.copyToClipboard(systemInfo);
                 showShortToast(getString(R.string.clipboard_copy_ok));
             });
-            share.setOnClickListener(view12 -> {
-                ClipboardUtils.copyToClipboard(systemInfo);
-                final Intent share = new Intent(Intent.ACTION_SENDTO);
-                share.setData(Uri.parse("mailto:"));
-                share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.about_system_info));
-                share.putExtra(Intent.EXTRA_TEXT, systemInfo);
-                startActivity(Intent.createChooser(share, getString(R.string.about_system_info_send_chooser)));
-            });
+            share.setOnClickListener(view12 -> ShareUtils.shareAsEMail(AboutActivity.this, getString(R.string.about_system_info), systemInfo, null, R.string.about_system_info_send_chooser));
+            logcat.setOnClickListener(view13 -> DebugUtils.createLogcat(AboutActivity.this));
+
             return view;
         }
     }

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -199,7 +199,6 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
             });
             share.setOnClickListener(view12 -> ShareUtils.shareAsEMail(AboutActivity.this, getString(R.string.about_system_info), systemInfo, null, R.string.about_system_info_send_chooser));
             logcat.setOnClickListener(view13 -> DebugUtils.createLogcat(AboutActivity.this));
-
             return view;
         }
     }

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -483,12 +483,14 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.removeObsoleteGeocacheDataDirectories(), () -> dialog.dismiss());
             return true;
             });
-        final Preference memoryDumpPref = getPreference(R.string.pref_memory_dump);
-        memoryDumpPref
-                .setOnPreferenceClickListener(preference -> {
-                    DebugUtils.createMemoryDump(SettingsActivity.this);
-                    return true;
-                });
+        getPreference(R.string.pref_memory_dump).setOnPreferenceClickListener(preference -> {
+            DebugUtils.createMemoryDump(SettingsActivity.this);
+            return true;
+        });
+        getPreference(R.string.pref_generate_logcat).setOnPreferenceClickListener(preference -> {
+            DebugUtils.createLogcat(SettingsActivity.this);
+            return true;
+        });
     }
 
     private static void initDeviceSpecificPreferences() {

--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -41,6 +41,7 @@ public final class LocalStorage {
     private static final String CGEO_DIRNAME = "cgeo";
     private static final String DATABASES_DIRNAME = "databases";
     private static final String BACKUP_DIR_NAME = "backup";
+    public static final String LOGFILES_DIR_NAME = "logfiles";
     private static final String GPX_DIR_NAME = "gpx";
     private static final String FIELD_NOTES_DIR_NAME = "field-notes";
     private static final String LEGACY_CGEO_DIR_NAME = ".cgeo";
@@ -301,6 +302,11 @@ public final class LocalStorage {
     @NonNull
     public static File getBackupDirectory() {
         return new File(getExternalPublicCgeoDirectory(), BACKUP_DIR_NAME);
+    }
+
+    @NonNull
+    public static File getLogfilesDirectory() {
+        return new File(getExternalPublicCgeoDirectory(), LOGFILES_DIR_NAME);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/utils/CalendarUtils.java
+++ b/main/src/cgeo/geocaching/utils/CalendarUtils.java
@@ -8,8 +8,11 @@ import android.content.Intent;
 import android.net.Uri;
 import android.provider.CalendarContract;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 public final class CalendarUtils {
 
@@ -64,4 +67,14 @@ public final class CalendarUtils {
         activity.startActivity(intent);
     }
 
+    /**
+     * returns current date/time formatted according to the supplied {SimpleDateFormat} string
+     * @param format string
+     * @return formatted date
+     */
+    public static String formatDateTime(final String format) {
+        final Date date = Calendar.getInstance().getTime();
+        final DateFormat dateFormat = new SimpleDateFormat(format, Locale.getDefault());
+        return dateFormat.format(date);
+    }
 }

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -1,18 +1,21 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.ui.dialog.Dialogs;
 
+import android.app.Activity;
 import android.content.Context;
-import android.os.Environment;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class DebugUtils {
 
@@ -22,9 +25,7 @@ public class DebugUtils {
 
     public static void createMemoryDump(@NonNull final Context context) {
         try {
-            final SimpleDateFormat fileNameDateFormat = new SimpleDateFormat("yyyy-MM-dd_hh-mm", Locale.US);
-            final File file = FileUtils.getUniqueNamedFile(new File(Environment.getExternalStorageDirectory(),
-                    "cgeo_dump_" + fileNameDateFormat.format(new Date()) + ".hprof"));
+            final File file = FileUtils.getUniqueNamedLogfile("cgeo_dump", "hprof");
             android.os.Debug.dumpHprofData(file.getPath());
             Toast.makeText(context, context.getString(R.string.init_memory_dumped, file.getAbsolutePath()),
                     Toast.LENGTH_LONG).show();
@@ -32,5 +33,33 @@ public class DebugUtils {
         } catch (final IOException e) {
             Log.e("createMemoryDump", e);
         }
+    }
+
+    public static void createLogcat(@NonNull final Activity activity) {
+        final AtomicBoolean success = new AtomicBoolean(false);
+        final File file = FileUtils.getUniqueNamedLogfile("logcat", "log");
+        final String filename = file.getName();
+        AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
+            try {
+                final Process process = new ProcessBuilder()
+                    .command("logcat", "-d", "cgeo.geocachin:D", "*:S", "-f", file.getAbsolutePath())
+                    .start();
+                final int result = process.waitFor();
+                success.set(result == 0);
+            } catch (IOException | InterruptedException e) {
+                Log.e("error calling logcat: " + e.getMessage());
+                success.set(false);
+            }
+        }, () -> {
+            if (success.get()) {
+                Dialogs.confirm(activity, activity.getString(R.string.about_system_write_logcat), String.format(activity.getString(R.string.about_system_write_logcat_success), filename, LocalStorage.LOGFILES_DIR_NAME), activity.getString(R.string.about_system_info_send_button), (dialog, which) -> {
+                    final String systemInfo = SystemInformation.getSystemInformation(activity);
+                    ShareUtils.shareAsEMail(activity, activity.getString(R.string.about_system_info), systemInfo, file, R.string.about_system_info_send_chooser);
+                });
+            } else {
+                ActivityMixin.showToast(activity, R.string.about_system_write_logcat_error);
+            }
+        });
+
     }
 }

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -7,17 +7,24 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 public class DebugUtils {
+
+    private enum LogcatResults {
+        LOGCAT_OK,
+        LOGCAT_EMPTY,
+        LOGCAT_ERROR
+    }
 
     private DebugUtils() {
         // utility class
@@ -36,28 +43,33 @@ public class DebugUtils {
     }
 
     public static void createLogcat(@NonNull final Activity activity) {
-        final AtomicBoolean success = new AtomicBoolean(false);
+        final AtomicInteger result = new AtomicInteger(LogcatResults.LOGCAT_ERROR.ordinal());
         final File file = FileUtils.getUniqueNamedLogfile("logcat", "log");
         final String filename = file.getName();
         AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
             try {
-                final Process process = new ProcessBuilder()
-                    .command("logcat", "-d", "cgeo.geocachin:D", "*:S", "-f", file.getAbsolutePath())
-                    .start();
-                final int result = process.waitFor();
-                success.set(result == 0);
+                final ProcessBuilder builder = new ProcessBuilder();
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                    builder.command("logcat", "-d", "-f", file.getAbsolutePath());
+                } else {
+                    builder.command("logcat", "-d", "AndroidRuntime:E", "cgeo:D", "cgeo.geocachin:E", "*:S", "-f", file.getAbsolutePath());
+                }
+                final int returnCode = builder.start().waitFor();
+                if (returnCode == 0) {
+                    result.set(file.exists() ? LogcatResults.LOGCAT_OK.ordinal() : LogcatResults.LOGCAT_EMPTY.ordinal());
+                }
+
             } catch (IOException | InterruptedException e) {
                 Log.e("error calling logcat: " + e.getMessage());
-                success.set(false);
             }
         }, () -> {
-            if (success.get()) {
+            if (result.get() == LogcatResults.LOGCAT_OK.ordinal()) {
                 Dialogs.confirm(activity, activity.getString(R.string.about_system_write_logcat), String.format(activity.getString(R.string.about_system_write_logcat_success), filename, LocalStorage.LOGFILES_DIR_NAME), activity.getString(R.string.about_system_info_send_button), (dialog, which) -> {
                     final String systemInfo = SystemInformation.getSystemInformation(activity);
                     ShareUtils.shareAsEMail(activity, activity.getString(R.string.about_system_info), systemInfo, file, R.string.about_system_info_send_chooser);
                 });
             } else {
-                ActivityMixin.showToast(activity, R.string.about_system_write_logcat_error);
+                ActivityMixin.showToast(activity, result.get() == LogcatResults.LOGCAT_EMPTY.ordinal() ? R.string.about_system_write_logcat_empty : R.string.about_system_write_logcat_error);
             }
         });
 

--- a/main/src/cgeo/geocaching/utils/FileUtils.java
+++ b/main/src/cgeo/geocaching/utils/FileUtils.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.storage.LocalStorage;
 
 import android.os.Handler;
 import android.os.Message;
@@ -365,6 +366,16 @@ public final class FileUtils {
             }
         }
         throw new IllegalStateException("Unable to generate a non-existing file name");
+    }
+
+    /**
+     * Creates a uniquely named file in the "logfiles" dir with prefix/suffix as given
+     */
+    @NonNull
+    public static File getUniqueNamedLogfile(final String prefix, final String suffix) {
+        final File logfilesDirectory = LocalStorage.getLogfilesDirectory();
+        mkdirs(logfilesDirectory);
+        return getUniqueNamedFile(new File(logfilesDirectory, prefix + "_" + CalendarUtils.formatDateTime("yyyy-MM-dd_hh-mm") + "." + suffix));
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/cgeo/geocaching/utils/ShareUtils.java
@@ -5,29 +5,66 @@ import cgeo.geocaching.R;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.FileProvider;
 
 import java.io.File;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class ShareUtils {
     private ShareUtils() {
         // utility class
     }
 
+    public static final String TYPE_EMAIL = "vnd.android.cursor.dir/email";
+
     public static void share(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int titleResourceId) {
-        final Intent shareIntent = new Intent();
-        shareIntent.setAction(Intent.ACTION_SEND);
-        final Uri uri = FileProvider.getUriForFile(context, context.getString(R.string.file_provider_authority), file);
-        shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
-        shareIntent.setType(mimeType);
-        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        context.startActivity(Intent.createChooser(shareIntent, context.getString(titleResourceId)));
+        shareInternal(context, mimeType, null, null, file, titleResourceId);
     }
 
     public static void share(final Context context, @NonNull final File file, @StringRes final int titleResourceId) {
-        share(context, file, "*/*", titleResourceId);
+        shareInternal(context, "*/*", null, null, file, titleResourceId);
     }
+
+    public static void shareAsEMail(final Context context, final String subject, final String body, @Nullable final File file, @StringRes final int titleResourceId) {
+        shareInternal(context, TYPE_EMAIL, subject, body, file, titleResourceId);
+    }
+
+    private static void shareInternal(final Context context, @NonNull final String mimeType, @Nullable final String subject, @Nullable final String body, @Nullable final File file, @StringRes final int titleResourceId) {
+        Uri uri = null;
+        if (null != file) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                uri = Uri.fromFile(file);
+            } else {
+                try {
+                    uri = FileProvider.getUriForFile(context, context.getString(R.string.file_provider_authority), file);
+                } catch (Exception e) {
+                    Log.e("error on LogCat sharing");
+                }
+            }
+        }
+        if (null == file || null != uri) {
+            final Intent intent = new Intent(Intent.ACTION_SEND);
+            intent.setType(mimeType);
+            if (StringUtils.isNotBlank(subject)) {
+                intent.putExtra(Intent.EXTRA_SUBJECT, subject);
+            }
+            if (StringUtils.isNotBlank(body)) {
+                intent.putExtra(Intent.EXTRA_TEXT, body);
+            }
+            if (null != file) {
+                // Grant temporary read permission to the content URI.
+                intent.putExtra(Intent.EXTRA_STREAM, uri);
+                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            }
+            context.startActivity(Intent.createChooser(intent, context.getString(titleResourceId)));
+        }
+
+    }
+
 }

--- a/main/src/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/cgeo/geocaching/utils/ShareUtils.java
@@ -17,11 +17,12 @@ import java.io.File;
 import org.apache.commons.lang3.StringUtils;
 
 public class ShareUtils {
+
+    public static final String TYPE_EMAIL = "vnd.android.cursor.dir/email";
+
     private ShareUtils() {
         // utility class
     }
-
-    public static final String TYPE_EMAIL = "vnd.android.cursor.dir/email";
 
     public static void share(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int titleResourceId) {
         shareInternal(context, mimeType, null, null, file, titleResourceId);


### PR DESCRIPTION
To make acquiring logcats easier I started implementing a little logcat functionality to c:geo. I tested in different emulated Android versions, and it seems to work starting from API level 24, but not up to 21 - although I'm not explicitly using any function with a higher API level. Android documentation on logcat itself is a bit sparse, though, so it may be due to a parameter not supported under those Android versions. - Therefore setting "WIP" for now to get some feedback first.

Logcat function is added to the c:geo - about - system screen:
(see the new "generate logfile" button at the bottom)

![image](https://user-images.githubusercontent.com/3754370/81613142-34700200-93de-11ea-853e-c5a4185af40b.png)

After successful write of the logfile to the new "logcat" directory a message confirms if you additionally want to send the file as e-mail:

![image](https://user-images.githubusercontent.com/3754370/81613208-54072a80-93de-11ea-9a0b-acb95854ff98.png)

When confirmed, the regular app chooser opens for you to select your preferred e-mail program:

![image](https://user-images.githubusercontent.com/3754370/81613533-ef000480-93de-11ea-956a-9d2722967b42.png)

