### PR TITLE
show second distance view below super size view

### DIFF
--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -7,7 +7,6 @@
 
     <TextView
         android:id="@+id/distance1"
-        android:layout_marginTop="-8dp"
         android:layout_alignParentTop="true"
         android:layout_alignParentRight="true"
         android:layout_width="100dp"
@@ -15,7 +14,6 @@
 
     <TextView
         android:id="@+id/distance1info"
-        android:layout_marginTop="-8dp"
         android:layout_toLeftOf="@id/distance1"
         android:layout_marginRight="0dp"
         android:layout_width="15sp"
@@ -48,8 +46,8 @@
 
     <TextView
         android:id="@+id/routeDistanceSupersize"
-        android:layout_marginTop="0dp"
-        android:layout_alignBottom="@id/distanceSupersize"
+        android:layout_marginTop="10dp"
+        android:layout_below="@id/distanceSupersize"
         android:layout_alignParentRight="true"
         android:layout_width="100dp"
         style="@style/map_distanceinfo" />

--- a/main/res/layout/map_mapsforge_v6.xml
+++ b/main/res/layout/map_mapsforge_v6.xml
@@ -25,23 +25,12 @@
             android:id="@+id/target"
             android:layout_alignParentTop="true"
             android:layout_alignParentLeft="true"
-            android:layout_marginTop="-8dp"
-            android:layout_marginLeft="-8dp"
+            android:layout_marginLeft="-2dp"
             android:layout_marginRight="92dp"
-            android:paddingTop="4dp"
             android:paddingLeft="8dp"
             android:paddingRight="8dp"
             android:layout_width="wrap_content"
-            android:layout_height="30dp"
-            android:background="@drawable/icon_bcg"
-            android:ellipsize="end"
-            android:gravity="center_horizontal"
-            android:lines="1"
-            android:textColor="@color/text_icon"
-            android:textStyle="bold"
-            android:textSize="18sp"
-            android:visibility="gone"
-            android:maxLines="1" />
+            style="@style/map_distanceinfo"/>
 
         <include layout="@layout/map_distanceinfo" />
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -412,7 +412,7 @@
     <style name="map_distanceinfo">
         <item name="android:layout_marginRight">-2dp</item>
         <item name="android:paddingTop">4dp</item>
-        <item name="android:layout_height">30dp</item>
+        <item name="android:layout_height">28dp</item>
         <item name="android:background">@drawable/icon_bcg</item>
         <item name="android:ellipsize">end</item>
         <item name="android:gravity">center_horizontal</item>
@@ -427,6 +427,8 @@
     <style name="map_distanceinfo_supersize" parent="map_distanceinfo">
         <item name="android:layout_marginLeft">-2dp</item>
         <item name="android:textSize">72sp</item>
+        <item name="android:paddingTop">15dp</item>
+        <item name="android:layout_marginBottom">-10dp</item>
     </style>
 
     <!-- about c:geo contributors style -->


### PR DESCRIPTION
- show second distance view below super size view
- move supersized text a bit down within its view to separate it a bit more from top text (target name, distance)