### PR TITLE
don't show "open in browser" for UDC's

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -380,7 +380,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
     @Override
     @Nullable
     public String getAndroidBeamUri() {
-        return cache != null ? cache.getCgeoUrl() : null;
+        return cache != null ? cache.getUrl() : null;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -91,6 +91,9 @@ public final class CacheMenuHandler extends AbstractUIFactory {
         menu.findItem(R.id.menu_log_visit_offline).setVisible(cache.supportsLogging() && Settings.getLogOffline());
 
         menu.findItem(R.id.menu_default_navigation).setTitle(NavigationAppFactory.getDefaultNavigationApplication().getName());
+
+        // some connectors don't support URL - we don't need "open in browser" for those caches
+        menu.findItem(R.id.menu_show_in_browser).setVisible(cache.getUrl() != null);
     }
 
     public static void addMenuItems(final MenuInflater inflater, final Menu menu, final Geocache cache) {
@@ -100,7 +103,5 @@ public final class CacheMenuHandler extends AbstractUIFactory {
 
     public static void addMenuItems(final Activity activity, final Menu menu, final Geocache cache) {
         addMenuItems(activity.getMenuInflater(), menu, cache);
-        // some connectors don't support URL - we don't need "open in browser" for those caches
-        menu.findItem(R.id.menu_show_in_browser).setVisible(cache != null && cache.getCgeoUrl() != null);
     }
 }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -805,11 +805,6 @@ public class Geocache implements IWaypoint {
         return getConnector().getLongCacheUrl(this);
     }
 
-    @Nullable
-    public String getCgeoUrl() {
-        return getConnector().getCacheUrl(this);
-    }
-
     public void setDescription(final String description) {
         this.description = description;
         this.eventTimeMinutes = null; // will be recalculated if/when necessary


### PR DESCRIPTION
- fix #9453
- remove duplicated method in geocache class (`getCgeoUrl()` and `getUrl()` had both returned `getConnector().getCacheUrl(this)`, so I merged them into one...) 