### PR TITLE
plugin updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
 
         // un-mocking of portable Android classes
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
@@ -29,7 +29,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.33.0'
 
     // use SpotBugs instead of FindBugs, see https://plugins.gradle.org/plugin/com.github.spotbugs
-    id 'com.github.spotbugs' version '4.5.0'
+    id 'com.github.spotbugs' version '4.5.1'
 }
 
 /*

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -265,13 +265,13 @@ dependencies {
 
     // SpotBugs (successor of FindBugs)
     implementation 'net.jcip:jcip-annotations:1.0'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.1.2'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.1.3'
 
     // GeographicLib
     implementation 'net.sf.geographiclib:GeographicLib-Java:1.50'
 
     // Jackson XML processing
-    def jacksonVersion = '2.11.2'
+    def jacksonVersion = '2.11.3'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
@@ -283,7 +283,7 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 
     // Leak Canary, memory leak detection
-    def leakCanaryVersion = '2.4'
+    def leakCanaryVersion = '2.5'
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
     implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
 
@@ -317,7 +317,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 
     // Play Services
-    implementation 'com.google.android.gms:play-services-location:17.0.0'
+    implementation 'com.google.android.gms:play-services-location:17.1.0'
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
     // somehow there is a transitive play service dependency which we don't want
     configurations.all*.exclude module: "play-services-measurement"
@@ -329,7 +329,7 @@ dependencies {
     implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation 'io.reactivex.rxjava3:rxjava:3.0.6'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.7'
     implementation "io.reactivex.rxjava3:rxandroid:3.0.0"
 
     // Support Library AppCompat


### PR DESCRIPTION
- gradle plugin 4.0.1 to 4.0.2
  for AS 4.0.2

- play-services-location 17.0.0 to 17.1.0
  https://developers.google.com/android/guides/releases#september_23_2020

- spotbugs 4.5.0 to 4.5.1
  https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/4.5.1
- spotbugs-annotations 4.1.2 to 4.1.3
  https://github.com/spotbugs/spotbugs/blob/4.1.3/CHANGELOG.md
- jackson 2.11.2 to 2.11.3
- leakCanary 2.4 to 2.5
  https://square.github.io/leakcanary/changelog/#version-25-2020-10-01
- rxjava 3.0.6 to 3.0.7
  https://github.com/ReactiveX/RxJava/releases/tag/v3.0.7