### PR TITLE
show fastscroll thumbs in cachelist view

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1011,6 +1011,7 @@
     <string name="cache_found_last_30_days">Found last 30 days</string>
     <string name="cache_status_archived">Archived</string>
     <string name="cache_status_disabled">Disabled</string>
+    <string name="cache_status_active">Active</string>
     <string name="cache_status_premium">Premium Members only</string>
     <string name="cache_status_not_premium">All Members Access</string>
     <string name="cache_status_stored">Stored</string>

--- a/main/src/cgeo/geocaching/sorting/CacheComparator.java
+++ b/main/src/cgeo/geocaching/sorting/CacheComparator.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
 import java.util.Comparator;
 
 public interface CacheComparator extends Comparator<Geocache> {
@@ -11,5 +13,7 @@ public interface CacheComparator extends Comparator<Geocache> {
      * user.
      */
     boolean isAutoManaged();
+
+    String getSortableSection(@NonNull Geocache cache);
 
 }

--- a/main/src/cgeo/geocaching/sorting/DateComparator.java
+++ b/main/src/cgeo/geocaching/sorting/DateComparator.java
@@ -2,6 +2,9 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.sensors.Sensors;
+import cgeo.geocaching.utils.CalendarUtils;
+
+import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -37,5 +40,10 @@ class DateComparator extends AbstractCacheComparator {
         list.add(cache2);
         final DistanceComparator distanceComparator = new DistanceComparator(Sensors.getInstance().currentGeo().getCoords(), list);
         return distanceComparator.compare(cache1, cache2);
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return CalendarUtils.yearMonth(cache.getHiddenDate());
     }
 }

--- a/main/src/cgeo/geocaching/sorting/DifficultyComparator.java
+++ b/main/src/cgeo/geocaching/sorting/DifficultyComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by difficulty
  *
@@ -16,5 +20,10 @@ class DifficultyComparator extends AbstractCacheComparator {
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         return Float.compare(cache1.getDifficulty(), cache2.getDifficulty());
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%.1f", cache.getDifficulty());
     }
 }

--- a/main/src/cgeo/geocaching/sorting/DistanceComparator.java
+++ b/main/src/cgeo/geocaching/sorting/DistanceComparator.java
@@ -1,13 +1,13 @@
 package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.Units;
 import cgeo.geocaching.models.Geocache;
 
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * sorts caches by distance to given position
@@ -63,6 +63,6 @@ public class DistanceComparator extends AbstractCacheComparator {
 
     @Override
     public String getSortableSection(@NonNull final Geocache cache) {
-        return String.format(Locale.getDefault(), "%.2f", cache.getDistance());
+        return Units.getDistanceFromKilometers(cache.getDistance());
     }
 }

--- a/main/src/cgeo/geocaching/sorting/DistanceComparator.java
+++ b/main/src/cgeo/geocaching/sorting/DistanceComparator.java
@@ -3,8 +3,11 @@ package cgeo.geocaching.sorting;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * sorts caches by distance to given position
@@ -58,4 +61,8 @@ public class DistanceComparator extends AbstractCacheComparator {
         return distance2 == null ? -1 : Float.compare(distance1, distance2);
     }
 
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%.2f", cache.getDistance());
+    }
 }

--- a/main/src/cgeo/geocaching/sorting/FindsComparator.java
+++ b/main/src/cgeo/geocaching/sorting/FindsComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 class FindsComparator extends AbstractCacheComparator {
 
     @Override
@@ -16,4 +20,8 @@ class FindsComparator extends AbstractCacheComparator {
         return finds2 - finds1;
     }
 
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%d", cache.getFindsCount());
+    }
 }

--- a/main/src/cgeo/geocaching/sorting/GeocodeComparator.java
+++ b/main/src/cgeo/geocaching/sorting/GeocodeComparator.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
 /**
  * sorts caches by geo code, therefore effectively sorting by cache age
  *
@@ -18,4 +20,10 @@ public class GeocodeComparator extends AbstractCacheComparator {
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         throw new IllegalStateException("should never be called");
     }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return cache.getGeocode();
+    }
+
 }

--- a/main/src/cgeo/geocaching/sorting/InventoryComparator.java
+++ b/main/src/cgeo/geocaching/sorting/InventoryComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by number of items in inventory
  */
