### PR TITLE
related to #9270: use own MapFiles for map attribution and close them

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1108,9 +1108,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             ActivityMixin.invalidateOptionsMenu(activity);
         }
 
-        if (mapSource != null) {
-            mapSource.releaseResources();
-        }
         mapSource = newSource;
 
         final int mapAttributionViewId = mapSource.getMapProvider().getMapAttributionTextId();

--- a/main/src/cgeo/geocaching/maps/interfaces/MapSource.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapSource.java
@@ -16,8 +16,4 @@ public interface MapSource {
 
     void setMapAttributionTo(TextView textView);
 
-    default void releaseResources() {
-        //do nothing
-    }
-
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -738,9 +738,6 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         final ITileLayer oldLayer = this.tileLayer;
         ITileLayer newLayer = null;
 
-        if (mapSource != null) {
-            mapSource.releaseResources();
-        }
         mapSource = newSource;
         mapSource.setMapAttributionTo(this.mapAttribution);
 


### PR DESCRIPTION
related to #9270: use own MapFiles for map attribution and close them