### PR TITLE
use HtmlCompat.fromHtml instead of deprecated Html.fromHtml

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -342,6 +342,9 @@ dependencies {
     // Support Library AppCompat
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
+    // Support Library core (used for eg. HtmlCompat)
+    implementation 'androidx.core:core:1.3.2'
+
     // Support Library ExifInterface
     implementation 'androidx.exifinterface:exifinterface:1.3.1'
 

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -17,7 +17,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.SpannableStringBuilder;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,6 +26,7 @@ import android.widget.TextView;
 
 import androidx.annotation.RawRes;
 import androidx.annotation.StringRes;
+import androidx.core.text.HtmlCompat;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -149,11 +149,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
             }
             sb.append("</ul>");
 
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                t.setText(Html.fromHtml(sb.toString(), Html.FROM_HTML_MODE_LEGACY));
-            } else {
-                t.setText(Html.fromHtml(sb.toString()));
-            }
+            t.setText(HtmlCompat.fromHtml(sb.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY));
         }
     }
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -111,7 +111,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.text.Editable;
-import android.text.Html;
 import android.text.InputType;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -149,6 +148,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.text.HtmlCompat;
 import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -1269,7 +1269,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             if (StringUtils.isNotBlank(license)) {
                 view.findViewById(R.id.license_box).setVisibility(View.VISIBLE);
                 final TextView licenseView = view.findViewById(R.id.license);
-                licenseView.setText(Html.fromHtml(license), BufferType.SPANNABLE);
+                licenseView.setText(HtmlCompat.fromHtml(license, HtmlCompat.FROM_HTML_MODE_LEGACY), BufferType.SPANNABLE);
                 licenseView.setClickable(true);
                 licenseView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
             } else {
@@ -1695,7 +1695,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final TextView hintView = view.findViewById(R.id.hint);
             if (StringUtils.isNotBlank(cache.getHint())) {
                 if (TextUtils.containsHtml(cache.getHint())) {
-                    hintView.setText(Html.fromHtml(cache.getHint(), new HtmlImage(cache.getGeocode(), false, false, false), null), TextView.BufferType.SPANNABLE);
+                    hintView.setText(HtmlCompat.fromHtml(cache.getHint(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(cache.getGeocode(), false, false, false), null), TextView.BufferType.SPANNABLE);
                     hintView.setText(CryptUtils.rot13((Spannable) hintView.getText()));
                 } else {
                     hintView.setText(CryptUtils.rot13(cache.getHint()));
@@ -1785,7 +1785,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 descriptionView.setBackgroundColor(backgroundColor);
 
                 final UnknownTagsHandler unknownTagsHandler = new UnknownTagsHandler();
-                final Editable description = new SpannableStringBuilder(Html.fromHtml(descriptionString, new HtmlImage(cache.getGeocode(), true, false, descriptionView, false), unknownTagsHandler));
+                final Editable description = new SpannableStringBuilder(HtmlCompat.fromHtml(descriptionString, HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(cache.getGeocode(), true, false, descriptionView, false), unknownTagsHandler));
                 addWarning(unknownTagsHandler, description);
                 if (StringUtils.isNotBlank(description)) {
                     fixRelativeLinks(description);
@@ -1844,7 +1844,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final int startPos = description.length();
             final IConnector connector = ConnectorFactory.getConnector(cache);
             if (StringUtils.isNotEmpty(cache.getUrl())) {
-                final Spanned tableNote = Html.fromHtml(res.getString(R.string.cache_description_table_note, "<a href=\"" + cache.getUrl() + "\">" + connector.getName() + "</a>"));
+                final Spanned tableNote = HtmlCompat.fromHtml(res.getString(R.string.cache_description_table_note, "<a href=\"" + cache.getUrl() + "\">" + connector.getName() + "</a>"), HtmlCompat.FROM_HTML_MODE_LEGACY);
                 description.append("\n\n").append(tableNote);
                 description.setSpan(new StyleSpan(Typeface.ITALIC), startPos, description.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             }
@@ -2069,7 +2069,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 noteView.setOnClickListener(new DecryptTextClickListener(noteView));
                 noteView.setVisibility(View.VISIBLE);
                 if (TextUtils.containsHtml(wpt.getNote())) {
-                    noteView.setText(Html.fromHtml(wpt.getNote(), new SmileyImage(cache.getGeocode(), noteView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+                    noteView.setText(HtmlCompat.fromHtml(wpt.getNote(), HtmlCompat.FROM_HTML_MODE_LEGACY, new SmileyImage(cache.getGeocode(), noteView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
                 } else {
                     noteView.setText(wpt.getNote());
                 }

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -38,7 +38,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
-import android.text.Html;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -56,6 +55,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.util.ArrayList;
@@ -156,7 +156,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                         final AutoCompleteTextView waypointName = activity.waypointName;
                         waypointName.setText(TextUtils.stripHtml(StringUtils.trimToEmpty(waypoint.getName())));
                         Dialogs.moveCursorToEnd(waypointName);
-                        activity.note.setText(Html.fromHtml(StringUtils.trimToEmpty(waypoint.getNote()), new SmileyImage(activity.geocode, activity.note), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+                        activity.note.setText(HtmlCompat.fromHtml(StringUtils.trimToEmpty(waypoint.getNote()), HtmlCompat.FROM_HTML_MODE_LEGACY, new SmileyImage(activity.geocode, activity.note), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
                         final EditText userNote = activity.userNote;
                         userNote.setText(StringUtils.trimToEmpty(waypoint.getUserNote()));
                         Dialogs.moveCursorToEnd(userNote);

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -37,7 +37,6 @@ import android.content.Intent;
 import android.graphics.Paint;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -53,6 +52,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.view.ActionMode;
+import androidx.core.text.HtmlCompat;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -468,7 +468,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             // trackable owner
             final TextView owner = details.add(R.string.trackable_owner, res.getString(R.string.trackable_unknown)).right;
             if (StringUtils.isNotBlank(trackable.getOwner())) {
-                owner.setText(Html.fromHtml(trackable.getOwner()), TextView.BufferType.SPANNABLE);
+                owner.setText(HtmlCompat.fromHtml(trackable.getOwner(), HtmlCompat.FROM_HTML_MODE_LEGACY), TextView.BufferType.SPANNABLE);
                 owner.setOnClickListener(UserClickListener.forOwnerOf(trackable));
             }
 
@@ -483,11 +483,11 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
                 switch (trackable.getSpottedType()) {
                     case Trackable.SPOTTED_CACHE:
                         // TODO: the whole sentence fragment should not be constructed, but taken from the resources
-                        text = new StringBuilder(res.getString(R.string.trackable_spotted_in_cache)).append(' ').append(Html.fromHtml(trackable.getSpottedName()));
+                        text = new StringBuilder(res.getString(R.string.trackable_spotted_in_cache)).append(' ').append(HtmlCompat.fromHtml(trackable.getSpottedName(), HtmlCompat.FROM_HTML_MODE_LEGACY));
                         break;
                     case Trackable.SPOTTED_USER:
                         // TODO: the whole sentence fragment should not be constructed, but taken from the resources
-                        text = new StringBuilder(res.getString(R.string.trackable_spotted_at_user)).append(' ').append(Html.fromHtml(trackable.getSpottedName()));
+                        text = new StringBuilder(res.getString(R.string.trackable_spotted_at_user)).append(' ').append(HtmlCompat.fromHtml(trackable.getSpottedName(), HtmlCompat.FROM_HTML_MODE_LEGACY));
                         break;
                     case Trackable.SPOTTED_UNKNOWN:
                         text = new StringBuilder(res.getString(R.string.trackable_spotted_unknown_location));
@@ -538,7 +538,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             // trackable origin
             if (StringUtils.isNotBlank(trackable.getOrigin())) {
                 final TextView origin = details.add(R.string.trackable_origin, "").right;
-                origin.setText(Html.fromHtml(trackable.getOrigin()), TextView.BufferType.SPANNABLE);
+                origin.setText(HtmlCompat.fromHtml(trackable.getOrigin(), HtmlCompat.FROM_HTML_MODE_LEGACY), TextView.BufferType.SPANNABLE);
                 addContextMenu(origin);
             }
 
@@ -557,7 +557,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (StringUtils.isNotBlank(HtmlUtils.extractText(trackable.getGoal()))) {
                 goalBox.setVisibility(View.VISIBLE);
                 goalTextView.setVisibility(View.VISIBLE);
-                goalTextView.setText(Html.fromHtml(trackable.getGoal(), new HtmlImage(geocode, true, false, goalTextView, false), null), TextView.BufferType.SPANNABLE);
+                goalTextView.setText(HtmlCompat.fromHtml(trackable.getGoal(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(geocode, true, false, goalTextView, false), null), TextView.BufferType.SPANNABLE);
                 goalTextView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
                 addContextMenu(goalTextView);
             }
@@ -566,7 +566,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (StringUtils.isNotBlank(HtmlUtils.extractText(trackable.getDetails()))) {
                 detailsBox.setVisibility(View.VISIBLE);
                 detailsTextView.setVisibility(View.VISIBLE);
-                detailsTextView.setText(Html.fromHtml(trackable.getDetails(), new HtmlImage(geocode, true, false, detailsTextView, false), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+                detailsTextView.setText(HtmlCompat.fromHtml(trackable.getDetails(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(geocode, true, false, detailsTextView, false), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
                 detailsTextView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
                 addContextMenu(detailsTextView);
             }

--- a/main/src/cgeo/geocaching/calendar/CalendarEntry.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarEntry.java
@@ -10,13 +10,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.provider.CalendarContract;
-import android.text.Html;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
 import android.view.Gravity;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -89,7 +89,7 @@ class CalendarEntry {
         description.append(url);
         if (StringUtils.isNotBlank(shortDesc)) {
             // remove images in short description
-            final Spanned spanned = Html.fromHtml(shortDesc, null, null);
+            final Spanned spanned = HtmlCompat.fromHtml(shortDesc, HtmlCompat.FROM_HTML_MODE_LEGACY);
             String text = spanned.toString();
             final ImageSpan[] spans = spanned.getSpans(0, spanned.length(), ImageSpan.class);
             for (int i = spans.length - 1; i >= 0; i--) {

--- a/main/src/cgeo/geocaching/helper/HelperAppAdapter.java
+++ b/main/src/cgeo/geocaching/helper/HelperAppAdapter.java
@@ -6,7 +6,6 @@ import cgeo.geocaching.ui.recyclerview.AbstractRecyclerViewHolder;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +13,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.Arrays;
@@ -66,7 +66,7 @@ final class HelperAppAdapter extends RecyclerView.Adapter<HelperAppAdapter.ViewH
         final Resources resources = context.getResources();
         holder.title.setText(resources.getString(app.titleId));
         holder.image.setImageDrawable(Compatibility.getDrawable(resources, app.iconId));
-        holder.description.setText(Html.fromHtml(resources.getString(app.descriptionId)));
+        holder.description.setText(HtmlCompat.fromHtml(resources.getString(app.descriptionId), HtmlCompat.FROM_HTML_MODE_LEGACY));
     }
 
 }

--- a/main/src/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/LogsViewCreator.java
@@ -17,7 +17,6 @@ import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.TranslationUtils;
 import cgeo.geocaching.utils.UnknownTagsHandler;
 
-import android.text.Html;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -25,6 +24,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,7 +95,7 @@ public abstract class LogsViewCreator extends AbstractCachingListViewPageViewCre
         // log text, avoid parsing HTML if not necessary
         if (TextUtils.containsHtml(log.log)) {
             final UnknownTagsHandler unknownTagsHandler = new UnknownTagsHandler();
-            holder.text.setText(TextUtils.trimSpanned(Html.fromHtml(log.getDisplayText(), new SmileyImage(getGeocode(), holder.text), unknownTagsHandler)), TextView.BufferType.SPANNABLE);
+            holder.text.setText(TextUtils.trimSpanned(HtmlCompat.fromHtml(log.getDisplayText(), HtmlCompat.FROM_HTML_MODE_LEGACY, new SmileyImage(getGeocode(), holder.text), unknownTagsHandler)), TextView.BufferType.SPANNABLE);
         } else {
             holder.text.setText(log.log, TextView.BufferType.SPANNABLE);
         }

--- a/main/src/cgeo/geocaching/log/TrackableLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/TrackableLogsViewCreator.java
@@ -7,8 +7,9 @@ import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.ui.UserClickListener;
 import cgeo.geocaching.utils.TextUtils;
 
-import android.text.Html;
 import android.view.View;
+
+import androidx.core.text.HtmlCompat;
 
 import java.util.List;
 
@@ -47,7 +48,7 @@ public class TrackableLogsViewCreator extends LogsViewCreator {
     @Override
     protected void fillCountOrLocation(final LogViewHolder holder, final LogEntry log) {
         if (StringUtils.isNotBlank(log.cacheName)) {
-            holder.gcinfo.setText(Html.fromHtml(log.cacheName));
+            holder.gcinfo.setText(HtmlCompat.fromHtml(log.cacheName, HtmlCompat.FROM_HTML_MODE_LEGACY));
             holder.gcinfo.setVisibility(View.VISIBLE);
             final String cacheGuid = log.cacheGuid;
             final String cacheName = log.cacheName;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -80,7 +80,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.preference.PreferenceManager;
-import android.text.Html;
 import android.text.SpannableString;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
@@ -99,6 +98,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.text.HtmlCompat;
 import androidx.core.util.Supplier;
 
 import java.io.File;
@@ -1862,7 +1862,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
     private static void displayMapAttribution(final Context ctx, final String attribution, final boolean linkify) {
 
         //create text message
-        CharSequence message = Html.fromHtml(attribution);
+        CharSequence message = HtmlCompat.fromHtml(attribution, HtmlCompat.FROM_HTML_MODE_LEGACY);
         if (linkify) {
             final SpannableString s = new SpannableString(message);
             Linkify.addLinks(s, Linkify.ALL);

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -56,10 +56,10 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Handler;
 import android.os.Message;
-import android.text.Html;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.text.HtmlCompat;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -1789,7 +1789,7 @@ public class Geocache implements IWaypoint {
 
             // store images from description
             if (StringUtils.isNotBlank(cache.getDescription())) {
-                Html.fromHtml(cache.getDescription(), imgGetter, null);
+                HtmlCompat.fromHtml(cache.getDescription(), HtmlCompat.FROM_HTML_MODE_LEGACY, imgGetter, null);
             }
 
             if (DisposableHandler.isDisposed(handler)) {

--- a/main/src/cgeo/geocaching/ui/CacheDetailsCreator.java
+++ b/main/src/cgeo/geocaching/ui/CacheDetailsCreator.java
@@ -16,7 +16,6 @@ import cgeo.geocaching.utils.UnknownTagsHandler;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.res.Resources;
-import android.text.Html;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RatingBar;
@@ -24,6 +23,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +71,7 @@ public final class CacheDetailsCreator {
     public ImmutablePair<RelativeLayout, TextView> addHtml(final int nameId, final CharSequence value, final String geocode) {
         final ImmutablePair<RelativeLayout, TextView> nameValue = createNameValueLine(nameId);
         final TextView valueView = nameValue.getRight();
-        valueView.setText(Html.fromHtml(value.toString(), new SmileyImage(geocode, valueView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+        valueView.setText(HtmlCompat.fromHtml(value.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY, new SmileyImage(geocode, valueView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
         return nameValue;
     }
 

--- a/main/src/cgeo/geocaching/ui/ImagesList.java
+++ b/main/src/cgeo/geocaching/ui/ImagesList.java
@@ -20,7 +20,6 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
-import android.text.Html;
 import android.util.SparseArray;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
@@ -35,6 +34,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.core.content.FileProvider;
+import androidx.core.text.HtmlCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.io.BufferedOutputStream;
@@ -118,12 +118,12 @@ public class ImagesList {
 
             if (StringUtils.isNotBlank(img.getTitle())) {
                 final TextView titleView = rowView.findViewById(R.id.title);
-                titleView.setText(Html.fromHtml(img.getTitle()));
+                titleView.setText(HtmlCompat.fromHtml(img.getTitle(), HtmlCompat.FROM_HTML_MODE_LEGACY));
             }
 
             if (StringUtils.isNotBlank(img.getDescription())) {
                 final TextView descView = rowView.findViewById(R.id.description);
-                descView.setText(Html.fromHtml(img.getDescription()), TextView.BufferType.SPANNABLE);
+                descView.setText(HtmlCompat.fromHtml(img.getDescription(), HtmlCompat.FROM_HTML_MODE_LEGACY), TextView.BufferType.SPANNABLE);
                 descView.setVisibility(View.VISIBLE);
             }
 

--- a/main/src/cgeo/geocaching/utils/HtmlUtils.java
+++ b/main/src/cgeo/geocaching/utils/HtmlUtils.java
@@ -1,10 +1,10 @@
 package cgeo.geocaching.utils;
 
-import android.text.Html;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
 
 import androidx.annotation.NonNull;
+import androidx.core.text.HtmlCompat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,7 +53,7 @@ public final class HtmlUtils {
         }
 
         // now that images are gone, do a normal html to text conversion
-        return Html.fromHtml(result).toString().trim();
+        return HtmlCompat.fromHtml(result, HtmlCompat.FROM_HTML_MODE_LEGACY).toString().trim();
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/cgeo/geocaching/utils/ImageUtils.java
@@ -16,13 +16,13 @@ import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.text.Html;
 import android.util.Base64;
 import android.util.Base64InputStream;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.text.HtmlCompat;
 import androidx.exifinterface.media.ExifInterface;
 
 import java.io.BufferedOutputStream;
@@ -402,7 +402,7 @@ public final class ImageUtils {
             urls.add(image.getUrl());
         }
         for (final String text: htmlText) {
-            Html.fromHtml(StringUtils.defaultString(text), source -> {
+            HtmlCompat.fromHtml(StringUtils.defaultString(text), HtmlCompat.FROM_HTML_MODE_LEGACY, source -> {
                 if (!urls.contains(source) && canBeOpenedExternally(source)) {
                     images.add(new Image.Builder()
                             .setUrl(source)

--- a/main/src/cgeo/geocaching/utils/LiUtils.java
+++ b/main/src/cgeo/geocaching/utils/LiUtils.java
@@ -3,9 +3,8 @@ package cgeo.geocaching.utils;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.os.Build;
 import android.text.Editable;
-import android.text.Html;
+import android.text.Html.TagHandler;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -13,6 +12,8 @@ import android.text.Spanned;
 import android.text.style.BulletSpan;
 import android.text.style.LeadingMarginSpan;
 import android.util.TypedValue;
+
+import androidx.core.text.HtmlCompat;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,7 +37,7 @@ public class LiUtils {
         final String input = m.find() ? m.replaceAll("<li>$2</li>") : html;
 
         // now apply HTML formatting (including <li> tags)
-        final Spanned spanned = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N ? Html.fromHtml(input, Html.FROM_HTML_MODE_LEGACY) : Html.fromHtml(input, null, new LiTagHandler());
+        final Spanned spanned = HtmlCompat.fromHtml(input, HtmlCompat.FROM_HTML_MODE_LEGACY, null, new LiTagHandler());
         final SpannableStringBuilder builder = new SpannableStringBuilder(spanned);
         final BulletSpan[] bulletSpans = builder.getSpans(0, builder.length(), BulletSpan.class);
         for (BulletSpan bulletSpan :bulletSpans) {
@@ -93,7 +94,7 @@ class LiAwareBulletSpan implements LeadingMarginSpan {
     }
 }
 
-class LiTagHandler implements Html.TagHandler {
+class LiTagHandler implements TagHandler {
 
     @Override
     public void handleTag(final boolean opening, final String tag, final Editable output, final XMLReader xmlReader) {

--- a/main/src/cgeo/geocaching/utils/TextUtils.java
+++ b/main/src/cgeo/geocaching/utils/TextUtils.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Geocache;
 
-import android.text.Html;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
@@ -13,6 +12,7 @@ import android.text.style.StrikethroughSpan;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 
 import java.nio.charset.StandardCharsets;
 import java.text.Collator;
@@ -229,7 +229,7 @@ public final class TextUtils {
     }
 
     /**
-     * When converting html to text using {@link Html#fromHtml(String)} then the result often contains unwanted trailing
+     * When converting html to text using {@link HtmlCompat#fromHtml(String, int)} then the result often contains unwanted trailing
      * linebreaks (from the conversion of paragraph tags). This method removes those.
      */
     public static CharSequence trimSpanned(final Spanned source) {
@@ -255,7 +255,7 @@ public final class TextUtils {
      * @return a string without any HTML markup
      */
     public static String stripHtml(final String html) {
-        return containsHtml(html) ? trimSpanned(Html.fromHtml(html)).toString() : html;
+        return containsHtml(html) ? trimSpanned(HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY)).toString() : html;
     }
 
     public static SpannableString coloredCacheText(@NonNull final Geocache cache, @NonNull final String text) {

--- a/tests/src-android/cgeo/geocaching/test/CgeoTestsActivity.java
+++ b/tests/src-android/cgeo/geocaching/test/CgeoTestsActivity.java
@@ -5,13 +5,14 @@ import android.content.ComponentName;
 import android.content.pm.InstrumentationInfo;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.core.text.HtmlCompat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -49,7 +50,7 @@ public class CgeoTestsActivity extends Activity {
             final String line = values[0];
             final boolean isAtBottom = scrollView.isAtBottom();
             if (!TextUtils.isEmpty(line)) {
-                logView.append(Html.fromHtml("<font color=\"" + color(line) + "\">" + line + "</font><br/>"));
+                logView.append(HtmlCompat.fromHtml("<font color=\"" + color(line) + "\">" + line + "</font><br/>", HtmlCompat.FROM_HTML_MODE_LEGACY));
                 if (isAtBottom) {
                     scrollView.scrollTo(0, logView.getBottom());
                 }


### PR DESCRIPTION
Since API24 the plain Html.fromHtml(string) is deprecated in favor of Html.fromHtml(string, int).
There is a wrapper class HtmlCompat where the method switch is done according to the Build version of the device.
The implementation uses now only the int FROM_HTML_MODE_LEGACY (value 0).

Maybe we can optimize later the code using some of the new parameters to solve issue #7306.