### PR TITLE
fix unparcelling error in RouteSegment + add own parcelling to ManualRoute

### DIFF
--- a/main/src/cgeo/geocaching/models/ManualRoute.java
+++ b/main/src/cgeo/geocaching/models/ManualRoute.java
@@ -5,13 +5,15 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.AndroidRxUtils;
 
 import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.widget.Toast;
 
 import java.util.ArrayList;
 
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public class ManualRoute extends Route {
+public class ManualRoute extends Route implements Parcelable {
 
     private enum ToggleItemState {
         ADDED,
@@ -129,4 +131,33 @@ public class ManualRoute extends Route {
         return -1;
     }
 
+    // Parcelable methods
+
+    public static final Creator<ManualRoute> CREATOR = new Creator<ManualRoute>() {
+
+        @Override
+        public ManualRoute createFromParcel(final Parcel source) {
+            return new ManualRoute(source);
+        }
+
+        @Override
+        public ManualRoute[] newArray(final int size) {
+            return new ManualRoute[size];
+        }
+
+    };
+
+    protected ManualRoute(final Parcel parcel) {
+        super(parcel);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+    }
 }

--- a/main/src/cgeo/geocaching/models/Route.java
+++ b/main/src/cgeo/geocaching/models/Route.java
@@ -168,7 +168,7 @@ public class Route implements Parcelable {
 
     };
 
-    private Route(final Parcel parcel) {
+    protected Route(final Parcel parcel) {
         name = parcel.readString();
         segments = parcel.readArrayList(RouteSegment.class.getClassLoader());
         routeable = parcel.readInt() != 0;

--- a/main/src/cgeo/geocaching/models/RouteSegment.java
+++ b/main/src/cgeo/geocaching/models/RouteSegment.java
@@ -90,7 +90,6 @@ public class RouteSegment implements Parcelable {
         item = parcel.readParcelable(RouteItem.class.getClassLoader());
         distance = parcel.readFloat();
         points = parcel.readArrayList(Geopoint.class.getClassLoader());
-        points = parcel.readArrayList(RouteSegment.class.getClassLoader());
     }
 
     @Override


### PR DESCRIPTION
Remove `points` being unparcelled twice (maybe related to #8941)

Also adds own parcelling methods to `ManualRoute`.