### PR TITLE
activate cache filtering in GMv2 when liveEnabled is set (fix #8300)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1357,7 +1357,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             final boolean excludeMine = Settings.isExcludeMyCaches();
             final boolean excludeDisabled = Settings.isExcludeDisabledCaches();
             final boolean excludeArchived = Settings.isExcludeArchivedCaches();
-            if (mapMode == MapMode.LIVE) {
+            if (mapMode == MapMode.LIVE || mapOptions.isLiveEnabled) {
                 synchronized (caches) {
                     MapUtils.filter(caches);
                 }


### PR DESCRIPTION
This is for the issue mentioned in #8300 only - so no general change or extension of cache/waypoint filtering yet.

Activate cache filtering when liveEnabled==true (which can be in `LIVE` map mode as well as in `SINGLE` map mode). Waypoint filtering is unchanged.