### PR TITLE
Code cleanup: Move display metrics functions to DisplayUtils

### DIFF
--- a/main/src/cgeo/geocaching/maps/DistanceDrawer.java
+++ b/main/src/cgeo/geocaching/maps/DistanceDrawer.java
@@ -1,11 +1,10 @@
 package cgeo.geocaching.maps;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.maps.interfaces.MapViewImpl;
+import cgeo.geocaching.utils.DisplayUtils;
 
-import android.content.Context;
 import android.graphics.BlurMaskFilter;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -14,7 +13,6 @@ import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.location.Location;
 import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 public class DistanceDrawer {
     private final Geopoint destinationCoords;
@@ -44,10 +42,7 @@ public class DistanceDrawer {
         this.destinationCoords = destinationCoords;
         this.showBothDistances = showBothDistances;
 
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-
+        final DisplayMetrics metrics = DisplayUtils.getDisplayMetrics();
         final float pixelDensity = metrics.density;
 
         boxPadding = 2;

--- a/main/src/cgeo/geocaching/maps/ScaleDrawer.java
+++ b/main/src/cgeo/geocaching/maps/ScaleDrawer.java
@@ -1,19 +1,16 @@
 package cgeo.geocaching.maps;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.maps.interfaces.GeoPointImpl;
 import cgeo.geocaching.maps.interfaces.MapViewImpl;
+import cgeo.geocaching.utils.DisplayUtils;
 import cgeo.geocaching.utils.Log;
 
-import android.content.Context;
 import android.graphics.BlurMaskFilter;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Typeface;
-import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -26,10 +23,7 @@ public class ScaleDrawer {
     private float pixelDensity = 0;
 
     public ScaleDrawer() {
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-        pixelDensity = metrics.density;
+        pixelDensity = DisplayUtils.getDisplayDensity();
     }
 
     private static double keepSignificantDigit(final double distance) {

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -9,15 +9,13 @@ import cgeo.geocaching.maps.routing.Route;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AngleUtils;
+import cgeo.geocaching.utils.DisplayUtils;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.location.Location;
-import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -187,12 +185,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     }
 
     private PolylineOptions getDirectionPolyline(final Geopoint from, final Geopoint to) {
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-
         final PolylineOptions options = new PolylineOptions()
-                .width(5f * metrics.density)
+                .width(5f * DisplayUtils.getDisplayDensity())
                 .color(0x80EB391E)
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(from.getLatitude(), from.getLongitude()));

--- a/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
@@ -1,20 +1,17 @@
 package cgeo.geocaching.maps.mapsforge;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.interfaces.MapItemFactory;
 import cgeo.geocaching.maps.interfaces.MapProjectionImpl;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.CanvasUtils;
+import cgeo.geocaching.utils.DisplayUtils;
 
-import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Point;
 import android.location.Location;
-import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 import java.util.ArrayList;
 
@@ -36,13 +33,7 @@ public class DirectionDrawer {
         this.destinationCoords = coords;
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
         this.postRealDistance = postRealDistance;
-
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-
-        width = 8f * metrics.density;
-
+        width = 8f * DisplayUtils.getDisplayDensity();
     }
 
     public void setCoordinates(final Location coordinatesIn) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
@@ -1,12 +1,10 @@
 package cgeo.geocaching.maps.mapsforge.v6.caches;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.IConversion;
 import cgeo.geocaching.maps.mapsforge.v6.TapHandler;
+import cgeo.geocaching.utils.DisplayUtils;
 
-import android.content.Context;
 import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Paint;
@@ -25,10 +23,7 @@ public class GeoitemLayer extends Marker {
 
     static {
 
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-
+        final DisplayMetrics metrics = DisplayUtils.getDisplayMetrics();
         tapSpanRadius = metrics.densityDpi * tapSpanInches / 2.0;
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -1,14 +1,11 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.DisplayUtils;
 
-import android.content.Context;
 import android.location.Location;
-import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 import androidx.core.util.Pair;
 
@@ -40,12 +37,7 @@ public class NavigationLayer extends Layer {
 
         this.destinationCoords = coords;
         this.postRealDistance = postRealDistance;
-
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-
-        width = 8f * metrics.density;
+        width = 8f * DisplayUtils.getDisplayDensity();
     }
 
     public void setDestination(final Geopoint coords) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -1,12 +1,8 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.routing.Route;
-
-import android.content.Context;
-import android.util.DisplayMetrics;
-import android.view.WindowManager;
+import cgeo.geocaching.utils.DisplayUtils;
 
 import androidx.core.util.Pair;
 
@@ -39,11 +35,7 @@ public class RouteLayer extends Layer implements Route.RouteUpdater {
 
     public RouteLayer(final PostRealDistance postRealRouteDistance) {
         this.postRealRouteDistance = postRealRouteDistance;
-
-        final DisplayMetrics metrics = new DisplayMetrics();
-        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
-        windowManager.getDefaultDisplay().getMetrics(metrics);
-        width = 8f * metrics.density;
+        width = 8f * DisplayUtils.getDisplayDensity();
     }
 
     public void updateRoute(final ArrayList<Geopoint> route, final float distance) {

--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.util.DisplayMetrics;
 import android.view.WindowManager;
 
 public class DisplayUtils {
@@ -17,5 +18,17 @@ public class DisplayUtils {
         ((WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE))
                 .getDefaultDisplay().getSize(dimensions);
         return dimensions;
+    }
+
+    public static float getDisplayDensity() {
+        final DisplayMetrics metrics = getDisplayMetrics();
+        return metrics.density;
+    }
+
+    public static DisplayMetrics getDisplayMetrics() {
+        final DisplayMetrics metrics = new DisplayMetrics();
+        final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
+        windowManager.getDefaultDisplay().getMetrics(metrics);
+        return metrics;
     }
 }


### PR DESCRIPTION
We query display metrics in several places, reusing the same duplicated code fragment several times. => Therefore moved it into utility class `DisplayUtils`.