### PR TITLE
remove unused translations

### DIFF
--- a/main/res/values-ar/strings.xml
+++ b/main/res/values-ar/strings.xml
@@ -85,7 +85,6 @@
     <string name="log_saving_and_uploading">جاري نشر السجل و تحميل الصورة&#8230;</string>
     <string name="log_posting_log">جاري نشر السجل&#8230;</string>
     <string name="log_posting_twitter">جاري نشر التغريدة&#8230;</string>
-    <string name="log_posting_gcvote">جاري نشر GCVote&#8230;</string>
     <string name="log_posting_image">نشر الصورة&#8230;</string>
     <string name="log_posting_generic_trackable">نشر %1$s %2$d/%3$d</string>
     <string name="log_clear">مسح</string>
@@ -419,8 +418,6 @@
     <string name="init_summary_su">تحميل المخبآت من opencaching.su</string>
     <string name="settings_activate_su">تنشيط</string>
     <string name="init_gcvote_password_description">لتكون قادر على تقييم مخبئ، تحتاج إلى اتباع الإرشادات التي تظهر في GCvote.com و إدخال كلمة المرور الخاص بك في GCvote، هنا.</string>
-    <string name="err_gcvote_send_rating">حدث خطأ أثناء إرسال لتقييم، تحقق من كلمة مرورك في GCVote داخل الإعدادات أو قم بمسحه.</string>
-    <string name="gcvote_sent">تم ارسال التصويت بنجاح</string>
     <string name="settings_activate_twitter">تنشيط</string>
     <string name="init_login_popup">تسجيل الدخول</string>
     <string name="init_login_popup_working">جاري تسجيل الدخول&#8230;</string>
@@ -775,7 +772,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">تحميل المخبآت من %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">تحميل الإحدثيات من %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d مخبآت مستوردة من %2$s</string>
     <string name="gpx_import_static_maps_skipped">تم إحباط تحميل الخرائط الثابتة</string>
     <string name="gpx_import_title_reading_file">قراءة الملف</string>
     <string name="gpx_import_title">استيراد GPX</string>

--- a/main/res/values-ca/strings.xml
+++ b/main/res/values-ca/strings.xml
@@ -80,7 +80,6 @@
     <string name="log_saving_and_uploading">Publicant registre i carregant la imatge…</string>
     <string name="log_posting_log">Publicant registre…</string>
     <string name="log_posting_twitter">Publicant Tweet…</string>
-    <string name="log_posting_gcvote">Publicant GCvote…</string>
     <string name="log_posting_image">Publicant imatge…</string>
     <string name="log_posting_generic_trackable">Publicant %1$s %2$d/%3$d</string>
     <string name="log_clear">Esborra</string>
@@ -435,8 +434,6 @@
     <string name="init_summary_su">Carregar catxés des de Geocaching.su</string>
     <string name="settings_activate_su">Activa</string>
     <string name="init_gcvote_password_description">Per poder puntuar un catxé, cal seguir les instruccions a GCVote.com i introduir aquí la contrasenya del GCVote.</string>
-    <string name="err_gcvote_send_rating">Hi ha un error al enviar la puntuació, comproveu la contrasenya de GCVote a les opcions  o deixeu-ho buit.</string>
-    <string name="gcvote_sent">Votació enviada correctament</string>
     <string name="settings_activate_twitter">Activa</string>
     <string name="init_login_popup">Accés</string>
     <string name="init_login_popup_working">S\'està accedint…</string>
@@ -819,7 +816,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Carregant catxés de %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Carregant fites de %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d catxés importats de %2$s</string>
     <string name="gpx_import_static_maps_skipped">La descarrega de mapes estàtics ha estat interrompuda</string>
     <string name="gpx_import_title_reading_file">S\'està llegint el fitxer</string>
     <string name="gpx_import_title">Importa GPX</string>

--- a/main/res/values-ceb/strings.xml
+++ b/main/res/values-ceb/strings.xml
@@ -75,7 +75,6 @@
     <string name="log_saving_and_uploading">Ang pagpamantala sa log ug pag-upload sa imahe…</string>
     <string name="log_posting_log">Ang pag-post sa log…</string>
     <string name="log_posting_twitter">Ang pag-post sa tweet…</string>
-    <string name="log_posting_gcvote">Ang pag-post sa GCVote…</string>
     <string name="log_posting_image">Ang pag-post sa imahe…</string>
     <string name="log_posting_generic_trackable">Nagpost sa %1$s %2$d/%3$d</string>
     <string name="log_clear">Tin-aw</string>
@@ -403,8 +402,6 @@
     <string name="init_summary_su">I-load ang mga cache gikan sa Geocaching.su</string>
     <string name="settings_activate_su">Pag-aktibo</string>
     <string name="init_gcvote_password_description">Para maka-rate sa cache, kinahanglan nimo sundon ang gitudlo sa GCVote.com ug ipasulod ang imong GCVote password dire.</string>
-    <string name="err_gcvote_send_rating">Problema sa pagpasa sa grado, susihi ang GCVote password sa mga kahimtangan o haw-i kini.</string>
-    <string name="gcvote_sent">Ang boto kay napasa ug tarung</string>
     <string name="settings_activate_twitter">Pag-aktibo</string>
     <string name="init_login_popup">Pasulod</string>
     <string name="init_login_popup_working">Pagpasulod…</string>
