### PR TITLE
add wrapping to title in route sort view

### DIFF
--- a/main/res/layout/twotexts_twobuttons_item.xml
+++ b/main/res/layout/twotexts_twobuttons_item.xml
@@ -18,17 +18,13 @@
         android:layout_marginRight="110dip"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:ellipsize="end"
-        android:lines="1"
         android:paddingRight="3dip"
         android:paddingTop="5dip"
         android:scrollHorizontally="true"
         android:textColor="?text_color"
         android:textIsSelectable="false"
         android:textSize="18sp"
-        tools:text="title"
-        android:maxLines="1" />
-
+        tools:text="title" />
     <TextView
         android:id="@+id/detail"
         android:layout_width="fill_parent"


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/cgeo/cgeo/issues/8670#issuecomment-667132652:

> Unfortunately, a lot of these have looong names and, even worse, with the significant part of the name at the very end (in form of a counter), which makes it really hard to say, which one is which ... so what would you think about a line wrap for cache names that do not fit into the column?

This PR adds wrapping to the title, if needed:

![image](https://user-images.githubusercontent.com/3754370/89127651-6aa9b300-d4ef-11ea-82c5-0b74876be02c.png)
