### PR TITLE
move show history track checkbox to history track submenu (fix #8517)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -83,13 +83,6 @@
                 app:showAsAction="ifRoom|withText">
             </item>
             <item
-                android:id="@+id/menu_trail_mode"
-                android:checkable="true"
-                android:icon="@drawable/ic_menu_trail"
-                android:title="@string/map_trail_show"
-                app:showAsAction="ifRoom|withText">
-            </item>
-            <item
                 android:id="@+id/menu_compactIconMode"
                 android:icon="@drawable/ic_menu_dot_mode"
                 android:title="@string/map_dot_mode"
@@ -252,12 +245,20 @@
         android:title="@string/trailhistory">
         <menu>
             <item
-                android:id="@+id/menu_clear_trailhistory"
-                android:title="@string/map_clear_trailhistory">
+                android:id="@+id/menu_trail_show"
+                android:title="@string/map_trail_show">
             </item>
             <item
                 android:id="@+id/menu_export_trailhistory"
                 android:title="@string/export_trailhistory_title">
+            </item>
+            <item
+                android:id="@+id/menu_trail_hide"
+                android:title="@string/map_trail_hide">
+            </item>
+            <item
+                android:id="@+id/menu_clear_trailhistory"
+                android:title="@string/map_clear_trailhistory">
             </item>
         </menu>
     </item>
@@ -269,13 +270,13 @@
                 android:id="@+id/menu_load_track"
                 android:title="@string/map_load_track" />
             <item
-                android:id="@+id/menu_unload_track"
-                android:title="@string/map_unload_track"
-                android:visible="false"/>
-            <item
                 android:id="@+id/menu_center_on_track"
                 android:title="@string/center_on_track"
                 android:visible="false" />
+            <item
+                android:id="@+id/menu_unload_track"
+                android:title="@string/map_unload_track"
+                android:visible="false"/>
         </menu>
     </item>
     <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1205,7 +1205,6 @@
     <string name="map_modes">Map settings</string>
     <string name="map_rotation">Map rotation</string>
     <string name="map_hide">Hide</string>
-    <string name="map_trail_show">Show history track</string>
     <string name="map_dot_mode">Use compact icons</string>
     <string name="map_circles_show">Show circles</string>
     <string name="map_mycaches_hide">Hide own/found caches</string>
@@ -1225,8 +1224,6 @@
     <string name="map_live_enable">Enable live</string>
     <string name="map_live_disable">Disable live</string>
     <string name="map_as_list">Show as list</string>
-    <string name="map_clear_trailhistory">Clear history track</string>
-    <string name="map_trailhistory_cleared">History track cleared</string>
     <string name="map_select_multiple_items">Select item</string>
     <string name="map_routing">Routing</string>
     <string name="map_routing_straight">Straight line</string>
@@ -1903,7 +1900,13 @@
     <string name="download_started">Downloading started in background</string>
     <string name="downloadmap_target_not_writable">Target \"%s\" is not writable - please select a different map file directory.</string>
 
-    <!-- history trail export -->
+    <!-- history track -->
+    <string name="map_clear_trailhistory">Clear history track</string>
+    <string name="map_trailhistory_cleared">History track cleared</string>
+    <string name="map_trail_show">Show history track</string>
+    <string name="map_trail_hide">Hide history track</string>
+
+    <!-- history track export -->
     <string name="trailhistory">History track</string>
     <string name="export_trailhistory_title">Export history track</string>
     <string name="export_trailhistory_success">Exported history track to \"%s\"</string>

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -324,6 +324,12 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
     @Override
     public void repaintRequired(final GeneralOverlay overlay) {
         // FIXME add recheck/readd markers and overlay
+        if (null != positionAndHistoryRef) {
+            final PositionAndHistory positionAndHistory = positionAndHistoryRef.get();
+            if (null != positionAndHistory) {
+                positionAndHistory.repaintRequired();
+            }
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/utils/HistoryTrackUtils.java
+++ b/main/src/cgeo/geocaching/utils/HistoryTrackUtils.java
@@ -1,0 +1,61 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.export.TrailHistoryExport;
+import cgeo.geocaching.settings.Settings;
+
+import android.app.Activity;
+import android.view.Menu;
+
+public class HistoryTrackUtils {
+
+    protected HistoryTrackUtils() {
+        // utility class
+    }
+
+    /**
+     * Enable/disable history track related menu entries
+     * @param menu menu to be configured
+     */
+    public static void onPrepareOptionsMenu(final Menu menu) {
+        menu.findItem(R.id.menu_trail_show).setVisible(!Settings.isMapTrail());
+        menu.findItem(R.id.menu_trail_hide).setVisible(Settings.isMapTrail());
+    }
+
+    /**
+     * Check if selected menu entry is for "load track" or hide/unhide track
+     * @param activity calling activity
+     * @param id menu entry id
+     * @return true, if selected menu entry is track related and consumed / false else
+     */
+    public static boolean onOptionsItemSelected(final Activity activity, final int id, final Runnable redrawHistoryTrack, final Runnable clearTrailHistory) {
+        switch (id) {
+            case R.id.menu_trail_show:
+                Settings.setMapTrail(true);
+                redrawHistoryTrack.run();
+                ActivityMixin.invalidateOptionsMenu(activity);
+                return true;
+            case R.id.menu_trail_hide:
+                Settings.setMapTrail(false);
+                redrawHistoryTrack.run();
+                ActivityMixin.invalidateOptionsMenu(activity);
+                return true;
+            case R.id.menu_clear_trailhistory: {
+                clearTrailHistory.run();
+                return true;
+            }
+            case R.id.menu_export_trailhistory: {
+                new TrailHistoryExport(activity, clearTrailHistory);
+                return true;
+            }
+            default:
+                return false;
+        }
+    }
+
+
+
+
+
+}


### PR DESCRIPTION
- move show history track checkbox to history track submenu (as show/hide menu entries)
- extract common history track functions to `HistoryTrackUtils`
- fix enabling/disabling history track display on Google Maps
- unify menu entry order for history track, GPX track/route, individual route

menu entry order now is:
|history track|GPX track/route|individual route|
|-------------|---------------|----------------|
|show         |load           |load            |
|             |               |sort            |
|             |center         |center          |
|export       |               |export          |
|hide         |unload         |                |
|clear        |               |clear           |
