### PR TITLE
WIP Fixes for Sailfish OS

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -8,12 +8,6 @@
 
 
     <style name="cgeo_main.base" parent="@style/Theme.AppCompat">
-
-        <!-- copy the style elements of the Wallpaper theme since AppCompat has no Wallpaper theme -->
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:colorBackgroundCacheHint">@null</item>
-        <item name="android:windowShowWallpaper">true</item>
-
         <item name="colorAccent">@color/colorAccent</item>
 
         <!-- system elements -->


### PR DESCRIPTION
DO NOT MERGE

This PR disables the transparent background effect on MainActivity which causes problems on recent versions of Sailfish OS  on Xperia XA2 and (probably) Xperia 10 series devices (#8752).

The configuration screens are still freezing when you navigate between hierarchy levels, but that problem can be worked around by using a gesture - a swipe from the side of the screen and back - to almost put the app in the background but then cancel it by swiping back. This needs to be repeated many times but after configuring the app can be used normally.