### PR TITLE
fix #9266: prevent parsing waypoints to type 'own'

### DIFF
--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -66,14 +66,20 @@ public enum WaypointType {
     }
 
     @NonNull
-    public static final List<WaypointType> ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL = orderedWaypointTypes();
+    public static final List<WaypointType> ALL_TYPES = orderedWaypointTypes(false);
+    @NonNull
+    public static final List<WaypointType> ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL = orderedWaypointTypes(true);
 
-    private static List<WaypointType> orderedWaypointTypes() {
+    private static List<WaypointType> orderedWaypointTypes(final boolean excludeInternalTypes) {
         // enforce an order for these types
         final Set<WaypointType> waypointTypes = new LinkedHashSet<>();
         waypointTypes.addAll(Arrays.asList(PARKING, TRAILHEAD, PUZZLE, STAGE, FINAL));
         // then add all remaining except "internal" types
         waypointTypes.addAll(EnumSet.complementOf(EnumSet.of(OWN, ORIGINAL)));
+        if (!excludeInternalTypes) {
+            //if wanted, add internal types at the end
+            waypointTypes.addAll(EnumSet.of(OWN, ORIGINAL));
+        }
         return Collections.unmodifiableList(new ArrayList<>(waypointTypes));
     }
 
@@ -97,7 +103,7 @@ public enum WaypointType {
     public final String getL10n() {
         //enable local unit testing
         if (CgeoApplication.getInstance() == null) {
-            return "" + stringId;
+            return name();
         }
         return CgeoApplication.getInstance().getBaseContext().getString(stringId);
     }

--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -31,6 +31,11 @@ public enum WaypointType {
     ORIGINAL("original", "h", "Original Coordinates", R.string.wp_original, R.drawable.waypoint_waypoint, 4, R.drawable.dot_waypoint_reference);
 
     @NonNull
+    public static final List<WaypointType> ALL_TYPES = orderedWaypointTypes(false);
+    @NonNull
+    public static final List<WaypointType> ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL = orderedWaypointTypes(true);
+
+    @NonNull
     public final String id;
 
     public final String shortId;
@@ -64,11 +69,6 @@ public enum WaypointType {
             FIND_BY_ID.put(wt.id, wt);
         }
     }
-
-    @NonNull
-    public static final List<WaypointType> ALL_TYPES = orderedWaypointTypes(false);
-    @NonNull
-    public static final List<WaypointType> ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL = orderedWaypointTypes(true);
 
     private static List<WaypointType> orderedWaypointTypes(final boolean excludeInternalTypes) {
         // enforce an order for these types

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -458,7 +458,7 @@ public class Waypoint implements IWaypoint {
     private static WaypointType parseWaypointType(final String input, final String lastWord) {
         final String lowerInput = input.toLowerCase(Locale.getDefault());
         final String lowerLastWord = lastWord.toLowerCase(Locale.getDefault());
-        for (final WaypointType wpType : WaypointType.values()) {
+        for (final WaypointType wpType : WaypointType.ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL) {
             final String lowerShortId = wpType.getShortId().toLowerCase(Locale.getDefault());
             if (lowerLastWord.equals(lowerShortId)) {
                 return wpType;

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -458,20 +458,41 @@ public class Waypoint implements IWaypoint {
     private static WaypointType parseWaypointType(final String input, final String lastWord) {
         final String lowerInput = input.toLowerCase(Locale.getDefault());
         final String lowerLastWord = lastWord.toLowerCase(Locale.getDefault());
-        for (final WaypointType wpType : WaypointType.ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL) {
+
+        //find the LAST (if any) enclosed one-letter-word in the input
+        String enclosedShortIdCandidate = null;
+        final int lastClosingIdx = lowerInput.lastIndexOf(PARSING_TYPE_CLOSE);
+        if (lastClosingIdx > 0) {
+            final int lastOpeningIdx = lowerInput.lastIndexOf(PARSING_TYPE_OPEN, lastClosingIdx);
+            if (lastOpeningIdx >= 0 && lastOpeningIdx + PARSING_TYPE_OPEN.length() + 1 == lastClosingIdx) {
+                enclosedShortIdCandidate = lowerInput.substring(lastClosingIdx - 1, lastClosingIdx);
+            }
+        }
+
+        for (final WaypointType wpType : WaypointType.ALL_TYPES) {
             final String lowerShortId = wpType.getShortId().toLowerCase(Locale.getDefault());
-            if (lowerLastWord.equals(lowerShortId)) {
+            if (lowerLastWord.equals(lowerShortId) || lowerLastWord.contains(PARSING_TYPE_OPEN + lowerShortId + PARSING_TYPE_CLOSE)) {
                 return wpType;
             }
-            if (lowerInput.contains(PARSING_TYPE_OPEN + lowerShortId + PARSING_TYPE_CLOSE)) {
-                return wpType;
+        }
+        if (enclosedShortIdCandidate != null) {
+            for (final WaypointType wpType : WaypointType.ALL_TYPES) {
+                if (enclosedShortIdCandidate.equals(wpType.getShortId().toLowerCase(Locale.getDefault()))) {
+                    return wpType;
+                }
             }
+        }
+        for (final WaypointType wpType : WaypointType.ALL_TYPES) {
             if (lowerInput.contains(wpType.getL10n().toLowerCase(Locale.getDefault()))) {
                 return wpType;
             }
+        }
+        for (final WaypointType wpType : WaypointType.ALL_TYPES) {
             if (lowerInput.contains(wpType.id)) {
                 return wpType;
             }
+        }
+        for (final WaypointType wpType : WaypointType.ALL_TYPES) {
             if (lowerInput.contains(wpType.name().toLowerCase(Locale.US))) {
                 return wpType;
             }

--- a/tests/src/cgeo/geocaching/models/WaypointTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointTest.java
@@ -178,7 +178,7 @@ public class WaypointTest {
 
     @Test
     public void testParseWaypointWithMultiwordNameAndMultilineDescription() {
-        final String note = "@ A   longer  name \twith (o) whitespaces  N45 49.739 E9 45.038 \"this is the \\\"description\\\"\nit goes on and on\" some more text";
+        final String note = "@ A   longer  name \twith (r) (o) whitespaces  N45 49.739 E9 45.038 \"this is the \\\"description\\\"\nit goes on and on\" some more text";
         final Collection<Waypoint> waypoints = Waypoint.parseWaypoints(note, "Prefix");
         assertThat(waypoints).hasSize(1);
         final Iterator<Waypoint> iterator = waypoints.iterator();


### PR DESCRIPTION
fix #9266: prevent parsing waypoints to type 'own'
Waypoints of type "reference Point" with name "reference point" in it where accidentally parsed as wptype "own" because it uses the same translated name. This lead to such waypoints becoming "own" when parsing them repeatedly from PN. This leads to switch type to "Parking" in waypoint edit dialog because "own" is not an allowed type in that list.

Prevented this by not allowing "own" (and "Original") as parsed wptypes any more. All allowed wptypes in parsing have different translations now