### PR TITLE
redesign onetime dialog and improve explanation text

### DIFF
--- a/main/res/layout/dialog_text_checkbox.xml
+++ b/main/res/layout/dialog_text_checkbox.xml
@@ -29,5 +29,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="-5dp"
-        android:text="@string/dont_shown_again" />
+        android:text="@string/dont_show_again" />
 </LinearLayout>

--- a/main/res/layout/dialog_text_checkbox.xml
+++ b/main/res/layout/dialog_text_checkbox.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingLeft="25dp"
+    android:paddingRight="25dp" >
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginBottom="10dp"
+        android:id="@+id/text_container">
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="10dip"
+            android:textSize="16sp"
+            android:textColor="@color/text_dark"
+            android:layout_marginTop="10dp"/>
+    </ScrollView>
+
+
+    <CheckBox
+        android:id="@+id/check_box"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="-5dp"
+        android:text="@string/dont_shown_again" />
+</LinearLayout>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -262,8 +262,8 @@
     <string name="info_select_logimage_cancelled">Image selection or capture was cancelled.</string>
     <string name="info_stored_image">New image saved to:</string>
     <string name="info_cache_saved">The cache has been stored locally</string>
-    <string name="info_feature_offline_counter">You have offline logs, which are not yet uploaded. Therefore a counter (eg. \"+ 1\") will be displayed. If you don\'t like the counter, you can disable it under Settings > Logging.\n\nTo easily find remaining offline logs, goto \"history list\" and filter for \"With personal data\" > \"With offline log\"</string>
     <string name="warn_calculator_state_save">Be sure to save waypoint if you want to keep the calculator state.</string>
+    <string name="feature_info_offline_counter">You have some caches with an offline saved log, which might not yet be logged online. For your comfort the count of these logs is displayed as \"+ x\" behind your number of found caches in the footer at c:geo\'s main page. \n\nMoreover these \"x\" logs will be added to the \"NUMBER\" template you might use in your log signature. \n\nIf you don\'t like this counter extension, you can disable it under \"Settings\" > \"Logging\" and/or use the \"NUMBER (without offline logs)\" template instead. \n\nTo easily find remaining offline logs, go to the list \"History\" and filter for \"With personal data\" > \"With offline log\".</string>
     <string name="err_trackable_log_not_anonymous">Logging %1$s from c:geo cannot be done anonymously. Do you want to open the settings to fill in your credentials from %2$s?</string>
     <string name="err_trackable_no_preference_activity">Sorry, cannot find a suitable preference screen.</string>
     <string name="confirm_unsaved_changes_title">Unsaved changes</string>
@@ -272,6 +272,7 @@
     <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
     <string name="more_information">More information</string>
     <string name="remind_later">Remind me later</string>
+    <string name="dont_shown_again">Don\'t shown again</string>
 
     <string name="warn_gm_not_available">Google Maps not available.</string>
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -272,7 +272,7 @@
     <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
     <string name="more_information">More information</string>
     <string name="remind_later">Remind me later</string>
-    <string name="dont_shown_again">Don\'t shown again</string>
+    <string name="dont_show_again">Don\'t show again</string>
 
     <string name="warn_gm_not_available">Google Maps not available.</string>
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>

--- a/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -18,7 +18,7 @@ public class OneTimeDialogs extends DataStore.DBExtension {
     public enum DialogType {
         // names must not be changed, as there are database entries depending on it
 
-        EXPLAIN_OFFLINE_FOUND_COUNTER(R.string.settings_information, R.string.info_feature_offline_counter);
+        EXPLAIN_OFFLINE_FOUND_COUNTER(R.string.settings_information, R.string.feature_info_offline_counter);
 
         public int messageTitle;
         public int messageText;


### PR DESCRIPTION
fix #9013

New string (created from the comments in #9013):
![Screenshot_20200918_171103_cgeo geocaching](https://user-images.githubusercontent.com/64581222/93618941-40954d00-f9d8-11ea-81d3-c35390c6f7cf.jpg)

Could someone please cross read if it sounds fine or any other changes are needed?