### PR TITLE
extend position history by timestamp + use timestamp on export (fix #9097)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -40,6 +40,7 @@ import cgeo.geocaching.models.IWaypoint;
 import cgeo.geocaching.models.ManualRoute;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.network.AndroidBeam;
 import cgeo.geocaching.permission.PermissionHandler;
@@ -464,7 +465,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         return null;
     }
 
-    protected void initializeMap(final ArrayList<Location> trailHistory) {
+    protected void initializeMap(final ArrayList<TrailHistoryElement> trailHistory) {
 
         mapView.setMapSource();
         mapView.setBuiltInZoomControls(true);
@@ -540,7 +541,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         final Bundle extras = activity.getIntent().getExtras();
         mapOptions = new MapOptions(activity, extras);
 
-        final ArrayList<Location> trailHistory;
+        final ArrayList<TrailHistoryElement> trailHistory;
 
         // Get fresh map information from the bundle if any
         if (savedInstanceState != null) {

--- a/main/src/cgeo/geocaching/maps/PositionHistory.java
+++ b/main/src/cgeo/geocaching/maps/PositionHistory.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.maps;
 
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 
@@ -24,7 +25,7 @@ public class PositionHistory {
      */
     private static final int MAX_POSITIONS = Settings.getMaximumMapTrailLength();
 
-    private ArrayList<Location> history = new ArrayList<>();
+    private ArrayList<TrailHistoryElement> history = new ArrayList<>();
 
     // load data from permanent storage
     public PositionHistory() {
@@ -56,17 +57,17 @@ public class PositionHistory {
         }
         if (history.isEmpty()) {
             saveToStorage(coordinates);
-            history.add(coordinates);
+            history.add(new TrailHistoryElement(coordinates));
             return;
         }
 
-        final Location historyRecent = history.get(history.size() - 1);
+        final TrailHistoryElement historyRecent = history.get(history.size() - 1);
         if (historyRecent.distanceTo(coordinates) <= MINIMUM_DISTANCE_METERS) {
             return;
         }
 
         saveToStorage(coordinates);
-        history.add(coordinates);
+        history.add(new TrailHistoryElement(coordinates));
 
         // avoid running out of memory
         final int itemsToRemove = getHistory().size() - MAX_POSITIONS;
@@ -77,11 +78,11 @@ public class PositionHistory {
         }
     }
 
-    public ArrayList<Location> getHistory() {
+    public ArrayList<TrailHistoryElement> getHistory() {
         return history;
     }
 
-    public void setHistory(final ArrayList<Location> history) {
+    public void setHistory(final ArrayList<TrailHistoryElement> history) {
         this.history = history;
     }
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.maps.interfaces.PositionAndHistory;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.models.ManualRoute;
 import cgeo.geocaching.models.Route;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.MapLineUtils;
@@ -147,12 +148,12 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
     }
 
     @Override
-    public ArrayList<Location> getHistory() {
+    public ArrayList<TrailHistoryElement> getHistory() {
         return history.getHistory();
     }
 
     @Override
-    public void setHistory(final ArrayList<Location> history) {
+    public void setHistory(final ArrayList<TrailHistoryElement> history) {
         if (history != this.history.getHistory()) {
             this.history.setHistory(history);
         }
@@ -264,15 +265,15 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
         }
         historyObjs.removeAll();
         if (Settings.isMapTrail()) {
-            final ArrayList<Location> paintHistory = new ArrayList<>(getHistory());
+            final ArrayList<TrailHistoryElement> paintHistory = new ArrayList<>(getHistory());
             final int size = paintHistory.size();
             if (size < 2) {
                 return;
             }
             // always add current position to drawn history to have a closed connection, even if it's not yet recorded
-            paintHistory.add(coordinates);
+            paintHistory.add(new TrailHistoryElement(coordinates));
 
-            Location prev = paintHistory.get(0);
+            Location prev = paintHistory.get(0).getLocation();
             int current = 1;
             while (current < size) {
                 final List<LatLng> points = new ArrayList<>(MAX_HISTORY_POINTS);
@@ -280,7 +281,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
                 boolean paint = false;
                 while (!paint && current < size) {
-                    final Location now = paintHistory.get(current);
+                    final Location now = paintHistory.get(current).getLocation();
                     current++;
                     if (now.distanceTo(prev) < LINE_MAXIMUM_DISTANCE_METERS) {
                         points.add(new LatLng(now.getLatitude(), now.getLongitude()));

--- a/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.maps.interfaces;
 
 import cgeo.geocaching.models.ManualRoute;
+import cgeo.geocaching.models.TrailHistoryElement;
 
 import android.location.Location;
 
@@ -17,9 +18,9 @@ public interface PositionAndHistory extends ManualRoute.UpdateManualRoute {
 
     float getHeading();
 
-    ArrayList<Location> getHistory();
+    ArrayList<TrailHistoryElement> getHistory();
 
-    void setHistory(ArrayList<Location> history);
+    void setHistory(ArrayList<TrailHistoryElement> history);
 
     void repaintRequired();
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgePositionAndHistory.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OverlayImpl;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
 import cgeo.geocaching.models.Route;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.storage.DataStore;
 
 import android.graphics.Canvas;
@@ -104,12 +105,12 @@ public class MapsforgePositionAndHistory implements GeneralOverlay, PositionAndH
     }
 
     @Override
-    public ArrayList<Location> getHistory() {
+    public ArrayList<TrailHistoryElement> getHistory() {
         return positionDrawer.getHistory();
     }
 
     @Override
-    public void setHistory(final ArrayList<Location> history) {
+    public void setHistory(final ArrayList<TrailHistoryElement> history) {
         positionDrawer.setHistory(history);
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/PositionDrawer.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.maps.PositionHistory;
 import cgeo.geocaching.maps.interfaces.GeoPointImpl;
 import cgeo.geocaching.maps.interfaces.MapItemFactory;
 import cgeo.geocaching.maps.interfaces.MapProjectionImpl;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.MapLineUtils;
 
@@ -104,8 +105,8 @@ public class PositionDrawer {
 
         if (Settings.isMapTrail()) {
             // always add current position to drawn history to have a closed connection
-            final ArrayList<Location> paintHistory = new ArrayList<>(positionHistory.getHistory());
-            paintHistory.add(coordinates);
+            final ArrayList<TrailHistoryElement> paintHistory = new ArrayList<>(positionHistory.getHistory());
+            paintHistory.add(new TrailHistoryElement(coordinates));
 
             final int size = paintHistory.size();
             if (size > 1) {
@@ -116,11 +117,11 @@ public class PositionDrawer {
 
                 final Point pointNow = new Point();
                 final Point pointPrevious = new Point();
-                final Location prev = paintHistory.get(0);
+                final Location prev = paintHistory.get(0).getLocation();
                 projection.toPixels(mapItemFactory.getGeoPointBase(new Geopoint(prev)), pointPrevious);
 
                 for (int cnt = 1; cnt < size; cnt++) {
-                    final Location now = paintHistory.get(cnt);
+                    final Location now = paintHistory.get(cnt).getLocation();
                     projection.toPixels(mapItemFactory.getGeoPointBase(new Geopoint(now)), pointNow);
 
                     final int alpha;
@@ -160,11 +161,11 @@ public class PositionDrawer {
         canvas.setDrawFilter(remfil);
     }
 
-    public ArrayList<Location> getHistory() {
+    public ArrayList<TrailHistoryElement> getHistory() {
         return positionHistory.getHistory();
     }
 
-    public void setHistory(final ArrayList<Location> history) {
+    public void setHistory(final ArrayList<TrailHistoryElement> history) {
         positionHistory.setHistory(history);
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -43,6 +43,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.ManualRoute;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.permission.PermissionHandler;
 import cgeo.geocaching.permission.PermissionRequestContext;
 import cgeo.geocaching.permission.RestartLocationPermissionGrantedCallback;
@@ -150,7 +151,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
     private DistanceView distanceView;
 
-    private ArrayList<Location> trailHistory = null;
+    private ArrayList<TrailHistoryElement> trailHistory = null;
 
     private String targetGeocode = null;
     private Geopoint lastNavTarget = null;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.maps.PositionHistory;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.MapLineUtils;
 
@@ -29,7 +30,7 @@ public class HistoryLayer extends Layer {
     private Location coordinates;
     private Paint historyLine;
 
-    public HistoryLayer(final ArrayList<Location> locationHistory) {
+    public HistoryLayer(final ArrayList<TrailHistoryElement> locationHistory) {
         super();
         if (locationHistory != null) {
             positionHistory.setHistory(locationHistory);
@@ -57,9 +58,9 @@ public class HistoryLayer extends Layer {
         positionHistory.rememberTrailPosition(coordinates);
 
         if (Settings.isMapTrail()) {
-            final ArrayList<Location> paintHistory = new ArrayList<>(getHistory());
+            final ArrayList<TrailHistoryElement> paintHistory = new ArrayList<>(getHistory());
             // always add current position to drawn history to have a closed connection, even if it's not yet recorded
-            paintHistory.add(coordinates);
+            paintHistory.add(new TrailHistoryElement(coordinates));
             final int size = paintHistory.size();
             if (size < 2) {
                 return;
@@ -67,7 +68,7 @@ public class HistoryLayer extends Layer {
 
             final long mapSize = MercatorProjection.getMapSize(zoomLevel, this.displayModel.getTileSize());
 
-            Location prev = paintHistory.get(0);
+            Location prev = paintHistory.get(0).getLocation();
             final Path path = AndroidGraphicFactory.INSTANCE.createPath();
             int current = 1;
             while (current < size) {
@@ -75,7 +76,7 @@ public class HistoryLayer extends Layer {
 
                 boolean paint = false;
                 while (!paint && current < size) {
-                    final Location now = paintHistory.get(current);
+                    final Location now = paintHistory.get(current).getLocation();
                     current++;
                     if (now.distanceTo(prev) < LINE_MAXIMUM_DISTANCE_METERS) {
                         path.lineTo((float) (MercatorProjection.longitudeToPixelX(now.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(now.getLatitude(), mapSize) - topLeftPoint.y));
@@ -92,7 +93,7 @@ public class HistoryLayer extends Layer {
         }
     }
 
-    public ArrayList<Location> getHistory() {
+    public ArrayList<TrailHistoryElement> getHistory() {
         return positionHistory.getHistory();
     }
 

--- a/main/src/cgeo/geocaching/models/TrailHistoryElement.java
+++ b/main/src/cgeo/geocaching/models/TrailHistoryElement.java
@@ -1,0 +1,76 @@
+package cgeo.geocaching.models;
+
+import android.location.Location;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class TrailHistoryElement implements Parcelable {
+    private Location location;
+    private long timestamp;
+
+    public TrailHistoryElement(final double latitude, final double longitude, final long timestamp) {
+        location = new Location("trailHistory");
+        location.setLatitude(latitude);
+        location.setLongitude(longitude);
+        this.timestamp = timestamp;
+    }
+
+    public TrailHistoryElement(final Location loc) {
+        location = loc;
+        timestamp = System.currentTimeMillis();
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public double getLatitude() {
+        return location.getLatitude();
+    }
+
+    public double getLongitude() {
+        return location.getLongitude();
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public float distanceTo(final Location dest) {
+        return location.distanceTo(dest);
+    }
+
+
+    // parcelable methods
+
+    public static final Parcelable.Creator<TrailHistoryElement> CREATOR = new Parcelable.Creator<TrailHistoryElement>() {
+
+        @Override
+        public TrailHistoryElement createFromParcel(final Parcel source) {
+            return new TrailHistoryElement(source);
+        }
+
+        @Override
+        public TrailHistoryElement[] newArray(final int size) {
+            return new TrailHistoryElement[size];
+        }
+
+    };
+
+    private TrailHistoryElement(final Parcel parcel) {
+        location = parcel.readParcelable(Location.class.getClassLoader());
+        timestamp = parcel.readLong();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeParcelable(location, flags);
+        dest.writeLong(timestamp);
+    }
+
+}

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -32,6 +32,7 @@ import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.models.RouteSegment;
 import cgeo.geocaching.models.Trackable;
+import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.search.SearchSuggestionCursor;
@@ -196,7 +197,7 @@ public class DataStore {
      */
     private static final CacheCache cacheCache = new CacheCache();
     private static volatile SQLiteDatabase database = null;
-    private static final int dbVersion = 87;
+    private static final int dbVersion = 88;
     public static final int customListIdOffset = 10;
 
     /**
@@ -218,8 +219,9 @@ public class DataStore {
      */
     private static final Set<Integer> DBVERSIONS_DOWNWARD_COMPATIBLE = new HashSet<>(Arrays.asList(new Integer[]{
             85, //adds offline logging columns/tables
-            86, // (re)create indices on c_logs and c_logImages
-            87  //adds service log id to logging tables
+            86, //(re)create indices on c_logs and c_logImages
+            87, //adds service log id to logging tables
+            88  //add timestamp to trail history
     }));
 
     @NonNull private static final String dbTableCaches = "cg_caches";
@@ -429,7 +431,8 @@ public class DataStore {
             = "CREATE TABLE " + dbTableTrailHistory + " ("
             + "_id INTEGER PRIMARY KEY AUTOINCREMENT, "
             + "latitude DOUBLE, "
-            + "longitude DOUBLE "
+            + "longitude DOUBLE, "
+            + "timestamp LONG"
             + "); ";
 
     private static final String dbCreateRoute
@@ -1349,6 +1352,16 @@ public class DataStore {
                         }
                     }
 
+                    // add timestamp to cg_trail_history
+                    if (oldVersion < 88) {
+                        try {
+                            createColumnIfNotExists(db, dbTableTrailHistory, "timestamp INTEGER DEFAULT 0");
+                            db.execSQL("UPDATE " + dbTableTrailHistory + " SET timestamp =" + System.currentTimeMillis());
+                        } catch (final SQLException e) {
+                            onUpgradeError(e, 88);
+                        }
+                    }
+
                 }
 
                 //at the very end of onUpgrade: rewrite downgradeable versions in database
@@ -1957,6 +1970,7 @@ public class DataStore {
             final SQLiteStatement insertTrailpoint = PreparedStatement.INSERT_TRAILPOINT.getStatement();
             insertTrailpoint.bindDouble(1, location.getLatitude());
             insertTrailpoint.bindDouble(2, location.getLongitude());
+            insertTrailpoint.bindLong(3, System.currentTimeMillis());
             insertTrailpoint.executeInsert();
             database.setTransactionSuccessful();
         } catch (final Exception e) {
@@ -2690,34 +2704,28 @@ public class DataStore {
      * @return A list of previously trail points or an empty list.
      */
     @NonNull
-    public static ArrayList<Location> loadTrailHistory() {
-        final ArrayList<Location> temp = queryToColl(dbTableTrailHistory,
-                new String[]{"_id", "latitude", "longitude"},
+    public static ArrayList<TrailHistoryElement> loadTrailHistory() {
+        final ArrayList<TrailHistoryElement> temp = queryToColl(dbTableTrailHistory,
+                new String[]{"_id", "latitude", "longitude", "timestamp"},
                 "latitude IS NOT NULL AND longitude IS NOT NULL",
                 null,
                 "_id DESC",
                 String.valueOf(DbHelper.MAX_TRAILHISTORY_LENGTH),
                 new ArrayList<>(),
-                cursor -> {
-                    final Location l = new Location("trailHistory");
-                    l.setLatitude(cursor.getDouble(1));
-                    l.setLongitude(cursor.getDouble(2));
-                    return l;
-                });
+                cursor -> new TrailHistoryElement(cursor.getDouble(1), cursor.getDouble(2), cursor.getLong(3))
+            );
         Collections.reverse(temp);
         return temp;
     }
 
-    public static Location[] loadTrailHistoryAsArray() {
+    public static TrailHistoryElement[] loadTrailHistoryAsArray() {
         init();
-        final Cursor cursor = database.query(dbTableTrailHistory, new String[]{"_id", "latitude", "longitude"}, "latitude IS NOT NULL AND longitude IS NOT NULL", null, null, null, "_id ASC", null);
-        final Location[] result = new Location[cursor.getCount()];
+        final Cursor cursor = database.query(dbTableTrailHistory, new String[]{"_id", "latitude", "longitude", "timestamp"}, "latitude IS NOT NULL AND longitude IS NOT NULL", null, null, null, "_id ASC", null);
+        final TrailHistoryElement[] result = new TrailHistoryElement[cursor.getCount()];
         int iPosition = 0;
         try {
             while (cursor.moveToNext()) {
-                result[iPosition] = new Location("trailHistory");
-                result[iPosition].setLatitude(cursor.getDouble(1));
-                result[iPosition].setLongitude(cursor.getDouble(2));
+                result[iPosition] = new TrailHistoryElement(cursor.getDouble(1), cursor.getDouble(2), cursor.getLong(3));
                 iPosition++;
             }
         } finally {
@@ -3996,7 +4004,7 @@ public class DataStore {
         GUID_OFFLINE("SELECT COUNT(l.list_id) FROM " + dbTableCachesLists + " l, " + dbTableCaches + " c WHERE c.guid = ? AND c.geocode = l.geocode AND c.detailed = 1 AND list_id != " + StoredList.TEMPORARY_LIST.id),
         GEOCODE_OF_GUID("SELECT geocode FROM " + dbTableCaches + " WHERE guid = ?"),
         GEOCODE_FROM_TITLE("SELECT geocode FROM " + dbTableCaches + " WHERE name = ?"),
-        INSERT_TRAILPOINT("INSERT INTO " + dbTableTrailHistory + " (latitude, longitude) VALUES (?, ?)"),
+        INSERT_TRAILPOINT("INSERT INTO " + dbTableTrailHistory + " (latitude, longitude, timestamp) VALUES (?, ?, ?)"),
         INSERT_ROUTEITEM("INSERT INTO " + dbTableRoute + " (precedence, type, id, latitude, longitude) VALUES (?, ?, ?, ?, ?)"),
         COUNT_TYPE_ALL_LIST("SELECT COUNT(c._id) FROM " + dbTableCaches + " c, " + dbTableCachesLists + " l  WHERE c.type = ? AND c.geocode = l.geocode AND l.list_id > 0"), // See use of COUNT_TYPE_LIST for synchronization
         COUNT_ALL_TYPES_ALL_LIST("SELECT COUNT(c._id) FROM " + dbTableCaches + " c, " + dbTableCachesLists + " l WHERE c.geocode = l.geocode AND l.list_id  > 0"), // See use of COUNT_TYPE_LIST for synchronization


### PR DESCRIPTION
- stores the current timestamp in position history (unix epoch format)
- uses this timestamp on GPX export of position history