### PR TITLE
Fixes map popup checkbox bug

### DIFF
--- a/main/res/layout/map_settings_item.xml
+++ b/main/res/layout/map_settings_item.xml
@@ -23,6 +23,7 @@
         android:layout_centerVertical="true" />
     <CheckBox
         android:id="@+id/settings_item_checkbox"
+        android:clickable="false"
         android:layout_width="30dp"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"


### PR DESCRIPTION
Fixes bug, that checkbox value is not applied when directly clicking on it. This PR sets `clickable` to "false" so that a click on the checkbox is handled by the superordinate view group which contains the on click listener...