### PR TITLE
reword logcat dialog to send/ok instead of cancel/send (fix #8636)

### DIFF
--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -219,6 +219,56 @@ public final class Dialogs {
     }
 
     /**
+     * Confirm using up to three configurable buttons "Positive", "Negative" and "Neutral". Buttons text are configurable.
+     *
+     * @param context
+     *            activity hosting the dialog
+     * @param title
+     *            dialog title
+     * @param msg
+     *            dialog message
+     * @param positiveTextButton
+     *            Text for the positive button
+     * @param negativeTextButton
+     *            Text for the negative button
+     * @param neutralTextButton
+     *            Text for the neutral button
+     * @param positiveListener
+     *            listener of the positive button
+     * @param negativeListener
+     *            listener of the negative button
+     * @param neutralListener
+     *            listener of the neutral button
+     */
+    public static AlertDialog.Builder confirmPositiveNegativeNeutral(final Activity context,
+                                                                     final String title,
+                                                                     final String msg,
+                                                                     final String positiveTextButton,
+                                                                     final String negativeTextButton,
+                                                                     final String neutralTextButton,
+                                                                     final OnClickListener positiveListener,
+                                                                     final OnClickListener negativeListener,
+                                                                     final OnClickListener neutralListener) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context)
+            .setTitle(title)
+            .setCancelable(true)
+            .setMessage(msg);
+        if (null != positiveTextButton) {
+            builder.setPositiveButton(positiveTextButton, positiveListener);
+        }
+        if (null != negativeTextButton) {
+            builder.setNegativeButton(negativeTextButton, negativeListener);
+        }
+        if (null != neutralTextButton) {
+            builder.setNeutralButton(neutralTextButton, neutralListener);
+        }
+        final AlertDialog dialog = builder.create();
+        dialog.setOwnerActivity(context);
+        dialog.show();
+        return builder;
+    }
+
+    /**
      * Confirm using three configurable buttons "Positive", "Negative" and "Neutral". Buttons text are configurable.
      *
      * @param context

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -64,7 +64,10 @@ public class DebugUtils {
             }
         }, () -> {
             if (result.get() == LogcatResults.LOGCAT_OK.ordinal()) {
-                Dialogs.confirm(activity, activity.getString(R.string.about_system_write_logcat), String.format(activity.getString(R.string.about_system_write_logcat_success), filename, LocalStorage.LOGFILES_DIR_NAME), activity.getString(R.string.about_system_info_send_button), (dialog, which) -> {
+                Dialogs.confirmPositiveNegativeNeutral(activity, activity.getString(R.string.about_system_write_logcat),
+                        String.format(activity.getString(R.string.about_system_write_logcat_success), filename, LocalStorage.LOGFILES_DIR_NAME),
+                        activity.getString(android.R.string.ok), null, activity.getString(R.string.about_system_info_send_button),
+                        null, null, (dialog, which) -> {
                     final String systemInfo = SystemInformation.getSystemInformation(activity);
                     ShareUtils.shareAsEMail(activity, activity.getString(R.string.about_system_info), systemInfo, file, R.string.about_system_info_send_chooser);
                 });


### PR DESCRIPTION
With this change, the logcat logfile feedback dialog reads sth. like "Logfile written successfully - send e-mail / ok" instead of "Logfile written successfully - cancel - send e-mail".