### PR TITLE
set all cache connector to https and code refactoring

### DIFF
--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -146,7 +146,7 @@ public abstract class AbstractConnector implements IConnector {
     protected abstract String getCacheUrlPrefix();
 
     @Override
-    public boolean getHttps() {
+    public boolean isHttps() {
         return true;
     }
 
@@ -156,7 +156,7 @@ public abstract class AbstractConnector implements IConnector {
         if (StringUtils.isBlank(getHost())) {
             return "";
         }
-        return (getHttps() ? "https://" : "http://") + getHost();
+        return (isHttps() ? "https://" : "http://") + getHost();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -28,6 +28,8 @@ import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.connector.trackable.TrackableTrackingCode;
 import cgeo.geocaching.connector.trackable.TravelBugConnector;
 import cgeo.geocaching.connector.trackable.UnknownTrackableConnector;
+import cgeo.geocaching.connector.unknown.UnknownConnector;
+import cgeo.geocaching.connector.wm.WaymarkingConnector;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -93,7 +93,7 @@ public interface IConnector {
     /**
      * Return <tt>true<tt> if https must be used.
      */
-    boolean getHttps();
+    boolean isHttps();
 
     /**
      * Get url of the connector server for dynamic loading of data.

--- a/main/src/cgeo/geocaching/connector/ec/ECConnector.java
+++ b/main/src/cgeo/geocaching/connector/ec/ECConnector.java
@@ -34,9 +34,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ECConnector extends AbstractConnector implements ISearchByGeocode, ISearchByCenter, ISearchByViewPort, ILogin, ICredentials {
 
-    // As of 2016-11-17, using https redirects to http
     @NonNull
-    private static final String CACHE_URL = "http://extremcaching.com/index.php/output-2/";
+    private static final String CACHE_URL = "https://extremcaching.com/index.php/output-2/";
 
     /**
      * Pattern for EC codes

--- a/main/src/cgeo/geocaching/connector/ec/package-info.java
+++ b/main/src/cgeo/geocaching/connector/ec/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * <a href="https://extremcaching.com">Extremcaching</a> implementation.
+ */
+package cgeo.geocaching.connector.ec;

--- a/main/src/cgeo/geocaching/connector/ga/GeocachingAustraliaConnector.java
+++ b/main/src/cgeo/geocaching/connector/ga/GeocachingAustraliaConnector.java
@@ -22,11 +22,6 @@ public class GeocachingAustraliaConnector extends AbstractConnector {
     }
 
     @Override
-    public boolean getHttps() {
-        return false;
-    }
-
-    @Override
     @NonNull
     public String getCacheUrl(@NonNull final Geocache cache) {
         return getCacheUrlPrefix() + cache.getGeocode();

--- a/main/src/cgeo/geocaching/connector/ga/package-info.java
+++ b/main/src/cgeo/geocaching/connector/ga/package-info.java
@@ -1,4 +1,4 @@
 /**
- * <a href="http://geocaching.com.au">Geocaching Australia</a> implementation.
+ * <a href="https://geocaching.com.au">Geocaching Australia</a> implementation.
  */
 package cgeo.geocaching.connector.ga;

--- a/main/src/cgeo/geocaching/connector/ge/GeopeitusConnector.java
+++ b/main/src/cgeo/geocaching/connector/ge/GeopeitusConnector.java
@@ -46,6 +46,6 @@ public class GeopeitusConnector extends AbstractConnector {
     @Override
     @NonNull
     protected String getCacheUrlPrefix() {
-        return "http://" + getHost() + "/aare/";
+        return getHostUrl() + "/aare/";
     }
 }

--- a/main/src/cgeo/geocaching/connector/ge/GeopeitusConnector.java
+++ b/main/src/cgeo/geocaching/connector/ge/GeopeitusConnector.java
@@ -34,11 +34,6 @@ public class GeopeitusConnector extends AbstractConnector {
     }
 
     @Override
-    public boolean getHttps() {
-        return false;
-    }
-
-    @Override
     public boolean isOwner(@NonNull final Geocache cache) {
         return false;
     }

--- a/main/src/cgeo/geocaching/connector/ge/package-info.java
+++ b/main/src/cgeo/geocaching/connector/ge/package-info.java
@@ -1,5 +1,5 @@
 /**
- * <a href="http://www.geopeitus.ee">Geopeitus.ee</a> implementation. Only capable of providing the URL for a given
+ * <a href="https://www.geopeitus.ee">Geopeitus.ee</a> implementation. Only capable of providing the URL for a given
  * cache.
  */
 package cgeo.geocaching.connector.ge;

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -91,7 +91,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     @Override
-    public boolean getHttps() {
+    public boolean isHttps() {
         return false;
     }
 

--- a/main/src/cgeo/geocaching/connector/oc/OCAuthParams.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCAuthParams.java
@@ -17,11 +17,11 @@ public class OCAuthParams extends OAuthParameters {
             R.string.auth_ocde, R.string.pref_ocde_tokenpublic, R.string.pref_ocde_tokensecret, R.string.pref_temp_ocde_token_public, R.string.pref_temp_ocde_token_secret);
 
     public static final OCAuthParams OC_NL_AUTH_PARAMS = new OCAuthParams("www.opencaching.nl",
-            R.string.oc_nl_okapi_consumer_key, R.string.oc_nl_okapi_consumer_secret, "callback://www.cgeo.org/opencaching.nl/", false,
+            R.string.oc_nl_okapi_consumer_key, R.string.oc_nl_okapi_consumer_secret, "callback://www.cgeo.org/opencaching.nl/", true,
             R.string.auth_ocnl, R.string.pref_ocnl_tokenpublic, R.string.pref_ocnl_tokensecret, R.string.pref_temp_ocnl_token_public, R.string.pref_temp_ocnl_token_secret);
 
     public static final OCAuthParams OC_PL_AUTH_PARAMS = new OCAuthParams("opencaching.pl",
-            R.string.oc_pl_okapi_consumer_key, R.string.oc_pl_okapi_consumer_secret, "callback://www.cgeo.org/opencaching.pl/", false,
+            R.string.oc_pl_okapi_consumer_key, R.string.oc_pl_okapi_consumer_secret, "callback://www.cgeo.org/opencaching.pl/", true,
             R.string.auth_ocpl, R.string.pref_ocpl_tokenpublic, R.string.pref_ocpl_tokensecret, R.string.pref_temp_ocpl_token_public, R.string.pref_temp_ocpl_token_secret);
 
     public static final OCAuthParams OC_US_AUTH_PARAMS = new OCAuthParams("www.opencaching.us",
@@ -29,11 +29,11 @@ public class OCAuthParams extends OAuthParameters {
             R.string.auth_ocus, R.string.pref_ocus_tokenpublic, R.string.pref_ocus_tokensecret, R.string.pref_temp_ocus_token_public, R.string.pref_temp_ocus_token_secret);
 
     public static final OCAuthParams OC_RO_AUTH_PARAMS = new OCAuthParams("www.opencaching.ro",
-            R.string.oc_ro_okapi_consumer_key, R.string.oc_ro_okapi_consumer_secret, "callback://www.cgeo.org/opencaching.ro/", false,
+            R.string.oc_ro_okapi_consumer_key, R.string.oc_ro_okapi_consumer_secret, "callback://www.cgeo.org/opencaching.ro/", true,
             R.string.auth_ocro, R.string.pref_ocro_tokenpublic, R.string.pref_ocro_tokensecret, R.string.pref_temp_ocro_token_public, R.string.pref_temp_ocro_token_secret);
 
     public static final OCAuthParams OC_UK_AUTH_PARAMS = new OCAuthParams("opencache.uk",
-            R.string.oc_uk2_okapi_consumer_key, R.string.oc_uk2_okapi_consumer_secret, "callback://www.cgeo.org/opencache.uk/", false,
+            R.string.oc_uk2_okapi_consumer_key, R.string.oc_uk2_okapi_consumer_secret, "callback://www.cgeo.org/opencache.uk/", true,
             R.string.auth_ocuk, R.string.pref_ocuk2_tokenpublic, R.string.pref_ocuk2_tokensecret, R.string.pref_temp_ocuk2_token_public, R.string.pref_temp_ocuk2_token_secret);
 
     @StringRes

--- a/main/src/cgeo/geocaching/connector/oc/OCConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCConnector.java
@@ -144,7 +144,7 @@ public class OCConnector extends AbstractConnector implements SmileyCapability {
     }
 
     @Override
-    public boolean getHttps() {
+    public boolean isHttps() {
         return https;
     }
 

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -901,7 +901,7 @@ final class OkapiClient {
                 if (!tokens.isValid()) {
                     return new JSONResult("invalid oauth tokens");
                 }
-                OAuth.signOAuth(host, service.methodName, method, connector.getHttps(), params, tokens, connector.getCK(), connector.getCS());
+                OAuth.signOAuth(host, service.methodName, method, connector.isHttps(), params, tokens, connector.getCK(), connector.getCS());
                 break;
             }
             case Level1 : {

--- a/main/src/cgeo/geocaching/connector/su/SuApi.java
+++ b/main/src/cgeo/geocaching/connector/su/SuApi.java
@@ -274,7 +274,7 @@ public class SuApi {
         if (!tokens.isValid()) {
             throw new NotAuthorizedException();
         }
-        OAuth.signOAuth(host, endpoint.methodName, method, connector.getHttps(), params, tokens, connector.getConsumerKey(), connector.getConsumerSecret());
+        OAuth.signOAuth(host, endpoint.methodName, method, connector.isHttps(), params, tokens, connector.getConsumerKey(), connector.getConsumerSecret());
 
         final String uri = connector.getHostUrl() + endpoint.methodName;
         final JSONResult result;

--- a/main/src/cgeo/geocaching/connector/su/SuAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/connector/su/SuAuthorizationActivity.java
@@ -18,7 +18,7 @@ public class SuAuthorizationActivity extends OAuthAuthorizationActivity {
             "/api/oauth/request_token.php",
             "/api/oauth/authorize.php",
             "/api/oauth/access_token.php",
-            SuConnector.getInstance().getHttps(),
+            SuConnector.getInstance().isHttps(),
             CgeoApplication.getInstance().getString(R.string.su_consumer_key),
             CgeoApplication.getInstance().getString(R.string.su_consumer_secret),
             "callback://www.cgeo.org/geocachingsu/");

--- a/main/src/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/cgeo/geocaching/connector/su/SuConnector.java
@@ -143,11 +143,6 @@ public class SuConnector extends AbstractConnector implements ISearchByCenter, I
     }
 
     @Override
-    public boolean getHttps() {
-        return true;
-    }
-
-    @Override
     @NonNull
     public String getHost() {
         return "geocaching.su";

--- a/main/src/cgeo/geocaching/connector/su/package-info.java
+++ b/main/src/cgeo/geocaching/connector/su/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Russian <a href="http://www.geocaching.su">Geocaching.su</a> implementation.
+ * Russian <a href="https://www.geocaching.su">Geocaching.su</a> implementation.
  */
 package cgeo.geocaching.connector.su;

--- a/main/src/cgeo/geocaching/connector/su/package-info.java
+++ b/main/src/cgeo/geocaching/connector/su/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Russian <a href="https://www.geocaching.su">Geocaching.su</a> implementation.
+ * Russian <a href="https://geocaching.su">Geocaching.su</a> implementation.
  */
 package cgeo.geocaching.connector.su;

--- a/main/src/cgeo/geocaching/connector/tc/TerraCachingConnector.java
+++ b/main/src/cgeo/geocaching/connector/tc/TerraCachingConnector.java
@@ -37,11 +37,6 @@ public class TerraCachingConnector extends AbstractConnector {
     }
 
     @Override
-    public boolean getHttps() {
-        return false;
-    }
-
-    @Override
     public boolean isOwner(@NonNull final Geocache cache) {
         return false;
     }

--- a/main/src/cgeo/geocaching/connector/tc/package-info.java
+++ b/main/src/cgeo/geocaching/connector/tc/package-info.java
@@ -1,4 +1,4 @@
 /**
- * <a href="http://www.terracaching.com">Terracaching</a> implementation.
+ * <a href="https://www.terracaching.com">Terracaching</a> implementation.
  */
 package cgeo.geocaching.connector.tc;

--- a/main/src/cgeo/geocaching/connector/unknown/UnknownConnector.java
+++ b/main/src/cgeo/geocaching/connector/unknown/UnknownConnector.java
@@ -1,5 +1,6 @@
-package cgeo.geocaching.connector;
+package cgeo.geocaching.connector.unknown;
 
+import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.models.Geocache;
 
 import androidx.annotation.NonNull;
@@ -7,7 +8,7 @@ import androidx.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 
-class UnknownConnector extends AbstractConnector {
+public class UnknownConnector extends AbstractConnector {
 
     @Override
     @NonNull

--- a/main/src/cgeo/geocaching/connector/unknown/package-info.java
+++ b/main/src/cgeo/geocaching/connector/unknown/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * a unknown cache connector implementation.
+ */
+package cgeo.geocaching.connector.unknown;

--- a/main/src/cgeo/geocaching/connector/wm/WaymarkingConnector.java
+++ b/main/src/cgeo/geocaching/connector/wm/WaymarkingConnector.java
@@ -1,5 +1,6 @@
-package cgeo.geocaching.connector;
+package cgeo.geocaching.connector.wm;
 
+import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.models.Geocache;
 
 import androidx.annotation.NonNull;
@@ -7,7 +8,7 @@ import androidx.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 
-class WaymarkingConnector extends AbstractConnector {
+public class WaymarkingConnector extends AbstractConnector {
 
     @Override
     @NonNull
@@ -33,12 +34,7 @@ class WaymarkingConnector extends AbstractConnector {
         return "www.waymarking.com";
     }
 
-    @Override
-    public boolean getHttps() {
-        return false;
-    }
-
-    @Override
+   @Override
     public boolean isOwner(@NonNull final Geocache cache) {
         // this connector has no user management
         return false;
@@ -63,7 +59,7 @@ class WaymarkingConnector extends AbstractConnector {
         if (canHandle(topLevel)) {
             return topLevel;
         }
-        // waymarking URLs http://www.waymarking.com/waymarks/WMNCDT_American_Legion_Flagpole_1983_University_of_Oregon
+        // waymarking URLs https://www.waymarking.com/waymarks/WMNCDT_American_Legion_Flagpole_1983_University_of_Oregon
         final String waymark = StringUtils.substringBetween(url, "waymarks/", "_");
         return waymark != null && canHandle(waymark) ? waymark : null;
     }

--- a/main/src/cgeo/geocaching/connector/wm/package-info.java
+++ b/main/src/cgeo/geocaching/connector/wm/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * <a href="https://www.waymarking.com/">Waymarking</a> implementation.
+ */
+package cgeo.geocaching.connector.wm;

--- a/tests/src-android/cgeo/geocaching/connector/ConnectorFactoryTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/ConnectorFactoryTest.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.oc.OCCZConnector;
 import cgeo.geocaching.connector.oc.OCConnector;
 import cgeo.geocaching.connector.oc.OCDEConnector;
+import cgeo.geocaching.connector.unknown.UnknownConnector;
 import cgeo.geocaching.test.AbstractResourceInstrumentationTestCase;
 import cgeo.geocaching.test.mock.GC1ZXX2;
 
@@ -67,13 +68,13 @@ public class ConnectorFactoryTest extends AbstractResourceInstrumentationTestCas
     }
 
     public static void testGetGeocodeFromUrl() {
-        assertThat(ConnectorFactory.getGeocodeFromURL("http://coord.info/GC34PJN")).isEqualTo("GC34PJN");
-        assertThat(ConnectorFactory.getGeocodeFromURL("http://www.coord.info/GC34PJN")).isEqualTo("GC34PJN");
+        assertThat(ConnectorFactory.getGeocodeFromURL("https://coord.info/GC34PJN")).isEqualTo("GC34PJN");
+        assertThat(ConnectorFactory.getGeocodeFromURL("https://www.coord.info/GC34PJN")).isEqualTo("GC34PJN");
 
-        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/GC12ABC")).isEqualTo("GC12ABC");
-        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://www.coord.info/GC12ABC")).isEqualTo("GC12ABC");
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://coord.info/GC12ABC")).isEqualTo("GC12ABC");
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://www.coord.info/GC12ABC")).isEqualTo("GC12ABC");
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://www.geocaching.com/geocache/GC12ABC_die-muhlen-im-schondratal-muhle-munchau")).isEqualTo("GC12ABC");
-        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://geocaching.com/geocache/GC12ABC_die-muhlen-im-schondratal-muhle-munchau")).isEqualTo("GC12ABC");
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://geocaching.com/geocache/GC12ABC_die-muhlen-im-schondratal-muhle-munchau")).isEqualTo("GC12ABC");
 
         // OC
         assertThat(ConnectorFactory.getGeocodeFromURL("https://www.opencaching.de/viewcache.php?wp=OC10F41&log=A#log1186982")).isEqualTo("OC10F41");
@@ -88,29 +89,29 @@ public class ConnectorFactoryTest extends AbstractResourceInstrumentationTestCas
         assertThat(new OCCZConnector().getGeocodeFromUrl("https://www.opencaching.de/viewcache.php?cacheid=123456&log=A#log1186982")).isNull();
 
         // trackable URLs
-        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/TB1234")).isNull();
-        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://www.coord.info/TB1234")).isNull();
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://coord.info/TB1234")).isNull();
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://www.coord.info/TB1234")).isNull();
 
         // make sure that a mixture of different connector and geocode is recognized as invalid
-        assertThat(ConnectorFactory.getGeocodeFromURL("http://www.opencaching.com/#!geocache/" + "GC12345")).isNull();
+        assertThat(ConnectorFactory.getGeocodeFromURL("https://www.opencaching.com/#!geocache/" + "GC12345")).isNull();
 
         // lowercase URL
-        assertThat(ConnectorFactory.getGeocodeFromURL("http://coord.info/gc77")).isEqualTo("GC77");
+        assertThat(ConnectorFactory.getGeocodeFromURL("https://coord.info/gc77")).isEqualTo("GC77");
     }
 
     public static void testGetTrackableFromURL() throws Exception {
-        assertThat(ConnectorFactory.getTrackableFromURL("http://www.geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
         assertThat(ConnectorFactory.getTrackableFromURL("https://www.geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
-        assertThat(ConnectorFactory.getTrackableFromURL("http://geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://www.geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
         assertThat(ConnectorFactory.getTrackableFromURL("https://geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
-        assertThat(ConnectorFactory.getTrackableFromURL("http://coord.info/TB1234")).isEqualTo("TB1234");
-        assertThat(ConnectorFactory.getTrackableFromURL("http://www.coord.info/TB1234")).isEqualTo("TB1234");
-        assertThat(ConnectorFactory.getTrackableFromURL("http://geocaching.com/track/details.aspx?tracker=TB1234")).isEqualTo("TB1234");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://coord.info/TB1234")).isEqualTo("TB1234");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://www.coord.info/TB1234")).isEqualTo("TB1234");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://geocaching.com/track/details.aspx?tracker=TB1234")).isEqualTo("TB1234");
         assertThat(ConnectorFactory.getTrackableFromURL("https://www.geocaching.com/track/details.aspx?tracker=TB1234")).isEqualTo("TB1234");
 
         // cache URLs
-        assertThat(ConnectorFactory.getTrackableFromURL("http://coord.info/GC1234")).isEqualTo("GC1234");
-        assertThat(ConnectorFactory.getTrackableFromURL("http://www.coord.info/GC1234")).isEqualTo("GC1234");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://coord.info/GC1234")).isEqualTo("GC1234");
+        assertThat(ConnectorFactory.getTrackableFromURL("https://www.coord.info/GC1234")).isEqualTo("GC1234");
     }
 
     public static Set<String> getGeocodeSample() {

--- a/tests/src-android/cgeo/geocaching/connector/su/SuParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/su/SuParserTest.java
@@ -71,12 +71,12 @@ public class SuParserTest extends AbstractResourceInstrumentationTestCase {
             "]," +
 
             "\"images\":[" +
-            "{\"id\":3749,\"type\":\"cachePhoto\",\"url\":\"http://www.geocaching.su/photos/caches/3749.jpg\"}," +
-            "{\"id\":15090,\"type\":\"areaPhoto\",\"url\":\"http://www.geocaching.su/photos/areas/15090.jpg\",\"description\":\"Ограда монастыря и собор\"}," +
-            "{\"id\":15091,\"type\":\"areaPhoto\",\"url\":\"http://www.geocaching.su/photos/areas/15091.jpg\",\"description\":\"Временная звонница и &quot;Васильевский&quot; келейный корпус\"}," +
-            "{\"id\":15092,\"type\":\"areaPhoto\",\"url\":\"http://www.geocaching.su/photos/areas/15092.jpg\",\"description\":\"Домик игуменьи\"}," +
-            "{\"id\":15093,\"type\":\"areaPhoto\",\"url\":\"http://www.geocaching.su/photos/areas/15093.jpg\",\"description\":\"Крестовоздвиженская церковь\"}," +
-            "{\"id\":15094,\"type\":\"areaPhoto\",\"url\":\"http://www.geocaching.su/photos/areas/15094.jpg\",\"description\":\"Памятный крест\"}]}}";
+            "{\"id\":3749,\"type\":\"cachePhoto\",\"url\":\"https://geocaching.su/photos/caches/3749.jpg\"}," +
+            "{\"id\":15090,\"type\":\"areaPhoto\",\"url\":\"https://geocaching.su/photos/areas/15090.jpg\",\"description\":\"Ограда монастыря и собор\"}," +
+            "{\"id\":15091,\"type\":\"areaPhoto\",\"url\":\"https://geocaching.su/photos/areas/15091.jpg\",\"description\":\"Временная звонница и &quot;Васильевский&quot; келейный корпус\"}," +
+            "{\"id\":15092,\"type\":\"areaPhoto\",\"url\":\"https://geocaching.su/photos/areas/15092.jpg\",\"description\":\"Домик игуменьи\"}," +
+            "{\"id\":15093,\"type\":\"areaPhoto\",\"url\":\"https://geocaching.su/photos/areas/15093.jpg\",\"description\":\"Крестовоздвиженская церковь\"}," +
+            "{\"id\":15094,\"type\":\"areaPhoto\",\"url\":\"https://geocaching.su/photos/areas/15094.jpg\",\"description\":\"Памятный крест\"}]}}";
     private static String simpleCache = "{\"status\":{\"code\":\"OK\"}," +
             "\"data\":{" +
             "\"id\":321," +


### PR DESCRIPTION
All cache connectors use now https addresses.
This needs to reflect in our code base.

Additionally, I did some refactoring to have all connectors in own package dirs with a package-info.