### PR TITLE
hide old mapsforge implementation (without actually removing it yet)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -794,9 +794,6 @@
     <string name="feature_favorite">Adding cache to favorites</string>
     <string name="feature_voting">Voting for caches</string>
     <string name="init_maplines_title">Map lines customization</string>
-    <string name="init_mapsforge_api_title">Mapsforge API</string>
-    <string name="init_mfold_api">Old Mapsforge V3</string>
-    <string name="init_mfold_api_description">We are using a new version of the Mapsforge map by default. If you miss some features or encounter issues you can go back to the old version here.</string>
 
     <!-- proximity notification -->
     <string name="settings_title_proximityNotification">Proximity notification</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -792,17 +792,6 @@
                 app:defaultColor="@color/default_circlefillcolor"
                 app:showOpaquenessSlider="true" />
         </PreferenceCategory>
-
-        <PreferenceCategory android:title="@string/init_mapsforge_api_title"
-            android:layout="@layout/preference_category" >
-            <cgeo.geocaching.settings.TextPreference
-                android:layout="@layout/text_preference"
-                android:text="@string/init_mfold_api_description" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_old_mapsforge_api"
-                android:title="@string/init_mfold_api" />
-        </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1527,7 +1527,8 @@ public class Settings {
     }
 
     public static boolean useOldMapsforgeAPI() {
-        return getBoolean(R.string.pref_old_mapsforge_api, false);
+        // force NewMap, if Mapsforge is selected
+        return false;
     }
 
     static void setOldMapsforgeAPI(final boolean useOldMapsforgeAPI) {


### PR DESCRIPTION
Intermediate step towards #7836 (remove old mapsforge):
- remove settings for MF0.3
- querying the "use old MF map" switch always returns false

By this old Mapsforge map is hidden without actually removing its code.