### PR TITLE
related to #9270: fix memory leak in Routing

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -284,7 +284,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState, R.layout.viewpager_activity);
 
-        Routing.connect(null);
+        Routing.connect();
 
         int startPage = Page.VERSION.ordinal();
         final Bundle extras = getIntent().getExtras();

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -35,7 +35,7 @@ public abstract class AbstractMap {
 
     public void onCreate(final Bundle savedInstanceState) {
         mapActivity.superOnCreate(savedInstanceState);
-        Routing.connect(null);
+        Routing.connect();
     }
 
     public void onResume() {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -136,6 +136,8 @@ import org.xmlpull.v1.XmlPullParserException;
 @SuppressLint("ClickableViewAccessibility")
 public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeMenuCallback, SharedPreferences.OnSharedPreferenceChangeListener, Observer {
 
+    private static final String ROUTING_SERVICE_KEY = "NewMap";
+
     private MfMapView mapView;
     private TileCache tileCache;
     private MapSource mapSource;
@@ -299,7 +301,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             postZoomToViewport(new Viewport(Settings.getMapCenter().getCoords(), 0, 0));
         }
         prepareFilterBar();
-        Routing.connect(() -> resumeRoute(true));
+        Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true));
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
     }
 
@@ -1009,7 +1011,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         this.mapView.destroy();
         ResourceBitmapCacheMonitor.release();
 
-        Routing.disconnect();
+        Routing.disconnect(ROUTING_SERVICE_KEY);
         super.onDestroy();
     }
 


### PR DESCRIPTION
related to #9270: fix memory leak in Routing
The way passing of callback to Routing was handled, this lead to Routing keeping a reference to NewMap object even after destroy. Also, only the callback of last Activity calling "connect" was maintained. Both is fixed with this PR.