### PR TITLE
fix #8950: falsely read update instead of date field when reading offline log

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -4364,7 +4364,7 @@ public class DataStore {
             init();
 
             final DBQuery query = new DBQuery.Builder().setTable(dbTableLogsOffline)
-                    .setColumns(new String[]{"_id", "geocode", "updated", "type", "log", "report_problem", "image_title_prefix", "image_scale", "favorite", "tweet", "rating", "password"})
+                    .setColumns(new String[]{"_id", "geocode", "date", "type", "log", "report_problem", "image_title_prefix", "image_scale", "favorite", "tweet", "rating", "password"})
                     .setWhereClause("geocode = ?").setWhereArgs(new String[]{geocode}).build();
             final OfflineLogEntry.Builder<?> logBuilder = query.selectFirstRow(database,
                     c -> new OfflineLogEntry.Builder<>()

--- a/tests/src-android/cgeo/geocaching/storage/DataStoreTest.java
+++ b/tests/src-android/cgeo/geocaching/storage/DataStoreTest.java
@@ -238,8 +238,9 @@ public class DataStoreTest extends CGeoTestCase {
 
     public static void testOfflineLog() {
         final String geocode = ARTIFICIAL_GEOCODE + "-O";
-        final Date logDate = new Date();
+        final Date logDate = new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 3);
         //ensure that we don't overwrite anything in database before starting this test
+        DataStore.clearLogOffline(geocode);
         final OfflineLogEntry logEntry = DataStore.loadLogOffline(geocode);
         assertThat(logEntry).isNull();
         assertThat(DataStore.clearLogOffline(geocode)).isEqualTo(false);
@@ -305,6 +306,7 @@ public class DataStoreTest extends CGeoTestCase {
         final String geocode = ARTIFICIAL_GEOCODE + "-O";
 
         //ensure that we don't overwrite anything in database before starting this test
+        DataStore.clearLogOffline(geocode);
         final OfflineLogEntry logEntry = DataStore.loadLogOffline(geocode);
         assertThat(logEntry).isNull();
 
@@ -330,6 +332,7 @@ public class DataStoreTest extends CGeoTestCase {
         assertThat(dbLogEntry.cacheGeocode).isEqualTo(expectedLogEntry.cacheGeocode);
         assertThat(dbLogEntry.logType).isEqualTo(expectedLogEntry.logType);
         assertThat(dbLogEntry.log).isEqualTo(expectedLogEntry.log);
+        assertThat(dbLogEntry.date).isEqualTo(expectedLogEntry.date);
         assertThat(dbLogEntry.reportProblem).isEqualTo(expectedLogEntry.reportProblem);
         assertThat(dbLogEntry.imageScale).isEqualTo(expectedLogEntry.imageScale);
         assertThat(dbLogEntry.imageTitlePraefix).isEqualTo(expectedLogEntry.imageTitlePraefix);


### PR DESCRIPTION
fix #8950: falsely read update instead of date field when reading offline log