### PR TITLE
fix bug in extracting waypoint and user note from text (fix #9157)

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/cgeo/geocaching/location/GeopointParser.java
@@ -31,8 +31,8 @@ public class GeopointParser {
     }
 
     private static class ResultWrapper {
-        final double result;
-        final int matcherLength;
+        private final double result;
+        private final int matcherLength;
 
         ResultWrapper(final double result, final int stringLength) {
             this.result = result;
@@ -510,7 +510,7 @@ public class GeopointParser {
     }
 
     private static String swapDotAndComma(@NonNull final String text) {
-        final char characterArray[] = text.toCharArray();
+        final char[] characterArray = text.toCharArray();
         for (int i = 0; i < characterArray.length; i++) {
             if (characterArray[i] == '.') {
                 characterArray[i] = ',';
@@ -576,14 +576,14 @@ public class GeopointParser {
                 if (geopointWrapper == null) {
                     continue;
                 }
-                if (best == null || geopointWrapper.matcherLength > best.matcherLength) {
+                if (best == null || geopointWrapper.isBetterThan(best)) {
                     best = geopointWrapper;
                 }
             }
         }
 
         if (best != null) {
-            return best.geopoint;
+            return best.getGeopoint();
         }
 
         throw new Geopoint.ParseException("Cannot parse coordinates");
@@ -602,7 +602,7 @@ public class GeopointParser {
 
         String text = initialText;
         int startIndex = 0;
-        GeopointWrapper best = null;
+        GeopointWrapper best;
         do {
             best = null;
             text = text.substring(startIndex);

--- a/main/src/cgeo/geocaching/location/GeopointWrapper.java
+++ b/main/src/cgeo/geocaching/location/GeopointWrapper.java
@@ -6,10 +6,10 @@ package cgeo.geocaching.location;
  */
 public class GeopointWrapper {
 
-    final Geopoint geopoint;
-    final String matcherText;
-    final int matcherStart;
-    final int matcherLength;
+    private final Geopoint geopoint;
+    private final String matcherText;
+    private final int matcherStart;
+    private final int matcherLength;
 
     public GeopointWrapper(final Geopoint geopoint, final int stringStart, final int stringLength, final String matcherText) {
         this.geopoint = geopoint;

--- a/main/src/cgeo/geocaching/location/GeopointWrapper.java
+++ b/main/src/cgeo/geocaching/location/GeopointWrapper.java
@@ -1,0 +1,67 @@
+package cgeo.geocaching.location;
+
+/**
+ * Class to store the information of a parsed geopoint with their starting and ending position and the appropriate text
+ * 'start' points at the first char of the coordinate text, 'end' points at the first char AFTER the coordinate text
+ */
+public class GeopointWrapper {
+
+    final Geopoint geopoint;
+    final String matcherText;
+    final int matcherStart;
+    final int matcherLength;
+
+    public GeopointWrapper(final Geopoint geopoint, final int stringStart, final int stringLength, final String matcherText) {
+        this.geopoint = geopoint;
+        this.matcherStart = stringStart;
+        this.matcherLength = stringLength;
+        this.matcherText = matcherText;
+    }
+
+    public Geopoint getGeopoint() {
+        return geopoint;
+    }
+
+    /**
+     * 'start' points at the first char of the coordinate text, 'end' points at the first char AFTER the coordinate text
+     */
+    public int getStart() {
+        return matcherStart;
+    }
+
+    /**
+     * 'end' points at the first char AFTER the coordinate text
+     */
+    public int getEnd() {
+        return matcherStart + matcherLength;
+    }
+
+    public int getLength() {
+        return matcherLength;
+    }
+
+    public String getText() {
+        return matcherText;
+    }
+
+    /**
+     * compares to parsed infos
+     * @param match object to compare
+     * @return true: Geopoint which comes first in text or is longer
+     */
+    public Boolean isBetterThan(final GeopointWrapper match) {
+        if (match == null) {
+            return true;
+        }
+
+        if (this.matcherStart < match.matcherStart) {
+            return true;
+        }
+
+        if (this.matcherStart == match.matcherStart && this.matcherLength > match.matcherLength) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.location.GeopointParser;
+import cgeo.geocaching.location.GeopointWrapper;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.ClipboardUtils;
@@ -28,7 +29,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.jetbrains.annotations.NotNull;
 
 public class Waypoint implements IWaypoint {
@@ -343,10 +343,10 @@ public class Waypoint implements IWaypoint {
     }
 
     private static void parseWaypoints(final Collection<Waypoint> waypoints, final String text, final String namePrefix) {
-        final Collection<ImmutableTriple<Geopoint, Integer, Integer>> matches = GeopointParser.parseAll(text);
+        final Collection<GeopointWrapper> matches = GeopointParser.parseAll(text);
         int count = 1;
-        for (final ImmutableTriple<Geopoint, Integer, Integer> match : matches) {
-            final Waypoint wp = parseSingleWaypoint(match, text, namePrefix, count);
+        for (final GeopointWrapper match : matches) {
+            final Waypoint wp = parseSingleWaypoint(match, namePrefix, count);
             if (wp != null) {
                 waypoints.add(wp);
                 count++;
@@ -356,8 +356,8 @@ public class Waypoint implements IWaypoint {
         // search waypoints with empty coordinates
         int idx = text.indexOf(PARSING_COORD_EMPTY);
         while (idx >= 0) {
-            final ImmutableTriple<Geopoint, Integer, Integer> match = new ImmutableTriple<>(null, idx, idx + PARSING_COORD_EMPTY.length());
-            final Waypoint wp = parseSingleWaypoint(match, text, namePrefix, count);
+            final GeopointWrapper match = new GeopointWrapper(null, idx, PARSING_COORD_EMPTY.length(), text);
+            final Waypoint wp = parseSingleWaypoint(match, namePrefix, count);
             if (wp != null) {
                 waypoints.add(wp);
                 count++;
@@ -366,11 +366,12 @@ public class Waypoint implements IWaypoint {
         }
     }
 
-    private static Waypoint parseSingleWaypoint(final ImmutableTriple<Geopoint, Integer, Integer> match, final String text, final String namePrefix, final int count) {
+    private static Waypoint parseSingleWaypoint(final GeopointWrapper match, final String namePrefix, final int count) {
 
-        final Geopoint point = match.getLeft();
-        final Integer start = match.getMiddle();
-        final Integer end = match.getRight();
+        final Geopoint point = match.getGeopoint();
+        final Integer start = match.getStart();
+        final Integer end = match.getEnd();
+        final String text = match.getText();
 
         final String[] wordsBefore = TextUtils.getWords(TextUtils.getTextBeforeIndexUntil(text, start, "\n"));
         final String lastWordBefore = wordsBefore.length == 0 ? "" : wordsBefore[wordsBefore.length - 1];

--- a/tests/src/cgeo/geocaching/location/GeoPointWrapperTest.java
+++ b/tests/src/cgeo/geocaching/location/GeoPointWrapperTest.java
@@ -1,0 +1,39 @@
+package cgeo.geocaching.location;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class GeoPointWrapperTest {
+
+    @Test
+    public void testIsBetterThan() {
+        final GeopointWrapper better = new GeopointWrapper(null, 0, 24,
+            "n48 01.194 · e011 43.814 note");
+
+        final GeopointWrapper worse = new GeopointWrapper(null, 0, 23,
+            "n48 01.194 · e011 43.814 note");
+
+        assertThat(better.isBetterThan(worse)).isTrue();
+        assertThat(worse.isBetterThan(better)).isFalse();
+    }
+
+    @Test
+    public void testIsBetterThanNull() {
+        final GeopointWrapper better = new GeopointWrapper(null, 0, 24,
+            "n48 01.194 · e011 43.814 note");
+
+        assertThat(better.isBetterThan(null)).isTrue();
+    }
+
+    @Test
+    public void testIsBetterThanReturnEqual() {
+        final GeopointWrapper better = new GeopointWrapper(null, 0, 24,
+            "n48 01.194 · e011 43.814 note");
+
+        final GeopointWrapper worse = new GeopointWrapper(null, 0, 24,
+            "n48 01.194 · e011 43.814 note");
+
+        assertThat(better.isBetterThan(worse)).isFalse();
+        assertThat(worse.isBetterThan(better)).isFalse();
+    }
+}

--- a/tests/src/cgeo/geocaching/models/WaypointTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointTest.java
@@ -78,6 +78,44 @@ public class WaypointTest {
         assertWaypoint(waypoints.iterator().next(), "Prefix 1", new Geopoint("N 45°3.5 E 27°7.5"));
     }
 
+    @Test
+    public void testParseWaypointsUserNoteWithDotAndWord() {
+        final String note = "1. 0815 - Word 1\n2. 4711 - Word 2\nn 45° 3.565 e 27° 7.578";
+        final Collection<Waypoint> waypoints = Waypoint.parseWaypoints(note, "Prefix");
+        assertThat(waypoints).hasSize(1);
+        final Waypoint wp = waypoints.iterator().next();
+        assertWaypoint(wp, "Prefix 1", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertThat(wp.getUserNote()).isEmpty();
+    }
+
+    @Test
+    public void testParseWaypointsUserNoteWithDot() {
+        final String note = "1. 0815\n2. 4711\nn 45° 3.565 e 27° 7.578";
+        final Collection<Waypoint> waypoints = Waypoint.parseWaypoints(note, "Prefix");
+        assertThat(waypoints).hasSize(2);
+        final Iterator<Waypoint> iterator = waypoints.iterator();
+        final Waypoint wp1 = iterator.next();
+        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 01° 4.890 E 2°28.266"));
+        assertThat(wp1.getUserNote()).isEmpty();
+        final Waypoint wp2 = iterator.next();
+        assertWaypoint(wp2, "Prefix 2", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertThat(wp2.getUserNote()).isEmpty();
+    }
+
+    @Test
+    public void testParseWaypointsUserNoteWithDotTwice() {
+        final String note = "1. 0815  2. 4711. 0815 2.4711 \n n 45° 3.565 e 27° 7.578";
+        final Collection<Waypoint> waypoints = Waypoint.parseWaypoints(note, "Prefix");
+        assertThat(waypoints).hasSize(2);
+        final Iterator<Waypoint> iterator = waypoints.iterator();
+        final Waypoint wp1 = iterator.next();
+        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 01° 4.890 E 2°28.266"));
+        assertThat(wp1.getUserNote()).isEqualTo(". 0815 2.4711");
+        final Waypoint wp2 = iterator.next();
+        assertWaypoint(wp2, "Prefix 2", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertThat(wp2.getUserNote()).isEmpty();
+    }
+
     private static void parseAndAssertFirstWaypoint(final String text, final String name, final WaypointType wpType, final String userNote) {
         final Collection<Waypoint> coll = Waypoint.parseWaypoints(text, "Praefix");
         assertThat(coll.size()).isEqualTo(1);


### PR DESCRIPTION
* use modifed string (after spaces are removed via GeopointParser:removeSpaceAfterSeparators) to extract user note from text. if there were spaces after points in the text, the determination of end-position was wrong
* use GeopointWrapper for transporting information about appropriate text and substring instead of Triple -> move to own file and add apprpriate text for start-end-position (different text due to parsedInput)