### PR TITLE
skip artificial track points in position history (fix #9360)

### DIFF
--- a/main/src/cgeo/geocaching/maps/PositionHistory.java
+++ b/main/src/cgeo/geocaching/maps/PositionHistory.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.maps;
 
 import cgeo.geocaching.models.TrailHistoryElement;
+import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 
@@ -53,6 +54,9 @@ public class PositionHistory {
             return;
         }
         if (coordinates.getLatitude() == 0.0 && coordinates.getLongitude() == 0.0) {
+            return;
+        }
+        if (GeoData.isArtificialLocationProvider(coordinates.getProvider())) {
             return;
         }
         if (history.isEmpty()) {

--- a/main/src/cgeo/geocaching/sensors/GeoData.java
+++ b/main/src/cgeo/geocaching/sensors/GeoData.java
@@ -116,4 +116,8 @@ public class GeoData extends Location {
         return null;
     }
 
+    public static boolean isArtificialLocationProvider(final String provider) {
+        return provider.equals(INITIAL_PROVIDER) || provider.equals(HOME_PROVIDER);
+    }
+
 }


### PR DESCRIPTION
do not record points coming from `HOME_PROVIDER` or `INITIAL_PROVIDER` in position history