### PR TITLE
move clear history menu entry to top level, end of menu (fix #8622)

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -83,11 +83,6 @@
                 android:enabled="false"
                 app:showAsAction="never|withText"/>
             <item
-                android:id="@+id/menu_remove_from_history"
-                android:title="@string/cache_clear_history"
-                android:enabled="false"
-                app:showAsAction="never|withText"/>
-            <item
                 android:id="@+id/menu_create_internal_cache"
                 android:title="@string/create_internal_cache"
                 app:showAsAction="ifRoom|withText"/>
@@ -158,4 +153,9 @@
                 android:title="@string/export_persnotes"/>
         </menu>
     </item>
+    <item
+        android:id="@+id/menu_remove_from_history"
+        android:title="@string/cache_clear_history"
+        android:enabled="false"
+        app:showAsAction="never|withText"/>
 </menu>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3754370/87341798-7fc39f80-c54a-11ea-86c7-91aaf016bf14.png)
