### PR TITLE
supersize distance view (fix #9282)

### DIFF
--- a/main/res/drawable/icon_bcg.xml
+++ b/main/res/drawable/icon_bcg.xml
@@ -5,9 +5,9 @@
     <solid android:color="#80000000" />
 
     <corners
-        android:bottomLeftRadius="8dp"
-        android:bottomRightRadius="8dp"
-        android:topLeftRadius="8dp"
-        android:topRightRadius="8dp" />
+        android:bottomLeftRadius="2dp"
+        android:bottomRightRadius="2dp"
+        android:topLeftRadius="2dp"
+        android:topRightRadius="2dp" />
 
 </shape>

--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -44,4 +44,13 @@
         android:layout_alignParentRight="true"
         android:layout_width="100dp"
         style="@style/map_distanceinfo" />
+
+    <TextView
+        android:id="@+id/distanceSupersize"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_alignParentTop="true"
+        style="@style/map_distanceinfo_supersize" />
+
 </RelativeLayout>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -75,6 +75,7 @@
     <string translatable="false" name="pref_excludeWpVisited">excludeWpVisited</string>
     <string translatable="false" name="pref_hide_track">hideTrack</string>
     <string translatable="false" name="pref_showCircles">showCircles</string>
+    <string translatable="false" name="pref_supersizeDistance">supersizeDistance</string>
     <string translatable="false" name="pref_plainLogs">plainLogs</string>
     <string translatable="false" name="pref_signature">signature</string>
     <string translatable="false" name="pref_sigautoinsert">sigautoinsert</string>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -410,7 +410,7 @@
 
     <!-- map distance info style -->
     <style name="map_distanceinfo">
-        <item name="android:layout_marginRight">-8dp</item>
+        <item name="android:layout_marginRight">-2dp</item>
         <item name="android:paddingTop">4dp</item>
         <item name="android:layout_height">30dp</item>
         <item name="android:background">@drawable/icon_bcg</item>
@@ -422,6 +422,11 @@
         <item name="android:textSize">18sp</item>
         <item name="android:visibility">gone</item>
         <item name="android:maxLines">1</item>
+    </style>
+
+    <style name="map_distanceinfo_supersize" parent="map_distanceinfo">
+        <item name="android:layout_marginLeft">-2dp</item>
+        <item name="android:textSize">96sp</item>
     </style>
 
     <!-- about c:geo contributors style -->

--- a/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
+++ b/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Units;
+import cgeo.geocaching.settings.Settings;
 
 import android.view.View;
 import android.widget.TextView;
@@ -15,6 +16,7 @@ public class MapDistanceDrawerCommons {
     private final TextView distance2InfoView;
     private final TextView distance2View;
     private final TextView routeDistanceView;
+    private final TextView distanceSupersizeView;
 
     public MapDistanceDrawerCommons(final View root) {
         distance1InfoView = root.findViewById(R.id.distance1info);
@@ -22,28 +24,52 @@ public class MapDistanceDrawerCommons {
         distance2InfoView = root.findViewById(R.id.distance2info);
         distance2View = root.findViewById(R.id.distance2);
         routeDistanceView = root.findViewById(R.id.routeDistance);
+        distanceSupersizeView = root.findViewById(R.id.distanceSupersize);
+
+        distance1InfoView.setOnClickListener(v -> swap());
+        distance1View.setOnClickListener(v -> swap());
+        distanceSupersizeView.setOnClickListener(v -> swap());
     }
 
     public void drawDistance(final boolean showBothDistances, final float distance, final float realDistance) {
         final boolean bothViewsNeeded = showBothDistances && realDistance != 0.0f && distance != realDistance;
-        distance1InfoView.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
+        final boolean supersize = Settings.getSupersizeDistance();
+        final TextView d = supersize ? distanceSupersizeView : distance1View;
+
+        distance1InfoView.setVisibility(bothViewsNeeded && !supersize ? View.VISIBLE : View.GONE);
         distance2InfoView.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
         distance2View.setVisibility(bothViewsNeeded ? View.VISIBLE : View.GONE);
         if (bothViewsNeeded) {
             distance1InfoView.setText(STRAIGHT_LINE_SYMBOL);
-            distance1View.setText(Units.getDistanceFromKilometers(distance));
+            d.setText(Units.getDistanceFromKilometers(distance));
             distance2InfoView.setText(WAVY_LINE_SYMBOL);
             distance2View.setText(Units.getDistanceFromKilometers(realDistance));
         } else {
-            distance1View.setText(Units.getDistanceFromKilometers(realDistance != 0.0f && distance != realDistance ? realDistance : distance));
+            d.setText(Units.getDistanceFromKilometers(realDistance != 0.0f && distance != realDistance ? realDistance : distance));
         }
-        distance1View.setVisibility(realDistance != 0.0f ? View.VISIBLE : View.GONE);
+        distance1View.setVisibility(realDistance != 0.0f && !supersize ? View.VISIBLE : View.GONE);
+        distanceSupersizeView.setVisibility(realDistance != 0.0f && supersize ? View.VISIBLE : View.GONE);
     }
 
     public void drawRouteDistance(final float routeDistance) {
         routeDistanceView.setVisibility(routeDistance != 0.0f ? View.VISIBLE : View.GONE);
         if (routeDistance != 0.0f) {
             routeDistanceView.setText(Units.getDistanceFromKilometers(routeDistance));
+        }
+    }
+
+    private void swap() {
+        final boolean supersize = !Settings.getSupersizeDistance();
+        Settings.setSupersizeDistance(supersize);
+
+        distanceSupersizeView.setVisibility(supersize ? View.VISIBLE : View.GONE);
+        distance1InfoView.setVisibility(supersize ? View.GONE : View.VISIBLE);
+        distance1View.setVisibility(supersize ? View.GONE : View.VISIBLE);
+
+        if (supersize) {
+            distanceSupersizeView.setText(distance1View.getText());
+        } else {
+            distance1View.setText(distanceSupersizeView.getText());
         }
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
@@ -37,10 +37,8 @@ public class DistanceView {
 
         final Geopoint currentCoords = new Geopoint(coordinatesIn);
         final float distance = null != destinationCoords ? currentCoords.distanceTo(destinationCoords) : 0.0f;
-
         mapDistanceDrawer.drawDistance(showBothDistances, distance, realDistance);
     }
-
 
     public void setRouteDistance(final float routeDistance) {
         this.routeDistance = routeDistance;

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1427,6 +1427,14 @@ public class Settings {
         return getBoolean(R.string.pref_showCircles, false);
     }
 
+    public static void setSupersizeDistance(final boolean supersizeDistance) {
+        putBoolean(R.string.pref_supersizeDistance, supersizeDistance);
+    }
+
+    public static boolean getSupersizeDistance() {
+        return getBoolean(R.string.pref_supersizeDistance, false);
+    }
+
     public static void setExcludeMine(final boolean exclude) {
         putBoolean(R.string.pref_excludemine, exclude);
     }


### PR DESCRIPTION
Optionally display current distance to navigation target in a super-sized font at the maps' head:

![image](https://user-images.githubusercontent.com/3754370/97806643-02d54680-1c5d-11eb-9044-de995a7227ba.png)

Supersize display can be switched either by using a menu item (Map Settings => Supersize distance) or by tapping on the distance shown in the upper right corner.