### PR TITLE
Properly detect failed signin because of invalid credentials in GC connector

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -199,7 +199,7 @@ public class GCLogin extends AbstractLogin {
                 return completeLoginProcess();
             }
 
-            if (loginData.contains("Your password or username/email is incorrect")) {
+            if (loginData.contains("id=\"signup-validation-error\"")) {
                 Log.i("Failed to log in Geocaching.com as " + username + " because of wrong username/password");
                 return resetGcCustomDate(StatusCode.WRONG_LOGIN_DATA); // wrong login
             }


### PR DESCRIPTION
See https://github.com/cgeo/cgeo/issues/8818#issuecomment-696409866
The "Your password or username/email is incorrect" string is always there and dynamically added to the div
with id #signup-validation-error via client-side JS, under the condition that this div is present in the page.

Fixes #8818