### PR TITLE
delete temporary map file after successful copy (fix #8712)

### DIFF
--- a/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
+++ b/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
@@ -136,7 +136,7 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                     // copy file
                     file.setWritable(true, false);
                     final OutputStream outputStream = new FileOutputStream(file);
-                    final byte[] buffer = new byte[4096];
+                    final byte[] buffer = new byte[32 << 10];
                     int length = 0;
                     while (!cancelled.get() && (length = inputStream.read(buffer)) > 0) {
                         outputStream.write(buffer, 0, length);
@@ -161,6 +161,7 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                             Settings.setMapSource(newMapSource);
                         }
                         status = CopyStates.SUCCESS;
+                        getContentResolver().delete(uri, null, null);
                     } else {
                         file.delete();
                         status = CopyStates.CANCELLED;


### PR DESCRIPTION
Map downloader now deletes the temporary map file in "downloads" after the copy operation has completed successfully.
(also increases buffer size for copy)