### PR TITLE
fix #8969: allow negative bearing angles for waypoint projection

### DIFF
--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -35,7 +35,7 @@
                 android:id="@+id/bearing"
                 style="@style/edittext_full"
                 android:hint="@string/waypoint_bearing"
-                android:inputType="numberDecimal"
+                android:inputType="numberDecimal|numberSigned"
                 android:enabled="false"/>
 
             <LinearLayout


### PR DESCRIPTION
fix #8969: allow negative bearing angles for waypoint projection