### PR TITLE
add map download button to map settings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1865,7 +1865,8 @@
 
     <!-- Download map preference and menu entry -->
     <string name="downloadmap_title">Download offline map</string>
-    <string name="downloadmap_info">You will be redirected to a download site for basic offline maps (no themeing support).\n\nChose the .map file for your region and tap on it to download the file.\n\nWhen downloading has completed, tap on the downloaded file to set this map as current map for c:geo</string>
+    <string name="downloadmap_info">Choose a map file for your region by tapping the \"Save\" icon.\n\nDownloading will run in the background. When downloading has completed, the downloaded file will be copied to c:geo\'s map directory and set as current map for c:geo.\n\nBe careful: Downloading a map can cause high network traffic!</string>
+    <string name="downloadmap_choose">Choose map</string>
     <string name="downloadmanager_not_available">Map file cannot be downloaded, system download manager not available</string>
     <string name="download_started">Downloading started in background</string>
 

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -555,12 +555,10 @@
                 android:title="@string/settings_info_offline_maps_title"
                 app:url="@string/settings_offline_maps_url"
                 app:urlButton="@string/settings_goto_url_button" />
-            <!-- disabled for now
             <cgeo.geocaching.settings.InfoPreferenceMap
                 android:text="@string/downloadmap_info"
                 android:title="@string/downloadmap_title"
-                app:url="@string/mapserver_osm_v5" />
-                -->
+                app:urlButton="@string/downloadmap_choose" />
             <Preference
                 android:key="@string/pref_mapDirectory"
                 android:title="@string/init_map_directory_description" />

--- a/main/src/cgeo/geocaching/settings/InfoPreferenceMap.java
+++ b/main/src/cgeo/geocaching/settings/InfoPreferenceMap.java
@@ -1,8 +1,11 @@
 package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
+import static cgeo.geocaching.utils.MapDownloadUtils.REQUEST_CODE;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.util.AttributeSet;
 
 /**
@@ -12,19 +15,23 @@ import android.util.AttributeSet;
  */
 public class InfoPreferenceMap extends AbstractInfoPreference {
 
+    private Activity activity;
+
     public InfoPreferenceMap(final Context context) {
-        super(context);
-        init(context, R.layout.preference_map_icon, true);
+        this(context, null);
     }
 
     public InfoPreferenceMap(final Context context, final AttributeSet attrs) {
-        super(context, attrs);
-        init(context, R.layout.preference_map_icon, true);
+        this(context, attrs, android.R.attr.preferenceStyle);
     }
 
     public InfoPreferenceMap(final Context context, final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
-        init(context, R.layout.preference_map_icon, true);
+        activity = (Activity) context;
+        init(activity, R.layout.preference_map_icon, this::startActivityForResult);
     }
 
+    private void startActivityForResult() {
+        activity.startActivityForResult(new Intent(activity, MapDownloadSelectorActivity.class), REQUEST_CODE);
+    }
 }

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -29,6 +29,7 @@ import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MapDownloadUtils;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.SharedPrefsBackupUtils;
 import static cgeo.geocaching.utils.MapUtils.showInvalidMapfileMessage;
@@ -704,6 +705,11 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+
+        if (MapDownloadUtils.onActivityResult(this, requestCode, resultCode, data)) {
+            return;
+        }
+
         if (resultCode != RESULT_OK) {
             return;
         }


### PR DESCRIPTION
Adds a button to map settings to start the new map downloader.

![image](https://user-images.githubusercontent.com/3754370/89100401-fd1a5b80-d3f6-11ea-9f9f-951df80720aa.png)

After pressing the button a short explanation and warning message is shown:

![image](https://user-images.githubusercontent.com/3754370/89100386-e4aa4100-d3f6-11ea-8e74-fc7333b9af62.png)

On pressing the "Choose map" button the new map downloader starts, following the same procedure as if started from map selector in map view. (For details on this see #8610.)