### PR TITLE
refine viewport caching searchresults (fix #8260)

### DIFF
--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -33,7 +33,6 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.AndroidRxUtils;
-import cgeo.geocaching.utils.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -339,24 +338,10 @@ public final class ConnectorFactory {
 
     /**
      * @see ISearchByViewPort#searchByViewport
-     * @param forceByZoomlevel: reset cache if true and cached searchResult >= 400 results and requested viewport changed
-     *  */
+     */
     @NonNull
-    public static SearchResult searchByViewport(@NonNull final Viewport viewport, final boolean forceByZoomlevel) {
-        final boolean viewportChanged = (null == lastViewportUsed) || !viewport.equals(lastViewportUsed);
-        final boolean skipCache = forceByZoomlevel && null != lastSearchResult && lastSearchResult.getCount() >= 400 && viewportChanged;
-        if (null != lastViewportUsed && lastViewportUsed.includes(viewport) && !skipCache) {
-            Log.d("searchByViewport: saved searchResult reused");            // @todo delete this line after testing
-            return lastSearchResult;
-        }
-
-        // @todo delete next two lines after testing
-        counterSearchByViewport++;
-        Log.d("called searchByViewport #" + counterSearchByViewport);
-
-        lastViewportUsed = viewport.resize(3);
-        lastSearchResult = SearchResult.parallelCombineActive(searchByViewPortConns, connector -> connector.searchByViewport(lastViewportUsed));
-        return lastSearchResult;
+    public static SearchResult searchByViewport(@NonNull final Viewport viewport) {
+        return SearchResult.parallelCombineActive(searchByViewPortConns, connector -> connector.searchByViewport(viewport));
     }
 
     @Nullable

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -257,7 +257,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
                 final Viewport viewport = new Viewport(mockedCache, 0.003, 0.003);
 
                 // check coords
-                final SearchResult search = ConnectorFactory.searchByViewport(viewport, false);
+                final SearchResult search = ConnectorFactory.searchByViewport(viewport);
                 assertThat(search).isNotNull();
                 assertThat(search.getGeocodes()).contains(mockedCache.getGeocode());
                 final Geocache parsedCache = DataStore.loadCache(mockedCache.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
@@ -32,41 +32,28 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
 
             {
                 final Viewport viewport = new Viewport(new Geopoint("N 52° 25.369 E 9° 35.499"), new Geopoint("N 52° 25.600 E 9° 36.200"));
-                final SearchResult searchResult = ConnectorFactory.searchByViewport(viewport, false);
+                final SearchResult searchResult = ConnectorFactory.searchByViewport(viewport);
                 assertThat(searchResult).isNotNull();
                 assertThat(searchResult.isEmpty()).isFalse();
-                // ConnectorFactory.searchByViewport enlarges the viewport automatically for better caching, so test along the enlarged bounding box
-                assertThat(searchResult.getGeocodes()).contains("GC4ER5H");
-                assertThat(searchResult.getGeocodes()).doesNotContain("GC4V0HV");
+                assertThat(searchResult.getGeocodes()).contains("GC1J1CT");
+                assertThat(searchResult.getGeocodes()).doesNotContain("GC4ER5H");
             }
 
             {
-                final Viewport viewport = new Viewport(new Geopoint("N 52° 24.000 E 9° 34.500"), new Geopoint("N 52° 26.000 E 9° 38.500"));
-                final SearchResult searchResult = ConnectorFactory.searchByViewport(viewport, false);
+                final Viewport viewport = new Viewport(new Geopoint("N 51° 36.000 E 7° 50.500"), new Geopoint("N 51° 37.350 E7° 51.500"));
+                final SearchResult searchResult = ConnectorFactory.searchByViewport(viewport);
                 assertThat(searchResult).isNotNull();
-                assertThat(searchResult.getGeocodes()).contains("GC4ER5H");
-            }
-
-            {
-                final Viewport viewport = new Viewport(new Geopoint("N 51° 36.000 E 7° 51.000"), new Geopoint("N 51° 37.000 E7° 51.500"));
-                final SearchResult searchResult = ConnectorFactory.searchByViewport(viewport, false);
-                assertThat(searchResult).isNotNull();
-                assertThat(searchResult.getGeocodes()).contains("GC75NF6");
+                assertThat(searchResult.getGeocodes()).contains("GC75NF6"); // N 51° 37.320 E 007° 50.600
 
                 // redo search with a smaller viewport completely contained in the last one - should lead to an identical searchResult due to caching
                 final Viewport viewport2 = new Viewport(new Geopoint("N 51° 36.500 E 7° 51.200"), new Geopoint("N 51° 36.750 E7° 51.400"));
-                final SearchResult searchResult2 = ConnectorFactory.searchByViewport(viewport2, false);
+                final SearchResult searchResult2 = ConnectorFactory.searchByViewport(viewport2);
                 assertThat(searchResult.equals(searchResult2));
 
-                // redo search with a slightly larger viewport - should lead to an identical searchResult due to caching
-                final Viewport viewport3 = new Viewport(new Geopoint("N 51° 35.800 E 7° 50.950"), new Geopoint("N 51° 37.250 E7° 51.600"));
-                final SearchResult searchResult3 = ConnectorFactory.searchByViewport(viewport3, false);
-                assertThat(searchResult.equals(searchResult3));
-
                 // redo search with a way bigger viewport - caching does not help here, so a new searchResult should be delivered
-                final Viewport viewport4 = new Viewport(new Geopoint("N 51° 35.000 E 7° 50.000"), new Geopoint("N 51° 38.000 E7° 52.000"));
-                final SearchResult searchResult4 = ConnectorFactory.searchByViewport(viewport4, false);
-                assertThat(!searchResult.equals(searchResult4));
+                final Viewport viewport3 = new Viewport(new Geopoint("N 51° 35.000 E 7° 50.000"), new Geopoint("N 51° 38.000 E7° 52.000"));
+                final SearchResult searchResult3 = ConnectorFactory.searchByViewport(viewport3);
+                assertThat(!searchResult.equals(searchResult3));
             }
         } finally {
             // restore user settings


### PR DESCRIPTION
Refine viewport caching results: If we retrieved a sufficient amount of caches in searchByViewport (400+) do not longer use the queried viewport as cached area but the bounding box of caches returned.
(as described in https://github.com/cgeo/cgeo/issues/8260#issuecomment-629660662)