### PR TITLE
Issues/5688: copy all modified waypoints to notes

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -124,6 +124,11 @@
                 android:text="@string/cache_personal_note_edit" />
 
             <Button
+                android:id="@+id/storewaypoints_personalnote"
+                style="@style/button_small"
+                android:text="@string/cache_personal_note_storewaypoints" />
+
+            <Button
                 android:id="@+id/upload_personalnote"
                 style="@style/button_small"
                 android:text="@string/cache_personal_note_upload" />

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -900,6 +900,11 @@
     <string name="cache_menu_preventWaypointsFromNote">Prevent waypoints from note</string>
     <string name="cache_menu_allowWaypointExtraction">Allow waypoints from note</string>
     <string name="cache_personal_note_edit">Edit</string>
+    <string name="cache_personal_note_storewaypoints">Store Waypoints</string>
+    <string name="cache_personal_note_storewaypoints_success">Waypoints were added to personal note</string>
+    <string name="cache_personal_note_storewaypoints_success_limited">Waypoints were added to note but had to be shortened</string>
+    <string name="cache_personal_note_storewaypoints_failed">Waypoints could not be stored in note due to size limits</string>
+    <string name="cache_personal_note_storewaypoints_nowaypoints">No user waypoints found</string>
     <string name="cache_personal_note_preventWaypointsExtraction">Prevent waypoints extraction</string>
     <string name="cache_personal_note_limit">Personal note limit</string>
     <string name="cache_personal_note_truncation" tools:ignore="PluralsCandidate">This personal note will be truncated after %d characters by Geocaching.com.</string>

