### PR TITLE
fix #8833 (missing SafeVarargs in TextUtilsTest)

### DIFF
--- a/tests/src-android/cgeo/geocaching/utils/TextUtilsTest.java
+++ b/tests/src-android/cgeo/geocaching/utils/TextUtilsTest.java
@@ -175,6 +175,7 @@ public class TextUtilsTest extends TestCase {
 
     }
 
+    @SafeVarargs
     private static <T> void assertThatListIsEqual(final List<T> list, final T... expected) {
         assertThat(list.size()).isEqualTo(expected.length);
         int cnt = 0;


### PR DESCRIPTION
Fixes #8833 (missing SafeVarargs in TextUtilsTest)