### PR TITLE
add version check and info message (fix #8651)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1621,6 +1621,7 @@
     <string name="status_geocaching_livemap" tools:ignore="UnusedResources">Recent changes on geocaching.com broke the live map feature.\nWe are working on it, check again soon.</string>
     <string name="status_geocaching_maintenance" tools:ignore="UnusedResources">geocaching.com is under maintenance.\nYou might run into various issues.</string>
     <string name="status_closeout_warning" tools:ignore="UnusedResources">You appear to be using an older version of Android. This version of c:geo is no longer compatible with your device and might fail or behave unexpectedly!\nTap on this message for further information.</string>
+    <string name="status_version_deprecated" tools:ignore="UnusedResources">You are using a version of c:geo which seems to be older than one year. Some features may not work anymore due to website or other technical changes. Please read our FAQ on how to upgrade.</string>
 
     <!-- text-to-speech for compass view -->
     <string name="tts_service">Talking compass</string>


### PR DESCRIPTION
If c:geo version string indicates a version year which is less than (current system year minus 1), then show a "version deprecated" warning on main screen:

![image](https://user-images.githubusercontent.com/3754370/87850277-29aa7f80-c8ef-11ea-80db-5aac1ed350fa.png)

This message is linked to our FAQ.

If c:geo can receive a message from our c:geo status server, that message is displayed instead.