### PR TITLE
set colorAccent to new logo's orange tone

### DIFF
--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -27,6 +27,8 @@
     <color name="button_default">#282828</color>
     <color name="steel">#675C68</color>
 
+    <color name="colorAccent">#F5981D</color>
+
     <color name="default_trailcolor">#80000000</color>
     <color name="default_routecolor">#800000FF</color>
     <color name="default_trackcolor">#80008000</color>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -380,17 +380,19 @@
     <!-- progress dialog theme -->
     <style name="cgeoProgressdialogTheme" parent="Theme.AppCompat.Dialog.Alert">
         <item name="android:textColor">?text_color</item>
+        <item name="colorAccent">@color/colorAccent</item>
         <item name="android:windowBackground">@drawable/border_straight</item>
     </style>
     <style name="cgeoProgressdialogTheme_light" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:textColor">?text_color</item>
+        <item name="colorAccent">@color/colorAccent</item>
         <item name="android:windowBackground">@drawable/border_straight_light</item>
     </style>
 
     <!-- map progressbar style -->
     <style name="map_progressbar" parent="@style/Widget.AppCompat.ProgressBar.Horizontal">
         <item name="android:height">8dp</item>
-        <item name="colorAccent">#007DD6</item>
+        <item name="colorAccent">@color/colorAccent</item>
         <item name="android:padding">0dp</item>
         <item name="android:layout_marginTop">-4dp</item>
     </style>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -14,6 +14,8 @@
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowShowWallpaper">true</item>
 
+        <item name="colorAccent">@color/colorAccent</item>
+
         <!-- system elements -->
         <item name="android:windowContentOverlay">@null</item>
         <item name="actionBarStyle">@style/cgeo_main.ActionBarStyle</item>
@@ -70,6 +72,8 @@
        <item name="android:editTextStyle">@style/edittext</item>
        <item name="android:windowContentOverlay">@null</item>
        <item name="actionBarStyle">@style/cgeo.ActionBarStyle</item>
+
+        <item name="colorAccent">@color/colorAccent</item>
 
         <!-- own values: colors -->
         <item name="just_color">@color/just_black</item>
@@ -177,6 +181,7 @@
 
     <style name="cgeo_popup" parent="cgeo.Translucent.Light">
         <item name="android:windowNoTitle">true</item>
+        <item name="colorAccent">@color/colorAccent</item>
      </style>
 
     <style name="popup_dark" parent="cgeo.Translucent">


### PR DESCRIPTION
set colorAccent to new logo's orange tone in several places (may have missed some, though)

Some areas the new color shows up:
- map loading progress indicator
- cache list view fastscroll thumb
- import GPX progress bar