--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -21,27 +21,31 @@ import org.apache.commons.lang3.StringUtils;
  * Enum listing waypoint types
  */
 public enum WaypointType {
-    FINAL("flag", "Final Location", R.string.wp_final, R.drawable.waypoint_flag, 3, R.drawable.dot_waypoint_flag),
-    OWN("own", "Own", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 5, R.drawable.dot_waypoint),
-    PARKING("pkg", "Parking Area", R.string.wp_pkg, R.drawable.waypoint_pkg, -1, R.drawable.dot_waypoint_pkg),
-    PUZZLE("puzzle", "Virtual Stage", R.string.wp_puzzle, R.drawable.waypoint_puzzle, 2, R.drawable.dot_waypoint),
-    STAGE("stage", "Physical Stage", R.string.wp_stage, R.drawable.waypoint_stage, 2, R.drawable.dot_waypoint),
-    TRAILHEAD("trailhead", "Trailhead", R.string.wp_trailhead, R.drawable.waypoint_trailhead, 1, R.drawable.dot_waypoint),
-    WAYPOINT("waypoint", "Reference Point", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 2, R.drawable.dot_waypoint_reference),
-    ORIGINAL("original", "Original Coordinates", R.string.wp_original, R.drawable.waypoint_waypoint, 4, R.drawable.dot_waypoint_reference);
+    FINAL("flag", "f", "Final Location", R.string.wp_final, R.drawable.waypoint_flag, 3, R.drawable.dot_waypoint_flag),
+    OWN("own", "o", "Own", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 5, R.drawable.dot_waypoint),
+    PARKING("pkg", "p", "Parking Area", R.string.wp_pkg, R.drawable.waypoint_pkg, -1, R.drawable.dot_waypoint_pkg),
+    PUZZLE("puzzle", "x", "Virtual Stage", R.string.wp_puzzle, R.drawable.waypoint_puzzle, 2, R.drawable.dot_waypoint),
+    STAGE("stage", "s", "Physical Stage", R.string.wp_stage, R.drawable.waypoint_stage, 2, R.drawable.dot_waypoint),
+    TRAILHEAD("trailhead", "t", "Trailhead", R.string.wp_trailhead, R.drawable.waypoint_trailhead, 1, R.drawable.dot_waypoint),
+    WAYPOINT("waypoint", "w", "Reference Point", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 2, R.drawable.dot_waypoint_reference),
+    ORIGINAL("original", "h", "Original Coordinates", R.string.wp_original, R.drawable.waypoint_waypoint, 4, R.drawable.dot_waypoint_reference);
 
     @NonNull
     public final String id;
 
-    @NonNull public final String gpx;
+    public final String shortId;
+
+    @NonNull
+    public final String gpx;
     public final int stringId;
     public final int markerId;
 
     public final int order;
     public final int dotMarkerId;
 
-    WaypointType(@NonNull final String id, @NonNull final String gpx, final int stringId, final int markerId, final int order, final int dotMarkerId) {
+    WaypointType(@NonNull final String id, @NonNull final String shortId, @NonNull final String gpx, final int stringId, final int markerId, final int order, final int dotMarkerId) {
         this.id = id;
+        this.shortId = shortId;
         this.gpx = gpx;
         this.stringId = stringId;
         this.markerId = markerId;
@@ -54,11 +58,13 @@ public enum WaypointType {
      * non public so that {@code null} handling can be handled centrally in the enum type itself
      */
     private static final Map<String, WaypointType> FIND_BY_ID = new HashMap<>();
+
     static {
         for (final WaypointType wt : values()) {
             FIND_BY_ID.put(wt.id, wt);
         }
     }
+
     @NonNull
     public static final List<WaypointType> ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL = orderedWaypointTypes();
 
@@ -90,6 +96,11 @@ public enum WaypointType {
     @NonNull
     public final String getL10n() {
         return CgeoApplication.getInstance().getBaseContext().getString(stringId);
+    }
+
+    @NonNull
+    public final String getShortId() {
+        return shortId;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/cgeo/geocaching/location/GeopointParser.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 /**
  * Parse coordinates.
@@ -571,11 +571,12 @@ public class GeopointParser {
      * Detects all coordinates in the given text.
      *
      * @param initialText Text to parse for coordinates
-     * @return a collection of parsed geopoints and their starting position in the given text
+     * @return a collection of parsed geopoints as well as their starting and ending position in the given text
+     *   'start' points at the first char of the coordinate text, 'end' points at the first char AFTER the coordinate text
      */
     @NonNull
-    public static Collection<ImmutablePair<Geopoint, Integer>> parseAll(@NonNull final String initialText) {
-        final List<ImmutablePair<Geopoint, Integer>> waypoints = new LinkedList<>();
+    public static Collection<ImmutableTriple<Geopoint, Integer, Integer>> parseAll(@NonNull final String initialText) {
+        final List<ImmutableTriple<Geopoint, Integer, Integer>> waypoints = new LinkedList<>();
 
         String text = initialText;
         int start = 0;
@@ -594,7 +595,7 @@ public class GeopointParser {
             }
 
             if (best != null) {
-                waypoints.add(new ImmutablePair<>(best.geopoint, start + best.matcherStart));
+                waypoints.add(new ImmutableTriple<>(best.geopoint, start + best.matcherStart, start + best.matcherStart + best.matcherLength));
 
                 final int nextOffset = best.matcherStart + best.matcherLength;
                 text = text.substring(nextOffset);

--- a/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
+++ b/tests/src-android/cgeo/geocaching/enumerations/WaypointTypeTest.java
@@ -2,6 +2,9 @@ package cgeo.geocaching.enumerations;
 
 import android.test.AndroidTestCase;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class WaypointTypeTest extends AndroidTestCase {
@@ -28,6 +31,15 @@ public class WaypointTypeTest extends AndroidTestCase {
         // subtype forms
         assertThat(WaypointType.fromGPXString("Parking Area", "Parking Area")).isEqualTo(WaypointType.PARKING);
         assertThat(WaypointType.fromGPXString("unknown sym", "Virtual Stage")).isEqualTo(WaypointType.PUZZLE);
+    }
+
+    public static void testUniqueShortId() {
+        final Set<String> shortIds = new HashSet<>();
+        for (final WaypointType wpType : WaypointType.values()) {
+            assertThat(shortIds.contains(wpType.getShortId())).isFalse();
+            shortIds.add(wpType.shortId);
+        }
+        assertThat(shortIds.size()).isEqualTo(WaypointType.values().length);
     }
 
 }

--- a/tests/src-android/cgeo/geocaching/utils/TextUtilsTest.java
+++ b/tests/src-android/cgeo/geocaching/utils/TextUtilsTest.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import junit.framework.TestCase;
@@ -41,7 +42,6 @@ public class TextUtilsTest extends TestCase {
         }
         return null;
     }
-
 
     public static void testRegEx() {
         final String page = readCachePage("GC2CJPF");
@@ -79,5 +79,124 @@ public class TextUtilsTest extends TestCase {
     public static void testStripHtml() {
         assertThat(TextUtils.stripHtml("foo bar")).isEqualTo("foo bar");
         assertThat(TextUtils.stripHtml("<div><span>foo</span> bar</div>")).isEqualTo("foo bar");
+    }
+
+    public static void testGetTextBeforeIndexUntil() {
+        final String testStr = "this is a test";
+        final int aIdx = testStr.indexOf("a");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, aIdx, "h")).isEqualTo("is is ");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, aIdx, " ")).isEqualTo("");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, aIdx, "a")).isEqualTo("this is ");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, aIdx, "his")).isEqualTo(" is ");
+        assertThat(TextUtils.getTextBeforeIndexUntil("a", 0, "a")).isEqualTo("");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, testStr.length(), "a")).isEqualTo(" test");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, -1, "a")).isEqualTo("");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, testStr.length(), "nonexisting")).isEqualTo(testStr);
+
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, aIdx, "t")).isEqualTo("his is ");
+        assertThat(TextUtils.getTextBeforeIndexUntil(testStr, aIdx, "t", 6)).isEqualTo("is is ");
+
+    }
+
+    public static void testGetTextAfterIndexUntilDelimiter() {
+        final String testStr = "this is a test";
+        final int aIdx = testStr.indexOf("a");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, aIdx, "s")).isEqualTo(" te");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, aIdx, " ")).isEqualTo("");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, aIdx, "a")).isEqualTo(" test");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, aIdx, "st")).isEqualTo(" te");
+        assertThat(TextUtils.getTextAfterIndexUntil("a", 0, "a")).isEqualTo("");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, testStr.length(), "a")).isEqualTo("");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, -1, "a")).isEqualTo("this is ");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, -1, "nonexisting")).isEqualTo(testStr);
+
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, aIdx, "st")).isEqualTo(" te");
+        assertThat(TextUtils.getTextAfterIndexUntil(testStr, aIdx, "st", 2)).isEqualTo(" t");
+
+    }
+
+    public static void testGetNextDelimValue() {
+        assertThat(TextUtils.parseNextDelimitedValue("before \"soon it is \\\"christmas\\\\holiday\\\" again\" after ", '"', '\\'))
+                .isEqualTo("soon it is \"christmas\\holiday\" again");
+        //test symbols with special meaning in regerx
+        assertThat(TextUtils.parseNextDelimitedValue("before *soon it is $*christmas$$holiday$* again* after ", '*', '$'))
+                .isEqualTo("soon it is *christmas$holiday* again");
+        //symbol and escape char are the same
+        assertThat(TextUtils.parseNextDelimitedValue("before 'soon it is ''christmas'' again' after ", '\'', '\''))
+                .isEqualTo("soon it is 'christmas' again");
+        //other chars are escaped
+        assertThat(TextUtils.parseNextDelimitedValue("before 'soon it \\is \\'christmas\\' \\again' after ", '\'', '\\'))
+                .isEqualTo("soon it is 'christmas' again");
+        //newline is used
+        assertThat(TextUtils.parseNextDelimitedValue("before\n \"soon it\n is \\\"christ\nmas\\\\holiday\\\" again\" \nafter ", '"', '\\'))
+                .isEqualTo("soon it\n is \"christ\nmas\\holiday\" again");
+
+        //stable for unclosed value
+        assertThat(TextUtils.parseNextDelimitedValue("before *soon it is \\*christmas\\* again after", '*', '\\'))
+                .isEqualTo(null);
+        //stable with empty values
+        assertThat(TextUtils.parseNextDelimitedValue("", ' ', ' '))
+                .isEqualTo(null);
+
+    }
+
+    public static void testGetDelimitedValue() {
+        final String test = "soon it is 'christmas' again";
+        final String expectedDelim = "'soon it is \\'christmas\\' again'";
+        assertThat(TextUtils.createDelimitedValue(test, '\'', '\\')).isEqualTo(expectedDelim);
+        assertThat(TextUtils.parseNextDelimitedValue(TextUtils.createDelimitedValue(test, '\'', '\\'), '\'', '\\')).isEqualTo(test);
+    }
+
+    public static void testGetWords() {
+        assertThat(TextUtils.getWords("this is a test").length).isEqualTo(4);
+        assertThat(TextUtils.getWords("this is a test")[0]).isEqualTo("this");
+        assertThat(TextUtils.getWords(" this is a test")[0]).isEqualTo("this");
+        assertThat(TextUtils.getWords("\n\t  \n\t this\tis a test")[0]).isEqualTo("this");
+        assertThat(TextUtils.getWords("this is a \ntest\t\r")[3]).isEqualTo("test");
+        assertThat(TextUtils.getWords("").length).isEqualTo(0);
+        assertThat(TextUtils.getWords(" \n\r\t").length).isEqualTo(0);
+        assertThat(TextUtils.getWords(null).length).isEqualTo(0);
+    }
+
+    public static void testGetAll() {
+        assertThatListIsEqual(TextUtils.getAll("this is a test", "t", "s"), "hi", "e");
+        assertThatListIsEqual(TextUtils.getAll("this is a test t", "t", "t"), "his is a ", " ");
+        assertThatListIsEqual(TextUtils.getAll("this is a test", "t", "t"), "his is a ");
+        assertThatListIsEqual(TextUtils.getAll("this is a test", "this", "test"), " is a ");
+        assertThatListIsEqual(TextUtils.getAll("this* is $a test", "*", "$"), " is ");
+        assertThatListIsEqual(TextUtils.getAll("this is a test", "", ""), "this is a test");
+        assertThatListIsEqual(TextUtils.getAll("this is a test", "", "a"), "this is ");
+        assertThatListIsEqual(TextUtils.getAll("this is a test", "a", ""), " test");
+
+        assertThatListIsEqual(TextUtils.getAll("th\nis is a test", "t", "s"), "h\ni", "e");
+
+        assertThatListIsEqual(TextUtils.getAll("", "a", "b"));
+        assertThatListIsEqual(TextUtils.getAll(null, "a", "b"));
+
+    }
+
+    private static <T> void assertThatListIsEqual(final List<T> list, final T... expected) {
+        assertThat(list.size()).isEqualTo(expected.length);
+        int cnt = 0;
+        for (final T e : list) {
+            assertThat(e).isEqualTo(expected[cnt++]);
+        }
+    }
+
+
+    public static void testReplaceAll() {
+        assertThat(TextUtils.replaceAll("this is a test", "t", "s", "")).isEqualTo(" is a t");
+        assertThat(TextUtils.replaceAll("this is a test", "this", "tes", "")).isEqualTo("t");
+        assertThat(TextUtils.replaceAll("this is a test", "this", "test", "")).isEqualTo("");
+        assertThat(TextUtils.replaceAll("this is a test", "t", "s", "$1")).isEqualTo("hi is a et");
+        assertThat(TextUtils.replaceAll("this* is $a test", "*", "$", "")).isEqualTo("thisa test");
+        assertThat(TextUtils.replaceAll("this is a test", "", "", "")).isEqualTo("");
+        assertThat(TextUtils.replaceAll("this is a test", "", "a", "")).isEqualTo(" test");
+        assertThat(TextUtils.replaceAll("this is a test", "a", "", "")).isEqualTo("this is ");
+        assertThat(TextUtils.replaceAll("", "a", "b", "")).isEqualTo("");
+        assertThat(TextUtils.replaceAll(null, "a", "b", "")).isEqualTo("");
+
+        assertThat(TextUtils.replaceAll("before <@@@@@> middle </@@@@@> after", "<@@@@@>", "</@@@@@>", "")).isEqualTo("before  after");
+
     }
 }

