### PR TITLE
Call the right superclass method when overriding onRestart

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -324,6 +324,6 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
     @Override
     protected void onRestart() {
         Log.v(logToken + ".onRestart()");
-        super.onResume();
+        super.onRestart();
     }
 }


### PR DESCRIPTION
When investigating #8752 I noticed a case where the onRestart method is overridden in AbstractActivity, but instead of calling the superclass method onRestart, the code calls onResume. 

This looks like a copy-paste error. I'm not sure if this bug has any consequences, but fixing it is surely the prudent thing to do. It looks like the bug was introduced in PR #8967.