### PR TITLE
fix duplicate extension checks

### DIFF
--- a/main/src/cgeo/geocaching/HandleLocalFilesActivity.java
+++ b/main/src/cgeo/geocaching/HandleLocalFilesActivity.java
@@ -5,6 +5,11 @@ import cgeo.geocaching.files.FileType;
 import cgeo.geocaching.files.FileTypeDetector;
 import cgeo.geocaching.settings.ReceiveMapFileActivity;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import static cgeo.geocaching.utils.FileUtils.COMPRESSED_GPX_FILE_EXTENSION;
+import static cgeo.geocaching.utils.FileUtils.GPX_FILE_EXTENSION;
+import static cgeo.geocaching.utils.FileUtils.LOC_FILE_EXTENSION;
+import static cgeo.geocaching.utils.FileUtils.MAP_FILE_EXTENSION;
+import static cgeo.geocaching.utils.FileUtils.ZIP_FILE_EXTENSION;
 
 import android.content.ContentResolver;
 import android.content.Intent;
@@ -29,10 +34,10 @@ public class HandleLocalFilesActivity extends AbstractActivity {
                 final int startExtension = parsedUri.lastIndexOf('.');
                 if (startExtension > -1) {
                     final String extension = parsedUri.substring(startExtension).toLowerCase();
-                    if (".zip".equals(extension) || ".gpx".equals(extension) || ".gpx".equals(extension)) {
+                    if (extension.equals(ZIP_FILE_EXTENSION) || extension.equals(GPX_FILE_EXTENSION) || extension.equals(COMPRESSED_GPX_FILE_EXTENSION) || extension.equals(LOC_FILE_EXTENSION)) {
                         continueWith(CacheListActivity.class, intent);
                         finished = true;
-                    } else if (".map".equals(extension)) {
+                    } else if (extension.equals(MAP_FILE_EXTENSION)) {
                         continueWith(ReceiveMapFileActivity.class, intent);
                         finished = true;
                     }

--- a/main/src/cgeo/geocaching/files/AbstractImportGpxZipThread.java
+++ b/main/src/cgeo/geocaching/files/AbstractImportGpxZipThread.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.files;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.TextUtils;
 
 import android.os.Handler;
@@ -38,7 +39,7 @@ abstract class AbstractImportGpxZipThread extends AbstractImportGpxThread {
             int ignoredFiles = 0;
             for (ZipEntry zipEntry = zisPass1.getNextZipEntry(); zipEntry != null; zipEntry = zisPass1.getNextZipEntry()) {
                 gpxFileName = zipEntry.getName();
-                if (StringUtils.endsWithIgnoreCase(gpxFileName, GPXImporter.GPX_FILE_EXTENSION)) {
+                if (StringUtils.endsWithIgnoreCase(gpxFileName, FileUtils.GPX_FILE_EXTENSION)) {
                     if (!StringUtils.endsWithIgnoreCase(gpxFileName, GPXImporter.WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
                         importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_READ_FILE, R.string.gpx_import_loading_caches_with_filename, (int) zipEntry.getSize(), getSourceDisplayName()));
                         caches = parser.parse(new NoCloseInputStream(zisPass1), progressHandler);

--- a/main/src/cgeo/geocaching/files/GPXImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXImporter.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.activity.Progress;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
@@ -36,12 +37,8 @@ public class GPXImporter {
     static final int IMPORT_STEP_CANCELED = 8;
     static final int IMPORT_STEP_STATIC_MAPS_SKIPPED = 9;
 
-    public static final String GPX_FILE_EXTENSION = ".gpx";
-    public static final String LOC_FILE_EXTENSION = ".loc";
-    public static final String ZIP_FILE_EXTENSION = ".zip";
-    public static final String COMPRESSED_GPX_FILE_EXTENSION = ".ggz";
     public static final String WAYPOINTS_FILE_SUFFIX = "-wpts";
-    public static final String WAYPOINTS_FILE_SUFFIX_AND_EXTENSION = WAYPOINTS_FILE_SUFFIX + GPX_FILE_EXTENSION;
+    public static final String WAYPOINTS_FILE_SUFFIX_AND_EXTENSION = WAYPOINTS_FILE_SUFFIX + FileUtils.GPX_FILE_EXTENSION;
 
     private static final List<String> GPX_MIME_TYPES = Arrays.asList("text/xml", "application/xml");
     private static final List<String> ZIP_MIME_TYPES = Arrays.asList("application/zip", "application/x-compressed", "application/x-zip-compressed", "application/x-zip", "application/octet-stream");
@@ -68,9 +65,9 @@ public class GPXImporter {
      *            the file to import
      */
     public void importGPX(final File file) {
-        if (StringUtils.endsWithIgnoreCase(file.getName(), GPX_FILE_EXTENSION)) {
+        if (StringUtils.endsWithIgnoreCase(file.getName(), FileUtils.GPX_FILE_EXTENSION)) {
             new ImportGpxFileThread(file, listId, importStepHandler, progressHandler).start();
-        } else if (StringUtils.endsWithIgnoreCase(file.getName(), ZIP_FILE_EXTENSION) || StringUtils.endsWithIgnoreCase(file.getName(), COMPRESSED_GPX_FILE_EXTENSION)) {
+        } else if (StringUtils.endsWithIgnoreCase(file.getName(), FileUtils.ZIP_FILE_EXTENSION) || StringUtils.endsWithIgnoreCase(file.getName(), FileUtils.COMPRESSED_GPX_FILE_EXTENSION)) {
             new ImportGpxZipFileThread(file, listId, importStepHandler, progressHandler).start();
         } else {
             new ImportLocFileThread(file, listId, importStepHandler, progressHandler).start();
@@ -114,11 +111,11 @@ public class GPXImporter {
     @NonNull
     private static FileType getFileTypeFromPathName(
             final String pathName) {
-        if (StringUtils.endsWithIgnoreCase(pathName, GPX_FILE_EXTENSION)) {
+        if (StringUtils.endsWithIgnoreCase(pathName, FileUtils.GPX_FILE_EXTENSION)) {
             return FileType.GPX;
         }
 
-        if (StringUtils.endsWithIgnoreCase(pathName, LOC_FILE_EXTENSION)) {
+        if (StringUtils.endsWithIgnoreCase(pathName, FileUtils.LOC_FILE_EXTENSION)) {
             return FileType.LOC;
         }
         return FileType.UNKNOWN;

--- a/main/src/cgeo/geocaching/files/GpxFileListActivity.java
+++ b/main/src/cgeo/geocaching/files/GpxFileListActivity.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.FileUtils;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -27,7 +28,7 @@ public class GpxFileListActivity extends AbstractFileListActivity<GPXListAdapter
 
     private static String[] supportedFileTypes() {
         final ArrayList<String> result = new ArrayList<>();
-        for (final String dotExtension : Arrays.asList(GPXImporter.GPX_FILE_EXTENSION, GPXImporter.LOC_FILE_EXTENSION, GPXImporter.COMPRESSED_GPX_FILE_EXTENSION, GPXImporter.ZIP_FILE_EXTENSION)) {
+        for (final String dotExtension : Arrays.asList(FileUtils.GPX_FILE_EXTENSION, FileUtils.LOC_FILE_EXTENSION, FileUtils.COMPRESSED_GPX_FILE_EXTENSION, FileUtils.ZIP_FILE_EXTENSION)) {
             result.add(StringUtils.substringAfter(dotExtension, "."));
         }
         return result.toArray(new String[result.size()]);
@@ -52,7 +53,7 @@ public class GpxFileListActivity extends AbstractFileListActivity<GPXListAdapter
     @Override
     protected boolean filenameBelongsToList(@NonNull final String filename) {
         if (super.filenameBelongsToList(filename)) {
-            if (StringUtils.endsWithIgnoreCase(filename, GPXImporter.ZIP_FILE_EXTENSION)) {
+            if (StringUtils.endsWithIgnoreCase(filename, FileUtils.ZIP_FILE_EXTENSION)) {
                 for (final IConnector connector : ConnectorFactory.getConnectors()) {
                     if (connector.isZippedGPXFile(filename)) {
                         return true;

--- a/main/src/cgeo/geocaching/utils/FileUtils.java
+++ b/main/src/cgeo/geocaching/utils/FileUtils.java
@@ -39,6 +39,12 @@ public final class FileUtils {
     public static final String HEADER_LAST_MODIFIED = "last-modified";
     public static final String HEADER_ETAG = "etag";
 
+    public static final String GPX_FILE_EXTENSION = ".gpx";
+    public static final String LOC_FILE_EXTENSION = ".loc";
+    public static final String ZIP_FILE_EXTENSION = ".zip";
+    public static final String COMPRESSED_GPX_FILE_EXTENSION = ".ggz";
+    public static final String MAP_FILE_EXTENSION = ".map";
+
     private static final int MAX_DIRECTORY_SCAN_DEPTH = 30;
     private static final String FILE_PROTOCOL = "file://";
 


### PR DESCRIPTION
- fixes the error and suggestions mentioned in #8445
- adds the missing `.loc` file extension
- moves the known file extensions to `FileUtils`
