### PR TITLE
Export trail history as GPX track (fix #8424)

### DIFF
--- a/main/res/layout/gpx_export_fragment.xml
+++ b/main/res/layout/gpx_export_fragment.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="0dp"
+    tools:context=".export.GpxExport" >
+
+    <TextView
+        android:id="@id/info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/export_gpx_info"
+        android:textColor="?text_color"
+        android:paddingTop="20dp"
+        android:paddingBottom="20dp"
+        android:paddingLeft="8dp"/>
+
+    <CheckBox
+        android:id="@+id/share"
+        style="@style/checkbox_full"
+        android:text="@string/init_share_after_export" />
+
+</LinearLayout>

--- a/main/res/layout/gpx_export_trail_dialog.xml
+++ b/main/res/layout/gpx_export_trail_dialog.xml
@@ -10,8 +10,7 @@
     <include layout="@layout/gpx_export_fragment" />
 
     <CheckBox
-        android:id="@+id/include_found_status"
+        android:id="@+id/clear_trailhistory_after_export"
         style="@style/checkbox_full"
         android:text="@string/export_trailhistory_clear_after_export" />
-
 </LinearLayout>

--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -234,18 +234,28 @@
         </menu>
     </item>
     <item
-        android:id="@+id/menu_as_list"
-        android:icon="@drawable/ic_menu_agenda"
-        android:title="@string/map_as_list">
-    </item>
-    <item
-        android:id="@+id/menu_clear_trailhistory"
-        android:title="@string/map_clear_trailhistory">
+        android:id="@+id/menu_trailhistory"
+        android:title="@string/trailhistory">
+        <menu>
+            <item
+                android:id="@+id/menu_clear_trailhistory"
+                android:title="@string/map_clear_trailhistory">
+            </item>
+            <item
+                android:id="@+id/menu_export_trailhistory"
+                android:title="@string/export_trailhistory_title">
+            </item>
+        </menu>
     </item>
     <item
         android:id="@+id/menu_clear_individual_route"
         android:title="@string/map_clear_individual_route"
         android:visible="false">
+    </item>
+    <item
+        android:id="@+id/menu_as_list"
+        android:icon="@drawable/ic_menu_agenda"
+        android:title="@string/map_as_list">
     </item>
 
 </menu>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -164,6 +164,7 @@
     <string translatable="false" name="pref_trackable_inventory_sort">trackableComparator</string>
     <string translatable="false" name="pref_shareafterexport">shareafterexport</string>
     <string translatable="false" name="pref_includefoundstatus">includefoundstatus</string>
+    <string translatable="false" name="pref_cleartrailafterexportstatus">cleartrailafterexportstatus</string>
     <string translatable="false" name="pref_renderthemefile">renderthemefile</string>
     <string translatable="false" name="pref_logImageScale">logImageScale</string>
     <string translatable="false" name="pref_ocde_tokensecret">ocde_tokensecret</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1746,4 +1746,11 @@
     <!-- Download map preference -->
     <string name="downloadmap_title">Download basic offline maps</string>
     <string name="downloadmap_info">You will be redirected to a download site for basic offline maps (no themeing support).\n\nChose the .map file for your region and tap on it to download the file.\n\nWhen downloading has completed, tap on the downloaded file to set this map as current map for c:geo</string>
+
+    <!-- history trail export -->
+    <string name="trailhistory">Trail history</string>
+    <string name="export_trailhistory_title">Export trail history</string>
+    <string name="export_trailhistory_success">Exported trail history to \"%s\"</string>
+    <string name="export_trailhistory_clear_after_export">Clear trail history after export</string>
+
 </resources>

--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -1,0 +1,159 @@
+package cgeo.geocaching.export;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.utils.AsyncTaskWithProgress;
+import cgeo.geocaching.utils.CalendarUtils;
+import cgeo.geocaching.utils.EnvironmentUtils;
+import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.ShareUtils;
+import cgeo.geocaching.utils.XmlUtils;
+import cgeo.org.kxml2.io.KXmlSerializer;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.location.Location;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.CharEncoding;
+import org.xmlpull.v1.XmlSerializer;
+
+public class TrailHistoryExport {
+
+    private String filename;
+
+    public TrailHistoryExport(final Activity activity, final Runnable clearTrailHistory) {
+        // quick check for being able to write the GPX file
+        if (!EnvironmentUtils.isExternalStorageAvailable()) {
+            return;
+        }
+        filename = "trail_" + CalendarUtils.formatDateTime("yyyy-MM-dd_hh-mm-ss") + ".gpx";
+
+        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        builder.setTitle(R.string.export_trailhistory_title);
+
+        final View layout = View.inflate(activity, R.layout.gpx_export_trail_dialog, null);
+        builder.setView(layout);
+
+        final TextView text = layout.findViewById(R.id.info);
+        text.setText(activity.getString(R.string.export_confirm_message, Settings.getGpxExportDir(), filename));
+
+        final CheckBox shareOption = layout.findViewById(R.id.share);
+        shareOption.setChecked(Settings.getShareAfterExport());
+
+        final CheckBox clearAfterExport = layout.findViewById(R.id.clear_trailhistory_after_export);
+        clearAfterExport.setChecked(Settings.getClearTrailAfterExportStatus());
+
+        builder.setPositiveButton(R.string.export, (dialog, which) -> {
+            Settings.setShareAfterExport(shareOption.isChecked());
+            Settings.setClearTrailAfterExportStatus(clearAfterExport.isChecked());
+            dialog.dismiss();
+            new Export(activity, clearTrailHistory).execute(DataStore.loadTrailHistoryAsArray());
+        });
+
+        builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss());
+
+        builder.create().show();
+    }
+
+    private class Export extends AsyncTaskWithProgress<Location, File> {
+
+        private static final String PREFIX_GPX = "";
+        private static final String NS_GPX = "http://www.topografix.com/GPX/1/0";
+        private static final String GPX_SCHEMA = NS_GPX + "/gpx.xsd";
+
+        private static final String PREFIX_XSI = "xsi";
+        private static final String NS_XSI = "http://www.w3.org/2001/XMLSchema-instance";
+
+        private Runnable clearTrailHistory;
+
+        Export(final Activity activity, final Runnable clearTrailHistory) {
+            super(activity, activity.getString(R.string.export_trailhistory_title));
+            this.clearTrailHistory = clearTrailHistory;
+        }
+
+        @Override
+        protected File doInBackgroundInternal(final Location[] trail) {
+            BufferedWriter writer = null;
+            final File exportFile = new File(LocalStorage.getGpxExportDirectory(), filename);
+
+            try {
+                writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(exportFile), CharEncoding.UTF_8));
+            } catch (IOException e) {
+                return null;
+            }
+            final XmlSerializer gpx = new KXmlSerializer();
+            try {
+                int countExported = 0;
+                gpx.setOutput(writer);
+
+                gpx.startDocument(CharEncoding.UTF_8, true);
+                gpx.setPrefix(PREFIX_GPX, NS_GPX);
+                gpx.setPrefix(PREFIX_XSI, NS_XSI);
+
+                gpx.startTag(NS_GPX, "gpx");
+                gpx.attribute("", "version", "1.0");
+                gpx.attribute("", "creator", "c:geo - http://www.cgeo.org/");
+                gpx.attribute(NS_XSI, "schemaLocation", NS_GPX + " " + GPX_SCHEMA);
+
+                    gpx.startTag(NS_GPX, "metadata");
+                    XmlUtils.simpleText(gpx, NS_GPX, "name", "c:geo history trail");
+                    XmlUtils.simpleText(gpx, NS_GPX, "time", CalendarUtils.formatDateTime("yyyy-MM-dd hh-mm-ss"));
+                    gpx.endTag(NS_GPX, "metadata");
+
+                    gpx.startTag(NS_GPX, "trk");
+                        XmlUtils.simpleText(gpx, NS_GPX, "name", "c:geo history trail " + CalendarUtils.formatDateTime("yyyy-MM-dd hh-mm-ss"));
+                        gpx.startTag(NS_GPX, "trkseg");
+                            for (Location loc : trail) {
+                                gpx.startTag(NS_GPX, "trkpt");
+                                gpx.attribute(NS_GPX, "lat", String.valueOf(loc.getLatitude()));
+                                gpx.attribute(NS_GPX, "lat", String.valueOf(loc.getLongitude()));
+                                gpx.endTag(NS_GPX, "trkpt");
+                                countExported++;
+                                publishProgress(countExported);
+                            }
+                        gpx.endTag(NS_GPX, "trkseg");
+                    gpx.endTag(NS_GPX, "trk");
+                gpx.endTag(NS_GPX, "gpx");
+            } catch (final IOException e) {
+                // delete partial GPX file on error
+                if (exportFile.exists()) {
+                    FileUtils.deleteIgnoringFailure(exportFile);
+                }
+                return null;
+            } finally {
+                IOUtils.closeQuietly(writer);
+            }
+            return exportFile;
+        }
+
+        @Override
+        protected void onPostExecuteInternal(final File exportFile) {
+            if (null != activity) {
+                if (null != exportFile) {
+                    ActivityMixin.showToast(activity, String.format(activity.getString(R.string.export_trailhistory_success), exportFile.toString()));
+                    if (Settings.getShareAfterExport()) {
+                        ShareUtils.share(activity, exportFile, "application/xml", R.string.export_gpx_to);
+                    }
+                    if (Settings.getClearTrailAfterExportStatus()) {
+                        clearTrailHistory.run();
+                    }
+                } else {
+                    ActivityMixin.showToast(activity, activity.getString(R.string.export_failed));
+                }
+            }
+        }
+    }
+}

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -16,6 +16,7 @@ import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.RemoveFlag;
 import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.export.TrailHistoryExport;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.ProximityNotification;
