### PR TITLE
remove duplicated calls to clearIndividualRoute

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -896,9 +896,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 new TrailHistoryExport(activity, this::clearTrailHistory);
                 return true;
             }
-            case R.id.menu_clear_individual_route:
-                clearIndividualRoute();
-                return true;
             case R.id.menu_hint:
                 menuShowHint();
                 return true;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -479,9 +479,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 new TrailHistoryExport(this, this::clearTrailHistory);
                 return true;
             }
-            case R.id.menu_clear_individual_route:
-                clearIndividualRoute();
-                return true;
             case R.id.menu_hint:
                 menuShowHint();
                 return true;


### PR DESCRIPTION
PR #8732 should have gone to release instead of master. Try to cherry-pick that commit and add it to release, as it is a prerequisite for #8739.

@Lineflyer 
Will that work? Or will we get a branch conflict anyway?
Or do I need to do a revert on #8732 on master first, then commit this PR to release?