### PR TITLE
use method references

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -91,7 +91,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         }
 
         final View overflowActionBar = v.findViewById(R.id.overflowActionBar);
-        overflowActionBar.setOnClickListener(v14 -> showPopup(v14));
+        overflowActionBar.setOnClickListener(this::showPopup);
     }
 
     public final void setTitle(final CharSequence title) {
@@ -114,7 +114,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         final android.widget.PopupMenu popupMenu = new android.widget.PopupMenu(getActivity(), view);
         CacheMenuHandler.addMenuItems(new MenuInflater(getActivity()), popupMenu.getMenu(), cache);
         popupMenu.setOnMenuItemClickListener(
-                item -> AbstractDialogFragment.this.onMenuItemClick(item)
+                AbstractDialogFragment.this::onMenuItemClick
         );
         popupMenu.show();
     }

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -753,7 +753,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 return true;
             case R.id.menu_clear_goto_history:
                 Dialogs.confirm(this, R.string.clear_goto_history_title, R.string.clear_goto_history, (dialog, which) -> {
-                    AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.clearGotoHistory(), () -> {
+                    AndroidRxUtils.andThenOnUi(Schedulers.io(), DataStore::clearGotoHistory, () -> {
                         cache = DataStore.loadCache(InternalConnector.GEOCODE_HISTORY_CACHE, LoadFlags.LOAD_ALL_DB_ONLY);
                         notifyDataSetChanged();
                     });
@@ -802,7 +802,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     }
 
     private void showVoteDialog() {
-        VoteDialog.show(this, cache, () -> notifyDataSetChanged());
+        VoteDialog.show(this, cache, this::notifyDataSetChanged);
     }
 
     private static final class CacheDetailsGeoDirHandler extends GeoDirHandler {
@@ -1045,7 +1045,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (Settings.getChooseList() || cache.isOffline()) {
             // let user select list to store cache in
             new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title,
-                    selectedListIds -> storeCacheInLists(selectedListIds), true, cache.getLists(), fastStoreOnLastSelection);
+                    this::storeCacheInLists, true, cache.getLists(), fastStoreOnLastSelection);
         } else {
             storeCacheInLists(Collections.singleton(StoredList.STANDARD_LIST_ID));
         }
@@ -1345,7 +1345,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             public void onClick(final View arg0) {
                 doExecute(R.string.cache_dialog_watchlist_add_title,
                         R.string.cache_dialog_watchlist_add_message,
-                        simpleCancellableHandler -> watchListAdd(simpleCancellableHandler));
+                        DetailsViewCreator.this::watchListAdd);
             }
         }
 
@@ -1357,7 +1357,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             public void onClick(final View arg0) {
                 doExecute(R.string.cache_dialog_watchlist_remove_title,
                         R.string.cache_dialog_watchlist_remove_message,
-                        simpleCancellableHandler -> watchListRemove(simpleCancellableHandler));
+                        DetailsViewCreator.this::watchListRemove);
             }
         }
 
@@ -1409,7 +1409,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             public void onClick(final View arg0) {
                 doExecute(R.string.cache_dialog_favorite_add_title,
                         R.string.cache_dialog_favorite_add_message,
-                        simpleCancellableHandler -> favoriteAdd(simpleCancellableHandler));
+                        DetailsViewCreator.this::favoriteAdd);
             }
         }
 
@@ -1421,7 +1421,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             public void onClick(final View arg0) {
                 doExecute(R.string.cache_dialog_favorite_remove_title,
                         R.string.cache_dialog_favorite_remove_message,
-                        simpleCancellableHandler -> favoriteRemove(simpleCancellableHandler));
+                        DetailsViewCreator.this::favoriteRemove);
             }
         }
 

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1592,7 +1592,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     @NonNull
     private Action1<Integer> getListSwitchingRunnable() {
-        return selectedListId -> switchListById(selectedListId);
+        return this::switchListById;
     }
 
     private void switchListById(final int id) {

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -197,7 +197,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
             if (Settings.getChooseList() || cache.isOffline()) {
                 // let user select list to store cache in
                 new StoredList.UserInterface(getActivity()).promptForMultiListSelection(R.string.lists_title,
-                        selectedListIds -> storeCacheOnLists(selectedListIds), true, cache.getLists(), fastStoreOnLastSelection);
+                        this::storeCacheOnLists, true, cache.getLists(), fastStoreOnLastSelection);
             } else {
                 storeCacheOnLists(Collections.singleton(StoredList.STANDARD_LIST_ID));
             }