@@ -756,7 +753,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Pagload sa mga cache gikan sa %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Nagload sa waypoints gikan sa %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d gi-import ang caches sa %2$s</string>
     <string name="gpx_import_static_maps_skipped">Ang pag-download ug static maps kay gi-abort</string>
     <string name="gpx_import_title_reading_file">Pagbasa sa file</string>
     <string name="gpx_import_title">I-import ang GPX</string>

--- a/main/res/values-cs/strings.xml
+++ b/main/res/values-cs/strings.xml
@@ -1116,9 +1116,6 @@
     <string name="map_rotation">Otáčení mapy</string>
     <string name="map_hide">Skrýt</string>
     <string name="map_trail_show">Zobrazit historii trasy</string>
-    <string name="map_reset_linecolors">Obnovit barvy čar</string>
-    <string name="map_reset_linecolors_confirm">Chcete obnovit výchozí barvu u všech konfigurovatelných čar v mapě?</string>
-    <string name="map_reset_linecolors_ok">Barvy čar obnoveny</string>
     <string name="map_dot_mode">Použít kompaktní ikony</string>
     <string name="map_circles_show">Zobrazit kruhy</string>
     <string name="map_mycaches_hide">Skrýt vlastní/nalezené keše</string>

--- a/main/res/values-da/strings.xml
+++ b/main/res/values-da/strings.xml
@@ -80,7 +80,6 @@
     <string name="log_saving_and_uploading">Sender logbesked og billede…</string>
     <string name="log_posting_log">Sender logbesked…</string>
     <string name="log_posting_twitter">Sender tweet…</string>
-    <string name="log_posting_gcvote">Sender GCVote…</string>
     <string name="log_posting_image">Sender billede…</string>
     <string name="log_posting_generic_trackable">Sender %1$s %2$d/%3$d</string>
     <string name="log_clear">Fjern</string>
@@ -458,8 +457,6 @@
     <string name="init_summary_su">Indlæs cacher fra Geocaching.su</string>
     <string name="settings_activate_su">Aktivér</string>
     <string name="init_gcvote_password_description">For at kunne bedømme en cache skal du følge instruktionerne på GCVote.com og angive dit password til GCVote her.</string>
-    <string name="err_gcvote_send_rating">Fejl under afsendelse af bedømmelse. Kontrollér eller fjern GCVote password under Indstillinger.</string>
-    <string name="gcvote_sent">Bedømmelse blev afsendt</string>
     <string name="settings_activate_twitter">Aktivér</string>
     <string name="init_login_popup_working">Logger ind…</string>
     <string name="init_login_popup_failed">Login fejlede</string>
@@ -860,7 +857,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Indlæser cacher fra %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Indlæser waypoints fra %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d cacher importeret fra %2$s</string>
     <string name="gpx_import_static_maps_skipped">Indlæsning af statiske kort blev afbrudt</string>
     <string name="gpx_import_title_reading_file">Indlæser fil</string>
     <string name="gpx_import_title">Importér GPX</string>

--- a/main/res/values-de/strings.xml
+++ b/main/res/values-de/strings.xml
@@ -1098,9 +1098,6 @@
     <string name="map_rotation">Kartendrehung</string>
     <string name="map_hide">Verbergen</string>
     <string name="map_trail_show">Zeige Positionsverlauf</string>
-    <string name="map_reset_linecolors">Linienfarben zurücksetzen</string>
-    <string name="map_reset_linecolors_confirm">Möchtest du alle konfigurierten Linienfarben auf die Standardfarben zurücksetzen?</string>
-    <string name="map_reset_linecolors_ok">Linienfarben zurückgesetzt</string>
     <string name="map_dot_mode">Nutze kompakte Symbole</string>
     <string name="map_circles_show">Kreise anzeigen</string>
     <string name="map_mycaches_hide">Eigene/gefundene Caches ausblenden</string>

--- a/main/res/values-el/strings.xml
+++ b/main/res/values-el/strings.xml
@@ -92,7 +92,6 @@
     <string name="log_saving_and_uploading">Καταχώρηση αρχείου καταγραφής και ανέβασμα εικόνας…</string>
     <string name="log_posting_log">Αποστολή καταγραφής…</string>
     <string name="log_posting_twitter">Αποστολή tweet…</string>
-    <string name="log_posting_gcvote">Αποστολή GCVote…</string>
     <string name="log_posting_image">Αποστολή εικόνας…</string>
     <string name="log_posting_generic_trackable">Αποστολή %1$s %2$d/%3$d</string>
     <string name="log_clear">Kαθαρισμός</string>
@@ -510,8 +509,6 @@
     <string name="init_summary_su">Φόρτωση κρυπτών από Geocaching.su</string>
     <string name="settings_activate_su">Ενεργοποίηση</string>
     <string name="init_gcvote_password_description">Για να είστε σε θέση να αξιολογήσετε μια κρύπτη, θα πρέπει να ακολουθήσετε τις οδηγίες στο GCVote.com και να εισάγετε εδώ τον κωδικό πρόσβασής σας GCVote.</string>
-    <string name="err_gcvote_send_rating">Σφάλμα κατά την αποστολή της βαθμολογίας, ελέγξτε τον GCVote κωδικό πρόσβασης στις ρυθμίσεις ή βάλτε κενό.</string>
-    <string name="gcvote_sent">Η ψήφος δόθηκε επιτυχώς</string>
     <string name="settings_activate_twitter">Ενεργοποίηση</string>
     <string name="init_login_popup">Σύνδεση</string>
     <string name="init_login_popup_working">Συνδέεται με…</string>
