### PR TITLE
BuildCacheConfiguration.local(Class, Action) method has been deprecated

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ include ':cgeo-contacts'
 // Configure the built-in local build cache to a pre-defined directory.
 // Gradle will periodically clean-up by removing entries that have not been used recently
 buildCache {
-    local(DirectoryBuildCache) {
+    local() {
         directory = new File(rootDir, 'build-cache')
         removeUnusedEntriesAfterDays = 30
     }


### PR DESCRIPTION
Fix this deprecation problem:
~~~
>gradlew help --warning-mode all
The BuildCacheConfiguration.local(Class, Action) method has been deprecated.
This is scheduled to be removed in Gradle 7.0.
Please use the local(Action) method instead.
Consult the upgrading guide for further information:
https://docs.gradle.org/6.6/userguide/upgrading_version_5.html#local_build_cache_is_always_a_directory_cache
        at settings_345qrx4yukxdtqjjxixz57t1j$_run_closure1.doCall(...\cgeo\settings.gradle:20)
~~~