@@ -758,7 +759,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
             menu.findItem(R.id.menu_as_list).setVisible(!isLoading() && caches.size() > 1);
 
-            menu.findItem(R.id.menu_clear_trailhistory).setVisible(Settings.isMapTrail());
+            menu.findItem(R.id.menu_trailhistory).setVisible(Settings.isMapTrail());
 
             menu.findItem(R.id.submenu_routing).setVisible(Routing.isAvailable());
             switch (Settings.getRoutingMode()) {
@@ -902,10 +903,11 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 return true;
             }
             case R.id.menu_clear_trailhistory: {
-                DataStore.clearTrailHistory();
-                overlayPositionAndScale.setHistory(new ArrayList<Location>());
-                mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null);
-                ActivityMixin.showToast(activity, res.getString(R.string.map_trailhistory_cleared));
+                clearTrailHistory();
+                return true;
+            }
+            case R.id.menu_export_trailhistory: {
+                new TrailHistoryExport(activity, this::clearTrailHistory);
                 return true;
             }
             case R.id.menu_clear_individual_route: {
@@ -970,6 +972,13 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     private void updateTrackHideStatus() {
         overlayPositionAndScale.repaintRequired();
+    }
+
+    private void clearTrailHistory() {
+        DataStore.clearTrailHistory();
+        overlayPositionAndScale.setHistory(new ArrayList<Location>());
+        mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null);
+        ActivityMixin.showToast(activity, res.getString(R.string.map_trailhistory_cleared));
     }
 
     private boolean storeCaches(final Set<String> geocodesInViewport) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -18,6 +18,7 @@ import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.export.TrailHistoryExport;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.ProximityNotification;
