### PR TITLE
related to #8457: remove map path from Settings

### DIFF
--- a/main/src/cgeo/geocaching/SelectMapfileActivity.java
+++ b/main/src/cgeo/geocaching/SelectMapfileActivity.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class SelectMapfileActivity extends AbstractSelectFileActivity {
 
     public SelectMapfileActivity() {
-        super("map", Intents.EXTRA_MAP_FILE, Settings.getMapFile(), true);
+        super("map", Intents.EXTRA_MAP_FILE, Settings.getMapFileDirectory(), true);
         setContext(SelectMapfileActivity.this);
     }
 

--- a/main/src/cgeo/geocaching/helper/QueryMapFile.java
+++ b/main/src/cgeo/geocaching/helper/QueryMapFile.java
@@ -21,7 +21,7 @@ public class QueryMapFile extends Activity {
         final Bundle bundle = getIntent().getExtras();
         final boolean forceAndFeedback = null != bundle && bundle.getBoolean(getString(R.string.cgeo_queryMapFile_actionParam));
 
-        final String mapFile = Settings.getMapFile();
+        final String mapFile = Settings.getMapFileDirectory();
         if (forceAndFeedback || (mapFile != null && !"".equals(mapFile))) {
             try {
                 final Intent intent = new Intent(Intent.ACTION_SENDTO);

--- a/main/src/cgeo/geocaching/maps/AbstractMapSource.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMapSource.java
@@ -8,17 +8,22 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public abstract class AbstractMapSource implements MapSource {
 
+    private static final Map<String, Integer> mapSourceIds = new HashMap<>();
+
     private final String name;
     @NonNull
     private final MapProvider mapProvider;
-    private final String id;
+    private Integer numericId;
 
-    protected AbstractMapSource(final String id, @NonNull final MapProvider mapProvider, final String name) {
-        this.id = id;
+
+    protected AbstractMapSource(@NonNull final MapProvider mapProvider, final String name) {
         this.mapProvider = mapProvider;
         this.name = name;
     }
@@ -34,15 +39,28 @@ public abstract class AbstractMapSource implements MapSource {
     }
 
     @Override
+    public int getNumericalId() {
+        if (numericId == null) {
+            final String id = getId();
+            //produce a guaranteed unique numerical id for the string id
+            synchronized (mapSourceIds) {
+                if (mapSourceIds.containsKey(id)) {
+                    numericId = mapSourceIds.get(id);
+                } else {
+                    numericId = -1000000000 + mapSourceIds.size();
+                    mapSourceIds.put(id, numericId);
+                }
+            }
+        }
+        return numericId;
+    }
+
+
+    @Override
     @NonNull
     public String toString() {
         // needed for adapter in selection lists
         return getName();
-    }
-
-    @Override
-    public int getNumericalId() {
-        return id.hashCode();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -35,6 +35,7 @@ import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
+import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IWaypoint;
@@ -535,6 +536,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         // class init
         res = this.getResources();
         activity = this.getActivity();
+
+        MapsforgeMapProvider.getInstance().updateOfflineMaps();
 
         final MapProvider mapProvider = Settings.getMapProvider();
         mapItemFactory = mapProvider.getMapItemFactory();

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapProvider.java
@@ -66,8 +66,8 @@ public final class GoogleMapProvider extends AbstractMapProvider {
 
     private abstract static class AbstractGoogleMapSource extends AbstractMapSource {
 
-        protected AbstractGoogleMapSource(final String id, final MapProvider mapProvider, final String name) {
-            super(id, mapProvider, name);
+        protected AbstractGoogleMapSource(final MapProvider mapProvider, final String name) {
+            super(mapProvider, name);
         }
 
     }
@@ -75,7 +75,7 @@ public final class GoogleMapProvider extends AbstractMapProvider {
     private static final class GoogleMapSource extends AbstractGoogleMapSource {
 
         GoogleMapSource(final MapProvider mapProvider, final String name) {
-            super(GOOGLE_MAP_ID, mapProvider, name);
+            super(mapProvider, name);
         }
 
     }
@@ -83,7 +83,7 @@ public final class GoogleMapProvider extends AbstractMapProvider {
     private static final class GoogleSatelliteSource extends AbstractGoogleMapSource {
 
         GoogleSatelliteSource(final MapProvider mapProvider, final String name) {
-            super(GOOGLE_SATELLITE_ID, mapProvider, name);
+            super(mapProvider, name);
         }
 
     }

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -19,7 +19,7 @@ import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.interfaces.PositionAndHistory;
-import cgeo.geocaching.maps.mapsforge.MapsforgeMapSource;
+import cgeo.geocaching.maps.mapsforge.AbstractMapsforgeMapSource;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -41,7 +41,6 @@ import android.view.View;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -188,9 +187,9 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
             // either play services are missing (should have been caught in MapProviderFactory) or Play Services version does not support this Google Maps API version
             Dialogs.confirmYesNo((Activity) context, R.string.warn_gm_not_available, R.string.switch_to_mf, (dialog, whichButton) -> {
                 // switch to first Mapsforge mapsource found
-                final List<MapSource> mapSources = MapProviderFactory.getMapSources();
+                final Collection<MapSource> mapSources = MapProviderFactory.getMapSources();
                 for (final MapSource mapSource : mapSources) {
-                    if (mapSource instanceof MapsforgeMapSource) {
+                    if (mapSource instanceof AbstractMapsforgeMapSource) {
                         Settings.setMapSource(mapSource);
                         Dialogs.message((Activity) context, R.string.warn_gm_not_available, R.string.switched_to_mf, (dialog2, whichButton2) -> ((Activity) context).finish());
                         break;

--- a/main/src/cgeo/geocaching/maps/interfaces/MapSource.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapSource.java
@@ -11,6 +11,10 @@ public interface MapSource {
 
     boolean isAvailable();
 
+    default String getId() {
+        return this.getClass().getName();
+    }
+
     int getNumericalId();
 
     @NonNull

--- a/main/src/cgeo/geocaching/maps/mapsforge/AbstractMapsforgeMapSource.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/AbstractMapsforgeMapSource.java
@@ -13,26 +13,25 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
-import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
 import org.mapsforge.map.model.IMapViewPosition;
 
-public class MapsforgeMapSource extends AbstractMapSource {
+public abstract class AbstractMapsforgeMapSource extends AbstractMapSource {
 
     public static final String MAPNIK_TILE_DOWNLOAD_UA = "cgeo";
 
-    private final MapGeneratorInternal generator;
+    private final AbstractTileSource source;
 
-    MapsforgeMapSource(final String id, final MapProvider mapProvider, final String name, final MapGeneratorInternal generator) {
-        super(id, mapProvider, name);
-        this.generator = generator;
+    AbstractMapsforgeMapSource(final MapProvider mapProvider, final String name, final AbstractTileSource source) {
+        super(mapProvider, name);
+        this.source = source;
     }
 
-    public MapGeneratorInternal getGenerator() {
-        return generator;
+    AbstractMapsforgeMapSource(final MapProvider mapProvider, final String name) {
+        this(mapProvider, name, null);
     }
+
 
     public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
-        final AbstractTileSource source = OpenStreetMapMapnik.INSTANCE;
         source.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA);
         return new DownloadLayer(tileCache, mapViewPosition, source, AndroidGraphicFactory.INSTANCE);
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapGeneratorInternal.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapGeneratorInternal.java
@@ -1,8 +1,0 @@
-package cgeo.geocaching.maps.mapsforge;
-
-public enum MapGeneratorInternal {
-    DATABASE_RENDERER,
-    MAPNIK,
-    OPENCYCLEMAP,
-    THUNDERFOREST;
-}

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.maps.interfaces.MapItemFactory;
 import cgeo.geocaching.maps.interfaces.MapProvider;
 import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.mapsforge.v6.NewMap;
-import cgeo.geocaching.maps.mapsforge.v6.layers.DownloadLayer;
 import cgeo.geocaching.maps.mapsforge.v6.layers.ITileLayer;
 import cgeo.geocaching.maps.mapsforge.v6.layers.MultiRendererLayer;
 import cgeo.geocaching.maps.mapsforge.v6.layers.RendererLayer;
@@ -23,6 +22,7 @@ import android.content.res.Resources;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,14 +30,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.cache.TileCache;
-import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
+import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
 import org.mapsforge.map.model.IMapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.reader.header.MapFileException;
@@ -45,18 +47,21 @@ import org.mapsforge.map.reader.header.MapFileException;
 
 public final class MapsforgeMapProvider extends AbstractMapProvider {
 
-    public static final String MAPSFORGE_MAPNIK_ID = "MAPSFORGE_MAPNIK";
-    public static final String MAPSFORGE_OSMDE_ID = "MAPSFORGE_OSMDE";
-    public static final String MAPSFORGE_CYCLOSM_ID = "MAPSFORGE_CYCLOSM";
+    private static final String OFFLINE_MAP_DEFAULT_ATTRIBUTION = "---";
+    private static final Map<Uri, String> OFFLINE_MAP_ATTRIBUTIONS = new HashMap<>();
 
     private MapItemFactory mapItemFactory = new MapsforgeMapItemFactory();
+
 
     private MapsforgeMapProvider() {
         final Resources resources = CgeoApplication.getInstance().getResources();
 
-        registerMapSource(new MapsforgeMapSource(MAPSFORGE_MAPNIK_ID, this, resources.getString(R.string.map_source_osm_mapnik), MapGeneratorInternal.MAPNIK));
-        registerMapSource(new OsmdeMapSource(MAPSFORGE_OSMDE_ID, this, resources.getString(R.string.map_source_osm_osmde), MapGeneratorInternal.MAPNIK));
-        registerMapSource(new CyclosmMapSource(MAPSFORGE_CYCLOSM_ID, this, resources.getString(R.string.map_source_osm_cyclosm), MapGeneratorInternal.MAPNIK));
+        //register fixed maps
+        registerMapSource(new OsmMapSource(this, resources.getString(R.string.map_source_osm_mapnik)));
+        registerMapSource(new OsmdeMapSource(this, resources.getString(R.string.map_source_osm_osmde)));
+        registerMapSource(new CyclosmMapSource(this, resources.getString(R.string.map_source_osm_cyclosm)));
+
+        //initiale offline maps (necessary here in constructor only so that initial setMapSource will succeed)
         updateOfflineMaps();
     }
 
@@ -68,7 +73,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         return Holder.INSTANCE;
     }
 
-    public static List<ImmutablePair<String, Uri>> getOfflineMaps() {
+    private List<ImmutablePair<String, Uri>> getOfflineMaps() {
 
         //Note: this method will be the "bridge" when incorporating Storage Access Framework
         //For now, it delivers Name/Uri combinations from File
@@ -79,7 +84,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
     }
 
     //This method will be replaced once SAF is incorporated
-    private static List<String> getOfflineMapFiles() {
+    private List<String> getOfflineMapFiles() {
         final String directoryPath = Settings.getMapFileDirectory();
         if (StringUtils.isBlank(directoryPath)) {
             return Collections.emptyList();
@@ -104,22 +109,6 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
             }
         }
         return Collections.emptyList();
-    }
-
-    public static boolean isValidMapFile(final Uri mapUri) {
-        MapFile mapFile = null;
-        try {
-            mapFile = createMapFile(mapUri);
-            if (mapFile == null) {
-                return false;
-            }
-            return mapFile.getMapFileInfo().fileVersion <= 5;
-        } catch (MapFileException ex) {
-            Log.w(String.format("Exception reading mapfile '%s'", mapUri.toString()), ex);
-        } finally {
-            closeMapFileQuietly(mapFile);
-        }
-        return false;
     }
 
     @Override
@@ -158,22 +147,28 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
      * longer need to differentiate between internal map sources and offline map sources, as they all just have an
      * numerical ID (based on the hash code).
      */
-    public static final class OfflineMapSource extends MapsforgeMapSource {
+    public static final class OfflineMapSource extends AbstractMapsforgeMapSource {
 
         private final Uri mapUri;
 
-        public OfflineMapSource(final String id, final Uri mapUri, final MapProvider mapProvider, final String name, final MapGeneratorInternal generator) {
-            super(id, mapProvider, name, generator);
+        public OfflineMapSource(final Uri mapUri, final MapProvider mapProvider, final String name) {
+            super(mapProvider, name);
             this.mapUri = mapUri;
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return isValidMapFile(mapUri);
         }
 
         public Uri getMapUri() {
             return mapUri;
+        }
+
+        @Override
+        @NonNull
+        public String getId() {
+            return super.getId() + ":" + mapUri.getLastPathSegment();
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return MapsforgeMapProvider.getInstance().isValidMapFile(mapUri);
         }
 
         /** Create new render layer, if mapfile exists */
@@ -184,27 +179,21 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
                 MapProviderFactory.setLanguages(mf.getMapLanguages());
                 return new RendererLayer(tileCache, mf, mapViewPosition, false, true, false, AndroidGraphicFactory.INSTANCE);
             }
+            MapsforgeMapProvider.getInstance().invalidateMapUri(mapUri);
             return null;
         }
 
         @Override
         public ImmutablePair<String, Boolean> calculateMapAttribution(final Context ctx) {
-            return new ImmutablePair<>(getAttributionFromMapFile(this.mapUri), true);
+            return new ImmutablePair<>(MapsforgeMapProvider.getInstance().getAttributionFor(this.mapUri), true);
         }
 
    }
 
-    public static final class CyclosmMapSource extends MapsforgeMapSource {
+    public static final class CyclosmMapSource extends AbstractMapsforgeMapSource {
 
-        public CyclosmMapSource(final String fileName, final MapProvider mapProvider, final String name, final MapGeneratorInternal generator) {
-            super(fileName, mapProvider, name, generator);
-        }
-
-        @Override
-        public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
-            final AbstractTileSource source = TileSourceCyclosm.INSTANCE;
-            source.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA);
-            return new DownloadLayer(tileCache, mapViewPosition, source, AndroidGraphicFactory.INSTANCE);
+        public CyclosmMapSource(final MapProvider mapProvider, final String name) {
+            super(mapProvider, name, TileSourceCyclosm.INSTANCE);
         }
 
         @Override
@@ -214,17 +203,10 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
 
     }
 
-    public static final class OsmdeMapSource extends MapsforgeMapSource {
+    public static final class OsmMapSource extends AbstractMapsforgeMapSource {
 
-        public OsmdeMapSource(final String fileName, final MapProvider mapProvider, final String name, final MapGeneratorInternal generator) {
-            super(fileName, mapProvider, name, generator);
-        }
-
-        @Override
-        public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
-            final AbstractTileSource source = TileSourceOsmde.INSTANCE;
-            source.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA);
-            return new DownloadLayer(tileCache, mapViewPosition, source, AndroidGraphicFactory.INSTANCE);
+        public OsmMapSource(final MapProvider mapProvider, final String name) {
+            super(mapProvider, name, OpenStreetMapMapnik.INSTANCE);
         }
 
         @Override
@@ -234,20 +216,33 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
 
     }
 
-    public static final class OfflineMultiMapSource extends MapsforgeMapSource {
+
+    public static final class OsmdeMapSource extends AbstractMapsforgeMapSource {
+
+        public OsmdeMapSource(final MapProvider mapProvider, final String name) {
+            super(mapProvider, name, TileSourceOsmde.INSTANCE);
+        }
+
+        @Override
+        public ImmutablePair<String, Boolean> calculateMapAttribution(final Context ctx) {
+            return new ImmutablePair<>(ctx.getString(R.string.map_attribution_openstreetmapde_html), false);
+        }
+
+    }
+
+    public static final class OfflineMultiMapSource extends AbstractMapsforgeMapSource {
         private final List<ImmutablePair<String, Uri>> mapUris;
 
-        public OfflineMultiMapSource(final List<ImmutablePair<String, Uri>> mapUris, final MapProvider mapProvider, final String name, final MapGeneratorInternal generator) {
-            super(StringUtils.join(mapUris, ";"), mapProvider, name, generator);
+        public OfflineMultiMapSource(final List<ImmutablePair<String, Uri>> mapUris, final MapProvider mapProvider, final String name) {
+            super(mapProvider, name);
             this.mapUris = mapUris;
         }
 
         @Override
         public boolean isAvailable() {
             boolean isValid = true;
-
-            for (ImmutablePair<String, Uri> fileName : mapUris) {
-                isValid &= isValidMapFile(fileName.right);
+            for (ImmutablePair<String, Uri> mapUri : mapUris) {
+                isValid &= MapsforgeMapProvider.getInstance().isValidMapFile(mapUri.right);
             }
             return isValid;
         }
@@ -262,6 +257,8 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
                 final MapFile mf = createMapFile(fileName.right);
                 if (mf != null) {
                     mapFiles.add(mf);
+                } else {
+                    MapsforgeMapProvider.getInstance().invalidateMapUri(fileName.right);
                 }
             }
 
@@ -272,35 +269,71 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         public ImmutablePair<String, Boolean> calculateMapAttribution(final Context ctx) {
 
             final StringBuilder attributation = new StringBuilder();
-            for (ImmutablePair<String, Uri> fileName : mapUris) {
-                attributation.append("<p><b>" + fileName.left + "</b>:<br>");
-                attributation.append(getAttributionFromMapFile(fileName.right));
+            for (ImmutablePair<String, Uri> mapUri : mapUris) {
+                attributation.append("<p><b>" + mapUri.left + "</b>:<br>");
+                attributation.append(MapsforgeMapProvider.getInstance().getAttributionFor(mapUri.right));
                 attributation.append("</p>");
             }
             return new ImmutablePair<>(attributation.toString(), true);
         }
 
-
      }
 
     @NonNull
-    private static String getAttributionFromMapFile(final Uri filePath) {
+    public String getAttributionFor(final Uri filePath) {
+        final String att = getAttributionIfValidFor(filePath);
+        return att == null ? OFFLINE_MAP_DEFAULT_ATTRIBUTION : att;
+    }
+
+    /**
+     * checks whether the given Uri is a valid map file.
+     * Thie methos uses cached results from previous checks
+     * Note: this method MUST be static because it is indirectly used in MapsforgeMapProvider-constructur
+     */
+    public static boolean isValidMapFile(final Uri filePath) {
+        return getAttributionIfValidFor(filePath) != null;
+    }
+
+    private static String getAttributionIfValidFor(final Uri filePath) {
+
+        if (OFFLINE_MAP_ATTRIBUTIONS.containsKey(filePath)) {
+            return OFFLINE_MAP_ATTRIBUTIONS.get(filePath);
+        }
+        OFFLINE_MAP_ATTRIBUTIONS.put(filePath, readAttributionFromMapFileIfValid(filePath));
+        return OFFLINE_MAP_ATTRIBUTIONS.get(filePath);
+    }
+
+    private void invalidateMapUri(final Uri filePath) {
+        OFFLINE_MAP_ATTRIBUTIONS.put(filePath, null);
+    }
+
+    /**
+     * Tries to open given uri as a mapfile.
+     * If mapfile is invalid in any way (not available, not readable, wrong version, ...), then null is returned.
+     * If mapfile is valid, then its attribution is read and returned (or a default attribution value in case attribution is null)
+     */
+    @Nullable
+    private static String readAttributionFromMapFileIfValid(final Uri mapUri) {
 
         MapFile mapFile = null;
         try {
-            mapFile = createMapFile(filePath);
-            if (mapFile != null && mapFile.getMapFileInfo() != null) {
+            mapFile = createMapFile(mapUri);
+            if (mapFile != null && mapFile.getMapFileInfo() != null && mapFile.getMapFileInfo().fileVersion <= 5) {
                 if (!StringUtils.isBlank(mapFile.getMapFileInfo().comment)) {
                     return mapFile.getMapFileInfo().comment;
                 }
                 if (!StringUtils.isBlank(mapFile.getMapFileInfo().createdBy)) {
                     return mapFile.getMapFileInfo().createdBy;
                 }
+                //map file is valid but has no attribution -> return default value
+                return OFFLINE_MAP_DEFAULT_ATTRIBUTION;
             }
-            return "---";
+        }  catch (MapFileException ex) {
+            Log.w(String.format("Exception reading mapfile '%s'", mapUri.toString()), ex);
         } finally {
             closeMapFileQuietly(mapFile);
         }
+        return null;
     }
 
     private static MapFile createMapFile(final Uri mapUri) {
@@ -316,7 +349,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         try {
             final InputStream fis = new FileInputStream(file);
             return new MapFile((FileInputStream) fis, 0, MapProviderFactory.getLanguage(Settings.getMapLanguage()));
-        } catch (IOException ie) {
+        } catch (IOException | MapFileException ie) {
             Log.e("Problem opening map file '" + mapUri + "'", ie);
         }
         return null;
@@ -330,15 +363,28 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
 
 
     public void updateOfflineMaps() {
+        updateOfflineMaps(null);
+    }
+
+    public void updateOfflineMaps(final Uri offlineMapToSet) {
+        MapSource msToSet = null;
         MapProviderFactory.deleteOfflineMapSources();
         final Resources resources = CgeoApplication.getInstance().getResources();
-        final List<ImmutablePair<String, Uri>> offlineMaps = getOfflineMaps();
+        final List<ImmutablePair<String, Uri>> offlineMaps =
+            CollectionStream.of(getOfflineMaps()).filter(mu -> isValidMapFile(mu.right)).toList();
         if (offlineMaps.size() > 1) {
-            registerMapSource(new OfflineMultiMapSource(offlineMaps, this, resources.getString(R.string.map_source_osm_offline_combined), MapGeneratorInternal.DATABASE_RENDERER));
+            registerMapSource(new OfflineMultiMapSource(offlineMaps, this, resources.getString(R.string.map_source_osm_offline_combined)));
         }
         for (final ImmutablePair<String, Uri> mapFile : offlineMaps) {
             final String mapName = StringUtils.capitalize(StringUtils.substringBeforeLast(mapFile.left, "."));
-            registerMapSource(new OfflineMapSource(mapFile.left, mapFile.right, this, mapName + " (" + resources.getString(R.string.map_source_osm_offline) + ")", MapGeneratorInternal.DATABASE_RENDERER));
+            final OfflineMapSource offlineMapSource = new OfflineMapSource(mapFile.right, this, mapName + " (" + resources.getString(R.string.map_source_osm_offline) + ")");
+            registerMapSource(offlineMapSource);
+            if (offlineMapToSet != null && offlineMapToSet.equals(offlineMapSource.getMapUri())) {
+                msToSet = offlineMapSource;
+            }
+        }
+        if (msToSet != null) {
+            Settings.setMapSource(msToSet);
         }
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -28,7 +28,8 @@ import cgeo.geocaching.maps.MapProviderFactory;
 import cgeo.geocaching.maps.MapState;
 import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
-import cgeo.geocaching.maps.mapsforge.MapsforgeMapSource;
+import cgeo.geocaching.maps.mapsforge.AbstractMapsforgeMapSource;
+import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.maps.mapsforge.v6.caches.CachesBundle;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.maps.mapsforge.v6.layers.HistoryLayer;
@@ -217,6 +218,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
         ResourceBitmapCacheMonitor.addRef();
         AndroidGraphicFactory.createInstance(this.getApplication());
+
+        MapsforgeMapProvider.getInstance().updateOfflineMaps();
 
         this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         this.sharedPreferences.registerOnSharedPreferenceChangeListener(this);
@@ -761,8 +764,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 new MapAttributionDisplayHandler(() -> this.mapSource.calculateMapAttribution(this)));
         }
 
-        if (newSource instanceof MapsforgeMapSource) {
-            newLayer = ((MapsforgeMapSource) newSource).createTileLayer(tileCache, this.mapView.getModel().mapViewPosition);
+        if (newSource instanceof AbstractMapsforgeMapSource) {
+            newLayer = ((AbstractMapsforgeMapSource) newSource).createTileLayer(tileCache, this.mapView.getModel().mapViewPosition);
         }
         ActivityMixin.invalidateOptionsMenu(this);
 

--- a/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
+++ b/main/src/cgeo/geocaching/settings/ReceiveMapFileActivity.java
@@ -2,8 +2,6 @@ package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
-import cgeo.geocaching.maps.MapProviderFactory;
-import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AsyncTaskWithProgressText;
@@ -146,21 +144,9 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                     inputStream.close();
                     outputStream.close();
 
-                    // remember map file and set it as current map source
+                    // clean up and refresh available map list
                     if (!cancelled.get()) {
-                        final String newMapPath = file.getPath();
-                        Settings.setMapFile(newMapPath);
-                        MapSource newMapSource = null;
-                        for (final MapSource mapSource : MapProviderFactory.getMapSources()) {
-                            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource && ((MapsforgeMapProvider.OfflineMapSource) mapSource).getMapUri()
-                                .equals(Uri.fromFile(new File(newMapPath)))) {
-                                newMapSource = mapSource;
-                                break;
-                            }
-                        }
-                        if (newMapSource != null) {
-                            Settings.setMapSource(newMapSource);
-                        }
+                        MapsforgeMapProvider.getInstance().updateOfflineMaps(Uri.fromFile(file));
                         status = CopyStates.SUCCESS;
                         getContentResolver().delete(uri, null, null);
                     } else {

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -31,7 +31,6 @@ import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapDownloadUtils;
 import cgeo.geocaching.utils.ProcessUtils;
-import static cgeo.geocaching.utils.MapUtils.showInvalidMapfileMessage;
 
 import android.R.string;
 import android.app.AlertDialog;
@@ -60,6 +59,7 @@ import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
@@ -256,12 +256,14 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     private void initMapSourcePreference() {
         final ListPreference pref = (ListPreference) getPreference(R.string.pref_mapsource);
 
-        final List<MapSource> mapSources = MapProviderFactory.getMapSources();
+        final Collection<MapSource> mapSources = MapProviderFactory.getMapSources();
         final CharSequence[] entries = new CharSequence[mapSources.size()];
         final CharSequence[] values = new CharSequence[mapSources.size()];
-        for (int i = 0; i < mapSources.size(); ++i) {
-            entries[i] = mapSources.get(i).getName();
-            values[i] = String.valueOf(mapSources.get(i).getNumericalId());
+        int idx = 0;
+        for (MapSource mapSource : MapProviderFactory.getMapSources()) {
+            entries[idx] = mapSource.getName();
+            values[idx] = String.valueOf(mapSource.getNumericalId());
+            idx++;
         }
         pref.setEntries(entries);
         pref.setEntryValues(values);
@@ -736,17 +738,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                     final String mapFile = data.getStringExtra(Intents.EXTRA_MAP_FILE);
                     final File file = new File(mapFile);
                     if (!file.isDirectory()) {
-                        Settings.setMapFile(mapFile);
-                        if (!Settings.isCurrentlySelectedMapUriValid()) {
-                            showInvalidMapfileMessage(this);
-                        } else {
-                            // Ensure map source preference is updated accordingly.
-                            // TODO: There should be a better way to find and select the map source for a map file
-                            final Integer mapSourceId = mapFile.hashCode();
-                            final ListPreference mapSource = (ListPreference) getPreference(R.string.pref_mapsource);
-                            mapSource.setValue(mapSourceId.toString());
-                            onPreferenceChange(mapSource, mapSourceId);
-                        }
+                        Settings.setMapFileDirectory(file.getParent());
                     } else {
                         Settings.setMapFileDirectory(mapFile);
                     }

--- a/tests/src-android/cgeo/geocaching/SettingsTest.java
+++ b/tests/src-android/cgeo/geocaching/SettingsTest.java
@@ -1,6 +1,5 @@
 package cgeo.geocaching;
 
-import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.settings.Settings;
 
 import android.annotation.TargetApi;
@@ -13,15 +12,6 @@ public class SettingsTest extends ActivityInstrumentationTestCase2<MainActivity>
 
     public SettingsTest() {
         super(MainActivity.class);
-    }
-
-    /**
-     * access settings.
-     * this should work fine without an exception (once there was an exception because of the empty map file string)
-     */
-    public static void testSettingsException() {
-        // We just want to ensure that it does not throw any exception but we do not know anything about the result
-        MapsforgeMapProvider.isValidMapFile(null);
     }
 
     public static void testSettings() {

--- a/tests/src-android/cgeo/geocaching/cgeo/geocaching/maps/MapsforgeMapProviderTest.java
+++ b/tests/src-android/cgeo/geocaching/cgeo/geocaching/maps/MapsforgeMapProviderTest.java
@@ -1,0 +1,42 @@
+package cgeo.geocaching.cgeo.geocaching.maps;
+
+import cgeo.geocaching.maps.interfaces.MapSource;
+import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
+
+import android.net.Uri;
+
+import java.io.File;
+import java.io.IOException;
+
+import junit.framework.TestCase;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class MapsforgeMapProviderTest extends TestCase {
+
+    public static void testInValidMapFileCheck() {
+        assertThat(MapsforgeMapProvider.isValidMapFile(null)).isFalse();
+        assertThat(MapsforgeMapProvider.getInstance().getAttributionFor(null)).isNotBlank();
+    }
+
+    public static void testOfflineMaps() throws IOException {
+        final File tempFile = File.createTempFile("pre", ".tmp");
+        final File tempFile2 = File.createTempFile("pre", ".tmp");
+        final Uri fakeUri = Uri.fromFile(tempFile);
+        final MapSource ms1 = new MapsforgeMapProvider.OfflineMapSource(fakeUri, MapsforgeMapProvider.getInstance(), "noname1");
+        final MapSource ms2 = new MapsforgeMapProvider.OfflineMapSource(fakeUri, MapsforgeMapProvider.getInstance(), "noname2");
+        final MapSource ms3 = new MapsforgeMapProvider.OfflineMapSource(Uri.fromFile(tempFile2), MapsforgeMapProvider.getInstance(), "noname2");
+
+        assertThat(ms1.getId()).isEqualTo(ms2.getId());
+        assertThat(ms1.getNumericalId() == ms2.getNumericalId()).isTrue();
+        assertThat(ms1.getId().endsWith(tempFile.getName())).isTrue();
+
+        assertThat(ms1.getId().equals(ms3.getId())).isFalse();
+        assertThat(ms1.getNumericalId() == ms3.getNumericalId()).isFalse();
+        assertThat(ms3.getId().endsWith(tempFile2.getName())).isTrue();
+
+        //cleanup
+        boolean deleteOk = tempFile.delete();
+        deleteOk &= tempFile2.delete();
+        assertThat(deleteOk).isTrue();
+    }
+}


### PR DESCRIPTION
related to #8457: remove map path from settings as one of many preliminaries for introducing SAF.

Additional cleanups:
* redesign mapsource-preselection based on stringids 
* redesigned numericId logic such that numers are guaranteed to be uniqueand uncolliding with other ressourceids
* introducing test class for MapsForgeProvider
* caching results of mapfile availablilty and map attributions to reduce repeated map file parsing