### PR TITLE
add Android 11 notice about storage spaces

### DIFF
--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -4,6 +4,9 @@
   <string name="changelog_master" translatable="false"><Data><![CDATA[<div>
 <h1>Developer version:</h1>
 
+<h4>Android 11 notice:</h4>
+Android 11 enforces a new way for storing data, which c:geo does not support yet. If you switch your system to Android 11, c:geo will not be able to access part of its data. This will most likely disable storing offline maps, importing/exporting data as well as backing up/restoring c:geo\'s database. Other effects may occur. We recommend to not upgrade to Android 11 for the time being.
+
 <h4>Map:</h4>
 <ul>
 <li>New: Map downloader for OpenStreetMap offline maps (see map selector menu and settings - map)</li>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1616,6 +1616,7 @@
     <string name="status_geocaching_maintenance" tools:ignore="UnusedResources">geocaching.com is under maintenance.\nYou might run into various issues.</string>
     <string name="status_closeout_warning" tools:ignore="UnusedResources">You appear to be using an older version of Android. This version of c:geo is no longer compatible with your device and might fail or behave unexpectedly!\nTap on this message for further information.</string>
     <string name="status_version_deprecated" tools:ignore="UnusedResources">You are using a version of c:geo which seems to be older than one year. Some features may not work anymore due to website or other technical changes. Please read our FAQ on how to upgrade.</string>
+    <string name="status_android11notice" tools:ignore="UnusedResources">You appear to be using Android 11, which c:geo does not support fully yet. Please read our FAQ to get more info on this.</string>
 
     <!-- text-to-speech for compass view -->
     <string name="tts_service">Talking compass</string>

--- a/main/src/cgeo/geocaching/network/StatusUpdater.java
+++ b/main/src/cgeo/geocaching/network/StatusUpdater.java
@@ -43,6 +43,8 @@ public class StatusUpdater {
             new Status("", "status_closeout_warning", "attribute_abandonedbuilding", "https://www.cgeo.org/faq#legacy");
         private static final Status VERSION_DEPRECATED_STATUS =
             new Status("", "status_version_deprecated", "attribute_abandonedbuilding", "https://www.cgeo.org/faq");
+        private static final Status ANDROID11NOTICE_STATUS =
+            new Status("", "status_android11notice", "attribute_abandonedbuilding", "https://www.cgeo.org/faq#android11");
 
         public final String message;
         public final String messageId;
@@ -79,7 +81,7 @@ public class StatusUpdater {
             } catch (NumberFormatException e) {
                 // skip version check if no parseable number returned
             }
-            return Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? CLOSEOUT_STATUS : NO_STATUS;
+            return Build.VERSION.SDK_INT >= 30 ? ANDROID11NOTICE_STATUS : Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? CLOSEOUT_STATUS : NO_STATUS;
         }
     }
 


### PR DESCRIPTION
Android 11 enforces storage spaces for all apps targeted to API 29 (which by itself is an upcoming requirement by Play Store). c:geo does not yet support storage spaces, which will lead to some of its data not being accessible by c:geo if running on Android 11. See #8457 for details.

I propose to add a info notice to our changelog to inform users not to upgrade their system to Android 11 for now (or at least only if they can live with the consequences regarding c:geo):

![image](https://user-images.githubusercontent.com/3754370/90330040-15b77380-dfaa-11ea-87ba-86b99a7bade1.png)