--- a/main/src/cgeo/geocaching/CreateShortcutActivity.java
+++ b/main/src/cgeo/geocaching/CreateShortcutActivity.java
@@ -93,7 +93,7 @@ public class CreateShortcutActivity extends AbstractActionBarActivity {
     }
 
     protected void promptForListShortcut() {
-        new StoredList.UserInterface(this).promptForListSelection(R.string.create_shortcut, listId -> createOfflineListShortcut(listId), true, PseudoList.NEW_LIST.id);
+        new StoredList.UserInterface(this).promptForListSelection(R.string.create_shortcut, this::createOfflineListShortcut, true, PseudoList.NEW_LIST.id);
     }
 
     protected void createOfflineListShortcut(final int listId) {

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -311,7 +311,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
         // infobox "not logged in" with link to service config; display delayed by 10 seconds
         final Handler handler = new Handler();
-        handler.postDelayed(() -> checkLoggedIn(), 10000);
+        handler.postDelayed(this::checkLoggedIn, 10000);
         notLoggedIn.setOnClickListener(v -> Dialogs.confirmYesNo(this, R.string.warn_notloggedin_title, R.string.warn_notloggedin_long, (dialog, which) -> SettingsActivity.openForScreen(R.string.preference_screen_services, this)));
     }
 
