### PR TITLE
show warning on loading empty track (fix #8686)

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXTrackImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXTrackImporter.java
@@ -29,14 +29,16 @@ public class GPXTrackImporter {
         AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
             try {
                 final TrackUtils.Tracks value = doInBackground(file);
-                success.set(null != value);
-                AndroidSchedulers.mainThread().createWorker().schedule(() -> {
-                    try {
-                        callback.updateTracks(value);
-                    } catch (final Throwable t) {
-                        //
-                    }
-                });
+                success.set(null != value && value.getSize() > 0);
+                if (success.get()) {
+                    AndroidSchedulers.mainThread().createWorker().schedule(() -> {
+                        try {
+                            callback.updateTracks(value);
+                        } catch (final Throwable t) {
+                            //
+                        }
+                    });
+                }
             } catch (final Exception e) {
                 //
             }


### PR DESCRIPTION
Emit warning "error loading track" on loading either an empty track or an GPX route file.
Remove current track only on successfully loading a new track.