### PR TITLE
use themeing for ui.Dialog based dialogs to support colorAccent

### DIFF
--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -10,7 +10,6 @@ import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
@@ -18,6 +17,7 @@ import android.graphics.drawable.Drawable;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
+import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -67,7 +67,7 @@ public final class Dialogs {
      *            listener of the positive button
      */
     public static AlertDialog.Builder confirm(final Activity context, final String title, final String msg, final String positiveButton, final OnClickListener okayListener) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog.Builder builder = newBuilder(context);
         final AlertDialog dialog = builder.setTitle(title)
                 .setCancelable(true)
                 .setMessage(msg)
@@ -110,7 +110,7 @@ public final class Dialogs {
      *            listener of the positive button
      */
     public static AlertDialog.Builder confirmYesNo(final Activity context, final String title, final String msg, final OnClickListener yesListener) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog.Builder builder = newBuilder(context);
         final AlertDialog dialog = builder.setTitle(title)
                 .setCancelable(true)
                 .setMessage(msg)
@@ -249,7 +249,7 @@ public final class Dialogs {
                                                                      final OnClickListener positiveListener,
                                                                      final OnClickListener negativeListener,
                                                                      final OnClickListener neutralListener) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context)
+        final AlertDialog.Builder builder = newBuilder(context)
             .setTitle(title)
             .setCancelable(true)
             .setMessage(msg);
@@ -299,7 +299,7 @@ public final class Dialogs {
                                                                      final OnClickListener positiveListener,
                                                                      final OnClickListener negativeListener,
                                                                      final OnClickListener neutralListener) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog.Builder builder = newBuilder(context);
         final AlertDialog dialog = builder.setTitle(title)
                 .setCancelable(true)
                 .setMessage(msg)
@@ -327,7 +327,7 @@ public final class Dialogs {
      *            label for positive button
      */
     public static AlertDialog.Builder message(final Activity context, final String title, final String msg, final String positiveButton, final OnClickListener okayListener) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog.Builder builder = newBuilder(context);
         final AlertDialog dialog = builder.setTitle(title)
                 .setCancelable(true)
                 .setMessage(msg)
@@ -415,7 +415,7 @@ public final class Dialogs {
      *            observable (may be <tt>null</tt>) containing the icon(s) to set
      */
     public static void message(final Activity context, @Nullable final String title, final String message, @Nullable final Observable<Drawable> iconObservable) {
-        final Builder builder = new AlertDialog.Builder(context)
+        final AlertDialog.Builder builder = newBuilder(context)
                 .setMessage(message)
                 .setCancelable(true)
                 .setPositiveButton(getString(android.R.string.ok), null);
@@ -488,7 +488,7 @@ public final class Dialogs {
      *            listener of the neutral button
      */
     public static AlertDialog.Builder messageNeutral(final Activity context, final String msg, final int neutralTextButton, final OnClickListener neutralListener) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog.Builder builder = newBuilder(context);
         final AlertDialog dialog = builder.setMessage(msg)
                 .setPositiveButton(android.R.string.ok, null)
                 .setNeutralButton(neutralTextButton, neutralListener)
@@ -517,7 +517,7 @@ public final class Dialogs {
         input.setInputType(InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_CLASS_TEXT);
         input.setText(defaultValue);
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog.Builder builder = newBuilder(context);
         builder.setTitle(title);
         builder.setView(input);
         builder.setPositiveButton(buttonTitle, (dialog, which) -> okayListener.call(input.getText().toString()));
@@ -594,7 +594,7 @@ public final class Dialogs {
             }
         };
 
-        new AlertDialog.Builder(activity)
+        newBuilder(activity)
                 .setTitle(title)
                 .setAdapter(adapter, (dialog, item) -> listener.call(items.get(item))).show();
     }
@@ -630,7 +630,7 @@ public final class Dialogs {
             items[i] = cacheTypes.get(i).getL10n();
         }
 
-        final Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = newBuilder(activity);
         builder.setTitle(R.string.menu_filter);
         builder.setSingleChoiceItems(items, checkedItem, (dialog, position) -> {
             final CacheType cacheType = cacheTypes.get(position);
@@ -639,6 +639,10 @@ public final class Dialogs {
             dialog.dismiss();
         });
         builder.create().show();
+    }
+
+    private static AlertDialog.Builder newBuilder(final Activity activity) {
+        return new AlertDialog.Builder(new ContextThemeWrapper(activity, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert));
     }
 
 }


### PR DESCRIPTION
Several dialogs are based on `ui/Dialog.java`, which does not actively use a theme with the new `colorAccent`. This PR changes the dialogs to use the `Alert_Dialog` theme, which includes the new `colorAccent`. Two examples:

![image](https://user-images.githubusercontent.com/3754370/89832153-4db05800-db5f-11ea-8c2b-76d29f51043b.png) ![image](https://user-images.githubusercontent.com/3754370/89832206-5739c000-db5f-11ea-9e85-0925483ce1a0.png)
