### PR TITLE
Simplify code by removing unnecessary factor

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/Tile.java
+++ b/main/src/cgeo/geocaching/connector/gc/Tile.java
@@ -42,7 +42,7 @@ public class Tile {
     static {
         for (int z = ZOOMLEVEL_MIN; z <= ZOOMLEVEL_MAX; z++) {
             NUMBER_OF_TILES[z] = 1 << z;
-            NUMBER_OF_PIXELS[z] = TILE_SIZE * 1 << z;
+            NUMBER_OF_PIXELS[z] = TILE_SIZE << z;
         }
     }
 


### PR DESCRIPTION
see also http://svn.openstreetmap.org/applications/viewer/jmapviewer/src/org/openstreetmap/gui/jmapviewer/OsmMercator.java (which is linked to from our source):

```
public long getMaxPixels(int aZoomlevel) {
    return tileSize * (1 << aZoomlevel);
}
```