### PR TITLE
detect login captcha (related to #9056)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <!-- errors, warnings, info toasts -->
     <string name="err_none">OK</string>
     <string name="err_parse">Failed Login page parsing</string>
+    <string name="err_captcha">Captcha required. Please refer to our <a href="https://www.cgeo.org/faq#login-failed">FAQ</a> for guidance.</string>
     <string name="err_server">Unable to contact Geocaching.com. The website may be down or your internet connection not working.</string>
     <string name="err_server_ec">Unable to contact Extremcaching.com. The website may be down or your internet connection not working.</string>
     <string name="err_server_su">Unable to contact Geocaching.su. The website may be down or your internet connection not working.</string>

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -199,8 +199,13 @@ public class GCLogin extends AbstractLogin {
                 return completeLoginProcess();
             }
 
+            if (loginData.contains("<div class=\"g-recaptcha\" data-sitekey=\"")) {
+                Log.i("Failed to log in to geocaching.com due to captcha required");
+                return resetGcCustomDate(StatusCode.LOGIN_CAPTCHA_ERROR);
+            }
+
             if (loginData.contains("id=\"signup-validation-error\"")) {
-                Log.i("Failed to log in Geocaching.com as " + username + " because of wrong username/password");
+                Log.i("Failed to log in to geocaching.com as " + username + " because of wrong username/password");
                 return resetGcCustomDate(StatusCode.WRONG_LOGIN_DATA); // wrong login
             }
 

--- a/main/src/cgeo/geocaching/enumerations/StatusCode.java
+++ b/main/src/cgeo/geocaching/enumerations/StatusCode.java
@@ -12,6 +12,7 @@ public enum StatusCode {
     NO_ERROR(R.string.err_none),
     LOG_SAVED(R.string.info_log_saved),
     LOGIN_PARSE_ERROR(R.string.err_parse),
+    LOGIN_CAPTCHA_ERROR(R.string.err_captcha),
     CONNECTION_FAILED(R.string.err_server),
     CONNECTION_FAILED_EC(R.string.err_server_ec),
     CONNECTION_FAILED_SU(R.string.err_server_su),


### PR DESCRIPTION
Detects if a captcha HTML code is found in the HTML returned during login process for gc.com and displays an suitable error message for this. Captcha check is the last check done before the "wrong username/password" check.