### PR TITLE
revert commons-io update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,12 @@ allprojects {
                         if (selection.candidate.group == 'org.assertj' && selection.candidate.module == 'assertj-core' && selection.candidate.version.substring(0,1).toInteger() > 2) {
                             selection.reject("assertj 3.x or higher requires Java 7 SE classes not available in Android")
                         }
+
+                        // Apache Commons IO 2.6 fails in FileUtils.deleteDirectory()
+                        // (uses java.nio.file.Path - which is first contained in Android API26)
+                        if (selection.candidate.group == 'commons-io' && selection.candidate.module == 'commons-io' && selection.candidate.version.substring(0,1).toInteger()*10+selection.candidate.version.substring(2,3).toInteger() > 25) {
+                            selection.reject("Apache Commons IO 2.6 calls methods not available in the Android runtime untli API26.")
+                        }
                     }
                 }
                 // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -246,9 +246,12 @@ dependencies {
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.commons:commons-compress:1.20'
-    implementation 'commons-io:commons-io:2.7'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'org.apache.commons:commons-text:1.8'
+    // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
+    // could be replaced by Storage Access Framework
+    //noinspection GradleDependency
+    implementation 'commons-io:commons-io:2.5'
 
     // AssertJ for testing, needed both for local unit tests and Android instrumentation tests
     def assertJVersion = '2.9.1'


### PR DESCRIPTION
fixes #8587

revert change of commons-io > 2.5.
It uses java.nio.file.Path - which is first contained in Android API26.