### PR TITLE
add view settings debug helper

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -225,6 +225,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="cgeo.geocaching.MainActivity" />
         </activity>
+        <activity android:name=".settings.ViewSettingsActivity" />
         <activity
             android:name=".CacheListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"

--- a/main/res/layout/view_settings_item.xml
+++ b/main/res/layout/view_settings_item.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:minHeight="40sp"
+    android:padding="3dp">
+
+    <TextView
+        android:id="@+id/settings_key"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="10sp"
+        android:layout_alignParentLeft="true"
+        android:textStyle="bold" />
+    <TextView
+        android:id="@+id/settings_value"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/settings_key"
+        tools:ignore="RelativeOverlap" />
+    <ImageButton
+        android:id="@+id/settings_edit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toLeftOf="@id/settings_delete"
+        android:src="@drawable/ic_menu_edit"
+        android:visibility="gone" />
+    <ImageButton
+        android:id="@+id/settings_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:src="@drawable/ic_menu_delete"
+        android:visibility="gone" />
+
+</RelativeLayout>

--- a/main/res/menu/view_settings.xml
+++ b/main/res/menu/view_settings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+
+    <item
+        android:id="@+id/view_settings_edit"
+        android:icon="@drawable/ic_menu_edit"
+        android:title="@string/activate_editmode_title"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction">
+    </item>
+
+</menu>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -231,6 +231,7 @@
     <string translatable="false" name="pref_ec_icons">ec_icons</string>
     <string translatable="false" name="pref_memory_dump">memory_dump</string>
     <string translatable="false" name="pref_generate_logcat">generate_logcat</string>
+    <string translatable="false" name="pref_view_settings">view_settings</string>
     <string translatable="false" name="pref_appearance">pref_appearance</string>
     <string translatable="false" name="pref_changelog_last_checksum">changelog_last_checksum</string>
     <string translatable="false" name="pref_caches_history">caches_history</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1697,4 +1697,14 @@
     <string name="switch_off">Off</string>
     <string name="switch_manual">Manual</string>
     <string name="switch_auto">Automatic</string>
+
+    <!-- view settings -->
+    <string name="view_settings">View settings</string>
+    <string name="delete_setting">Delete setting</string>
+    <string name="delete_setting_warning">Delete key \"%s\" from settings?\n\nThis operation cannot be undone.</string>
+    <string name="edit_setting">Edit setting \"%s\"</string>
+    <string name="edit_setting_error_unknown_type">Unknown setting type - editing not supported</string>
+    <string name="edit_setting_error_invalid_data">Invalid data \"%s\" entered. Setting\'s value unchanged.</string>
+    <string name="activate_editmode_title">Activate edit mode</string>
+    <string name="activate_editmode_warning">You are entering dangerous area here!\n\nChanging settings directly might confuse c:geo, might prevent further program starts or might your mobile make explode!\n\nAre you sure you want to proceed at your own risk?</string>
 </resources>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -974,6 +974,9 @@
             <Preference
                 android:key="@string/pref_memory_dump"
                 android:title="@string/init_create_memory_dump" />
+            <Preference
+                android:key="@string/pref_view_settings"
+                android:title="@string/view_settings" />
         </PreferenceCategory>
     </PreferenceScreen>
 

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -74,9 +74,17 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
         ActivityMixin.showToast(this, text);
     }
 
+    public final void showToast(final int textId) {
+        showToast(getString(textId));
+    }
+
     @Override
     public final void showShortToast(final String text) {
         ActivityMixin.showShortToast(this, text);
+    }
+
+    public final void showShortToast(final int textId) {
+        showShortToast(getString(textId));
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -491,6 +491,10 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             DebugUtils.createLogcat(SettingsActivity.this);
             return true;
         });
