### PR TITLE
change personal note edit size to minLines=8 (fix #8773)

### DIFF
--- a/main/res/layout/fragment_edit_note.xml
+++ b/main/res/layout/fragment_edit_note.xml
@@ -15,17 +15,20 @@
         android:layout_height="wrap_content"
         android:gravity="start"
         android:inputType="textMultiLine"
-        android:lines="8"
+        android:minLines="8"
         android:hint="@string/waypoint_note"
-        android:importantForAutofill="no"/>
+        android:importantForAutofill="no"
+        android:layout_weight="1"/>
 
     <View style="@style/action_bar_separator"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        android:layout_weight="0"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:layout_weight="0">
         <CheckBox
             android:id="@+id/preventWaypointsFromNote"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Currently personal note edit window is set to a fixed height of eight lines.

This PR changes this to start with a minimum of eight lines, but let the window increase in length on demand:

![image](https://user-images.githubusercontent.com/3754370/89822302-4170ce80-db50-11ea-9e59-515afeccb94d.png)

(Tricky part was to keep the bottom text and checkbox on screen even for very long texts - that's what the `layout_weight` lines are for.)