### PR TITLE
Revert geolutin test disabling - Fix #8392

### DIFF
--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeolutinsParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeolutinsParserTest.java
@@ -1,11 +1,14 @@
 package cgeo.geocaching.connector.trackable;
 
 import cgeo.geocaching.models.Trackable;
+import cgeo.geocaching.network.Network;
 import cgeo.geocaching.test.AbstractResourceInstrumentationTestCase;
 import cgeo.geocaching.test.R;
 
+import java.io.InputStream;
 import java.util.List;
 
+import org.apache.commons.compress.utils.IOUtils;
 import org.xml.sax.InputSource;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -46,13 +49,6 @@ public class GeolutinsParserTest extends AbstractResourceInstrumentationTestCase
     }
 
     public static void testService() {
-        /*
-
-        disabled for now,
-        as the page throws a http 403
-        as of 2020-05-30
-
-
         final InputStream page = Network.getResponseStream(Network.getRequest("http://www.geolutins.com/xml/api.php?G=GL007B8"));
         assertThat(page).isNotNull();
 
@@ -69,6 +65,5 @@ public class GeolutinsParserTest extends AbstractResourceInstrumentationTestCase
         } finally {
             IOUtils.closeQuietly(page);
         }
-        */
     }
 }

--- a/tests/src-android/cgeo/watchdog/WatchdogTest.java
+++ b/tests/src-android/cgeo/watchdog/WatchdogTest.java
@@ -6,7 +6,6 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.oc.OCApiConnector;
-import cgeo.geocaching.connector.trackable.GeolutinsConnector;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
@@ -86,8 +85,7 @@ public class WatchdogTest extends CGeoTestCase {
     @NotForIntegrationTests
     public static void testTrackableWebsites() {
         for (final TrackableConnector trackableConnector : ConnectorFactory.getTrackableConnectors()) {
-            // temporarily disable Geolutins connector
-            if (!trackableConnector.equals(ConnectorFactory.UNKNOWN_TRACKABLE_CONNECTOR) && !(trackableConnector instanceof GeolutinsConnector)) {
+            if (!trackableConnector.equals(ConnectorFactory.UNKNOWN_TRACKABLE_CONNECTOR)) {
                 checkWebsite("trackable website " + trackableConnector.getHost(), trackableConnector.getTestUrl());
                 if (StringUtils.isNotBlank(trackableConnector.getProxyUrl())) {
                     checkWebsite("trackable website " + trackableConnector.getHost() + " proxy " + trackableConnector.getProxyUrl(), trackableConnector.getProxyUrl());


### PR DESCRIPTION
Should be merged to release and afterwards release upstream towards master to reenable tests on both branches.

I simply used git revert of the two commits used to disable the tests. Hope it will be fine.
