### PR TITLE
apply map popup changes also when closing via clicking outside

### DIFF
--- a/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -49,13 +49,13 @@ public class MapSettingsUtils {
         Dialogs.newBuilder(activity)
             .setView(dialogView)
             .setTitle(R.string.quick_settings)
-            .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            .setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss())
+            .setOnDismissListener(dialog -> {
                 for (SettingsElementModel item : settingsElements) {
                     item.setValue.call(item.currentValue);
                 }
                 onMapSettingsPopupFinished.run();
             })
-            .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss())
             .create()
             .show();
     }


### PR DESCRIPTION
As the map popup settings are not "dangerous", there is no need why an explicit confirmation via the OK button should be requested (also mentioned by @MagpieFourtyTwo)...