### PR TITLE
[Personal Note] Immediately activate keyboard on press of "edit"

### DIFF
--- a/main/src/cgeo/geocaching/ui/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/EditNoteDialog.java
@@ -93,6 +93,7 @@ public class EditNoteDialog extends DialogFragment {
         });
         done.setVisibility(View.VISIBLE);
 
+        mEditText.requestFocus();
         new Keyboard(activity).showDelayed(mEditText);
 
         //prevent popup window to extend under the virtual keyboard or above the top of phone display (see #8793)


### PR DESCRIPTION
fix #8774 - fixes bug that keyboard doesn't show up on newer API when clicking on [edit] Personal Note