### PR TITLE
Update external references, configuration

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -54,11 +54,14 @@ android {
 
 dependencies {
     // Apache Commons
+    implementation 'org.apache.commons:commons-lang3:3.10'
+    // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
+    // could be replaced by Storage Access Framework
+    //noinspection GradleDependency
     implementation 'commons-io:commons-io:2.5'
-    implementation 'org.apache.commons:commons-lang3:3.5'
 
     // Support Library AppCompat
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 
     // Android annotations
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -284,8 +284,9 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 
     // Leak Canary, memory leak detection
-    def leakCanaryVersion = '2.3'
+    def leakCanaryVersion = '2.4'
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
+    implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
 
     // Locus Maps integration
     //noinspection GradleDependency
@@ -326,11 +327,11 @@ dependencies {
     implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation 'io.reactivex.rxjava3:rxjava:3.0.4'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.5'
     implementation "io.reactivex.rxjava3:rxandroid:3.0.0"
 
     // Support Library AppCompat
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 
     // Support Library ExifInterface
     implementation 'androidx.exifinterface:exifinterface:1.2.0'


### PR DESCRIPTION
- main
  - update dependencies
    - leakcanary to 2.4
    - rxjava to 3.0.5
    - appcompat to 1.2.0
  - add leakcanary:plumber-android, see https://square.github.io/leakcanary/changelog/#plumber-android-is-a-new-artifact-that-fixes-known-android-leaks

- cgeo-contacts
  - update dependencies
    - commons-lang3 to 3.10
	- (let commons-io stay at 2.5)
	- appcompat to 1.2.0

changed:
  - removed leakcanary-object-watcher-android, does not help for #8339
  - remove compileSdkVersion and targetSdkVersion to 29 according for c:geo contacts
