### PR TITLE
remove map option to reset all line colors

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -110,11 +110,6 @@
                     </group>
                 </menu>
             </item>
-            <item
-                android:id="@+id/menu_reset_linecolors"
-                android:icon="@drawable/ic_menu_colors"
-                android:title="@string/map_reset_linecolors">
-            </item>
         </menu>
     </item>
     <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1195,9 +1195,6 @@
     <string name="map_rotation">Map rotation</string>
     <string name="map_hide">Hide</string>
     <string name="map_trail_show">Show history track</string>
-    <string name="map_reset_linecolors">Reset line colors</string>
-    <string name="map_reset_linecolors_confirm">Do you want to reset all configurable map lines to their default colors?</string>
-    <string name="map_reset_linecolors_ok">Line colors reset</string>
     <string name="map_dot_mode">Use compact icons</string>
     <string name="map_circles_show">Show circles</string>
     <string name="map_mycaches_hide">Hide own/found caches</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -60,7 +60,6 @@ import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.LeastRecentlyUsedSet;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapDownloadUtils;
-import cgeo.geocaching.utils.MapLineUtils;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TrackUtils;
 import static cgeo.geocaching.location.Viewport.containingGCliveCaches;
@@ -906,9 +905,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 return true;
             case R.id.menu_compass:
                 menuCompass();
-                return true;
-            case R.id.menu_reset_linecolors:
-                MapLineUtils.resetLinecolors(activity, null);
                 return true;
             default:
                 if (!TrackUtils.onOptionsItemSelected(activity, id, this::updateTrackHideStatus, this::setTracks)

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -59,7 +59,6 @@ import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapDownloadUtils;
-import cgeo.geocaching.utils.MapLineUtils;
 import cgeo.geocaching.utils.TrackUtils;
 import static cgeo.geocaching.maps.mapsforge.v6.caches.CachesBundle.NO_OVERLAY_ID;
 
@@ -489,26 +488,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 return true;
             case R.id.menu_compass:
                 menuCompass();
-                return true;
-            case R.id.menu_reset_linecolors:
-                MapLineUtils.resetLinecolors(this, () -> {
-                    if (null != historyLayer) {
-                        historyLayer.resetColor();
-                        historyLayer.requestRedraw();
-                    }
-                    if (null != trackLayer) {
-                        trackLayer.resetColor();
-                        trackLayer.requestRedraw();
-                    }
-                    if (null != routeLayer) {
-                        routeLayer.resetColor();
-                        routeLayer.requestRedraw();
-                    }
-                    if (null != navigationLayer) {
-                        navigationLayer.resetColor();
-                        navigationLayer.requestRedraw();
-                    }
-                });
                 return true;
             default:
                 if (!TrackUtils.onOptionsItemSelected(this, id, this::updateTrackHideStatus, this::setTracks)

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -831,10 +831,6 @@ public class Settings {
         return getInt(prefKeyId, getKeyInt(defaultValueKeyId));
     }
 
-    public static void resetMapLineValue(final int prefKeyId, final int defaultValueKeyId) {
-        putInt(prefKeyId, getKeyInt(defaultValueKeyId));
-    }
-
     public static int getCompactIconMode() {
         final String prefValue = getString(R.string.pref_compactIconMode, "");
         if (prefValue.equals(getKey(R.string.pref_compacticon_on))) {

--- a/main/src/cgeo/geocaching/utils/MapLineUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapLineUtils.java
@@ -1,11 +1,7 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.ui.dialog.Dialogs;
-
-import android.app.Activity;
 
 public class MapLineUtils {
 
@@ -80,21 +76,6 @@ public class MapLineUtils {
 
     private static float getWidth(final int prefKeyId, final int defaultValueKeyId) {
         return (Settings.getMapLineValue(prefKeyId, defaultValueKeyId) / 2.0f + 1.0f) * DisplayUtils.getDisplayDensity();
-    }
-
-    public static void resetLinecolors(final Activity activity, final Runnable doOnChange) {
-        Dialogs.confirm(activity, R.string.map_reset_linecolors, R.string.map_reset_linecolors_confirm, (dialog, which) -> {
-            Settings.resetMapLineValue(R.string.pref_mapline_trailcolor, R.color.default_trailcolor);
-            Settings.resetMapLineValue(R.string.pref_mapline_directioncolor, R.color.default_directioncolor);
-            Settings.resetMapLineValue(R.string.pref_mapline_routecolor, R.color.default_routecolor);
-            Settings.resetMapLineValue(R.string.pref_mapline_trackcolor, R.color.default_trackcolor);
-            Settings.resetMapLineValue(R.string.pref_mapline_circlecolor, R.color.default_circlecolor);
-            Settings.resetMapLineValue(R.string.pref_mapline_circlefillcolor, R.color.default_circlefillcolor);
-            ActivityMixin.showShortToast(activity, activity.getString(R.string.map_reset_linecolors_ok));
-            if (null != doOnChange) {
-                doOnChange.run();
-            }
-        });
     }
 
 }


### PR DESCRIPTION
A follow-up to the discussion in https://github.com/cgeo/cgeo/issues/8699#issuecomment-666677719:

Remove the map option to reset all map line colors to their defaults.
See #8720 for an alternative integrated into the `ColorpickerPreference`.