### PR TITLE
adapt mockfile for GC2JVEH to changed listing

### DIFF
--- a/tests/src-android/cgeo/geocaching/test/mock/GC2JVEH.java
+++ b/tests/src-android/cgeo/geocaching/test/mock/GC2JVEH.java
@@ -83,7 +83,7 @@ public class GC2JVEH extends MockedCache {
 
     @Override
     public String getDescription() {
-        return "<img src=\"http://img.geocaching.com/cache/large/1711f8a1-796a-405b-82ba-8685f2e9f024.jpg\">";
+        return "<img src=\"http://img.geocaching.com/cache/large/1711f8a1-796a-405b-82ba-8685f2e9f024.jpg\" />";
     }
 
     @Override

--- a/tests/src/cgeo/geocaching/test/mock/GC2JVEH.html
+++ b/tests/src/cgeo/geocaching/test/mock/GC2JVEH.html
@@ -651,7 +651,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                     <br />
                     <div class="UserSuppliedContent">
 
-                        <span id="ctl00_ContentBody_LongDescription"><img src="http://img.geocaching.com/cache/large/1711f8a1-796a-405b-82ba-8685f2e9f024.jpg"></span>
+                        <span id="ctl00_ContentBody_LongDescription"><img src="http://img.geocaching.com/cache/large/1711f8a1-796a-405b-82ba-8685f2e9f024.jpg" /></span>
 
                     </div>
 


### PR DESCRIPTION
Description in original listing now has an integrated closing tag in the `<img>`-Tag