### PR TITLE
work on trail copy to display + return correct trail segment on load (fix #8663)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -269,7 +269,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Route
         }
         historyObjs.removeAll();
         if (Settings.isMapTrail()) {
-            final ArrayList<Location> paintHistory = getHistory();
+            final ArrayList<Location> paintHistory = new ArrayList<>(getHistory());
             final int size = paintHistory.size();
             if (size < 2) {
                 return;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -58,7 +58,7 @@ public class HistoryLayer extends Layer {
                 historyLine.setColor(trailColor);
             }
 
-            final ArrayList<Location> paintHistory = getHistory();
+            final ArrayList<Location> paintHistory = new ArrayList<>(getHistory());
             // always add current position to drawn history to have a closed connection, even if it's not yet recorded
             paintHistory.add(coordinates);
             final int size = paintHistory.size();

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2267,17 +2267,18 @@ public class DataStore {
     }
 
     /**
-     * Loads the trail history from the database
+     * Loads the trail history from the database, limited to allowed MAX_TRAILHISTORY_LENGTH
+     * Trail is returned in chronological order, oldest entry first.
      *
      * @return A list of previously trail points or an empty list.
      */
     @NonNull
     public static ArrayList<Location> loadTrailHistory() {
-        return queryToColl(dbTableTrailHistory,
+        final ArrayList<Location> temp = queryToColl(dbTableTrailHistory,
                 new String[]{"_id", "latitude", "longitude"},
                 "latitude IS NOT NULL AND longitude IS NOT NULL",
                 null,
-                "_id ASC",
+                "_id DESC",
                 String.valueOf(DbHelper.MAX_TRAILHISTORY_LENGTH),
                 new ArrayList<>(),
                 cursor -> {
@@ -2286,6 +2287,8 @@ public class DataStore {
                     l.setLongitude(cursor.getDouble(2));
                     return l;
                 });
+        Collections.reverse(temp);
+        return temp;
     }
 
     public static Location[] loadTrailHistoryAsArray() {


### PR DESCRIPTION
Using the original trail object lead to strange display artifacts, especially after returning from subview.
Now works on copy of trail for display, in both GMv2 and in NewMap.

Additionally return the correct segment of the trail on loading (most recent part, in correct order).

Attempts to fix #8663.