### PR TITLE
Fix #8589: Make coordinate parsing more strict

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/cgeo/geocaching/location/GeopointParser.java
@@ -294,7 +294,7 @@ public class GeopointParser {
 
         //                                        (   1  )    (    2    )    (       3      )
         private static final String STRING_LON = "([WEO]?)\\s*(\\d++°?|°)\\s*(\\d++[.,]\\d++)\\b['′]?";
-        private static final String STRING_SEPARATOR = "[^\\w'′\"″°]*";
+        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.,]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile("\\b" + STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);
@@ -333,7 +333,7 @@ public class GeopointParser {
 
         //                                        (   1  )    (  2  )( 3)    (  4  )         (       5      )
         private static final String STRING_LON = "([WEO]?)\\s*(\\d++)(°?)\\s*(\\d++)['′]?\\s*(\\d++[.,]\\d++)\\b(?:''|\"|″)?";
-        private static final String STRING_SEPARATOR = "[^\\w'′\"″°]*";
+        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.,]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile("\\b" + STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);
@@ -409,7 +409,7 @@ public class GeopointParser {
 
         //                                        (        1       )
         private static final String STRING_LON = "(-?\\d++[.,]\\d++)\\b°?";
-        private static final String STRING_SEPARATOR = "[^\\w'′\"″°-]*";
+        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.,-]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);

--- a/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
@@ -161,11 +161,6 @@ public class GeoPointParserTest {
     }
 
     @Test
-    public void testDoubleComma() {
-        assertThat(GeopointParser.parse("47.648883,122.348067").equals(GeopointParser.parse("47.648883 122.348067")));
-    }
-
-    @Test
     public void testGerman() {
         assertThat(GeopointParser.parse("N 47° 38.933 O 122° 20.884")).isEqualTo(GeopointParser.parse("N 47° 38.933 E 122° 20.884"));
     }
@@ -313,4 +308,13 @@ public class GeoPointParserTest {
         }
     }
 
+    @Test
+    public void test8078() {
+        assertParsingFails("2.2.3.8");
+    }
+
+    @Test
+    public void test8589() {
+        assertParsingFails("6, 12, 16, 29");
+    }
 }


### PR DESCRIPTION
We now forbid all special characters of the coordinates to occur between the coordinate parts.