### PR TITLE
unify map lines stroke width between GMv2 and OSM maps

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -186,7 +186,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
 
     private PolylineOptions getDirectionPolyline(final Geopoint from, final Geopoint to) {
         final PolylineOptions options = new PolylineOptions()
-                .width(5f * DisplayUtils.getDisplayDensity())
+                .width(DisplayUtils.getThinLineWidth())
                 .color(0x80EB391E)
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(from.getLatitude(), from.getLongitude()));
@@ -286,7 +286,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                 historyObjs.addPolyline(new PolylineOptions()
                     .addAll(points)
                     .color(0xFFFFFFFF)
-                    .width(3)
+                    .width(DisplayUtils.getThinLineInsetWidth())
                     .zIndex(ZINDEX_HISTORY)
                 );
 
@@ -294,7 +294,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                 historyObjs.addPolyline(new PolylineOptions()
                     .addAll(points)
                     .color(trailColor)
-                    .width(7)
+                    .width(DisplayUtils.getThinLineWidth())
                     .zIndex(ZINDEX_HISTORY_SHADOW)
                 );
             }
@@ -307,7 +307,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
             routeObjs.addPolyline(new PolylineOptions()
                     .addAll(route)
                     .color(0xFF0000FF)
-                    .width(7)
+                    .width(DisplayUtils.getThinLineWidth())
                     .zIndex(ZINDEX_ROUTE)
             );
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
@@ -33,7 +33,7 @@ public class DirectionDrawer {
         this.destinationCoords = coords;
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
         this.postRealDistance = postRealDistance;
-        width = 8f * DisplayUtils.getDisplayDensity();
+        width = DisplayUtils.getThinLineWidth();
     }
 
     public void setCoordinates(final Location coordinatesIn) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.maps.PositionHistory;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.DisplayUtils;
 
 import android.location.Location;
 
@@ -49,13 +50,13 @@ public class HistoryLayer extends Layer {
 
         if (historyLine == null) {
             historyLine = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLine.setStrokeWidth(3.0f);
+            historyLine.setStrokeWidth(DisplayUtils.getThinLineInsetWidth());
             historyLine.setColor(0xFFFFFFFF);
         }
 
         if (historyLineShadow == null) {
             historyLineShadow = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLineShadow.setStrokeWidth(7.0f);
+            historyLineShadow.setStrokeWidth(DisplayUtils.getThinLineWidth());
             historyLineShadow.setColor(trailColor);
         }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -37,7 +37,7 @@ public class NavigationLayer extends Layer {
 
         this.destinationCoords = coords;
         this.postRealDistance = postRealDistance;
-        width = 8f * DisplayUtils.getDisplayDensity();
+        width = DisplayUtils.getThinLineWidth();
     }
 
     public void setDestination(final Geopoint coords) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -35,7 +35,7 @@ public class RouteLayer extends Layer implements Route.RouteUpdater {
 
     public RouteLayer(final PostRealDistance postRealRouteDistance) {
         this.postRealRouteDistance = postRealRouteDistance;
-        width = 8f * DisplayUtils.getDisplayDensity();
+        width = DisplayUtils.getThinLineWidth();
     }
 
     public void updateRoute(final ArrayList<Geopoint> route, final float distance) {

--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -9,6 +9,9 @@ import android.view.WindowManager;
 
 public class DisplayUtils {
 
+    private static final float THIN_LINE = 5f;
+    private static final float THIN_LINE_INSET = THIN_LINE / 2;
+
     private DisplayUtils() {
         // Utility class, do not instantiate
     }
@@ -30,5 +33,13 @@ public class DisplayUtils {
         final WindowManager windowManager = (WindowManager) CgeoApplication.getInstance().getSystemService(Context.WINDOW_SERVICE);
         windowManager.getDefaultDisplay().getMetrics(metrics);
         return metrics;
+    }
+
+    public static float getThinLineWidth() {
+        return THIN_LINE * getDisplayDensity();
+    }
+
+    public static float getThinLineInsetWidth() {
+        return THIN_LINE_INSET * getDisplayDensity();
     }
 }


### PR DESCRIPTION
- unify the different stroke widths in GMv2 and OSM
- use a density based width for history line and route