--- a/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointParserTest.java
@@ -1,5 +1,9 @@
 package cgeo.geocaching.location;
 
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.junit.Test;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.api.Assertions.offset;
@@ -317,4 +321,30 @@ public class GeoPointParserTest {
     public void test8589() {
         assertParsingFails("6, 12, 16, 29");
     }
+
+    public void parseMultipleCoordinatesWithCorrectStartEndPositions() {
+        Collection<ImmutableTriple<Geopoint, Integer, Integer>> parsed = GeopointParser.parseAll(
+                "@n1 (W) N 48° 01.194' · E 011° 43.814'\n" +
+                        "@n2 (W) N 48° 01.194' · E 011° 43.814'");
+        assertThat(parsed.size()).isEqualTo(2);
+        Iterator<ImmutableTriple<Geopoint, Integer, Integer>> it = parsed.iterator();
+        assertGeopointTriple(it.next(), new Geopoint("N 48° 01.194' · E 011° 43.814'"), 8, 38);
+        assertGeopointTriple(it.next(), new Geopoint("N 48° 01.194' · E 011° 43.814'"), 47, 77);
+
+        parsed = GeopointParser.parseAll(
+                "@n1 (W) N48 01.194 E011 43.814\n" +
+                        "@n2 (W) N48 01.194 E011 43.814");
+        assertThat(parsed.size()).isEqualTo(2);
+        it = parsed.iterator();
+        assertGeopointTriple(it.next(), new Geopoint("N 48° 01.194' · E 011° 43.814'"), 8, 30);
+        assertGeopointTriple(it.next(), new Geopoint("N 48° 01.194' · E 011° 43.814'"), 39, 61);
+
+    }
+
+    private static void assertGeopointTriple(final ImmutableTriple<Geopoint, Integer, Integer> triple, final Geopoint gp, final int start, final int end) {
+        assertThat(triple.getLeft()).isEqualTo(gp);
+        assertThat(triple.getMiddle()).isEqualTo(start);
+        assertThat(triple.getRight()).isEqualTo(end);
+    }
+
 }


