### PR TITLE
extract own wp with empty coords from PCN (fix #9338)

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1589,8 +1589,8 @@ public class Geocache implements IWaypoint {
         boolean changed = false;
         if (forceExtraction || !preventWaypointsFromNote) {
             for (final Waypoint parsedWaypoint : Waypoint.parseWaypoints(StringUtils.defaultString(text), namePrefix)) {
-                final Waypoint existingWaypoint = findWaypoint(parsedWaypoint.getPrefix(), parsedWaypoint.getCoords());
-                if (existingWaypoint == null) {
+                final Waypoint existingWaypoint = findWaypoint(parsedWaypoint);
+                if (null == existingWaypoint) {
                     //add as new waypoint
                     addOrChangeWaypoint(parsedWaypoint, updateDb);
                     changed = true;
@@ -1606,21 +1606,40 @@ public class Geocache implements IWaypoint {
         return changed;
     }
 
-    private Waypoint findWaypoint(final String prefix, final Geopoint point) {
-
+    private Waypoint findWaypoint(final Waypoint searchWp) {
         //try to match prefix
-        for (final Waypoint waypoint: waypoints) {
-            if (!StringUtils.isBlank(prefix) && !StringUtils.isBlank(waypoint.getPrefix()) && prefix.equals(waypoint.getPrefix())) {
-                return waypoint;
+        final String prefix = searchWp.getPrefix();
+        if (null != prefix) {
+            for (final Waypoint waypoint : waypoints) {
+                if (!StringUtils.isBlank(prefix) && !StringUtils.isBlank(waypoint.getPrefix()) && prefix.equals(waypoint.getPrefix())) {
+                    return waypoint;
+                }
             }
+            return null;
         }
 
         //try to match coordinate
-        for (final Waypoint waypoint: waypoints) {
-            // waypoint can have no coords such as a Final set by cache owner
-            final Geopoint coords = waypoint.getCoords();
-            if (coords != null && coords.equalsDecMinute(point)) {
-                return waypoint;
+        final Geopoint point = searchWp.getCoords();
+        if (null != point) {
+            for (final Waypoint waypoint : waypoints) {
+                // waypoint can have no coords such as a Final set by cache owner
+                final Geopoint coords = waypoint.getCoords();
+                if (coords != null && coords.equalsDecMinute(point)) {
+                    return waypoint;
+                }
+            }
+            return null;
+        }
+
+        //try to match name if prefix and coords are null
+        for (final Waypoint waypoint : waypoints) {
+            final String searchWpName = searchWp.getName();
+            if (!StringUtils.isBlank(searchWpName)) {
+                final String wpName = waypoint.getName();
+                final WaypointType wpType = waypoint.getWaypointType();
+                if (searchWpName.equals(wpName) && searchWp.getWaypointType().getL10n().equals(wpType.getL10n())) {
+                    return waypoint;
+                }
             }
         }
         return null;

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -398,11 +398,7 @@ public class Waypoint implements IWaypoint {
             waypoint.setUserNote(userNote.trim());
         }
 
-        if (point != null || prefix != null) {
-            return waypoint;
-        }
-        return null;
-
+        return waypoint;
     }
 
     private static String parseUserNote(final String text, final int end) {

--- a/tests/src/cgeo/geocaching/models/WaypointTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointTest.java
@@ -221,6 +221,38 @@ public class WaypointTest {
 
     }
 
+    @Test
+    public void testCreateParseableWaypointTextUserWpWithoutCoordinateAndParseIt() {
+        final Waypoint wp = new Waypoint("name", WaypointType.FINAL, false);
+        wp.setCoords(null);
+        wp.setUserDefined();
+        wp.setUserNote("user note with \"escaped\" text\nand a newline");
+        final String parseableText = wp.getParseableText(-1);
+        assertThat(parseableText).isEqualTo(
+            "@name (F) (NO-COORD)\n" +
+                "\"user note with \\\"escaped\\\" text\nand a newline\"");
+
+        final Collection<Waypoint> parsedWaypoints = Waypoint.parseWaypoints(parseableText, "Prefix");
+        assertThat(parsedWaypoints).hasSize(1);
+        final Iterator<Waypoint> iterator = parsedWaypoints.iterator();
+        final Waypoint newWp = iterator.next();
+        assertWaypoint(newWp, wp);
+        assertThat(newWp.isUserDefined()).isTrue();
+
+    }
+
+    @Test
+    public void testParseTwoUserDefinedWaypointWithSameNameAndWithoutCoordinate() {
+        final String parseableText = "@name (F) (NO-COORD)\n" +
+            "\"user note with \\\"escaped\\\" text\nand a newline\"" +
+        "@name (F) (NO-COORD)\n" +
+        "\"user note 2 with \\\"escaped\\\" text\nand a newline\"";
+
+        final Collection<Waypoint> parsedWaypoints = Waypoint.parseWaypoints(parseableText, "Prefix");
+        assertThat(parsedWaypoints).hasSize(2);
+
+    }
+
     private static String toParseableWpString(final Geopoint gp) {
         return gp.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT_RAW);
 


### PR DESCRIPTION
This PR improves the extraction of waypoint from PCN for own waypoint with empty coords:
Own waypoint with empty coords will be extracted. 
If already a waypoint with same name and type exists, the new waypoint will not be added.
(fix #9338)
So user can add waypoint with formula in PCN and it will be extracted to user-note of waypoint:
e.g. 
@Final (F) (NO-COORD)
"N50 57.(A+E)(B+B)(E) W001 21.(D)(B+D)(A+B+B)"