### PR TITLE
apply colorAccent for preferences using AppCompat theme

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -203,6 +203,7 @@
         <item name="settings_info_icon">@drawable/settings_info_icon_white</item>
         <item name="settings_map_icon">@drawable/settings_map_white</item>
         <item name="android:colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert</item>
     </style>
 
@@ -219,6 +220,7 @@
         <item name="settings_info_icon">@drawable/settings_info_icon_black</item>
         <item name="settings_map_icon">@drawable/settings_map_black</item>
         <item name="android:colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert_light</item>
     </style>
 


### PR DESCRIPTION
Tries to fix https://github.com/cgeo/cgeo/issues/8783#issuecomment-674456981 by adding colorAccent for themes using AppCompat attributes