### PR DESCRIPTION
This PR attempts to solve Issue #5688: https://github.com/cgeo/cgeo/issues/5688

The following "Waypoint text pattern" (for both creating and parsing) was created:
@name (type) coordinate\n"user note"

Example:
@my Waypoint (puzzle) N48 10.123 E11 05.456
"My User Note"

Additional notes:
- Regarding the @: if no @ is found during parse then no name is created from text (default name applies). If there would not be a name marker, then coords parsed from within text might get very strange names...
- Type: type will also be recognized when NOT in () like today, but will then additionally be part of the name. E.g. "@parking Spot N48 10.123 E11 05.456" will become waypoint of type "Parking" with name "Parking spot". Type in () will be filtered out in name creation.
- Type: for easier typing I created one-char-shortcuts for each waypoint type: F=final, P=parking, X=puzzle,... E.g. "@the End (F) N48 10.123 E11 05.456" will be parsed as Final waypoint
- User note: " can be used optionally because user note can be multilined. Escaped " in user note (") are recognized. " to start note can be placed both on same line (after coord) and on next line. If no " is found after coord, then "user note" is filled from coord until next linebreak.

![personalnote](https://user-images.githubusercontent.com/6909759/87202839-b195f580-c301-11ea-92d3-9605b87c7f25.png)
![waypoints](https://user-images.githubusercontent.com/6909759/87202842-b22e8c00-c301-11ea-879b-c9186e0d31aa.png)
