### PR TITLE
check for empty entries on loading individual route

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2616,7 +2616,7 @@ public class DataStore {
     public static ArrayList<RouteItem> loadIndividualRoute() {
         return queryToColl(dbTableRoute,
             new String[]{"id", "latitude", "longitude"},
-            null,
+            "id IS NOT NULL OR (latitude IS NOT NULL AND longitude IS NOT NULL)",
             null,
             "precedence ASC",
             null,


### PR DESCRIPTION
Part of fixing issue #8876 - make route loading more robust

Adds additional checks on loading individual route items:
- skip null entries
- if an entry has no/empty id string, resort to coordinates only
