### PR TITLE
WP calc: lower-case all equation variables on demand (fix #9213)

### DIFF
--- a/main/res/layout/coordinates_equations.xml
+++ b/main/res/layout/coordinates_equations.xml
@@ -20,14 +20,29 @@
         android:orientation="horizontal"
         android:padding="6dp" >
 
-        <androidx.gridlayout.widget.GridLayout
-
-            android:id="@+id/EquationTable"
+        <RelativeLayout
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_width="match_parent"
+            android:padding="0dp">
 
-            app:orientation="vertical"/>
-            <!--grid:columnCount="2"/>-->
+            <androidx.gridlayout.widget.GridLayout
+
+                android:id="@+id/EquationTable"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+
+                app:orientation="vertical"/>
+
+            <Button
+                android:id="@+id/LowerCaseVariables"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/EquationTable"
+                style="@style/button"
+                android:layout_marginTop="10dp"
+                android:text="@string/lowercase"
+                android:visibility="gone"/>
+        </RelativeLayout>
 
         <View
             android:id="@+id/VariableDivider"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1131,6 +1131,7 @@
     <string name="cc_hint_minutes">minutes</string>
     <string name="cc_hint_seconds">seconds</string>
     <string name="cc_hint_fraction">fraction</string>
+    <string name="lowercase">lower-case</string>
 
     <!-- editor dialog -->
 

--- a/main/src/cgeo/geocaching/ui/CalculatorVariable.java
+++ b/main/src/cgeo/geocaching/ui/CalculatorVariable.java
@@ -78,6 +78,10 @@ public class CalculatorVariable extends LinearLayout {
 
             return returnValue;
         }
+
+        public void switchToLowerCase() {
+            this.expression = this.expression.toLowerCase();
+        }
     }
 
     public static class VariableDataFactory implements JSONAbleFactory<VariableData> {
@@ -245,4 +249,9 @@ public class CalculatorVariable extends LinearLayout {
         return getCachedValue();
     }
 
+    public void switchToLowerCase() {
+        variableData.switchToLowerCase();
+        expression.setText(variableData.expression);
+        setCacheDirty();
+    }
 }

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -119,6 +119,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
     private HorizontalScrollView variablesPanel;
     private View variablesScrollableContent, variableDivider;
     private GridLayout equationGrid, variableGrid;
+    private Button lowerCaseVariables;
 
     private TextView tLatResult, tLonResult;
 
@@ -432,6 +433,10 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         variableDivider = v.findViewById(R.id.VariableDivider);
         equationGrid = v.findViewById(R.id.EquationTable);
         variableGrid = v.findViewById(R.id.FreeVariableTable);
+        lowerCaseVariables = v.findViewById(R.id.LowerCaseVariables);
+        lowerCaseVariables.setOnClickListener(v1 -> {
+            switchVariablesInEquationsToLowerCase();
+        });
 
         tLatResult = v.findViewById(R.id.latRes);
         tLonResult = v.findViewById(R.id.lonRes);
@@ -1030,7 +1035,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         int id = startId;
 
         // If 'freeVariables' are to be displayed include a border around the tables
-        // such that it becomes apparent that their is a second table which may be off the screen.
+        // such that it becomes apparent that there is a second table which may be off the screen.
         if (freeVariables.isEmpty()) {
             variablesScrollableContent.setBackgroundResource(0);
             variableDivider.setVisibility(View.GONE);
@@ -1324,6 +1329,7 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         // replace the old equation list with a newly created ones
         equations = sortVariables(equations, coordinateChars, new CaseCheck(true), getString(R.string.equation_hint), new EquationWatcher());
         updateGrid(equations, equationGrid, 0);
+        lowerCaseVariables.setVisibility(equations.size() > 0 ? View.VISIBLE : View.GONE);
         resortFreeVariables();
     }
 
@@ -1340,6 +1346,13 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         // replace the old free variables list with a newly created ones.
         freeVariables = sortVariables(freeVariables, equationStrings, new CaseCheck(false), getString(R.string.free_variable_hint), new VariableWatcher());
         updateGrid(freeVariables, variableGrid, equations.size());
+    }
+
+    private void switchVariablesInEquationsToLowerCase() {
+        for (CalculatorVariable equation : equations) {
+            equation.switchToLowerCase();
+        }
+        resortEquations();
     }
 
     private void resetCalculator() {


### PR DESCRIPTION
Adds a button "lower-case" to the waypoint calculator dialog, which convert all variables in formulas (left pane) to lower case:

![image](https://user-images.githubusercontent.com/3754370/96425419-4c08ad80-11fc-11eb-8d3e-d22c003f6687.png)![image](https://user-images.githubusercontent.com/3754370/96425466-59259c80-11fc-11eb-9094-8c70d515ee30.png)
