### PR TITLE
remove dbversion 84 from downgradeables (leaving it empty for now)

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -210,7 +210,7 @@ public class DataStore {
      * * {@link DbHelper#onUpgrade(SQLiteDatabase, int, int)} will fail later if db is "upgraded" again from "x-1" to x
      */
     private static final Set<Integer> DBVERSIONS_DOWNWARD_COMPATIBLE = new HashSet<>(Arrays.asList(new Integer[]{
-            84 //adds offline logging columns/tables
+            //empty for now
     }));
 
     @NonNull private static final String dbTableCaches = "cg_caches";

--- a/main/src/cgeo/geocaching/storage/extension/DBDowngradeableVersions.java
+++ b/main/src/cgeo/geocaching/storage/extension/DBDowngradeableVersions.java
@@ -23,8 +23,12 @@ public class DBDowngradeableVersions extends DataStore.DBExtension {
     private DBDowngradeableVersions(final DataStore.DBExtension copyFrom) {
         try {
             for (String version : copyFrom.getString1().split(",")) {
-                final Integer vInt = Integer.parseInt(version);
-                downgradeableVersions.add(vInt);
+                try {
+                    final Integer vInt = Integer.parseInt(version);
+                    downgradeableVersions.add(vInt);
+                } catch (NumberFormatException nfe) {
+                    //can happen when string is completey empty in db, thus ignore
+                }
             }
         } catch (Exception e) {
             Log.w("Problems reading downgradeable versions from db ('" + copyFrom.getString1() + "'), aborting", e);


### PR DESCRIPTION
Fixing up: dbversion 84 is currently accidentally marked as downgradeable in master, shoudl be 85

Update: change to: remove dbversion 84 from downgradeables (leaving it empty for now)