### PR TITLE
individual route polishing (fix #8830) (fix #8759)

### DIFF
--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -116,7 +116,7 @@ public class IndividualRouteExport {
                     final Geopoint point = loc.getPoint();
                     gpx.attribute(null, "lat", String.valueOf(point.getLatitude()));
                     gpx.attribute(null, "lon", String.valueOf(point.getLongitude()));
-                    XmlUtils.simpleText(gpx, null, "name", loc.getItem().getGeocode());
+                    XmlUtils.simpleText(gpx, null, "name", loc.getItem().getIdentifier());
                     gpx.endTag(null, "rtept");
                     countExported++;
                     publishProgress(countExported);

--- a/main/src/cgeo/geocaching/files/GPXIndividualRouteImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXIndividualRouteImporter.java
@@ -1,7 +1,7 @@
 package cgeo.geocaching.files;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.Route;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -52,21 +51,21 @@ public class GPXIndividualRouteImporter {
         }
         try {
             GPXIndividualRouteParser parser = new GPXIndividualRouteParser("http://www.topografix.com/GPX/1/1", "1.1");
-            ArrayList<RouteItem> routeItems = null;
+            Route route = null;
             try {
                 try {
-                    routeItems = parser.parse(stream);
+                    route = parser.parse(stream);
                 } catch (ParserException e) {
                     // retry with v1.0 format
                     parser = new GPXIndividualRouteParser("http://www.topografix.com/GPX/1/0", "1.0");
-                    routeItems = parser.parse(stream);
+                    route = parser.parse(stream);
                 }
             } catch (IOException | ParserException e) {
                 Log.e(e.getMessage());
             }
-            if (null != routeItems && routeItems.size() > 0) {
-                DataStore.saveRoute(routeItems);
-                return routeItems.size();
+            if (null != route && route.getNumSegments() > 0) {
+                DataStore.saveIndividualRoute(route);
+                return route.getNumSegments();
             }
         } finally {
             IOUtils.closeQuietly(stream);

--- a/main/src/cgeo/geocaching/files/GPXIndividualRouteParser.java
+++ b/main/src/cgeo/geocaching/files/GPXIndividualRouteParser.java
@@ -1,49 +1,38 @@
 package cgeo.geocaching.files;
 
-import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.RouteSegment;
 
-import android.sax.Element;
 import android.sax.RootElement;
-import android.util.Xml;
 
 import androidx.annotation.NonNull;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
-import org.xml.sax.SAXException;
-
-class GPXIndividualRouteParser {
-    protected final String namespace;
-    private final String version;
-    private final ArrayList<RouteItem> routeItems = new ArrayList<>();
+public class GPXIndividualRouteParser extends AbstractTrackOrRouteParser implements AbstractTrackOrRouteParser.RouteParse {
+    private String tempName = "";
 
     protected GPXIndividualRouteParser(final String namespaceIn, final String versionIn) {
-        namespace = namespaceIn;
-        version = versionIn;
+        super(namespaceIn, versionIn, true);
     }
 
     @NonNull
-    public ArrayList<RouteItem> parse(@NonNull final InputStream stream) throws IOException, ParserException {
+    public Route parse(@NonNull final InputStream stream) throws IOException, ParserException {
         final RootElement root = new RootElement(namespace, "gpx");
-        final Element route = root.getChild(namespace, "rte");
-        final Element routePoint = route.getChild(namespace, "rtept");
+        points = root.getChild(namespace, "rte");
+        point = points.getChild(namespace, "rtept");
 
-        routePoint.getChild(namespace, "name").setEndTextElementListener(body -> routeItems.add(new RouteItem(ConnectorFactory.canHandle(body) ? RouteItem.RouteItemType.GEOCACHE : RouteItem.RouteItemType.WAYPOINT, body)));
+        point.getChild(namespace, "name").setEndTextElementListener(body -> tempName = body);
+        point.setEndElementListener(() -> {
+            if (temp.size() > 0) {
+                result.add(new RouteSegment(new RouteItem(tempName, temp.get(temp.size() - 1)), temp));
+                temp = new ArrayList<>();
+            }
+        });
 
-        try {
-            final ProgressInputStream progressStream = new ProgressInputStream(stream);
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(progressStream, StandardCharsets.UTF_8));
-            Xml.parse(new InvalidXMLCharacterFilterReader(reader), root.getContentHandler());
-            return routeItems;
-        } catch (final SAXException e) {
-            throw new ParserException("Cannot parse .gpx file as GPX " + version + ": could not parse XML", e);
-        }
+        return super.parse(stream, root);
     }
-
 }

--- a/main/src/cgeo/geocaching/models/ManualRoute.java
+++ b/main/src/cgeo/geocaching/models/ManualRoute.java
@@ -34,7 +34,7 @@ public class ManualRoute extends Route {
             return;
         }
 
-        if (item.getType() == RouteItem.RouteItemType.WAYPOINT && item.getId() == -1) {
+        if (item.getType() == RouteItem.RouteItemType.WAYPOINT && item.getWaypointId() == -1) {
             Toast.makeText(context, R.string.individual_route_error_single_waypoint_mode, Toast.LENGTH_SHORT).show();
             return;
         }
@@ -65,7 +65,7 @@ public class ManualRoute extends Route {
 
     private synchronized void loadRouteInternal() {
         loadingRoute = true;
-        final ArrayList<RouteItem> routeItems = DataStore.loadRoute();
+        final ArrayList<RouteItem> routeItems = DataStore.loadIndividualRoute();
         for (int i = 0; i < routeItems.size(); i++) {
             toggleItemInternal(routeItems.get(i));
         }
@@ -74,16 +74,12 @@ public class ManualRoute extends Route {
 
     private synchronized void saveRoute() {
         if (segments != null) {
-            final ArrayList<RouteItem> routeItems = new ArrayList<>();
-            for (int i = 0; i < segments.size(); i++) {
-                routeItems.add(segments.get(i).getItem());
-            }
-            Schedulers.io().scheduleDirect(() -> DataStore.saveRoute(routeItems));
+            Schedulers.io().scheduleDirect(() -> DataStore.saveIndividualRoute(this));
         }
     }
     private void clearRouteInternal(final UpdateManualRoute routeUpdater, final boolean deleteInDatabase) {
         if (deleteInDatabase) {
-            Schedulers.io().scheduleDirect(DataStore::clearRoute);
+            Schedulers.io().scheduleDirect(DataStore::clearIndividualRoute);
         }
         segments = null;
         if (null != routeUpdater) {
@@ -119,15 +115,13 @@ public class ManualRoute extends Route {
         }
     }
 
-    // @todo: Only works for GEOCACHE and WAYPOINT items yet
     private int pos(final RouteItem item) {
         if (segments == null || segments.size() == 0) {
             return -1;
         }
-
-        final String geocode = item.getGeocode();
+        final String identifier = item.getIdentifier();
         for (int i = 0; i < segments.size(); i++) {
-            if (segments.get(i).getItem().getGeocode().equals(geocode)) {
+            if (segments.get(i).getItem().getIdentifier().equals(identifier)) {
                 return i;
             }
         }

--- a/main/src/cgeo/geocaching/models/RouteItem.java
+++ b/main/src/cgeo/geocaching/models/RouteItem.java
@@ -1,45 +1,113 @@
 package cgeo.geocaching.models;
 
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.MatcherWrapper;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
 public class RouteItem implements Parcelable {
-    private RouteItemType type;
-    private int id;
-    private String geocode;
+    // groups: 1=geocode, 3=wp prefix, 4=additional text
+    private static final Pattern GEOINFO_PATTERN = Pattern.compile("^([A-Za-z]{1,2}[0-9A-Za-z]{1,6})(-([A-Za-z0-9]{1,10}))?( .*)?$");
+
+    // only identifier and point are needed to identify a RouteItem
+    private String identifier;
     private Geopoint point;
+    // other values are for convenience and speed
+    private RouteItemType type;
+    private String cacheGeocode;
+    private int waypointId;
 
     public RouteItem(final IWaypoint item) {
         setDetails(item);
     }
 
     public RouteItem(final Geopoint point) {
-        setDetails(RouteItemType.COORDS, "COORD", 0, point);
+        setDetails(buildIdentifier(point), point, RouteItemType.COORDS, "", 0);
     }
 
-    // @todo: Can handle GEOCACHE and WAYPOINT only yet
-    public RouteItem(final RouteItemType type, final String geocode, final int id) {
-        setDetails(type, geocode, id, null);
+    // parse name info of GPX route point entry into RouteItem
+    public RouteItem(final String name, final Geopoint p) {
+
+        // init with default values
+        setDetails(buildIdentifier(p), p, RouteItemType.COORDS, "", 0);
+
+        // try to parse name string
+        final MatcherWrapper matches = new MatcherWrapper(GEOINFO_PATTERN, name);
+        if (matches.find()) {
+
+            // do we have a valid geocode, and a cache available for it?
+            final String temp = matches.group(1);
+            if (ConnectorFactory.canHandle(temp)) {
+                final Geocache cache = DataStore.loadCache(temp, LoadFlags.LOAD_CACHE_OR_DB);
+                if (null != cache) {
+                    cacheGeocode = temp;
+
+                    // if no waypoint data is available: stay with geocache
+                    if (matches.groupCount() < 3 || null == matches.group(3)) {
+                        setDetails(cache);
+                        return;
+                    }
+
+                    // try to extract waypoint data
+                    final String prefix = matches.group(3);
+                    if (StringUtils.isNotBlank(prefix)) {
+                        final List<Waypoint> waypoints = DataStore.loadWaypoints(cacheGeocode);
+                        if (null != waypoints && !waypoints.isEmpty()) {
+                            int counter = 0;
+                            Waypoint tempWaypoint = null;
+                            for (Waypoint waypoint : waypoints) {
+                                if (prefix.equals(waypoint.getPrefix())) {
+                                    tempWaypoint = waypoint;
+                                    counter++;
+                                }
+                            }
+                            if (counter == 1) {
+                                // unique prefix => use waypoint
+                                setDetails(tempWaypoint);
+                                return;
+                            } else if (counter > 1) {
+                                // for non-unique prefixes try to find a user-defined waypoint with the same coordinates
+                                for (Waypoint waypoint : waypoints) {
+                                    if (point.equalsDecMinute(waypoint.getCoords())) {
+                                        setDetails(waypoint);
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // else stay with defaults (=coords)
     }
 
-    // @todo: Can handle GEOCACHE and WAYPOINT only yet
-    public RouteItem(final RouteItemType type, final String geocode) {
-        setDetails(type, geocode, type == RouteItemType.GEOCACHE ? 0 : Integer.parseInt(geocode.substring(2)), null);
-    }
-
-    // @todo: Can handle GEOCACHE and WAYPOINT only yet
     public RouteItem(final GeoitemRef item) {
         switch (item.getType()) {
             case CACHE:
-                setDetails(RouteItemType.GEOCACHE, item.getGeocode(), 0, null);
+                final Geocache geocache = DataStore.loadCache(item.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);
+                if (null != geocache) {
+                    setDetails(buildIdentifier(geocache), geocache.getCoords(), RouteItemType.GEOCACHE, item.getGeocode(), 0);
+                } else {
+                    setDetails(item.getGeocode(), null, RouteItemType.GEOCACHE, item.getGeocode(), 0);
+                }
                 break;
             case WAYPOINT:
-                setDetails(RouteItemType.WAYPOINT, "WP" + item.getGeocode(), item.getId(), null);
+                final Waypoint waypoint = DataStore.loadWaypoint(item.getId());
+                if (null != waypoint) {
+                    setDetails(buildIdentifier(waypoint), waypoint.getCoords(), RouteItemType.WAYPOINT, item.getGeocode(), item.getId());
+                }
                 break;
             default:
                 throw new IllegalStateException("RouteItem: unknown item type");
@@ -50,12 +118,16 @@ public class RouteItem implements Parcelable {
         return type;
     }
 
-    public int getId() {
-        return id;
+    public int getWaypointId() {
+        return waypointId;
     }
 
     public String getGeocode() {
-        return geocode;
+        return cacheGeocode;
+    }
+
+    public String getIdentifier() {
+        return identifier;
     }
 
     public Geopoint getPoint() {
@@ -64,17 +136,18 @@ public class RouteItem implements Parcelable {
 
     private void setDetails(final IWaypoint item) {
         if (item instanceof Geocache) {
-            setDetails(RouteItemType.GEOCACHE, item.getGeocode(), 0, item.getCoords());
+            setDetails(buildIdentifier(item), item.getCoords(), RouteItemType.GEOCACHE, item.getGeocode(), 0);
         } else {
-            setDetails(RouteItemType.WAYPOINT, "WP" + item.getId(), item.getId(), item.getCoords());
+            setDetails(buildIdentifier(item), item.getCoords(), RouteItemType.WAYPOINT, item.getGeocode(), item.getId());
         }
     }
 
-    private void setDetails(final RouteItemType type, final String geocode, final int id, final Geopoint point) {
-        this.type = type;
-        this.geocode = geocode;
-        this.id = id;
+    private void setDetails(final String identifier, final Geopoint point, final RouteItemType type, final String geocode, final int waypointId) {
+        this.identifier = identifier;
         this.point = point;
+        this.type = type;
+        this.cacheGeocode = geocode;
+        this.waypointId = waypointId;
         checkForCoordinates();
     }
 
@@ -82,17 +155,29 @@ public class RouteItem implements Parcelable {
         if (null == point) {
             // try to load geocache/waypoint to get coords
             if (type == RouteItemType.GEOCACHE) {
-                final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+                final Geocache cache = DataStore.loadCache(cacheGeocode, LoadFlags.LOAD_CACHE_OR_DB);
                 if (cache != null) {
                     point = cache.getCoords();
                 }
-            } else if (type == RouteItemType.WAYPOINT && id > 0) {
-                final Waypoint waypoint = DataStore.loadWaypoint(id);
+            } else if (type == RouteItemType.WAYPOINT && waypointId > 0) {
+                final Waypoint waypoint = DataStore.loadWaypoint(waypointId);
                 if (waypoint != null) {
                     point = waypoint.getCoords();
                 }
             }
         }
+    }
+
+    private String buildIdentifier(final IWaypoint item) {
+        String name = item.getGeocode();
+        if (item instanceof Waypoint) {
+            name += "-" + ((Waypoint) item).getPrefix();
+        }
+        return name;
+    }
+
+    private String buildIdentifier(final Geopoint point) {
+        return "COORDS!" + (null == point ? "" : " " + GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT, point));
     }
 
     public enum RouteItemType {
@@ -118,10 +203,11 @@ public class RouteItem implements Parcelable {
     };
 
     private RouteItem(final Parcel parcel) {
-        type = RouteItemType.values()[parcel.readInt()];
-        id = parcel.readInt();
-        geocode = parcel.readString();
+        identifier = parcel.readString();
         point = parcel.readParcelable(Geopoint.class.getClassLoader());
+        type = RouteItemType.values()[parcel.readInt()];
+        cacheGeocode = parcel.readString();
+        waypointId = parcel.readInt();
     }
 
     @Override
@@ -131,10 +217,11 @@ public class RouteItem implements Parcelable {
 
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
-        dest.writeInt(type.ordinal());
-        dest.writeInt(id);
-        dest.writeString(geocode);
+        dest.writeString(identifier);
         dest.writeParcelable(point, flags);
+        dest.writeInt(type.ordinal());
+        dest.writeString(cacheGeocode);
+        dest.writeInt(waypointId);
     }
 
 }


### PR DESCRIPTION
- import individual route can import regular GPX route files
- change individual route point identifier to be database-independant / switch to waypoint prefix and coordinates
- change export of individual route to handle coordinate points
- adapt database structure accordingly and migrate existing data

Identifier for individual route waypoints are:
- for geocache: geocode
- for waypoint: geocode, "-", waypoint prefix
- for coords: "COORDS!" + coordinates
This identifier is stored into the GPX routepoint `name` field. `lat` and `lon` attributes are filled with the item's coordinates.