### PR TITLE
store recreated waypoints to db (fix #9042)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1064,7 +1064,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                         cache.deleteWaypoint(waypoint);
                     }
                 }
-                cache.addWaypointsFromNote();
+                if (cache.addWaypointsFromNote()) {
+                    Schedulers.io().scheduleDirect(() -> DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB)));
+                }
                 ActivityMixin.showShortToast(this, R.string.cache_delete_userdefined_waypoints_success);
                 invalidateOptionsMenu();
                 reinitializePage(Page.WAYPOINTS);


### PR DESCRIPTION
After deleting all user-defined waypoints the ones stored in a personal note get recreated automatically (if not suppressed) - but only in memory (= bug). This PR fixes this by directly storing the cache to database, if any waypoints got recreated from personal note after calling the "delete user-defined waypoints" function.