### PR TITLE
userName/displayName in different meaning in GC and OC

### DIFF
--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -274,14 +274,14 @@ public abstract class AbstractConnector implements IConnector {
         final List<UserAction> actions = getDefaultUserActions();
 
         if (this instanceof ISearchByOwner) {
-            actions.add(new UserAction(R.string.user_menu_view_hidden, context -> CacheListActivity.startActivityOwner(context.getContext(), context.displayName)));
+            actions.add(new UserAction(R.string.user_menu_view_hidden, context -> CacheListActivity.startActivityOwner(context.getContext(), context.userName)));
         }
 
         if (this instanceof ISearchByFinder) {
-            actions.add(new UserAction(R.string.user_menu_view_found, context -> CacheListActivity.startActivityFinder(context.getContext(), context.displayName)));
+            actions.add(new UserAction(R.string.user_menu_view_found, context -> CacheListActivity.startActivityFinder(context.getContext(), context.userName)));
         }
         actions.add(new UserAction(R.string.copy_to_clipboard, context -> {
-            ClipboardUtils.copyToClipboard(context.displayName);
+            ClipboardUtils.copyToClipboard(context.userName);
             ActivityMixin.showToast(context.getContext(), R.string.clipboard_copy_ok);
         }));
         return actions;
@@ -294,7 +294,7 @@ public abstract class AbstractConnector implements IConnector {
     public static List<UserAction> getDefaultUserActions() {
         final List<UserAction> actions = new ArrayList<>();
         if (ContactsAddon.isAvailable()) {
-            actions.add(new UserAction(R.string.user_menu_open_contact, context -> ContactsAddon.openContactCard(context.getContext(), context.displayName)));
+            actions.add(new UserAction(R.string.user_menu_open_contact, context -> ContactsAddon.openContactCard(context.getContext(), context.userName)));
         }
 
         return actions;

--- a/main/src/cgeo/geocaching/ui/UserClickListener.java
+++ b/main/src/cgeo/geocaching/ui/UserClickListener.java
@@ -59,7 +59,7 @@ public abstract class UserClickListener implements View.OnClickListener {
         final CharSequence[] items = labels.toArray(new String[labels.size()]);
 
         final AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(res.getString(R.string.user_menu_title) + " " + user.displayName);
+        builder.setTitle(res.getString(R.string.user_menu_title) + " " + user.userName);
         builder.setItems(items, (dialog, item) -> userActions.get(item).run(user));
         final AlertDialog alert = builder.create();
         alert.show();


### PR DESCRIPTION
Set to the old behavior - works for GC, works not for OC, unknown for other cache connectors
needs to create a better solution for all connectors

fixes #7998: "Caches hidden" fails to load with customized "cache owner" name
revert #7125: Owner actions not working
revert #7818: different usage of userName and displayName