### PR TITLE
remove buildToolsVersion

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -21,8 +21,6 @@ if (isContinuousIntegrationServer()) {
 android {
     compileSdkVersion 29
 
-    buildToolsVersion "28.0.3"
-
     compileOptions {
         // use the diamond operator and some other goodies in Android
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
See https://developer.android.com/studio/releases/build-tools.
~~~
If you're using Android plugin for Gradle 3.0.0 or higher, your project automatically uses a default version of the build tools that the plugin specifies.
~~~