@@ -989,7 +986,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Φόρτωση κρυπτών από %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Φόρτωση σημείων αναφοράς από %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d κρύπτες εισήχθησαν από %2$s</string>
     <string name="gpx_import_static_maps_skipped">Το κατέβασμα των στατικών χαρτών ματαιώθηκε</string>
     <string name="gpx_import_title_reading_file">Ανάγνωση αρχείου</string>
     <string name="gpx_import_title">Εισαγωγή GPX</string>

--- a/main/res/values-es/strings.xml
+++ b/main/res/values-es/strings.xml
@@ -82,7 +82,6 @@
     <string name="log_saving_and_uploading">Enviando registro y subiendo imagen…</string>
     <string name="log_posting_log">Enviando registro…</string>
     <string name="log_posting_twitter">Publicando tweet…</string>
-    <string name="log_posting_gcvote">Publicando GCVote…</string>
     <string name="log_posting_image">Publicando imagen…</string>
     <string name="log_posting_generic_trackable">Publicando %1$s %2$d/%3$d</string>
     <string name="log_clear">Limpiar</string>
@@ -451,8 +450,6 @@
     <string name="init_summary_su">Carga cachés de Geocaching.su</string>
     <string name="settings_activate_su">Activar</string>
     <string name="init_gcvote_password_description">Para poder calificar un caché, tienes que seguir las instrucciones en GCVote.com e introducir tu contraseña de GCVote aquí.</string>
-    <string name="err_gcvote_send_rating">Error al enviar la calificación, comprueba tu contraseña de GCVote en configuración o déjala en blanco.</string>
-    <string name="gcvote_sent">Voto enviado con éxito</string>
     <string name="settings_activate_twitter">Activar</string>
     <string name="init_login_popup">Acceso</string>
     <string name="init_login_popup_working">Accediendo a Geocaching.com…</string>
@@ -850,7 +847,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Cargando cachés desde %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Cargando waypoints desde %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d cachés importados de %2$s</string>
     <string name="gpx_import_static_maps_skipped">Descarga de mapas estáticos abortada</string>
     <string name="gpx_import_title_reading_file">Leyendo archivo</string>
     <string name="gpx_import_title">Importar GPX</string>

--- a/main/res/values-fi/strings.xml
+++ b/main/res/values-fi/strings.xml
@@ -1098,9 +1098,6 @@
     <string name="map_rotation">Kartan kääntö</string>
     <string name="map_hide">Piilota</string>
     <string name="map_trail_show">Näytä reittihistoria</string>
-    <string name="map_reset_linecolors">Nollaa viivojen värit</string>
-    <string name="map_reset_linecolors_confirm">Haluatko nollata kaikki muokattavat viivojen värit niiden oletusväreihin?</string>
-    <string name="map_reset_linecolors_ok">Viivojen värit nollattu</string>
     <string name="map_dot_mode">Käytä pieniä kuvakkeita</string>
     <string name="map_circles_show">Näytä ympyrät</string>
     <string name="map_mycaches_hide">Piilota omat/löydetyt kätköt</string>

--- a/main/res/values-fil/strings.xml
+++ b/main/res/values-fil/strings.xml
@@ -79,7 +79,6 @@
     <string name="log_saving_and_uploading">Pagpapaskil ng log at pag-a-upload ng imahe&#8230;</string>
     <string name="log_posting_log">Pagpapaskil ng log&#8230;</string>
     <string name="log_posting_twitter">Pagpapaskil ng tweet&#8230;</string>
-    <string name="log_posting_gcvote">Pagpapaskil ng GCVote&#8230;</string>
     <string name="log_posting_image">Pagpapaskil ng imahe&#8230;</string>
     <string name="log_posting_generic_trackable">Nakapaskil na %1$s %2$d/%3$d</string>
     <string name="log_clear">Malinaw</string>
@@ -418,8 +417,6 @@
     <string name="init_summary_su">Mag-load ng caches mula sa Geocaching.su</string>
     <string name="settings_activate_su">Gawing Aktibo</string>
     <string name="init_gcvote_password_description">Para mai-rate ang cache, kinakailangan mo sumunod sa mga tagubilin ng Gcvote.com at ipasok ang iyong GCvote password dito.</string>
-    <string name="err_gcvote_send_rating">May maling nagaganap habang ipinapadala ang pagri-rate, rebisahin ang pasword ng GCVote sa mga setting o kaya ito ay walang laman.</string>
-    <string name="gcvote_sent">Ang pagboto ay naipadala ng matagumpay</string>
     <string name="settings_activate_twitter">Gawing Aktibo</string>
     <string name="init_login_popup">Mag-login</string>
     <string name="init_login_popup_working">Naglo-login sa&#8230;</string>
@@ -801,7 +798,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Nag-load ang cache mula sa %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Nag-loading ang waypoints mula sa %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">Ang %1$d ang pag-iimport ng mga cache mula sa %2$s</string>
     <string name="gpx_import_static_maps_skipped">Ang naudlot na istatik ng mga mapa ay i-download</string>
     <string name="gpx_import_title_reading_file">Binabasa ang payl</string>
     <string name="gpx_import_title">Ang GPX ay iimport</string>

--- a/main/res/values-fr/strings.xml
+++ b/main/res/values-fr/strings.xml
@@ -993,7 +993,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Chargement des caches depuis %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Chargement des points intermédiaires depuis %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d caches importées de %2$s</string>
     <string name="gpx_import_static_maps_skipped">Chargement des cartes statiques interrompu</string>
     <string name="gpx_import_title_reading_file">Lecture du fichier</string>
     <string name="gpx_import_title">Import GPX</string>

