### PR TITLE
related to #9288: preserve zoom level

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/MfMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/MfMapView.java
@@ -89,12 +89,12 @@ public class MfMapView extends MapView {
         getModel().mapViewPosition.setZoomLevel((byte) zoomLevel);
     }
 
-    public void zoomToViewport(final Viewport viewport) {
+    public void zoomToViewport(final Viewport viewport, final MapMode mapMode) {
 
         getModel().mapViewPosition.setCenter(new LatLong(viewport.getCenter().getLatitude(), viewport.getCenter().getLongitude()));
 
         if (viewport.bottomLeft.equals(viewport.topRight)) {
-            setMapZoomLevel(Settings.getMapZoom(MapMode.SINGLE));
+            setMapZoomLevel(Settings.getMapZoom(mapMode));
         } else {
             final int tileSize = getModel().displayModel.getTileSize();
             final byte newZoom = LatLongUtils.zoomForBounds(new Dimension(getWidth(), getHeight()),

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -199,6 +199,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
     private Viewport lastViewport = null;
     private boolean lastCompactIconMode = false;
 
+    private MapMode mapMode;
+
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -270,6 +272,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         final DragHandler dragHandler = new DragHandler(this);
         mapView.setOnMapDragListener(dragHandler);
 
+        mapMode = (mapOptions != null && mapOptions.mapMode != null) ? mapOptions.mapMode : MapMode.LIVE;
+
         // prepare initial settings of mapView
         if (mapOptions.mapState != null) {
             this.mapView.getModel().mapViewPosition.setCenter(MapsforgeUtils.toLatLong(mapOptions.mapState.getCenter()));
@@ -306,7 +310,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
     }
 
     private void postZoomToViewport(final Viewport viewport) {
-        mapView.post(() -> mapView.zoomToViewport(viewport));
+        mapView.post(() -> mapView.zoomToViewport(viewport, this.mapMode));
     }
 
     @Override
@@ -1620,7 +1624,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
     }
 
     private void savePrefs() {
-        Settings.setMapZoom(MapMode.SINGLE, mapView.getMapZoomLevel());
+        Settings.setMapZoom(this.mapMode, mapView.getMapZoomLevel());
         Settings.setMapCenter(new MapsforgeGeoPoint(mapView.getModel().mapViewPosition.getCenter()));
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -924,7 +924,7 @@ public class Settings {
      * @return zoom used for the (live) map
      */
     private static int getMapZoom() {
-        return Math.max(getInt(R.string.pref_lastmapzoom, 14), INITIAL_MAP_ZOOM_LIMIT);
+        return  Math.max(0, Math.min(getInt(R.string.pref_lastmapzoom, 14), INITIAL_MAP_ZOOM_LIMIT));
     }
 
     private static void setMapZoom(final int mapZoomLevel) {
@@ -935,7 +935,7 @@ public class Settings {
      * @return zoom used for the map of a single cache
      */
     private static int getCacheZoom() {
-        return Math.max(getInt(R.string.pref_cache_zoom, 14), INITIAL_MAP_ZOOM_LIMIT);
+        return Math.max(0, Math.min(getInt(R.string.pref_cache_zoom, 14), INITIAL_MAP_ZOOM_LIMIT));
     }
 
     private static void setCacheZoom(final int zoomLevel) {


### PR DESCRIPTION
related to #9288: preserve zoom level

This PR is supposed to make the NewMap preserve last zoom levels and restore them when map is reopened.
However, I really wonder whether I oversaw something in the code, because if I fixed this the right way this means that zoom preserving was never enabled for NewMap before... and I cannot really believe that.

@moving-bits : can you please take a close look at this one? 