### PR TITLE
Disable extremcaching.com watchdog tests

### DIFF
--- a/tests/src-android/cgeo/watchdog/WatchdogTest.java
+++ b/tests/src-android/cgeo/watchdog/WatchdogTest.java
@@ -71,6 +71,15 @@ public class WatchdogTest extends CGeoTestCase {
     }
 
     private static void checkWebsite(final String connectorName, final String url) {    
+
+        // temporarily disable extremcaching.com
+        // It fails if the SSL certificate of the API has expired, which happens quite regular due to bad maintenance of the site
+        // As it blocks more relevant test results we keep it disabled for the time being
+
+        if (connectorName.equalsIgnoreCase("geocaching website extremcaching.com")) {
+            return;
+        }
+
         final String page = Network.getResponseData(Network.getRequest(url));
         assertThat(page).overridingErrorMessage("Failed to get response from " + connectorName).isNotEmpty();
     }


### PR DESCRIPTION
Their certificate is expired once again...