+        getPreference(R.string.pref_view_settings).setOnPreferenceClickListener(preference -> {
+            startActivity(new Intent(this, ViewSettingsActivity.class));
+            return true;
+        });
     }
 
     private static void initDeviceSpecificPreferences() {

--- a/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -1,0 +1,169 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.utils.ApplicationSettings;
+import cgeo.geocaching.utils.SettingsUtils;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.text.InputType;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+public class ViewSettingsActivity extends AbstractActivity {
+
+    private ArrayAdapter<KeyValue> debugAdapter;
+    private ArrayList<KeyValue> items;
+    private SharedPreferences prefs;
+    private boolean editMode = false;
+
+    private static class KeyValue {
+        public String key;
+        public String value;
+        public SettingsUtils.SettingsType type;
+
+        KeyValue(final String key, final String value, final SettingsUtils.SettingsType type) {
+            this.key = key;
+            this.value = value;
+            this.type = type;
+        }
+    }
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTheme();
+        setTitle(getString(R.string.view_settings));
+
+        items = new ArrayList<>();
+        prefs = getSharedPreferences(ApplicationSettings.getPreferencesName(), MODE_PRIVATE);
+        final Map<String, ?> keys = prefs.getAll();
+        for (Map.Entry<String, ?> entry : keys.entrySet()) {
+            final Object value = entry.getValue();
+            final String key = entry.getKey();
+            final SettingsUtils.SettingsType type = SettingsUtils.getType(value);
+            items.add(new KeyValue(key, value.toString(), type));
+        }
+        Collections.sort(items, (o1, o2) -> o1.key.compareTo(o2.key));
+
+        debugAdapter = new ArrayAdapter<KeyValue>(this, 0, items) {
+            public View getView(final int position, final View convertView, final ViewGroup parent) {
+                View v = convertView;
+                if (null == convertView) {
+                    v = getLayoutInflater().inflate(R.layout.view_settings_item, null, false);
+                }
+                final KeyValue keyValue = items.get(position);
+                ((TextView) v.findViewById(R.id.settings_key)).setText(keyValue.key);
+                ((TextView) v.findViewById(R.id.settings_value)).setText(keyValue.value);
+
+                final View buttonDelete = v.findViewById(R.id.settings_delete);
+                buttonDelete.setOnClickListener(v2 -> deleteItem(position));
+                buttonDelete.setVisibility(editMode ? View.VISIBLE : View.GONE);
+
+                final View buttonEdit = v.findViewById(R.id.settings_edit);
+                buttonEdit.setOnClickListener(v3 -> editItem(position));
+                buttonEdit.setVisibility(editMode ? keyValue.type != SettingsUtils.SettingsType.TYPE_UNKNOWN ? View.VISIBLE : View.INVISIBLE : View.GONE);
+
+                return v;
+            }
+        };
+        final ListView list = new ListView(this);
+        setContentView(list);
+        list.setAdapter(debugAdapter);
+    }
+
+    private void deleteItem(final int position) {
+        final KeyValue keyValue = items.get(position);
+        final String key = keyValue.key;
+        Dialogs.confirm(this, R.string.delete_setting, String.format(getString(R.string.delete_setting_warning), key), (dialog, which) -> {
+            final SharedPreferences.Editor editor = prefs.edit();
+            editor.remove(key);
+            editor.apply();
+            debugAdapter.remove(keyValue);
+        });
+    }
+
+    private void editItem(final int position) {
+        final KeyValue keyValue = items.get(position);
+        final String key = keyValue.key;
+        final SettingsUtils.SettingsType type = keyValue.type;
+
+        int inputType = 0;
+        switch (type) {
+            case TYPE_INTEGER:
+            case TYPE_LONG:
+                inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL;
+                break;
+            case TYPE_FLOAT:
+                inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_DECIMAL;
+                break;
+            default:
+                inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL;
+                break;
+        }
+        final EditText editText = new EditText(this);
+        editText.setInputType(inputType);
+        editText.setText(keyValue.value);
+
+        new AlertDialog.Builder(this)
+            .setTitle(String.format(getString(R.string.edit_setting), key))
+            .setView(editText)
+            .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
+                final String newValue = editText.getText().toString();
+                final SharedPreferences.Editor editor = prefs.edit();
+                try {
+                    SettingsUtils.putValue(editor, type, key, newValue);
+                    editor.apply();
+                    debugAdapter.remove(keyValue);
+                    debugAdapter.insert(new KeyValue(key, newValue, type), position);
+                } catch (XmlPullParserException | NumberFormatException e) {
+                    showToast(String.format(getString(R.string.edit_setting_error_invalid_data), newValue));
+                }
+            })
+            .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })
+            .show()
+        ;
+    };
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        getMenuInflater().inflate(R.menu.view_settings, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == R.id.view_settings_edit) {
+            if (editMode) {
+                editMode = false;
+                debugAdapter.notifyDataSetChanged();
+            } else {
+                Dialogs.confirm(this, R.string.activate_editmode_title, R.string.activate_editmode_warning, (dialog, which) -> {
+                    editMode = true;
+                    debugAdapter.notifyDataSetChanged();
+                });
+            }
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/main/src/cgeo/geocaching/utils/SettingsUtils.java
+++ b/main/src/cgeo/geocaching/utils/SettingsUtils.java
@@ -1,0 +1,84 @@
+package cgeo.geocaching.utils;
+
+import android.content.SharedPreferences;
+
+import org.xmlpull.v1.XmlPullParserException;
+
+public class SettingsUtils {
+
+    public enum SettingsType {
+        TYPE_STRING     ("string"),
+        TYPE_BOOLEAN    ("boolean"),
+        TYPE_INTEGER    ("integer"),
+        TYPE_LONG       ("long"),
+        TYPE_FLOAT      ("float"),
+        TYPE_UNKNOWN    ("unknown");
+
+        private String id;
+
+        SettingsType(final String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    private SettingsUtils() {
+        // utility class
+    }
+
+    public static SettingsType getType(final Object value) {
+        if (value instanceof String) {
+            return SettingsType.TYPE_STRING;
+        } else if (value instanceof Boolean) {
+            return SettingsType.TYPE_BOOLEAN;
+        } else if (value instanceof Integer) {
+            return SettingsType.TYPE_INTEGER;
+        } else if (value instanceof Long) {
+            return SettingsType.TYPE_LONG;
+        } else if (value instanceof Float) {
+            return SettingsType.TYPE_FLOAT;
+        }
+        return SettingsType.TYPE_UNKNOWN;
+    }
+
+    public static SettingsType getType(final String type) {
+        for (final SettingsType settingsType : SettingsType.values()) {
+            if (type.equalsIgnoreCase(settingsType.getId())) {
+                return settingsType;
+            }
+        }
+        return SettingsType.TYPE_UNKNOWN;
+    }
+
+    public static void putValue(final SharedPreferences.Editor editor, final SettingsType type, final String key, final String value) throws XmlPullParserException, NumberFormatException {
+        switch (type) {
+            case TYPE_STRING:
+                editor.putString(key, value);
+                break;
+            case TYPE_LONG:
+                editor.putLong(key, Long.parseLong(value));
+                break;
+            case TYPE_INTEGER:
+                editor.putInt(key, Integer.parseInt(value));
+                break;
+            case TYPE_BOOLEAN:
+                // do not use Boolean.parseBoolean as it silently ignores malformed values
+                if ("true".equalsIgnoreCase(value) || "1".equals(value)) {
+                    editor.putBoolean(key, true);
+                } else if ("false".equalsIgnoreCase(value) || "0".equals(value)) {
+                    editor.putBoolean(key, false);
+                } else {
+                    throw new NumberFormatException();
+                }
+                break;
+            case TYPE_FLOAT:
+                editor.putFloat(key, Float.parseFloat(value));
+                break;
+            default:
+                throw new XmlPullParserException("unknown type");
+        }
+    }
+}

--- a/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.R;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import static cgeo.geocaching.utils.SettingsUtils.SettingsType.TYPE_STRING;
+import static cgeo.geocaching.utils.SettingsUtils.SettingsType.TYPE_UNKNOWN;
 
 import android.app.Activity;
 import android.content.SharedPreferences;
@@ -28,13 +30,6 @@ import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
 public class SharedPrefsBackupUtils extends Activity {
-
-    static final String TYPE_BOOLEAN    = "boolean";
-    static final String TYPE_FLOAT      = "float";
-    static final String TYPE_INTEGER    = "int";
-    static final String TYPE_LONG       = "long";
-    static final String TYPE_STRING     = "string";
-    static final String TYPE_UNKNOWN    = "unknown";
 
     static final String ATTRIBUTE_NAME  = "name";
     static final String ATTRIBUTE_VALUE = "value";
@@ -105,28 +100,17 @@ public class SharedPrefsBackupUtils extends Activity {
                 final Object value = entry.getValue();
                 final String key = entry.getKey();
                 if (!ignoreKeys.contains(key)) {
-                    if (value instanceof String) {
-                        xmlSerializer.startTag(null, TYPE_STRING);
+                    final SettingsUtils.SettingsType type = SettingsUtils.getType(value);
+                    if (type == TYPE_STRING) {
+                        xmlSerializer.startTag(null, type.getId());
                         xmlSerializer.attribute(null, ATTRIBUTE_NAME, key);
                         xmlSerializer.text(value.toString());
-                        xmlSerializer.endTag(null, TYPE_STRING);
-                    } else {
-                        String type = TYPE_UNKNOWN;
-                        if (value instanceof Boolean) {
-                            type = TYPE_BOOLEAN;
-                        } else if (value instanceof Integer) {
-                            type = TYPE_INTEGER;
-                        } else if (value instanceof Long) {
-                            type = TYPE_LONG;
-                        } else if (value instanceof Float) {
-                            type = TYPE_FLOAT;
-                        }
-                        if (type != TYPE_UNKNOWN) {
-                            xmlSerializer.startTag(null, type);
-                            xmlSerializer.attribute(null, ATTRIBUTE_NAME, key);
-                            xmlSerializer.attribute(null, ATTRIBUTE_VALUE, value.toString());
-                            xmlSerializer.endTag(null, type);
-                        }
+                        xmlSerializer.endTag(null, type.getId());
+                    } else if (type != TYPE_UNKNOWN) {
+                        xmlSerializer.startTag(null, type.getId());
+                        xmlSerializer.attribute(null, ATTRIBUTE_NAME, key);
+                        xmlSerializer.attribute(null, ATTRIBUTE_VALUE, value.toString());
+                        xmlSerializer.endTag(null, type.getId());
                     }
                 }
             }
@@ -168,7 +152,7 @@ public class SharedPrefsBackupUtils extends Activity {
 
             // retrieve data
             Boolean inTag = false;
-            String type = TYPE_UNKNOWN;
+            SettingsUtils.SettingsType type = TYPE_UNKNOWN;
             String key = "";
             String value = "";
             int eventType = 0;
@@ -179,7 +163,7 @@ public class SharedPrefsBackupUtils extends Activity {
                     if (parser.getName().equals(TAG_MAP)) {
                         inTag = true;
                     } else if (inTag) {
-                        type = parser.getName();
+                        type = SettingsUtils.getType(parser.getName());
                         key = "";
                         value = "";
 
@@ -199,29 +183,11 @@ public class SharedPrefsBackupUtils extends Activity {
                     }
                 } else if (eventType == XmlPullParser.END_TAG) {
                     if (inTag) {
-                        if (parser.getName().equals(type)) {
-                            switch (type) {
-                                case TYPE_BOOLEAN:
-                                    editor.putBoolean(key, Boolean.parseBoolean(value));
-                                    break;
-                                case TYPE_FLOAT:
-                                    editor.putFloat(key, Float.parseFloat(value));
-                                    break;
-                                case TYPE_INTEGER:
-                                    editor.putInt(key, Integer.parseInt(value));
-                                    break;
-                                case TYPE_LONG:
-                                    editor.putLong(key, Long.parseLong(value));
-                                    break;
-                                case TYPE_STRING:
-                                    editor.putString(key, value);
-                                    break;
-                                default:
-                                    throw new XmlPullParserException("unknown type");
-                            }
-                            type = TYPE_UNKNOWN;
-                        } else if (parser.getName().equals(TAG_MAP)) {
+                        if (parser.getName().equals(TAG_MAP)) {
                             inTag = false;
+                        } else if (SettingsUtils.getType(parser.getName()) == type) {
+                            SettingsUtils.putValue(editor, type, key, value);
+                            type = TYPE_UNKNOWN;
                         } else {
                             throw new XmlPullParserException("invalid structure: unexpected closing tag " + parser.getName());
                         }
@@ -237,7 +203,7 @@ public class SharedPrefsBackupUtils extends Activity {
                 throw new XmlPullParserException("could not commit changed preferences");
             }
             return true;
-        } catch (IOException | XmlPullParserException e) {
+        } catch (IOException | XmlPullParserException | NumberFormatException e) {
             final String error = e.getMessage();
             if (null != error) {
                 Log.d("error reading settings file: " + error);


### PR DESCRIPTION
During development and/or debugging I frequently have the need to see, change or remove certain settings. This PR adds a view under `prefs => System => Debug` to view settings:

![image](https://user-images.githubusercontent.com/3754370/84400798-cbf58a00-ac02-11ea-9124-760a1ec5928c.png)

This view lists all settings in alphabetical order of the key, and their according values:

![image](https://user-images.githubusercontent.com/3754370/84400904-eaf41c00-ac02-11ea-8290-b0b503c998d4.png)

If there is need to change or delete a setting you can do so after activating edit mode by pressing the edit button in the upper right. A warning message will be presented:

![image](https://user-images.githubusercontent.com/3754370/84401044-15de7000-ac03-11ea-961c-f7d195764a4a.png)

If confirmed, edit and delete buttons are added to the view:

![image](https://user-images.githubusercontent.com/3754370/84401150-3a3a4c80-ac03-11ea-9b1f-83b8f1a7853a.png)

(You can leave edit mode by pressing the edit button again. Edit and delete buttons will be removed then.)

On pressing the edit button a small edit dialog appears:

![image](https://user-images.githubusercontent.com/3754370/84401267-5c33cf00-ac03-11ea-8a01-46c6ba1f5d68.png)

It's a simple text edit line, with some formatting rules for numeric values, but nothing fancy. It's a debug feature, after all.

If the value entered does not fit to the data type, a small error info is shown, and the stored value does not get changed or removed.

On pressing the delete button a confirmation dialog is shown:

![image](https://user-images.githubusercontent.com/3754370/84401459-93a27b80-ac03-11ea-8a01-b2f680ca6ec0.png)

