### PR TITLE
[NUMBER template] don't add +1 for other types than FOUND_IT/ATTENDED/WEBCAM_PHOTO_TAKEN

### DIFF
--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -305,7 +305,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
             lastSavedState = getEntryFromView();
             //set initial signature. Setting this AFTER setting lastSavedState and GUI leads to the signature being a change-to-save as requested in #8973
             if (StringUtils.isNotBlank(Settings.getSignature()) && Settings.isAutoInsertSignature() && StringUtils.isBlank(currentLogText())) {
-                insertIntoLog(LogTemplateProvider.applyTemplates(Settings.getSignature(), new LogContext(cache, null)), false);
+                insertIntoLog(LogTemplateProvider.applyTemplates(Settings.getSignature(), new LogContext(cache, lastSavedState)), false);
             }
         } else {
             fillViewFromEntry(lastSavedState);
@@ -527,7 +527,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
 
     @Override
     protected LogContext getLogContext() {
-        return new LogContext(cache, null);
+        return new LogContext(cache, getEntryFromView());
     }
 
     private void addOrEditImage(final int imageIndex) {

--- a/main/src/cgeo/geocaching/log/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/log/LogTemplateProvider.java
@@ -161,7 +161,7 @@ public final class LogTemplateProvider {
             public String getValue(final LogContext context) {
 
                 final boolean increment;
-                if (null != context.logEntry && (context.logEntry.logType == LogType.FOUND_IT || context.logEntry.logType == LogType.ATTENDED || context.logEntry.logType == LogType.WEBCAM_PHOTO_TAKEN)) {
+                if (null == context.logEntry || context.logEntry.logType == LogType.FOUND_IT || context.logEntry.logType == LogType.ATTENDED || context.logEntry.logType == LogType.WEBCAM_PHOTO_TAKEN) {
                     increment = true;
                 } else {
                     increment = false;
@@ -194,7 +194,7 @@ public final class LogTemplateProvider {
             @Override
             public String getValue(final LogContext context) {
 
-                if (null != context.logEntry && (context.logEntry.logType == LogType.FOUND_IT || context.logEntry.logType == LogType.ATTENDED || context.logEntry.logType == LogType.WEBCAM_PHOTO_TAKEN)) {
+                if (null == context.logEntry || context.logEntry.logType == LogType.FOUND_IT || context.logEntry.logType == LogType.ATTENDED || context.logEntry.logType == LogType.WEBCAM_PHOTO_TAKEN) {
                     return getCounter(context, true);
                 } else {
                     return getCounter(context, false);

--- a/main/src/cgeo/geocaching/log/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/log/LogTemplateProvider.java
@@ -159,12 +159,20 @@ public final class LogTemplateProvider {
 
             @Override
             public String getValue(final LogContext context) {
+
+                final boolean increment;
+                if (null != context.logEntry && (context.logEntry.logType == LogType.FOUND_IT || context.logEntry.logType == LogType.ATTENDED || context.logEntry.logType == LogType.WEBCAM_PHOTO_TAKEN)) {
+                    increment = true;
+                } else {
+                    increment = false;
+                }
+
                 final Geocache cache = context.getCache();
                 if (cache == null) {
                     return StringUtils.EMPTY;
                 }
                 long counter;
-                final String onlineNum = getCounter(context, true);
+                final String onlineNum = getCounter(context, increment);
                 final IConnector connector = ConnectorFactory.getConnector(cache);
 
                 if (onlineNum.equals(StringUtils.EMPTY)) {
@@ -172,7 +180,7 @@ public final class LogTemplateProvider {
                     if (f == null) {
                         return StringUtils.EMPTY;
                     }
-                    counter = f.getCounter(true);
+                    counter = f.getCounter(increment);
                 } else {
                     counter = Long.parseLong(onlineNum);
                 }
@@ -185,7 +193,12 @@ public final class LogTemplateProvider {
 
             @Override
             public String getValue(final LogContext context) {
-                return getCounter(context, true);
+
+                if (null != context.logEntry && (context.logEntry.logType == LogType.FOUND_IT || context.logEntry.logType == LogType.ATTENDED || context.logEntry.logType == LogType.WEBCAM_PHOTO_TAKEN)) {
+                    return getCounter(context, true);
+                } else {
+                    return getCounter(context, false);
+                }
             }
         });
         templates.add(new LogTemplate("OWNER", R.string.init_signature_template_owner) {

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -577,7 +577,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
     public boolean onCreateOptionsMenu(final Menu menu) {
         final boolean result = super.onCreateOptionsMenu(menu);
         for (final LogTemplate template : LogTemplateProvider.getTemplatesWithoutSignature()) {
-            if (template.getTemplateString().equals("NUMBER")) {
+            if (template.getTemplateString().equals("NUMBER") || template.getTemplateString().equals("ONLINENUM")) {
                 menu.findItem(R.id.menu_templates).getSubMenu().removeItem(template.getItemId());
             }
         }

--- a/tests/src-android/cgeo/geocaching/log/LogTemplateProviderTest.java
+++ b/tests/src-android/cgeo/geocaching/log/LogTemplateProviderTest.java
@@ -63,12 +63,25 @@ public class LogTemplateProviderTest extends TestCase {
     public static void testNoNumberIncrement() {
         final Geocache cache = new Geocache();
         cache.setGeocode("GC45GGA");
-        final LogContext context = new LogContext(cache, new LogEntry.Builder().build());
+        final LogContext context = new LogContext(cache, new LogEntry.Builder().setLogType(LogType.FOUND_IT).build());
         final String template = "[NUMBER]";
         final String withIncrement = LogTemplateProvider.applyTemplates(template, context);
         final String withoutIncrement = LogTemplateProvider.applyTemplatesNoIncrement(template, context);
 
         // both strings represent integers with an offset of one.
+        assertThat(Integer.parseInt(withIncrement) - Integer.parseInt(withoutIncrement)).isEqualTo(1);
+    }
+
+    public static void testNumberLogTypeIncrement() {
+        final Geocache cache = new Geocache();
+        cache.setGeocode("GC45GGA");
+        final LogContext context = new LogContext(cache, new LogEntry.Builder().setLogType(LogType.FOUND_IT).build());
+        final LogContext context2 = new LogContext(cache, new LogEntry.Builder().setLogType(LogType.DIDNT_FIND_IT).build());
+        final String template = "[NUMBER]";
+        final String withIncrement = LogTemplateProvider.applyTemplates(template, context);
+        final String withoutIncrement = LogTemplateProvider.applyTemplates(template, context2);
+
+        // both strings represent integers - the number template should not increase if the log type is not FOUND_IT or something equal
         assertThat(Integer.parseInt(withIncrement) - Integer.parseInt(withoutIncrement)).isEqualTo(1);
     }
 


### PR DESCRIPTION
- fix #7839
- don't show legacy number template for trackable logging (adapted to  normal NUMBER)

With this change, it doesn't count +1, if a LogEntry is provided and the log type is not found (or sth. equal)