### PR TITLE
allow LI tags in changelog

### DIFF
--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- changelog for the master branch -->
-  <string name="changelog_master" translatable="false">
-     <b>Next release:</b>\n
-    \n
+  <string name="changelog_master" translatable="false"><Data><![CDATA[<div>
+<h1>Next release:</h1>
 
-<b>Map:</b>\n
+<h4>Map:</h4>
+<ul>
 · New: Offer a link to download OpenStreetMap offline maps\n
 · New: Integrate downloaded OpenStreetMap offline map files into c:geo after tapping on them\n
 · New: Optionally switch between compact and regular icon modes automatically depending on amount of caches displayed\n
@@ -15,40 +15,47 @@
 · New: Load GPX track files and show individual track on map\n
 · New: Individual routes: Allow sorting of route elements\n
 · New: Customize history track, circle, individual route and individual track map line colors and widths\n
-\n
+</ul>
 
-<b>Cache list:</b>\n
+<h4>Cache list:</h4>
+<ul>
 · Change: Difficulty and terrain filter match exact values only, no longer ranges\n
 · Change: Fast scroll only gets enabled after fling gesture with minimum length\n
 · New: Fast scroll thumbs (info on position in list)\n
-\n
+</ul>
 
-<b>Cache details:</b>\n
+<h4>Cache details:</h4>
+<ul>
 · Change: Open links in cache description as separate task\n
 · Fix: Adapt Whereigo URL checker to catch more Whereigo links\n
-\n
+</ul>
 
-<b>Supported geocaching platforms:</b>\n
+<h4>Supported geocaching platforms:</h4>
+<ul>
 · Change: Set all connectors to https\n
 · New: Support cache rating and managing of favorites for geocaching.su\n
 · Fix: Adapt to updated terracaching details URL\n
-\n
+</ul>
 
-<b>System requirements:</b>\n
+<h4>System requirements:</h4>
+<ul>
 · Change: System requirements: c:geo now requires your system to run at least Android 5.0\n
 · Change: Set target SDK to 29 to comply with upcoming requirements for Play store\n
 · New: Internal: Upgraded several included libraries to reflect our new minimum system requirements\n
 · Fix: Internal: Removed styles / themes workarounds used for older Android versions\n
 · Fix: Internal: Remove old program code no longer used for supported Android versions\n
-\n
+</ul>
 
-<b>Other changes:</b>\n
+<h4>Other changes:</h4>
+<ul>
 · Change: New adaptive launcher icon, following the new specs from Play store (also used on mainscreen)\n
 · New: Debug view for program settings (settings - system - view settings)\n
 · Fix: Fix for slider preference problem on Android 7\n
 · Fix: Fix translation issues for several plural forms\n
 · Fix: Allow restore of settings backup created with c:geo version 2020.03.30 or earlier\n
 · Fix: Other code cleanup\n
+</ul>
 
+</div>]]></Data>
   </string>
 </resources>

--- a/main/res/values/changelog_release.xml
+++ b/main/res/values/changelog_release.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <!-- changelog for the release branch -->
-  <string name="changelog_release" translatable="false">\n
-     <b>2020.07.02:</b>\n
+  <string name="changelog_release" translatable="false"><Data><![CDATA[<div>
+  <h1>2020.07.02:</h1>
+  <ul>
     · Fix: Wrong numbers in french language for amount of caches on lists\n
     · Fix: Wrong error message when login fails due to wrong username and/or password\n
-    \n
-    \n
-     <b>2020.06.14</b>\n
+  </ul>
+
+  <h1>2020.06.14</h1>
+  <ul>
     · Change: Added closeout message for systems running on Android &lt; 5.0\n
     · Change: Unified Google Maps rotation settings into menu entry \"Map rotation\"\n
     · Change: Allow max zoom on combined OpenStreetMap offline map\n
@@ -43,7 +45,7 @@
     · Fix: Update waypoint list after nested waypoint delete\n
     · Fix: Updated useful apps icons for send2cgeo and cgeo contacts\n
     · Fix: A couple of other minor issues\n
-    \n
-    \n
+  </ul>
+</div>]]></Data>
 </string>
 </resources>

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.ui.AbstractCachingPageViewCreator;
 import cgeo.geocaching.ui.AnchorAwareLinkMovementMethod;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.DebugUtils;
+import cgeo.geocaching.utils.LiUtils;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.SystemInformation;
@@ -173,6 +174,10 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
                 changeLogMaster.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
             }
             changeLogLink.setOnClickListener(v -> startUrl("https://github.com/cgeo/cgeo/releases"));
+
+            changeLogMaster.setText(LiUtils.formatHTML(getString(R.string.changelog_master)));
+            changeLogRelease.setText(LiUtils.formatHTML(getString(R.string.changelog_release)));
+
             return view;
         }
 

