### PR TITLE
[related to Issue:#8787] shorten coordinates in PN Offline Waypoint storage

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointFormatter.java
+++ b/main/src/cgeo/geocaching/location/GeopointFormatter.java
@@ -26,6 +26,9 @@ public class GeopointFormatter {
         /** Example: "N 10° 12,345 · W 5° 12,345" */
         LAT_LON_DECMINUTE,
 
+        /** Example: "N10 12,345 W5 12,345" */
+        LAT_LON_DECMINUTE_SHORT,
+
         /** Example: "N 10° 12.345 W 5° 12.345" */
         LAT_LON_DECMINUTE_RAW,
 
@@ -89,6 +92,13 @@ public class GeopointFormatter {
             case LAT_LON_DECMINUTE: {
                 final Geopoint rgp = gp.roundedAt(60 * 1000);
                 return String.format(Locale.getDefault(), "%c %02d° %06.3f\'" + Formatter.SEPARATOR + "%c %03d° %06.3f\'",
+                        rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMinRaw(),
+                        rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
+            }
+
+            case LAT_LON_DECMINUTE_SHORT: {
+                final Geopoint rgp = gp.roundedAt(60 * 1000);
+                return String.format(Locale.getDefault(), "%c%d %06.3f %c%d %06.3f",
                         rgp.getLatDir(), rgp.getLatDeg(), rgp.getLatMinRaw(),
                         rgp.getLonDir(), rgp.getLonDeg(), rgp.getLonMinRaw());
             }

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.location.GeopointParser;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
@@ -497,12 +498,16 @@ public class Waypoint implements IWaypoint {
      */
     public String getParseableText(final boolean includeName, final int maxUserNoteSize) {
         final StringBuilder sb = new StringBuilder();
+        //name
         if (includeName) {
             sb.append(PARSING_NAME_PRAEFIX).append(this.getName()).append(" ");
         }
+        //type
         sb.append(PARSING_TYPE_OPEN).append(this.getWaypointType().getShortId().toUpperCase(Locale.US))
                 .append(PARSING_TYPE_CLOSE).append(" ");
-        sb.append(getCoords());
+        //coordinate
+        sb.append(getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT));
+        //user note
         if (maxUserNoteSize != 0 && !StringUtils.isBlank(getUserNote())) {
             String userNote = getUserNote();
             if (maxUserNoteSize > 0 && userNote.length() > maxUserNoteSize) {

--- a/tests/src-android/cgeo/geocaching/models/WaypointTest.java
+++ b/tests/src-android/cgeo/geocaching/models/WaypointTest.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.models;
 import cgeo.CGeoTestCase;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -145,13 +146,18 @@ public class WaypointTest extends CGeoTestCase {
         wp.setCoords(gp);
         wp.setUserNote("user note with \"escaped\" text");
         assertThat(wp.getParseableText(true, -1)).isEqualTo(
-                "@name (F) " + gp.toString() + "\n" +
+                "@name (F) " + toParseableWpString(gp) + "\n" +
                         "\"user note with \\\"escaped\\\" text\"");
 
         final Collection<Waypoint> parsedWaypoints = Waypoint.parseWaypoints(wp.getParseableText(true, -1), "Prefix");
         assertThat(parsedWaypoints).hasSize(1);
         final Iterator<Waypoint> iterator = parsedWaypoints.iterator();
         assertWaypoint(iterator.next(), wp);
+
+    }
+
+    private static String toParseableWpString(final Geopoint gp) {
+        return gp.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT);
 
     }
 
@@ -167,7 +173,7 @@ public class WaypointTest extends CGeoTestCase {
         final Collection<Waypoint> wpColl = new ArrayList<>();
         wpColl.add(wp1);
         wpColl.add(wp2);
-        final String gpStr = gp.toString();
+        final String gpStr = toParseableWpString(gp);
 
         assertThat(Waypoint.getParseableText(wpColl, 10, false)).isNull();
 
@@ -223,9 +229,9 @@ public class WaypointTest extends CGeoTestCase {
 
     public static void testGetAndReplaceExistingStoredWaypoints() {
         final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
-        final String gpStr = gp.toString();
+        final String gpStr = toParseableWpString(gp);
         final Geopoint gp2 = new Geopoint("N 45°49.745 E 9°45.038");
-        final String gp2Str = gp2.toString();
+        final String gp2Str = toParseableWpString(gp2);
 
         final String waypoints = "@wp1 (X) " + gpStr + "\n\"note\"\n@wp2 (F) " + gp2Str + "\n\"note2\"";
         final Collection<Waypoint> wps = Waypoint.parseWaypoints(waypoints, "Praefix");


### PR DESCRIPTION
when storing WPs in PN, generated coordinates are not shorter
Format before: N xx° xx.xxx' - E xxx° xx.xxx'
Format after: Nx xx.xxx Ex xx.xxx