### PR TITLE
add auto-target option for individual routes on OSM (rel. to #9281)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -288,6 +288,12 @@
                 android:title="@string/map_load_individual_route">
             </item>
             <item
+                android:id="@+id/menu_autotarget_individual_route"
+                android:checkable="true"
+                android:title="@string/map_autotarget_individual_route"
+                android:visible="false">
+            </item>
+            <item
                 android:id="@+id/menu_sort_individual_route"
                 android:title="@string/map_sort_individual_route"
                 android:visible="false">

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -156,6 +156,7 @@
     <string translatable="false" name="pref_usecompass">usecompass</string>
     <string translatable="false" name="pref_mapfile">mfmapfile</string>
     <string translatable="false" name="pref_trackfile">trackfile</string>
+    <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>
     <string translatable="false" name="pref_memberstatus">memberstatus</string>
     <string translatable="false" name="pref_coordinputformat">coordinputformat</string>
     <string translatable="false" name="pref_gccustomdate">gccustomdate</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1902,6 +1902,7 @@
     <string name="map_export_individual_route">Export individual route</string>
     <string name="map_load_individual_route">Load individual route</string>
     <string name="map_load_individual_route_confirm">Overwrite existing route?</string>
+    <string name="map_autotarget_individual_route">Set as target automatically</string>
     <string name="map_clear_individual_route">Clear individual route</string>
     <string name="map_clear_individual_route_confirm">Do you want to remove all caches/waypoints from your individual route?</string>>
     <string name="map_individual_route_cleared">Individual route cleared</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -490,7 +490,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             overlayPositionAndScale.setHistory(trailHistory);
         }
         if (null == manualRoute) {
-            manualRoute = new ManualRoute();
+            manualRoute = new ManualRoute(null);
             manualRoute.reloadRoute(overlayPositionAndScale);
         } else {
             manualRoute.updateRoute(overlayPositionAndScale);
@@ -603,7 +603,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             return;
         }
         if (manualRoute == null) {
-            manualRoute = new ManualRoute();
+            manualRoute = new ManualRoute(null);
         }
         manualRoute.toggleItem(this.mapView.getContext(), new RouteItem(item), overlayPositionAndScale);
         ActivityMixin.invalidateOptionsMenu(activity);

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -650,6 +650,14 @@ public class Settings {
         }
     }
 
+    public static boolean getAutotargetIndividualRoute() {
+        return getBoolean(R.string.pref_autotarget_individualroute, false);
+    }
+
+    public static void setAutotargetIndividualRoute(final boolean autotargetIndividualRoute) {
+        putBoolean(R.string.pref_autotarget_individualroute, autotargetIndividualRoute);
+    }
+
     public static String getTrackFile() {
         return getString(R.string.pref_trackfile, null);
     }

--- a/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
+++ b/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
@@ -7,7 +7,9 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.export.IndividualRouteExport;
 import cgeo.geocaching.files.GPXIndividualRouteImporter;
 import cgeo.geocaching.maps.routing.RouteSortActivity;
+import cgeo.geocaching.models.ManualRoute;
 import cgeo.geocaching.models.Route;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.Activity;
@@ -31,7 +33,7 @@ public class IndividualRouteUtils {
      *
      * @param menu menu to be configured
      */
-    public static void onPrepareOptionsMenu(final Menu menu, final Route route) {
+    public static void onPrepareOptionsMenu(final Menu menu, final ManualRoute route) {
         final boolean isVisible = route != null && route.getNumSegments() > 0;
         menu.findItem(R.id.menu_sort_individual_route).setVisible(isVisible);
         menu.findItem(R.id.menu_center_on_route).setVisible(isVisible);
@@ -46,7 +48,7 @@ public class IndividualRouteUtils {
      * @param id       menu entry id
      * @return true, if selected menu entry is individual route related and consumed / false else
      */
-    public static boolean onOptionsItemSelected(final Activity activity, final int id, final Route route, final Runnable clearIndividualRoute, final Route.CenterOnPosition centerOnPosition) {
+    public static boolean onOptionsItemSelected(final Activity activity, final int id, final ManualRoute route, final Runnable clearIndividualRoute, final Route.CenterOnPosition centerOnPosition) {
         switch (id) {
             case R.id.menu_load_individual_route:
                 if (null == route || route.getNumSegments() == 0) {
@@ -69,6 +71,11 @@ public class IndividualRouteUtils {
                     clearIndividualRoute.run();
                     ActivityMixin.invalidateOptionsMenu(activity);
                 });
+                return true;
+            case R.id.menu_autotarget_individual_route:
+                Settings.setAutotargetIndividualRoute(!Settings.getAutotargetIndividualRoute());
+                route.triggerTargetUpdate();
+                ActivityMixin.invalidateOptionsMenu(activity);
                 return true;
             default:
                 return false;
@@ -97,8 +104,5 @@ public class IndividualRouteUtils {
         }
         return false;
     }
-
-
-
 
 }


### PR DESCRIPTION
OSM implementation for #9281: Add option to "Individual route" map menu to automatically set the first route point as navigation target.