### PR TITLE
auto-adjust super-sized distance font (fix #9380)

### DIFF
--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -2,7 +2,8 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <TextView
         android:id="@+id/distance1"
@@ -51,6 +52,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_alignParentTop="true"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="64sp"
+        app:autoSizeMaxTextSize="120sp"
+        app:autoSizeStepGranularity="2sp"
         style="@style/map_distanceinfo_supersize" />
 
 </RelativeLayout>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -426,7 +426,7 @@
 
     <style name="map_distanceinfo_supersize" parent="map_distanceinfo">
         <item name="android:layout_marginLeft">-2dp</item>
-        <item name="android:textSize">96sp</item>
+        <item name="android:textSize">72sp</item>
     </style>
 
     <!-- about c:geo contributors style -->


### PR DESCRIPTION
- auto-resized font size in a range from 64sp to 120sp
- sets a smaller default font size for supersized distance display (72sp instead of 96sp) (fallback)
