### PR TITLE
apply fastscroll listener to settings view

### DIFF
--- a/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.ui.FastScrollListener;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.SettingsUtils;
@@ -74,7 +75,7 @@ public class ViewSettingsActivity extends AbstractActivity {
         final ListView list = new ListView(this);
         setContentView(list);
         list.setAdapter(debugAdapter);
-        list.setFastScrollEnabled(true);
+        list.setOnScrollListener(new FastScrollListener(list));
     }
 
     private class SettingsAdapter extends ArrayAdapter<KeyValue> implements SectionIndexer {


### PR DESCRIPTION
Current settings view has the problem, that some buttons cannot be reached due to fast scroll with thumbs being activated. Applying our new fastscroll listener automatically disables fastscroll after one second of (fling mode) scrolling inactivity, which also solves the button problem.