### PR TITLE
tryout: new fastscroll mechanism for CacheListActivity

### DIFF
--- a/main/res/layout/cacheslist_activity.xml
+++ b/main/res/layout/cacheslist_activity.xml
@@ -33,7 +33,7 @@
         android:cacheColorHint="?background_color"
         android:clipToPadding="false"
         android:dividerHeight="1dip"
-        android:fastScrollEnabled="true"
+        android:fastScrollEnabled="false"
         android:padding="0dip"
         android:scrollbarStyle="outsideOverlay"
         android:visibility="gone"

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -186,6 +186,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     };
     private long mLastScroll = 0; // for fast scroll control
+    private int mScrollState = 0;
     private ContextMenuInfo lastMenuInfo;
     private String contextMenuGeocode = "";
     private final CompositeDisposable resumeDisposables = new CompositeDisposable();
@@ -1275,14 +1276,14 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                             listView.setFastScrollEnabled(false);
                         }
                     }, 1000);
-
                 }
+                mScrollState = state;
             }
 
             @Override
             public void onScroll(final AbsListView view, final int firstVisibleItem, final int visibleItemCount, final int totalItemCount) {
                 mLastScroll = System.currentTimeMillis();
-                if (!listView.isFastScrollEnabled()) {
+                if (mScrollState == SCROLL_STATE_FLING && !listView.isFastScrollEnabled()) {
                     listView.setFastScrollEnabled(true);
                 }
             }


### PR DESCRIPTION
Following up the discussion in #8406 here's a tryout version for CacheListActivity:
- disable fastscroll by default
- activate on scrolling, but only in fling mode
- deactivate automatically after one second of not scrolling
