### PR TITLE
related to #8457: let Mapsforge use Uris instead of Files

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapView.java
@@ -239,7 +239,7 @@ public class MapsforgeMapView extends MapView implements MapViewImpl<MapsforgeCa
                 return;
             }
             setMapFile(new File(Settings.getMapFile()));
-            if (!Settings.isValidMapFile(Settings.getMapFile())) {
+            if (!Settings.isCurrentlySelectedMapUriValid()) {
                 showInvalidMapfileMessage(getContext());
             }
         }

--- a/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
+++ b/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
@@ -152,7 +152,8 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                         Settings.setMapFile(newMapPath);
                         MapSource newMapSource = null;
                         for (final MapSource mapSource : MapProviderFactory.getMapSources()) {
-                            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource && ((MapsforgeMapProvider.OfflineMapSource) mapSource).getFileName().equals(newMapPath)) {
+                            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource && ((MapsforgeMapProvider.OfflineMapSource) mapSource).getMapUri()
+                                .equals(Uri.fromFile(new File(newMapPath)))) {
                                 newMapSource = mapSource;
                                 break;
                             }

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -737,7 +737,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                     final File file = new File(mapFile);
                     if (!file.isDirectory()) {
                         Settings.setMapFile(mapFile);
-                        if (!Settings.isValidMapFile(Settings.getMapFile())) {
+                        if (!Settings.isCurrentlySelectedMapUriValid()) {
                             showInvalidMapfileMessage(this);
                         } else {
                             // Ensure map source preference is updated accordingly.

--- a/tests/src-android/cgeo/geocaching/SettingsTest.java
+++ b/tests/src-android/cgeo/geocaching/SettingsTest.java
@@ -21,7 +21,7 @@ public class SettingsTest extends ActivityInstrumentationTestCase2<MainActivity>
      */
     public static void testSettingsException() {
         // We just want to ensure that it does not throw any exception but we do not know anything about the result
-        MapsforgeMapProvider.isValidMapFile(Settings.getMapFile());
+        MapsforgeMapProvider.isValidMapFile(null);
     }
 
     public static void testSettings() {


### PR DESCRIPTION
related to #8457: let Mapsforge use Uris instead of Files
Refactoring towards to SAF, no functional change: let MapsforgeMapProvider use Uris instead of Files