### PR TITLE
remove history track shadow

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -41,7 +41,6 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
     public static final float ZINDEX_ROUTE = 5;
     public static final float ZINDEX_POSITION_ACCURACY_CIRCLE = 3;
     public static final float ZINDEX_HISTORY = 2;
-    public static final float ZINDEX_HISTORY_SHADOW = 1;
 
     /**
      * maximum distance (in meters) up to which two points in the trail get connected by a drawn line
@@ -301,17 +300,9 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
                     // history line
                     historyObjs.addPolyline(new PolylineOptions()
                             .addAll(points)
-                            .color(0xFFFFFFFF)
-                            .width(MapLineUtils.getHistoryLineInsetWidth())
-                            .zIndex(ZINDEX_HISTORY)
-                    );
-
-                    // history line shadow
-                    historyObjs.addPolyline(new PolylineOptions()
-                            .addAll(points)
                             .color(MapLineUtils.getTrailColor())
-                            .width(MapLineUtils.getHistoryLineShadowWidth())
-                            .zIndex(ZINDEX_HISTORY_SHADOW)
+                            .width(MapLineUtils.getHistoryLineWidth())
+                            .zIndex(ZINDEX_HISTORY)
                     );
                 }
             }

--- a/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
@@ -34,7 +34,6 @@ public class PositionDrawer {
     private float heading = 0f;
     private Paint accuracyCircle = null;
     private Paint historyLine = null;
-    private Paint historyLineShadow = null;
     private final int trailColor;
     private final Point center = new Point();
     private final Point left = new Point();
@@ -65,15 +64,8 @@ public class PositionDrawer {
         if (historyLine == null) {
             historyLine = new Paint();
             historyLine.setAntiAlias(true);
-            historyLine.setStrokeWidth(MapLineUtils.getHistoryLineInsetWidth());
-            historyLine.setColor(0xFFFFFFFF);
-        }
-
-        if (historyLineShadow == null) {
-            historyLineShadow = new Paint();
-            historyLineShadow.setAntiAlias(true);
-            historyLineShadow.setStrokeWidth(MapLineUtils.getHistoryLineShadowWidth());
-            historyLineShadow.setColor(trailColor);
+            historyLine.setStrokeWidth(MapLineUtils.getHistoryLineWidth());
+            historyLine.setColor(trailColor);
         }
 
         if (setfil == null) {
@@ -138,12 +130,10 @@ public class PositionDrawer {
                         alpha = 255;
                     }
 
-                    historyLineShadow.setAlpha(alpha);
                     historyLine.setAlpha(alpha);
 
                     // connect points by line, but only if distance between previous and current point is less than defined max
                     if (now.distanceTo(prev) < LINE_MAXIMUM_DISTANCE_METERS) {
-                        canvas.drawLine(pointPrevious.x, pointPrevious.y, pointNow.x, pointNow.y, historyLineShadow);
                         canvas.drawLine(pointPrevious.x, pointPrevious.y, pointNow.x, pointNow.y, historyLine);
                     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -27,7 +27,6 @@ public class HistoryLayer extends Layer {
     private final PositionHistory positionHistory = new PositionHistory();
     private Location coordinates;
     private Paint historyLine;
-    private Paint historyLineShadow;
     private final int trailColor;
 
     public HistoryLayer(final ArrayList<Location> locationHistory) {
@@ -50,14 +49,8 @@ public class HistoryLayer extends Layer {
 
         if (historyLine == null) {
             historyLine = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLine.setStrokeWidth(MapLineUtils.getHistoryLineInsetWidth());
-            historyLine.setColor(0xFFFFFFFF);
-        }
-
-        if (historyLineShadow == null) {
-            historyLineShadow = AndroidGraphicFactory.INSTANCE.createPaint();
-            historyLineShadow.setStrokeWidth(MapLineUtils.getHistoryLineShadowWidth());
-            historyLineShadow.setColor(trailColor);
+            historyLine.setStrokeWidth(MapLineUtils.getHistoryLineWidth());
+            historyLine.setColor(trailColor);
         }
 
         positionHistory.rememberTrailPosition(coordinates);
@@ -80,7 +73,6 @@ public class HistoryLayer extends Layer {
 
                     // connect points by line, but only if distance between previous and current point is less than defined max
                     if (now.distanceTo(prev) < LINE_MAXIMUM_DISTANCE_METERS) {
-                        canvas.drawLine((int) pointPrevious.x, (int) pointPrevious.y, (int) pointNow.x, (int) pointNow.y, historyLineShadow);
                         canvas.drawLine((int) pointPrevious.x, (int) pointPrevious.y, (int) pointNow.x, (int) pointNow.y, historyLine);
                     }
 

--- a/main/src/cgeo/geocaching/utils/MapLineUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapLineUtils.java
@@ -13,12 +13,8 @@ public class MapLineUtils {
 
     // history trail line
 
-    public static float getHistoryLineShadowWidth() {
+    public static float getHistoryLineWidth() {
         return getWidth(R.string.pref_mapline_trailwidth, R.integer.default_trailwidth);
-    }
-
-    public static float getHistoryLineInsetWidth() {
-        return getHistoryLineShadowWidth() / 2.0f;
     }
 
     public static int getTrailColor() {


### PR DESCRIPTION
Make history track line consistent with the other map lines, therefore remove shadow.
Following a discussion in https://github.com/cgeo/cgeo/issues/8477#issuecomment-650517642 (and other places).