### PR TITLE
Remove track setting on unsuccessful load (fix #9410)

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.files;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Route;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 
@@ -48,6 +49,8 @@ public class GPXTrackOrRouteImporter {
         }, () -> {
             if (!success.get()) {
                 Toast.makeText(context, R.string.load_track_error, Toast.LENGTH_SHORT).show();
+                Settings.setTrackFile(null);
+                callback.updateRoute(null);
             }
         });
     }


### PR DESCRIPTION
"Unload" track (= remove remembered trackfile name from settings) on error loading trackfile