### PR TITLE
add mapcache bounding box for GMv2 when in debug mode

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -21,6 +21,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.location.WaypointDistanceInfo;
+import cgeo.geocaching.maps.google.v2.GooglePositionAndHistory;
 import cgeo.geocaching.maps.interfaces.CachesOverlayItemImpl;
 import cgeo.geocaching.maps.interfaces.GeneralOverlay;
 import cgeo.geocaching.maps.interfaces.GeoPointImpl;
@@ -1439,6 +1440,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             lastSearchResult = searchResult;
             if (null == lastViewport || (!caches.isEmpty() && lastSearchResult.getCount() > 400)) {
                 lastViewport = containing(caches);
+                if (Settings.isDebug() && overlayPositionAndScale instanceof GooglePositionAndHistory) {
+                    ((GooglePositionAndHistory) overlayPositionAndScale).drawViewport(lastViewport);
+                }
             }
             Log.d("searchByViewport: cached=" + useLastSearchResult + ", results=" + lastSearchResult.getCount() + ", viewport=" + lastViewport);
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps.google.v2;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.PositionHistory;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
 import cgeo.geocaching.maps.routing.Route;
@@ -66,6 +67,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     private static Bitmap locationIcon;
 
     private ArrayList<LatLng> route = null;
+    private Viewport lastViewport = null;
 
 
     public GooglePositionAndHistory(final GoogleMap googleMap, final GoogleMapView mapView, final GoogleMapView.PostRealDistance postRealDistance, final GoogleMapView.PostRealDistance postRouteDistance) {
@@ -174,6 +176,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
             drawHistory();
         }
         drawRoute();
+        drawViewport(lastViewport);
     }
 
 
@@ -311,6 +314,24 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                     .zIndex(ZINDEX_ROUTE)
             );
         }
+    }
+
+    public synchronized void drawViewport(final Viewport viewport) {
+        if (null == viewport) {
+            return;
+        }
+        final PolylineOptions options = new PolylineOptions()
+                .width(DisplayUtils.getThinLineWidth())
+                .color(0x80EB391E)
+                .zIndex(ZINDEX_DIRECTION_LINE)
+                .add(new LatLng(viewport.getLatitudeMin(), viewport.getLongitudeMin()))
+                .add(new LatLng(viewport.getLatitudeMin(), viewport.getLongitudeMax()))
+                .add(new LatLng(viewport.getLatitudeMax(), viewport.getLongitudeMax()))
+                .add(new LatLng(viewport.getLatitudeMax(), viewport.getLongitudeMin()))
+                .add(new LatLng(viewport.getLatitudeMin(), viewport.getLongitudeMin()));
+
+        positionObjs.addPolyline(options);
+        lastViewport = viewport;
     }
 
 }


### PR DESCRIPTION
For testing #8260/#8364:
- activate debug mode in c:geo settings
- go to Google Maps live map
- zoom out until max. number of caches got loaded => see red box around it
- red box will move when you start panning the map and caches get loaded additionally

see https://github.com/cgeo/cgeo/issues/8260#issuecomment-633713331 for examples