### PR TITLE
(fix #8409) : export waypoint without coordinates

### DIFF
--- a/main/project/xsd/cgeo.xsd
+++ b/main/project/xsd/cgeo.xsd
@@ -10,6 +10,7 @@ Currently two items are defined: visited and userdefined.
 <xsd:complexType>
 <xsd:sequence>
 <xsd:element name="visited" type="xsd:boolean" />
+<xsd:element name="originalCoordsEmpty" type="xsd:boolean" />
 <xsd:element name="userdefined" type="xsd:boolean" />
 </xsd:sequence>
 </xsd:complexType></xsd:element>

--- a/main/src/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/cgeo/geocaching/export/GpxSerializer.java
@@ -262,7 +262,7 @@ public final class GpxSerializer {
             gpx.attribute("", "lon", Double.toString(coords.getLongitude()));
         } else {
             // coords are required information
-            // "xsi:nil" is not supported by schema, hence use 0/0 as GSAK does.
+            // "xsi:nil" is not supported by schema, hence use 0/0 as OKAPI does.
             gpx.attribute("", "lat", Double.toString(0.0));
             gpx.attribute("", "lon", Double.toString(0.0));
         }

--- a/main/src/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/cgeo/geocaching/export/GpxSerializer.java
@@ -203,7 +203,7 @@ public final class GpxSerializer {
             gpx.startTag(NS_CGEO, "originalCoordsEmpty");
             gpx.text("true");
             gpx.endTag(NS_CGEO, "originalCoordsEmpty");
-        }        
+        }
     }
 
     /**
@@ -271,16 +271,10 @@ public final class GpxSerializer {
         // combine note and user note with SEPARATOR "\n--\n"
         final String waypointNote = wp.getCombinedNoteAndUserNote();
         XmlUtils.multipleTexts(gpx, NS_GPX, "name", wp.getGpxId(), "cmt", waypointNote, "desc", wp.getName(), "sym", waypointTypeGpx, "type", "Waypoint|" + waypointTypeGpx);
-        // add parent reference the GSAK-way
-        writeGsakExtensions(wp);
-
-        // combine note and user note with SEPARATOR "\n--\n"
-        final String waypointNote = wp.getCombinedNoteAndUserNote();
-        XmlUtils.multipleTexts(gpx, NS_GPX, "name", wp.getGpxId(), "cmt", waypointNote, "desc", wp.getName(), "sym", waypointTypeGpx, "type", "Waypoint|" + waypointTypeGpx);
 
         // add parent reference the GSAK-way
         writeGsakExtensions(wp);
-
+        // add specific cgeo-attributes
         writeCGeoAttributes(wp);
 
         gpx.endTag(NS_GPX, "wpt");

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -791,7 +791,7 @@ abstract class GPXParser extends FileParser {
             cgeoUserDefined.setEndTextElementListener(userDefined -> wptUserDefined = Boolean.parseBoolean(userDefined.trim()));
 
             final Element cgeoEmptyCoords = cacheParent.getChild(cgeoNamespace, "originalCoordsEmpty");
-            cgeoEmptyCoords.setEndTextElementListener(emptyCoords -> wptEmptyCoordinates = Boolean.parseBoolean(emptyCoords.trim()));
+            cgeoEmptyCoords.setEndTextElementListener(originalCoordsEmpty -> wptEmptyCoordinates = Boolean.parseBoolean(originalCoordsEmpty.trim()));
         }
     }
 

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -126,6 +126,7 @@ abstract class GPXParser extends FileParser {
     private String parentCacheCode = null;
     private boolean wptVisited = false;
     private boolean wptUserDefined = false;
+    private boolean wptEmptyCoordinates = false;
     private List<LogEntry> logs = new ArrayList<>();
 
     /**
@@ -209,10 +210,14 @@ abstract class GPXParser extends FileParser {
                 if (attrs.getIndex("lat") > -1 && attrs.getIndex("lon") > -1) {
                     final String latitude = attrs.getValue("lat");
                     final String longitude = attrs.getValue("lon");
-                    // latitude and longitude are required attributes, but we export them empty for waypoints without coordinates
+                    // latitude and longitude are required attributes, but we export them (0/0) for waypoints without coordinates
                     if (StringUtils.isNotBlank(latitude) && StringUtils.isNotBlank(longitude)) {
-                        cache.setCoords(new Geopoint(Double.parseDouble(latitude),
-                                Double.parseDouble(longitude)));
+                        final Geopoint latLon = new Geopoint(Double.parseDouble(latitude),
+                                Double.parseDouble(longitude));
+                        final Geopoint pt0 = new Geopoint(0, 0);
+                        if (!latLon.equals(pt0)) {
+                            cache.setCoords(latLon);
+                        }
                     }
                 }
             } catch (final NumberFormatException e) {
@@ -301,7 +306,13 @@ abstract class GPXParser extends FileParser {
                         waypoint.setPrefix(cacheForWaypoint.getWaypointPrefix(cache.getName()));
                         waypoint.setLookup("---");
                         // there is no lookup code in gpx file
-                        waypoint.setCoords(cache.getCoords());
+
+                        if (wptEmptyCoordinates) {
+                            waypoint.setCoords(null);
+                            waypoint.setOriginalCoordsEmpty(true);
+                        } else {
+                            waypoint.setCoords(cache.getCoords());
+                        }
 
                         waypoint.updateNoteAndUserNote(cache.getDescription());
 
@@ -774,12 +785,13 @@ abstract class GPXParser extends FileParser {
     private void registerCgeoExtensions(final Element cacheParent) {
         for (final String cgeoNamespace : CGEO_NS) {
             final Element cgeoVisited = cacheParent.getChild(cgeoNamespace, "visited");
-
             cgeoVisited.setEndTextElementListener(visited -> wptVisited = Boolean.parseBoolean(visited.trim()));
 
             final Element cgeoUserDefined = cacheParent.getChild(cgeoNamespace, "userdefined");
-
             cgeoUserDefined.setEndTextElementListener(userDefined -> wptUserDefined = Boolean.parseBoolean(userDefined.trim()));
+
+            final Element cgeoEmptyCoords = cacheParent.getChild(cgeoNamespace, "originalCoordsEmpty");
+            cgeoEmptyCoords.setEndTextElementListener(emptyCoords -> wptEmptyCoordinates = Boolean.parseBoolean(emptyCoords.trim()));
         }
     }
 
@@ -865,6 +877,7 @@ abstract class GPXParser extends FileParser {
         parentCacheCode = null;
         wptVisited = false;
         wptUserDefined = false;
+        wptEmptyCoordinates = false;
         logs = new ArrayList<>();
 
         cache = createCache();

--- a/tests/res/raw/gc31j2h_wpts_empty_coord.gpx
+++ b/tests/res/raw/gc31j2h_wpts_empty_coord.gpx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gpx xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" creator="Groundspeak, Inc. All Rights Reserved. http://www.groundspeak.com" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0 http://www.groundspeak.com/cache/1/0/cache.xsd" xmlns="http://www.topografix.com/GPX/1/0">
+  <name>Waypoints for Cache Listings Generated from Geocaching.com</name>
+  <desc>This is a list of supporting waypoints for caches generated from Geocaching.com</desc>
+  <author>Various users from Geocaching.com</author>
+  <email>contact@geocaching.com</email>
+  <url>http://www.geocaching.com</url>
+  <urlname>Geocaching - High Tech Treasure Hunting</urlname>
+  <time>2011-09-16T21:13:24.7355791Z</time>
+  <keywords>cache, geocache, waypoints</keywords>
+  <bounds minlat="49.317517" minlon="8.545083" maxlat="49.317517" maxlon="8.545083" />
+  <wpt lat="49.317517" lon="8.545083">
+    <time>2011-08-05T11:35:49.217</time>
+    <name>0031J2H</name>
+    <cmt>Kostenfreies Parken (je nach Parkreihe Parkscheibe erforderlich)</cmt>
+    <desc>Parkplatz</desc>
+    <url>http://www.geocaching.com/seek/wpt.aspx?WID=f10270dc-0a0d-413d-97e7-8620e86f6cae</url>
+    <urlname>Parkplatz</urlname>
+    <sym>Parking Area</sym>
+    <type>Waypoint|Parking Area</type>
+  </wpt>
+  <wpt lat="0" lon="0">
+    <time>2011-08-05T11:35:49.217</time>
+    <name>S231J2H</name>
+    <cmt>Ein zweiter Wegpunkt, der nicht wirklich existiert sondern nur zum Testen gedacht ist.</cmt>
+    <desc>Station 1</desc>
+    <url>http://www.geocaching.com/seek/wpt.aspx?WID=f10270dc-0a0d-413d-97e7-8620e86f6xxx</url>
+    <urlname>Station 1</urlname>
+    <sym>Stages of a Multicache</sym>
+    <type>Waypoint|Stages of a Multicache</type>
+  </wpt>
+</gpx>

--- a/tests/res/raw/ocddd2_empty_coord.gpx
+++ b/tests/res/raw/ocddd2_empty_coord.gpx
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:cgeo="http://www.cgeo.org/wptext/1/0" version="1.0" creator="Opencaching.de - http://www.opencaching.de" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd" xmlns="http://www.topografix.com/GPX/1/0">
+    <name>Cache listing generated from Opencaching.de</name>
+    <desc>This is a waypoint file generated from Opencaching.de</desc>
+    <author>Opencaching.de</author>
+    <email>contact@opencaching.de</email>
+    <url>http://www.opencaching.de</url>
+    <urlname>Opencaching.de - Geocaching in Deutschland, Oesterreich und der Schweiz</urlname>
+    <time>2013-11-10T14:52:05Z</time>
+    <keywords>cache, geocache, opencaching, waypoint</keywords>
+    <wpt lat="48.88417" lon="9.17660">
+        <time>2012-03-23T00:00:00Z</time>
+        <name>OCDDD2</name>
+        <desc>Kaiserstein und Grabhügel Ludwigsburg</desc>
+        <src>www.opencaching.de</src>
+        <url>http://www.opencaching.de/viewcache.php?cacheid=159890</url>
+        <urlname>Kaiserstein und Grabhügel Ludwigsburg</urlname>
+        <sym>Geocache</sym>
+        <type>Geocache|Virtual Cache</type>
+        <groundspeak:cache id="159890" available="True" archived="False" xmlns:groundspeak="http://www.groundspeak.com/cache/1/0/1">
+            <groundspeak:name>Kaiserstein und Grabhügel Ludwigsburg</groundspeak:name>
+            <groundspeak:placed_by>Emmett</groundspeak:placed_by>
+            <groundspeak:owner id="114440">Emmett</groundspeak:owner>
+            <groundspeak:type>Virtual Cache</groundspeak:type>
+            <groundspeak:container>Virtual</groundspeak:container>
+            <groundspeak:attributes>
+                <groundspeak:attribute id="106" inc="1">Only loggable at Opencaching</groundspeak:attribute>
+                <groundspeak:attribute id="25" inc="1">Parking available</groundspeak:attribute>
+                <groundspeak:attribute id="13" inc="1">Available at all times</groundspeak:attribute>
+                <groundspeak:attribute id="62" inc="0">Seasonal access</groundspeak:attribute>
+            </groundspeak:attributes>
+            <groundspeak:difficulty>1.5</groundspeak:difficulty>
+            <groundspeak:terrain>1.5</groundspeak:terrain>
+            <groundspeak:country>Germany</groundspeak:country>
+            <groundspeak:state>Baden-Württemberg</groundspeak:state>
+            <groundspeak:short_description html="True">Virtueller Cache am Römerhügelweg Ludwigsburg</groundspeak:short_description>
+            <groundspeak:long_description html="True">Im Süden der Stadt Ludwigsburg am heutigen Römerhügelweg liegen zwei Stellen, an denen zum Gedenken an zu ihrer Zeit gesellschaftlich bedeutende Menschen gebaut wurde.&lt;br /&gt;
+                &lt;br /&gt;
+                Zum einen der inzwischen abgetragene Grabhügel aus der späten Hallstattzeit, 6. Jahrhundert v. Chr. Informationen über ihn findet Ihr vor Ort.&lt;br /&gt;
+                &lt;br /&gt;
+                Zum anderen gegenüber ein Kaiserstein. Zwischen 1867 und 1918 wurden im deutschsprachigen Raum mehr als 1000 Kaiser-Wilhelm-Denkmäler errichtet.&lt;br /&gt;
+                &lt;br /&gt;
+                Um den Code zum Loggen zu erhalten, sucht vor Ort die Antworten auf folgende Fragen:&lt;br /&gt;
+                1. Am Kaiserstein (N 48 53.050 E 009 10.596) ist eine metallene Tafel angebracht. Wieviele Buchstaben hat die letzte Zeile ihrer Inschrift?&lt;br /&gt;
+                2. Südlich des Wasserturms ist eine Tafel mit 2 numerierten Abbildungen zu sehen (N 48 53.070 E 009 10.594). Was ist das 2. Wort der 8. Zeile des (unteren) Abschnittes links der Abbildung 2?&lt;br /&gt;
+                3. An der Rückseite des Kaisersteins steht eine Sitzgelegenheit. Wieviele Beine hat sie?&lt;br /&gt;
+                Der Code besteht aus den 3 Antworten, direkt hintereinandergeschrieben (Beispiel für das Format: 48Cache9 ).&lt;br /&gt;
+                &lt;br /&gt;
+                Parkmöglichkeiten: N 48 53.125 E 009 10.224 oder N 48 53.023 E 009 10.870 abends und am Wochenende, siehe Beschilderung&lt;br /&gt;
+                &lt;br /&gt;
+                Viel Spaß!&lt;p&gt;&lt;em&gt;© &lt;a href='http://www.opencaching.de/viewprofile.php?userid=114440' target='_blank'&gt;Emmett&lt;/a&gt;, &lt;a href='http://www.opencaching.de/viewcache.php?cacheid=159890' target='_blank'&gt;Opencaching.de&lt;/a&gt;, &lt;a href='http://creativecommons.org/licenses/by-nc-nd/3.0/de/' target='_blank'&gt;CC BY-NC-ND&lt;/a&gt;, Stand: 10.11.2013; alle Logeinträge © jeweiliger Autor&lt;/em&gt;&lt;/p&gt;
+                &lt;br /&gt;</groundspeak:long_description>
+            <groundspeak:logs>
+                <groundspeak:log id="871676">
+                    <groundspeak:date>2013-03-05T00:00:00Z</groundspeak:date>
+                    <groundspeak:type>Found it</groundspeak:type>
+                    <groundspeak:finder id="253417">andierdbeere</groundspeak:finder>
+                    <groundspeak:text encoded="False">&lt;p&gt;Dankeschön für die Suche!&lt;/p&gt;
+                        &lt;p&gt;Habe den Cache am ersten schönen Frühlingstag gemacht!&lt;/p&gt;
+                        &lt;p&gt;Andi&lt;/p&gt;</groundspeak:text>
+                </groundspeak:log>
+                <groundspeak:log id="855833">
+                    <groundspeak:date>2012-10-20T00:00:00Z</groundspeak:date>
+                    <groundspeak:type>Found it</groundspeak:type>
+                    <groundspeak:finder id="248085">Lazumako</groundspeak:finder>
+                    <groundspeak:text encoded="False">Geschafft!!! &lt;br /&gt;
+                        :-)</groundspeak:text>
+                </groundspeak:log>
+                <groundspeak:log id="821979">
+                    <groundspeak:date>2012-05-12T00:00:00Z</groundspeak:date>
+                    <groundspeak:type>Found it</groundspeak:type>
+                    <groundspeak:finder id="233619">R2-D2</groundspeak:finder>
+                    <groundspeak:text encoded="False">&lt;p&gt;War mein erster Cache überhaupt.&lt;/p&gt;
+                        &lt;p&gt;Hat echt Spaß gemacht. Gut für Grundschulkinder geeignet.&lt;/p&gt;
+                        &lt;p&gt;12.05.2012&lt;/p&gt;
+                        &lt;p&gt;R2-D2&lt;/p&gt;</groundspeak:text>
+                </groundspeak:log>
+            </groundspeak:logs>
+            <groundspeak:travelbugs>
+            </groundspeak:travelbugs>
+        </groundspeak:cache>
+    </wpt>
+    <wpt lat="48.88542" lon="9.17040">
+        <time>2012-03-23T00:00:00Z</time>
+        <name>OCDDD2-1</name>
+        <cmt>Parkmöglichkeit</cmt>
+        <desc>Parkplatz</desc>
+        <url>http://www.opencaching.de/viewcache.php?cacheid=159890</url>
+        <urlname>OCDDD2 Kaiserstein und Grabhügel Ludwigsburg</urlname>
+        <sym>Parking Area</sym>
+        <type>Waypoint|Parking Area</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
+    </wpt>
+    <wpt lat="48.88372" lon="9.18117">
+        <time>2012-03-23T00:00:00Z</time>
+        <name>OCDDD2-2</name>
+        <cmt>Parkmöglichkeit abends und am Wochenende</cmt>
+        <desc>Parkplatz</desc>
+        <url>http://www.opencaching.de/viewcache.php?cacheid=159890</url>
+        <urlname>OCDDD2 Kaiserstein und Grabhügel Ludwigsburg</urlname>
+        <sym>Parking Area</sym>
+        <type>Waypoint|Parking Area</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
+    </wpt>
+    <wpt lat="48.88450" lon="9.17657">
+        <time>2012-03-23T00:00:00Z</time>
+        <name>OCDDD2-3</name>
+        <cmt>Tafel</cmt>
+        <desc>Station oder Referenzpunkt</desc>
+        <url>http://www.opencaching.de/viewcache.php?cacheid=159890</url>
+        <urlname>OCDDD2 Kaiserstein und Grabhügel Ludwigsburg</urlname>
+        <sym>Flag, Green</sym>
+        <type>Waypoint|Flag, Green</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
+    </wpt>
+    <wpt lat="48.885" lon="9.174999999999999">
+        <name>01</name>
+        <cmt>Ttt</cmt>
+        <desc>Wegpunkt 4</desc>
+        <sym>Question to Answer</sym>
+        <type>Waypoint|Question to Answer</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
+        <cgeo:userdefined>true</cgeo:userdefined>
+        <cgeo:originalCoordsEmpty>true</cgeo:originalCoordsEmpty>
+    </wpt>
+</gpx>

--- a/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
+++ b/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
@@ -179,6 +179,22 @@ public class GpxSerializerTest extends AbstractResourceInstrumentationTestCase {
         assertEqualTags(imported, exported, "groundspeak:date");
     }
 
+    public void testWaypointEmpty() throws IOException, ParserException {
+        final String geocode = "GC31J2H";
+        try {
+            final int cacheResource = R.raw.gc31j2h;
+            final Geocache cache = loadCacheFromResource(cacheResource);
+            final Waypoint waypoint = new Waypoint("WP", WaypointType.FINAL, false);
+            cache.addOrChangeWaypoint(waypoint, true);
+
+            final String gpxFromCache = getGPXFromCache(geocode);
+            assertThat(gpxFromCache).contains("<sym>Final Location</sym>").contains("<type>Waypoint|Final Location</type>");
+            assertThat(gpxFromCache).contains("<cgeo:originalCoordsEmpty>true</cgeo:originalCoordsEmpty>");
+        } finally {
+            DataStore.removeCache(geocode, LoadFlags.REMOVE_ALL);
+        }
+    }
+
     @NonNull
     private static String extractWaypoint(final String gpx) {
         return StringUtils.substringBetween(gpx, "<wpt", "</wpt>");

--- a/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
@@ -115,6 +115,19 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
         assertGc31j2hWaypoints(cache);
     }
 
+    public void testGc31j2hWptsEmptyCoord() throws IOException, ParserException {
+        removeCacheCompletely("GC31J2H");
+        final List<Geocache> caches = readGPX10(R.raw.gc31j2h, R.raw.gc31j2h_wpts_empty_coord);
+        assertThat(caches).hasSize(1);
+        final Geocache cache = caches.get(0);
+        assertGc31j2h(cache);
+
+        final List<Waypoint> waypointList = cache.getWaypoints();
+        assertThat(waypointList).isNotNull();
+        assertThat(waypointList).hasSize(2);
+        assertThat(waypointList.get(1).getCoords()).isNull();
+    }
+
     private static void checkWaypointType(final Collection<Geocache> caches, final String geocode, final int wpIndex, final WaypointType waypointType) {
         for (final Geocache cache : caches) {
             if (cache.getGeocode().equals(geocode)) {


### PR DESCRIPTION
fix #8409 
Waypoints with no / empty coordinates are no exported.
Since the gpx-schema does not allow empty lat / lon -attributes, "0" is written like OKAPI does.
In addition a cgeo-attribute is written, that indicates the empty coordinates explicitly. Hence the cgeo.xsd was changed.