### PR TITLE
combine note and user note for export waypoint, on import split them up (#6914)

### DIFF
--- a/main/src/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/cgeo/geocaching/export/GpxSerializer.java
@@ -256,8 +256,10 @@ public final class GpxSerializer {
             gpx.attribute("", "lon", Double.toString(coords.getLongitude()));
 
             final String waypointTypeGpx = wp.getWaypointType().gpx;
-            XmlUtils.multipleTexts(gpx, NS_GPX, "name", wp.getGpxId(), "cmt", wp.getNote(), "desc", wp.getName(), "sym", waypointTypeGpx, "type", "Waypoint|" + waypointTypeGpx);
-
+            // combine note and user note with SEPARATOR "\n--\n"
+            final String waypointNote = wp.getCombinedNoteAndUserNote();
+            XmlUtils.multipleTexts(gpx, NS_GPX, "name", wp.getGpxId(), "cmt", waypointNote, "desc", wp.getName(), "sym", waypointTypeGpx, "type", "Waypoint|" + waypointTypeGpx);
+            
             // add parent reference the GSAK-way
             writeGsakExtensions(wp);
 

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -302,7 +302,9 @@ abstract class GPXParser extends FileParser {
                         waypoint.setLookup("---");
                         // there is no lookup code in gpx file
                         waypoint.setCoords(cache.getCoords());
-                        waypoint.setNote(cache.getDescription());
+
+                        waypoint.updateNoteAndUserNote(cache.getDescription());
+
                         waypoint.setVisited(wptVisited);
                         final List<Waypoint> mergedWayPoints = new ArrayList<>(cacheForWaypoint.getWaypoints());
 

--- a/tests/src/cgeo/geocaching/models/WaypointTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointTest.java
@@ -394,4 +394,122 @@ public class WaypointTest {
         assertThat(server.getUserNote()).isEqualTo("");
     }
 
+    @Test
+    public void testGetNoteWithUserNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.setNote("Note");
+        wp.setUserNote("User Note");
+        final String mergedNote = wp.getCombinedNoteAndUserNote();
+        assertThat(mergedNote).isEqualTo("Note\n--\nUser Note");
+    }
+
+    @Test
+    public void testGetNoteWithUserNoteUserWaypoint() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, true);
+        wp.setNote("");
+        wp.setUserNote("User Note");
+        final String mergedNote = wp.getCombinedNoteAndUserNote();
+        assertThat(mergedNote).isEqualTo("User Note");
+    }
+    @Test
+    public void testGetNoteWithUserNoteEmptyNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.setNote("");
+        wp.setUserNote("User Note");
+        final String mergedNote = wp.getCombinedNoteAndUserNote();
+        assertThat(mergedNote).isEqualTo("\n--\nUser Note");
+    }
+
+    @Test
+    public void testGetNoteWithUserNoteNullNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.setUserNote("User Note");
+        final String mergedNote = wp.getCombinedNoteAndUserNote();
+        assertThat(mergedNote).isEqualTo("\n--\nUser Note");
+    }
+
+    @Test
+    public void testGetNoteWithUserNoteMigratedNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.setNote("Note\n--\nUser Note 1");
+        wp.setUserNote("User Note 2");
+        final String mergedNote = wp.getCombinedNoteAndUserNote();
+        assertThat(mergedNote).isEqualTo("Note\n--\nUser Note 1\n--\nUser Note 2");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.updateNoteAndUserNote("provider note\n--\nuser note");
+        assertThat(wp.getNote()).isEqualTo("provider note");
+        assertThat(wp.getUserNote()).isEqualTo("user note");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteNull() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.setNote("Note");
+        wp.setUserNote("User Note");
+        wp.updateNoteAndUserNote(null);
+        assertThat(wp.getNote()).isEqualTo("Note");
+        assertThat(wp.getUserNote()).isEqualTo("User Note");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteEmpty() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.setNote("Note");
+        wp.setUserNote("User Note");
+        wp.updateNoteAndUserNote("");
+        assertThat(wp.getNote()).isEmpty();
+        assertThat(wp.getUserNote()).isEmpty();
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteEmptyUserNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.updateNoteAndUserNote("provider note");
+        assertThat(wp.getNote()).isEqualTo("provider note");
+        assertThat(wp.getUserNote()).isEmpty();
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteEmptyProviderNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.updateNoteAndUserNote("\n--\nuser note");
+        assertThat(wp.getNote()).isEmpty();
+        assertThat(wp.getUserNote()).isEqualTo("user note");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteCombinedUserNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.updateNoteAndUserNote("provider note\n--\nuser note 1\n--\nuser note 2");
+        assertThat(wp.getNote()).isEqualTo("provider note");
+        assertThat(wp.getUserNote()).isEqualTo("user note 1\n--\nuser note 2");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteTrimmedNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        wp.updateNoteAndUserNote("--\nuser note 1\n--\nuser note 2");
+        assertThat(wp.getNote()).isEmpty();
+        assertThat(wp.getUserNote()).isEqualTo("user note 1\n--\nuser note 2");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteUserWaypoint() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, true);
+        wp.updateNoteAndUserNote("provider note\n--\nuser note");
+        assertThat(wp.getNote()).isEmpty();
+        assertThat(wp.getUserNote()).isEqualTo("provider note\n--\nuser note");
+    }
+
+    @Test
+    public void testUpdateNoteAndUserNoteUserWaypointCombinedNote() {
+        final Waypoint wp = new Waypoint("Stage 1", WaypointType.STAGE, true);
+        wp.updateNoteAndUserNote("\n--\nuser note");
+        assertThat(wp.getNote()).isEmpty();
+        assertThat(wp.getUserNote()).isEqualTo("\n--\nuser note");
+    }
 }


### PR DESCRIPTION
For issue #6914 (user note for Waypoints):
because gpx and gsak has only one field for waypoint-notes, the server note (which is the description) and user note are concatenated on export. On import the note is analyzed and split up again in server note and the user note.
The same separator as for the PersonalNote is used ("\n--\n").

As on an empty server note, the first "\n" is removed within the "validate/trim"-functionality, there is a little "hack" to recognize this special case.
If someone has a better solution....

There is no merge of different user-notes on importing, so the user-note will be overwritten on merge
Probably this can be done in a different PR.
