### PR TITLE
adjust map download location (fix #8944)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1901,9 +1901,10 @@
     <string name="downloadmap_title">Download offline map</string>
     <string name="downloadmap_info">Choose a map file for your region by tapping the \"Save\" icon.\n\nDownloading will run in the background. When downloading has completed, the downloaded file will be copied to c:geo\'s map directory and set as current map for c:geo.\n\nBe careful: Downloading a map can cause high network traffic!</string>
     <string name="downloadmap_choose">Choose map</string>
+    <string name="downloadmap_filename">Downloading %s</string>
     <string name="downloadmanager_not_available">Map file cannot be downloaded, system download manager not available</string>
     <string name="download_started">Downloading started in background</string>
-    <string name="downloadmap_target_not_writable">Target \"%s\" is not writable - please select a different map file directory.</string>
+    <string name="downloadmap_target_not_writable">Target \"%s\" is not writable - downloaded map file will be stored in system download directory and has to be moved manually to the map directory.</string>
 
     <!-- history track -->
     <string name="map_clear_trailhistory">Clear history track</string>

--- a/main/src/cgeo/geocaching/settings/MapDownloadSelectorActivity.java
+++ b/main/src/cgeo/geocaching/settings/MapDownloadSelectorActivity.java
@@ -183,7 +183,7 @@ public class MapDownloadSelectorActivity extends AbstractActionBarActivity {
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState, R.layout.mapdownloader_activity);
-        MapDownloadUtils.checkMapDirectory(this, (path, isWritable) -> {
+        MapDownloadUtils.checkMapDirectory(this, true, (path, isWritable) -> {
             if (isWritable) {
                 final RecyclerView view = RecyclerViewProvider.provideRecyclerView(this, R.id.mapdownloader_list, true, true);
                 view.setAdapter(adapter);

--- a/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
+++ b/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
@@ -57,7 +57,7 @@ public class ReceiveMapFileActivity extends AbstractActivity {
         final String preset = intent.getStringExtra(EXTRA_FILENAME);
         final AbstractActivity that = this;
 
-        MapDownloadUtils.checkMapDirectory(this, (path, isWritable) -> {
+        MapDownloadUtils.checkMapDirectory(this, false, (path, isWritable) -> {
             if (isWritable) {
                 mapDirectory = Settings.getMapFileDirectory();
                 if (guessFilename(preset)) {


### PR DESCRIPTION
- uses the public `Download` dir as temporary storage (also makes temporary files visible)
- if the destination dir is not writable: ask user whether to continue with above default dir instead of skipping the download

Message shown _before_ map file selector, if destination dir is not writable:
![image](https://user-images.githubusercontent.com/3754370/92288131-366d4c00-ef0c-11ea-93fa-e321a81db800.png)

Downloaded files are shown in the download manager / system default public Donwload dir:
![image](https://user-images.githubusercontent.com/3754370/92288145-47b65880-ef0c-11ea-90ca-2fd3b49dea3d.png)
