### PR TITLE
fix several AlertDialog themes

### DIFF
--- a/main/src/cgeo/geocaching/export/FieldNoteExport.java
+++ b/main/src/cgeo/geocaching/export/FieldNoteExport.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AsyncTaskWithProgress;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
@@ -61,7 +62,7 @@ public class FieldNoteExport extends AbstractExport {
     }
 
     private Dialog getExportOptionsDialog(final Geocache[] caches, final Activity activity) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(activity.getString(R.string.export_confirm_title, activity.getString(R.string.export_fieldnotes)));
 
         final View layout = View.inflate(activity, R.layout.fieldnote_export_dialog, null);

--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AsyncTaskWithProgress;
 import cgeo.geocaching.utils.EnvironmentUtils;
 import cgeo.geocaching.utils.FileUtils;
@@ -73,7 +74,7 @@ public class GpxExport extends AbstractExport {
     }
 
     private Dialog getExportDialog(final String[] geocodes, final Activity activity) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(activity.getString(R.string.export_confirm_title, activity.getString(R.string.export_gpx)));
 
         final View layout = View.inflate(activity, R.layout.gpx_export_dialog, null);

--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteSegment;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AsyncTaskWithProgress;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.EnvironmentUtils;
@@ -57,7 +58,7 @@ public class IndividualRouteExport {
             return null;
         };
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(R.string.export_individualroute_title);
 
         final View layout = View.inflate(activity, R.layout.gpx_export_individual_route_dialog, null);

--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AsyncTaskWithProgress;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.EnvironmentUtils;
@@ -45,7 +46,7 @@ public class TrailHistoryExport {
         }
         filename = "trail_" + CalendarUtils.formatDateTime("yyyy-MM-dd_HH-mm-ss") + ".gpx";
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(R.string.export_trailhistory_title);
 
         final View layout = View.inflate(activity, R.layout.gpx_export_trail_dialog, null);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -52,6 +52,7 @@ import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.BRouterUtils;
@@ -1869,13 +1870,12 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             message = s;
         }
 
-        final AlertDialog alertDialog = new AlertDialog.Builder(ctx)
+        final AlertDialog alertDialog = Dialogs.newBuilder(ctx)
             .setTitle(ctx.getString(R.string.map_source_attribution_dialog_title))
             .setCancelable(true)
             .setMessage(message)
             .setPositiveButton(android.R.string.ok, (dialog, pos) -> dialog.dismiss())
             .create();
-
         alertDialog.show();
 
         // Make the URLs in TextView clickable. Must be called after show()

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.utils.functions.Action1;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.res.ColorStateList;
@@ -831,5 +832,9 @@ public final class Dialogs {
 
     public static AlertDialog.Builder newBuilder(final Activity activity) {
         return new AlertDialog.Builder(new ContextThemeWrapper(activity, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert));
+    }
+
+    public static AlertDialog.Builder newBuilder(final Context context) {
+        return new AlertDialog.Builder(new ContextThemeWrapper(context, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert));
     }
 }

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -91,7 +91,7 @@ public class BackupUtils extends Activity {
                 settingsCheckbox.setText(activityContext.getString(R.string.init_backup_program_settings) + "\n(" + activityContext.getString(R.string.init_backup_unavailable) + ")");
             }
 
-            final AlertDialog dialog = new AlertDialog.Builder(new ContextThemeWrapper(activityContext, R.style.Dialog_Alert))
+            final AlertDialog dialog = Dialogs.newBuilder(activityContext)
                     .setTitle(activityContext.getString(R.string.init_backup_restore))
                     .setView(content)
                     .setPositiveButton(activityContext.getString(android.R.string.yes), (alertDialog, id) -> {

--- a/main/src/cgeo/geocaching/utils/MapDownloadUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapDownloadUtils.java
@@ -56,7 +56,7 @@ public class MapDownloadUtils {
                 }
                 final String filename = temp;
 
-                final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
                 builder.setTitle(R.string.downloadmap_title);
                 final View layout = View.inflate(activity, R.layout.mapdownloader_confirmation, null);
                 builder.setView(layout);


### PR DESCRIPTION
Many of our dialogs use the default theme implicitly, not the c:geo theme. This PR fixes this for a couple of `AlertDialog`s by using `Dialogs.newBuilder()` instead of `new AlertDialog.Builder()`.