### PR TITLE
Improve settings debug helper (fix #9123)

### DIFF
--- a/main/res/layout/view_settings_add.xml
+++ b/main/res/layout/view_settings_add.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="3dip"
+    tools:context=".settings.ViewSettingsActivity" >
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="20dp"
+        android:paddingLeft="8dp"
+        android:text="@string/add_setting_preference_name"
+        android:labelFor="@id/preference_name" />
+
+    <EditText
+        android:id="@+id/preference_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:inputType="text" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="20dp"
+        android:paddingLeft="8dp"
+        android:text="@string/add_setting_preference_type" />
+
+    <RadioGroup
+        android:id="@+id/preference_type"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:orientation="vertical" />
+</LinearLayout>

--- a/main/res/menu/view_settings.xml
+++ b/main/res/menu/view_settings.xml
@@ -11,4 +11,13 @@
         tools:ignore="AlwaysShowAction">
     </item>
 
+    <item
+        android:id="@+id/view_settings_add"
+        android:icon="@drawable/ic_menu_add"
+        android:title="@string/add_setting"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction"
+        android:visible="false">
+    </item>
+
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1959,6 +1959,12 @@
     <string name="edit_setting_error_invalid_data">Invalid data \"%s\" entered. Setting\'s value unchanged.</string>
     <string name="activate_editmode_title">Activate edit mode</string>
     <string name="activate_editmode_warning">You are entering dangerous area here!\n\nChanging settings directly might confuse c:geo or might prevent further program starts, so be careful!\n\nAre you sure you want to proceed at your own risk?</string>
+    <string name="add_setting">Add setting</string>
+    <string name="add_setting_preference_name">Preference name</string>
+    <string name="add_setting_preference_type">Preference type</string>
+    <string name="add_setting_missing_name">You need to select a preference name</string>
+    <string name="add_setting_missing_type">You need to select a preference type</string>
+    <string name="add_setting_already_exists">A preference with this name already exists</string>
 
     <!-- HandleLocalFilesActivity -->
     <string name="localfile_intenttitle">c:geo Local file handler</string>

--- a/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -179,7 +179,7 @@ public class ViewSettingsActivity extends AbstractActivity {
         switch (type) {
             case TYPE_INTEGER:
             case TYPE_LONG:
-                inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL;
+                inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_SIGNED;
                 break;
             case TYPE_FLOAT:
                 inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_DECIMAL;

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -829,8 +829,7 @@ public final class Dialogs {
         builder.create().show();
     }
 
-    private static AlertDialog.Builder newBuilder(final Activity activity) {
+    public static AlertDialog.Builder newBuilder(final Activity activity) {
         return new AlertDialog.Builder(new ContextThemeWrapper(activity, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert));
     }
-
 }

--- a/main/src/cgeo/geocaching/utils/SettingsUtils.java
+++ b/main/src/cgeo/geocaching/utils/SettingsUtils.java
@@ -2,27 +2,46 @@ package cgeo.geocaching.utils;
 
 import android.content.SharedPreferences;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.xmlpull.v1.XmlPullParserException;
 
 public class SettingsUtils {
 
     public enum SettingsType {
-        TYPE_STRING     ("string"),
-        TYPE_BOOLEAN    ("boolean"),
-        TYPE_INTEGER    ("integer"),
-        TYPE_INTEGER_COMPATIBILITY ("int"),     // for reading compatibility with early backups
-        TYPE_LONG       ("long"),
-        TYPE_FLOAT      ("float"),
-        TYPE_UNKNOWN    ("unknown");
+        TYPE_STRING     ("string", ""),
+        TYPE_BOOLEAN    ("boolean", "false"),
+        TYPE_INTEGER    ("integer", "0"),
+        TYPE_INTEGER_COMPATIBILITY ("int", "0"),     // for reading compatibility with early backups
+        TYPE_LONG       ("long", "0"),
+        TYPE_FLOAT      ("float", "0.0"),
+        TYPE_UNKNOWN    ("unknown", "");
 
         private final String id;
+        private final String defaultString;
 
-        SettingsType(final String id) {
+        SettingsType(final String id, final String defaultString) {
             this.id = id;
+            this.defaultString = defaultString;
         }
 
         public String getId() {
             return id;
+        }
+
+        public String getDefaultString() {
+            return defaultString;
+        }
+
+        public static List<String> getStringList() {
+            final List<String> result = new ArrayList<>();
+            for (final SettingsType type : values()) {
+                if (type != TYPE_INTEGER_COMPATIBILITY && type != TYPE_UNKNOWN) {
+                    result.add(type.id);
+                }
+            }
+            return result;
         }
     }
 


### PR DESCRIPTION
- allow negative integer values
- remove "enter edit mode" icon when in edit mode
- allow adding new items
- apply standard `DialogAlert` theme to edit / add / delete dialogs

(note: `Dialogs.newBuilder()` can now be used for other `AlertDialog` usages as well)

![image](https://user-images.githubusercontent.com/3754370/99878620-23af0d00-2c07-11eb-8208-c78c6d851cca.png)
![image](https://user-images.githubusercontent.com/3754370/99878624-2b6eb180-2c07-11eb-883f-0f23a07c8af0.png)
![image](https://user-images.githubusercontent.com/3754370/99878629-332e5600-2c07-11eb-9234-2f128783aea7.png)
