### PR TITLE
Set targetSDK and compileSDK to 29 (fix #8382)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,7 +19,7 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     buildToolsVersion "28.0.3"
 
@@ -32,7 +32,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         //noinspection OldTargetApi
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 


### PR DESCRIPTION
Scanning the information linked to in #8382 I couldn't find any areas relevant to c:geo, and the tests ran fine locally, but still let's merge this early in this upcoming version to have time to fix any upcoming issues.