### PR TITLE
extend logging info for failing logins (related to #8818)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -311,6 +311,8 @@ public class GCLogin extends AbstractLogin {
             setActualUserName(Settings.getUserName());
             // number of caches found is not part of this page
             return true;
+        } else {
+            Log.d("setLoginStatus: PATTERN_LOGIN_NAME_LOGIN_PAGE not matched, page is:\n" + page);
         }
 
         setActualStatus(CgeoApplication.getInstance().getString(R.string.init_login_popup_failed));


### PR DESCRIPTION
To get a grip on #8818 this PR adds a tiny bit of extra logging info to the `getLoginStatus()` method, as this is the last method being called before the mentioned error message is shown. Extra logging writes the received HTML page to the log in case `getLoginStatus()` is doomed to fail, to see whether our regular expression to retrieve the login name needs to be adapted. - As I cannot reproduce the error locally, this is sort of a blind guess (or reverse engineering) where the root for this error may lay.

Users have to activate debug info within c:geo to get this info written to the log. (I'm using `Log.d` in this case to not pollute the log.)