### PR TITLE
WIP grant access to base dir

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
         android:usesCleartextTraffic="true"
         android:supportsRtl="true"
         android:largeHeap="true"
-        android:requestLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="false">
 
         <!-- Samsung Multi-Window support -->
         <uses-library

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         //noinspection OldTargetApi
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -263,6 +263,13 @@
     <string translatable="false" name="pref_map_routing">map_routing</string>
     <string translatable="false" name="pref_theme_menu">theme_menu</string>
 
+
+
+
+    <!-- store the base directory where the user has granted c:geo access to (relevant for Android 10+ scoped storage -->
+    <string translatable="false" name="pref_granted_basedir">granted_basedir</string>
+
+    <!-- preference values -->
     <string translatable="false" name="pref_maprotation_off">off</string>
     <string translatable="false" name="pref_maprotation_manual">manual</string>
     <string translatable="false" name="pref_maprotation_auto">auto</string>

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -40,6 +40,7 @@ import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
 
@@ -1641,5 +1642,16 @@ public class Settings {
 
     public static boolean allowMultipleBackups() {
         return getBoolean(R.string.pref_backups_backup_history, false);
+    }
+
+    public static void setBaseDir(final Uri uri) {
+        putString(R.string.pref_granted_basedir, uri.getPath());
+        LocalStorage.resetExternalPublicCgeoDirectory();
+    }
+
+    @Nullable
+    public static File getBaseDir() {
+        final String pref = getString(R.string.pref_granted_basedir, "");
+        return StringUtils.isNotBlank(pref) ? new File(pref) : null;
     }
 }

--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -248,7 +248,12 @@ public final class LocalStorage {
     @NonNull
     public static File getExternalPublicCgeoDirectory() {
         if (externalPublicCgeoDirectory == null) {
-            externalPublicCgeoDirectory = new File(Environment.getExternalStorageDirectory().getAbsolutePath(), CGEO_DIRNAME);
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                final File baseDir = Settings.getBaseDir();
+                externalPublicCgeoDirectory = null != baseDir ? baseDir : new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), CGEO_DIRNAME);
+            } else {
+                externalPublicCgeoDirectory = new File(Environment.getExternalStorageDirectory().getAbsolutePath(), CGEO_DIRNAME);
+            }
             FileUtils.mkdirs(externalPublicCgeoDirectory);
             if (!externalPublicCgeoDirectory.exists() || !externalPublicCgeoDirectory.canWrite()) {
                 Log.w("External public cgeo directory '" + externalPublicCgeoDirectory + "' not available");


### PR DESCRIPTION
This is a first step in trying to get a grip on the new storage framework requirements enforced with Android 11.

I've set up a new branch 'storage_framework' to be able to collaborate on this topic. Whether we merge this branch later on into `master` or put the findings into separate PR is to be decided later.

This PR includes the following first steps:
- Enforces using the new storage framework by setting `targetSDK` to 30 and removing the `requestLegacyExternalStorage` workaround.
- Creates a new base dir for public c:geo data beneath the `Download` directory.
- Tries to acquire access rights for all files in that directory and store the grant in settings.
- Tries to use this new base dir as replacement for our current base dir.

The first results are promising in some places, but not everything works yet as expected:
- Step 1 works. As our current base dir (`/sdcard/cgeo`) is no longer accessible, c:geo falls back to the internal dir (`data/user/0/cgeo/geocaching`) as you can see in our system info page.
- The directory created in step 2 does work, and c:geo has access to all files within that directory structure - as long as the files and dirs get created by c:geo! If you move a new file into this structure externally (eg: a map file), c:geo won't see this file at all!
- In step 3 the system dialog to grant rights opens, and after user confirmation returns a uri like `tree/primary:Download/cgeo` which looks ok to me, but I've found no way so far to reuse this uri in further file access (step 4).

Still I'm sharing this intermediate state so that we are able to collaborate upon this.