--- a/main/res/values-hu/strings.xml
+++ b/main/res/values-hu/strings.xml
@@ -87,7 +87,6 @@
     <string name="log_saving_and_uploading">Log küldése és kép feltöltése…</string>
     <string name="log_posting_log">Log küldése…</string>
     <string name="log_posting_twitter">Twittelés…</string>
-    <string name="log_posting_gcvote">Értékelés küldése…</string>
     <string name="log_posting_image">Kép küldése…</string>
     <string name="log_posting_generic_trackable">%1$s %2$d/%3$d log küldése</string>
     <string name="log_clear">Törlés</string>
@@ -488,8 +487,6 @@
     <string name="init_summary_su">Ládák letöltése a geocaching.su-ról</string>
     <string name="settings_activate_su">Aktiválás</string>
     <string name="init_gcvote_password_description">Ládák értékeléséhez itt add meg a GCVote jelszavad és kövesd az utasításokat a GCVote.com-on!</string>
-    <string name="err_gcvote_send_rating">Az értélkelés elküldése sikertelen. Ellenőrizd a GCVote jelszavad a beállításoknál! Próbálkozz a törlésével!</string>
-    <string name="gcvote_sent">Értékelés sikeresen elküldve</string>
     <string name="settings_activate_twitter">Aktiválás</string>
     <string name="init_login_popup">Bejelentkezés</string>
     <string name="init_login_popup_working">Bejelentkezés a geocaching.com-ra…</string>
@@ -908,7 +905,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">%1$s: ládák betöltése</string>
     <string name="gpx_import_loading_waypoints_with_filename">%1$s: útpontok betöltése</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d láda importálva %2$s fájlból</string>
     <string name="gpx_import_static_maps_skipped">A statikus térképek letöltése megszakítva.</string>
     <string name="gpx_import_title_reading_file">Fájl olvasása</string>
     <string name="gpx_import_title">GPX importálása</string>

--- a/main/res/values-in/strings.xml
+++ b/main/res/values-in/strings.xml
@@ -80,7 +80,6 @@
     <string name="log_saving_and_uploading">Memposting log dan mengunggah gambar&#8230;</string>
     <string name="log_posting_log">Memposting log&#8230;</string>
     <string name="log_posting_twitter">Posting tweet&#8230;</string>
-    <string name="log_posting_gcvote">Memposting GCVote&#8230;</string>
     <string name="log_posting_image">Memposting gambar&#8230;</string>
     <string name="log_posting_generic_trackable">Mencatat %1$s %2$d/%3$d</string>
     <string name="log_clear">Bersihkan</string>
@@ -412,8 +411,6 @@
     <string name="init_summary_su">Muat cache dari Geocaching.su</string>
     <string name="settings_activate_su">Aktifkan</string>
     <string name="init_gcvote_password_description">Untuk bisa menilai sebuah cache, anda perlu mengikuti petunjuk di GCVote.com dan masukkan kata sandi GCVote anda di sini.</string>
-    <string name="err_gcvote_send_rating">Kesalahan ketika mengirim penilaian, periksa kata sandi GCVote di pengaturan atau kosongkan itu.</string>
-    <string name="gcvote_sent">Pemungutan suara berhasil dikirim</string>
     <string name="settings_activate_twitter">Aktifkan</string>
     <string name="init_login_popup_working">Sedang masuk&#8230;</string>
     <string name="init_login_popup_ok">Masuk Ok</string>
@@ -778,7 +775,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Memuat cache dri %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Memuat waypoints dari %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d cache diimpor dari %2$s</string>
     <string name="gpx_import_static_maps_skipped">Download peta statis dibatalkan</string>
     <string name="gpx_import_title_reading_file">Membaca file</string>
     <string name="gpx_import_title">Impor GPX</string>

--- a/main/res/values-is/strings.xml
+++ b/main/res/values-is/strings.xml
@@ -73,7 +73,6 @@
     <string name="log_saving_and_uploading">Set færslu inn og hleð upp mynd…</string>
     <string name="log_posting_log">Set færslu inn…</string>
     <string name="log_posting_twitter">Set tíst inn…</string>
-    <string name="log_posting_gcvote">Set inn GCVote…</string>
     <string name="log_posting_image">Set inn mynd…</string>
     <string name="log_posting_generic_trackable">Set inn %1$s %2$d/%3$d</string>
     <string name="log_clear">Hreinsa</string>

--- a/main/res/values-it/strings.xml
+++ b/main/res/values-it/strings.xml
@@ -1098,9 +1098,6 @@
     <string name="map_rotation">Rotazione mappa</string>
     <string name="map_hide">Nascondi</string>
     <string name="map_trail_show">Mostra traccia cronologia movimenti</string>
-    <string name="map_reset_linecolors">Ripristina i colori delle linee</string>
-    <string name="map_reset_linecolors_confirm">Vuoi ripristinare tutte le linee della mappa configurabili ai loro colori predefiniti?</string>
-    <string name="map_reset_linecolors_ok">Ripristino dei colori delle linee</string>
     <string name="map_dot_mode">Usa icone compatte</string>
     <string name="map_circles_show">Mostra area cache</string>
     <string name="map_mycaches_hide">Nascondi i tuoi cache o che hai trovato</string>

--- a/main/res/values-iw/strings.xml
+++ b/main/res/values-iw/strings.xml
@@ -84,7 +84,6 @@
     <string name="log_saving_and_uploading">מפרסם רישום ביומן ומעלה תמונה&#8230;</string>
     <string name="log_posting_log">מפרסם רישום ביומן&#8230;</string>
     <string name="log_posting_twitter">מפרסם ציוץ&#8230;</string>
