### PR TITLE
use black map icon for map info preference in light mode

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -217,7 +217,7 @@
         <item name="settings_sdcard">@drawable/settings_sdcard_black</item>
         <item name="settings_backup">@drawable/settings_backup_black</item>
         <item name="settings_info_icon">@drawable/settings_info_icon_black</item>
-        <item name="settings_map_icon">@drawable/settings_map_white</item>
+        <item name="settings_map_icon">@drawable/settings_map_black</item>
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert_light</item>
     </style>


### PR DESCRIPTION
In light mode the map icon for "Download offline map" setting is barely readable - should be the black variant instead:

![image](https://user-images.githubusercontent.com/3754370/90279942-64f68a80-de6a-11ea-966c-37fbf62a70c0.png) ![image](https://user-images.githubusercontent.com/3754370/90279967-6d4ec580-de6a-11ea-8b21-078f3a00d288.png)


