### PR TITLE
add info on BRouter availability to system information

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractViewPagerActivity;
+import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.ui.AbstractCachingPageViewCreator;
 import cgeo.geocaching.ui.AnchorAwareLinkMovementMethod;
@@ -281,6 +282,8 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState, R.layout.viewpager_activity);
 
+        Routing.connect(null);
+
         int startPage = Page.VERSION.ordinal();
         final Bundle extras = getIntent().getExtras();
         if (extras != null) {
@@ -288,6 +291,12 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
         }
         createViewPager(startPage, position -> setTitle(res.getString(R.string.about) + " - " + getTitle(Page.values()[position])));
         reinitializeViewPager();
+    }
+
+    @Override
+    protected void onDestroy() {
+        Routing.disconnect();
+        super.onDestroy();
     }
 
     public final void setClickListener(final View view, final String url) {

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.playservices.GooglePlayServices;
 import cgeo.geocaching.sensors.MagnetometerAndAccelerometerProvider;
 import cgeo.geocaching.sensors.OrientationProvider;
@@ -85,6 +86,7 @@ public final class SystemInformation {
             body.append("\nGeocaching.com date format: ").append(Settings.getGcCustomDate());
         }
         appendAddons(body);
+        body.append("\nBRouter connection available: ").append(Routing.isAvailable());
         body.append("\n--- End of system information ---\n");
         return body.toString();
     }


### PR DESCRIPTION
Coming from a discussion in #6280:
Add info to "about - system info" whether BRouter is available or not:

![image](https://user-images.githubusercontent.com/3754370/90978175-0016f080-e54c-11ea-8de0-47e13e5e1607.png)
