### PR TITLE
DO NOT MERGE: Main screen transparency switch through theme selection

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -115,7 +115,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/cgeo_main"
+            android:theme="@style/cgeo_main.transparent"
             android:windowSoftInputMode="stateAlwaysHidden" >
         </activity>
         <activity

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -115,7 +115,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/cgeo_main.transparent"
+            android:theme="@style/cgeo_main"
             android:windowSoftInputMode="stateAlwaysHidden" >
         </activity>
         <activity

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -291,9 +291,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
 
     // Leak Canary, memory leak detection
-    def leakCanaryVersion = '2.5'
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
-    implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
+    //def leakCanaryVersion = '2.5'
+    //debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
+    //implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
 
     // Locus Maps integration
     //noinspection GradleDependency

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -9,11 +9,6 @@
 
     <style name="cgeo_main.base" parent="@style/Theme.AppCompat">
 
-        <!-- copy the style elements of the Wallpaper theme since AppCompat has no Wallpaper theme -->
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:colorBackgroundCacheHint">@null</item>
-        <item name="android:windowShowWallpaper">true</item>
-
         <item name="colorAccent">@color/colorAccent</item>
 
         <!-- system elements -->
@@ -23,9 +18,17 @@
 
     </style>
 
+    <style name="cgeo_main.transparent" parent="cgeo_main.base">
+
+        <!-- copy the style elements of the Wallpaper theme since AppCompat has no Wallpaper theme -->
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowShowWallpaper">true</item>
+
+        <item name="android:windowTranslucentNavigation">true</item>
+    </style>
 
     <style name="cgeo_main" parent="cgeo_main.base">
-        <item name="android:windowTranslucentNavigation">true</item>
     </style>
 
     <style name="cgeo.Widget.AppCompat.Base.ProgressBar.Medium" parent="android:Widget.ProgressBar">

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -18,7 +18,7 @@
 
     </style>
 
-    <style name="cgeo_main.transparent" parent="cgeo_main.base">
+    <style name="cgeo_main_transparent" parent="cgeo_main.base">
 
         <!-- copy the style elements of the Wallpaper theme since AppCompat has no Wallpaper theme -->
         <item name="android:windowBackground">@android:color/transparent</item>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -275,6 +275,9 @@ public class MainActivity extends AbstractActionBarActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
+        if (Settings.isTransparentBackground()) {
+            setTheme(R.style.cgeo_main_transparent);
+        }
         // don't call the super implementation with the layout argument, as that would set the wrong theme
         super.onCreate(savedInstanceState);
 
