### PR TITLE
Refactor favorites

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -730,6 +730,7 @@
     <string name="feature_search_geocode">Search by geocode</string>
     <string name="feature_search_owner">Search by owner</string>
     <string name="feature_search_finder">Search by finder</string>
+    <string name="feature_favorite">Adding cache to favorites</string>
     <string name="init_mapsforge_api_title">Mapsforge API</string>
     <string name="init_mfold_api">Old Mapsforge V3</string>
     <string name="init_mfold_api_description">We are using a new version of the Mapsforge map by default. If you miss some features or encounter issues you can go back to the old version here.</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -14,11 +14,11 @@ import cgeo.geocaching.command.MoveToListAndRemoveFromOthersCommand;
 import cgeo.geocaching.compatibility.Compatibility;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.IgnoreCapability;
 import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.connector.capability.PgcChallengeCheckerCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
-import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
@@ -1381,7 +1381,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         /** Add this cache to the favorite list of the user */
         private void favoriteAdd(final SimpleDisposableHandler handler) {
-            if (GCConnector.addToFavorites(cache)) {
+            final IFavoriteCapability connector = (IFavoriteCapability) ConnectorFactory.getConnector(cache);
+            if (connector.addToFavorites(cache)) {
                 handler.obtainMessage(MESSAGE_SUCCEEDED).sendToTarget();
             } else {
                 handler.sendTextMessage(MESSAGE_FAILED, R.string.err_favorite_failed);
@@ -1390,7 +1391,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         /** Remove this cache to the favorite list of the user */
         private void favoriteRemove(final SimpleDisposableHandler handler) {
-            if (GCConnector.removeFromFavorites(cache)) {
+            final IFavoriteCapability connector = (IFavoriteCapability) ConnectorFactory.getConnector(cache);
+            if (connector.removeFromFavorites(cache)) {
                 handler.obtainMessage(MESSAGE_SUCCEEDED).sendToTarget();
             } else {
                 handler.sendTextMessage(MESSAGE_FAILED, R.string.err_favorite_failed);
@@ -1485,7 +1487,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final LinearLayout layout = view.findViewById(R.id.favpoint_box);
             final boolean supportsFavoritePoints = cache.supportsFavoritePoints();
             layout.setVisibility(supportsFavoritePoints ? View.VISIBLE : View.GONE);
-            if (!supportsFavoritePoints || cache.isOwner() || !Settings.isGCPremiumMember()) {
+            if (!supportsFavoritePoints) {
                 return;
             }
             final ImageButton buttonAdd = view.findViewById(R.id.add_to_favpoint);

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.CacheListActivity;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.capability.ISearchByFinder;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
@@ -68,10 +69,6 @@ public abstract class AbstractConnector implements IConnector {
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public boolean supportsFavoritePoints(@NonNull final Geocache cache) {
-        return false;
-    }
 
     @Override
     public boolean supportsLogging() {
@@ -80,11 +77,6 @@ public abstract class AbstractConnector implements IConnector {
 
     @Override
     public boolean supportsLogImages() {
-        return false;
-    }
-
-    @Override
-    public boolean supportsAddToFavorite(final Geocache cache, final LogType type) {
         return false;
     }
 
@@ -260,6 +252,7 @@ public abstract class AbstractConnector implements IConnector {
             list.add(feature(R.string.feature_own_coordinates));
         }
         addCapability(list, WatchListCapability.class, R.string.feature_watch_list);
+        addCapability(list, IFavoriteCapability.class, R.string.feature_favorite);
         return list;
     }
 

--- a/main/src/cgeo/geocaching/connector/AbstractLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/AbstractLoggingManager.java
@@ -22,19 +22,9 @@ public abstract class AbstractLoggingManager implements ILoggingManager {
     }
 
     @Override
-    public boolean hasFavPointLoadError() {
-        return false;
-    }
-
-    @Override
     @NonNull
     public List<TrackableLog> getTrackables() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public int getPremFavoritePoints() {
-        return 0;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -53,12 +53,6 @@ public interface IConnector {
     String getLongCacheUrl(@NonNull Geocache cache);
 
     /**
-     * enable/disable favorite points controls in cache details
-     *
-     */
-    boolean supportsFavoritePoints(@NonNull Geocache cache);
-
-    /**
      * enable/disable logging controls in cache details
      *
      */
@@ -228,17 +222,6 @@ public interface IConnector {
 
     @NonNull
     List<UserAction> getUserActions(UserAction.UAContext user);
-
-    /**
-     * Check cache is eligible for adding to favorite
-     *
-     * @param cache
-     *         a cache that this connector must be able to handle
-     * @param type
-     *         a log type selected by the user
-     * @return true, when cache can be added to favorite
-     */
-    boolean supportsAddToFavorite(Geocache cache, LogType type);
 
     /**
      * @return the URL to register a new account or {@code null}

--- a/main/src/cgeo/geocaching/connector/ILoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/ILoggingManager.java
@@ -42,7 +42,6 @@ public interface ILoggingManager {
 
     void init();
 
-    int getPremFavoritePoints();
 
     Long getMaxImageUploadSize();
 
@@ -53,5 +52,4 @@ public interface ILoggingManager {
 
     boolean hasTrackableLoadError();
 
-    boolean hasFavPointLoadError();
 }

--- a/main/src/cgeo/geocaching/connector/ILoggingWithFavorites.java
+++ b/main/src/cgeo/geocaching/connector/ILoggingWithFavorites.java
@@ -1,0 +1,20 @@
+package cgeo.geocaching.connector;
+
+/**
+ * This is the counterpart of {@link cgeo.geocaching.connector.capability.IFavoriteCapability} for logging.
+ * This Interface  has to be implemented by Logging Managers in order to be able to mark caches
+ * as favorites directly on Cache Logging screen.
+ * Typically the implementation of the fetching is done inside @code {onLoadFinished} method.
+ */
+public interface ILoggingWithFavorites extends ILoggingManager {
+
+    /**
+     * @return number of available favorite points. This number will be displayed near "add to favorites" checkbox
+     */
+    int getFavoritePoints();
+
+    /**
+     * @return true if there was loading error, false otherwise.
+     */
+    boolean hasFavPointLoadError();
+}

--- a/main/src/cgeo/geocaching/connector/capability/IFavoriteCapability.java
+++ b/main/src/cgeo/geocaching/connector/capability/IFavoriteCapability.java
@@ -1,0 +1,47 @@
+package cgeo.geocaching.connector.capability;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Connector interface to implement possibility to give recommendations (aka Favorite Points) to
+ * caches.
+ * See {@link cgeo.geocaching.connector.ILoggingWithFavorites} for possibility to give favorite point
+ * directly on logging screen.
+ */
+public interface IFavoriteCapability extends IConnector {
+
+    /**
+     * Add the cache to favorites
+     *
+     * @return True - success/False - failure
+     */
+    boolean addToFavorites(@NonNull Geocache cache);
+
+    /**
+     * Remove the cache from favorites
+     *
+     * @return True - success/False - failure
+     */
+    boolean removeFromFavorites(@NonNull Geocache cache);
+
+
+    /**
+     * Enable/disable favorite points controls in cache details
+     */
+    boolean supportsFavoritePoints(@NonNull Geocache cache);
+
+
+    /**
+     * Check whether to show favorite controls during logging for the given log type
+     *
+     * @param cache a cache that this connector must be able to handle
+     * @param type  a log type selected by the user
+     * @return true, when cache can be added to favorite
+     */
+    boolean supportsAddToFavorite(@NonNull Geocache cache, LogType type);
+
+}

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.connector.ILoggingManager;
 import cgeo.geocaching.connector.UserAction;
 import cgeo.geocaching.connector.capability.FieldNotesCapability;
 import cgeo.geocaching.connector.capability.ICredentials;
+import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.capability.ISearchByFinder;
@@ -52,7 +53,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
-public class GCConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter, ISearchByNextPage, ISearchByViewPort, ISearchByKeyword, ILogin, ICredentials, ISearchByOwner, ISearchByFinder, FieldNotesCapability, IgnoreCapability, WatchListCapability, PersonalNoteCapability, SmileyCapability, PgcChallengeCheckerCapability {
+public class GCConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter, ISearchByNextPage, ISearchByViewPort, ISearchByKeyword, ILogin, ICredentials, ISearchByOwner, ISearchByFinder, FieldNotesCapability, IgnoreCapability, WatchListCapability, PersonalNoteCapability, SmileyCapability, PgcChallengeCheckerCapability, IFavoriteCapability {
 
     @NonNull
     private static final String CACHE_URL_SHORT = "https://coord.info/";
@@ -256,8 +257,8 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
      *            the cache to add
      * @return {@code true} if the cache was successfully added, {@code false} otherwise
      */
-
-    public static boolean addToFavorites(final Geocache cache) {
+    @Override
+    public boolean addToFavorites(@NonNull final Geocache cache) {
         final boolean added = GCParser.addToFavorites(cache);
         if (added) {
             DataStore.saveChangedCache(cache);
@@ -274,8 +275,8 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
      *            the cache to add
      * @return {@code true} if the cache was successfully added, {@code false} otherwise
      */
-
-    public static boolean removeFromFavorites(final Geocache cache) {
+    @Override
+    public boolean removeFromFavorites(@NonNull final Geocache cache) {
         final boolean removed = GCParser.removeFromFavorites(cache);
         if (removed) {
             DataStore.saveChangedCache(cache);
@@ -322,12 +323,12 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
 
     @Override
     public boolean supportsFavoritePoints(@NonNull final Geocache cache) {
-        return !cache.getType().isEvent();
+        return Settings.isGCPremiumMember() && !cache.getType().isEvent()  && !cache.isOwner();
     }
 
     @Override
-    public boolean supportsAddToFavorite(final Geocache cache, final LogType type) {
-        return cache.supportsFavoritePoints() && Settings.isGCPremiumMember() && !cache.isOwner() && type.isFoundLog();
+    public boolean supportsAddToFavorite(@NonNull final Geocache cache, final LogType type) {
+        return cache.supportsFavoritePoints() && type.isFoundLog();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/gc/GCLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLoggingManager.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.connector.AbstractLoggingManager;
+import cgeo.geocaching.connector.ILoggingWithFavorites;
 import cgeo.geocaching.connector.ImageResult;
 import cgeo.geocaching.connector.LogResult;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
@@ -36,7 +37,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.LoaderCallbacks<String> {
+class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.LoaderCallbacks<String>, ILoggingWithFavorites {
 
     private final LogCacheActivity activity;
     private final Geocache cache;
@@ -213,7 +214,7 @@ class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.L
     }
 
     @Override
-    public int getPremFavoritePoints() {
+    public int getFavoritePoints() {
         return (hasLoaderError || hasFavPointLoadError) ? 0 : premFavcount;
     }
 

--- a/main/src/cgeo/geocaching/connector/su/SuApiEndpoint.java
+++ b/main/src/cgeo/geocaching/connector/su/SuApiEndpoint.java
@@ -13,6 +13,7 @@ enum SuApiEndpoint {
     CACHE_LIST_KEYWORD("/api/list_keyword.php", OAuthLevel.Level1),
     NOTE("/api/note.php", OAuthLevel.Level1),
     MARK("/api/mark.php", OAuthLevel.Level1),
+    RECOMMENDATION("/api/recommendation.php", OAuthLevel.Level1),
     POST_IMAGE("/api/photo.php", OAuthLevel.Level1),
     USER("/api/profile.php", OAuthLevel.Level1),
     PERSONAL_NOTE("/api/personal_note.php", OAuthLevel.Level1);

--- a/main/src/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/cgeo/geocaching/connector/su/SuConnector.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.connector.ILoggingManager;
 import cgeo.geocaching.connector.UserInfo;
 import cgeo.geocaching.connector.UserInfo.UserInfoStatus;
+import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.IOAuthCapability;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
@@ -38,7 +39,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class SuConnector extends AbstractConnector implements ISearchByCenter, ISearchByGeocode, ISearchByViewPort, ILogin, IOAuthCapability, WatchListCapability, PersonalNoteCapability, ISearchByKeyword, ISearchByOwner {
+public class SuConnector extends AbstractConnector implements ISearchByCenter, ISearchByGeocode, ISearchByViewPort, ILogin, IOAuthCapability, WatchListCapability, PersonalNoteCapability, ISearchByKeyword, ISearchByOwner, IFavoriteCapability {
 
     private static final CharSequence PREFIX_MULTISTEP_VIRTUAL = "MV";
     private static final CharSequence PREFIX_TRADITIONAL = "TR";
@@ -358,6 +359,50 @@ public class SuConnector extends AbstractConnector implements ISearchByCenter, I
             Log.e("SuConnector.searchByOwner failed: ", e);
             return new SearchResult(StatusCode.UNKNOWN_ERROR);
         }
+    }
+
+    /**
+     * Add the cache to favorites
+     *
+     * @param cache
+     * @return True - success/False - failure
+     */
+    @Override
+    public boolean addToFavorites(@NonNull final Geocache cache) {
+        return SuApi.setRecommendation(cache, true);
+    }
+
+    /**
+     * Remove the cache from favorites
+     *
+     * @param cache
+     * @return True - success/False - failure
+     */
+    @Override
+    public boolean removeFromFavorites(@NonNull final Geocache cache) {
+        return SuApi.setRecommendation(cache, false);
+    }
+
+    /**
+     * enable/disable favorite points controls in cache details
+     *
+     * @param cache
+     */
+    @Override
+    public boolean supportsFavoritePoints(@NonNull final Geocache cache) {
+        return !cache.isOwner();
+    }
+
+    /**
+     * Check whether to show favorite controls during logging for the given log type
+     *
+     * @param cache a cache that this connector must be able to handle
+     * @param type  a log type selected by the user
+     * @return true, when cache can be added to favorite
+     */
+    @Override
+    public boolean supportsAddToFavorite(@NonNull final Geocache cache, final LogType type) {
+        return type == LogType.FOUND_IT && cache.supportsFavoritePoints();
     }
 
     /**

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.activity.SimpleWebviewActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.ILoggingManager;
+import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.capability.WatchListCapability;
@@ -570,7 +571,8 @@ public class Geocache implements IWaypoint {
     }
 
     public boolean supportsFavoritePoints() {
-        return getConnector().supportsFavoritePoints(this);
+        final IConnector connector = getConnector();
+        return (connector instanceof IFavoriteCapability) && ((IFavoriteCapability) connector).supportsFavoritePoints(this);
     }
 
     public boolean supportsLogging() {


### PR DESCRIPTION
This is implementation of #7183 splitting Favorites functionality to separated interfaces in order to decouple it from geocaching.com and make it reusable for other services.

Also this implements favorites support using new interface in GC.SU connector.

Fixes #7183
Unblocks #3879