### PR TITLE
show floppy symbol instead of text offline in cache lists

### DIFF
--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -179,9 +179,6 @@ public final class Formatter {
         if (cache.isPremiumMembersOnly()) {
             infos.add(CgeoApplication.getInstance().getString(R.string.cache_premium));
         }
-        if (cache.isOffline()) {
-            infos.add(CgeoApplication.getInstance().getString(R.string.cache_offline));
-        }
         return StringUtils.join(infos, SEPARATOR);
     }
 

--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -413,7 +413,7 @@ public final class MapMarkerUtils {
      *         True if the floppy overlay should be displayed
      */
     private static boolean showFloppyOverlay(@Nullable final CacheListType cacheListType) {
-        return cacheListType != CacheListType.OFFLINE; // also covers null check
+        return cacheListType != null;
     }
 
     private static void readLists() {


### PR DESCRIPTION
Follow-up to the discussion in #9029:
Replace the text "Offline" by floppy-disk overlay on the cache icon

|Before|After|
|------|-----|
|![image](https://user-images.githubusercontent.com/3754370/93814485-e1903c00-fc54-11ea-8595-c408fe0cc533.png)|![image](https://user-images.githubusercontent.com/3754370/93816273-9a577a80-fc57-11ea-8f3f-bb8b42c061d4.png)|