### PR TITLE
avoid NPE in DistanceDrawer if no target is set

### DIFF
--- a/main/src/cgeo/geocaching/maps/DistanceDrawer.java
+++ b/main/src/cgeo/geocaching/maps/DistanceDrawer.java
@@ -62,8 +62,8 @@ public class DistanceDrawer {
     public void setCoordinates(final Location location) {
         final Geopoint currentCoords = new Geopoint(location);
 
-        distance = currentCoords.distanceTo(destinationCoords);
-        distanceText = Units.getDistanceFromKilometers(distance);
+        distance = null != destinationCoords ? currentCoords.distanceTo(destinationCoords) : 0.0f;
+        distanceText = null != destinationCoords ? Units.getDistanceFromKilometers(distance) : null;
     }
 
     public Geopoint getDestinationCoords() {


### PR DESCRIPTION
Found the NPE in the logfile attached to https://github.com/cgeo/cgeo/pull/8918#issuecomment-683797328
(This happens when DistanceDrawer gets initialized without a target - which will happen nowadays to display the length of an individual route.)