### PR TITLE
remove duplicated calls to clearIndividualRoute

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -897,9 +897,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 new TrailHistoryExport(activity, this::clearTrailHistory);
                 return true;
             }
-            case R.id.menu_clear_individual_route:
-                clearIndividualRoute();
-                return true;
             case R.id.menu_hint:
                 menuShowHint();
                 return true;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -480,9 +480,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 new TrailHistoryExport(this, this::clearTrailHistory);
                 return true;
             }
-            case R.id.menu_clear_individual_route:
-                clearIndividualRoute();
-                return true;
             case R.id.menu_hint:
                 menuShowHint();
                 return true;


### PR DESCRIPTION
checking `R.id.menu_clear_individual_route` is already covered by calls to `IndividualRouteUtils.onOptionsItemSelected()` further down, no need to duplicate it here