### PR TITLE
related to #9015 and PR #9080: add missing unit test, adjust comment in AbstractFilter

### DIFF
--- a/main/src/cgeo/geocaching/filter/AbstractFilter.java
+++ b/main/src/cgeo/geocaching/filter/AbstractFilter.java
@@ -30,7 +30,8 @@ abstract class AbstractFilter implements IFilter {
     @Override
     public void filter(@NonNull final List<Geocache> list) {
 
-        //method must be performant when used with very large lists (e.g. 50000 elements) filtered into very short lists (e.g. 30 elements)
+        //method must be performant when used with very large lists (e.g. 50000 elements)
+        // filtered into very large lists and also very short lists (e.g. 30 elements)
         //be aware that "list" most likely is an ArrayList, thus "get(i)" is very performant but "remove" is definitely not -> don't use it!
 
         final List<Geocache> itemsToKeep = new ArrayList<>();
@@ -41,6 +42,7 @@ abstract class AbstractFilter implements IFilter {
         }
 
         list.clear();
+        //note that since both "list" and "itemsToKeep" are ArrayLists, the addAll-operation is very fast (two arraycopies of the references)
         list.addAll(itemsToKeep);
     }
 

--- a/tests/src/cgeo/geocaching/filter/SizeFilterTest.java
+++ b/tests/src/cgeo/geocaching/filter/SizeFilterTest.java
@@ -52,7 +52,7 @@ public class SizeFilterTest {
     }
 
     @Test(timeout = 5000) //filtering large lists in memory should take only MILLISECONDS. we set a very generous timeout of 5s here
-    public void testFilteringPerformanceOnLargeLists() {
+    public void testFilteringPerformanceOnLargeListToSmallList() {
         //filter a very large list such that is becomes a very short list
         final List<Geocache> list = new ArrayList<>();
         for (int i = 0; i < 50000; i++) {
@@ -71,6 +71,28 @@ public class SizeFilterTest {
 
         microFilter.filter(list);
         assertThat(list).hasSize(50);
+    }
+
+    @Test(timeout = 5000) //filtering large lists in memory should take only MILLISECONDS. we set a very generous timeout of 5s here
+    public void testFilteringPerformanceOnLargeListToLargeList() {
+        //filter a very large list such that is becomes a very short list
+        final List<Geocache> list = new ArrayList<>();
+        for (int i = 0; i < 50000; i++) {
+            final Geocache microGc = new Geocache();
+            microGc.setGeocode("GCFAKE" + i);
+            microGc.setSize(CacheSize.MICRO);
+            list.add(microGc);
+            if (i % 1000 == 0) {
+                final Geocache regularGc = new Geocache();
+                regularGc.setGeocode("GCFAKE" + i);
+                regularGc.setSize(CacheSize.REGULAR);
+                list.add(regularGc);
+            }
+        }
+        assertThat(list).hasSize(50000 + 50);
+
+        microFilter.filter(list);
+        assertThat(list).hasSize(50000);
     }
 
 }


### PR DESCRIPTION
related to #9015 and PR #9080: add missing unit test, adjust comment in AbstractFilter

As #okainov commented correctly in PR #9080, there should be corect commenting and unit testing also for large lists filtered to large lists (not only to slow lists). This PR adds that.
Thanks, @okainov , for the good assesment