### PR TITLE
Make map lines customizable (fix #8416)

### DIFF
--- a/main/res/layout/preference_colorpicker.xml
+++ b/main/res/layout/preference_colorpicker.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/preference_colorpicker_select_color_scheme"
+            android:paddingTop="10dp"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"/>
+        <GridLayout
+            android:id="@+id/colorpicker_basegrid"
+            android:paddingTop="10dp"
+            android:paddingLeft="22dp"
+            android:paddingRight="22dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" />
+        <!-- respect item margin for padding calculation -->
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/preference_colorpicker_select_color"
+            android:paddingTop="10dp"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp" />
+        <GridLayout
+            android:id="@+id/colorpicker_colorgrid"
+            android:paddingTop="10dp"
+            android:paddingLeft="22dp"
+            android:paddingRight="22dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:numColumns="auto_fit" />
+        <!-- respect item margin for padding calculation -->
+
+        <LinearLayout
+            android:id="@+id/colorpicker_opaqueness_items"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/colorpicker_opaqueness_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/preference_colorpicker_select_opaqueness"
+                android:paddingTop="10dp"
+                android:paddingLeft="24dp"
+                android:paddingRight="24dp" />
+
+            <LinearLayout
+                android:id="@+id/colorpicker_opaqueness_slider_box"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="0dp"
+                android:paddingRight="0dp"
+                android:paddingTop="10dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginRight="10dp"
+                android:paddingBottom="10dp"
+                android:orientation="horizontal">
+
+                <SeekBar
+                    android:id="@+id/colorpicker_opaqueness_slider"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:min="0"
+                    android:max="255"
+                    android:layout_gravity="left"
+                    android:layout_weight="1"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="4dp" />
+
+                <TextView
+                    android:id="@+id/colorpicker_opaqueness_value"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/preference_colorpicker_select_opaqueness"
+                    android:layout_weight="7"
+                    android:gravity="right"
+                    android:layout_gravity="right"
+                    android:paddingRight="16dp"/>
+
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/main/res/layout/preference_colorpicker_item.xml
+++ b/main/res/layout/preference_colorpicker_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="2dp">
+
+    <ImageView
+        android:id="@+id/colorpicker_item"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_gravity="center"
+        android:scaleType="fitXY" />
+</FrameLayout>

--- a/main/res/values/arrays.xml
+++ b/main/res/values/arrays.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="trailcolors">
-        <item>@string/color_grey</item>
-        <item>@string/color_blue</item>
-        <item>@string/color_green</item>
-    </string-array>
-
-    <string-array name="trailcolorValues">
-        <item>@string/pref_value_grey</item>
-        <item>@string/pref_value_blue</item>
-        <item>@string/pref_value_green</item>
-    </string-array>
-
     <string-array name="proximity_notification_types">
         <item>@string/pn_tone_only</item>
         <item>@string/pn_text_only</item>

--- a/main/res/values/attrs.xml
+++ b/main/res/values/attrs.xml
@@ -44,7 +44,12 @@
     <attr name="url" format="string" />
     <attr name="urlButton" format="string" />
     <attr name="connector" format="string" />
-    
+
+    <!-- attributes for ColorpickerPreference -->
+    <declare-styleable name="ColorpickerPreference">
+        <attr name="showOpaquenessSlider" format="boolean" />
+    </declare-styleable>
+
     <!-- others -->
     <attr name="compass" format="integer" />
     <attr name="progressSpinnerLarge" format="integer" />

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -27,5 +27,10 @@
     <color name="button_default">#282828</color>
     <color name="steel">#675C68</color>
 
+    <color name="default_trailcolor">#80000000</color>
+    <color name="default_routecolor">#800000FF</color>
+    <color name="default_directioncolor">#80FF3333</color>
+    <color name="default_circlecolor">#44BB0000</color>
+    <color name="default_circlefillcolor">#66BB0000</color>
 
 </resources>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -29,6 +29,7 @@
 
     <color name="default_trailcolor">#80000000</color>
     <color name="default_routecolor">#800000FF</color>
+    <color name="default_trackcolor">#80008000</color>
     <color name="default_directioncolor">#80FF3333</color>
     <color name="default_circlecolor">#44BB0000</color>
     <color name="default_circlefillcolor">#66BB0000</color>

--- a/main/res/values/numbers.xml
+++ b/main/res/values/numbers.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- map line width defaults -->
+    <integer name="default_linewidth">6</integer>
+    <integer name="default_trailwidth">4</integer>
+    <integer name="default_directionwidth">6</integer>
+    <integer name="default_routewidth">6</integer>
+    <integer name="default_trackwidth">6</integer>
+</resources>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -101,8 +101,13 @@
     <string translatable="false" name="pref_value_pn_tone_and_text">3</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_mapline_trailcolor">mapline_trailcolor</string>
+    <string translatable="false" name="pref_mapline_trailwidth">mapline_trailwidth</string>
     <string translatable="false" name="pref_mapline_directioncolor">mapline_directioncolor</string>
+    <string translatable="false" name="pref_mapline_directionwidth">mapline_directionwidth</string>
     <string translatable="false" name="pref_mapline_routecolor">mapline_routecolor</string>
+    <string translatable="false" name="pref_mapline_routewidth">mapline_routewidth</string>
+    <string translatable="false" name="pref_mapline_trackcolor">mapline_trackcolor</string>
+    <string translatable="false" name="pref_mapline_trackwidth">mapline_trackwidth</string>
     <string translatable="false" name="pref_mapline_circlecolor">mapline_circlecolor</string>
     <string translatable="false" name="pref_mapline_circlefillcolor">mapline_circlefillcolor</string>
     <string translatable="false" name="pref_showListsInCacheList">showListsInCacheList</string>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -100,7 +100,11 @@
     <string translatable="false" name="pref_value_pn_text_only">2</string>
     <string translatable="false" name="pref_value_pn_tone_and_text">3</string>
     <string translatable="false" name="pref_maptrail">maptrail</string>
-    <string translatable="false" name="pref_trailcolor">trailcolor</string>
+    <string translatable="false" name="pref_mapline_trailcolor">mapline_trailcolor</string>
+    <string translatable="false" name="pref_mapline_directioncolor">mapline_directioncolor</string>
+    <string translatable="false" name="pref_mapline_routecolor">mapline_routecolor</string>
+    <string translatable="false" name="pref_mapline_circlecolor">mapline_circlecolor</string>
+    <string translatable="false" name="pref_mapline_circlefillcolor">mapline_circlefillcolor</string>
     <string translatable="false" name="pref_showListsInCacheList">showListsInCacheList</string>
     <string translatable="false" name="pref_dot_mode">dot_mode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>
@@ -245,10 +249,6 @@
     <string translatable="false" name="pref_map_direction">map_direction</string>
     <string translatable="false" name="pref_map_routing">map_routing</string>
     <string translatable="false" name="pref_theme_menu">theme_menu</string>
-
-    <string translatable="false" name="pref_value_blue">blue</string>
-    <string translatable="false" name="pref_value_green">green</string>
-    <string translatable="false" name="pref_value_grey">grey</string>
 
     <string translatable="false" name="pref_maprotation_off">off</string>
     <string translatable="false" name="pref_maprotation_manual">manual</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -658,7 +658,11 @@
     <string name="init_dataDir_note">You may choose to store the additional data for geocaches (spoilers, log images, …) on your external storage (emulated or real external SD card depending on your device).</string>
     <string name="init_maptrail">Show Trail</string>
     <string name="init_summary_maptrail">Show trail on Map</string>
-    <string name="init_trailcolor">Trail color</string>
+    <string name="init_trailcolor">History trail line color</string>
+    <string name="init_directioncolor">Direction line color</string>
+    <string name="init_routecolor">Route line color</string>
+    <string name="init_circlecolor">Circle line color</string>
+    <string name="init_circlefillcolor">Circle fill color</string>
     <string name="init_share_after_export">Open share menu after GPX export</string>
     <string name="init_include_found_status">Include \"Found\" status</string>
     <string name="init_trackautovisit">Visit TBs</string>
@@ -733,6 +737,7 @@
     <string name="feature_search_finder">Search by finder</string>
     <string name="feature_favorite">Adding cache to favorites</string>
     <string name="feature_voting">Voting for caches</string>
+    <string name="init_maplines_title">Map lines customization</string>
     <string name="init_mapsforge_api_title">Mapsforge API</string>
     <string name="init_mfold_api">Old Mapsforge V3</string>
     <string name="init_mfold_api_description">We are using a new version of the Mapsforge map by default. If you miss some features or encounter issues you can go back to the old version here.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1672,6 +1672,9 @@
     <string name="color_red">Red</string>
     <string name="color_turquoise">Turquoise</string>
     <string name="color_black">Black</string>
+    <string name="preference_colorpicker_select_color_scheme">Select color scheme</string>
+    <string name="preference_colorpicker_select_color">Select color</string>
+    <string name="preference_colorpicker_select_opaqueness">Select opaqueness</string>
 
     <!-- number input -->
     <string name="number_input_title">Enter a value between %1$s and %2$s</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -659,8 +659,13 @@
     <string name="init_maptrail">Show Trail</string>
     <string name="init_summary_maptrail">Show trail on Map</string>
     <string name="init_trailcolor">History trail line color</string>
+    <string name="init_trailwidth">History trail line width</string>
     <string name="init_directioncolor">Direction line color</string>
+    <string name="init_directionwidth">Direction line width</string>
     <string name="init_routecolor">Route line color</string>
+    <string name="init_routewidth">Route line width</string>
+    <string name="init_trackcolor">Track line color</string>
+    <string name="init_trackwidth">Track line width</string>
     <string name="init_circlecolor">Circle line color</string>
     <string name="init_circlefillcolor">Circle fill color</string>
     <string name="init_share_after_export">Open share menu after GPX export</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -676,22 +676,62 @@
 
         <PreferenceCategory android:title="@string/init_maplines_title"
             android:layout="@layout/preference_category">
+
             <cgeo.geocaching.settings.ColorpickerPreference
                 android:title="@string/init_trailcolor"
                 android:key="@string/pref_mapline_trailcolor"
                 android:defaultValue="@color/default_trailcolor"
                 android:dependency="@string/pref_maptrail"
                 app:showOpaquenessSlider="true" />
+            <Preference
+                android:title="@string/init_trailwidth"
+                android:dependency="@string/pref_maptrail"
+                android:selectable="false" />
+            <cgeo.geocaching.settings.MapLineWidthPreference
+                android:key="@string/pref_mapline_trailwidth"
+                android:defaultValue="@integer/default_trailwidth"
+                android:dependency="@string/pref_maptrail"
+                android:layout="@layout/preference_seekbar" />
+
             <cgeo.geocaching.settings.ColorpickerPreference
                 android:title="@string/init_directioncolor"
                 android:key="@string/pref_mapline_directioncolor"
                 android:defaultValue="@color/default_directioncolor"
                 app:showOpaquenessSlider="true" />
+            <Preference
+                android:title="@string/init_directionwidth"
+                android:selectable="false" />
+            <cgeo.geocaching.settings.MapLineWidthPreference
+                android:key="@string/pref_mapline_directionwidth"
+                android:defaultValue="@integer/default_directionwidth"
+                android:layout="@layout/preference_seekbar" />
+
             <cgeo.geocaching.settings.ColorpickerPreference
                 android:title="@string/init_routecolor"
                 android:key="@string/pref_mapline_routecolor"
                 android:defaultValue="@color/default_routecolor"
                 app:showOpaquenessSlider="true" />
+            <Preference
+                android:title="@string/init_routewidth"
+                android:selectable="false" />
+            <cgeo.geocaching.settings.MapLineWidthPreference
+                android:key="@string/pref_mapline_routewidth"
+                android:defaultValue="@integer/default_routewidth"
+                android:layout="@layout/preference_seekbar" />
+
+            <cgeo.geocaching.settings.ColorpickerPreference
+                android:title="@string/init_trackcolor"
+                android:key="@string/pref_mapline_trackcolor"
+                android:defaultValue="@color/default_trackcolor"
+                app:showOpaquenessSlider="true" />
+            <Preference
+                android:title="@string/init_trackwidth"
+                android:selectable="false" />
+            <cgeo.geocaching.settings.MapLineWidthPreference
+                android:key="@string/pref_mapline_trackwidth"
+                android:defaultValue="@integer/default_trackwidth"
+                android:layout="@layout/preference_seekbar" />
+
             <cgeo.geocaching.settings.ColorpickerPreference
                 android:title="@string/init_circlecolor"
                 android:key="@string/pref_mapline_circlecolor"

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -624,14 +624,6 @@
                 android:key="@string/pref_maptrail"
                 android:summary="@string/init_summary_maptrail"
                 android:title="@string/init_maptrail" />
-            <ListPreference
-                android:title="@string/init_trailcolor"
-                android:summary="%s"
-                android:key="@string/pref_trailcolor"
-                android:defaultValue="@string/pref_value_grey"
-                android:dependency="@string/pref_maptrail"
-                android:entries="@array/trailcolors"
-                android:entryValues="@array/trailcolorValues" />
             <Preference
                 android:selectable="false"
                 android:summary="@string/init_brouterThreshold_description"
@@ -680,6 +672,36 @@
                 android:defaultValue="@string/pref_value_pn_tone_only"
                 android:entries="@array/proximity_notification_types"
                 android:entryValues="@array/proximity_notification_values" />
+        </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/init_maplines_title"
+            android:layout="@layout/preference_category">
+            <cgeo.geocaching.settings.ColorpickerPreference
+                android:title="@string/init_trailcolor"
+                android:key="@string/pref_mapline_trailcolor"
+                android:defaultValue="@color/default_trailcolor"
+                android:dependency="@string/pref_maptrail"
+                app:showOpaquenessSlider="true" />
+            <cgeo.geocaching.settings.ColorpickerPreference
+                android:title="@string/init_directioncolor"
+                android:key="@string/pref_mapline_directioncolor"
+                android:defaultValue="@color/default_directioncolor"
+                app:showOpaquenessSlider="true" />
+            <cgeo.geocaching.settings.ColorpickerPreference
+                android:title="@string/init_routecolor"
+                android:key="@string/pref_mapline_routecolor"
+                android:defaultValue="@color/default_routecolor"
+                app:showOpaquenessSlider="true" />
+            <cgeo.geocaching.settings.ColorpickerPreference
+                android:title="@string/init_circlecolor"
+                android:key="@string/pref_mapline_circlecolor"
+                android:defaultValue="@color/default_circlecolor"
+                app:showOpaquenessSlider="true" />
+            <cgeo.geocaching.settings.ColorpickerPreference
+                android:title="@string/init_circlefillcolor"
+                android:key="@string/pref_mapline_circlefillcolor"
+                android:defaultValue="@color/default_circlefillcolor"
+                app:showOpaquenessSlider="true" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_mapsforge_api_title"

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.maps.interfaces.CachesOverlayItemImpl;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IWaypoint;
+import cgeo.geocaching.settings.Settings;
 
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.CircleOptions;
@@ -65,9 +66,9 @@ public class GoogleCacheOverlayItem implements CachesOverlayItemImpl, MapObjectO
         if (showCircles && applyDistanceRule) {
             final CircleOptions circle = new CircleOptions()
                     .center(toLatLng(coord))
-                    .strokeColor(0x44BB0000)
+                    .strokeColor(Settings.getCircleColor())
                     .strokeWidth(2)
-                    .fillColor(0x66BB0000)
+                    .fillColor(Settings.getCircleFillColor())
                     .radius(GoogleCachesList.CIRCLE_RADIUS)
                     .zIndex(GoogleCachesList.ZINDEX_CIRCLE);
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
@@ -4,7 +4,7 @@ import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.maps.interfaces.CachesOverlayItemImpl;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IWaypoint;
-import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.CircleOptions;
@@ -66,9 +66,9 @@ public class GoogleCacheOverlayItem implements CachesOverlayItemImpl, MapObjectO
         if (showCircles && applyDistanceRule) {
             final CircleOptions circle = new CircleOptions()
                     .center(toLatLng(coord))
-                    .strokeColor(Settings.getCircleColor())
+                    .strokeColor(MapLineUtils.getCircleColor())
                     .strokeWidth(2)
-                    .fillColor(Settings.getCircleFillColor())
+                    .fillColor(MapLineUtils.getCircleFillColor())
                     .radius(GoogleCachesList.CIRCLE_RADIUS)
                     .zIndex(GoogleCachesList.ZINDEX_CIRCLE);
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -10,7 +10,7 @@ import cgeo.geocaching.maps.routing.Route;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AngleUtils;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 import cgeo.geocaching.utils.TrackUtils;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
@@ -63,9 +63,6 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     private GoogleMapObjects routeObjs;
     private GoogleMapObjects trackObjs;
     private GoogleMapView mapView;
-    private final int trailColor;
-    private final int routeColor;
-    private final int directionColor;
     private GoogleMapView.PostRealDistance postRealDistance = null;
     private GoogleMapView.PostRealDistance postRouteDistance = null;
 
@@ -82,9 +79,6 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         routeObjs = new GoogleMapObjects(googleMap);
         trackObjs = new GoogleMapObjects(googleMap);
         this.mapView = mapView;
-        trailColor = Settings.getTrailColor();
-        routeColor = Settings.getRouteColor();
-        directionColor = Settings.getDirectionColor();
         this.postRealDistance = postRealDistance;
         this.postRouteDistance = postRouteDistance;
         updateMapRotation();
@@ -205,8 +199,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
 
     private PolylineOptions getDirectionPolyline(final Geopoint from, final Geopoint to) {
         final PolylineOptions options = new PolylineOptions()
-                .width(DisplayUtils.getDirectionLineWidth())
-                .color(directionColor)
+                .width(MapLineUtils.getDirectionLineWidth())
+                .color(MapLineUtils.getDirectionColor())
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(from.getLatitude(), from.getLongitude()));
 
@@ -243,9 +237,9 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         // accuracy circle
         positionObjs.addCircle(new CircleOptions()
                 .center(latLng)
-                .strokeColor(0x66000000)
-                .strokeWidth(3)
-                .fillColor(0x08000000)
+                .strokeColor(MapLineUtils.getCircleColor())
+                .strokeWidth(MapLineUtils.getDefaultThinLineWidth())
+                .fillColor(MapLineUtils.getCircleFillColor())
                 .radius(coordinates.getAccuracy())
                 .zIndex(ZINDEX_POSITION_ACCURACY_CIRCLE)
         );
@@ -305,15 +299,15 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                     historyObjs.addPolyline(new PolylineOptions()
                             .addAll(points)
                             .color(0xFFFFFFFF)
-                            .width(DisplayUtils.getHistoryLineInsetWidth())
+                            .width(MapLineUtils.getHistoryLineInsetWidth())
                             .zIndex(ZINDEX_HISTORY)
                     );
 
                     // history line shadow
                     historyObjs.addPolyline(new PolylineOptions()
                             .addAll(points)
-                            .color(trailColor)
-                            .width(DisplayUtils.getHistoryLineShadowWidth())
+                            .color(MapLineUtils.getTrailColor())
+                            .width(MapLineUtils.getHistoryLineShadowWidth())
                             .zIndex(ZINDEX_HISTORY_SHADOW)
                     );
                 }
@@ -326,8 +320,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         if (route != null && route.size() > 1) {
             routeObjs.addPolyline(new PolylineOptions()
                     .addAll(route)
-                    .color(routeColor)
-                    .width(DisplayUtils.getRouteLineWidth())
+                    .color(MapLineUtils.getRouteColor())
+                    .width(MapLineUtils.getRouteLineWidth())
                     .zIndex(ZINDEX_ROUTE)
             );
         }
@@ -338,7 +332,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
             return;
         }
         final PolylineOptions options = new PolylineOptions()
-                .width(DisplayUtils.getDirectionLineWidth())
+                .width(MapLineUtils.getDebugLineWidth())
                 .color(0x80EB391E)
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(viewport.getLatitudeMin(), viewport.getLongitudeMin()))
@@ -356,8 +350,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         if (track != null && track.size() > 1 && !Settings.isHideTrack()) {
             trackObjs.addPolyline(new PolylineOptions()
                 .addAll(track)
-                .color(0xFF00A000)
-                .width(DisplayUtils.getTrackLineWidth())
+                .color(MapLineUtils.getTrackColor())
+                .width(MapLineUtils.getTrackLineWidth())
                 .zIndex(ZINDEX_TRACK)
             );
         }

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -64,6 +64,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     private GoogleMapObjects trackObjs;
     private GoogleMapView mapView;
     private final int trailColor;
