### PR TITLE
reactivate local file handler for .map files (fix #8676)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -231,6 +231,31 @@
             android:name=".settings.ReceiveMapFileActivity">
         </activity>
         <activity
+            android:name=".HandleLocalFilesActivity"
+            android:exported="true"
+            android:label="@string/localfile_intenttitle">
+            <!-- don't use fixed parent activity, since we may come from main activity, pocket query activity or search activity -->
+            <!-- intent filter for local map files -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="file" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\\.map" />
+                <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
+                <data android:pathPattern=".*\\..*\\.map" />
+                <data android:pathPattern=".*\\..*\\..*\\.map" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.map" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.map" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".CacheListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true"

--- a/main/src/cgeo/geocaching/HandleLocalFilesActivity.java
+++ b/main/src/cgeo/geocaching/HandleLocalFilesActivity.java
@@ -5,11 +5,6 @@ import cgeo.geocaching.files.FileType;
 import cgeo.geocaching.files.FileTypeDetector;
 import cgeo.geocaching.settings.ReceiveMapFileActivity;
 import cgeo.geocaching.ui.dialog.Dialogs;
-import static cgeo.geocaching.utils.FileUtils.COMPRESSED_GPX_FILE_EXTENSION;
-import static cgeo.geocaching.utils.FileUtils.GPX_FILE_EXTENSION;
-import static cgeo.geocaching.utils.FileUtils.LOC_FILE_EXTENSION;
-import static cgeo.geocaching.utils.FileUtils.MAP_FILE_EXTENSION;
-import static cgeo.geocaching.utils.FileUtils.ZIP_FILE_EXTENSION;
 
 import android.content.ContentResolver;
 import android.content.Intent;
@@ -28,39 +23,21 @@ public class HandleLocalFilesActivity extends AbstractActivity {
         final Uri uri = intent.getData();
         boolean finished = false;
 
-        if (Intent.ACTION_VIEW.equals(action) && uri != null) {
-            final String parsedUri = uri.getPath();
-            if (parsedUri != null) {
-                final int startExtension = parsedUri.lastIndexOf('.');
-                if (startExtension > -1) {
-                    final String extension = parsedUri.substring(startExtension).toLowerCase();
-                    if (extension.equals(ZIP_FILE_EXTENSION) || extension.equals(GPX_FILE_EXTENSION) || extension.equals(COMPRESSED_GPX_FILE_EXTENSION) || extension.equals(LOC_FILE_EXTENSION)) {
-                        continueWith(CacheListActivity.class, intent);
-                        finished = true;
-                    } else if (extension.equals(MAP_FILE_EXTENSION)) {
-                        continueWith(ReceiveMapFileActivity.class, intent);
-                        finished = true;
-                    }
-                }
-            }
-        }
-        if (!finished) {
-            final ContentResolver contentResolver = getContentResolver();
-            final FileType fileType = new FileTypeDetector(uri, contentResolver).getFileType();
-            switch (fileType) {
-                case GPX:
-                case ZIP:
-                case LOC:
-                    continueWith(CacheListActivity.class, intent);
-                    finished = true;
-                    break;
-                case MAP:
-                    continueWith(ReceiveMapFileActivity.class, intent);
-                    finished = true;
-                    break;
-                default:
-                    break;
-            }
+        final ContentResolver contentResolver = getContentResolver();
+        final FileType fileType = new FileTypeDetector(uri, contentResolver).getFileType();
+        switch (fileType) {
+            case GPX:
+            case ZIP:
+            case LOC:
+                continueWith(CacheListActivity.class, intent);
+                finished = true;
+                break;
+            case MAP:
+                continueWith(ReceiveMapFileActivity.class, intent);
+                finished = true;
+                break;
+            default:
+                break;
         }
         if (!finished) {
             Dialogs.message(this, R.string.localfile_title, R.string.localfile_cannot_handle, (dialog, button) -> finish());


### PR DESCRIPTION
On tapping a local file with extension ".map" this file gets copied to c:geo's map dir and set as default map.
(Includes a check for magic OSM map file string and a warning message, if magic string not found.)