### PR TITLE
remove some redundant code

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1398,7 +1398,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         if (Settings.getChooseList() && type != CacheListType.OFFLINE && type != CacheListType.HISTORY) {
             // let user select list to store cache in
             new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title,
-                    selectedListIds -> refreshStoredInternal(caches, selectedListIds), true, Collections.singleton(StoredList.TEMPORARY_LIST.id), Collections.<Integer>emptySet(), listNameMemento, false);
+                    selectedListIds -> refreshStoredInternal(caches, selectedListIds), true, Collections.singleton(StoredList.TEMPORARY_LIST.id), Collections.emptySet(), listNameMemento, false);
         } else {
             final Set<Integer> additionalListIds = new HashSet<>();
             if (type != CacheListType.OFFLINE && type != CacheListType.HISTORY) {

--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -105,7 +105,7 @@ public class CompassActivity extends AbstractActionBarActivity {
                 setTarget(waypoint, cache);
             }
         } else if (extras.containsKey(Intents.EXTRA_COORDS)) {
-            setTarget(extras.<Geopoint> getParcelable(Intents.EXTRA_COORDS), extras.getString(Intents.EXTRA_COORD_DESCRIPTION));
+            setTarget(extras.getParcelable(Intents.EXTRA_COORDS), extras.getString(Intents.EXTRA_COORD_DESCRIPTION));
         } else if (cache != null) {
             setTarget(cache);
         } else {

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -611,7 +611,6 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                     ActivityMixin.showApplicationToast(activity.getString(R.string.waypoint_coordinates_has_been_modified_on_website, coords));
                     break;
                 case SUCCESS:
-                    break;
                 case UPLOAD_START:
                     break;
                 case UPLOAD_ERROR:

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -469,10 +469,7 @@ public class MainActivity extends AbstractActionBarActivity {
     public boolean onOptionsItemSelected(final MenuItem item) {
         final int id = item.getItemId();
         switch (id) {
-            case android.R.id.home:
-                // this activity must handle the home navigation different than all others
-                showAbout(null);
-                return true;
+            case android.R.id.home: // this activity must handle the home navigation different than all others
             case R.id.menu_about:
                 showAbout(null);
                 return true;

--- a/main/src/cgeo/geocaching/address/AndroidGeocoder.java
+++ b/main/src/cgeo/geocaching/address/AndroidGeocoder.java
@@ -70,7 +70,7 @@ public class AndroidGeocoder {
 
     private static Observable<Address> addressesToObservable(final List<Address> addresses) {
         return CollectionUtils.isEmpty(addresses) ?
-                Observable.<Address>error(new RuntimeException("no result from Android geocoder")) :
+                Observable.error(new RuntimeException("no result from Android geocoder")) :
                 Observable.fromIterable(addresses);
     }
 

--- a/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -289,6 +289,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
             case LETTERBOX:
                 return GeocachingData.CACHE_TYPE_LETTERBOX;
             case EVENT:
+            case BLOCK_PARTY:                                       // no special locus type for BLOCK_PARTY
                 return GeocachingData.CACHE_TYPE_EVENT;
             case MEGA_EVENT:
                 return GeocachingData.CACHE_TYPE_MEGA_EVENT;
@@ -314,8 +315,6 @@ public abstract class AbstractLocusApp extends AbstractApp {
                 return GeocachingData.CACHE_TYPE_LF_CELEBRATION;
             case GPS_EXHIBIT:
                 return GeocachingData.CACHE_TYPE_GPS_ADVENTURE;
-            case BLOCK_PARTY:
-                return GeocachingData.CACHE_TYPE_EVENT; // no special locus type
             case LOCATIONLESS:
                 return GeocachingData.CACHE_TYPE_LOCATIONLESS;
             default:
@@ -325,8 +324,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
 
     private static int toLocusSize(final CacheSize cs) {
         switch (cs) {
-            case NANO:
-                return GeocachingData.CACHE_SIZE_MICRO; // used by OC only
+            case NANO:       // used by OC only
             case MICRO:
                 return GeocachingData.CACHE_SIZE_MICRO;
             case SMALL:
@@ -352,13 +350,12 @@ public abstract class AbstractLocusApp extends AbstractApp {
             case FINAL:
                 return GeocachingWaypoint.CACHE_WAYPOINT_TYPE_FINAL;
             case OWN:
+            case STAGE:
                 return GeocachingWaypoint.CACHE_WAYPOINT_TYPE_PHYSICAL_STAGE;
             case PARKING:
                 return GeocachingWaypoint.CACHE_WAYPOINT_TYPE_PARKING;
             case PUZZLE:
                 return GeocachingWaypoint.CACHE_WAYPOINT_TYPE_VIRTUAL_STAGE;
-            case STAGE:
-                return GeocachingWaypoint.CACHE_WAYPOINT_TYPE_PHYSICAL_STAGE;
             case TRAILHEAD:
                 return GeocachingWaypoint.CACHE_WAYPOINT_TYPE_TRAILHEAD;
             case WAYPOINT:

--- a/main/src/cgeo/geocaching/connector/gc/GCLoggingManager.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLoggingManager.java
@@ -154,7 +154,7 @@ class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.L
             }
 
             if (reportProblem != ReportProblemType.NO_PROBLEM) {
-                GCWebAPI.postLog(cache, reportProblem.logType, date.getTime(), CgeoApplication.getInstance().getString(reportProblem.textId), Collections.<TrackableLog>emptyList(), false);
+                GCWebAPI.postLog(cache, reportProblem.logType, date.getTime(), CgeoApplication.getInstance().getString(reportProblem.textId), Collections.emptyList(), false);
             }
 
             return new LogResult(postResult.left, postResult.right);

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -733,7 +733,7 @@ public final class GCParser {
         }
 
         // waypoints - reset collection
-        cache.setWaypoints(Collections.<Waypoint> emptyList(), false);
+        cache.setWaypoints(Collections.emptyList(), false);
 
         // add waypoint for original coordinates in case of user-modified listing-coordinates
         try {
@@ -1761,7 +1761,7 @@ public final class GCParser {
         final Observable<LogEntry> logs = getLogs(userToken, Logs.ALL);
         final Observable<LogEntry> ownLogs = getLogs(userToken, Logs.OWN).cache();
         final Observable<LogEntry> specialLogs = Settings.isFriendLogsWanted() ?
-                Observable.merge(getLogs(userToken, Logs.FRIENDS), ownLogs) : Observable.<LogEntry>empty();
+                Observable.merge(getLogs(userToken, Logs.FRIENDS), ownLogs) : Observable.empty();
         final Single<List<LogEntry>> mergedLogs = Single.zip(logs.toList(), specialLogs.toList(),
                 (logEntries, specialLogEntries) -> {
                     mergeFriendsLogs(logEntries, specialLogEntries);

--- a/main/src/cgeo/geocaching/connector/su/SuParser.java
+++ b/main/src/cgeo/geocaching/connector/su/SuParser.java
@@ -345,13 +345,11 @@ public class SuParser {
             case "1":
                 return LogType.FOUND_IT;
             case "2":
+            case "4":
                 return LogType.DIDNT_FIND_IT;
             case "3":
                 return LogType.NOTE;
-            case "4":
-                return LogType.DIDNT_FIND_IT;
             case "5":
-                return LogType.OWNER_MAINTENANCE;
             case "6":
                 return LogType.OWNER_MAINTENANCE;
             default:
@@ -361,8 +359,6 @@ public class SuParser {
 
     private static CacheSize parseSize(final String size) {
         switch (size) {
-            case "1":
-                return CacheSize.UNKNOWN;
             case "2":
                 return CacheSize.MICRO;
             case "3":
@@ -371,6 +367,7 @@ public class SuParser {
                 return CacheSize.REGULAR;
             case "5":
                 return CacheSize.OTHER;
+            case "1":
             default:
                 return CacheSize.UNKNOWN;
         }
@@ -389,7 +386,6 @@ public class SuParser {
             case "5":
                 return WaypointType.FINAL;
             case "6":
-                return WaypointType.WAYPOINT;
             default:
                 return WaypointType.WAYPOINT;
         }
@@ -421,22 +417,16 @@ public class SuParser {
             case 2:
                 return CacheType.MULTI;
             case 3:
+            case 7: // Virtual Multi-step
                 return CacheType.VIRTUAL;
             case 4:
+            case 8: // Contest
                 return CacheType.EVENT;
             case 5:
                 // Not used
                 return CacheType.WEBCAM;
-            case 7:
-                // Virtual Multi-step
-                return CacheType.VIRTUAL;
-            case 8:
-                // Contest
-                return CacheType.EVENT;
             case 9:
-                return CacheType.MYSTERY;
-            case 10:
-                // Mystery Virtual
+            case 10: // Mystery Virtual
                 return CacheType.MYSTERY;
             case 6:
                 // "Extreme cache", not used.

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyConnector.java
@@ -373,18 +373,18 @@ public class GeokretyConnector extends AbstractTrackableConnector {
         Log.d("GeokretyConnector.postLogTrackable: nr=" + trackableLog.trackCode);
         if (trackableLog.brand != TrackableBrand.GEOKRETY) {
             Log.d("GeokretyConnector.postLogTrackable: received invalid brand");
-            return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.<String> emptyList());
+            return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.emptyList());
         }
         if (trackableLog.action == LogTypeTrackable.DO_NOTHING) {
             Log.d("GeokretyConnector.postLogTrackable: received invalid logtype");
-            return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.<String> emptyList());
+            return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.emptyList());
         }
         try {
             // SecId is mandatory when using API, anonymous log are only possible via website
             final String secId = Settings.getGeokretySecId();
             if (StringUtils.isEmpty(secId)) {
                 Log.d("GeokretyConnector.postLogTrackable: not authenticated");
-                return new ImmutablePair<>(StatusCode.NO_LOGIN_INFO_STORED, Collections.<String> emptyList());
+                return new ImmutablePair<>(StatusCode.NO_LOGIN_INFO_STORED, Collections.emptyList());
             }
 
             // Construct Post Parameters
@@ -419,13 +419,13 @@ public class GeokretyConnector extends AbstractTrackableConnector {
             final String page = Network.getResponseData(Network.postRequest(URL + "/ruchy.php", params));
             if (page == null) {
                 Log.d("GeokretyConnector.postLogTrackable: No data from server");
-                return new ImmutablePair<>(StatusCode.CONNECTION_FAILED_GK, Collections.<String> emptyList());
+                return new ImmutablePair<>(StatusCode.CONNECTION_FAILED_GK, Collections.emptyList());
             }
 
             final ImmutablePair<Integer, List<String>> response = GeokretyParser.parseResponse(page);
             if (response == null) {
                 Log.w("GeokretyConnector.postLogTrackable: Cannot parseResponse GeoKrety");
-                return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.<String> emptyList());
+                return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.emptyList());
             }
 
             final List<String> errors = response.getRight();
@@ -436,10 +436,10 @@ public class GeokretyConnector extends AbstractTrackableConnector {
                 return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, errors);
             }
             Log.i("Geokrety Log successfully posted to trackable #" + trackableLog.trackCode);
-            return new ImmutablePair<>(StatusCode.NO_ERROR, Collections.<String> emptyList());
+            return new ImmutablePair<>(StatusCode.NO_ERROR, Collections.emptyList());
         } catch (final RuntimeException e) {
             Log.w("GeokretyConnector.searchTrackable", e);
-            return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.<String> emptyList());
+            return new ImmutablePair<>(StatusCode.LOG_POST_ERROR_GK, Collections.emptyList());
         }
     }
 

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -45,6 +45,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -871,9 +872,7 @@ abstract class GPXParser extends FileParser {
         cache.setShortDescription("");
         cache.setHint("");
 
-        for (int i = 0; i < userData.length; i++) {
-            userData[i] = null;
-        }
+        Arrays.fill(userData, null);
         originalLon = null;
         originalLat = null;
         logPasswordRequired = false;
@@ -888,8 +887,8 @@ abstract class GPXParser extends FileParser {
         final Geocache newCache = new Geocache();
 
         newCache.setReliableLatLon(true); // always assume correct coordinates, when importing from file instead of website
-        newCache.setAttributes(Collections.<String> emptyList()); // override the lazy initialized list
-        newCache.setWaypoints(Collections.<Waypoint> emptyList(), false); // override the lazy initialized list
+        newCache.setAttributes(Collections.emptyList()); // override the lazy initialized list
+        newCache.setWaypoints(Collections.emptyList(), false); // override the lazy initialized list
 
         return newCache;
     }

--- a/main/src/cgeo/geocaching/filter/ModifiedFilter.java
+++ b/main/src/cgeo/geocaching/filter/ModifiedFilter.java
@@ -44,6 +44,6 @@ class ModifiedFilter extends AbstractFilter implements IFilterFactory {
     @Override
     @NonNull
     public List<IFilter> getFilters() {
-        return Collections.<IFilter> singletonList(this);
+        return Collections.singletonList(this);
     }
 }

--- a/main/src/cgeo/geocaching/filter/OwnRatingFilter.java
+++ b/main/src/cgeo/geocaching/filter/OwnRatingFilter.java
@@ -48,6 +48,6 @@ public class OwnRatingFilter extends AbstractFilter implements IFilterFactory {
     @Override
     @NonNull
     public List<IFilter> getFilters() {
-        return Collections.<IFilter> singletonList(this);
+        return Collections.singletonList(this);
     }
 }

--- a/main/src/cgeo/geocaching/filter/OwnWaypointFilter.java
+++ b/main/src/cgeo/geocaching/filter/OwnWaypointFilter.java
@@ -52,6 +52,6 @@ public class OwnWaypointFilter extends AbstractFilter implements IFilterFactory 
     @Override
     @NonNull
     public List<IFilter> getFilters() {
-        return Collections.<IFilter> singletonList(this);
+        return Collections.singletonList(this);
     }
 }

--- a/main/src/cgeo/geocaching/filter/PersonalDataFilterFactory.java
+++ b/main/src/cgeo/geocaching/filter/PersonalDataFilterFactory.java
@@ -10,7 +10,7 @@ public class PersonalDataFilterFactory implements IFilterFactory {
     @Override
     @NonNull
     public List<IFilter> getFilters() {
-        return Arrays.<IFilter> asList(
+        return Arrays.asList(
                 new OwnRatingFilter(), 
                 new PersonalNoteFilter(), 
                 new ModifiedFilter(), 

--- a/main/src/cgeo/geocaching/filter/PersonalNoteFilter.java
+++ b/main/src/cgeo/geocaching/filter/PersonalNoteFilter.java
@@ -47,6 +47,6 @@ public class PersonalNoteFilter extends AbstractFilter implements IFilterFactory
     @Override
     @NonNull
     public List<IFilter> getFilters() {
-        return Collections.<IFilter> singletonList(this);
+        return Collections.singletonList(this);
     }
 }

--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -81,7 +81,7 @@ public final class StoredList extends AbstractList {
         }
 
         public void promptForMultiListSelection(final int titleId, @NonNull final Action1<Set<Integer>> runAfterwards, final boolean onlyConcreteLists, final Set<Integer> currentListIds, final boolean fastStoreOnLastSelection) {
-            promptForMultiListSelection(titleId, runAfterwards, onlyConcreteLists, Collections.<Integer>emptySet(), currentListIds, ListNameMemento.EMPTY, fastStoreOnLastSelection);
+            promptForMultiListSelection(titleId, runAfterwards, onlyConcreteLists, Collections.emptySet(), currentListIds, ListNameMemento.EMPTY, fastStoreOnLastSelection);
         }
 
         public void promptForListSelection(final int titleId, @NonNull final Action1<Integer> runAfterwards, final boolean onlyConcreteLists, final int exceptListId, @NonNull final ListNameMemento listNameMemento) {
@@ -129,7 +129,7 @@ public final class StoredList extends AbstractList {
         }
 
         public void promptForListSelection(final int titleId, @NonNull final Action1<Integer> runAfterwards, final boolean onlyConcreteLists, final Set<Integer> exceptListIds, @NonNull final ListNameMemento listNameMemento) {
-            final List<AbstractList> lists = getMenuLists(onlyConcreteLists, exceptListIds, Collections.<Integer>emptySet());
+            final List<AbstractList> lists = getMenuLists(onlyConcreteLists, exceptListIds, Collections.emptySet());
 
             final List<CharSequence> listsTitle = new ArrayList<>();
             for (final AbstractList list : lists) {
@@ -154,7 +154,7 @@ public final class StoredList extends AbstractList {
         }
 
         public static List<AbstractList> getMenuLists(final boolean onlyConcreteLists, final int exceptListId) {
-            return getMenuLists(onlyConcreteLists, Collections.singleton(exceptListId), Collections.<Integer>emptySet());
+            return getMenuLists(onlyConcreteLists, Collections.singleton(exceptListId), Collections.emptySet());
         }
 
         public static List<AbstractList> getMenuLists(final boolean onlyConcreteLists, final Set<Integer> exceptListIds, final Set<Integer> selectedLists) {

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -683,12 +683,10 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
         menu.findItem(R.id.clear).setVisible(true);
         menu.findItem(R.id.menu_sort_trackables_by).setVisible(true);
         switch (Settings.getTrackableComparator()) {
-            case TRACKABLE_COMPARATOR_NAME:
-                menu.findItem(R.id.menu_sort_trackables_name).setChecked(true);
-                break;
             case TRACKABLE_COMPARATOR_TRACKCODE:
                 menu.findItem(R.id.menu_sort_trackables_code).setChecked(true);
                 break;
+            case TRACKABLE_COMPARATOR_NAME:
             default:
                 menu.findItem(R.id.menu_sort_trackables_name).setChecked(true);
         }
@@ -895,7 +893,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
                     final LogEntry logNow = logBuilder.build();
                     newLogs.add(0, logNow);
                     if (reportProblemSelected != ReportProblemType.NO_PROBLEM) {
-                        final LogEntry logProblem = logBuilder.setLog(getString(reportProblemSelected.textId)).setLogImages(Collections.<Image>emptyList()).setLogType(reportProblemSelected.logType).build();
+                        final LogEntry logProblem = logBuilder.setLog(getString(reportProblemSelected.textId)).setLogImages(Collections.emptyList()).setLogType(reportProblemSelected.logType).build();
                         newLogs.add(0, logProblem);
                     }
                     DataStore.saveLogs(cache.getGeocode(), newLogs);

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -999,7 +999,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
             if (Settings.getChooseList()) {
                 // let user select list to store cache in
-                new StoredList.UserInterface(activity).promptForMultiListSelection(R.string.lists_title, selectedListIds -> storeCaches(geocodesInViewport, selectedListIds), true, Collections.<Integer>emptySet(), false);
+                new StoredList.UserInterface(activity).promptForMultiListSelection(R.string.lists_title, selectedListIds -> storeCaches(geocodesInViewport, selectedListIds), true, Collections.emptySet(), false);
             } else {
                 storeCaches(geocodesInViewport, Collections.singleton(StoredList.STANDARD_LIST_ID));
             }

--- a/main/src/cgeo/geocaching/maps/ScaleDrawer.java
+++ b/main/src/cgeo/geocaching/maps/ScaleDrawer.java
@@ -78,17 +78,17 @@ public class ScaleDrawer {
             scale.setColor(0xFF000000);
         }
 
-        final String formatString = distanceRound >= 1 ? "%.0f" : "%.1f";
+        final String info = String.format(distanceRound >= 1 ? "%.0f" : "%.1f", distanceRound) + " " + scaled.right;
 
         canvas.drawLine(10, bottom, 10, bottom - 8 * pixelDensity, scaleShadow);
         canvas.drawLine((int) (pixels + 10), bottom, (int) (pixels + 10), bottom - 8 * pixelDensity, scaleShadow);
         canvas.drawLine(8, bottom, (int) (pixels + 12), bottom, scaleShadow);
-        canvas.drawText(String.format(formatString, distanceRound) + " " + scaled.right, (float) (pixels - 10 * pixelDensity), bottom - 10 * pixelDensity, scaleShadow);
+        canvas.drawText(info, (float) (pixels - 10 * pixelDensity), bottom - 10 * pixelDensity, scaleShadow);
 
         canvas.drawLine(11, bottom, 11, bottom - (6 * pixelDensity), scale);
         canvas.drawLine((int) (pixels + 9), bottom, (int) (pixels + 9), bottom - 6 * pixelDensity, scale);
         canvas.drawLine(10, bottom, (int) (pixels + 10), bottom, scale);
-        canvas.drawText(String.format(formatString, distanceRound) + " " + scaled.right, (float) (pixels - 10 * pixelDensity), bottom - 10 * pixelDensity, scale);
+        canvas.drawText(info, (float) (pixels - 10 * pixelDensity), bottom - 10 * pixelDensity, scale);
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -573,7 +573,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
             if (Settings.getChooseList()) {
                 // let user select list to store cache in
-                new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title, selectedListIds -> storeCaches(geocodes, selectedListIds), true, Collections.<Integer>emptySet(), false);
+                new StoredList.UserInterface(this).promptForMultiListSelection(R.string.lists_title, selectedListIds -> storeCaches(geocodes, selectedListIds), true, Collections.emptySet(), false);
             } else {
                 storeCaches(geocodes, Collections.singleton(StoredList.STANDARD_LIST_ID));
             }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1040,7 +1040,7 @@ public class Geocache implements IWaypoint {
      */
     @NonNull
     public List<Trackable> getInventory() {
-        return inventory == null ? Collections.<Trackable> emptyList() : Collections.unmodifiableList(inventory);
+        return inventory == null ? Collections.emptyList() : Collections.unmodifiableList(inventory);
     }
 
     /**
@@ -1184,7 +1184,7 @@ public class Geocache implements IWaypoint {
      */
     @NonNull
     public List<LogEntry> getLogs() {
-        return inDatabase() ? DataStore.loadLogs(geocode) : Collections.<LogEntry>emptyList();
+        return inDatabase() ? DataStore.loadLogs(geocode) : Collections.emptyList();
     }
 
     /**
@@ -1934,7 +1934,7 @@ public class Geocache implements IWaypoint {
      */
     public int getFindsCount() {
         if (getLogCounts().isEmpty()) {
-            setLogCounts(inDatabase() ? DataStore.loadLogCounts(getGeocode()) : Collections.<LogType, Integer>emptyMap());
+            setLogCounts(inDatabase() ? DataStore.loadLogCounts(getGeocode()) : Collections.emptyMap());
         }
         int sumFound = 0;
         for (final Entry<LogType, Integer> logCount : getLogCounts().entrySet()) {

--- a/main/src/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/cgeo/geocaching/network/HtmlImage.java
@@ -207,7 +207,7 @@ public class HtmlImage implements Html.ImageGetter {
         if (FileUtils.isFileUrl(url)) {
             return Observable.defer(() -> {
                 final Bitmap bitmap = loadCachedImage(FileUtils.urlToFile(url), true).left;
-                return bitmap != null ? Observable.just(ImageUtils.scaleBitmapToFitDisplay(bitmap)) : Observable.<BitmapDrawable>empty();
+                return bitmap != null ? Observable.just(ImageUtils.scaleBitmapToFitDisplay(bitmap)) : Observable.empty();
             }).subscribeOn(AndroidRxUtils.computationScheduler);
         }
 

--- a/main/src/cgeo/geocaching/network/Network.java
+++ b/main/src/cgeo/geocaching/network/Network.java
@@ -624,7 +624,7 @@ public final class Network {
     /**
      * Filter only successful responses for use with flatMap.
      */
-    public static final Function<Response, Single<Response>> withSuccess = response -> response.isSuccessful() ? Single.just(response) : Single.<Response>error(new IOException("unsuccessful response: " + response));
+    public static final Function<Response, Single<Response>> withSuccess = response -> response.isSuccessful() ? Single.just(response) : Single.error(new IOException("unsuccessful response: " + response));
 
     /**
      * Wait until a request has completed and check its response status. An exception will be thrown if the

--- a/main/src/cgeo/geocaching/settings/AbstractProximityPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractProximityPreference.java
@@ -27,13 +27,13 @@ public abstract class AbstractProximityPreference extends AbstractSeekbarPrefere
     @Override
     protected int valueToProgress(final int value) {
         final int progress = valueToProgressHelper(value);
-        return progress < 0 ? 0 : progress > maxSeekbarLength ? maxSeekbarLength : progress;
+        return progress < 0 ? 0 : Math.min(progress, maxSeekbarLength);
     }
 
     @Override
     protected int progressToValue(final int progress) {
         final int value = (int) Math.pow(10, Double.valueOf(progress) / 250.0) - 1;
-        return value < 0 ? 0 : value > Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE ? Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE : value;
+        return value < 0 ? 0 : Math.min(value, Settings.PROXIMITY_NOTIFICATION_MAX_DISTANCE);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -622,21 +622,25 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> {
                     return false;
                 }
 
-                // left to right swipe
-                if ((e2.getX() - e1.getX()) > SWIPE_MIN_DISTANCE && Math.abs(velocityX) > Math.abs(velocityY)) {
-                    if (!adapter.selectMode) {
-                        adapter.switchSelectMode();
-                        cache.setStatusChecked(true);
-                    }
-                    return true;
-                }
+                // horizontal swipe
+                if (Math.abs(velocityX) > Math.abs(velocityY)) {
 
-                // right to left swipe
-                if ((e1.getX() - e2.getX()) > SWIPE_MIN_DISTANCE && Math.abs(velocityX) > Math.abs(velocityY)) {
-                    if (adapter.selectMode) {
-                        adapter.switchSelectMode();
+                    // left to right swipe
+                    if ((e2.getX() - e1.getX()) > SWIPE_MIN_DISTANCE) {
+                        if (!adapter.selectMode) {
+                            adapter.switchSelectMode();
+                            cache.setStatusChecked(true);
+                        }
+                        return true;
                     }
-                    return true;
+
+                    // right to left swipe
+                    if ((e1.getX() - e2.getX()) > SWIPE_MIN_DISTANCE) {
+                        if (adapter.selectMode) {
+                            adapter.switchSelectMode();
+                        }
+                        return true;
+                    }
                 }
             } catch (final Exception e) {
                 Log.w("CacheListAdapter.FlingGesture.onFling", e);

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -875,7 +875,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
                                 result = String.valueOf(resInt);
                             }
 
-                            returnValue = returnValue.substring(0, openIndex) + result + returnValue.substring(closeIndex + 1, returnValue.length());
+                            returnValue = returnValue.substring(0, openIndex) + result + returnValue.substring(closeIndex + 1);
                         } else {
                             // Reached end without finding enough closing brackets
                             throw new IllegalArgumentException("Unmatched opening bracket '" + returnValue.charAt(openIndex) + "' at index " + openIndex + " of \"" + returnValue + "\"/");

--- a/main/src/cgeo/geocaching/utils/AngleUtils.java
+++ b/main/src/cgeo/geocaching/utils/AngleUtils.java
@@ -46,14 +46,13 @@ public final class AngleUtils {
 
     public static int getRotationOffset() {
         switch (WindowManagerHolder.WINDOW_MANAGER.getDefaultDisplay().getRotation()) {
-            case Surface.ROTATION_0:
-                return 0;
             case Surface.ROTATION_90:
                 return 90;
             case Surface.ROTATION_180:
                 return 180;
             case Surface.ROTATION_270:
                 return 270;
+            case Surface.ROTATION_0:
             default:
                 return 0;
         }

--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -375,7 +375,7 @@ public final class MapMarkerUtils {
      *         True if the floppy overlay should be displayed
      */
     private static boolean showFloppyOverlay(@Nullable final CacheListType cacheListType) {
-        return cacheListType == null || cacheListType != CacheListType.OFFLINE;
+        return cacheListType != CacheListType.OFFLINE;  // covers null check
     }
 
     private static void readLists() {

--- a/main/src/cgeo/geocaching/utils/RxUtils.java
+++ b/main/src/cgeo/geocaching/utils/RxUtils.java
@@ -24,7 +24,7 @@ public class RxUtils {
         final AtomicReference<T> lastValue = new AtomicReference<>(initialValue);
         return observable.doOnNext(lastValue::set).startWith(Observable.defer(() -> {
             final T last = lastValue.get();
-            return last != null ? Observable.just(last) : Observable.<T>empty();
+            return last != null ? Observable.just(last) : Observable.empty();
         })).replay(1).refCount();
     }
 

--- a/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
+++ b/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
@@ -30,7 +30,7 @@ public class GpxSerializerTest extends AbstractResourceInstrumentationTestCase {
 
     public static void testWriteEmptyGPX() throws Exception {
         final StringWriter writer = new StringWriter();
-        new GpxSerializer().writeGPX(Collections.<String> emptyList(), writer, null);
+        new GpxSerializer().writeGPX(Collections.emptyList(), writer, null);
         assertThat(writer.getBuffer().toString()).isEqualTo("<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>" +
                 "<gpx version=\"1.0\" creator=\"c:geo - http://www.cgeo.org/\" " +
                 "xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd " +

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -151,7 +151,7 @@ public class GeocacheTest extends CGeoTestCase {
         download.setType(CacheType.MULTI);
         download.setCoords(new Geopoint(41.0, 9.0));
         download.setDescription("Test2");
-        download.setAttributes(Collections.<String>emptyList());
+        download.setAttributes(Collections.emptyList());
 
         download.gatherMissingFrom(stored);
 


### PR DESCRIPTION
- remove unnecessary type identifiers which can be inferred by return / parameter type
- merge duplicate switch branches
- use `Arrays.fill` instead of loop resetting each value manually
- use `Math.min` instead of manual comparison
- remove duplicate string expression
- remove unnecessary null check