### PR TITLE
remove geokrety auth token from limited shared prefs backup

### DIFF
--- a/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/SharedPrefsBackupUtils.java
@@ -82,7 +82,8 @@ public class SharedPrefsBackupUtils extends Activity {
                 activityContext.getString(R.string.pref_ocus_tokensecret), activityContext.getString(R.string.pref_ocus_tokenpublic), activityContext.getString(R.string.pref_temp_ocus_token_secret), activityContext.getString(R.string.pref_temp_ocus_token_public),
                 activityContext.getString(R.string.pref_ocro_tokensecret), activityContext.getString(R.string.pref_ocro_tokenpublic), activityContext.getString(R.string.pref_temp_ocro_token_secret), activityContext.getString(R.string.pref_temp_ocro_token_public),
                 activityContext.getString(R.string.pref_ocuk2_tokensecret), activityContext.getString(R.string.pref_ocuk2_tokenpublic), activityContext.getString(R.string.pref_temp_ocuk2_token_secret), activityContext.getString(R.string.pref_temp_ocuk2_token_public),
-                activityContext.getString(R.string.pref_su_tokensecret), activityContext.getString(R.string.pref_su_tokenpublic), activityContext.getString(R.string.pref_temp_su_token_secret), activityContext.getString(R.string.pref_temp_su_token_public)
+                activityContext.getString(R.string.pref_su_tokensecret), activityContext.getString(R.string.pref_su_tokenpublic), activityContext.getString(R.string.pref_temp_su_token_secret), activityContext.getString(R.string.pref_temp_su_token_public),
+                activityContext.getString(R.string.pref_fakekey_geokrety_authorization)
             );
         }
 


### PR DESCRIPTION
Auth keys / tokens etc. should not be part of the limited shared prefs backup, therefore exclude the geokrety auth token prefkey from it.

(Cause was: Auth token for geokrety seems to be handled a bit different than the other auth tokens, using a different prefkey structure, so it has been missed so far.)