### PR TITLE
skip testFormatStoredAgo on non English device

### DIFF
--- a/tests/src-android/cgeo/geocaching/utils/FormatterTest.java
+++ b/tests/src-android/cgeo/geocaching/utils/FormatterTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Locale;
 
 import junit.framework.TestCase;
+import org.apache.commons.lang3.StringUtils;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 
@@ -94,6 +95,10 @@ public class FormatterTest extends TestCase {
     }
 
     public static void testFormatStoredAgo() {
+        // skip test on non english device
+        if (!StringUtils.equals(Locale.getDefault().getLanguage(), Locale.ENGLISH.getLanguage())) {
+            return;
+        }
         assertThat(Formatter.formatStoredAgo(0)).isEqualTo("Stored in device\n");
         assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 10, "Stored in device\na few minutes ago");
         assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 20, "Stored in device\nabout 20 minutes ago");


### PR DESCRIPTION
The test testFormatStoredAgo only works on a device with language EN.
When testing (e.g. on a dedicated physical device) it fails on devices with other languages.
Therefore we should skip this test in this situation.