### PR TITLE
missing string parameter & use string substitutes with positional parameters

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1042,7 +1042,7 @@
     <string name="cache_menu_challenge_checker">Search challenge checker</string>
     <string name="cache_menu_ignore">Ignore cache</string>
     <string name="cache_log_menu_decrypt">Decrypt/Encrypt</string>
-    <string name="cache_log_menu_title">Log %s of %s</string>
+    <string name="cache_log_menu_title">Log %1$s of %2$s</string>
     <string name="ignore_confirm_title">Be careful</string>
     <string name="ignore_confirm_message">Ignoring a cache means that this cache will never occur again when loading data from geocaching.com. You will only be able to see the cache again by unignoring it on the website.</string>
     <string name="cache_status">Status</string>


### PR DESCRIPTION
as seen on CI console:
`/home/jenkins/slave/workspace/cgeo pull request/main/build/intermediates/incremental/mergeBasicDebugResources/merged.dir/values/values.xml:1523: warn: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?.`