### PR TITLE
Update libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
 
         // monitor our application method limit
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.2'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.3'
 
         // ribbonizer for easier distinction of non-release builds
         classpath 'com.github.gfx.ribbonizer:ribbonizer-plugin:2.1.0'
@@ -94,18 +94,6 @@ allprojects {
                         // https://github.com/joel-costigliola/assertj-core/issues/345
                         if (selection.candidate.group == 'org.assertj' && selection.candidate.module == 'assertj-core' && selection.candidate.version.substring(0,1).toInteger() > 2) {
                             selection.reject("assertj 3.x or higher requires Java 7 SE classes not available in Android")
-                        }
-                        // Apache Commons IO 2.6 fails in FileUtils.deleteDirectory()
-                        if (selection.candidate.group == 'commons-io' && selection.candidate.module == 'commons-io' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 25) {
-                            selection.reject("Apache Commons IO 2.6 calls methods not available in the Android runtime.")
-                        }
-                        // Apache Commons lang3 3.6+ fails in StringUtils.join() for API < 19
-                        if (selection.candidate.group == 'org.apache.commons' && selection.candidate.module == 'commons-lang3' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 35) {
-                            selection.reject("Apache Commons lang3 3.6+ calls methods not available in the Android runtime.")
-                        }
-                        // Apache Commons Text 1.2+ requires Apache Commons lang3 3.6+ (see above)
-                        if (selection.candidate.group == 'org.apache.commons' && selection.candidate.module == 'commons-text' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 11) {
-                            selection.reject("Apache Commons text 1.2+ requires Apache Commons lang3 3.6+.")
                         }
                     }
                 }

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -246,12 +246,9 @@ dependencies {
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.commons:commons-compress:1.20'
-    //noinspection GradleDependency
-    implementation 'commons-io:commons-io:2.5'
-    //noinspection GradleDependency
-    implementation 'org.apache.commons:commons-lang3:3.5'
-    //noinspection GradleDependency
-    implementation 'org.apache.commons:commons-text:1.1'
+    implementation 'commons-io:commons-io:2.7'
+    implementation 'org.apache.commons:commons-lang3:3.10'
+    implementation 'org.apache.commons:commons-text:1.8'
 
     // AssertJ for testing, needed both for local unit tests and Android instrumentation tests
     def assertJVersion = '2.9.1'
@@ -265,7 +262,7 @@ dependencies {
 
     // SpotBugs (successor of FindBugs)
     implementation 'net.jcip:jcip-annotations:1.0'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.0.3'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.0.6'
 
     // GeographicLib
     implementation 'net.sf.geographiclib:GeographicLib-Java:1.50'
@@ -314,7 +311,6 @@ dependencies {
     // Metadata Extractor, EXIF location extraction from images
     implementation 'com.drewnoakes:metadata-extractor:2.14.0'
 
-    //noinspection GradleDependency
     implementation 'com.squareup.okhttp3:okhttp:4.7.2'
 
     // Play Services

--- a/tests/src-android/cgeo/geocaching/files/GPXImporterTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXImporterTest.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.test.AbstractResourceInstrumentationTestCase;
 import cgeo.geocaching.test.R;
 import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.net.Uri;
@@ -23,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -52,8 +52,8 @@ public class GPXImporterTest extends AbstractResourceInstrumentationTestCase {
             // the "real" method check
             assertThat(GPXImporter.getWaypointsFileNameForGpxFile(gpx)).isEqualTo(wptsFileName);
             // they also need to be deleted, because of case sensitive tests that will not work correct on case insensitive file systems
-            FileUtils.deleteQuietly(gpx);
-            FileUtils.deleteQuietly(wpts);
+            FileUtils.delete(gpx);
+            FileUtils.delete(wpts);
         }
         final File gpx1 = new File(tempDir, "abc.gpx");
         assertThat(GPXImporter.getWaypointsFileNameForGpxFile(gpx1)).isNull();
@@ -341,7 +341,7 @@ public class GPXImporterTest extends AbstractResourceInstrumentationTestCase {
         assertThat(StringUtils.isNotBlank(globalTempDir)).overridingErrorMessage("java.io.tmpdir is not defined").isTrue();
 
         tempDir = new File(globalTempDir, "cgeogpxesTest");
-        cgeo.geocaching.utils.FileUtils.mkdirs(tempDir);
+        FileUtils.mkdirs(tempDir);
         assertThat(tempDir).overridingErrorMessage("Could not create directory %s", tempDir.getPath()).exists();
         // workaround to get storage initialized
         DataStore.getAllHistoryCachesCount();


### PR DESCRIPTION
- commons-lang3: 3.5 to 3.10
  now possible after API > 19
- commons-text: 1.1 to 1.8
  as commons-lang3
- commons-io: 2.5 to 2.7
  as preparation: removed the commons.io.FileUtils from GPXImporterTest, used instead cgeo.geocaching.utils.FileUtils
- spotbugs-annotations: 4.0.3 to 4.0.6
- dexcount-gradle-plugin: 1.0.2 to 1.0.3