### PR TITLE
edit maps.me lint config

### DIFF
--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -15,4 +15,12 @@ android {
     java.srcDirs = ['src']
     res.srcDirs = ['res']
   }
+
+  lintOptions {
+    // generally we accept lint errors when building
+    abortOnError false
+
+    // abort release builds in case of FATAL errors
+    checkReleaseBuilds true
+  }
 }

--- a/mapswithme-api/lint.xml
+++ b/mapswithme-api/lint.xml
@@ -37,7 +37,6 @@
     <issue id="ExportedService" severity="ignore" />
     <issue id="ExtraText" severity="ignore" />
     <issue id="ExtraTranslation" severity="ignore" />
-    <issue id="FloatMath" severity="ignore" />
     <issue id="GetInstance" severity="ignore" />
     <issue id="GifUsage" severity="ignore" />
     <issue id="GradleCompatible" severity="ignore" />
@@ -93,7 +92,6 @@
     <issue id="MissingId" severity="ignore" />
     <issue id="MissingPrefix" severity="ignore" />
     <issue id="MissingQuantity" severity="ignore" />
-    <issue id="MissingRegistered" severity="ignore" />
     <issue id="MissingSuperCall" severity="ignore" />
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="MissingVersion" severity="ignore" />


### PR DESCRIPTION
- add lintOptions like in the other plugins
- delete 2 no more valid parameters

Info:
You can made local lint check by
(global or for sub project)
  gradlew -q check
  gradlew -q :cmapswithme-api:check