### PR TITLE
fix GPX export checkbox label (fix #8767)

### DIFF
--- a/main/res/layout/gpx_export_dialog.xml
+++ b/main/res/layout/gpx_export_dialog.xml
@@ -12,6 +12,5 @@
     <CheckBox
         android:id="@+id/include_found_status"
         style="@style/checkbox_full"
-        android:text="@string/export_trailhistory_clear_after_export" />
-
+        android:text="@string/init_include_found_status" />
 </LinearLayout>


### PR DESCRIPTION
With #8438 I accidentally changed the label of the second checkbox in the export caches list as GPX popup. This PR reverts the label to the original one.

![image](https://user-images.githubusercontent.com/3754370/90977502-3487ae00-e546-11ea-8f61-1f9f46e3a6dd.png)