@@ -10,5 +14,10 @@ class InventoryComparator extends AbstractCacheComparator {
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         return cache2.getInventoryItems() - cache1.getInventoryItems();
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%d", cache.getInventoryItems());
     }
 }

--- a/main/src/cgeo/geocaching/sorting/InverseComparator.java
+++ b/main/src/cgeo/geocaching/sorting/InverseComparator.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
 /**
  * comparator which inverses the sort order of the given other comparator
  *
@@ -24,4 +26,8 @@ public class InverseComparator implements CacheComparator {
         return originalComparator.isAutoManaged();
     }
 
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return originalComparator.getSortableSection(cache);
+    }
 }

--- a/main/src/cgeo/geocaching/sorting/NameComparator.java
+++ b/main/src/cgeo/geocaching/sorting/NameComparator.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.sorting;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -19,5 +21,10 @@ public class NameComparator extends AbstractCacheComparator {
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         return TextUtils.COLLATOR.compare(cache1.getNameForSorting(), cache2.getNameForSorting());
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return StringUtils.upperCase(StringUtils.substring(cache.getNameForSorting(), 0, 2));
     }
 }

--- a/main/src/cgeo/geocaching/sorting/PopularityComparator.java
+++ b/main/src/cgeo/geocaching/sorting/PopularityComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by popularity (favorite count)
  *
@@ -11,5 +15,10 @@ class PopularityComparator extends AbstractCacheComparator {
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         return cache2.getFavoritePoints() - cache1.getFavoritePoints();
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%d", cache.getFavoritePoints());
     }
 }

--- a/main/src/cgeo/geocaching/sorting/PopularityRatioComparator.java
+++ b/main/src/cgeo/geocaching/sorting/PopularityRatioComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by popularity ratio (favorites per find in %).
  */
@@ -22,5 +26,11 @@ class PopularityRatioComparator extends AbstractCacheComparator {
         }
 
         return Float.compare(ratio2, ratio1);
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        final int finds = cache.getFindsCount();
+        return 0 == finds ? "--" : String.format(Locale.getDefault(), "%.2f", ((float) cache.getFavoritePoints()) / finds);
     }
 }

--- a/main/src/cgeo/geocaching/sorting/RatingComparator.java
+++ b/main/src/cgeo/geocaching/sorting/RatingComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by gcvote.com rating
  *
@@ -30,4 +34,8 @@ class RatingComparator extends AbstractCacheComparator {
         return (votes * rating + AVERAGE_VOTES * AVERAGE_RATING) / (votes + AVERAGE_VOTES);
     }
 
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%.2f", getWeightedArithmeticMean(cache));
+    }
 }

--- a/main/src/cgeo/geocaching/sorting/SizeComparator.java
+++ b/main/src/cgeo/geocaching/sorting/SizeComparator.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
 /**
  * sorts caches by size
  *
@@ -11,5 +13,10 @@ class SizeComparator extends AbstractCacheComparator {
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         return cache2.getSize().comparable - cache1.getSize().comparable;
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return cache.getSize().toString();
     }
 }

--- a/main/src/cgeo/geocaching/sorting/StateComparator.java
+++ b/main/src/cgeo/geocaching/sorting/StateComparator.java
@@ -1,12 +1,19 @@
 package cgeo.geocaching.sorting;
 
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
 import cgeo.geocaching.models.Geocache;
+
+import androidx.annotation.NonNull;
 
 /**
  * sort caches by state (normal, disabled, archived)
  *
  */
 class StateComparator extends AbstractCacheComparator {
+    private final String stateActive = CgeoApplication.getInstance().getString(R.string.cache_status_active);
+    private final String stateDisabled = CgeoApplication.getInstance().getString(R.string.cache_status_disabled);
+    private final String stateArchived = CgeoApplication.getInstance().getString(R.string.cache_status_archived);
 
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
@@ -21,6 +28,18 @@ class StateComparator extends AbstractCacheComparator {
             return 2;
         }
         return 0;
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        switch (getState(cache)) {
+            case 1:
+                return stateDisabled;
+            case 2:
+                return stateArchived;
+            default:
+                return stateActive;
+        }
     }
 
 }

