### PR TITLE
add map option to clear individual targets

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -185,6 +185,11 @@
         </menu>
     </item>
     <item
+        android:id="@+id/menu_clear_targets"
+        android:title="@string/map_clear_manual_targets"
+        android:visible="false">
+    </item>
+    <item
         android:id="@+id/menu_as_list"
         android:icon="@drawable/ic_menu_agenda"
         android:title="@string/map_as_list">

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1904,6 +1904,8 @@
     <string name="map_load_individual_route_confirm">Overwrite existing route?</string>
     <string name="map_autotarget_individual_route">Set as target automatically</string>
     <string name="map_disable_autotarget_individual_route">Disabled \"Set as target automatically\"</string>
+    <string name="map_clear_manual_targets">Clear manual targets</string>
+    <string name="map_manual_targets_cleared">Manual targets cleared</string>
     <string name="map_clear_individual_route">Clear individual route</string>
     <string name="map_clear_individual_route_confirm">Do you want to remove all caches/waypoints from your individual route?</string>>
     <string name="map_individual_route_cleared">Individual route cleared</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -760,7 +760,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
             menu.findItem(R.id.menu_as_list).setVisible(!isLoading() && caches.size() > 1);
 
-            IndividualRouteUtils.onPrepareOptionsMenu(menu, manualRoute);
+            IndividualRouteUtils.onPrepareOptionsMenu(menu, manualRoute, false);
 
             menu.findItem(R.id.menu_hint).setVisible(mapOptions.mapMode == MapMode.SINGLE);
             menu.findItem(R.id.menu_compass).setVisible(mapOptions.mapMode == MapMode.SINGLE);
@@ -812,7 +812,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             menuCompass();
         } else if (!HistoryTrackUtils.onOptionsItemSelected(activity, id, () -> mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null), this::clearTrailHistory)
             && !TrackUtils.onOptionsItemSelected(activity, id, tracks, this::setTracks, this::centerOnPosition)
