### PR TITLE
waypoint coordinate format stays on scrolling (fix #8795)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1200,7 +1200,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             // cache coordinates
             if (cache.getCoords() != null) {
                 final TextView valueView = details.add(R.string.cache_coordinates, cache.getCoords().toString()).right;
-                valueView.setOnClickListener(new CoordinatesFormatSwitcher(cache.getCoords()));
+                new CoordinatesFormatSwitcher().setView(valueView).setCoordinate(cache.getCoords());
                 addContextMenu(valueView);
             }
 
@@ -1952,8 +1952,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final TextView coordinatesView = holder.coordinatesView;
             final Geopoint coordinates = wpt.getCoords();
             if (coordinates != null) {
-                coordinatesView.setOnClickListener(new CoordinatesFormatSwitcher(coordinates));
-                coordinatesView.setText(coordinates.toString());
+                holder.setCoordinate(coordinates);
                 coordinatesView.setVisibility(View.VISIBLE);
             } else {
                 coordinatesView.setVisibility(View.GONE);

--- a/main/src/cgeo/geocaching/WaypointViewHolder.java
+++ b/main/src/cgeo/geocaching/WaypointViewHolder.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching;
 
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.ui.AbstractViewHolder;
+import cgeo.geocaching.ui.CoordinatesFormatSwitcher;
 
 import android.view.View;
 import android.widget.ImageView;
@@ -17,8 +19,16 @@ public class WaypointViewHolder extends AbstractViewHolder {
     @BindView(R.id.user_note) protected TextView userNoteView;
     @BindView(R.id.wpDefaultNavigation) protected ImageView wpNavView;
 
+    private CoordinatesFormatSwitcher coordinateFormatSwitcher;
+
     public WaypointViewHolder(final View rowView) {
         super(rowView);
+        this.coordinateFormatSwitcher = new CoordinatesFormatSwitcher().setView(this.coordinatesView);
+    }
+
+    public void setCoordinate(final Geopoint coordinate) {
+        this.coordinateFormatSwitcher.setCoordinate(coordinate);
+
     }
 
 }

--- a/main/src/cgeo/geocaching/ui/CoordinatesFormatSwitcher.java
+++ b/main/src/cgeo/geocaching/ui/CoordinatesFormatSwitcher.java
@@ -11,7 +11,7 @@ import android.widget.TextView;
  * view click listener to automatically switch different coordinate formats
  *
  */
-public class CoordinatesFormatSwitcher implements OnClickListener {
+public class CoordinatesFormatSwitcher {
 
     private static final GeopointFormatter.Format[] availableFormats = {
             GeopointFormatter.Format.LAT_LON_DECMINUTE,
@@ -21,19 +21,32 @@ public class CoordinatesFormatSwitcher implements OnClickListener {
     };
 
     private int position = 0;
+    private Geopoint coordinates;
+    private TextView view;
 
-    private final Geopoint coordinates;
-
-    public CoordinatesFormatSwitcher(final Geopoint coordinates) {
-        this.coordinates = coordinates;
+    public CoordinatesFormatSwitcher setView(final TextView view) {
+        this.view = view;
+        this.view.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(final View v) {
+                position = (position + 1) % availableFormats.length;
+                renderView();
+            }
+        });
+        renderView();
+        return this;
     }
 
-    @Override
-    public void onClick(final View view) {
-        position = (position + 1) % availableFormats.length;
-        final TextView textView = (TextView) view;
-        // rotate coordinate formats on click
-        textView.setText(coordinates.format(availableFormats[position]));
+    public CoordinatesFormatSwitcher setCoordinate(final Geopoint coordinate) {
+        this.coordinates = coordinate;
+        renderView();
+        return this;
+    }
+
+    private void renderView() {
+        if (this.view != null && this.coordinates != null) {
+            this.view.setText(coordinates.format(availableFormats[position]));
+        }
     }
 
 }


### PR DESCRIPTION
Stores the current setting of coordinate format in the waypoint list item view (transient)