### PR TITLE
add warning about automatic waypoint extraction (fix #9026)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -871,6 +871,7 @@
     <string name="cache_offline_drop">Remove</string>
     <string name="cache_delete_userdefined_waypoints">Remove user-defined waypoints</string>
     <string name="cache_delete_userdefined_waypoints_confirm">Remove all user-defined waypoints of this cache?\n\nWaypoints will be deleted immediately, there is no undo.</string>
+    <string name="cache_delete_userdefined_waypoints_note">Note: You have \"waypoints from note\" enabled. If you have coordinates in your personal note recognized by c:geo, waypoints will be recreated for them automatically. You can disable this in the personal note edit dialog.</string>
     <string name="cache_delete_userdefined_waypoints_success">User-defined waypoints deleted</string>
     <string name="cache_offline_store">Store</string>
     <string name="cache_offline_stored">Stored in device</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1054,7 +1054,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
     private void dropUserdefinedWaypoints() {
         if (null != cache && cache.hasUserdefinedWaypoints()) {
-            Dialogs.confirm(this, R.string.cache_delete_userdefined_waypoints, R.string.cache_delete_userdefined_waypoints_confirm, (dialog, which) -> {
+            String info = getString(R.string.cache_delete_userdefined_waypoints_confirm);
+            if (!cache.isPreventWaypointsFromNote()) {
+                info += "\n\n" + getString(R.string.cache_delete_userdefined_waypoints_note);
+            }
+            Dialogs.confirm(this, getString(R.string.cache_delete_userdefined_waypoints), info, (dialog, which) -> {
                 for (Waypoint waypoint : new LinkedList<>(cache.getWaypoints())) {
                     if (waypoint.isUserDefined()) {
                         cache.deleteWaypoint(waypoint);

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1064,6 +1064,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                         cache.deleteWaypoint(waypoint);
                     }
                 }
+                cache.addWaypointsFromNote();
                 ActivityMixin.showShortToast(this, R.string.cache_delete_userdefined_waypoints_success);
                 invalidateOptionsMenu();
                 reinitializePage(Page.WAYPOINTS);


### PR DESCRIPTION
Confirmation dialog extended, if "prevent waypoint extraction" is NOT set for this cache:

![image](https://user-images.githubusercontent.com/3754370/93684480-a30d4c80-faaf-11ea-9a21-30f0b1120586.png)

@eddiemuc 
Or is there an easy way to detect programatically if there would be any waypoints detected from personal note?
Then I would add this check and only show the extended info when "prevent waypoint extraction" is not set AND there would be waypoints detected/created from PN.