### PR TITLE
lint changes/fixes

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -44,6 +44,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -408,7 +409,7 @@ public class CompassActivity extends AbstractActionBarActivity {
         while (direction >= 360f) {
             direction -= 360f;
         }
-        deviceHeading.setText(String.format("%3.1f°", direction));
+        deviceHeading.setText(String.format(Locale.getDefault(), "%3.1f°", direction));
 
         if (deviceOrientationMode.get() == DirectionData.DeviceOrientation.AUTO) {
             deviceOrientationMode.setTextDisplayMapper(d -> getString(R.string.device_orientation) + ": " + getString(dir.getDeviceOrientation().resId) + " (" + getString(DirectionData.DeviceOrientation.AUTO.resId) + ")");
@@ -419,7 +420,7 @@ public class CompassActivity extends AbstractActionBarActivity {
 
     /** formats a float to a decimal with length 4 and no places behind comma. Handles "-0" case. */
     private static String formatDecimalFloat(final float value) {
-        final String formattedValue = String.format("% 4.0f", value);
+        final String formattedValue = String.format(Locale.US, "% 4.0f", value);
         if (formattedValue.endsWith("-0")) {
             return "   0";
         }

--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -113,7 +113,7 @@ public class TrailHistoryExport {
                 gpx.attribute("", "creator", "c:geo - http://www.cgeo.org/");
                 gpx.attribute(NS_XSI, "schemaLocation", NS_GPX + " " + GPX_SCHEMA);
 
-                    final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                    final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
                     formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
 
                     gpx.startTag(NS_GPX, "metadata");

--- a/main/src/cgeo/geocaching/ui/CalculatorVariable.java
+++ b/main/src/cgeo/geocaching/ui/CalculatorVariable.java
@@ -22,6 +22,7 @@ import androidx.gridlayout.widget.GridLayout;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Locale;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -80,7 +81,7 @@ public class CalculatorVariable extends LinearLayout {
         }
 
         public void switchToLowerCase() {
-            this.expression = this.expression.toLowerCase();
+            this.expression = this.expression.toLowerCase(Locale.US);
         }
     }
 

--- a/main/src/cgeo/geocaching/utils/ContextLogger.java
+++ b/main/src/cgeo/geocaching/utils/ContextLogger.java
@@ -7,6 +7,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Locale;
 
 /**
  * Helper class to construct log messages. Optimized to log what is happening in a method,
@@ -16,7 +17,7 @@ import java.util.Collection;
  */
 public class ContextLogger implements Closeable {
 
-    private static final DateFormat DATETIME_FORMAT = new SimpleDateFormat("MM-dd HH:mm:ss.SSS");
+    private static final DateFormat DATETIME_FORMAT = new SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.getDefault());
     static {
         DATETIME_FORMAT.setTimeZone(Calendar.getInstance().getTimeZone());
     }

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -103,7 +103,7 @@ public final class Formatter {
      */
     @NonNull
     public static String formatDateForFilename(final long date) {
-        return new SimpleDateFormat("yyyy-MM-dd HH-mm").format(date);
+        return new SimpleDateFormat("yyyy-MM-dd HH-mm", Locale.getDefault()).format(date);
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/Log.java
+++ b/main/src/cgeo/geocaching/utils/Log.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.storage.LocalStorage;
 
 import java.io.File;
 import java.io.FileReader;
+import java.util.Locale;
 import java.util.Properties;
 
 public final class Log {
@@ -106,7 +107,7 @@ public final class Log {
             return null;
         }
         try {
-            return LogLevel.valueOf(logProps.getProperty(propName).toUpperCase());
+            return LogLevel.valueOf(logProps.getProperty(propName).toUpperCase(Locale.US));
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
- categorie Correctness
  - type DefaultLocale:
    Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead
    - CalculatorVariable.java
	- CompassActivity.java
	- Log.java
  - type SimpleDateFormat:
    To get local formatting use `getDateInstance()`, `getDateTimeInstance()`, or `getTimeInstance()`, or use `new SimpleDateFormat(String template, Locale locale)` with for example `Locale.US` for ASCII dates.
    - ContextLogger.java
	- Formatter.java
	- TrailHistoryExport.java

@eddiemuc @moving-bits 
Please check that the changes are set as intended in your PR´s.
