### PR TITLE
adjust line widths and separate different targets (fix #8393)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -189,7 +189,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
 
     private PolylineOptions getDirectionPolyline(final Geopoint from, final Geopoint to) {
         final PolylineOptions options = new PolylineOptions()
-                .width(DisplayUtils.getThinLineWidth())
+                .width(DisplayUtils.getDirectionLineWidth())
                 .color(0x80EB391E)
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(from.getLatitude(), from.getLongitude()));
@@ -289,7 +289,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                 historyObjs.addPolyline(new PolylineOptions()
                     .addAll(points)
                     .color(0xFFFFFFFF)
-                    .width(DisplayUtils.getThinLineInsetWidth())
+                    .width(DisplayUtils.getHistoryLineInsetWidth())
                     .zIndex(ZINDEX_HISTORY)
                 );
 
@@ -297,7 +297,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                 historyObjs.addPolyline(new PolylineOptions()
                     .addAll(points)
                     .color(trailColor)
-                    .width(DisplayUtils.getThinLineWidth())
+                    .width(DisplayUtils.getHistoryLineShadowWidth())
                     .zIndex(ZINDEX_HISTORY_SHADOW)
                 );
             }
@@ -310,7 +310,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
             routeObjs.addPolyline(new PolylineOptions()
                     .addAll(route)
                     .color(0xFF0000FF)
-                    .width(DisplayUtils.getThinLineWidth())
+                    .width(DisplayUtils.getRouteLineWidth())
                     .zIndex(ZINDEX_ROUTE)
             );
         }
@@ -321,7 +321,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
             return;
         }
         final PolylineOptions options = new PolylineOptions()
-                .width(DisplayUtils.getThinLineWidth())
+                .width(DisplayUtils.getDirectionLineWidth())
                 .color(0x80EB391E)
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(viewport.getLatitudeMin(), viewport.getLongitudeMin()))

--- a/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
@@ -33,7 +33,7 @@ public class DirectionDrawer {
         this.destinationCoords = coords;
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
         this.postRealDistance = postRealDistance;
-        width = DisplayUtils.getThinLineWidth();
+        width = DisplayUtils.getDirectionLineWidth();
     }
 
     public void setCoordinates(final Location coordinatesIn) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.maps.interfaces.GeoPointImpl;
 import cgeo.geocaching.maps.interfaces.MapItemFactory;
 import cgeo.geocaching.maps.interfaces.MapProjectionImpl;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.DisplayUtils;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -64,14 +65,14 @@ public class PositionDrawer {
         if (historyLine == null) {
             historyLine = new Paint();
             historyLine.setAntiAlias(true);
-            historyLine.setStrokeWidth(3.0f);
+            historyLine.setStrokeWidth(DisplayUtils.getHistoryLineInsetWidth());
             historyLine.setColor(0xFFFFFFFF);
         }
 
         if (historyLineShadow == null) {
             historyLineShadow = new Paint();
             historyLineShadow.setAntiAlias(true);
-            historyLineShadow.setStrokeWidth(7.0f);
+            historyLineShadow.setStrokeWidth(DisplayUtils.getHistoryLineShadowWidth());
             historyLineShadow.setColor(trailColor);
         }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -50,13 +50,13 @@ public class HistoryLayer extends Layer {
 
         if (historyLine == null) {
             historyLine = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLine.setStrokeWidth(DisplayUtils.getThinLineInsetWidth());
+            historyLine.setStrokeWidth(DisplayUtils.getHistoryLineInsetWidth());
             historyLine.setColor(0xFFFFFFFF);
         }
 
         if (historyLineShadow == null) {
             historyLineShadow = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLineShadow.setStrokeWidth(DisplayUtils.getThinLineWidth());
+            historyLineShadow.setStrokeWidth(DisplayUtils.getHistoryLineShadowWidth());
             historyLineShadow.setColor(trailColor);
         }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -37,7 +37,7 @@ public class NavigationLayer extends Layer {
 
         this.destinationCoords = coords;
         this.postRealDistance = postRealDistance;
-        width = DisplayUtils.getThinLineWidth();
+        width = DisplayUtils.getDirectionLineWidth();
     }
 
     public void setDestination(final Geopoint coords) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -35,7 +35,7 @@ public class RouteLayer extends Layer implements Route.RouteUpdater {
 
     public RouteLayer(final PostRealDistance postRealRouteDistance) {
         this.postRealRouteDistance = postRealRouteDistance;
-        width = DisplayUtils.getThinLineWidth();
+        width = DisplayUtils.getRouteLineWidth();
     }
 
     public void updateRoute(final ArrayList<Geopoint> route, final float distance) {

--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -9,8 +9,9 @@ import android.view.WindowManager;
 
 public class DisplayUtils {
 
-    private static final float THIN_LINE = 5f;
-    private static final float THIN_LINE_INSET = THIN_LINE / 2;
+    private static final float THIN_LINE = 4f;
+    private static final float HISTORY_LINE_SHADOW = 3f;
+    private static final float HISTORY_LINE_INSET = HISTORY_LINE_SHADOW / 2;
 
     private DisplayUtils() {
         // Utility class, do not instantiate
@@ -35,11 +36,24 @@ public class DisplayUtils {
         return metrics;
     }
 
-    public static float getThinLineWidth() {
+    public static float getRouteLineWidth() {
         return THIN_LINE * getDisplayDensity();
     }
 
-    public static float getThinLineInsetWidth() {
-        return THIN_LINE_INSET * getDisplayDensity();
+    public static float getDirectionLineWidth() {
+        return THIN_LINE * getDisplayDensity();
+    }
+
+    public static float getHistoryLineShadowWidth() {
+        return HISTORY_LINE_SHADOW * getDisplayDensity();
+    }
+
+    public static float getHistoryLineInsetWidth() {
+        return HISTORY_LINE_INSET * getDisplayDensity();
+    }
+
+    // for drawing debug relevant lines
+    public static float getDebugLineWidth() {
+        return THIN_LINE * getDisplayDensity();
     }
 }


### PR DESCRIPTION
- made the common line base a bit smaller (4.0f instead of 5.0f)
- made the history line even smaller to match old GMv2 style (3.0f instead of 5.0f)
- expose widths for different targets (routing, history, direction etc.) as separate functions to be able to make them configurable separately later