-    <string name="log_posting_gcvote">מפרסם GCVote&#8230;</string>
     <string name="log_posting_image">מעלה תמונה&#8230;</string>
     <string name="log_posting_generic_trackable">מפרסם %1$s %2$d %3$d</string>
     <string name="log_clear">נקה</string>

--- a/main/res/values-ja/strings.xml
+++ b/main/res/values-ja/strings.xml
@@ -89,7 +89,6 @@
     <string name="log_saving_and_uploading">ログを投稿し、画像をアップロード中…</string>
     <string name="log_posting_log">ログを投稿中…</string>
     <string name="log_posting_twitter">ツイートを投稿中…</string>
-    <string name="log_posting_gcvote">GCVoteを投稿中…</string>
     <string name="log_posting_image">画像を投稿中…</string>
     <string name="log_posting_generic_trackable">投稿中 %1$s %2$d/%3$d</string>
     <string name="log_clear">消去</string>
@@ -490,8 +489,6 @@
     <string name="init_summary_su">Geocaching.su からキャッシュをロード</string>
     <string name="settings_activate_su">有効化</string>
     <string name="init_gcvote_password_description">キャッシュを評価するためにGCVote.comにある指図を従ってここにGCVoteのパスワードを入力してください。</string>
-    <string name="err_gcvote_send_rating">評価の送信が失敗しました。設定でGCVoteのパスワードを確認してください。</string>
-    <string name="gcvote_sent">評価の送信が完了しました</string>
     <string name="settings_activate_twitter">有効化</string>
     <string name="init_login_popup">ログイン</string>
     <string name="init_login_popup_working">ログイン中…</string>
@@ -920,7 +917,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">%1$s からキャッシュをロード中</string>
     <string name="gpx_import_loading_waypoints_with_filename">%1$s からウェイポイントをロード中</string>
-    <string name="gpx_import_caches_imported_with_filename">%2$s から %1$d キャッシュをインポートしました</string>
     <string name="gpx_import_static_maps_skipped">オフライン用地図のダウンロードを中止しました</string>
     <string name="gpx_import_title_reading_file">ファイル読み込み中</string>
     <string name="gpx_import_title">GPXファイルをインポート</string>

--- a/main/res/values-ko/strings.xml
+++ b/main/res/values-ko/strings.xml
@@ -92,7 +92,6 @@
     <string name="log_saving_and_uploading">로그 및 사진 올리는 중…</string>
     <string name="log_posting_log">로그 올리는 중…</string>
     <string name="log_posting_twitter">트위터에 올리는 중…</string>
-    <string name="log_posting_gcvote">GCVote에 올리는 중…</string>
     <string name="log_posting_image">사진 올리는 중…</string>
     <string name="log_posting_generic_trackable">%1$s %2$d/%3$d 를 올리는 중</string>
     <string name="log_clear">지우기</string>
@@ -509,8 +508,6 @@
     <string name="init_summary_su">Geocaching.su 에서 캐시 불러오기</string>
     <string name="settings_activate_su">활성화</string>
     <string name="init_gcvote_password_description">캐시를 평가하려면, GCVote.com의 지시사항에 따른 후, GCVOte의 비밀번호를 여기 입력하세요.</string>
-    <string name="err_gcvote_send_rating">평가를 보내는중 오류발생. 설정에서 GCVote 비밀번호를 확인하거나 없애세요.</string>
-    <string name="gcvote_sent">투표가 성공적으로 송신됨</string>
     <string name="settings_activate_twitter">활성화</string>
     <string name="init_login_popup">로그인</string>
     <string name="init_login_popup_working">로그인 중…</string>
@@ -981,7 +978,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">%1$s 에서 캐시 불러오는 중</string>
     <string name="gpx_import_loading_waypoints_with_filename">%1$s 에서 웨이포인트 불러오는 중</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d 개의 캐시를 %2$s 에서 가져왔습니다.</string>
     <string name="gpx_import_static_maps_skipped">정적지도 다운로드가 중단됨</string>
     <string name="gpx_import_title_reading_file">파일 읽는 중</string>
     <string name="gpx_import_title">GPX 가져오기</string>

--- a/main/res/values-lt/strings.xml
+++ b/main/res/values-lt/strings.xml
@@ -84,7 +84,6 @@
     <string name="log_saving_and_uploading">Talpinamas įrašas ir įkeliamas paveiksliukas…</string>
     <string name="log_posting_log">Talpinamas įrašas…</string>
     <string name="log_posting_twitter">Skelbiamas Tweet…</string>
-    <string name="log_posting_gcvote">Skelbiama GCVote…</string>
     <string name="log_posting_image">Talpinamas vaizdas…</string>
     <string name="log_posting_generic_trackable">Talpinama %1$s %2$d/%3$d</string>
     <string name="log_clear">Išvalyti</string>
@@ -471,8 +470,6 @@
     <string name="init_summary_su">Įkelti slėptuves iš Geocaching.su</string>
     <string name="settings_activate_su">Aktyvuoti</string>
     <string name="init_gcvote_password_description">Kad būtų galima reitinguoti slėptuvę, sekite instrukciją GCVote.com svetainėje ir čia  įveskite GCVote slaptažodį.</string>
-    <string name="err_gcvote_send_rating">Klaida siunčiant reitingą, patikrinkite GCVote slaptažodį parametruose arba jį ištrinkite.</string>
-    <string name="gcvote_sent">Balsas sėkmingai išsiųstas</string>
     <string name="settings_activate_twitter">Aktyvuoti</string>
     <string name="init_login_popup">Prisijungti</string>
     <string name="init_login_popup_working">Jungiamasi…</string>
