### PR TITLE
add GPX formatting to position history / indiv. route exports

### DIFF
--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -92,6 +92,7 @@ public class IndividualRouteExport {
             try {
                 int countExported = 0;
                 gpx.setOutput(writer);
+                gpx.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
 
                 gpx.startDocument(StandardCharsets.UTF_8.name(), true);
                 gpx.setPrefix(PREFIX_GPX, NS_GPX);

--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -102,6 +102,7 @@ public class TrailHistoryExport {
             try {
                 int countExported = 0;
                 gpx.setOutput(writer);
+                gpx.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
 
                 gpx.startDocument(StandardCharsets.UTF_8.name(), true);
                 gpx.setPrefix(PREFIX_GPX, NS_GPX);


### PR DESCRIPTION
#9238 add GPX output formatting for cache exports etc. only.
This PR adds it for exports of individual routes and position history.