### PR TITLE
Issue #8729: fix

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -902,8 +902,8 @@
     <string name="cache_personal_note_edit">Edit</string>
     <string name="cache_personal_note_storewaypoints">Store Waypoints</string>
     <string name="cache_personal_note_storewaypoints_success">Waypoints were added to personal note</string>
-    <string name="cache_personal_note_storewaypoints_success_limited">Waypoints were added to note but had to be shortened</string>
-    <string name="cache_personal_note_storewaypoints_failed">Waypoints could not be stored in note due to size limits</string>
+    <string name="cache_personal_note_storewaypoints_success_limited">Waypoints were added to note but had to be shortened (max personal note size: %1$d)</string>
+    <string name="cache_personal_note_storewaypoints_failed">Waypoints could not be stored in note due to size limits (max personal note size: %1$d)</string>
     <string name="cache_personal_note_storewaypoints_nowaypoints">No user waypoints found</string>
     <string name="cache_personal_note_preventWaypointsExtraction">Prevent waypoints extraction</string>
     <string name="cache_personal_note_limit">Personal note limit</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2557,18 +2557,21 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             return;
         }
 
-        final String newNote = Waypoint.putParseableWaypointTextstore(note, userDefinedWaypoints, maxPersonalNotesChars);
+        //if given maxSize is obviously bogus, then make length unlimited
+        final int maxSize = maxPersonalNotesChars == 0 ? -1 : maxPersonalNotesChars;
+
+        final String newNote = Waypoint.putParseableWaypointTextstore(note, userDefinedWaypoints, maxSize);
 
         if (newNote != null) {
             setNewPersonalNote(newNote);
             final String newNoteNonShorted = Waypoint.putParseableWaypointTextstore(note, userDefinedWaypoints, -1);
             if (newNoteNonShorted.length() > newNote.length()) {
-                showShortToast(getString(R.string.cache_personal_note_storewaypoints_success_limited));
+                showShortToast(getString(R.string.cache_personal_note_storewaypoints_success_limited, maxSize));
             } else {
                 showShortToast(getString(R.string.cache_personal_note_storewaypoints_success));
             }
         } else {
-            showShortToast(getString(R.string.cache_personal_note_storewaypoints_failed));
+            showShortToast(getString(R.string.cache_personal_note_storewaypoints_failed, maxSize));
         }
 
     }


### PR DESCRIPTION
this PR contains code which SHOULD fix #8729 (although I couldn't reproduce it I think this is caused by a not correctly initialized maxPersonalNoteSize variable), and in case it doesn't it contains code helping to analyze situation better (now the max size of personal note is added to the error toast)