### PR TITLE
rename hide individual track to hide GPX track/route

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1262,7 +1262,7 @@
     <string name="map_hidewp_original">Hide original waypoints</string>
     <string name="map_hidewp_parking">Hide parking waypoints</string>
     <string name="map_hidewp_visited">Hide visited waypoints</string>
-    <string name="map_hide_track">Hide individual track</string>
+    <string name="map_hide_track">Hide GPX track/route</string>
     <string name="init_hidewp">Hide waypoints</string>
     <string name="init_summary_hidewp_original">Hide original waypoints on the map</string>
     <string name="init_summary_hidewp_parking">Hide parking waypoints on the map</string>


### PR DESCRIPTION
renames the "hide individual track" menu entry to "hide GPX track/route" to make it consistent with the "GPX track/route" submenu