### PR TITLE
open about activity on click at c:geo's logo

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -281,12 +281,10 @@ public class MainActivity extends AbstractActionBarActivity {
         // Disable the up navigation for this activity
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setDisplayHomeAsUpEnabled(false);
 
             // show c:geo logo
-            actionBar.setLogo(R.drawable.cgeo_actionbar_squircle);
-            actionBar.setDisplayUseLogoEnabled(true);
-            actionBar.setDisplayShowHomeEnabled(true);
+            actionBar.setHomeAsUpIndicator(R.drawable.cgeo_actionbar_squircle);
+            actionBar.setDisplayHomeAsUpEnabled(true);
 
             actionBar.setBackgroundDrawable(getResources().getDrawable(R.drawable.ab_transparent_example));
         }


### PR DESCRIPTION
This was already implemented but not working, as the icon was disabled as logo instead of an up Indicator. 

Just for info, this is the actual code part which was designed to start the AboutActivity...
https://github.com/cgeo/cgeo/blob/cac5eb2040623da6c66620eb2850b49b6afe21cc/main/src/cgeo/geocaching/MainActivity.java#L501-L507