### PR TITLE
toggle supersize distances (fix #9367)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -75,7 +75,7 @@
     <string translatable="false" name="pref_excludeWpVisited">excludeWpVisited</string>
     <string translatable="false" name="pref_hide_track">hideTrack</string>
     <string translatable="false" name="pref_showCircles">showCircles</string>
-    <string translatable="false" name="pref_supersizeDistance">supersizeDistance</string>
+    <string translatable="false" name="pref_supersizeDistance">supersizeDistanceToggle</string>
     <string translatable="false" name="pref_plainLogs">plainLogs</string>
     <string translatable="false" name="pref_signature">signature</string>
     <string translatable="false" name="pref_sigautoinsert">sigautoinsert</string>

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1417,12 +1417,12 @@ public class Settings {
         return getBoolean(R.string.pref_showCircles, false);
     }
 
-    public static void setSupersizeDistance(final boolean supersizeDistance) {
-        putBoolean(R.string.pref_supersizeDistance, supersizeDistance);
+    public static void setSupersizeDistance(final int supersizeDistance) {
+        putInt(R.string.pref_supersizeDistance, supersizeDistance);
     }
 
-    public static boolean getSupersizeDistance() {
-        return getBoolean(R.string.pref_supersizeDistance, false);
+    public static int getSupersizeDistance() {
+        return getInt(R.string.pref_supersizeDistance, 0);
     }
 
     public static void setExcludeMine(final boolean exclude) {


### PR DESCRIPTION
- make all (up to) three tiny distance fields clickable
- add toggle cycle: first distance supersized => second distance supersized (if available) => no distance supersized
