### PR TITLE
[Basics, related to Issue:#2553] provide Streaming-like functionality to cgeo

### DIFF
--- a/main/src/cgeo/geocaching/utils/CollectionStream.java
+++ b/main/src/cgeo/geocaching/utils/CollectionStream.java
@@ -1,0 +1,177 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.utils.functions.Action1;
+import cgeo.geocaching.utils.functions.Func1;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Provides Streaming-like functionality for Collection classes
+ * <p>
+ * Poor-mans replacement for {@link Collection#stream()} functionality for Collections which is only
+ * available starting at API Level 24. This class can be completely replaced once c:geo switches to
+ * that API level.
+ * <p>
+ * This class is meant for immediate processing and collecting ONLY!
+ * Methods called on this class manipulate its internal state directly. This prevents creation of unnecessary intermediate collection objects.
+ * However, IT IS NOT SAFE TO CACHE INSTANCES OF THIS CLASS FOR LATER USAGE!
+ * <p>
+ * This class will be redundant and shall be deprecated once we use API level >= 24
+ */
+@SuppressWarnings("unchecked")
+public class CollectionStream<T> {
+
+    private final Collection<?> originalCollection;
+    //LinkedList can be used most efficiently for 'map' and 'filter' methods
+    private LinkedList<Object> collection;
+
+    /**
+     * creates CollectionStream with a Collection as its source
+     */
+    public static <TT> CollectionStream<TT> of(final Collection<TT> coll) {
+        return new CollectionStream<>(coll);
+    }
+
+    /**
+     * creates CollectionStream with an array as its source
+     */
+    public static <TT> CollectionStream<TT> of(final TT[] coll) {
+        return new CollectionStream<>(Arrays.asList(coll));
+    }
+
+    private CollectionStream(final Collection<?> coll) {
+        this.originalCollection = coll == null ? Collections.emptyList() : coll;
+    }
+
+    /**
+     * mimics {@link java.util.stream.Stream#map(Function)}
+     * Note that mapping is immediately executed and a new CollectionStream object is created as a result.
+     */
+    public <U> CollectionStream<U> map(final Func1<T, U> mapper) {
+        if (mapper != null) {
+            final LinkedList<Object> coll = getCollectionForWrite();
+            final int size = coll.size();
+            for (int i = 0; i < size; i++) {
+                final Object newElement = mapper.call((T) coll.removeLast());
+                coll.addFirst(newElement);
+            }
+        }
+        return (CollectionStream<U>) this;
+    }
+
+    /**
+     * mimics {@link java.util.stream.Stream#filter(Predicate)}
+     * Note that mapping is immediately executed and a new CollectionStream object is created as a result.
+     */
+    public CollectionStream<T> filter(final Func1<T, Boolean> filter) {
+        if (filter != null) {
+            final LinkedList<Object> coll = getCollectionForWrite();
+            final Iterator<Object> it = coll.iterator();
+            while (it.hasNext()) {
+                final Object element = it.next();
+                if (!filter.call((T) element)) {
+                    it.remove();
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * mimics {@link java.util.stream.Collectors#joining()}
+     */
+    public String toJoinedString() {
+        return toJoinedString(null);
+    }
+
+    /**
+     * mimics {@link java.util.stream.Collectors#joining(CharSequence)}
+     */
+    public String toJoinedString(final String separator) {
+        final StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Object element : getCollectionForRead()) {
+            if (!first && separator != null) {
+                sb.append(separator);
+            }
+            first = false;
+            sb.append(element);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * mimics {@link Collectors#toList()}
+     */
+    public List<T> toList() {
+        return (List<T>) getCollectionForWrite();
+    }
+
+    /**
+     * mimics {@link Collectors#toSet()}
+     */
+    public Set<T> toSet() {
+        return new HashSet<>((Collection<T>) getCollectionForRead());
+    }
+
+    /**
+     * mimics {@link Collectors#toMap(Function, Function)}
+     */
+    public <K, V> Map<K, V> toMap(final Func1<T, K> keyMapper, final Func1<T, V> valueMapper) {
+        final Map<K, V> result = new HashMap<>();
+        for (Object element : getCollectionForRead()) {
+            result.put(keyMapper.call((T) element), valueMapper.call((T) element));
+        }
+        return result;
+    }
+
+    /**
+     * convenient function to convert to array
+     *
+     * Implementation Note: explicit type parameter 'arrayClass' is necessary,
+     * otherwise returned array might be of type Object[] instead ot T[].
+     */
+    public T[] toArray(final Class<T> arrayClass) {
+        //the following seems to be the only way to keep warning messages away...
+        final T[] newArray = (T[]) Array.newInstance(arrayClass, getCollectionForRead().size());
+        int idx = 0;
+        for (final Object e : getCollectionForRead()) {
+            newArray[idx++] = (T) e;
+        }
+        return newArray;
+    }
+
+    /**
+     * mimics {@link java.util.stream.Stream#forEach(Consumer)}
+     */
+    public void forEach(final Action1<T> action) {
+        for (Object element : getCollectionForRead()) {
+            action.call((T) element);
+        }
+    }
+
+    private Collection<Object> getCollectionForRead() {
+        return this.collection == null ? (Collection<Object>) this.originalCollection : this.collection;
+    }
+
+    private LinkedList<Object> getCollectionForWrite() {
+        if (this.collection == null) {
+            this.collection = new LinkedList<>(this.originalCollection);
+        }
+        return this.collection;
+    }
+}

--- a/tests/src/cgeo/geocaching/utils/CollectionStreamTest.java
+++ b/tests/src/cgeo/geocaching/utils/CollectionStreamTest.java
@@ -1,0 +1,72 @@
+package cgeo.geocaching.utils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class CollectionStreamTest {
+
+    @Test
+    public void testBasicRoundtrip() {
+        //a very basic map/filter/collectToString example
+        final String result = CollectionStream.of(new Integer[]{1, 2, 3, 4})
+                .filter(e -> e >= 2)
+                .map(e -> "s" + e)
+                .toJoinedString(",");
+        assertThat(result).isEqualTo("s2,s3,s4");
+    }
+
+    @Test
+    public void testStability() {
+        assertThat(CollectionStream.of((Collection<Object>) null).toJoinedString(",")).isEqualTo("");
+        assertThat(CollectionStream.of(new Integer[]{1, 2}).map(null).filter(null).toJoinedString(",")).isEqualTo("1,2");
+        assertThat(CollectionStream.of(new Integer[]{1, 2}).toJoinedString(null)).isEqualTo("12");
+    }
+
+    @Test
+    public void testOriginalNotModified() {
+        final List<String> original = Arrays.asList("eins", "zwei", "drei", "vier");
+        final List<String> changed = CollectionStream.of(original).map(s -> s + s).filter(s -> s.contains("ei")).toList();
+
+        assertThat(original).isEqualTo(Arrays.asList("eins", "zwei", "drei", "vier"));
+        assertThat(changed).isEqualTo(Arrays.asList("einseins", "zweizwei", "dreidrei"));
+
+        //ensure that outcome of Collector is definitely NOT the original!
+        assertThat(CollectionStream.of(original).toList()).isNotSameAs(original);
+    }
+
+    @Test
+    public void testCollectors() {
+        final String[] originalArray = new String[]{"eins", "zwei", "drei", "vier"};
+        final List<String> original = Arrays.asList(originalArray);
+
+        //to test also correct casting of result, even after processing, dummy map/filters are
+        //used and result is stored to local variable before assert
+
+        final List<String> newList = CollectionStream.of(original).map(s -> s).filter(s -> true).toList();
+        assertThat(newList).isEqualTo(original);
+
+        assertThat(CollectionStream.of(original).map(s -> s).filter(s -> true).toJoinedString()).isEqualTo("einszweidreivier");
+        assertThat(CollectionStream.of(original).map(s -> s).filter(s -> true).toJoinedString(",")).isEqualTo("eins,zwei,drei,vier");
+
+        final Set<String> newSet = CollectionStream.of(original).map(s -> s).filter(s -> true).toSet();
+        assertThat(newSet).isEqualTo(new HashSet<>(original));
+
+        final String[] newArray = CollectionStream.of(original).map(s -> s).filter(s -> true).toArray(String.class);
+        assertThat(newArray).isEqualTo(originalArray);
+
+        final Map<Character, String> expected = new HashMap<>();
+        for (String o : original) {
+            expected.put(o.charAt(0), o);
+        }
+        final Map<Character, String> newMap = CollectionStream.of(original).map(s -> s).filter(s -> true).toMap(e -> e.charAt(0), e -> e);
+        assertThat(newMap).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
While working on Issue #2553 (Offline Log with image upload doesn't save image to log) I realized at some point that I need some more fundamental changes in order to implement this in a future-proof way. This became much too big for one Pull Request. Thus the idea is to push parts of this as independent pull requests and glueing the code pieces together once they are through. This also allows separate discussion with regards of different things I suggest to bring to the code.
This is one of those Pull Request.

This PR introduces Streaming-like functionality to cgeo for collections since Java streaming API is only available starting at API level 24. If approved, it will be heavily used in #2553 implementation and IMHO substantially dramatically increases code amintainability/readability