--- a/main/src/cgeo/geocaching/utils/LiUtils.java
+++ b/main/src/cgeo/geocaching/utils/LiUtils.java
@@ -1,0 +1,120 @@
+package cgeo.geocaching.utils;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.os.Build;
+import android.text.Editable;
+import android.text.Html;
+import android.text.Layout;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.style.BulletSpan;
+import android.text.style.LeadingMarginSpan;
+import android.util.TypedValue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.xml.sax.XMLReader;
+
+/**
+ * Extends the standard spannable by recognizing and formatting <li>...</li> tags
+ * even on systems < API 24 + including fixes for higher API levels
+ */
+public class LiUtils {
+
+    private LiUtils() {
+        // utility class
+    }
+
+    public static SpannableStringBuilder formatHTML(final String html) {
+        // replace our standard bullet points ... \n by HTML <li> ... </li>
+        final Pattern p = Pattern.compile("([·])([^·\n\r]+)([\\n]?)([\n\r]+)");
+        final Matcher m = p.matcher(html);
+        final String input = m.find() ? m.replaceAll("<li>$2</li>") : html;
+
+        // now apply HTML formatting (including <li> tags)
+        final Spanned spanned = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ? Html.fromHtml(input, Html.FROM_HTML_MODE_LEGACY) : Html.fromHtml(input, null, new LiTagHandler());
+        final SpannableStringBuilder builder = new SpannableStringBuilder(spanned);
+        final BulletSpan[] bulletSpans = builder.getSpans(0, builder.length(), BulletSpan.class);
+        for (BulletSpan bulletSpan :bulletSpans) {
+            final int start = builder.getSpanStart(bulletSpan);
+            final int end = builder.getSpanEnd(bulletSpan);
+            builder.removeSpan(bulletSpan);
+            builder.setSpan(new LiAwareBulletSpan(), start, end, Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+        }
+        return builder;
+    }
+}
+
+class LiAwareBulletSpan implements LeadingMarginSpan {
+
+    private static final int BULLET_RADIUS = dip(3);
+
+    @Override
+    public int getLeadingMargin(final boolean first) {
+        return dip(8) + 2 * BULLET_RADIUS;
+    }
+
+    @Override
+    public void drawLeadingMargin(final Canvas canvas, final Paint paint, final int x, final int dir, final int top, final int baseline,
+                                  final int bottom, final CharSequence text, final int start, final int end, final boolean first, final Layout layout) {
+        Path bullet = null;
+
+        if (((Spanned) text).getSpanStart(this) == start) {
+            final Paint.Style style = paint.getStyle();
+            paint.setStyle(Paint.Style.FILL);
+
+            final float yPosition = layout != null ? layout.getLineBaseline(layout.getLineForOffset(start)) - BULLET_RADIUS * 2f : (top + bottom) / 2f;
+            final float xPosition = x + dir * BULLET_RADIUS;
+
+            if (canvas.isHardwareAccelerated()) {
+                if (null == bullet) {
+                    bullet = new Path();
+                    bullet.addCircle(0.0f, 0.0f, BULLET_RADIUS, Path.Direction.CW);
+                }
+
+                canvas.save();
+                canvas.translate(xPosition, yPosition);
+                canvas.drawPath(bullet, paint);
+                canvas.restore();
+            } else {
+                canvas.drawCircle(xPosition, yPosition, BULLET_RADIUS, paint);
+            }
+
+            paint.setStyle(style);
+        }
+    }
+
+    private static int dip(final int dp) {
+        return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, DisplayUtils.getDisplayMetrics());
+    }
+}
+
+class LiTagHandler implements Html.TagHandler {
+
+    @Override
+    public void handleTag(final boolean opening, final String tag, final Editable output, final XMLReader xmlReader) {
+        if (tag.equals("li")) {
+            if (opening) {
+                output.setSpan(new Bullet(), output.length(), output.length(), Spannable.SPAN_INCLUSIVE_EXCLUSIVE);
+            } else {
+                output.append("\n\n");
+                final Bullet[] bullets = output.getSpans(0, output.length(), Bullet.class);
+                if (bullets.length > 0) {
+                    final int start = output.getSpanStart(bullets[bullets.length - 1]);
+                    output.removeSpan(bullets[bullets.length - 1]);
+                    if (start != output.length()) {
+                        output.setSpan(new BulletSpan(), start, output.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+                    }
+                }
+            }
+        }
+    }
+
+    public static final class Bullet {
+    }
+
+}


### PR DESCRIPTION
Add a bit of formatting to make changelog more readable. Among other things `<li>` are now allowed, even on low API devices, to support correct indenting. To ease migration, our currently used bullet points will be transformed into `<li>...</li>` internally.

Example picture is taken from API 21 emulated device:
![image](https://user-images.githubusercontent.com/3754370/87231258-ecf1fc00-c3b5-11ea-9e57-3e22dc6c6c1b.png)

Not much has to be changed in our changelog files, mainly surrounding our current manual lists with `<ul>` and `</ul>` and adding a `CDATA` frame. `\n` at the line ends are no longer needed.