--- a/main/src/cgeo/geocaching/sorting/StorageTimeComparator.java
+++ b/main/src/cgeo/geocaching/sorting/StorageTimeComparator.java
@@ -1,6 +1,9 @@
 package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.CalendarUtils;
+
+import androidx.annotation.NonNull;
 
 class StorageTimeComparator extends AbstractCacheComparator {
 
@@ -9,4 +12,8 @@ class StorageTimeComparator extends AbstractCacheComparator {
         return Long.compare(cache1.getUpdated(), cache2.getUpdated());
     }
 
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return CalendarUtils.yearMonth(cache.getUpdated());
+    }
 }

--- a/main/src/cgeo/geocaching/sorting/TerrainComparator.java
+++ b/main/src/cgeo/geocaching/sorting/TerrainComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by terrain rating
  *
@@ -16,5 +20,10 @@ class TerrainComparator extends AbstractCacheComparator {
     @Override
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         return Float.compare(cache1.getTerrain(), cache2.getTerrain());
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%.1f", cache.getTerrain());
     }
 }

--- a/main/src/cgeo/geocaching/sorting/VisitComparator.java
+++ b/main/src/cgeo/geocaching/sorting/VisitComparator.java
@@ -1,6 +1,9 @@
 package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.CalendarUtils;
+
+import androidx.annotation.NonNull;
 
 /**
  * sorts caches by last visited date
@@ -22,4 +25,8 @@ public class VisitComparator extends AbstractCacheComparator {
         return Long.compare(lhs, rhs);
     }
 
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return CalendarUtils.yearMonth(cache.getVisitedDate());
+    }
 }

--- a/main/src/cgeo/geocaching/sorting/VoteComparator.java
+++ b/main/src/cgeo/geocaching/sorting/VoteComparator.java
@@ -2,6 +2,10 @@ package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
 
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
 /**
  * sorts caches by the users own voting (if available at all)
  */
@@ -11,5 +15,10 @@ class VoteComparator extends AbstractCacheComparator {
     protected int compareCaches(final Geocache cache1, final Geocache cache2) {
         // if there is no vote available, put that cache at the end of the list
         return Float.compare(cache2.getMyVote(), cache1.getMyVote());
+    }
+
+    @Override
+    public String getSortableSection(@NonNull final Geocache cache) {
+        return String.format(Locale.getDefault(), "%.2f", cache.getMyVote());
     }
 }

--- a/main/src/cgeo/geocaching/utils/CalendarUtils.java
+++ b/main/src/cgeo/geocaching/utils/CalendarUtils.java
@@ -14,6 +14,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
+import javax.annotation.Nullable;
+
 public final class CalendarUtils {
 
     private CalendarUtils() {
@@ -77,4 +79,33 @@ public final class CalendarUtils {
         final DateFormat dateFormat = new SimpleDateFormat(format, Locale.getDefault());
         return dateFormat.format(date);
     }
+
+    /**
+     * returns given date in format yyyy-mm, or empty string if null given
+     * @param date Date to be formatted
+     * @return String formatted date
+     */
+    public static String yearMonth(@Nullable final Date date) {
+        final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
+        if (null == date) {
+            return "";
+        } else {
+            return dateFormat.format(date);
+        }
+    }
+
+    /**
+     * returns given date in format yyyy-mm, or empty string if 0 given
+     * @param date Date to be formatted
+     * @return String formatted date
+     */
+    public static String yearMonth(final long date) {
+        final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
+        if (0 == date) {
+            return "";
+        } else {
+            return dateFormat.format(date);
+        }
+    }
+
 }


### PR DESCRIPTION
Adds fastscroll thumbs to cache list view (similar to #8583) to make fastscroll in cache list view more visible + more useful.

What gets shown as thumb depends on the currently selected sorting, eg.:
- sort by name: shows the first two letters
- sort by date: shows year + month
- sort by rating: shows rating
etc.