@@ -916,7 +913,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Įkeliamos slėptuvės nuo %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Įkeliami papildomi taškai nuo %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d slėptuvės importuotos iš %2$s</string>
     <string name="gpx_import_static_maps_skipped">Statinių žemėlapių atsisiuntimas nutrauktas</string>
     <string name="gpx_import_title_reading_file">Skaitomas failas</string>
     <string name="gpx_import_title">Importuoti GPX</string>

--- a/main/res/values-lv/strings.xml
+++ b/main/res/values-lv/strings.xml
@@ -84,7 +84,6 @@
     <string name="log_saving_and_uploading">Publicē ierakstu un augšupielādē attēlu…</string>
     <string name="log_posting_log">Publicē ierakstu…</string>
     <string name="log_posting_twitter">Publicē tvītu…</string>
-    <string name="log_posting_gcvote">Publicē GCVote…</string>
     <string name="log_posting_image">Publicē attēlu…</string>
     <string name="log_posting_generic_trackable">Publicē %1$s %2$d/%3$d</string>
     <string name="log_clear">Notīrīt</string>
@@ -439,8 +438,6 @@
     <string name="init_summary_su">Ielādēt slēpņus no Geocaching.su</string>
     <string name="settings_activate_su">Aktivizēt</string>
     <string name="init_gcvote_password_description">Lai spētu novērtēt slēpni, tev jāseko instrukcijām GCVote.com mājas lapā un jāievada sava GCVote parole šeit.</string>
-    <string name="err_gcvote_send_rating">Kļūda, nosūtot vērtējumu, pārbaudiet GCVote paroli iestatījumos vai izdzēsiet to.</string>
-    <string name="gcvote_sent">Balsojums veiksmīgi nosūtīts</string>
     <string name="settings_activate_twitter">Aktivizēt</string>
     <string name="init_login_popup">Pieteikšanās</string>
     <string name="init_login_popup_working">Piesakās sistēmā…</string>
@@ -829,7 +826,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Ielādē slēpņus no %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Ielādē starpposmus no %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">importēti %1$d slēpņi no %2$s</string>
     <string name="gpx_import_static_maps_skipped">Statisko karšu lejupielāde tika pārtraukta</string>
     <string name="gpx_import_title_reading_file">Faila lasīšana</string>
     <string name="gpx_import_title">GPX importēšana</string>

--- a/main/res/values-nb/strings.xml
+++ b/main/res/values-nb/strings.xml
@@ -88,7 +88,6 @@
     <string name="log_saving_and_uploading">Laster opp logg og bilde…</string>
     <string name="log_posting_log">Laster opp logg…</string>
     <string name="log_posting_twitter">Laster opp tweet…</string>
-    <string name="log_posting_gcvote">Laster opp GCVote…</string>
     <string name="log_posting_image">Laster opp bilde…</string>
     <string name="log_posting_generic_trackable">Logger %1$s %2$d/%3$d</string>
     <string name="log_clear">Tøm</string>
@@ -486,8 +485,6 @@
     <string name="init_summary_su">Last cacher fra Geocaching.su</string>
     <string name="settings_activate_su">Aktiver</string>
     <string name="init_gcvote_password_description">For å kunne vurdere en cache må du følge instruksjonene på GCVote.com og angi ditt GCVote passord her.</string>
-    <string name="err_gcvote_send_rating">Feil ved sending av vurdering. Sjekk at passordet for GCVote i innstillingene er riktig eller fjern passordet.</string>
-    <string name="gcvote_sent">Stemmegivning sendt</string>
     <string name="settings_activate_twitter">Aktiver</string>
     <string name="init_login_popup">Logg inn</string>
     <string name="init_login_popup_working">Logger inn på Geocaching.com…</string>
@@ -924,7 +921,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Laster cacher fra %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Laster veipunkter fra %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d cacher importert fra %2$s</string>
     <string name="gpx_import_static_maps_skipped">Nedlasting av statiske kart er avbrutt</string>
     <string name="gpx_import_title_reading_file">Leser fil</string>
     <string name="gpx_import_title">Importer GPX</string>

--- a/main/res/values-nl/strings.xml
+++ b/main/res/values-nl/strings.xml
@@ -1098,9 +1098,6 @@
     <string name="map_rotation">Kaart rotatie</string>
     <string name="map_hide">Verbergen</string>
     <string name="map_trail_show">Geschiedenisspoor tonen</string>
-    <string name="map_reset_linecolors">Lijnkleuren resetten</string>
-    <string name="map_reset_linecolors_confirm">Wil je alle configureerbare kaartlijnen resetten naar hun standaard kleuren?</string>
-    <string name="map_reset_linecolors_ok">Lijnkleuren gereset</string>
     <string name="map_dot_mode">Compacte iconen gebruiken</string>
     <string name="map_circles_show">Toon cirkels</string>
     <string name="map_mycaches_hide">Verberg eigen/gevonden caches</string>

--- a/main/res/values-pl/strings.xml
+++ b/main/res/values-pl/strings.xml
@@ -92,7 +92,6 @@
     <string name="log_saving_and_uploading">Wysyłanie wpisu i obrazu…</string>
     <string name="log_posting_log">Wysyłanie wpisu…</string>
     <string name="log_posting_twitter">Wysyłanie tweetu…</string>
