### PR TITLE
add compatibility for restore of early settings backup versions

### DIFF
--- a/main/src/cgeo/geocaching/utils/SettingsUtils.java
+++ b/main/src/cgeo/geocaching/utils/SettingsUtils.java
@@ -10,6 +10,7 @@ public class SettingsUtils {
         TYPE_STRING     ("string"),
         TYPE_BOOLEAN    ("boolean"),
         TYPE_INTEGER    ("integer"),
+        TYPE_INTEGER_COMPATIBILITY ("int"),     // for reading compatibility with early backups
         TYPE_LONG       ("long"),
         TYPE_FLOAT      ("float"),
         TYPE_UNKNOWN    ("unknown");
@@ -62,6 +63,7 @@ public class SettingsUtils {
                 editor.putLong(key, Long.parseLong(value));
                 break;
             case TYPE_INTEGER:
+            case TYPE_INTEGER_COMPATIBILITY:
                 editor.putInt(key, Integer.parseInt(value));
                 break;
             case TYPE_BOOLEAN:


### PR DESCRIPTION
Settings backup created with older c:geo versions created entries with `<int name="xxx" value="xxx" />` instead of `<integer ... />`, which cannot be restored by current c:geo versions. This PR adds compatibility to those old backups.