### PR TITLE
rel to #9015: impr in-memory-filter perf, adjusts datastore-logs, logs logcat command

### DIFF
--- a/main/src/cgeo/geocaching/filter/AbstractFilter.java
+++ b/main/src/cgeo/geocaching/filter/AbstractFilter.java
@@ -29,13 +29,19 @@ abstract class AbstractFilter implements IFilter {
 
     @Override
     public void filter(@NonNull final List<Geocache> list) {
-        final List<Geocache> itemsToRemove = new ArrayList<>();
+
+        //method must be performant when used with very large lists (e.g. 50000 elements) filtered into very short lists (e.g. 30 elements)
+        //be aware that "list" most likely is an ArrayList, thus "get(i)" is very performant but "remove" is definitely not -> don't use it!
+
+        final List<Geocache> itemsToKeep = new ArrayList<>();
         for (final Geocache item : list) {
-            if (!accepts(item)) {
-                itemsToRemove.add(item);
+            if (accepts(item)) {
+                itemsToKeep.add(item);
             }
         }
-        list.removeAll(itemsToRemove);
+
+        list.clear();
+        list.addAll(itemsToKeep);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/utils/ContextLogger.java
+++ b/main/src/cgeo/geocaching/utils/ContextLogger.java
@@ -12,7 +12,7 @@ import java.util.Collection;
  * Helper class to construct log messages. Optimized to log what is happening in a method,
  * but can be used in other situations as well.
  *
- * All logging is done on VERBOSE level.
+ * All logging is done on level given in constructor, default is VERBOSE level.
  */
 public class ContextLogger implements Closeable {
 
@@ -27,14 +27,20 @@ public class ContextLogger implements Closeable {
     private final String contextString;
 
     private final boolean doLog;
+    private final Log.LogLevel logLevel;
     private boolean hasLogged = false;
 
     public ContextLogger(final String context, final Object ... params) {
+        this(Log.LogLevel.VERBOSE, context, params);
+    }
+
+    public ContextLogger(final Log.LogLevel logLevel, final String context, final Object ... params) {
         this.startTime = System.currentTimeMillis();
-        this.doLog = Log.isEnabled(Log.LogLevel.VERBOSE);
+        this.logLevel = logLevel;
+        this.doLog = Log.isEnabled(logLevel);
         if (this.doLog) {
             this.contextString = String.format(context, params) + ":";
-            Log.v(contextString + "START");
+            Log.log(logLevel, contextString + "START");
         } else {
             this.contextString = null;
         }
@@ -75,13 +81,12 @@ public class ContextLogger implements Closeable {
     public void endLog() {
         if (doLog) {
             hasLogged = true;
-            final String logMsg = this.contextString + "END " + message.toString() +
-                    (this.exception == null ? "" : "EXC:" + exception.getClass().getName() + "[" + exception.getMessage() + "]") +
-                    "(" + (System.currentTimeMillis() - startTime) + "ms)";
+            final String logMsg = this.contextString + "END (" + (System.currentTimeMillis() - startTime) + "ms)" + message.toString() +
+                    (this.exception == null ? "" : "EXC:" + exception.getClass().getName() + "[" + exception.getMessage() + "]");
             if (this.exception == null) {
-                Log.v(logMsg);
+                Log.log(logLevel, logMsg);
             } else {
-                Log.v(logMsg, this.exception);
+                Log.log(logLevel, logMsg, this.exception);
             }
         }
     }

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -77,6 +77,7 @@ public class DebugUtils {
                         builder.command("logcat", "-d", "AndroidRuntime:E", "cgeo:D", "cgeo.geocachin:I", "*:S", "-f", file.getAbsolutePath());
                     }
                 }
+                Log.iForce("[LogCat]Issuing command: " + builder.command());
                 final int returnCode = builder.start().waitFor();
                 if (returnCode == 0) {
                     result.set(file.exists() ? LogcatResults.LOGCAT_OK.ordinal() : LogcatResults.LOGCAT_EMPTY.ordinal());

--- a/main/src/cgeo/geocaching/utils/Log.java
+++ b/main/src/cgeo/geocaching/utils/Log.java
@@ -136,8 +136,6 @@ public final class Log {
             return "[" + shortName + "] " + msg + " {" + getCallerInfo(addCallerInfoMaxDepth) + "}";
         }
         return "[" + shortName + "] " + msg;
-
-
     }
 
     public static void v(final String msg) {
@@ -161,6 +159,32 @@ public final class Log {
     public static void d(final String msg, final Throwable t) {
         if (SETTING_DO_LOGGING[LogLevel.DEBUG.ordinal()]) {
             android.util.Log.d(TAG, adjustMessage(msg, LogLevel.DEBUG), t);
+        }
+    }
+
+    public static void log(final LogLevel level, final String msg) {
+        if (SETTING_DO_LOGGING[level.ordinal()]) {
+            switch (level) {
+                case ERROR: e(msg); break;
+                case WARN:  w(msg); break;
+                case INFO:  i(msg); break;
+                case DEBUG: d(msg); break;
+                case VERBOSE:
+                default: v(msg); break;
+            }
+        }
+    }
+
+    public static void log(final LogLevel level, final String msg, final Throwable thr) {
+        if (SETTING_DO_LOGGING[level.ordinal()]) {
+            switch (level) {
+                case ERROR: e(msg, thr); break;
+                case WARN:  w(msg, thr); break;
+                case INFO:  i(msg, thr); break;
+                case DEBUG: d(msg, thr); break;
+                case VERBOSE:
+                default: v(msg, thr); break;
+            }
         }
     }
 

--- a/tests/src-android/cgeo/geocaching/storage/DataStoreTestHelpers.java
+++ b/tests/src-android/cgeo/geocaching/storage/DataStoreTestHelpers.java
@@ -1,0 +1,146 @@
+package cgeo.geocaching.storage;
+
+import cgeo.CGeoTestCase;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+
+
+import android.test.suitebuilder.annotation.Suppress;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Methods (modelled as test cases) helping to set up (artificial) test data for development
+ * <p>
+ * It is vital that these methods are IGNORED/SUPPRESSED by default!
+ */
+public class DataStoreTestHelpers extends CGeoTestCase  {
+
+    private static final boolean EXECUTE_METHODS = false;
+
+    private static final String ARTIFICIAL_GEOCACHES_PRAEFIX = "GCFAKE";
+    private static final int ARTIFICAL_GEOCACHES_COUNT = 50000;
+
+    /**
+     * Method creates dummy caches in the database
+     */
+    @Suppress
+    public static void testCreateDummyCaches() {
+
+        //add a manual guard to be extra sure that this is not executed by default!
+        if (!EXECUTE_METHODS) {
+            return;
+        }
+
+        final List<Geocache> dummyCaches = new ArrayList<>();
+        for (int i = 0; i < ARTIFICAL_GEOCACHES_COUNT; i++) {
+            dummyCaches.add(createDummyCache(i));
+        }
+        DataStore.saveCaches(dummyCaches, EnumSet.of(LoadFlags.SaveFlag.DB));
+
+        for (int i = 0; i < ARTIFICAL_GEOCACHES_COUNT; i++) {
+            final String geocode = dummyCaches.get(i).getGeocode();
+            DataStore.saveLogs(geocode, createDummyLogsForCache(geocode, 30));
+        }
+    }
+
+    @Suppress
+    public static void testRemoveDummyCaches() {
+        //add a manual guard to be extra sure that this is not executed by default!
+        if (!EXECUTE_METHODS) {
+            return;
+        }
+
+        final Set<String> dummyCacheCodes = new HashSet<>();
+        for (int i = 0; i < ARTIFICAL_GEOCACHES_COUNT; i++) {
+            dummyCacheCodes.add(getArtificialGeocode(i));
+        }
+        DataStore.removeCaches(dummyCacheCodes, EnumSet.of(LoadFlags.RemoveFlag.DB));
+    }
+
+
+    private static List<LogEntry> createDummyLogsForCache(final String geocode, final int count) {
+        final List<LogEntry> result = new ArrayList<>();
+        for (int idx = 0; idx < count; idx++) {
+            result.add(new LogEntry.Builder<>()
+                    .setCacheGeocode(geocode)
+                    .setLog("Some log " + idx)
+                    .setLogType(LogType.NOTE).build());
+        }
+        return result;
+    }
+
+    private static Geocache createDummyCache(final int idx) {
+        final Geocache cache = new Geocache();
+        final long current = System.currentTimeMillis();
+        final Geopoint coords = new Geopoint(48 + (idx / 100f), 11 + (idx / 100f));
+        final Set<Integer> lists = new HashSet<>();
+        lists.add(StoredList.STANDARD_LIST_ID);
+
+        cache.setGeocode(getArtificialGeocode(idx));
+        cache.setGuid("none");
+        cache.setCacheId("none");
+        cache.setCoords(coords);
+        cache.setLists(lists);
+
+        cache.setDetailed(true);
+        cache.setDetailedUpdate(current);
+        cache.setVisitedDate(current);
+        cache.setType(CacheType.TRADITIONAL);
+        cache.setName("Fake Cache No " + idx);
+        cache.setOwnerDisplayName("TestCase");
+        cache.setOwnerUserId("none");
+        cache.setHidden(new Date());
+        cache.setHint("no hint");
+        cache.setSize(CacheSize.REGULAR);
+        cache.setDifficulty(2f);
+        cache.setTerrain(2f);
+        cache.setLocation("on earth");
+        cache.setDistance(500f);
+        cache.setDirection(0f);
+        cache.setShortDescription("A short description");
+        cache.setDescription("A long description");
+        cache.setPersonalNote("My Note");
+
+        return cache;
+
+//        Possible other values to set:
+//
+//        values.put("reliable_latlon", cache.isReliableLatLon() ? 1 : 0);
+//        values.put("shortdesc", cache.getShortDescription());
+//        values.put("personal_note", cache.getPersonalNote());
+//        values.put("description", cache.getDescription());
+//        values.put("favourite_cnt", cache.getFavoritePoints());
+//        values.put("rating", cache.getRating());
+//        values.put("votes", cache.getVotes());
+//        values.put("myvote", cache.getMyVote());
+//        values.put("disabled", cache.isDisabled() ? 1 : 0);
+//        values.put("archived", cache.isArchived() ? 1 : 0);
+//        values.put("members", cache.isPremiumMembersOnly() ? 1 : 0);
+//        values.put("found", cache.isFound() ? 1 : 0);
+//        values.put("favourite", cache.isFavorite() ? 1 : 0);
+//        values.put("inventoryunknown", cache.getInventoryItems());
+//        values.put("onWatchlist", cache.isOnWatchlist() ? 1 : 0);
+//        values.put("coordsChanged", cache.hasUserModifiedCoords() ? 1 : 0);
+//        values.put("finalDefined", cache.hasFinalDefined() ? 1 : 0);
+//        values.put("logPasswordRequired", cache.isLogPasswordRequired() ? 1 : 0);
+//        values.put("watchlistCount", cache.getWatchlistCount());
+//        values.put("preventWaypointsFromNote", cache.isPreventWaypointsFromNote() ? 1 : 0);
+
+    }
+
+    private static String getArtificialGeocode(final int idx) {
+        return ARTIFICIAL_GEOCACHES_PRAEFIX + idx;
+    }
+}

--- a/tests/src/cgeo/geocaching/filter/SizeFilterTest.java
+++ b/tests/src/cgeo/geocaching/filter/SizeFilterTest.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.models.Geocache;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +49,28 @@ public class SizeFilterTest {
 
         microFilter.filter(list);
         assertThat(list).hasSize(1);
+    }
+
+    @Test(timeout = 5000) //filtering large lists in memory should take only MILLISECONDS. we set a very generous timeout of 5s here
+    public void testFilteringPerformanceOnLargeLists() {
+        //filter a very large list such that is becomes a very short list
+        final List<Geocache> list = new ArrayList<>();
+        for (int i = 0; i < 50000; i++) {
+            final Geocache regularGc = new Geocache();
+            regularGc.setGeocode("GCFAKE" + i);
+            regularGc.setSize(CacheSize.REGULAR);
+            list.add(regularGc);
+            if (i % 1000 == 0) {
+                final Geocache microGc = new Geocache();
+                microGc.setGeocode("GCFAKE" + i);
+                microGc.setSize(CacheSize.MICRO);
+                list.add(micro);
+            }
+        }
+        assertThat(list).hasSize(50000 + 50);
+
+        microFilter.filter(list);
+        assertThat(list).hasSize(50);
     }
 
 }


### PR DESCRIPTION
related to #9015: This PR
* improves in-memory-filtering performance for large cache lists
* adjusts logging in class DataStore
* adds logging of logcat command issued to extract c:geo logs via Settings-> System
* adds a helper class to create/remove artificial cache test data into developer databases