### PR TITLE
offer c:geo for navigation intents (fix #8925)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -205,6 +205,11 @@
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="cgeo.geocaching.MainActivity" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="geo" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity
             android:name="cgeo.geocaching.address.AddressListActivity"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1257,7 +1257,7 @@
     <string name="search_tb">Trackable</string>
     <string name="search_tb_hint">Trackable identification</string>
     <string name="search_tb_button">Search for trackable</string>
-    <string name="search_destination">Destination</string>
+    <string name="search_destination">Open destination in c:geo</string>
     <string name="search_address_started">Searching for places</string>
     <string name="search_address_result">Found places</string>
     <string name="search_own_caches">Search my caches</string>

--- a/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
+++ b/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
@@ -2,14 +2,67 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.connector.internal.InternalConnector;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MatcherWrapper;
 
 import android.os.Bundle;
 
+import androidx.annotation.Nullable;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
 public class NavigateAnyPointActivity extends AbstractActionBarActivity {
+    private static final Pattern PATTERN_COORDS_NAME = Pattern.compile("^geo:0,0\\?q=([-]?[0-9]{1,2}\\.[0-9]{1,15}),([-]?[0-9]{1,3}\\.[0-9]{1,15})(\\((.*)\\))?$");
+    private static final Pattern PATTERN_COORDS = Pattern.compile("^geo:([-]?[0-9]{1,2}\\.[0-9]{1,15}),([-]?[0-9]{1,3}\\.[0-9]{1,15})$");
+    private static final Pattern PATTERN_COORDS_ZOOM = Pattern.compile("^geo:([-]?[0-9]{1,2}\\.[0-9]{1,15}),([-]?[0-9]{1,3}\\.[0-9]{1,15})\\?z=([1-9]|1[0-9]|2[0-3])$");
+
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        InternalConnector.assertHistoryCacheExists(this);
+
+        // check if "geo" action is requested
+        final String data = getIntent().getDataString();
+        if (StringUtils.isNotBlank(data)) {
+            MatcherWrapper match = new MatcherWrapper(PATTERN_COORDS, data);
+            if (match.find()) {
+                Log.i("Received a geo intent: lat=" + match.group(1) + ", lon=" + match.group(2));
+                createHistoryWaypoint(Double.parseDouble(match.group(1)), Double.parseDouble(match.group(2)), null);
+            } else {
+                match = new MatcherWrapper(PATTERN_COORDS_NAME, data);
+                if (match.find()) {
+                    Log.i("Received a geo intent: lat=" + match.group(1) + ", lon=" + match.group(2) + ", name=" + match.group(4));
+                    createHistoryWaypoint(Double.parseDouble(match.group(1)), Double.parseDouble(match.group(2)), match.group(4));
+                } else {
+                    match = new MatcherWrapper(PATTERN_COORDS_ZOOM, data);
+                    if (match.find()) {
+                        Log.i("Received a geo intent: lat=" + match.group(1) + ", lon=" + match.group(2) + ", zoom=" + match.group(3) + " (zoom level being ignored currently)");
+                        createHistoryWaypoint(Double.parseDouble(match.group(1)), Double.parseDouble(match.group(2)), null);
+                    }
+                }
+            }
+        }
+
         CacheDetailActivity.startActivity(this, InternalConnector.GEOCODE_HISTORY_CACHE, true);
         finish();
+    }
+
+    private static void createHistoryWaypoint(final double latitude, final double longitude, @Nullable final String name) {
+        final Geocache cache = DataStore.loadCache(InternalConnector.GEOCODE_HISTORY_CACHE, LoadFlags.LOAD_CACHE_OR_DB);
+        if (null != cache) {
+            final Waypoint newWaypoint = new Waypoint(null != name ? name : Waypoint.getDefaultWaypointName(cache, WaypointType.WAYPOINT), WaypointType.WAYPOINT, true);
+            newWaypoint.setCoords(new Geopoint(latitude, longitude));
+            newWaypoint.setGeocode(cache.getGeocode());
+            cache.addOrChangeWaypoint(newWaypoint, true);
+        }
     }
 }


### PR DESCRIPTION
On receiving a `geo:` intent in one of the following formats, c:geo creates a new "go to" history waypoint and opens the waypoint page, with the newly created waypoint on top. By tapping on the navigation symbol beside this waypoint, c:geo opens the map centered to this waypoint, and shows a navigation line (if BRoute is active).

Example, started from the "Lab Adventure" app:
- tap on navigation symbol in "Lab Adventure" app:
  ![image](https://user-images.githubusercontent.com/3754370/92033440-f7a09000-ed6b-11ea-9746-0a5080f00d9b.png)

- c:geo is offered as navigation app (besides any other navigation app you have installed):
  ![image](https://user-images.githubusercontent.com/3754370/92033522-156df500-ed6c-11ea-8c1d-758323d2e26c.png)

- Waypoint gets added to history, named accordingly (if given on opening intent), shown at the top of the list:
  ![image](https://user-images.githubusercontent.com/3754370/92033545-1ef75d00-ed6c-11ea-9a55-328eab4e2294.png)

- If you tap on the navigation symbol beside the waypoint name, map view starts and direction or navigation line is shown: (configured to yellow in this test setting)
  ![image](https://user-images.githubusercontent.com/3754370/92033706-67af1600-ed6c-11ea-8409-bb4002922f9c.png)
