### PR TITLE
support legacy external storage as temporary fix

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -49,7 +49,8 @@
         android:hardwareAccelerated="false"
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"
-        android:largeHeap="true">
+        android:largeHeap="true"
+        android:requestLegacyExternalStorage="true">
 
         <!-- Samsung Multi-Window support -->
         <uses-library


### PR DESCRIPTION
Temporary workaround for #8457: use compatibility flag "legacyExternalStorage" to be able to access user data on Android Q devices again (like database backup etc.)

This is a temporary workaround only - we still need to investigate the new scoped storage concepts and adapt c:geo accordingly.