@@ -287,7 +290,6 @@ public class MainActivity extends AbstractActionBarActivity {
 
         setContentView(R.layout.main_activity);
         if (!Settings.isTransparentBackground()) {
-            setTheme(R.style.cgeo_main);
             final View mainscreen = findViewById(R.id.mainscreen);
             mainscreen.setBackgroundColor(getResources().getColor(Settings.isLightSkin() ? R.color.background_light_notice : R.color.background_dark_notice));
         }

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -287,6 +287,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
         setContentView(R.layout.main_activity);
         if (!Settings.isTransparentBackground()) {
+            setTheme(R.style.cgeo_main);
             final View mainscreen = findViewById(R.id.mainscreen);
             mainscreen.setBackgroundColor(getResources().getColor(Settings.isLightSkin() ? R.color.background_light_notice : R.color.background_dark_notice));
         }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -85,6 +85,16 @@ public class Settings {
     @NonNull private static final String TWITTER_KEY_CONSUMER_PUBLIC = CryptUtils.rot13("ESnsCvAv3kEupF1GCR3jGj");
     @NonNull private static final String TWITTER_KEY_CONSUMER_SECRET = CryptUtils.rot13("7vQWceACV9umEjJucmlpFe9FCMZSeqIqfkQ2BnhV9x");
 
+    private static final boolean TRANSPARENT_BACKGROUND_DEFAULT;
+
+    static {
+        if (Build.PRODUCT.startsWith("asop") && Build.VERSION.SDK_INT == 27) {
+            TRANSPARENT_BACKGROUND_DEFAULT = false;
+        } else {
+            TRANSPARENT_BACKGROUND_DEFAULT = true;
+        }
+    }
+
     private static boolean useCompass = true;
     private static DirectionData.DeviceOrientation deviceOrientationMode = DirectionData.DeviceOrientation.AUTO;
 
@@ -1068,7 +1078,7 @@ public class Settings {
     }
 
     public static boolean isTransparentBackground() {
-        return getBoolean(R.string.pref_transparentBackground, true);
+        return getBoolean(R.string.pref_transparentBackground, TRANSPARENT_BACKGROUND_DEFAULT);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -88,7 +88,7 @@ public class Settings {
     private static final boolean TRANSPARENT_BACKGROUND_DEFAULT;
 
     static {
-        if (Build.PRODUCT.startsWith("asop") && Build.VERSION.SDK_INT == 27) {
+        if (Build.PRODUCT.startsWith("aosp") && Build.VERSION.SDK_INT == 27) {
             TRANSPARENT_BACKGROUND_DEFAULT = false;
         } else {
             TRANSPARENT_BACKGROUND_DEFAULT = true;

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -86,16 +86,6 @@ public class Settings {
     @NonNull private static final String TWITTER_KEY_CONSUMER_PUBLIC = CryptUtils.rot13("ESnsCvAv3kEupF1GCR3jGj");
     @NonNull private static final String TWITTER_KEY_CONSUMER_SECRET = CryptUtils.rot13("7vQWceACV9umEjJucmlpFe9FCMZSeqIqfkQ2BnhV9x");
 
-    private static final boolean TRANSPARENT_BACKGROUND_DEFAULT;
-
-    static {
-        if (EnvironmentUtils.isSailfishOs()) {
-            TRANSPARENT_BACKGROUND_DEFAULT = false;
-        } else {
-            TRANSPARENT_BACKGROUND_DEFAULT = true;
-        }
-    }
-
     private static boolean useCompass = true;
     private static DirectionData.DeviceOrientation deviceOrientationMode = DirectionData.DeviceOrientation.AUTO;
 
@@ -1079,7 +1069,7 @@ public class Settings {
     }
 
     public static boolean isTransparentBackground() {
-        return getBoolean(R.string.pref_transparentBackground, TRANSPARENT_BACKGROUND_DEFAULT);
+        return getBoolean(R.string.pref_transparentBackground, EnvironmentUtils.defaultBackgroundTransparent());
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -32,6 +32,7 @@ import cgeo.geocaching.sensors.RotationProvider;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.utils.CryptUtils;
+import cgeo.geocaching.utils.EnvironmentUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.FileUtils.FileSelector;
 import cgeo.geocaching.utils.Log;
@@ -88,7 +89,7 @@ public class Settings {
     private static final boolean TRANSPARENT_BACKGROUND_DEFAULT;
 
     static {
-        if (Build.PRODUCT.startsWith("aosp") && Build.VERSION.SDK_INT == 27) {
+        if (EnvironmentUtils.isSailfishOs()) {
             TRANSPARENT_BACKGROUND_DEFAULT = false;
         } else {
             TRANSPARENT_BACKGROUND_DEFAULT = true;

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1072,6 +1072,10 @@ public class Settings {
         return getBoolean(R.string.pref_transparentBackground, EnvironmentUtils.defaultBackgroundTransparent());
     }
 
+    public static void setIsTransparentBackground(final boolean value) {
+        putBoolean(R.string.pref_transparentBackground, value);
+    }
+
     @NonNull
     public static String getTwitterKeyConsumerPublic() {
         return TWITTER_KEY_CONSUMER_PUBLIC;

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -507,6 +507,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         // will get the appropriate ones.
         Settings.setUseHardwareAcceleration(Settings.useHardwareAcceleration());
         Settings.setUseGooglePlayServices(Settings.useGooglePlayServices());
+        Settings.setIsTransparentBackground(Settings.isTransparentBackground());
     }
 
     private static void initUnitPreferences() {

--- a/main/src/cgeo/geocaching/utils/EnvironmentUtils.java
+++ b/main/src/cgeo/geocaching/utils/EnvironmentUtils.java
@@ -8,10 +8,20 @@ public class EnvironmentUtils {
         // utility class
     }
 
+    private static final boolean DEFAULT_TRANSPARENT_BACKGROUND;
+
+    static {
+        DEFAULT_TRANSPARENT_BACKGROUND = ! isSailfishOs();
+    }
+
     public static boolean isSailfishOs() {
         return Build.PRODUCT.startsWith("aosp") && Build.VERSION.SDK_INT == 27;
     }
     public static boolean isExternalStorageAvailable() {
         return Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState());
+    }
+
+    public static boolean defaultBackgroundTransparent() {
+        return DEFAULT_TRANSPARENT_BACKGROUND;
     }
 }

--- a/main/src/cgeo/geocaching/utils/EnvironmentUtils.java
+++ b/main/src/cgeo/geocaching/utils/EnvironmentUtils.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.utils;
 
+import android.os.Build;
 import android.os.Environment;
 
 public class EnvironmentUtils {
@@ -7,6 +8,9 @@ public class EnvironmentUtils {
         // utility class
     }
 
+    public static boolean isSailfishOs() {
+        return Build.PRODUCT.startsWith("aosp") && Build.VERSION.SDK_INT == 27;
+    }
     public static boolean isExternalStorageAvailable() {
         return Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState());
     }

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -55,7 +55,8 @@ public final class SystemInformation {
         final String hideWaypoints = (Settings.isExcludeWpOriginal() ? "original " : "") + (Settings.isExcludeWpParking() ? "parking " : "") + (Settings.isExcludeWpVisited() ? "visited" : "");
         final StringBuilder body = new StringBuilder("--- System information ---")
                 .append("\nDevice: ").append(Build.MODEL).append(" (").append(Build.PRODUCT).append(", ").append(Build.BRAND).append(')')
-                .append("\nAndroid version: ").append(VERSION.RELEASE)
+                .append("\nAndroid version: ").append(VERSION.RELEASE).append(", ").append(VERSION.SDK_INT)
+                .append("\nI am a Sailfish: ").append(EnvironmentUtils.isSailfishOs())
                 .append("\nAndroid build: ").append(Build.DISPLAY)
                 .append("\nc:geo version: ").append(Version.getVersionName(context));
         appendGooglePlayServicesVersion(context, body);


### PR DESCRIPTION
In order to circumvent issues in the latest version of Android support in Sailfish OS (see #8752), switch the transparency on the main screen through theme selection.
In addition does this version try to detect SFOS and switches transparency off by default in this case.
This PR also disables leak canary, to make working with it as a user a bit smoother.
So do not merge this PR in any case, I'll prepare one without the latter change in case of successful testing.