### PR TITLE
Fix #9069 - Hint is not displayed on compass view, when launched directly from map

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -236,7 +236,7 @@ public class CompassActivity extends AbstractActionBarActivity {
     @Override
     public boolean onPrepareOptionsMenu(final Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        menu.findItem(R.id.menu_hint).setVisible(cache != null);
+        menu.findItem(R.id.menu_hint).setVisible(cache != null && StringUtils.isNotEmpty(cache.getHint()));
         return true;
     }
 

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -222,6 +222,16 @@ public class Geocache implements IWaypoint {
             // boolean values must be enumerated here. Other types are assigned outside this if-statement
             reliableLatLon = other.reliableLatLon;
             finalDefined = other.finalDefined;
+
+            if (StringUtils.isBlank(getHint())) {
+                hint = other.getHint();
+            }
+            if (StringUtils.isBlank(getShortDescription())) {
+                shortdesc = other.getShortDescription();
+            }
+            if (attributes.isEmpty() && other.attributes != null) {
+                attributes.addAll(other.attributes);
+            }
         }
 
         if (premiumMembersOnly == null) {
@@ -273,9 +283,6 @@ public class Geocache implements IWaypoint {
         if (hidden == null) {
             hidden = other.hidden;
         }
-        if (!detailed && StringUtils.isBlank(getHint())) {
-            hint = other.getHint();
-        }
         if (size == CacheSize.UNKNOWN) {
             size = other.size;
         }
@@ -297,9 +304,6 @@ public class Geocache implements IWaypoint {
 
         personalNote.gatherMissingDataFrom(other.personalNote);
 
-        if (!detailed && StringUtils.isBlank(getShortDescription())) {
-            shortdesc = other.getShortDescription();
-        }
         if (StringUtils.isBlank(getDescription())) {
             description = other.getDescription();
         }
@@ -314,9 +318,6 @@ public class Geocache implements IWaypoint {
         }
         if (myVote == 0) {
             myVote = other.myVote;
-        }
-        if (!detailed && attributes.isEmpty() && other.attributes != null) {
-            attributes.addAll(other.attributes);
         }
         if (waypoints.isEmpty()) {
             this.setWaypoints(other.waypoints, false);


### PR DESCRIPTION
When gathering from another cache, if this cache wasn't detailed, and the other is,
the hint, etc. would never be copied. This fixes the case where the cache is stored
in the database.

Also, if there isn't a hint (or it isn't stored), don't show the show-hint icon on
the compass UI.