### PR TITLE
refactor map distance views

### DIFF
--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -6,17 +6,22 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <TextView
+        android:id="@+id/target"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_marginLeft="-2dp"
+        android:layout_marginRight="92dp"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:layout_width="wrap_content"
+        style="@style/map_distanceinfo"
+        android:gravity="left" />
+
+    <TextView
         android:id="@+id/distance1"
         android:layout_alignParentTop="true"
         android:layout_alignParentRight="true"
         android:layout_width="100dp"
-        style="@style/map_distanceinfo" />
-
-    <TextView
-        android:id="@+id/distance1info"
-        android:layout_toLeftOf="@id/distance1"
-        android:layout_marginRight="0dp"
-        android:layout_width="15sp"
         style="@style/map_distanceinfo" />
 
     <TextView
@@ -28,26 +33,9 @@
         style="@style/map_distanceinfo" />
 
     <TextView
-        android:id="@+id/distance2info"
-        android:layout_marginTop="0dp"
-        android:layout_below="@id/distance1info"
-        android:layout_toLeftOf="@id/distance2"
-        android:layout_marginRight="0dp"
-        android:layout_width="15sp"
-        style="@style/map_distanceinfo" />
-
-    <TextView
-        android:id="@+id/routeDistance"
+        android:id="@+id/distance3"
         android:layout_marginTop="0dp"
         android:layout_below="@id/distance2"
-        android:layout_alignParentRight="true"
-        android:layout_width="100dp"
-        style="@style/map_distanceinfo" />
-
-    <TextView
-        android:id="@+id/routeDistanceSupersize"
-        android:layout_marginTop="10dp"
-        android:layout_below="@id/distanceSupersize"
         android:layout_alignParentRight="true"
         android:layout_width="100dp"
         style="@style/map_distanceinfo" />
@@ -63,5 +51,32 @@
         app:autoSizeMaxTextSize="120sp"
         app:autoSizeStepGranularity="2sp"
         style="@style/map_distanceinfo_supersize" />
+
+    <TextView
+        android:id="@+id/targetSupersize"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_marginLeft="-2dp"
+        android:layout_marginRight="92dp"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:layout_width="wrap_content"
+        style="@style/map_distanceinfo_no_background"
+        android:gravity="left" />
+
+    <TextView
+        android:id="@+id/distance1Supersize"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentRight="true"
+        android:layout_width="100dp"
+        style="@style/map_distanceinfo_no_background" />
+
+    <TextView
+        android:id="@+id/distance2Supersize"
+        android:layout_marginTop="10dp"
+        android:layout_below="@id/distanceSupersize"
+        android:layout_alignParentRight="true"
+        android:layout_width="100dp"
+        style="@style/map_distanceinfo" />
 
 </RelativeLayout>

--- a/main/res/layout/map_mapsforge_v6.xml
+++ b/main/res/layout/map_mapsforge_v6.xml
@@ -21,17 +21,6 @@
             android:enabled="true"
             android:keepScreenOn="true" />
 
-        <TextView
-            android:id="@+id/target"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentLeft="true"
-            android:layout_marginLeft="-2dp"
-            android:layout_marginRight="92dp"
-            android:paddingLeft="8dp"
-            android:paddingRight="8dp"
-            android:layout_width="wrap_content"
-            style="@style/map_distanceinfo"/>
-
         <include layout="@layout/map_distanceinfo" />
 
         <ImageView

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -409,13 +409,13 @@
     </style>
 
     <!-- map distance info style -->
-    <style name="map_distanceinfo">
-        <item name="android:layout_marginRight">-2dp</item>
-        <item name="android:paddingTop">4dp</item>
+    <style name="map_distanceinfo_no_background">
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingLeft">4dp</item>
+        <item name="android:paddingRight">4dp</item>
         <item name="android:layout_height">28dp</item>
-        <item name="android:background">@drawable/icon_bcg</item>
         <item name="android:ellipsize">end</item>
-        <item name="android:gravity">center_horizontal</item>
+        <item name="android:gravity">right</item>
         <item name="android:lines">1</item>
         <item name="android:textColor">@color/text_icon</item>
         <item name="android:textStyle">bold</item>
@@ -424,11 +424,16 @@
         <item name="android:maxLines">1</item>
     </style>
 
+    <style name="map_distanceinfo" parent="map_distanceinfo_no_background">
+        <item name="android:background">@drawable/icon_bcg</item>
+    </style>
+
     <style name="map_distanceinfo_supersize" parent="map_distanceinfo">
         <item name="android:layout_marginLeft">-2dp</item>
         <item name="android:textSize">72sp</item>
         <item name="android:paddingTop">15dp</item>
         <item name="android:layout_marginBottom">-10dp</item>
+        <item name="android:gravity">center_horizontal</item>
     </style>
 
     <!-- about c:geo contributors style -->

--- a/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
+++ b/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
@@ -1,5 +1,26 @@
 package cgeo.geocaching.maps;
 
