### PR TITLE
direct logging of PM-only caches from search

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="err_detail_cache_find_any">c:geo can\'t find any geocaches.</string>
     <string name="err_detail_no_spoiler">c:geo found no spoiler images for this cache.</string>
     <string name="err_detail_still_working">Still working on another task.</string>
+    <string name="err_detail_premium_log_found">This Cache is only available to Geocaching.com Premium Members. Therefore the cache details could not be downloaded. \n\nIf you have already found the cache, you can log it here.</string>
     <string name="err_watchlist_still_managing">Still managing your watchlist.</string>
     <string name="err_watchlist_failed">Changing your watchlist failed.</string>
     <string name="err_application_no">c:geo can\'t find any suitable application.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="err_detail_cache_find_any">c:geo can\'t find any geocaches.</string>
     <string name="err_detail_no_spoiler">c:geo found no spoiler images for this cache.</string>
     <string name="err_detail_still_working">Still working on another task.</string>
-    <string name="err_detail_premium_log_found">This Cache is only available to Geocaching.com Premium Members. Therefore the cache details could not be downloaded. \n\nIf you have already found the cache, you can log it here.</string>
+    <string name="err_detail_premium_log_found">This cache is only available to premium members of geocaching.com.\nTherefore, the cache information cannot be displayed.\n\nHowever, if you have already found this cache, you can log it here.</string>
     <string name="err_watchlist_still_managing">Still managing your watchlist.</string>
     <string name="err_watchlist_failed">Changing your watchlist failed.</string>
     <string name="err_application_no">c:geo can\'t find any suitable application.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="err_detail_cache_find_any">c:geo can\'t find any geocaches.</string>
     <string name="err_detail_no_spoiler">c:geo found no spoiler images for this cache.</string>
     <string name="err_detail_still_working">Still working on another task.</string>
-    <string name="err_detail_premium_log_found">This cache is only available to premium members of geocaching.com.\nTherefore, the cache information cannot be displayed.\n\nHowever, if you have already found this cache, you can log it here.</string>
+    <string name="err_detail_premium_log_found">This cache is only available to premium members of geocaching.com. Therefore, the cache information cannot be displayed.\n\nHowever, if you have already found this cache, you can log it here.</string>
     <string name="err_watchlist_still_managing">Still managing your watchlist.</string>
     <string name="err_watchlist_failed">Changing your watchlist failed.</string>
     <string name="err_application_no">c:geo can\'t find any suitable application.</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -39,6 +39,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.log.CacheLogsViewCreator;
+import cgeo.geocaching.log.LogCacheActivity;
 import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
@@ -855,9 +856,20 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     final StatusCode error = activity.search.getError();
                     final Resources res = activity.getResources();
                     final String toastPrefix = error != StatusCode.CACHE_NOT_FOUND ? res.getString(R.string.err_dwld_details_failed) + " " : "";
-                    activity.showToast(toastPrefix + error.getErrorString(res));
-                    dismissProgress();
-                    finishActivity();
+
+                    if (error == StatusCode.PREMIUM_ONLY) {
+                        Dialogs.confirm(activity, R.string.cache_status_premium, R.string.err_detail_premium_log_found, R.string.cache_menu_visit, (dialog, which) -> {
+                            activity.startActivity(LogCacheActivity.getLogCacheIntent(activity, null, activity.geocode));
+                            finishActivity();
+                        }, dialog -> finishActivity());
+
+                        dismissProgress();
+
+                    } else {
+                        activity.showToast(toastPrefix + error.getErrorString(res));
+                        dismissProgress();
+                        finishActivity();
+                    }
                     return;
                 }
 

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -98,6 +98,56 @@ public final class Dialogs {
     }
 
     /**
+     * Confirm using two buttons "yourText" and "Cancel", where both buttons have action listener.
+     *
+     * @param context
+     *            activity hosting the dialog
+     * @param title
+     *            dialog title
+     * @param msg
+     *            dialog message
+     * @param positiveButton
+     *            text of the positive button (which would typically be the OK button)
+     * @param okayListener
+     *            listener of the positive button
+     * @param cancelListener
+     *            listener of the negative button
+     */
+    public static AlertDialog.Builder confirm(final Activity context, final String title, final String msg, final String positiveButton, final OnClickListener okayListener, final DialogInterface.OnCancelListener cancelListener) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        final AlertDialog dialog = builder.setTitle(title)
+                .setCancelable(true)
+                .setOnCancelListener(cancelListener)
+                .setMessage(msg)
+                .setPositiveButton(positiveButton, okayListener)
+                .setNegativeButton(android.R.string.cancel, (dialog1, which) -> dialog1.cancel())
+                .create();
+        dialog.setOwnerActivity(context);
+        dialog.show();
+        return builder;
+    }
+
+    /**
+     * Confirm using two buttons "yourText" and "Cancel", where both buttons have action listener.
+     *
+     * @param context
+     *            activity hosting the dialog
+     * @param title
+     *            dialog title
+     * @param msg
+     *            dialog message
+     * @param positiveButton
+     *            text of the positive button (which would typically be the OK button)
+     * @param okayListener
+     *            listener of the positive button
+     * @param cancelListener
+     *            listener of the negative button
+     */
+    public static AlertDialog.Builder confirm(final Activity context, final int title, final int msg, final int positiveButton, final OnClickListener okayListener, final DialogInterface.OnCancelListener cancelListener) {
+        return confirm(context, getString(title), getString(msg), getString(positiveButton), okayListener, cancelListener);
+    }
+
+    /**
      * Confirm using two buttons "Yes" and "No", where "No" just closes the dialog.
      *
      * @param context


### PR DESCRIPTION
fix #2288

it shows folowing dialog when trying to load a PM cache as basic member instead of "c:geo failed to download cache details. This Cache is only available to Geocaching.com Premium Members."

![Screenshot (Aug 11, 2020 2 24 02 PM)](https://user-images.githubusercontent.com/64581222/89897762-d53dab80-dbdf-11ea-93b0-58494afdf5d0.png)