@@ -341,7 +342,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
             menu.findItem(R.id.menu_as_list).setVisible(!caches.isDownloading() && caches.getVisibleCachesCount() > 1);
 
-            menu.findItem(R.id.menu_clear_trailhistory).setVisible(Settings.isMapTrail());
+            menu.findItem(R.id.menu_trailhistory).setVisible(Settings.isMapTrail());
 
             menu.findItem(R.id.submenu_routing).setVisible(Routing.isAvailable());
             switch (Settings.getRoutingMode()) {
@@ -482,10 +483,12 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 CacheListActivity.startActivityMap(this, new SearchResult(caches.getVisibleCacheGeocodes()));
                 return true;
             case R.id.menu_clear_trailhistory:
-                this.historyLayer.reset();
-                this.historyLayer.requestRedraw();
-                showToast(res.getString(R.string.map_trailhistory_cleared));
+                clearTrailHistory();
                 return true;
+            case R.id.menu_export_trailhistory: {
+                new TrailHistoryExport(this, this::clearTrailHistory);
+                return true;
+            }
             case R.id.menu_clear_individual_route:
                 route.clearRoute(routeLayer);
                 ActivityMixin.invalidateOptionsMenu(this);
@@ -539,6 +542,12 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 }
         }
         return false;
+    }
+
+    private void clearTrailHistory() {
+        this.historyLayer.reset();
+        this.historyLayer.requestRedraw();
+        showToast(res.getString(R.string.map_trailhistory_cleared));
     }
 
     private Set<String> getUnsavedGeocodes(final Set<String> geocodes) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1242,6 +1242,14 @@ public class Settings {
         putBoolean(R.string.pref_includefoundstatus, includeFoundStatus);
     }
 
+    public static boolean getClearTrailAfterExportStatus() {
+        return getBoolean(R.string.pref_cleartrailafterexportstatus, false);
+    }
+
+    public static void setClearTrailAfterExportStatus(final boolean clearTrailAfterExportStatus) {
+        putBoolean(R.string.pref_cleartrailafterexportstatus, clearTrailAfterExportStatus);
+    }
+
     /**
      * Get Trackable inventory sort method based on the last Trackable inventory sort method.
      *

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2294,6 +2294,24 @@ public class DataStore {
                 });
     }
 
+    public static Location[] loadTrailHistoryAsArray() {
+        init();
+        final Cursor cursor = database.query(dbTableTrailHistory, new String[]{"_id", "latitude", "longitude"}, "latitude IS NOT NULL AND longitude IS NOT NULL", null, null, null, "_id DESC", null);
+        final Location[] result = new Location[cursor.getCount()];
+        int iPosition = 0;
+        try {
+            while (cursor.moveToNext()) {
+                result[iPosition] = new Location("trailHistory");
+                result[iPosition].setLatitude(cursor.getDouble(1));
+                result[iPosition].setLongitude(cursor.getDouble(2));
+                iPosition++;
+            }
+        } finally {
+            cursor.close();
+        }
+        return result;
+    }
+
     public static boolean clearTrailHistory() {
         init();
         database.beginTransaction();


### PR DESCRIPTION
- Add function to export current trail history to GPX track file in GPX export folder.
- Add menu "Trail history" to map menus, including the existing "Clear trail history" and the new "Export trail history" as sub menu entries.

On calling this function the user gets the options
- to share the created GPX file (as in cache list => export), and
- to clear the history trail automatically after export.

![image](https://user-images.githubusercontent.com/3754370/84574293-c8e6cf00-ada5-11ea-995d-3d34ff825f98.png)

During export a progress bar is shown.
