### PR TITLE
unset autotarget on manually setting a target

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1903,6 +1903,7 @@
     <string name="map_load_individual_route">Load individual route</string>
     <string name="map_load_individual_route_confirm">Overwrite existing route?</string>
     <string name="map_autotarget_individual_route">Set as target automatically</string>
+    <string name="map_disable_autotarget_individual_route">Disabled \"Set as target automatically\"</string>
     <string name="map_clear_individual_route">Clear individual route</string>
     <string name="map_clear_individual_route_confirm">Do you want to remove all caches/waypoints from your individual route?</string>>
     <string name="map_individual_route_cleared">Individual route cleared</string>

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -385,7 +385,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             BRouterUtils.onPrepareOptionsMenu(menu);
 
             // can be moved to IndividualRouteUtils as soon as setAutoTarget is available for all map types
-            menu.findItem(R.id.menu_autotarget_individual_route).setVisible(true).setChecked(Settings.getAutotargetIndividualRoute());
+            menu.findItem(R.id.menu_autotarget_individual_route).setVisible(true).setChecked(Settings.isAutotargetIndividualRoute());
 
         } catch (final RuntimeException e) {
             Log.e("NewMap.onPrepareOptionsMenu", e);
@@ -1704,6 +1704,10 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             if (resultCode == AbstractDialogFragment.RESULT_CODE_SET_TARGET) {
                 final TargetInfo targetInfo = data.getExtras().getParcelable(Intents.EXTRA_TARGET_INFO);
                 if (targetInfo != null) {
+                    if (Settings.isAutotargetIndividualRoute()) {
+                        Settings.setAutotargetIndividualRoute(false);
+                        Toast.makeText(this, R.string.map_disable_autotarget_individual_route, Toast.LENGTH_SHORT).show();
+                    }
                     setTarget(targetInfo.coords, targetInfo.geocode);
                 }
             }

--- a/main/src/cgeo/geocaching/models/ManualRoute.java
+++ b/main/src/cgeo/geocaching/models/ManualRoute.java
@@ -79,7 +79,7 @@ public class ManualRoute extends Route implements Parcelable {
     public void triggerTargetUpdate(final boolean resetTarget) {
         if (resetTarget) {
             setTarget.setTarget(null, "");
-        } else if (Settings.getAutotargetIndividualRoute() && setTarget != null) {
+        } else if (Settings.isAutotargetIndividualRoute() && setTarget != null) {
             if (getNumSegments() == 0) {
                 setTarget.setTarget(null, "");
             } else {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -629,7 +629,7 @@ public class Settings {
         }
     }
 
-    public static boolean getAutotargetIndividualRoute() {
+    public static boolean isAutotargetIndividualRoute() {
         return getBoolean(R.string.pref_autotarget_individualroute, false);
     }
 

--- a/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
+++ b/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
@@ -67,8 +67,8 @@ public class IndividualRouteUtils {
                 ActivityMixin.invalidateOptionsMenu(activity);
             });
         } else if (id == R.id.menu_autotarget_individual_route) {
-            Settings.setAutotargetIndividualRoute(!Settings.getAutotargetIndividualRoute());
-            route.triggerTargetUpdate(!Settings.getAutotargetIndividualRoute());
+            Settings.setAutotargetIndividualRoute(!Settings.isAutotargetIndividualRoute());
+            route.triggerTargetUpdate(!Settings.isAutotargetIndividualRoute());
             ActivityMixin.invalidateOptionsMenu(activity);
         } else {
             return false;


### PR DESCRIPTION
On manually setting a target using the cache popup: Unset the "auto-target" for individual route and display an info message, if it has been set currently.

![image](https://user-images.githubusercontent.com/3754370/100649526-dcc9c180-3342-11eb-956b-1d5df7cd090b.png)

(Also renames the `getAutotargetIndividualRoute()` to the more standard compliant `isAutotargetIndividualRoute()`)