### PR TITLE
update/configure plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
     id 'idea'
 
     // check for updates of gradle plugin dependencies
-    id 'com.github.ben-manes.versions' version '0.30.0'
+    id 'com.github.ben-manes.versions' version '0.31.0'
 
     // use SpotBugs instead of FindBugs, see https://plugins.gradle.org/plugin/com.github.spotbugs
     id 'com.github.spotbugs' version '4.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -157,5 +157,5 @@ tasks.named('dependencyUpdates') {
     checkForGradleUpdate = true
     revision = "release"
     gradleReleaseChannel = "current"
-    outputFormatter = "plain,html"
+    outputFormatter = "plain, html"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,10 @@ plugins {
     id 'idea'
 
     // check for updates of gradle plugin dependencies
-    id 'com.github.ben-manes.versions' version '0.28.0'
+    id 'com.github.ben-manes.versions' version '0.30.0'
 
     // use SpotBugs instead of FindBugs, see https://plugins.gradle.org/plugin/com.github.spotbugs
-    id 'com.github.spotbugs' version '4.3.0'
+    id 'com.github.spotbugs' version '4.5.0'
 }
 
 /*
@@ -157,4 +157,5 @@ tasks.named('dependencyUpdates') {
     checkForGradleUpdate = true
     revision = "release"
     gradleReleaseChannel = "current"
+    outputFormatter = "plain,html"
 }

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -54,7 +54,7 @@ android {
 
 dependencies {
     // Apache Commons
-    implementation 'org.apache.commons:commons-lang3:3.10'
+    implementation 'org.apache.commons:commons-lang3:3.11'
     // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
     // could be replaced by Storage Access Framework
     //noinspection GradleDependency

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -246,8 +246,8 @@ dependencies {
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.commons:commons-compress:1.20'
-    implementation 'org.apache.commons:commons-lang3:3.10'
-    implementation 'org.apache.commons:commons-text:1.8'
+    implementation 'org.apache.commons:commons-lang3:3.11'
+    implementation 'org.apache.commons:commons-text:1.9'
     // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
     // could be replaced by Storage Access Framework
     //noinspection GradleDependency
@@ -259,26 +259,25 @@ dependencies {
     androidTestImplementation "org.assertj:assertj-core:$assertJVersion"
 
     // ButterKnife view injection, https://github.com/JakeWharton/butterknife
-    def butterKnifeVersion = '10.2.1'
+    def butterKnifeVersion = '10.2.3'
     implementation "com.jakewharton:butterknife:$butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
 
     // SpotBugs (successor of FindBugs)
     implementation 'net.jcip:jcip-annotations:1.0'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.0.6'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.1.2'
 
     // GeographicLib
     implementation 'net.sf.geographiclib:GeographicLib-Java:1.50'
 
     // Jackson XML processing
-    def jacksonVersion = '2.9.10'
-    def jacksonVersionPatch = '2.9.10.4'
+    def jacksonVersion = '2.11.2'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersionPatch"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
 
     // Jsoup HTML parsing
-    implementation 'org.jsoup:jsoup:1.12.1'
+    implementation 'org.jsoup:jsoup:1.13.1'
 
     // Junit only needed for local unit tests
     testImplementation 'junit:junit:4.13'
@@ -315,7 +314,7 @@ dependencies {
     // Metadata Extractor, EXIF location extraction from images
     implementation 'com.drewnoakes:metadata-extractor:2.14.0'
 
-    implementation 'com.squareup.okhttp3:okhttp:4.7.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.8.1'
 
     // Play Services
     implementation 'com.google.android.gms:play-services-location:17.0.0'
@@ -350,8 +349,8 @@ dependencies {
     androidTestImplementation "androidx.annotation:annotation:$annotationVersion"
 
     // Testing Support Libraries
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     // Undo toast
     implementation 'com.github.jenzz.undobar:library:1.3:api15Release@aar'


### PR DESCRIPTION
- global
  - update versions to 0.31.0
    add new output formatter "html"
  - update spotbugs to 4.5.0
- contacts
  - update commons-lang3 to 3.11
- cgeo
  - update commons-lang3 to 3.11
  - update commons-text to 1.9
  - update butterknife to 10.2.3
  - update spotbugs-annotations to 4.1.2
  - update jackson to 2.11.2
  - update jsoup to 1.13.1
  - update okhttp to 4.8.1
  - update junit to 1.1.2
  - update espresso-core to 3.3.0