### PR TITLE
add default function to ColorpickerPreference

### DIFF
--- a/main/res/values/attrs.xml
+++ b/main/res/values/attrs.xml
@@ -48,6 +48,7 @@
     <!-- attributes for ColorpickerPreference -->
     <declare-styleable name="ColorpickerPreference">
         <attr name="showOpaquenessSlider" format="boolean" />
+        <attr name="defaultColor" format="color" />
     </declare-styleable>
 
     <!-- attributes for SeekbarPreference -->

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1799,6 +1799,7 @@
     <string name="preference_colorpicker_select_color_scheme">Select color scheme</string>
     <string name="preference_colorpicker_select_color">Select color</string>
     <string name="preference_colorpicker_select_opaqueness">Select opaqueness</string>
+    <string name="reset_to_default">Default</string>
 
     <!-- number input -->
     <string name="number_input_title">Enter a value between %1$s and %2$s</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -705,8 +705,8 @@
                 android:title="@string/init_trailcolor"
                 android:summary="@string/init_trailcolor_summary"
                 android:key="@string/pref_mapline_trailcolor"
-                android:defaultValue="@color/default_trailcolor"
                 android:dependency="@string/pref_maptrail"
+                app:defaultColor="@color/default_trailcolor"
                 app:showOpaquenessSlider="true" />
             <Preference
                 android:title="@string/init_trailwidth"
@@ -725,7 +725,7 @@
                 android:title="@string/init_directioncolor"
                 android:summary="@string/init_directioncolor_summary"
                 android:key="@string/pref_mapline_directioncolor"
-                android:defaultValue="@color/default_directioncolor"
+                app:defaultColor="@color/default_directioncolor"
                 app:showOpaquenessSlider="true" />
             <Preference
                 android:title="@string/init_directionwidth"
@@ -743,7 +743,7 @@
                 android:title="@string/init_routecolor"
                 android:summary="@string/init_routecolor_summary"
                 android:key="@string/pref_mapline_routecolor"
-                android:defaultValue="@color/default_routecolor"
+                app:defaultColor="@color/default_routecolor"
                 app:showOpaquenessSlider="true" />
             <Preference
                 android:title="@string/init_routewidth"
@@ -761,7 +761,7 @@
                 android:title="@string/init_trackcolor"
                 android:summary="@string/init_trackcolor_summary"
                 android:key="@string/pref_mapline_trackcolor"
-                android:defaultValue="@color/default_trackcolor"
+                app:defaultColor="@color/default_trackcolor"
                 app:showOpaquenessSlider="true" />
             <Preference
                 android:title="@string/init_trackwidth"
@@ -779,13 +779,13 @@
                 android:title="@string/init_circlecolor"
                 android:summary="@string/init_circlecolor_summary"
                 android:key="@string/pref_mapline_circlecolor"
-                android:defaultValue="@color/default_circlecolor"
+                app:defaultColor="@color/default_circlecolor"
                 app:showOpaquenessSlider="true" />
             <cgeo.geocaching.settings.ColorpickerPreference
                 android:title="@string/init_circlefillcolor"
                 android:summary="@string/init_circlefillcolor_summary"
                 android:key="@string/pref_mapline_circlefillcolor"
-                android:defaultValue="@color/default_circlefillcolor"
+                app:defaultColor="@color/default_circlefillcolor"
                 app:showOpaquenessSlider="true" />
         </PreferenceCategory>
 


### PR DESCRIPTION
A follow-up to the discussion in https://github.com/cgeo/cgeo/issues/8699#issuecomment-666677719

Adds a button labelled "default" if the preference has an `app:defaultColor` entry in `preference.xml`:
![image](https://user-images.githubusercontent.com/3754370/89080311-cdcd0580-d388-11ea-96f0-f24df7ddf42a.png)

On pressing the button the color picker returns to the default color (but does not store it yet - you can still decide to cancel).