-            && !IndividualRouteUtils.onOptionsItemSelected(activity, id, manualRoute, this::clearIndividualRoute, this::centerOnPosition)
+            && !IndividualRouteUtils.onOptionsItemSelected(activity, id, manualRoute, this::clearIndividualRoute, this::centerOnPosition, null)
             && !MapDownloadUtils.onOptionsItemSelected(activity, id)) {
             final MapSource mapSource = MapProviderFactory.getMapSource(id);
             if (mapSource != null) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -371,7 +371,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
             menu.findItem(R.id.menu_as_list).setVisible(!caches.isDownloading() && caches.getVisibleCachesCount() > 1);
 
-            IndividualRouteUtils.onPrepareOptionsMenu(menu, manualRoute);
+            IndividualRouteUtils.onPrepareOptionsMenu(menu, manualRoute, StringUtils.isNotBlank(targetGeocode) && null != lastNavTarget);
 
             menu.findItem(R.id.menu_hint).setVisible(mapOptions.mapMode == MapMode.SINGLE);
             menu.findItem(R.id.menu_compass).setVisible(mapOptions.mapMode == MapMode.SINGLE);
@@ -432,7 +432,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             menuCompass();
         } else if (!HistoryTrackUtils.onOptionsItemSelected(this, id, () -> historyLayer.requestRedraw(), this::clearTrailHistory)
             && !TrackUtils.onOptionsItemSelected(this, id, tracks, this::setTracks, this::centerOnPosition)
-            && !IndividualRouteUtils.onOptionsItemSelected(this, id, manualRoute, this::clearIndividualRoute, this::centerOnPosition)
+            && !IndividualRouteUtils.onOptionsItemSelected(this, id, manualRoute, this::clearIndividualRoute, this::centerOnPosition, this::setTarget)
             && !MapDownloadUtils.onOptionsItemSelected(this, id)) {
             final String language = MapProviderFactory.getLanguage(id);
             if (language != null || id == MAP_LANGUAGE_DEFAULT) {
@@ -1595,6 +1595,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             targetGeocode = null;
             targetView.setTarget(null, null);
         }
+        ActivityMixin.invalidateOptionsMenu(this);
     }
 
     private void savePrefs() {

--- a/main/src/cgeo/geocaching/models/ManualRoute.java
+++ b/main/src/cgeo/geocaching/models/ManualRoute.java
@@ -77,9 +77,12 @@ public class ManualRoute extends Route implements Parcelable {
     }
 
     public void triggerTargetUpdate(final boolean resetTarget) {
+        if (setTarget == null) {
+            return;
+        }
         if (resetTarget) {
             setTarget.setTarget(null, "");
-        } else if (Settings.isAutotargetIndividualRoute() && setTarget != null) {
+        } else if (Settings.isAutotargetIndividualRoute()) {
             if (getNumSegments() == 0) {
                 setTarget.setTarget(null, "");
             } else {

--- a/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
+++ b/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
@@ -6,11 +6,13 @@ import cgeo.geocaching.SelectIndividualRouteFileActivity;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.export.IndividualRouteExport;
 import cgeo.geocaching.files.GPXIndividualRouteImporter;
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.routing.RouteSortActivity;
 import cgeo.geocaching.models.ManualRoute;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.utils.functions.Action2;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -33,12 +35,13 @@ public class IndividualRouteUtils {
      *
      * @param menu menu to be configured
      */
-    public static void onPrepareOptionsMenu(final Menu menu, final ManualRoute route) {
+    public static void onPrepareOptionsMenu(final Menu menu, final ManualRoute route, final boolean targetIsSet) {
         final boolean isVisible = route != null && route.getNumSegments() > 0;
         menu.findItem(R.id.menu_sort_individual_route).setVisible(isVisible);
         menu.findItem(R.id.menu_center_on_route).setVisible(isVisible);
         menu.findItem(R.id.menu_export_individual_route).setVisible(isVisible);
         menu.findItem(R.id.menu_clear_individual_route).setVisible(isVisible);
+        menu.findItem(R.id.menu_clear_targets).setVisible(targetIsSet || Settings.isAutotargetIndividualRoute());
     }
 
     /**
@@ -48,7 +51,7 @@ public class IndividualRouteUtils {
      * @param id       menu entry id
      * @return true, if selected menu entry is individual route related and consumed / false else
      */
-    public static boolean onOptionsItemSelected(final Activity activity, final int id, final ManualRoute route, final Runnable clearIndividualRoute, final Route.CenterOnPosition centerOnPosition) {
+    public static boolean onOptionsItemSelected(final Activity activity, final int id, final ManualRoute route, final Runnable clearIndividualRoute, final Route.CenterOnPosition centerOnPosition, final Action2<Geopoint, String> setTarget) {
         if (id == R.id.menu_load_individual_route) {
             if (null == route || route.getNumSegments() == 0) {
                 startIndividualRouteFileSelector(activity);
@@ -70,6 +73,14 @@ public class IndividualRouteUtils {
             Settings.setAutotargetIndividualRoute(!Settings.isAutotargetIndividualRoute());
             route.triggerTargetUpdate(!Settings.isAutotargetIndividualRoute());
             ActivityMixin.invalidateOptionsMenu(activity);
+        } else if (id == R.id.menu_clear_targets) {
+            if (setTarget != null) {
+                setTarget.call(null, null);
+            }
+            Settings.setAutotargetIndividualRoute(false);
+            route.triggerTargetUpdate(true);
+            ActivityMixin.invalidateOptionsMenu(activity);
+            ActivityMixin.showToast(activity, R.string.map_manual_targets_cleared);
         } else {
             return false;
         }

--- a/main/src/cgeo/geocaching/utils/functions/Action2.java
+++ b/main/src/cgeo/geocaching/utils/functions/Action2.java
@@ -1,0 +1,5 @@
+package cgeo.geocaching.utils.functions;
+
+public interface Action2<A, B> {
+    void call(A a, B b);
+}


### PR DESCRIPTION
Menu item is shown if either a manual target is set (coming from cache/waypoint popup) or if the "auto set target" is set for an individual route. (Currently both OSM only)

When using this menu entry, both possible individual targets are cleared (and the menu entry hidden).