### PR TITLE
Handle null-value ratings in stored offline logs (fix #8935)

### DIFF
--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -346,7 +346,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
         date.setDate(new Date(logEntry.date));
         setLogText(logEntry.log);
         reportProblem.set(logEntry.reportProblem);
-        cacheVotingBar.setRating(logEntry.rating);
+        cacheVotingBar.setRating(logEntry.rating == null ? cache.getMyVote() : logEntry.rating);
         favCheck.setChecked(logEntry.favorite);
         tweetCheck.setChecked(logEntry.tweet);
         logPassword.setText(logEntry.password);


### PR DESCRIPTION
fix #8935 