### PR TITLE
introduce [OFFLINENUM]

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -565,6 +565,7 @@
     <string name="init_signature_template_datetime">Date &amp; Time</string>
     <string name="init_signature_template_user">User</string>
     <string name="init_signature_template_number">Number</string>
+    <string name="init_signature_template_offlinenum">Number (offline support)</string>
     <string name="init_signature_template_owner">Owner</string>
     <string name="init_signature_template_name">Name</string>
     <string name="init_signature_template_difficulty">Difficulty</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -565,7 +565,6 @@
     <string name="init_signature_template_datetime">Date &amp; Time</string>
     <string name="init_signature_template_user">User</string>
     <string name="init_signature_template_number">Number</string>
-    <string name="init_signature_template_offlinenum">Number (offline support)</string>
     <string name="init_signature_template_owner">Owner</string>
     <string name="init_signature_template_name">Name</string>
     <string name="init_signature_template_difficulty">Difficulty</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -28,6 +28,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
@@ -149,6 +150,7 @@ public class MainActivity extends AbstractActionBarActivity {
                             userInfo.append(conn.getUserName());
                             if (conn.getCachesFound() >= 0) {
                                 userInfo.append(" (").append(conn.getCachesFound()).append(')');
+                                FoundNumCounter.updateFoundNum(conn.getName(), conn.getCachesFound());
                             }
                             userInfo.append(Formatter.SEPARATOR);
                             activity.checkLoggedIn();

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -25,6 +25,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.twitter.Twitter;
 import cgeo.geocaching.ui.AbstractViewHolder;
 import cgeo.geocaching.ui.dialog.DateDialog;
@@ -673,6 +674,11 @@ public class LogCacheActivity extends AbstractLoggingActivity implements DateDia
     private void sendLogInternal() {
         new Poster(this, res.getString(R.string.log_saving)).execute(currentLogText(), currentLogPassword());
         Settings.setLastCacheLog(currentLogText());
+
+        final IConnector cacheConnector = ConnectorFactory.getConnector(cache);
+        if (cacheConnector instanceof ILogin && ((ILogin) cacheConnector).isLoggedIn() && ((ILogin) cacheConnector).getCachesFound() >= 0) {
+            FoundNumCounter.updateFoundNum(((ILogin) cacheConnector).getName(), ((ILogin) cacheConnector).getCachesFound());
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/log/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/log/LogTemplateProvider.java
@@ -7,6 +7,8 @@ import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.utils.Formatter;
 
 import androidx.annotation.NonNull;
@@ -160,6 +162,33 @@ public final class LogTemplateProvider {
                 return getCounter(context, true);
             }
         });
+
+        templates.add(new LogTemplate("OFFLINENUM", R.string.init_signature_template_offlinenum) {
+
+            @Override
+            public String getValue(final LogContext context) {
+                final Geocache cache = context.getCache();
+                if (cache == null) {
+                    return StringUtils.EMPTY;
+                }
+                long counter;
+                final String onlineNum = getCounter(context, true);
+                final IConnector connector = ConnectorFactory.getConnector(cache);
+
+                if (onlineNum.equals(StringUtils.EMPTY)) {
+                    final FoundNumCounter f = FoundNumCounter.load(connector.getName());
+                    if (f == null) {
+                        return StringUtils.EMPTY;
+                    }
+                    counter = f.getCounter(true);
+                } else {
+                    counter = Long.parseLong(onlineNum);
+                }
+                counter += DataStore.getFoundsOffline(connector.getName());
+                return String.valueOf(counter);
+            }
+        });
+
         templates.add(new LogTemplate("OWNER", R.string.init_signature_template_owner) {
 
             @Override

--- a/main/src/cgeo/geocaching/log/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/log/LogTemplateProvider.java
@@ -159,14 +159,6 @@ public final class LogTemplateProvider {
 
             @Override
             public String getValue(final LogContext context) {
-                return getCounter(context, true);
-            }
-        });
-
-        templates.add(new LogTemplate("OFFLINENUM", R.string.init_signature_template_offlinenum) {
-
-            @Override
-            public String getValue(final LogContext context) {
                 final Geocache cache = context.getCache();
                 if (cache == null) {
                     return StringUtils.EMPTY;
@@ -188,7 +180,6 @@ public final class LogTemplateProvider {
                 return String.valueOf(counter);
             }
         });
-
         templates.add(new LogTemplate("OWNER", R.string.init_signature_template_owner) {
 
             @Override

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2828,7 +2828,8 @@ public class DataStore {
         int counter = 0;
 
         try {
-            final Cursor cursor = database.rawQuery("SELECT geocode FROM " + dbTableLogsOffline + " WHERE type = ?", new String[]{LogType.FOUND_IT.iconName});
+            final Cursor cursor = database.rawQuery("SELECT geocode FROM " + dbTableLogsOffline + " WHERE type = ? OR type = ? OR type = ?",
+                    new String[]{LogType.FOUND_IT.iconName, LogType.ATTENDED.iconName, LogType.WEBCAM_PHOTO_TAKEN.iconName});
             final Set<String> geocodes = cursorToColl(cursor, new HashSet<>(), GET_STRING_0);
 
             for (String geocode : geocodes) {

--- a/main/src/cgeo/geocaching/storage/extension/FoundNumCounter.java
+++ b/main/src/cgeo/geocaching/storage/extension/FoundNumCounter.java
@@ -1,0 +1,41 @@
+package cgeo.geocaching.storage.extension;
+
+import cgeo.geocaching.storage.DataStore;
+
+import androidx.annotation.Nullable;
+
+
+public class FoundNumCounter extends DataStore.DBExtension {
+
+    private static final DataStore.DBExtensionType type = DataStore.DBExtensionType.DBEXTENSION_FOUNDNUM;
+
+    private FoundNumCounter(final DataStore.DBExtension copyFrom) {
+        this.id = copyFrom.getId();
+        this.key = copyFrom.getKey();
+        this.long1 = copyFrom.getLong1();
+    }
+
+    public long getCounter(final boolean incrementCounter) {
+        return incrementCounter ? getLong1() + 1 : getLong1();
+    }
+
+    @Nullable
+    public static FoundNumCounter load(final String serviceName) {
+        final DataStore.DBExtension temp = load(type, serviceName);
+        return null == temp ? null : new FoundNumCounter(temp);
+    }
+
+    public static void updateFoundNum(final String serviceName, final int foundNum) {
+
+        //avoid recreation of same key/value pair
+        final FoundNumCounter f = load(serviceName);
+        if (f != null) {
+            if (f.getCounter(false) == foundNum) {
+                return;
+            }
+        }
+
+        removeAll(type, serviceName);
+        add(type, serviceName, foundNum, 0, "", "");
+    }
+}

--- a/main/src/cgeo/geocaching/storage/extension/FoundNumCounter.java
+++ b/main/src/cgeo/geocaching/storage/extension/FoundNumCounter.java
@@ -29,10 +29,8 @@ public class FoundNumCounter extends DataStore.DBExtension {
 
         //avoid recreation of same key/value pair
         final FoundNumCounter f = load(serviceName);
-        if (f != null) {
-            if (f.getCounter(false) == foundNum) {
-                return;
-            }
+        if (f != null && f.getCounter(false) == foundNum) {
+            return;
         }
 
         removeAll(type, serviceName);


### PR DESCRIPTION
fix #987 
fix https://github.com/cgeo/cgeo/pull/8603#issuecomment-668718020

It uses the `DBExtension` to store the found number for each geocaching service. The values will be updated each time the main activity is called and a connection to a geocaching service is established.

when the signature variable is used, all offlinelogs of the specific connector will be summed up added to the cached found number

For additional description see https://github.com/cgeo/cgeo/issues/987#issuecomment-669544510 