### PR TITLE
allow setting target from cache/waypoint popup for GMv2 (fix #7969)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -34,7 +34,6 @@ import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.interfaces.MapViewImpl;
 import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
-import cgeo.geocaching.maps.interfaces.PositionAndHistory;
 import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.maps.routing.RoutingMode;
@@ -153,8 +152,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private Activity activity;
     private MapItemFactory mapItemFactory;
     private final LeastRecentlyUsedSet<Geocache> caches = new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount());
-    private MapViewImpl<CachesOverlayItemImpl> mapView;
-    private PositionAndHistory overlayPositionAndScale;
     private final Progress progress = new Progress();
     private MapSource mapSource;
 
@@ -562,6 +559,10 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
         if (null != proximityNotification) {
             proximityNotification.setTextNotifications(activity);
+        }
+        if (mapOptions.mapState != null) {
+            this.targetGeocode = mapOptions.mapState.getTargetGeocode();
+            this.lastNavTarget = mapOptions.mapState.getLastNavTarget();
         }
 
         activity.setContentView(mapProvider.getMapLayoutId());
@@ -1073,7 +1074,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             return null;
         }
 
-        return new MapState(mapCenter.getCoords(), mapView.getMapZoomLevel(), followMyLocation, mapView.getCircles(), null, null, mapOptions.isLiveEnabled, mapOptions.isStoredEnabled);
+        return new MapState(mapCenter.getCoords(), mapView.getMapZoomLevel(), followMyLocation, mapView.getCircles(), targetGeocode, lastNavTarget, mapOptions.isLiveEnabled, mapOptions.isStoredEnabled);
     }
 
     private void savePrefs() {
@@ -1795,7 +1796,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         if (coordType == CoordinatesType.WAYPOINT && waypoint.getId() >= 0) {
             CGeoMap.markCacheAsDirty(waypoint.getGeocode());
-            WaypointPopup.startActivity(context, waypoint.getId(), waypoint.getGeocode());
+            WaypointPopup.startActivityAllowTarget(getActivity(), waypoint.getId(), waypoint.getGeocode());
         } else {
             progress.dismiss();
             return;
@@ -1844,7 +1845,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 GCMap.searchByGeocodes(Collections.singleton(cache.getGeocode()));
             }
             CGeoMap.markCacheAsDirty(cache.getGeocode());
-            CachePopup.startActivity(mapView.getContext(), cache.getGeocode());
+            CachePopup.startActivityAllowTarget(activity, cache.getGeocode());
             progress.dismiss();
         }
     }

--- a/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
+++ b/main/src/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
@@ -8,7 +8,7 @@ package cgeo.geocaching.maps;
  *                  distance2
  *                  distance3
  *
- * - target is only used when in target navigation mode in OSM
+ * - target is only used when in target navigation (opened via cache/waypoint popup)
  * - distance1, distance2, distance will be filled with straight distance, routed distance,
  *   individual route length (depending on settings and current data)
  * - By tapping on any of the distance fields either straight or routed distance can be supersized.

--- a/main/src/cgeo/geocaching/maps/interfaces/MapActivityImpl.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapActivityImpl.java
@@ -23,6 +23,8 @@ public interface MapActivityImpl {
 
     void superOnDestroy();
 
+    void superOnStart();
+
     void superOnStop();
 
     void superOnPause();

--- a/main/src/cgeo/geocaching/maps/interfaces/MapViewImpl.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapViewImpl.java
@@ -43,6 +43,8 @@ public interface MapViewImpl<T extends CachesOverlayItemImpl> {
 
     int getHeight();
 
+    void setDestinationCoords(Geopoint destCoords);
+
     MapProjectionImpl getMapProjection();
 
     Context getContext();


### PR DESCRIPTION
Setting a navigation target from cache/waypoint popup in Google Maps, similar to what we have for OSM maps.
Working mostly, but having some rough edges still.

![image](https://user-images.githubusercontent.com/3754370/101237341-29612400-36d8-11eb-8ecd-53c6cbdd059f.png)