-    <string name="log_posting_gcvote">Wysyłanie GCVote…</string>
     <string name="log_posting_image">Wysyłanie obrazka…</string>
     <string name="log_posting_generic_trackable">Wysyłanie %1$s %2$d/%3$d</string>
     <string name="log_clear">Wyczyść</string>
@@ -506,8 +505,6 @@
     <string name="init_summary_su">Załaduj skrzynki z Geocaching.su</string>
     <string name="settings_activate_su">Aktywuj</string>
     <string name="init_gcvote_password_description">Aby móc oceniać skrzynki, należy postępować zgodnie z instrukcjami zawartymi na  GCVote.com i podać swoje hasło do serwisu tutaj.</string>
-    <string name="err_gcvote_send_rating">Błąd podczas wysyłania oceny, sprawdź swoje hasło do GCVote w ustawieniach albo wyczyść je.</string>
-    <string name="gcvote_sent">Głos pomyślnie oddany</string>
     <string name="settings_activate_twitter">Aktywuj</string>
     <string name="init_login_popup">Nazwa użytkownika</string>
     <string name="init_login_popup_working">Logowanie…</string>
@@ -999,7 +996,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Ładowanie skrzynek z %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Ładowanie punktów orientacyjnych z %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d skrzynek zostało importowane z %2$s</string>
     <string name="gpx_import_static_maps_skipped">Pobieranie map statycznych wstrzymane</string>
     <string name="gpx_import_title_reading_file">Czytanie pliku</string>
     <string name="gpx_import_title">Importuj GPX</string>

--- a/main/res/values-ro/strings.xml
+++ b/main/res/values-ro/strings.xml
@@ -82,7 +82,6 @@
     <string name="log_saving_and_uploading">Se publică însemnarea şi imaginea…</string>
     <string name="log_posting_log">Se publică însemnarea…</string>
     <string name="log_posting_twitter">Se publică tweet…</string>
-    <string name="log_posting_gcvote">Se publică GCVote…</string>
     <string name="log_posting_image">Se publică imaginea…</string>
     <string name="log_posting_generic_trackable">Postare %1$s %2$d/%3$d</string>
     <string name="log_clear">Şterge</string>
@@ -413,8 +412,6 @@
     <string name="init_summary_su">Încarcă geocutii de la Geocaching.su</string>
     <string name="settings_activate_su">Activează</string>
     <string name="init_gcvote_password_description">Pentru a putea evalua o geocutie, trebuie să urmezi instrucţiunile de la GCVote.com şi să introduci aici parola GCVote.</string>
-    <string name="err_gcvote_send_rating">Eroare la trimiterea evaluării, verifică-ţi parola GCVote din configuraţie sau şterge această parolă.</string>
-    <string name="gcvote_sent">Votul a fost trimis</string>
     <string name="settings_activate_twitter">Activează</string>
     <string name="init_login_popup">Autentificare</string>
     <string name="init_login_popup_working">Autentificare în curs…</string>
@@ -789,7 +786,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Se încarcă geocutiile din %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Se încarcă punctele din %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d geocutii importate din %2$s</string>
     <string name="gpx_import_static_maps_skipped">Descărcarea hărţilor statice a fost anulată</string>
     <string name="gpx_import_title_reading_file">Citire fişier</string>
     <string name="gpx_import_title">Importă GPX</string>

--- a/main/res/values-ru/strings.xml
+++ b/main/res/values-ru/strings.xml
@@ -92,7 +92,6 @@
     <string name="log_saving_and_uploading">Отправка записи и загрузка изображения…</string>
     <string name="log_posting_log">Отправка записи…</string>
     <string name="log_posting_twitter">Отправка твита…</string>
-    <string name="log_posting_gcvote">Отправка GCVote…</string>
     <string name="log_posting_image">Отправка изображения…</string>
     <string name="log_posting_generic_trackable">Отправка %1$s %2$d/%3$d</string>
     <string name="log_clear">Очистить</string>
@@ -512,8 +511,6 @@
     <string name="init_summary_su">Загрузить тайники с Geocaching.su</string>
     <string name="settings_activate_su">Активировать</string>
     <string name="init_gcvote_password_description">Чтобы оценивать тайники, вам необходимо проследовать инструкциям на GCVote.com и ввести здесь ваш пароль GCVote.</string>
-    <string name="err_gcvote_send_rating">Ошибка при отправке оценки, проверьте ваш GCVote пароль в настройках.</string>
-    <string name="gcvote_sent">Оценка успешно отправлена</string>
     <string name="settings_activate_twitter">Активировать</string>
     <string name="init_login_popup">Вход</string>
     <string name="init_login_popup_working">Выполняется вход</string>
@@ -1005,7 +1002,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Загрузка тайников из %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Загрузка файла точек из %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d тайника (-ов) импортировано из %2$s</string>
     <string name="gpx_import_static_maps_skipped">Загрузка статических карт прервана</string>
     <string name="gpx_import_title_reading_file">Чтение файла</string>
     <string name="gpx_import_title">Импортировать GPX</string>

--- a/main/res/values-sk/strings.xml
+++ b/main/res/values-sk/strings.xml
@@ -1116,9 +1116,6 @@
     <string name="map_rotation">Otáčanie mapy</string>
     <string name="map_hide">Skryť</string>
     <string name="map_trail_show">Zobraziť históriu trasy</string>
-    <string name="map_reset_linecolors">Obnoviť farby čiar</string>
-    <string name="map_reset_linecolors_confirm">Chcete obnoviť všetky predvolené nastaviteľné čiary na mape?</string>
-    <string name="map_reset_linecolors_ok">Farby čiar obnovené</string>
     <string name="map_dot_mode">Použiť kompaktné ikony</string>
     <string name="map_circles_show">Zobraziť kruhy</string>
     <string name="map_mycaches_hide">Skryť vlastné/nájdené skrýše</string>

