### PR TITLE
rename maps.api.key to maps.api2.key also in private.properties template

### DIFF
--- a/templates/private.properties
+++ b/templates/private.properties
@@ -5,7 +5,7 @@ key.store.password=password
 key.alias.password=password
 
 # Google Maps
-maps.api.key=
+maps.api2.key=
 
 # Opencaching.de
 ocde.okapi.consumer.key=


### PR DESCRIPTION
was forgotten when renaming in the keys.xml in abc8ad7dee9595e71dc5514678d6af2277500843,
see also https://github.com/bekuno/cgeo/blob/master/README.md#api-keys-installation