### PR TITLE
avoid NPE on unfinished elements in routesort view (fix #8672)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1819,6 +1819,7 @@
     <string name="map_individual_route_cleared">Individual route cleared</string>
     <string name="save_sorted_route">Save</string>
     <string name="sorted_route_saved">Individual route saved</string>
+    <string name="route_item_not_yet_loaded">Route item not yet loaded</string>
 
     <!-- distance units -->
     <string name="unit_m">m</string>

--- a/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -60,18 +60,22 @@ public class RouteSortActivity extends AbstractActivity {
                 final IWaypoint data = routeItem.getType() == CoordinatesType.CACHE ? DataStore.loadCache(routeItem.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB) : DataStore.loadWaypoint(routeItem.getId());
 
                 final TextView title = v.findViewById(R.id.title);
-                title.setText(data.getName());
-
                 final TextView detail = v.findViewById(R.id.detail);
-                if (routeItem.getType() == CoordinatesType.CACHE) {
-                    assert data instanceof Geocache;
-                    detail.setText(Formatter.formatCacheInfoLong((Geocache) data));
-                    title.setCompoundDrawablesWithIntrinsicBounds(MapMarkerUtils.getCacheMarker(res, (Geocache) data, CacheListType.OFFLINE).getDrawable(), null, null, null);
+                if (null == data) {
+                    title.setText(routeItem.getGeocode());
+                    detail.setText(R.string.route_item_not_yet_loaded);
                 } else {
-                    assert data instanceof Waypoint;
-                    final Geocache cache = DataStore.loadCache(data.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);
-                    detail.setText(data.getGeocode() + Formatter.SEPARATOR + cache.getName());
-                    title.setCompoundDrawablesWithIntrinsicBounds(data.getWaypointType().markerId, 0, 0, 0);
+                    title.setText(data.getName());
+                    if (routeItem.getType() == CoordinatesType.CACHE) {
+                        assert data instanceof Geocache;
+                        detail.setText(Formatter.formatCacheInfoLong((Geocache) data));
+                        title.setCompoundDrawablesWithIntrinsicBounds(MapMarkerUtils.getCacheMarker(res, (Geocache) data, CacheListType.OFFLINE).getDrawable(), null, null, null);
+                    } else {
+                        assert data instanceof Waypoint;
+                        final Geocache cache = DataStore.loadCache(data.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);
+                        detail.setText(data.getGeocode() + Formatter.SEPARATOR + cache.getName());
+                        title.setCompoundDrawablesWithIntrinsicBounds(data.getWaypointType().markerId, 0, 0, 0);
+                    }
                 }
 
                 final View buttonUp = v.findViewById(R.id.button_left);


### PR DESCRIPTION
Show replacement text instead (see last entry):

![image](https://user-images.githubusercontent.com/3754370/88455724-0a27cf80-ce78-11ea-997b-5ffb857ea61c.png)