--- a/main/res/values-sl/strings.xml
+++ b/main/res/values-sl/strings.xml
@@ -83,7 +83,6 @@
     <string name="log_saving_and_uploading">Pošiljam zapis in nalagam sliko…</string>
     <string name="log_posting_log">Pošiljam zapis…</string>
     <string name="log_posting_twitter">Pošiljam na Twitter…</string>
-    <string name="log_posting_gcvote">Pošiljam na GCVote…</string>
     <string name="log_posting_image">Nalagam sliko…</string>
     <string name="log_clear">Počisti</string>
     <string name="log_post_not_possible">Prenos podatkov je v teku…\nPoskusite znova čez nekaj sekund ali preverite vašo povezavo z internetom.</string>

--- a/main/res/values-tl/strings.xml
+++ b/main/res/values-tl/strings.xml
@@ -85,7 +85,6 @@
     <string name="log_saving_and_uploading">Pagsulat ng mensahe at pag-upload ng imahe&#8230;</string>
     <string name="log_posting_log">Ang pag-post ng log&#8230;</string>
     <string name="log_posting_twitter">Ang pag-post ng tweet&#8230;</string>
-    <string name="log_posting_gcvote">Ang pag-post ng GCvote&#8230;</string>
     <string name="log_posting_image">Ang pag-post ng imahe&#8230;</string>
     <string name="log_posting_generic_trackable">Ang pag-popost ay %1$s%2$d%3$d</string>
     <string name="log_clear">Malinaw</string>
@@ -423,8 +422,6 @@
     <string name="init_summary_su">Mag-load ng mga caches mula sa geocaching.su</string>
     <string name="settings_activate_su">Gawing aktibo</string>
     <string name="init_gcvote_password_description">Para maaaring markahan ang cache, kailangan mong sumunod sa mga pagtuturo na nasa GCVote.com at ipasok ang iyong GCVote password dito.</string>
-    <string name="err_gcvote_send_rating">May maling nangyari habang ipinapadala ang marka, suriin ang GCVote password na nasa mga setting o burahin ito.</string>
-    <string name="gcvote_sent">Matagumpay na naipadala ang iyong pagboto</string>
     <string name="settings_activate_twitter">Gawing aktibo</string>
     <string name="init_login_popup">Mag-login</string>
     <string name="init_login_popup_working">Naglo-login na&#8230;</string>
@@ -789,7 +786,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Ang nag-loloading na mga caches sa %1$s</string>
     <string name="gpx_import_loading_waypoints_with_filename">Ang pag-loading a mga waypoints mula sa %1$s</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d na mga cache ay inangkat mula sa %2$s</string>
     <string name="gpx_import_static_maps_skipped">Ang pagdownload sa istatik na mapa ay naiurong</string>
     <string name="gpx_import_title_reading_file">Bumabasa na file</string>
     <string name="gpx_import_title">I-angkat ang GPX</string>

--- a/main/res/values-tr/strings.xml
+++ b/main/res/values-tr/strings.xml
@@ -92,7 +92,6 @@
     <string name="log_saving_and_uploading">Kayıt gönderiliyor ve görüntü yükleniyor…</string>
     <string name="log_posting_log">Kayıt gönderiliyor…</string>
     <string name="log_posting_twitter">Tweet gönderiliyor…</string>
-    <string name="log_posting_gcvote">GCVote gönderiliyor…</string>
     <string name="log_posting_image">Resim gönderiliyor…</string>
     <string name="log_posting_generic_trackable">Gönderiliyor %1$s %2$d/%3$d</string>
     <string name="log_clear">Temizle</string>
@@ -500,8 +499,6 @@
     <string name="init_summary_su">Geocaching.su üzerinden Geocache\'leri yükle</string>
     <string name="settings_activate_su">Etkinleştir</string>
     <string name="init_gcvote_password_description">Bir Geocache\'i derecelendirmek için GCVote.com\'daki talimatları takip etmeniz ve buraya GCVote şifrenizi girmeniz gereklidir.</string>
-    <string name="err_gcvote_send_rating">Derecelendirme gönderilirken hata, ayarlardan GCVote şifresini kontrol edin veya şifreyi boş bırakın.</string>
-    <string name="gcvote_sent">Oylama başarıyla gönderildi</string>
     <string name="settings_activate_twitter">Etkinleştir</string>
     <string name="init_login_popup">Oturum açma</string>
     <string name="init_login_popup_working">Oturum açılıyor…</string>
@@ -970,7 +967,6 @@
     <!-- gpx -->
     <string name="gpx_import_loading_caches_with_filename">Geocache\'ler %1$s\'den yükleniyor</string>
     <string name="gpx_import_loading_waypoints_with_filename">Yol noktaları %1$s\'den yükleniyor</string>
-    <string name="gpx_import_caches_imported_with_filename">%1$d Geocache %2$s\'den içe aktarıldı</string>
     <string name="gpx_import_static_maps_skipped">Statik haritaların indirilmesi iptal edildi</string>
     <string name="gpx_import_title_reading_file">Dosya okunuyor</string>
     <string name="gpx_import_title">GPX\'i İçe Aktar</string>


### PR DESCRIPTION
Remove a couple of translation string which are no longer in use, but haven't been removed automatically by crowdin update yet. This is not a problem per se, and removing them does not change the resulting apk, but erases some warnings during compilation.