### PR TITLE
widen and shorten found marker line in cache list

### DIFF
--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -22,9 +22,11 @@
     <!-- "found" marker, vertical green/red line -->
     <ImageView
         android:id="@+id/log_status_mark"
-        android:layout_width="2dip"
+        android:layout_width="4dip"
         android:layout_height="match_parent"
         android:layout_marginRight="4dip"
+        android:layout_marginTop="5dip"
+        android:layout_marginBottom="5dip"
         android:scaleType="centerCrop"
         android:gravity="left|center_vertical"
         android:src="@drawable/mark_transparent"


### PR DESCRIPTION
Following the discussion in https://github.com/cgeo/cgeo/issues/9029#issuecomment-696053797:
- double the width of the found marker line from 2dp to 4dp
- add a bottom margin of 10dp to more clearly separate this entry from the next

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/3754370/93814485-e1903c00-fc54-11ea-8595-c408fe0cc533.png)|![image](https://user-images.githubusercontent.com/3754370/93814518-e94fe080-fc54-11ea-9dd7-ce97cfb20bf7.png)|