### PR TITLE
fix pressing cancel in ColorpickerPreference

### DIFF
--- a/main/src/cgeo/geocaching/settings/ColorpickerPreference.java
+++ b/main/src/cgeo/geocaching/settings/ColorpickerPreference.java
@@ -203,7 +203,8 @@ public class ColorpickerPreference extends DialogPreference {
 
     @Override
     protected void onSetInitialValue(final boolean restoreValue, final Object defaultValue) {
-        setValue(restoreValue ? getPersistedInt(defaultColor) : (Integer) defaultValue);
+        color = restoreValue ? getPersistedInt(defaultColor) : (Integer) defaultValue;
+        setValue(color);
     }
 
     public void setValue(final int value) {


### PR DESCRIPTION
Aims to fix https://github.com/cgeo/cgeo/pull/8720#issuecomment-668019749

Error cause seems to be a wrong preset of the `originalColor` value, so we now set it manually on startup.