### PR TITLE
fixes bugs in #8793: note edit popup window

### DIFF
--- a/main/src/cgeo/geocaching/ui/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/EditNoteDialog.java
@@ -9,6 +9,7 @@ import android.app.Dialog;
 import android.os.Bundle;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageButton;
@@ -47,6 +48,7 @@ public class EditNoteDialog extends DialogFragment {
 
         return dialog;
     }
+
 
     @Override
     @androidx.annotation.NonNull
@@ -92,6 +94,10 @@ public class EditNoteDialog extends DialogFragment {
         done.setVisibility(View.VISIBLE);
 
         new Keyboard(activity).showDelayed(mEditText);
+
+        //prevent popup window to extend under the virtual keyboard or above the top of phone display (see #8793)
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+
         return dialog;
     }
 }


### PR DESCRIPTION
Fixes bugs out of #8793 s reported by @fm-sys 
* headline of the personal note going out of range while editing when a lot of text is involved
* if started to edit somewhere in the upper half of the page, the last lines are covered by the keyboard

Issue should still stay open since it discusses introduction of a separate note window.