### PR TITLE
hide separator when personal note is empty

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -119,6 +119,7 @@
                 tools:text="Personal note text\nline 2\nline 3" />
 
             <View style="@style/separator_horizontal"
+                android:id="@+id/personalnote_button_separator"
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"/>
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1581,11 +1581,16 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             }
 
             // cache personal note
-            setPersonalNote(personalNoteView, cache.getPersonalNote());
+            final View separator = view.findViewById(R.id.personalnote_button_separator);
+            setPersonalNote(personalNoteView, separator, cache.getPersonalNote());
             personalNoteView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
             addContextMenu(personalNoteView);
             final Button personalNoteEdit = view.findViewById(R.id.edit_personalnote);
             personalNoteEdit.setOnClickListener(v -> {
+                ensureSaved();
+                editPersonalNote(cache, CacheDetailActivity.this);
+            });
+            personalNoteView.setOnClickListener(v -> {
                 ensureSaved();
                 editPersonalNote(cache, CacheDetailActivity.this);
             });
@@ -2622,8 +2627,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         setMenuPreventWaypointsFromNote(cache.isPreventWaypointsFromNote());
 
         final TextView personalNoteView = findViewById(R.id.personalnote);
+        final View separator = findViewById(R.id.personalnote_button_separator);
         if (personalNoteView != null) {
-            setPersonalNote(personalNoteView, newNote);
+            setPersonalNote(personalNoteView, separator, newNote);
         } else {
             reinitializePage(Page.DESCRIPTION);
         }
@@ -2631,13 +2637,15 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         Schedulers.io().scheduleDirect(() -> DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB)));
     }
 
-    private static void setPersonalNote(final TextView personalNoteView, final String personalNote) {
+    private static void setPersonalNote(final TextView personalNoteView, final View separator, final String personalNote) {
         personalNoteView.setText(personalNote, TextView.BufferType.SPANNABLE);
         if (StringUtils.isNotBlank(personalNote)) {
             personalNoteView.setVisibility(View.VISIBLE);
+            separator.setVisibility(View.VISIBLE);
             Linkify.addLinks(personalNoteView, Linkify.MAP_ADDRESSES | Linkify.WEB_URLS);
         } else {
             personalNoteView.setVisibility(View.GONE);
+            separator.setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
partially fixes issue #8898:
- hide separator when personal note is empty
- apply onclick method to personal note text view

would be nice if this could be merged before merging branches, so that we have a nice UI in our beta version. If I'm to late we can also close this and create a new PR for merging this to release.

Edit: Clicking on links will still open them in browser, so there should be no regression. The onclick method does only impact normal text...