### PR TITLE
bottom-align route distance in supersize mode

### DIFF
--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -47,6 +47,14 @@
         style="@style/map_distanceinfo" />
 
     <TextView
+        android:id="@+id/routeDistanceSupersize"
+        android:layout_marginTop="0dp"
+        android:layout_alignBottom="@id/distanceSupersize"
+        android:layout_alignParentRight="true"
+        android:layout_width="100dp"
+        style="@style/map_distanceinfo" />
+
+    <TextView
         android:id="@+id/distanceSupersize"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
+++ b/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
@@ -18,6 +18,7 @@ public class MapDistanceDrawerCommons {
     private final TextView distance2InfoView;
     private final TextView distance2View;
     private final TextView routeDistanceView;
+    private final TextView routeDistanceViewSupersize;
     private final TextView distanceSupersizeView;
     private boolean bothViewsNeeded = false;
 
@@ -27,6 +28,7 @@ public class MapDistanceDrawerCommons {
         distance2InfoView = root.findViewById(R.id.distance2info);
         distance2View = root.findViewById(R.id.distance2);
         routeDistanceView = root.findViewById(R.id.routeDistance);
+        routeDistanceViewSupersize = root.findViewById(R.id.routeDistanceSupersize);
         distanceSupersizeView = root.findViewById(R.id.distanceSupersize);
 
         distance1InfoView.setOnClickListener(v -> swap());
@@ -62,9 +64,12 @@ public class MapDistanceDrawerCommons {
     }
 
     public void drawRouteDistance(final float routeDistance) {
-        routeDistanceView.setVisibility(routeDistance != 0.0f ? View.VISIBLE : View.GONE);
+        routeDistanceView.setVisibility(View.GONE);
+        routeDistanceViewSupersize.setVisibility(View.GONE);
         if (routeDistance != 0.0f) {
-            routeDistanceView.setText(Units.getDistanceFromKilometers(routeDistance));
+            final TextView view = bothViewsNeeded && Settings.getSupersizeDistance() > 0 ? routeDistanceViewSupersize : routeDistanceView;
+            view.setVisibility(View.VISIBLE);
+            view.setText(Units.getDistanceFromKilometers(routeDistance));
         }
     }
 


### PR DESCRIPTION
follow-up to #9380, see https://github.com/cgeo/cgeo/issues/9380#issuecomment-727269485

bottom-align route distance info view if in supersize mode, to stay in white space.

Only applies if "show straight distance" is active, as otherwise the route distance is the only distance displayed beside the supersized one and can stay top-right in that case.

![image](https://user-images.githubusercontent.com/3754370/99181235-71baa100-272d-11eb-8acf-3d47553332f3.png)
