### PR TITLE
restore old save icon overlay handling (fix #9050) (fix #9045)

### DIFF
--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -413,7 +413,7 @@ public final class MapMarkerUtils {
      *         True if the floppy overlay should be displayed
      */
     private static boolean showFloppyOverlay(@Nullable final CacheListType cacheListType) {
-        return cacheListType != null;
+        return cacheListType != CacheListType.OFFLINE; // also covers null check
     }
 
     private static void readLists() {


### PR DESCRIPTION
- restores the old "stored" icon overlay from before #9036,
- but leaves the textual info "Offline" removed.