+    private final int routeColor;
+    private final int directionColor;
     private GoogleMapView.PostRealDistance postRealDistance = null;
     private GoogleMapView.PostRealDistance postRouteDistance = null;
 
@@ -81,6 +83,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         trackObjs = new GoogleMapObjects(googleMap);
         this.mapView = mapView;
         trailColor = Settings.getTrailColor();
+        routeColor = Settings.getRouteColor();
+        directionColor = Settings.getDirectionColor();
         this.postRealDistance = postRealDistance;
         this.postRouteDistance = postRouteDistance;
         updateMapRotation();
@@ -202,7 +206,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     private PolylineOptions getDirectionPolyline(final Geopoint from, final Geopoint to) {
         final PolylineOptions options = new PolylineOptions()
                 .width(DisplayUtils.getDirectionLineWidth())
-                .color(0x80EB391E)
+                .color(directionColor)
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(from.getLatitude(), from.getLongitude()));
 
@@ -322,7 +326,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         if (route != null && route.size() > 1) {
             routeObjs.addPolyline(new PolylineOptions()
                     .addAll(route)
-                    .color(0xFF0000FF)
+                    .color(routeColor)
                     .width(DisplayUtils.getRouteLineWidth())
                     .zIndex(ZINDEX_ROUTE)
             );

--- a/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
@@ -6,7 +6,7 @@ import cgeo.geocaching.maps.interfaces.MapProjectionImpl;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.CanvasUtils;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -33,7 +33,7 @@ public class DirectionDrawer {
         this.destinationCoords = coords;
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
         this.postRealDistance = postRealDistance;
-        width = DisplayUtils.getDirectionLineWidth();
+        width = MapLineUtils.getDirectionLineWidth();
     }
 
     public void setCoordinates(final Location coordinatesIn) {
@@ -54,7 +54,7 @@ public class DirectionDrawer {
             linePaint.setAntiAlias(true);
             linePaint.setStrokeWidth(width);
             linePaint.setStyle(Paint.Style.STROKE);
-            linePaint.setColor(Settings.getDirectionColor());
+            linePaint.setColor(MapLineUtils.getDirectionColor());
         }
 
         final Geopoint[] routingPoints = Routing.getTrack(currentCoords, destinationCoords);

--- a/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/DirectionDrawer.java
@@ -54,7 +54,7 @@ public class DirectionDrawer {
             linePaint.setAntiAlias(true);
             linePaint.setStrokeWidth(width);
             linePaint.setStyle(Paint.Style.STROKE);
-            linePaint.setColor(0xD0EB391E);
+            linePaint.setColor(Settings.getDirectionColor());
         }
 
         final Geopoint[] routingPoints = Routing.getTrack(currentCoords, destinationCoords);

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeCachesList.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeCachesList.java
@@ -123,12 +123,12 @@ public class MapsforgeCachesList extends AbstractItemizedOverlay {
                 projection.toPixels(itemGeo, center);
                 if (center.x > -radius && center.y > -radius && center.x < width + radius && center.y < height + radius) {
                     // dashed circle around the waypoint
-                    blockedCircle.setColor(0x66BB0000);
+                    blockedCircle.setColor(Settings.getCircleColor());
                     blockedCircle.setStyle(Style.STROKE);
                     canvas.drawCircle(center.x, center.y, radius, blockedCircle);
 
                     // filling the circle area with a transparent color
-                    blockedCircle.setColor(0x44BB0000);
+                    blockedCircle.setColor(Settings.getCircleFillColor());
                     blockedCircle.setStyle(Style.FILL);
                     canvas.drawCircle(center.x, center.y, radius, blockedCircle);
                 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeCachesList.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeCachesList.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import android.content.res.Resources.NotFoundException;
 import android.graphics.Canvas;
@@ -123,12 +124,12 @@ public class MapsforgeCachesList extends AbstractItemizedOverlay {
                 projection.toPixels(itemGeo, center);
                 if (center.x > -radius && center.y > -radius && center.x < width + radius && center.y < height + radius) {
                     // dashed circle around the waypoint
-                    blockedCircle.setColor(Settings.getCircleColor());
+                    blockedCircle.setColor(MapLineUtils.getCircleColor());
                     blockedCircle.setStyle(Style.STROKE);
                     canvas.drawCircle(center.x, center.y, radius, blockedCircle);
 
                     // filling the circle area with a transparent color
-                    blockedCircle.setColor(Settings.getCircleFillColor());
+                    blockedCircle.setColor(MapLineUtils.getCircleFillColor());
                     blockedCircle.setStyle(Style.FILL);
                     canvas.drawCircle(center.x, center.y, radius, blockedCircle);
                 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
@@ -8,7 +8,7 @@ import cgeo.geocaching.maps.interfaces.GeoPointImpl;
 import cgeo.geocaching.maps.interfaces.MapItemFactory;
 import cgeo.geocaching.maps.interfaces.MapProjectionImpl;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -48,7 +48,7 @@ public class PositionDrawer {
 
     public PositionDrawer() {
         this.mapItemFactory = Settings.getMapProvider().getMapItemFactory();
-        trailColor = Settings.getTrailColor();
+        trailColor = MapLineUtils.getTrailColor();
     }
 
     void drawPosition(final Canvas canvas, final MapProjectionImpl projection) {
@@ -65,14 +65,14 @@ public class PositionDrawer {
         if (historyLine == null) {
             historyLine = new Paint();
             historyLine.setAntiAlias(true);
-            historyLine.setStrokeWidth(DisplayUtils.getHistoryLineInsetWidth());
+            historyLine.setStrokeWidth(MapLineUtils.getHistoryLineInsetWidth());
             historyLine.setColor(0xFFFFFFFF);
         }
 
         if (historyLineShadow == null) {
             historyLineShadow = new Paint();
             historyLineShadow.setAntiAlias(true);
-            historyLineShadow.setStrokeWidth(DisplayUtils.getHistoryLineShadowWidth());
+            historyLineShadow.setStrokeWidth(MapLineUtils.getHistoryLineShadowWidth());
             historyLineShadow.setColor(trailColor);
         }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.location.IConversion;
 import cgeo.geocaching.maps.mapsforge.v6.TapHandler;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.DisplayUtils;
 
 import android.util.DisplayMetrics;
@@ -42,11 +43,11 @@ public class GeoitemLayer extends Marker {
         strokePaint = AndroidGraphicFactory.INSTANCE.createPaint();
         strokePaint.setStrokeWidth(2.0f);
         strokePaint.setDashPathEffect(new float[] { 3, 2 });
-        strokePaint.setColor(0x66BB0000);
+        strokePaint.setColor(Settings.getCircleColor());
         strokePaint.setStyle(Style.STROKE);
 
         fillPaint = AndroidGraphicFactory.INSTANCE.createPaint();
-        fillPaint.setColor(0x44BB0000);
+        fillPaint.setColor(Settings.getCircleFillColor());
         fillPaint.setStyle(Style.FILL);
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemLayer.java
@@ -2,8 +2,8 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.location.IConversion;
 import cgeo.geocaching.maps.mapsforge.v6.TapHandler;
-import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import android.util.DisplayMetrics;
 
@@ -43,11 +43,11 @@ public class GeoitemLayer extends Marker {
         strokePaint = AndroidGraphicFactory.INSTANCE.createPaint();
         strokePaint.setStrokeWidth(2.0f);
         strokePaint.setDashPathEffect(new float[] { 3, 2 });
-        strokePaint.setColor(Settings.getCircleColor());
+        strokePaint.setColor(MapLineUtils.getCircleColor());
         strokePaint.setStyle(Style.STROKE);
 
         fillPaint = AndroidGraphicFactory.INSTANCE.createPaint();
-        fillPaint.setColor(Settings.getCircleFillColor());
+        fillPaint.setColor(MapLineUtils.getCircleFillColor());
         fillPaint.setStyle(Style.FILL);
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/AbstractLineLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/AbstractLineLayer.java
@@ -1,7 +1,7 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.location.Geopoint;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import androidx.core.util.Pair;
 
@@ -28,7 +28,7 @@ abstract class AbstractLineLayer extends Layer {
     private long mapSize = 0;
 
     protected AbstractLineLayer() {
-        width = DisplayUtils.getDefaultThinLineWidth();
+        width = MapLineUtils.getDefaultThinLineWidth();
     }
 
     public void updateTrack(final ArrayList<Geopoint> track) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -2,7 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.maps.PositionHistory;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import android.location.Location;
 
@@ -35,7 +35,7 @@ public class HistoryLayer extends Layer {
         if (locationHistory != null) {
             positionHistory.setHistory(locationHistory);
         }
-        trailColor = Settings.getTrailColor();
+        trailColor = MapLineUtils.getTrailColor();
     }
 
     public void reset() {
@@ -50,13 +50,13 @@ public class HistoryLayer extends Layer {
 
         if (historyLine == null) {
             historyLine = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLine.setStrokeWidth(DisplayUtils.getHistoryLineInsetWidth());
+            historyLine.setStrokeWidth(MapLineUtils.getHistoryLineInsetWidth());
             historyLine.setColor(0xFFFFFFFF);
         }
 
         if (historyLineShadow == null) {
             historyLineShadow = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLineShadow.setStrokeWidth(DisplayUtils.getHistoryLineShadowWidth());
+            historyLineShadow.setStrokeWidth(MapLineUtils.getHistoryLineShadowWidth());
             historyLineShadow.setColor(trailColor);
         }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -58,7 +58,7 @@ public class NavigationLayer extends Layer {
             line = AndroidGraphicFactory.INSTANCE.createPaint();
             line.setStrokeWidth(width);
             line.setStyle(Style.STROKE);
-            line.setColor(0xD0EB391E);
+            line.setColor(Settings.getDirectionColor());
             line.setTextSize(20);
         }
         final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -3,7 +3,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import android.location.Location;
 
@@ -37,7 +37,7 @@ public class NavigationLayer extends Layer {
 
         this.destinationCoords = coords;
         this.postRealDistance = postRealDistance;
-        width = DisplayUtils.getDirectionLineWidth();
+        width = MapLineUtils.getDirectionLineWidth();
     }
 
     public void setDestination(final Geopoint coords) {
@@ -58,7 +58,7 @@ public class NavigationLayer extends Layer {
             line = AndroidGraphicFactory.INSTANCE.createPaint();
             line.setStrokeWidth(width);
             line.setStyle(Style.STROKE);
-            line.setColor(Settings.getDirectionColor());
+            line.setColor(MapLineUtils.getDirectionColor());
             line.setTextSize(20);
         }
         final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -2,8 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.routing.Route;
-import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.utils.DisplayUtils;
+import cgeo.geocaching.utils.MapLineUtils;
 
 import java.util.ArrayList;
 
@@ -22,9 +21,9 @@ public class RouteLayer extends AbstractLineLayer implements Route.RouteUpdater 
 
     public RouteLayer(final PostRealDistance postRealRouteDistance) {
         super();
-        lineColor = Settings.getRouteColor();
         this.postRealRouteDistance = postRealRouteDistance;
-        width = DisplayUtils.getRouteLineWidth();
+        lineColor = MapLineUtils.getRouteColor();
+        width = MapLineUtils.getRouteLineWidth();
     }
 
     public void updateRoute(final ArrayList<Geopoint> route, final float distance) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.routing.Route;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.DisplayUtils;
 
 import java.util.ArrayList;
@@ -21,7 +22,7 @@ public class RouteLayer extends AbstractLineLayer implements Route.RouteUpdater 
 
     public RouteLayer(final PostRealDistance postRealRouteDistance) {
         super();
-        lineColor = 0xD00000A0;
+        lineColor = Settings.getRouteColor();
         this.postRealRouteDistance = postRealRouteDistance;
         width = DisplayUtils.getRouteLineWidth();
     }
@@ -43,5 +44,4 @@ public class RouteLayer extends AbstractLineLayer implements Route.RouteUpdater 
             postRealRouteDistance.postRealDistance(distance);
         }
     }
-
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TrackLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TrackLayer.java
@@ -1,12 +1,14 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
+import cgeo.geocaching.utils.MapLineUtils;
 import cgeo.geocaching.utils.TrackUtils;
 
 public class TrackLayer extends AbstractLineLayer implements TrackUtils.TrackUpdaterSingle {
 
     public TrackLayer(final boolean isHidden) {
         this.isHidden = isHidden;
-        lineColor = 0xD000A000;
+        lineColor = MapLineUtils.getTrackColor();
+        width = MapLineUtils.getTrackLineWidth();
     }
 
     public void updateTrack(final TrackUtils.Track track) {

--- a/main/src/cgeo/geocaching/settings/ColorpickerPreference.java
+++ b/main/src/cgeo/geocaching/settings/ColorpickerPreference.java
@@ -1,0 +1,230 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.utils.DisplayUtils;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.GridLayout;
+import android.widget.ImageView;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import java.util.Locale;
+
+public class ColorpickerPreference extends DialogPreference {
+
+    private int colorScheme = 0;                    // currently selected color scheme
+    private int color = 0xffff0000;                 // currently selected color (incl. opaqueness)
+    private boolean showOpaquenessSlider = false;   // show opaqueness slider?
+
+    private GridLayout colorSchemeGrid = null;
+    private GridLayout colorGrid = null;
+    private TextView opaquenessValue = null;
+    private SeekBar opaquenessSlider = null;
+
+    private int iconSize = 0;
+    private final DisplayMetrics dm = DisplayUtils.getDisplayMetrics();
+    private final float radius = DisplayUtils.getDisplayDensity() * 2.0f;
+    private final float[] radii = { radius, radius, radius, radius, radius, radius, radius, radius };
+    private final int strokeWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2, dm);
+
+    public ColorpickerPreference(final Context context) {
+        this(context, null);
+    }
+
+    public ColorpickerPreference(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.dialogPreferenceStyle);
+    }
+
+    public ColorpickerPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        setWidgetLayoutResource(R.layout.preference_colorpicker_item);
+        setDialogLayoutResource(R.layout.preference_colorpicker);
+        setPositiveButtonText(android.R.string.ok);
+        setNegativeButtonText(android.R.string.cancel);
+
+        // set icon size dynamically, based on screen dimensions
+        iconSize = Math.max(50, Math.min(dm.widthPixels, dm.heightPixels) / 10);
+
+        // get additional params, if given
+        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ColorpickerPreference, defStyle, 0);
+        try {
+            showOpaquenessSlider = a.getBoolean(R.styleable.ColorpickerPreference_showOpaquenessSlider, false);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    @Override
+    protected void onBindView(final View view) {
+        super.onBindView(view);
+        final ImageView colorView = view.findViewById(R.id.colorpicker_item);
+        if (colorView != null) {
+            setViewColor(colorView, color, false);
+        }
+    }
+
+    @Override
+    protected void onBindDialogView(final View v) {
+        super.onBindDialogView(v);
+        if (null != v) {
+            colorSchemeGrid = v.findViewById(R.id.colorpicker_basegrid);
+            colorSchemeGrid.setColumnCount(6);
+
+            colorGrid = v.findViewById(R.id.colorpicker_colorgrid);
+            colorGrid.setColumnCount(6);
+
+            int opaqueness = getOpaqueness();
+            opaquenessSlider = v.findViewById(R.id.colorpicker_opaqueness_slider);
+            opaquenessValue = v.findViewById(R.id.colorpicker_opaqueness_value);
+
+            if (showOpaquenessSlider) {
+                v.findViewById(R.id.colorpicker_opaqueness_items).setVisibility(View.VISIBLE);
+                opaquenessSlider.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                    @Override
+                    public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
+                        selectOpaqueness(progress);
+                    }
+
+                    @Override
+                    public void onStartTrackingTouch(final SeekBar seekBar) {
+                        // nothing to do
+                    }
+
+                    @Override
+                    public void onStopTrackingTouch(final SeekBar seekBar) {
+                        // nothing to do
+                    }
+                });
+            } else {
+                // without opaqueness slider don't use fully transparent colors
+                if (opaqueness == 0) {
+                    opaqueness = 0xff;
+                }
+            }
+
+            opaquenessSlider.setProgress(opaqueness);
+            selectOpaqueness(opaqueness);
+
+        } else {
+            throw new IllegalStateException("onBindDialogView without view?");
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(final TypedArray a, final int index) {
+        return a.getInt(index, 0xffff0000);
+    }
+
+    @Override
+    protected void onSetInitialValue(final boolean restoreValue, final Object defaultValue) {
+        setValue(restoreValue ? getPersistedInt(0) : (Integer) defaultValue);
+    }
+
+    public void setValue(final int value) {
+        if (callChangeListener(value)) {
+            color = value;
+            colorScheme = getColorScheme();
+            if (null != opaquenessSlider) {
+                opaquenessSlider.setProgress(getOpaqueness());
+            }
+            persistInt(value);
+            notifyChanged();
+        }
+    }
+
+    @Override
+    protected void onDialogClosed(final boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+        if (positiveResult) {
+            setValue(color);
+        }
+    }
+
+    private void initColorSchemeGrid() {
+        final LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        colorSchemeGrid.removeAllViews();
+        final int opaqueness = color & 0xff000000;
+        for (int r = 0; r < 6; r++) {
+            final int newColor = opaqueness + ((r * 51) << 16);
+            colorSchemeGrid.addView(getIcon(inflater, colorSchemeGrid, r, newColor, r == colorScheme, this::selectColorScheme));
+        }
+    }
+
+    private void initColorGrid(final int red) {
+        final LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        colorGrid.removeAllViews();
+        final int opaqueness = color & 0xff000000;
+        for (int green = 0; green < 6; green++) {
+            for (int blue = 0; blue < 6; blue++) {
+                final int newColor = opaqueness + (((red * 51) << 16) + ((green * 51) << 8) + (blue * 51));
+                colorGrid.addView(getIcon(inflater, colorGrid, newColor, newColor, newColor == color, this::selectColor));
+            }
+        }
+    }
+
+    private View getIcon(final LayoutInflater inflater, final GridLayout grid, final int id, final int newColor, final boolean selected, final View.OnClickListener onClickListener) {
+        final View itemView = inflater.inflate(R.layout.preference_colorpicker_item, grid, false);
+        itemView.findViewById(R.id.colorpicker_item).setLayoutParams(new FrameLayout.LayoutParams(iconSize, iconSize));
+        setViewColor(itemView.findViewById(R.id.colorpicker_item), newColor, selected);
+        itemView.setId(id);
+        itemView.setClickable(true);
+        itemView.setFocusable(true);
+        itemView.setOnClickListener(onClickListener);
+        return itemView;
+    }
+
+    private void setViewColor(final ImageView imageView, final int color, final boolean selected) {
+        final Drawable current = imageView.getDrawable();
+        final GradientDrawable drawable;
+        if (current instanceof GradientDrawable) {
+            drawable = (GradientDrawable) current;
+        } else {
+            drawable = new GradientDrawable();
+            drawable.setShape(selected ? GradientDrawable.OVAL : GradientDrawable.RECTANGLE);
+        }
+        drawable.setCornerRadii(radii);
+        drawable.setColor(color);
+        drawable.setStroke(strokeWidth, Color.rgb(Color.red(color) * 224 / 256, Color.green(color) * 224 / 256, Color.blue(color) * 224 / 256));
+        imageView.setImageDrawable(drawable);
+    }
+
+    private int getColorScheme() {
+        return ((color & 0xffffff) >> 16) / 51;
+    }
+
+    private int getOpaqueness() {
+        return (color >> 24) & 0xff;
+    }
+
+    private void selectColor(final View button) {
+        color = button.getId();
+        initColorGrid(colorScheme);
+    }
+
+    private void selectColorScheme(final View button) {
+        colorScheme = button.getId();
+        initColorSchemeGrid();
+        initColorGrid(colorScheme);
+    }
+
+    private void selectOpaqueness(final int opaqueness) {
+        opaquenessValue.setText(String.format(Locale.getDefault(), "%d", opaqueness));
+        color = ((opaqueness & 0xff) << 24) + (color & 0xffffff);
+        colorScheme = getColorScheme();
+        initColorSchemeGrid();
+        initColorGrid(colorScheme);
+    }
+
+}

--- a/main/src/cgeo/geocaching/settings/MapLineWidthPreference.java
+++ b/main/src/cgeo/geocaching/settings/MapLineWidthPreference.java
@@ -1,0 +1,53 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+class MapLineWidthPreference extends AbstractSeekbarPreference {
+
+    private int startValue = 0;
+
+    MapLineWidthPreference(final Context context) {
+        this(context, null);
+    }
+
+    MapLineWidthPreference(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.preferenceStyle);
+    }
+
+    MapLineWidthPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+        setPersistent(true);
+        setLayoutResource(R.layout.preference_seekbar);
+    }
+
+    @Override
+    protected void onSetInitialValue(final boolean restoreValue, final Object defaultValue) {
+        startValue = restoreValue ? getPersistedInt(getContext().getResources().getInteger(R.integer.default_linewidth)) : (Integer) defaultValue;
+    }
+
+    @Override
+    protected void saveSetting(final int progress) {
+        if (callChangeListener(progress)) {
+            persistInt(progress);
+            notifyChanged();
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(final TypedArray a, final int index) {
+        return a.getInt(index, getContext().getResources().getInteger(R.integer.default_linewidth));
+    }
+
+    @Override
+    protected View onCreateView(final ViewGroup parent) {
+        configure(0, 50, startValue, null, false);
+        return super.onCreateView(parent);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -832,24 +832,8 @@ public class Settings {
         putBoolean(R.string.pref_showListsInCacheList, showListsInCacheList);
     }
 
-    public static int getTrailColor() {
-        return getInt(R.string.pref_mapline_trailcolor, getKeyInt(R.color.default_trailcolor));
-    }
-
-    public static int getRouteColor() {
-        return getInt(R.string.pref_mapline_routecolor, getKeyInt(R.color.default_routecolor));
-    }
-
-    public static int getDirectionColor() {
-        return getInt(R.string.pref_mapline_directioncolor, getKeyInt(R.color.default_directioncolor));
-    }
-
-    public static int getCircleColor() {
-        return getInt(R.string.pref_mapline_circlecolor, getKeyInt(R.color.default_circlecolor));
-    }
-
-    public static int getCircleFillColor() {
-        return getInt(R.string.pref_mapline_circlefillcolor, getKeyInt(R.color.default_circlefillcolor));
+    public static int getMapLineValue(final int prefKeyId, final int defaultValueKeyId) {
+        return getInt(prefKeyId, getKeyInt(defaultValueKeyId));
     }
 
     public static boolean isDotMode() {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -304,6 +304,10 @@ public class Settings {
         return CgeoApplication.getInstance().getString(prefKeyId);
     }
 
+    private static int getKeyInt(final int prefKeyId) {
+        return CgeoApplication.getInstance().getResources().getInteger(prefKeyId);
+    }
+
     static String getString(final int prefKeyId, final String defaultValue) {
         return sharedPrefs.getString(getKey(prefKeyId), defaultValue);
     }
@@ -829,16 +833,23 @@ public class Settings {
     }
 
     public static int getTrailColor() {
-        final Context baseContext = CgeoApplication.getInstance().getBaseContext();
-        final String defaultValue = baseContext.getString(R.string.pref_value_grey);
-        final String trailColor = getString(R.string.pref_trailcolor, defaultValue);
-        if (trailColor.equals(baseContext.getString(R.string.pref_value_blue))) {
-            return 0xff0000dd;
-        } else if (trailColor.equals(baseContext.getString(R.string.pref_value_green))) {
-            return 0xff006b00;
-        } else {
-            return 0x66000000;
-        }
+        return getInt(R.string.pref_mapline_trailcolor, getKeyInt(R.color.default_trailcolor));
+    }
+
+    public static int getRouteColor() {
+        return getInt(R.string.pref_mapline_routecolor, getKeyInt(R.color.default_routecolor));
+    }
+
+    public static int getDirectionColor() {
+        return getInt(R.string.pref_mapline_directioncolor, getKeyInt(R.color.default_directioncolor));
+    }
+
+    public static int getCircleColor() {
+        return getInt(R.string.pref_mapline_circlecolor, getKeyInt(R.color.default_circlecolor));
+    }
+
+    public static int getCircleFillColor() {
+        return getInt(R.string.pref_mapline_circlefillcolor, getKeyInt(R.color.default_circlefillcolor));
     }
 
     public static boolean isDotMode() {

--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -9,10 +9,6 @@ import android.view.WindowManager;
 
 public class DisplayUtils {
 
-    private static final float THIN_LINE = 4f;
-    private static final float HISTORY_LINE_SHADOW = 3f;
-    private static final float HISTORY_LINE_INSET = HISTORY_LINE_SHADOW / 2;
-
     private DisplayUtils() {
         // Utility class, do not instantiate
     }
@@ -36,32 +32,4 @@ public class DisplayUtils {
         return metrics;
     }
 
-    public static float getRouteLineWidth() {
-        return THIN_LINE * getDisplayDensity();
-    }
-
-    public static float getDirectionLineWidth() {
-        return THIN_LINE * getDisplayDensity();
-    }
-
-    public static float getHistoryLineShadowWidth() {
-        return HISTORY_LINE_SHADOW * getDisplayDensity();
-    }
-
-    public static float getHistoryLineInsetWidth() {
-        return HISTORY_LINE_INSET * getDisplayDensity();
-    }
-
-    public static float getTrackLineWidth() {
-        return THIN_LINE * getDisplayDensity();
-    }
-
-    public static float getDefaultThinLineWidth() {
-        return THIN_LINE * getDisplayDensity();
-    }
-
-    // for drawing debug relevant lines
-    public static float getDebugLineWidth() {
-        return THIN_LINE * getDisplayDensity();
-    }
 }

--- a/main/src/cgeo/geocaching/utils/MapLineUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapLineUtils.java
@@ -1,0 +1,85 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+
+public class MapLineUtils {
+
+    private static final float THIN_LINE = 4f;
+
+    private MapLineUtils() {
+        // utility class
+    }
+
+    // history trail line
+
+    public static float getHistoryLineShadowWidth() {
+        return getWidth(R.string.pref_mapline_trailwidth, R.integer.default_trailwidth);
+    }
+
+    public static float getHistoryLineInsetWidth() {
+        return getHistoryLineShadowWidth() / 2.0f;
+    }
+
+    public static int getTrailColor() {
+        return Settings.getMapLineValue(R.string.pref_mapline_trailcolor, R.color.default_trailcolor);
+    }
+
+    // direction line
+
+    public static float getDirectionLineWidth() {
+        return getWidth(R.string.pref_mapline_directionwidth, R.integer.default_directionwidth);
+    }
+
+    public static int getDirectionColor() {
+        return Settings.getMapLineValue(R.string.pref_mapline_directioncolor, R.color.default_directioncolor);
+    }
+
+    // route line
+
+    public static float getRouteLineWidth() {
+        return getWidth(R.string.pref_mapline_routewidth, R.integer.default_routewidth);
+    }
+
+    public static int getRouteColor() {
+        return Settings.getMapLineValue(R.string.pref_mapline_routecolor, R.color.default_routecolor);
+    }
+
+    // track line
+
+    public static float getTrackLineWidth() {
+        return getWidth(R.string.pref_mapline_trackwidth, R.integer.default_trackwidth);
+    }
+
+    public static int getTrackColor() {
+        return Settings.getMapLineValue(R.string.pref_mapline_trackcolor, R.color.default_trackcolor);
+    }
+
+    // circle line
+
+    public static int getCircleColor() {
+        return Settings.getMapLineValue(R.string.pref_mapline_circlecolor, R.color.default_circlecolor);
+    }
+
+    public static int getCircleFillColor() {
+        return Settings.getMapLineValue(R.string.pref_mapline_circlefillcolor, R.color.default_circlefillcolor);
+    }
+
+    // other lines
+
+    public static float getDefaultThinLineWidth() {
+        return THIN_LINE * DisplayUtils.getDisplayDensity();
+    }
+
+    // for drawing debug relevant lines
+    public static float getDebugLineWidth() {
+        return THIN_LINE * DisplayUtils.getDisplayDensity();
+    }
+
+    // helper methods
+
+    private static float getWidth(final int prefKeyId, final int defaultValueKeyId) {
+        return (Settings.getMapLineValue(prefKeyId, defaultValueKeyId) / 5.0f + 1.0f) * DisplayUtils.getDisplayDensity();
+    }
+
+}


### PR DESCRIPTION
Code cleanup + customization for map line colors and width:
- Default values are now constants in `colors.xml` (colors) resp. `numbers.xml` (widths).
- Google Maps and OSM use the same utility functions for colors and widths
- Colors and widths are customizable using settings => map => map lines customization
- Dialog works in dark and light theme
- Old trail color functions and resources removed

Preference dialog:
![image](https://user-images.githubusercontent.com/3754370/84599610-92778580-ae73-11ea-9984-ee65300c0703.png)

Color picker:
![image](https://user-images.githubusercontent.com/3754370/84599619-9dcab100-ae73-11ea-9436-a06723914463.png)

Available for:
- Trail history line
- Direction / navigation line
- Route line
- Track line
- Circle line / fill
