### PR TITLE
respect timezone info in position history (fix #9143)

### DIFF
--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -28,6 +28,7 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.apache.commons.io.IOUtils;
 import org.xmlpull.v1.XmlSerializer;
@@ -111,6 +112,7 @@ public class TrailHistoryExport {
                 gpx.attribute(NS_XSI, "schemaLocation", NS_GPX + " " + GPX_SCHEMA);
 
                     final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                    formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
 
                     gpx.startTag(NS_GPX, "metadata");
                     XmlUtils.simpleText(gpx, NS_GPX, "name", "c:geo history trail");

--- a/main/src/cgeo/geocaching/models/TrailHistoryElement.java
+++ b/main/src/cgeo/geocaching/models/TrailHistoryElement.java
@@ -4,6 +4,8 @@ import android.location.Location;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import java.util.TimeZone;
+
 public class TrailHistoryElement implements Parcelable {
     private Location location;
     private long timestamp;
@@ -17,7 +19,7 @@ public class TrailHistoryElement implements Parcelable {
 
     public TrailHistoryElement(final Location loc) {
         location = loc;
-        timestamp = System.currentTimeMillis();
+        timestamp = System.currentTimeMillis() - TimeZone.getDefault().getOffset(timestamp);
     }
 
     public Location getLocation() {


### PR DESCRIPTION
- store timestamp based on GMT internally (substract timezone delta)
- write timestamp based on GMT on export (set GMT timezone for export)