@@ -551,10 +551,10 @@ public class MainActivity extends AbstractActionBarActivity {
         initialized = true;
 
         findOnMap.setClickable(true);
-        findOnMap.setOnClickListener(v -> cgeoFindOnMap(v));
+        findOnMap.setOnClickListener(this::cgeoFindOnMap);
 
         findByOffline.setClickable(true);
-        findByOffline.setOnClickListener(v -> cgeoFindByOffline(v));
+        findByOffline.setOnClickListener(this::cgeoFindByOffline);
         findByOffline.setOnLongClickListener(v -> {
             new StoredList.UserInterface(MainActivity.this).promptForListSelection(R.string.list_title, selectedListId -> {
                 Settings.setLastDisplayedList(selectedListId);
@@ -565,10 +565,10 @@ public class MainActivity extends AbstractActionBarActivity {
         findByOffline.setLongClickable(true);
 
         advanced.setClickable(true);
-        advanced.setOnClickListener(v -> cgeoSearch(v));
+        advanced.setOnClickListener(this::cgeoSearch);
 
         any.setClickable(true);
-        any.setOnClickListener(v -> cgeoPoint(v));
+        any.setOnClickListener(this::cgeoPoint);
 
         filter.setClickable(true);
         filter.setOnClickListener(v -> selectGlobalTypeFilter());
@@ -630,7 +630,7 @@ public class MainActivity extends AbstractActionBarActivity {
             if (!nearestView.isClickable()) {
                 nearestView.setFocusable(true);
                 nearestView.setClickable(true);
-                nearestView.setOnClickListener(v -> cgeoFindNearest(v));
+                nearestView.setOnClickListener(MainActivity.this::cgeoFindNearest);
                 nearestView.setBackgroundResource(R.drawable.main_nearby);
             }
 
@@ -650,7 +650,7 @@ public class MainActivity extends AbstractActionBarActivity {
                 }
                 if (addCoords == null || currentCoords.distanceTo(addCoords) > 0.5) {
                     addCoords = currentCoords;
-                    final Single<String> address = (new AndroidGeocoder(MainActivity.this).getFromLocation(currentCoords)).map(address1 -> formatAddress(address1)).onErrorResumeWith(Single.just(currentCoords.toString()));
+                    final Single<String> address = (new AndroidGeocoder(MainActivity.this).getFromLocation(currentCoords)).map(MainActivity::formatAddress).onErrorResumeWith(Single.just(currentCoords.toString()));
                     AndroidRxUtils.bindActivity(MainActivity.this, address)
                             .subscribeOn(AndroidRxUtils.networkScheduler)
                             .subscribe(address12 -> navLocation.setText(address12));

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -192,12 +192,12 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
 
         buttonSearchCoords.setOnClickListener(arg0 -> findByCoordsFn());
 
-        setSearchAction(addressEditText, buttonSearchAddress, () -> findByAddressFn(), null);
-        setSearchAction(geocodeEditText, buttonSearchGeocode, () -> findByGeocodeFn(), input -> DataStore.getSuggestionsGeocode(input));
-        setSearchAction(keywordEditText, buttonSearchKeyword, () -> findByKeywordFn(), input -> DataStore.getSuggestionsKeyword(input));
-        setSearchAction(finderNameEditText, buttonSearchFinder, () -> findByFinderFn(), input -> DataStore.getSuggestionsFinderName(input));
-        setSearchAction(ownerNameEditText, buttonSearchOwner, () -> findByOwnerFn(), input -> DataStore.getSuggestionsOwnerName(input));
-        setSearchAction(trackableEditText, buttonSearchTrackable, () -> findTrackableFn(), input -> DataStore.getSuggestionsTrackableCode(input));
+        setSearchAction(addressEditText, buttonSearchAddress, this::findByAddressFn, null);
+        setSearchAction(geocodeEditText, buttonSearchGeocode, this::findByGeocodeFn, DataStore::getSuggestionsGeocode);
+        setSearchAction(keywordEditText, buttonSearchKeyword, this::findByKeywordFn, DataStore::getSuggestionsKeyword);
+        setSearchAction(finderNameEditText, buttonSearchFinder, this::findByFinderFn, DataStore::getSuggestionsFinderName);
+        setSearchAction(ownerNameEditText, buttonSearchOwner, this::findByOwnerFn, DataStore::getSuggestionsOwnerName);
+        setSearchAction(trackableEditText, buttonSearchTrackable, this::findTrackableFn, DataStore::getSuggestionsTrackableCode);
     }
 
     private static void setSearchAction(final AutoCompleteTextView editText, final Button button, @NonNull final Runnable runnable, @Nullable final Func1<String, String[]> suggestionFunction) {

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -574,7 +574,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
                 trackableImage.setClickable(true);
                 trackableImage.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(trackable.getImage()))));
 
-                AndroidRxUtils.bindActivity(TrackableActivity.this, new HtmlImage(geocode, true, false, false).fetchDrawable(trackable.getImage())).subscribe(bitmapDrawable -> trackableImage.setImageDrawable(bitmapDrawable));
+                AndroidRxUtils.bindActivity(TrackableActivity.this, new HtmlImage(geocode, true, false, false).fetchDrawable(trackable.getImage())).subscribe(trackableImage::setImageDrawable);
 
                 imageView.addView(trackableImage);
             }

--- a/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
@@ -318,7 +318,7 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
                 startButton.setOnClickListener(null);
 
                 actitity.setTempTokens(null, null);
-                AndroidRxUtils.networkScheduler.scheduleDirect(() -> actitity.requestToken());
+                AndroidRxUtils.networkScheduler.scheduleDirect(actitity::requestToken);
             }
         }
     }

--- a/main/src/cgeo/geocaching/command/RenameListCommand.java
+++ b/main/src/cgeo/geocaching/command/RenameListCommand.java
@@ -23,7 +23,7 @@ public abstract class RenameListCommand extends AbstractCommand {
     public void execute() {
         final StoredList list = DataStore.getList(listId);
         oldName = list.getTitle();
-        new StoredList.UserInterface(getContext()).promptForListRename(listId, () -> RenameListCommand.super.execute());
+        new StoredList.UserInterface(getContext()).promptForListRename(listId, RenameListCommand.super::execute);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -136,7 +136,7 @@ public class GpxExport extends AbstractExport {
                 FileUtils.mkdirs(exportLocation);
 
                 writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(exportFile), StandardCharsets.UTF_8));
-                new GpxSerializer().writeGPX(allGeocodes, writer, countExported -> ExportTask.this.publishProgress(countExported));
+                new GpxSerializer().writeGPX(allGeocodes, writer, ExportTask.this::publishProgress);
             } catch (final IOException e) {
                 Log.e("GpxExport.ExportTask export", e);
                 // delete partial GPX file on error

--- a/main/src/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/cgeo/geocaching/location/ProximityNotification.java
@@ -239,10 +239,10 @@ public class ProximityNotification implements Parcelable {
                 if (tone == TONE_NEAR) {
                     handler.postDelayed(() -> {
                         toneG.startTone(TONE_NEAR);
-                        handler.postDelayed(() -> toneG.release(), 350);
+                        handler.postDelayed(toneG::release, 350);
                     }, 350);
                 } else {
-                    handler.postDelayed(() -> toneG.release(), 350);
+                    handler.postDelayed(toneG::release, 350);
                 }
             }
         }

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -332,7 +332,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
         AndroidRxUtils.bindActivity(this,
                 // Obtain the actives connectors
                 Observable.fromIterable(ConnectorFactory.getLoggableGenericTrackablesConnectors())
-                        .flatMap((Function<TrackableConnector, Observable<TrackableLog>>) trackableConnector -> Observable.defer(() -> trackableConnector.trackableLogInventory()).subscribeOn(AndroidRxUtils.networkScheduler)).toList()
+                        .flatMap((Function<TrackableConnector, Observable<TrackableLog>>) trackableConnector -> Observable.defer(trackableConnector::trackableLogInventory).subscribeOn(AndroidRxUtils.networkScheduler)).toList()
         ).subscribe(trackableLogs -> {
             // Store trackables
             trackables.addAll(trackableLogs);

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -305,7 +305,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
 
     private void init() {
         registerForContextMenu(typeButton);
-        typeButton.setOnClickListener(view -> openContextMenu(view));
+        typeButton.setOnClickListener(this::openContextMenu);
 
         setType(typeSelected);
         dateButton.setOnClickListener(new DateListener());
@@ -342,7 +342,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Dat
      * Link the geocodeEditText to the SuggestionsGeocode.
      */
     private void initGeocodeSuggestions() {
-        geocodeEditText.setAdapter(new AutoCompleteAdapter(geocodeEditText.getContext(), layout.simple_dropdown_item_1line, input -> DataStore.getSuggestionsGeocode(input)));
+        geocodeEditText.setAdapter(new AutoCompleteAdapter(geocodeEditText.getContext(), layout.simple_dropdown_item_1line, DataStore::getSuggestionsGeocode));
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -108,8 +108,8 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         mapController.setGoogleMap(googleMap);
 
         cachesList = new GoogleCachesList(googleMap);
-        googleMap.setOnCameraMoveListener(() -> recognizePositionChange());
-        googleMap.setOnCameraIdleListener(() -> recognizePositionChange());
+        googleMap.setOnCameraMoveListener(this::recognizePositionChange);
+        googleMap.setOnCameraIdleListener(this::recognizePositionChange);
         googleMap.setOnMarkerClickListener(marker -> {
             // onCacheTapListener will fire on onSingleTapUp event, not here, because this event
             // is fired 300 ms after map tap, which is too slow for UI

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/SinglePointOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/SinglePointOverlay.java
@@ -22,7 +22,7 @@ public class SinglePointOverlay extends AbstractCachesOverlay {
         this.coords = coords;
         this.type = type;
 
-        AndroidRxUtils.computationScheduler.scheduleDirect(() -> fill());
+        AndroidRxUtils.computationScheduler.scheduleDirect(this::fill);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/routing/Route.java
+++ b/main/src/cgeo/geocaching/maps/routing/Route.java
@@ -158,14 +158,14 @@ public class Route implements Parcelable {
 
     public void reloadRoute(final RouteUpdater routeUpdater) {
         clearRouteInternal(routeUpdater, false);
-        AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> loadRouteInternal(), () -> updateRoute(routeUpdater));
+        AndroidRxUtils.andThenOnUi(Schedulers.io(), this::loadRouteInternal, () -> updateRoute(routeUpdater));
     }
 
     public void loadRoute() {
         if (loadingRoute) {
             return;
         }
-        Schedulers.io().scheduleDirect(() -> loadRouteInternal());
+        Schedulers.io().scheduleDirect(this::loadRouteInternal);
     }
 
     public boolean isEmpty() {
@@ -174,7 +174,7 @@ public class Route implements Parcelable {
 
     private void clearRouteInternal(final RouteUpdater routeUpdater, final boolean deleteInDatabase) {
         if (deleteInDatabase) {
-            Schedulers.io().scheduleDirect(() -> DataStore.clearRoute());
+            Schedulers.io().scheduleDirect(DataStore::clearRoute);
         }
         segments = null;
         if (null != routeUpdater) {

--- a/main/src/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/cgeo/geocaching/network/HtmlImage.java
@@ -84,7 +84,7 @@ public class HtmlImage implements Html.ImageGetter {
     final WeakReference<TextView> viewRef;
     private final Map<String, BitmapDrawable> cache = new HashMap<>();
 
-    private final ObservableCache<String, BitmapDrawable> observableCache = new ObservableCache<>(url -> fetchDrawableUncached(url));
+    private final ObservableCache<String, BitmapDrawable> observableCache = new ObservableCache<>(this::fetchDrawableUncached);
 
     // Background loading
     // .cache() is not yet available on Completable instances as of RxJava 2.0.0, so we have to go back
@@ -218,7 +218,7 @@ public class HtmlImage implements Html.ImageGetter {
             @Override
             public void subscribe(final ObservableEmitter<BitmapDrawable> emitter) throws Exception {
                 // Canceling disposable must sever this connection
-                final CancellableDisposable aborter = new CancellableDisposable(() -> emitter.onComplete());
+                final CancellableDisposable aborter = new CancellableDisposable(emitter::onComplete);
                 disposable.add(aborter);
                 // Canceling this subscription must dispose the data retrieval
                 emitter.setDisposable(AndroidRxUtils.computationScheduler.scheduleDirect(() -> {

--- a/main/src/cgeo/geocaching/network/Network.java
+++ b/main/src/cgeo/geocaching/network/Network.java
@@ -634,7 +634,7 @@ public final class Network {
         Completable.fromSingle(response.flatMap(withSuccess)).blockingAwait();
     }
 
-    public static final Function<Response, Single<String>> getResponseDataReplaceWhitespace = response -> getResponseData.apply(response).map(s -> TextUtils.replaceWhitespace(s));
+    public static final Function<Response, Single<String>> getResponseDataReplaceWhitespace = response -> getResponseData.apply(response).map(TextUtils::replaceWhitespace);
 
     @Nullable
     public static String rfc3986URLEncode(final String text) {

--- a/main/src/cgeo/geocaching/sensors/GeoDirHandler.java
+++ b/main/src/cgeo/geocaching/sensors/GeoDirHandler.java
@@ -89,14 +89,14 @@ public abstract class GeoDirHandler {
         final Sensors sensors = Sensors.getInstance();
 
         if ((flags & UPDATE_GEODATA) != 0) {
-            disposables.add(throttleIfNeeded(sensors.geoDataObservable(lowPower).observeOn(AndroidSchedulers.mainThread()), windowDuration, unit).subscribe(geoData -> updateGeoData(geoData)));
+            disposables.add(throttleIfNeeded(sensors.geoDataObservable(lowPower).observeOn(AndroidSchedulers.mainThread()), windowDuration, unit).subscribe(this::updateGeoData));
         }
         if ((flags & UPDATE_DIRECTION) != 0) {
-            disposables.add(throttleIfNeeded(sensors.directionObservable().observeOn(AndroidSchedulers.mainThread()), windowDuration, unit).subscribe(direction -> updateDirection(direction)));
+            disposables.add(throttleIfNeeded(sensors.directionObservable().observeOn(AndroidSchedulers.mainThread()), windowDuration, unit).subscribe(this::updateDirection));
         }
         if ((flags & UPDATE_GEODIR) != 0) {
             // combineOnLatest() does not implement backpressure handling, so we need to explicitly use a backpressure operator there.
-            disposables.add(throttleIfNeeded(Observable.combineLatest(sensors.geoDataObservable(lowPower), sensors.directionObservable(), (geoData, direction) -> ImmutablePair.of(geoData, direction)).observeOn(AndroidSchedulers.mainThread()), windowDuration, unit).subscribe(geoDir -> updateGeoDir(geoDir.left, geoDir.right)));
+            disposables.add(throttleIfNeeded(Observable.combineLatest(sensors.geoDataObservable(lowPower), sensors.directionObservable(), ImmutablePair::of).observeOn(AndroidSchedulers.mainThread()), windowDuration, unit).subscribe(geoDir -> updateGeoDir(geoDir.left, geoDir.right)));
         }
         return disposables;
     }

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -480,7 +480,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             final Resources res = getResources();
             final SettingsActivity activity = SettingsActivity.this;
             final ProgressDialog dialog = ProgressDialog.show(activity, res.getString(R.string.init_maintenance), res.getString(R.string.init_maintenance_directories), true, false);
-            AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.removeObsoleteGeocacheDataDirectories(), () -> dialog.dismiss());
+            AndroidRxUtils.andThenOnUi(Schedulers.io(), DataStore::removeObsoleteGeocacheDataDirectories, dialog::dismiss);
             return true;
             });
         getPreference(R.string.pref_memory_dump).setOnPreferenceClickListener(preference -> {

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2207,7 +2207,7 @@ public class DataStore {
                 "_id",
                 null,
                 new LinkedList<Waypoint>(),
-                cursor -> createWaypointFromDatabaseContent(cursor));
+                DataStore::createWaypointFromDatabaseContent);
     }
 
     @NonNull
@@ -3581,7 +3581,7 @@ public class DataStore {
                 .append(".geocode == ").append(dbTableCaches).append(".geocode AND ").append(where)
                 .append(" LIMIT " + (Settings.SHOW_WP_THRESHOLD_MAX * 2));  // Hardcoded limit to avoid memory overflow
 
-        return cursorToColl(database.rawQuery(query.toString(), null), new HashSet<Waypoint>(), cursor -> createWaypointFromDatabaseContent(cursor));
+        return cursorToColl(database.rawQuery(query.toString(), null), new HashSet<Waypoint>(), DataStore::createWaypointFromDatabaseContent);
     }
 
     public static void saveChangedCache(final Geocache cache) {

--- a/main/src/cgeo/geocaching/ui/ImagesList.java
+++ b/main/src/cgeo/geocaching/ui/ImagesList.java
@@ -106,7 +106,7 @@ public class ImagesList {
     public Disposable loadImages(final View parentView, final Collection<Image> images) {
         // Start with a fresh disposable because of this method can be called several times if the
         // enclosing activity is stopped/restarted.
-        final CompositeDisposable disposables = new CompositeDisposable(new CancellableDisposable(() -> removeAllViews()));
+        final CompositeDisposable disposables = new CompositeDisposable(new CancellableDisposable(this::removeAllViews));
 
         imagesView = parentView.findViewById(R.id.spoiler_list);
 

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -375,7 +375,7 @@ public final class Dialogs {
 
         final AlertDialog dialog = builder.create();
         if (iconObservable != null) {
-            iconObservable.observeOn(AndroidSchedulers.mainThread()).subscribe(drawable -> dialog.setIcon(drawable));
+            iconObservable.observeOn(AndroidSchedulers.mainThread()).subscribe(dialog::setIcon);
         }
         dialog.show();
     }

--- a/main/src/cgeo/geocaching/utils/DatabaseBackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/DatabaseBackupUtils.java
@@ -85,7 +85,7 @@ public class DatabaseBackupUtils {
         final ProgressDialog dialog = ProgressDialog.show(activity,
                 activity.getString(R.string.init_backup),
                 activity.getString(R.string.init_backup_running), true, false);
-        AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.backupDatabaseInternal(), backupFileName -> {
+        AndroidRxUtils.andThenOnUi(Schedulers.io(), DataStore::backupDatabaseInternal, backupFileName -> {
             dialog.dismiss();
             Dialogs.message(activity,
                     R.string.init_backup_backup,

--- a/main/src/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/cgeo/geocaching/utils/ImageUtils.java
@@ -392,7 +392,7 @@ public final class ImageUtils {
         private static final Object lock = new Object(); // Used to lock the queue to determine if a refresh needs to be scheduled
         private static final LinkedBlockingQueue<ImmutablePair<ContainerDrawable, Drawable>> REDRAW_QUEUE = new LinkedBlockingQueue<>();
         private static final Set<TextView> VIEWS = new HashSet<>();  // Modified only on the UI thread, from redrawQueuedDrawables
-        private static final Runnable REDRAW_QUEUED_DRAWABLES = () -> redrawQueuedDrawables();
+        private static final Runnable REDRAW_QUEUED_DRAWABLES = ContainerDrawable::redrawQueuedDrawables;
 
         private Drawable drawable;
         protected final WeakReference<TextView> viewRef;

--- a/main/src/cgeo/geocaching/utils/RxUtils.java
+++ b/main/src/cgeo/geocaching/utils/RxUtils.java
@@ -22,7 +22,7 @@ public class RxUtils {
 
     public static<T> Observable<T> rememberLast(final Observable<T> observable, final T initialValue) {
         final AtomicReference<T> lastValue = new AtomicReference<>(initialValue);
-        return observable.doOnNext(value -> lastValue.set(value)).startWith(Observable.defer(() -> {
+        return observable.doOnNext(lastValue::set).startWith(Observable.defer(() -> {
             final T last = lastValue.get();
             return last != null ? Observable.just(last) : Observable.<T>empty();
         })).replay(1).refCount();
@@ -96,7 +96,7 @@ public class RxUtils {
                 public void onSubscribe(final Disposable d) {
                     observer.onSubscribe(new CancellableDisposable(() -> {
                         canceled.set(true);
-                        Schedulers.computation().scheduleDirect(() -> d.dispose(), time, unit);
+                        Schedulers.computation().scheduleDirect(d::dispose, time, unit);
                     }));
                 }
 

--- a/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
+++ b/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
@@ -48,7 +48,7 @@ public class GpxSerializerTest extends AbstractResourceInstrumentationTestCase {
         final Geocache cache = loadCacheFromResource(R.raw.gc1bkp3_gpx101);
         assertThat(cache).isNotNull();
 
-        new GpxSerializer().writeGPX(Collections.singletonList("GC1BKP3"), writer, countExported -> importedCount.set(countExported));
+        new GpxSerializer().writeGPX(Collections.singletonList("GC1BKP3"), writer, importedCount::set);
         assertEquals("Progress listener not called", 1, importedCount.get().intValue());
     }
 

--- a/tests/src-android/cgeo/geocaching/files/InvalidXMLCharacterFilterReaderTest.java
+++ b/tests/src-android/cgeo/geocaching/files/InvalidXMLCharacterFilterReaderTest.java
@@ -14,7 +14,7 @@ public class InvalidXMLCharacterFilterReaderTest extends AndroidTestCase {
     public static void testFilterInvalid() throws Exception {
         final RootElement root = new RootElement("desc");
         final AtomicReference<String> description = new AtomicReference<>();
-        root.setEndTextElementListener(body -> description.set(body));
+        root.setEndTextElementListener(description::set);
         final StringReader reader = new StringReader("<?xml version=\"1.0\" encoding=\"utf-8\"?><desc>Invalid&#xB;description</desc>");
         Xml.parse(new InvalidXMLCharacterFilterReader(reader), root.getContentHandler());
         assertThat(description.get()).isEqualTo("Invaliddescription");
@@ -23,7 +23,7 @@ public class InvalidXMLCharacterFilterReaderTest extends AndroidTestCase {
     public static void testGC5AYC6() throws Exception {
         final RootElement root = new RootElement("desc");
         final AtomicReference<String> description = new AtomicReference<>();
-        root.setEndTextElementListener(body -> description.set(body));
+        root.setEndTextElementListener(description::set);
         final StringReader reader = new StringReader("<?xml version=\"1.0\" encoding=\"utf-8\"?><desc>V‹¥IR‡U½S©&#x15; by Master-Chief, Unknown Cache (5/2)</desc>");
         Xml.parse(new InvalidXMLCharacterFilterReader(reader), root.getContentHandler());
         assertThat(description.get()).isEqualTo("V‹¥IR‡U½S© by Master-Chief, Unknown Cache (5/2)");


### PR DESCRIPTION
Replace calls to lambda functions by method references (where possible) to make code more readable and to reduce the need for artificially named parameters