+/*
+ * Manages the distance views
+ *
+ * Standard view is: (at the top of the map view)
+ * target           distance1
+ *                  distance2
+ *                  distance3
+ *
+ * - target is only used when in target navigation mode in OSM
+ * - distance1, distance2, distance will be filled with straight distance, routed distance,
+ *   individual route length (depending on settings and current data)
+ * - By tapping on any of the distance fields either straight or routed distance can be supersized.
+ *   It gets removed from the three distance fields and displayed in a larger font:
+ *
+ * target           distance1
+ *     supersize    distance2
+ *
+ * - Tapping on the supersized window toggles between distance1 supersized, distance 2 supersized
+ *   (depending on availability) and no supersize
+ */
+
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.settings.Settings;
@@ -13,68 +34,105 @@ public class MapDistanceDrawerCommons {
     private static final String STRAIGHT_LINE_SYMBOL = Character.toString((char) 0x007C);
     private static final String WAVY_LINE_SYMBOL = Character.toString((char) 0x2307);
 
-    private final TextView distance1InfoView;
     private final TextView distance1View;
-    private final TextView distance2InfoView;
+    private final TextView distance1ViewSupersize;
     private final TextView distance2View;
-    private final TextView routeDistanceView;
-    private final TextView routeDistanceViewSupersize;
+    private final TextView distance2ViewSupersize;
+    private final TextView distance3View;
+    private final TextView targetView;
+    private final TextView targetViewSupersize;
     private final TextView distanceSupersizeView;
     private boolean bothViewsNeeded = false;
 
+    private boolean showBothDistances = false;
+    private float distance = 0.0f;
+    private float realDistance = 0.0f;
+    private float routeDistance = 0.0f;
+
     public MapDistanceDrawerCommons(final View root) {
-        distance1InfoView = root.findViewById(R.id.distance1info);
         distance1View = root.findViewById(R.id.distance1);
-        distance2InfoView = root.findViewById(R.id.distance2info);
+        distance1ViewSupersize = root.findViewById(R.id.distance1Supersize);
         distance2View = root.findViewById(R.id.distance2);
-        routeDistanceView = root.findViewById(R.id.routeDistance);
-        routeDistanceViewSupersize = root.findViewById(R.id.routeDistanceSupersize);
+        distance2ViewSupersize = root.findViewById(R.id.distance2Supersize);
+        distance3View = root.findViewById(R.id.distance3);
+        targetView = root.findViewById(R.id.target);
+        targetViewSupersize = root.findViewById(R.id.targetSupersize);
         distanceSupersizeView = root.findViewById(R.id.distanceSupersize);
 
-        distance1InfoView.setOnClickListener(v -> swap());
         distance1View.setOnClickListener(v -> swap());
-        distance2InfoView.setOnClickListener(v -> swap());
         distance2View.setOnClickListener(v -> swap());
-        routeDistanceView.setOnClickListener(v -> swap());
+        distance3View.setOnClickListener(v -> swap());
         distanceSupersizeView.setOnClickListener(v -> swap());
     }
 
     public void drawDistance(final boolean showBothDistances, final float distance, final float realDistance) {
+        this.showBothDistances = showBothDistances;
+        this.distance = distance;
+        this.realDistance = realDistance;
+
         final boolean showRealDistance = realDistance != 0.0f && distance != realDistance;
         bothViewsNeeded = showBothDistances && showRealDistance;
-        final int supersize = Settings.getSupersizeDistance() % (bothViewsNeeded ? 3 : 2);
+        final int supersize = distance == 0 ? 0 : Settings.getSupersizeDistance() % (bothViewsNeeded ? 3 : 2);
+        final String[] values = { "", "", ""};
+        String superValue = "";
+        int current = 0;
 
-        distanceSupersizeView.setVisibility(supersize > 0 ? View.VISIBLE : View.GONE);
+        // collect data to be displayed
         if (bothViewsNeeded) {
-            updateDisplay(supersize == 1, distance1InfoView, STRAIGHT_LINE_SYMBOL, distance1View, distance);
-            updateDisplay(supersize == 2, distance2InfoView, WAVY_LINE_SYMBOL, distance2View, realDistance);
-        } else {
-            updateDisplay(supersize > 0, distance1InfoView, "", distance1View, showRealDistance ? realDistance : distance);
+            if (supersize == 1) {
+                superValue = STRAIGHT_LINE_SYMBOL + " " + Units.getDistanceFromKilometers(distance);
+                values[current++] = WAVY_LINE_SYMBOL + " " + Units.getDistanceFromKilometers(realDistance);
+            } else if (supersize == 2) {
+                values[current++] = STRAIGHT_LINE_SYMBOL + " " + Units.getDistanceFromKilometers(distance);
+                superValue = WAVY_LINE_SYMBOL + " " + Units.getDistanceFromKilometers(realDistance);
+            } else {
+                values[current++] = STRAIGHT_LINE_SYMBOL + " " + Units.getDistanceFromKilometers(distance);
+                values[current++] = WAVY_LINE_SYMBOL + " " + Units.getDistanceFromKilometers(realDistance);
+            }
+        } else if (distance != 0.0f) {
+            if (supersize > 0) {
+                superValue = Units.getDistanceFromKilometers(showRealDistance ? realDistance : distance);
+            } else {
+                values[current++] = Units.getDistanceFromKilometers(showRealDistance ? realDistance : distance);
+            }
         }
-    }
+        if (routeDistance != 0.0f) {
+            values[current] = Units.getDistanceFromKilometers(routeDistance);
+        }
 
-    private void updateDisplay(final boolean showAsSupersize, final TextView infoView, final String info, final TextView distanceView, final float distance) {
-        final String distanceString = Units.getDistanceFromKilometers(distance);
-        final boolean zeroDistance = distance == 0.0f;
-
-        infoView.setVisibility(showAsSupersize || zeroDistance || StringUtils.isEmpty(info) ? View.GONE : View.VISIBLE);
-        distanceView.setVisibility(showAsSupersize || zeroDistance ? View.GONE : View.VISIBLE);
-        if (showAsSupersize) {
-            distanceSupersizeView.setText(StringUtils.isNotEmpty(info) ? info + " " + distanceString : distanceString);
-        } else if (!zeroDistance) {
-            infoView.setText(info);
-            distanceView.setText(distanceString);
+        // adjust visibility and fill views
+        if (targetView != null) {
+            final boolean targetIsSet = StringUtils.isNotBlank(targetView.getText());
+            targetView.setVisibility(supersize > 0 || !targetIsSet ? View.GONE : View.VISIBLE);
+            targetViewSupersize.setVisibility(supersize > 0 && targetIsSet ? View.VISIBLE : View.GONE);
+            targetViewSupersize.setText(targetView.getText());
+        }
+        if (supersize > 0) {
+            distanceSupersizeView.setVisibility(View.VISIBLE);
+            distanceSupersizeView.setText(superValue);
+            distance1View.setVisibility(View.GONE);
+            distance1ViewSupersize.setVisibility(StringUtils.isNotBlank(values[0]) ? View.VISIBLE : View.GONE);
+            distance1ViewSupersize.setText(values[0]);
+            distance2View.setVisibility(View.GONE);
+            distance2ViewSupersize.setVisibility(StringUtils.isNotBlank(values[1]) ? View.VISIBLE : View.GONE);
+            distance2ViewSupersize.setText(values[1]);
+            distance3View.setVisibility(View.GONE);
+        } else {
+            distanceSupersizeView.setVisibility(View.GONE);
+            distance1View.setVisibility(StringUtils.isNotBlank(values[0]) ? View.VISIBLE : View.GONE);
+            distance1View.setText(values[0]);
+            distance1ViewSupersize.setVisibility(View.GONE);
+            distance2View.setVisibility(StringUtils.isNotBlank(values[1]) ? View.VISIBLE : View.GONE);
+            distance2View.setText(values[1]);
+            distance2ViewSupersize.setVisibility(View.GONE);
+            distance3View.setVisibility(StringUtils.isNotBlank(values[2]) ? View.VISIBLE : View.GONE);
+            distance3View.setText(values[2]);
         }
     }
 
     public void drawRouteDistance(final float routeDistance) {
-        routeDistanceView.setVisibility(View.GONE);
-        routeDistanceViewSupersize.setVisibility(View.GONE);
-        if (routeDistance != 0.0f) {
-            final TextView view = bothViewsNeeded && Settings.getSupersizeDistance() > 0 ? routeDistanceViewSupersize : routeDistanceView;
-            view.setVisibility(View.VISIBLE);
-            view.setText(Units.getDistanceFromKilometers(routeDistance));
-        }
+        this.routeDistance = routeDistance;
+        drawDistance(showBothDistances, distance, realDistance);
     }
 
     private void swap() {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -908,7 +908,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         this.mapView.getLayerManager().getLayers().add(positionLayer);
 
         //Distance view
-        this.distanceView = new DistanceView(findViewById(R.id.distance1info).getRootView(), navTarget, Settings.isBrouterShowBothDistances());
+        this.distanceView = new DistanceView(findViewById(R.id.distance1).getRootView(), navTarget, Settings.isBrouterShowBothDistances());
 
         //Target view
         this.targetView = new TargetView((TextView) findViewById(R.id.target), StringUtils.EMPTY, StringUtils.EMPTY);


### PR DESCRIPTION
Refactor map distance views:
- target info (OSM only) and non-supersized distance get displayed without extra grey background when in supersize mode
- distances in small views are right-aligned
- distance type indicators are displayed in the same TextView as their distance (fixes #9381)
- lots of code and layout file cleanup

Some screenshots of different combinations:
![image](https://user-images.githubusercontent.com/3754370/99728895-6adbb780-2aba-11eb-9f23-fa4426a422ab.png) ![image](https://user-images.githubusercontent.com/3754370/99728853-5992ab00-2aba-11eb-9a06-e4198dfbc26a.png)
![image](https://user-images.githubusercontent.com/3754370/99728944-7c24c400-2aba-11eb-9332-ced95312d816.png) ![image](https://user-images.githubusercontent.com/3754370/99728980-89da4980-2aba-11eb-9c4c-2fec6e9f0262.png)
