### PR TITLE
update TerraCaching cache detail URL (fix #8449)

### DIFF
--- a/main/src/cgeo/geocaching/connector/tc/TerraCachingConnector.java
+++ b/main/src/cgeo/geocaching/connector/tc/TerraCachingConnector.java
@@ -49,7 +49,7 @@ public class TerraCachingConnector extends AbstractConnector {
     @Override
     @NonNull
     protected String getCacheUrlPrefix() {
-        return "http://www.terracaching.com/Cache/";
+        return "https://play.terracaching.com/Cache/";
     }
 
     @Override

--- a/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
@@ -462,7 +462,7 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(cache.getOwnerDisplayName()).isEqualTo("Berengarius");
         assertThat(cache.getType()).isEqualTo(CacheType.VIRTUAL);
         assertThat(cache.getLocation()).isEqualTo("Baden-Wurttemberg, Germany");
-        assertThat(cache.getUrl()).isEqualTo("http://www.terracaching.com/Cache/TCEHL");
+        assertThat(cache.getUrl()).isEqualTo("https://play.terracaching.com/Cache/TCEHL");
         assertThat(cache.getDescription()).startsWith("<b> Hier ruht </b>");
         assertThat(cache.getHint()).isEmpty();
 


### PR DESCRIPTION
Still can't see the cache's listing page as I have no account on tc.com, but with this change I don't get a 404, whereas without I get one.