### PR TITLE
auto select compact icon mode (optional) (fix #8261)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -87,11 +87,25 @@
                 app:showAsAction="ifRoom|withText">
             </item>
             <item
-                android:id="@+id/menu_dot_mode"
-                android:checkable="true"
+                android:id="@+id/menu_compactIconMode"
                 android:icon="@drawable/ic_menu_dot_mode"
                 android:title="@string/map_dot_mode"
                 app:showAsAction="ifRoom|withText">
+                <menu>
+                    <group
+                        android:id="@+id/menu_group_compactIconMode"
+                        android:checkableBehavior="single" >
+                        <item
+                            android:id="@+id/menu_map_compactIconModeOff"
+                            android:title="@string/switch_off" />
+                        <item
+                            android:id="@+id/menu_map_compactIconModeOn"
+                            android:title="@string/switch_on" />
+                        <item
+                            android:id="@+id/menu_map_compactIconModeAuto"
+                            android:title="@string/switch_auto" />
+                    </group>
+                </menu>
             </item>
         </menu>
     </item>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -111,7 +111,7 @@
     <string translatable="false" name="pref_mapline_circlecolor">mapline_circlecolor</string>
     <string translatable="false" name="pref_mapline_circlefillcolor">mapline_circlefillcolor</string>
     <string translatable="false" name="pref_showListsInCacheList">showListsInCacheList</string>
-    <string translatable="false" name="pref_dot_mode">dot_mode</string>
+    <string translatable="false" name="pref_compactIconMode">compactIconMode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>
     <string translatable="false" name="pref_defaultNavigationTool2">defaultNavigationTool2</string>
     <string translatable="false" name="pref_gpxExportDir">gpxExportDir</string>
@@ -259,4 +259,8 @@
     <string translatable="false" name="pref_maprotation_off">off</string>
     <string translatable="false" name="pref_maprotation_manual">manual</string>
     <string translatable="false" name="pref_maprotation_auto">auto</string>
+
+    <string translatable="false" name="pref_compacticon_off">off</string>
+    <string translatable="false" name="pref_compacticon_on">manual</string>
+    <string translatable="false" name="pref_compacticon_auto">auto</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1714,6 +1714,7 @@
 
     <!-- switch settings -->
     <string name="switch_off">Off</string>
+    <string name="switch_on">On</string>
     <string name="switch_manual">Manual</string>
     <string name="switch_auto">Automatic</string>
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -7,7 +7,9 @@ import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.location.WaypointDistanceInfo;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
 import cgeo.geocaching.maps.mapsforge.v6.MfMapView;
+import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.CompactIconModeUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,6 +29,7 @@ public class CachesBundle {
     private static final int STORED_SEPARATOR = 3;
     private static final int LIVE_SEPARATOR = 4;
 
+    public static final int NO_OVERLAY_ID = -1;
     private static final int WP_OVERLAY_ID = 0;
     private static final int BASE_OVERLAY_ID = 1;
     private static final int STORED_OVERLAY_ID = 2;
@@ -51,7 +54,7 @@ public class CachesBundle {
      * @param mapView     the map view this bundle is displayed on
      * @param mapHandlers the handlers of the map to send events to
      */
-    public CachesBundle(final MfMapView mapView, final MapHandlers mapHandlers) {
+    public CachesBundle(final NewMap map, final MfMapView mapView, final MapHandlers mapHandlers) {
         this.mapView = mapView;
         this.mapHandlers = mapHandlers;
 
@@ -72,7 +75,7 @@ public class CachesBundle {
         this.separators.add(separator5);
         this.mapView.getLayerManager().getLayers().add(separator5);
 
-        this.wpOverlay = new WaypointsOverlay(WP_OVERLAY_ID, this.geoEntries, this, separators.get(WP_SEPERATOR), this.mapHandlers);
+        this.wpOverlay = new WaypointsOverlay(map, WP_OVERLAY_ID, this.geoEntries, this, separators.get(WP_SEPERATOR), this.mapHandlers);
     }
 
     /**
@@ -82,9 +85,9 @@ public class CachesBundle {
      * @param mapView     the map view this bundle is displayed on
      * @param mapHandlers the handlers of the map to send events to
      */
-    public CachesBundle(final SearchResult search, final MfMapView mapView, final MapHandlers mapHandlers) {
-        this(mapView, mapHandlers);
-        this.baseOverlay = new CachesOverlay(search, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers);
+    public CachesBundle(final NewMap map, final SearchResult search, final MfMapView mapView, final MapHandlers mapHandlers) {
+        this(map, mapView, mapHandlers);
+        this.baseOverlay = new CachesOverlay(map, search, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers);
     }
 
     /**
@@ -94,10 +97,10 @@ public class CachesBundle {
      * @param mapView     the map view this bundle is displayed on
      * @param mapHandlers the handlers of the map to send events to
      */
-    public CachesBundle(final String geocode, final MfMapView mapView, final MapHandlers mapHandlers) {
-        this(mapView, mapHandlers);
+    public CachesBundle(final NewMap map, final String geocode, final MfMapView mapView, final MapHandlers mapHandlers) {
+        this(map, mapView, mapHandlers);
         this.mapModeSingle = true;
-        this.baseOverlay = new CachesOverlay(geocode, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers);
+        this.baseOverlay = new CachesOverlay(map, geocode, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers);
     }
 
     /**
@@ -108,16 +111,16 @@ public class CachesBundle {
      * @param mapView      the map view this bundle is displayed on
      * @param mapHandlers  the handlers of the map to send events to
      */
-    public CachesBundle(final Geopoint coords, final WaypointType waypointType, final MfMapView mapView, final MapHandlers mapHandlers) {
-        this(mapView, mapHandlers);
-        this.baseOverlay = new SinglePointOverlay(coords, waypointType, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers);
+    public CachesBundle(final NewMap map, final Geopoint coords, final WaypointType waypointType, final MfMapView mapView, final MapHandlers mapHandlers) {
+        this(map, mapView, mapHandlers);
+        this.baseOverlay = new SinglePointOverlay(map, coords, waypointType, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers);
     }
 
-    public void handleLiveLayers(final boolean enable) {
+    public void handleLiveLayers(final NewMap map, final boolean enable) {
         if (enable) {
             if (this.liveOverlay == null) {
                 final SeparatorLayer separator2 = this.separators.get(LIVE_SEPARATOR);
-                this.liveOverlay = new LiveCachesOverlay(LIVE_OVERLAY_ID, this.geoEntries, this, separator2, this.mapHandlers);
+                this.liveOverlay = new LiveCachesOverlay(map, LIVE_OVERLAY_ID, this.geoEntries, this, separator2, this.mapHandlers);
             }
         } else {
             // Disable only download, keep stored caches
@@ -133,13 +136,13 @@ public class CachesBundle {
      *
      * @param enable true - enable stored layer, false - leave untouched
      */
-    public void enableStoredLayers(final boolean enable) {
+    public void enableStoredLayers(final NewMap map, final boolean enable) {
         if (!enable || this.storedOverlay != null) {
             return;
         }
 
         final SeparatorLayer separator1 = this.separators.get(STORED_SEPARATOR);
-        this.storedOverlay = new StoredCachesOverlay(STORED_OVERLAY_ID, this.geoEntries, this, separator1, this.mapHandlers);
+        this.storedOverlay = new StoredCachesOverlay(map, STORED_OVERLAY_ID, this.geoEntries, this, separator1, this.mapHandlers);
     }
 
     public void onDestroy() {
@@ -161,21 +164,22 @@ public class CachesBundle {
         this.separators.clear();
     }
 
-    public int getVisibleCachesCount() {
-
-        int result = 0;
-
-        if (this.baseOverlay != null) {
+    public int getVisibleCachesCount(final int exceptOverlayId, final int countForThisOverlay) {
+        int result = countForThisOverlay;
+        if (this.baseOverlay != null && exceptOverlayId != BASE_OVERLAY_ID) {
             result += this.baseOverlay.getVisibleCachesCount();
         }
-        if (this.storedOverlay != null) {
+        if (this.storedOverlay != null && exceptOverlayId != STORED_OVERLAY_ID) {
             result += this.storedOverlay.getVisibleCachesCount();
         }
-        if (this.liveOverlay != null) {
+        if (this.liveOverlay != null && exceptOverlayId != LIVE_OVERLAY_ID) {
             result += this.liveOverlay.getVisibleCachesCount();
         }
-
         return result;
+    }
+
+    public int getVisibleCachesCount() {
+        return getVisibleCachesCount(NO_OVERLAY_ID, 0);
     }
 
     public Set<String> getVisibleCacheGeocodes() {
@@ -245,17 +249,17 @@ public class CachesBundle {
     /**
      * Forces redraw of all cache layers (e.g. for icon change)
      */
-    public void invalidateAll() {
+    public void invalidateAll(final int exceptOverlay) {
         if (wpOverlay != null) {
             wpOverlay.invalidateAll();
         }
-        if (baseOverlay != null) {
+        if (baseOverlay != null && exceptOverlay != BASE_OVERLAY_ID) {
             baseOverlay.invalidateAll();
         }
-        if (storedOverlay != null) {
+        if (storedOverlay != null && exceptOverlay != STORED_OVERLAY_ID) {
             storedOverlay.invalidateAll();
         }
-        if (liveOverlay != null) {
+        if (liveOverlay != null && exceptOverlay != LIVE_OVERLAY_ID) {
             liveOverlay.invalidateAll();
         }
         if (wpOverlay != null) {
@@ -303,13 +307,16 @@ public class CachesBundle {
     }
 
     public void handleWaypoints() {
-        if (this.mapModeSingle || getVisibleCachesCount() < Settings.getWayPointsThreshold()) {
+        final int cachesToDisplay = getVisibleCachesCount();
+        if (this.mapModeSingle || cachesToDisplay < Settings.getWayPointsThreshold()) {
             Collection<String> baseGeocodes = Collections.emptyList();
             if (baseOverlay != null) {
                 baseGeocodes = baseOverlay.getCacheGeocodes();
             }
             final boolean showStored = storedOverlay != null;
-            wpOverlay.showWaypoints(baseGeocodes, showStored, !this.mapModeSingle);
+
+            final boolean forceCompactIconMode = CompactIconModeUtils.forceCompactIconMode(cachesToDisplay);
+            wpOverlay.showWaypoints(baseGeocodes, showStored, !this.mapModeSingle, forceCompactIconMode);
         } else {
             wpOverlay.hideWaypoints();
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesOverlay.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
+import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.Log;
 
@@ -24,15 +25,15 @@ public class CachesOverlay extends AbstractCachesOverlay {
     private boolean firstRun = true;
     private boolean updating = false;
 
-    CachesOverlay(final SearchResult search, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
-        super(overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
+    CachesOverlay(final NewMap map, final SearchResult search, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
+        super(map, overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
 
         this.search = search;
         this.timer = startTimer();
     }
 
-    CachesOverlay(final String geocode, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer layerAnchor, final MapHandlers mapHandlers) {
-        super(overlayId, geoEntries, bundle, layerAnchor, mapHandlers);
+    CachesOverlay(final NewMap map, final String geocode, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer layerAnchor, final MapHandlers mapHandlers) {
+        super(map, overlayId, geoEntries, bundle, layerAnchor, mapHandlers);
 
         this.search = new SearchResult();
         this.search.addGeocode(geocode);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.enumerations.LoadFlags.RemoveFlag;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
+import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.Log;
@@ -33,8 +34,8 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
     private SearchResult lastSearchResult = null;
     private Viewport lastViewport = null;
 
-    public LiveCachesOverlay(final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
-        super(overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
+    public LiveCachesOverlay(final NewMap map, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
+        super(map, overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
 
         this.timer = startTimer();
     }
@@ -79,12 +80,12 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
                     if (1000 < (currentTime - overlay.loadThreadRun)) {
                         overlay.downloading = true;
                         previousZoom = zoomNow;
-                        previousViewport = viewportNow;
                         overlay.download();
                     }
                 } else if (!previousViewport.equals(viewportNow)) {
                     overlay.updateTitle();
                 }
+                previousViewport = viewportNow;
             } catch (final Exception e) {
                 Log.w("LiveCachesOverlay.startLoadtimer.start", e);
             } finally {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/SinglePointOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/SinglePointOverlay.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
+import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.utils.AndroidRxUtils;
 
@@ -15,8 +16,8 @@ public class SinglePointOverlay extends AbstractCachesOverlay {
     private final Geopoint coords;
     private final WaypointType type;
 
-    public SinglePointOverlay(final Geopoint coords, final WaypointType type, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
-        super(overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
+    public SinglePointOverlay(final NewMap map, final Geopoint coords, final WaypointType type, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
+        super(map, overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
 
         this.coords = coords;
         this.type = type;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/StoredCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/StoredCachesOverlay.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
+import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
@@ -24,8 +25,8 @@ public class StoredCachesOverlay extends AbstractCachesOverlay {
 
     private final Disposable timer;
 
-    public StoredCachesOverlay(final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
-        super(overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
+    public StoredCachesOverlay(final NewMap map, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
+        super(map, overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
         this.timer = startTimer();
     }
 
@@ -66,12 +67,12 @@ public class StoredCachesOverlay extends AbstractCachesOverlay {
                 if (moved) {
 
                     previousZoom = zoomNow;
-                    previousViewport = viewportNow;
                     overlay.load();
                     overlay.refreshed();
                 } else if (!previousViewport.equals(viewportNow)) {
                     overlay.updateTitle();
                 }
+                previousViewport = viewportNow;
             } catch (final Exception e) {
                 Log.w("StoredCachesOverlay.startLoadtimer.start", e);
             }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
+import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
@@ -18,8 +19,8 @@ import java.util.Set;
 import org.mapsforge.map.layer.Layer;
 
 public class WaypointsOverlay extends AbstractCachesOverlay {
-    public WaypointsOverlay(final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
-        super(overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
+    public WaypointsOverlay(final NewMap map, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
+        super(map, overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
     }
 
     void hideWaypoints() {
@@ -54,12 +55,10 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         return waypoints;
     }
 
-    void showWaypoints(final Collection<String> baseGeoCodes, final boolean showStored, final boolean checkOwnership) {
+    protected void showWaypoints(final Collection<String> baseGeoCodes, final boolean showStored, final boolean checkOwnership, final boolean forceCompactIconMode) {
         final Collection<String> removeCodes = getGeocodes();
         final Collection<String> newCodes = new HashSet<>();
-
         final Set<Waypoint> waypoints = filterWaypoints(baseGeoCodes, showStored, checkOwnership);
-        final boolean isDotMode = Settings.isDotMode();
 
         for (final Waypoint waypoint : waypoints) {
             if (waypoint == null || waypoint.getCoords() == null) {
@@ -68,7 +67,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
             if (removeCodes.contains(waypoint.getGpxId())) {
                 removeCodes.remove(waypoint.getGpxId());
             } else {
-                if (addItem(waypoint, isDotMode)) {
+                if (addItem(waypoint, forceCompactIconMode)) {
                     newCodes.add(waypoint.getGpxId());
                 }
             }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -84,6 +84,10 @@ public class Settings {
     public static final int MAPROTATION_MANUAL = 1;
     public static final int MAPROTATION_AUTO = 2;
 
+    public static final int COMPACTICON_OFF = 0;
+    public static final int COMPACTICON_ON = 1;
+    public static final int COMPACTICON_AUTO = 2;
+
     private static final int MAP_SOURCE_DEFAULT = GoogleMapProvider.GOOGLE_MAP_ID.hashCode();
 
     private static final String PHONE_MODEL_AND_SDK = Build.MODEL + "/" + Build.VERSION.SDK_INT;
@@ -836,12 +840,31 @@ public class Settings {
         return getInt(prefKeyId, getKeyInt(defaultValueKeyId));
     }
 
-    public static boolean isDotMode() {
-        return getBoolean(R.string.pref_dot_mode, false);
+    public static int getCompactIconMode() {
+        final String prefValue = getString(R.string.pref_compactIconMode, "");
+        if (prefValue.equals(getKey(R.string.pref_compacticon_on))) {
+            return COMPACTICON_ON;
+        } else if (prefValue.equals(getKey(R.string.pref_compacticon_auto))) {
+            return COMPACTICON_AUTO;
+        }
+        return COMPACTICON_OFF;
     }
 
-    public static void setDotMode(final boolean dotMode) {
-        putBoolean(R.string.pref_dot_mode, dotMode);
+    public static void setCompactIconMode(final int compactIconMode) {
+        switch (compactIconMode) {
+            case COMPACTICON_OFF:
+                putString(R.string.pref_compactIconMode, getKey(R.string.pref_compacticon_off));
+                break;
+            case COMPACTICON_ON:
+                putString(R.string.pref_compactIconMode, getKey(R.string.pref_compacticon_on));
+                break;
+            case COMPACTICON_AUTO:
+                putString(R.string.pref_compactIconMode, getKey(R.string.pref_compacticon_auto));
+                break;
+            default:
+                // do nothing except satisfy static code analysis
+                break;
+        }
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/CompactIconModeUtils.java
+++ b/main/src/cgeo/geocaching/utils/CompactIconModeUtils.java
@@ -1,0 +1,70 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.util.DisplayMetrics;
+import android.view.Menu;
+
+public class CompactIconModeUtils {
+
+    private static int compactIconModeThreshold = -1;
+
+    private CompactIconModeUtils() {
+        // utility class
+    }
+
+
+    public static void onPrepareOptionsMenu(final Menu menu) {
+        switch (Settings.getCompactIconMode()) {
+            case Settings.COMPACTICON_OFF:
+                menu.findItem(R.id.menu_map_compactIconModeOff).setChecked(true);
+                break;
+            case Settings.COMPACTICON_ON:
+                menu.findItem(R.id.menu_map_compactIconModeOn).setChecked(true);
+                break;
+            case Settings.COMPACTICON_AUTO:
+                menu.findItem(R.id.menu_map_compactIconModeAuto).setChecked(true);
+                break;
+            default:
+                // do nothing
+        }
+    }
+
+    public static boolean onOptionsMenuItemSelected(final int id, final Runnable setCompactIconMode) {
+        switch (id) {
+            case R.id.menu_map_compactIconModeOff:
+                Settings.setCompactIconMode(Settings.COMPACTICON_OFF);
+                break;
+            case R.id.menu_map_compactIconModeOn:
+                Settings.setCompactIconMode(Settings.COMPACTICON_ON);
+                break;
+            case R.id.menu_map_compactIconModeAuto:
+                Settings.setCompactIconMode(Settings.COMPACTICON_AUTO);
+                break;
+            default:
+                return false;
+        }
+        setCompactIconMode.run();
+        return true;
+    }
+
+    public static void setCompactIconModeThreshold(final Resources resources) {
+        // cache density metrics
+        final Bitmap marker = ((BitmapDrawable) resources.getDrawable(R.drawable.marker)).getBitmap();
+        final DisplayMetrics displayMetrics = resources.getDisplayMetrics();
+        // compactIconModeThreshold = (int) ((displayMetrics.heightPixels / displayMetrics.density) * (displayMetrics.widthPixels / displayMetrics.density) / 1500.0f);
+        compactIconModeThreshold = (int) ((displayMetrics.heightPixels / marker.getHeight()) * (displayMetrics.widthPixels / marker.getWidth()) / 4f);
+    }
+
+    public static boolean forceCompactIconMode(final int size) {
+        if (compactIconModeThreshold == -1) {
+            setCompactIconModeThreshold(Resources.getSystem());
+        }
+        final int compactIconMode = Settings.getCompactIconMode();
+        return compactIconMode == Settings.COMPACTICON_ON || (compactIconMode == Settings.COMPACTICON_AUTO && size >= compactIconModeThreshold);
+    }
+}


### PR DESCRIPTION
- Changed compact icon mode settings to off / on / auto, default=off
- If set to auto: Switches automatically between regular cache markers and compact icon markers.

Threshold is determined by screen size (in px^2) divided by cache marker size (in px^2) divided by 4, so a maximum of one fourth of the screen space is covered by cache markers until display switches to compact icon markers, if mode is set to AUTO.