### PR TITLE
add elevation info to position history (fix #9140)

### DIFF
--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.io.IOUtils;
@@ -124,11 +125,11 @@ public class TrailHistoryExport {
                         gpx.startTag(NS_GPX, "trkseg");
                             for (TrailHistoryElement trailHistoryElement : trail) {
                                 gpx.startTag(null, "trkpt");
+                                    // all decimal points have to be ".", thus use non-localizing methods
                                     gpx.attribute(null, "lat", String.valueOf(trailHistoryElement.getLatitude()));
                                     gpx.attribute(null, "lon", String.valueOf(trailHistoryElement.getLongitude()));
                                     XmlUtils.simpleText(gpx, null, "time", formatter.format(trailHistoryElement.getTimestamp()));
-                                    // write additional dummy elevation info to make track file importable by osm.org
-                                    XmlUtils.simpleText(gpx, null, "ele", "0.0");
+                                    XmlUtils.simpleText(gpx, null, "ele", String.format(Locale.US, "%.2f", trailHistoryElement.getAltitude()));
                                 gpx.endTag(null, "trkpt");
                                 countExported++;
                                 publishProgress(countExported);

--- a/main/src/cgeo/geocaching/models/TrailHistoryElement.java
+++ b/main/src/cgeo/geocaching/models/TrailHistoryElement.java
@@ -7,19 +7,22 @@ import android.os.Parcelable;
 import java.util.TimeZone;
 
 public class TrailHistoryElement implements Parcelable {
-    private Location location;
-    private long timestamp;
+    private final Location location;
+    private final long timestamp;
 
-    public TrailHistoryElement(final double latitude, final double longitude, final long timestamp) {
+    public TrailHistoryElement(final double latitude, final double longitude, final double altitude, final long timestamp) {
         location = new Location("trailHistory");
         location.setLatitude(latitude);
         location.setLongitude(longitude);
+        location.setAltitude(altitude);
         this.timestamp = timestamp;
     }
 
     public TrailHistoryElement(final Location loc) {
+        final long t = System.currentTimeMillis();
+
         location = loc;
-        timestamp = System.currentTimeMillis() - TimeZone.getDefault().getOffset(timestamp);
+        timestamp = t - TimeZone.getDefault().getOffset(t);
     }
 
     public Location getLocation() {
@@ -32,6 +35,10 @@ public class TrailHistoryElement implements Parcelable {
 
     public double getLongitude() {
         return location.getLongitude();
+    }
+
+    public double getAltitude() {
+        return location.getAltitude();
     }
 
     public long getTimestamp() {


### PR DESCRIPTION
- extends db scheme to store elevation info for position history (default = 0.0)
- use the stored info on GPX export of position history
