### PR TITLE
remove superflous connection in history track (fix #8648)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -269,13 +269,9 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         }
         historyObjs.removeAll();
         if (Settings.isMapTrail()) {
-
-            // always add current position to drawn history to have a closed connection
             final ArrayList<Location> paintHistory = getHistory();
-            paintHistory.add(coordinates);
-
             final int size = paintHistory.size();
-            if (size == 1) {
+            if (size < 2) {
                 return;
             }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -59,37 +59,31 @@ public class HistoryLayer extends Layer {
         positionHistory.rememberTrailPosition(coordinates);
 
         if (Settings.isMapTrail()) {
-            // always add current position to drawn history to have a closed connection
             final ArrayList<Location> paintHistory = new ArrayList<>(positionHistory.getHistory());
-            paintHistory.add(coordinates);
+            final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
 
-            final int size = paintHistory.size();
-            if (size > 1) {
-                final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
-
-                final Iterator<Location> iterator = paintHistory.iterator();
-                if (!iterator.hasNext()) {
-                    return;
-                }
-
-                Location point = iterator.next();
-                final Path path = AndroidGraphicFactory.INSTANCE.createPath();
-                path.moveTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
-                Location prev = point;
-
-                while (iterator.hasNext()) {
-                    point = iterator.next();
-
-                    // connect points by line, but only if distance between previous and current point is less than defined max
-                    if (point.distanceTo(prev) < LINE_MAXIMUM_DISTANCE_METERS) {
-                        path.lineTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
-                    } else {
-                        path.moveTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
-                    }
-                    prev = point;
-                }
-                canvas.drawPath(path, historyLine);
+            final Iterator<Location> iterator = paintHistory.iterator();
+            if (!iterator.hasNext()) {
+                return;
             }
+
+            Location point = iterator.next();
+            final Path path = AndroidGraphicFactory.INSTANCE.createPath();
+            path.moveTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
+            Location prev = point;
+
+            while (iterator.hasNext()) {
+                point = iterator.next();
+
+                // connect points by line, but only if distance between previous and current point is less than defined max
+                if (point.distanceTo(prev) < LINE_MAXIMUM_DISTANCE_METERS) {
+                    path.lineTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
+                } else {
+                    path.moveTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
+                }
+                prev = point;
+            }
+            canvas.drawPath(path, historyLine);
         }
     }
 

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2277,7 +2277,7 @@ public class DataStore {
                 new String[]{"_id", "latitude", "longitude"},
                 "latitude IS NOT NULL AND longitude IS NOT NULL",
                 null,
-                "_id DESC",
+                "_id ASC",
                 String.valueOf(DbHelper.MAX_TRAILHISTORY_LENGTH),
                 new ArrayList<>(),
                 cursor -> {
@@ -2290,7 +2290,7 @@ public class DataStore {
 
     public static Location[] loadTrailHistoryAsArray() {
         init();
-        final Cursor cursor = database.query(dbTableTrailHistory, new String[]{"_id", "latitude", "longitude"}, "latitude IS NOT NULL AND longitude IS NOT NULL", null, null, null, "_id DESC", null);
+        final Cursor cursor = database.query(dbTableTrailHistory, new String[]{"_id", "latitude", "longitude"}, "latitude IS NOT NULL AND longitude IS NOT NULL", null, null, null, "_id ASC", null);
         final Location[] result = new Location[cursor.getCount()];
         int iPosition = 0;
         try {


### PR DESCRIPTION
- Remove superflous connection in history track by returning a track on restore in the same order as on writing.
- Also removes unnecessary duplicated current position on drawing a track as well as some duplicated length check.