### PR TITLE
remove duplicated method

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -199,7 +199,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
                 ClipboardUtils.copyToClipboard(systemInfo);
                 showShortToast(getString(R.string.clipboard_copy_ok));
             });
-            share.setOnClickListener(view12 -> ShareUtils.shareAsGCSupportEmail(AboutActivity.this, getString(R.string.about_system_info), systemInfo, null, R.string.about_system_info_send_chooser));
+            share.setOnClickListener(view12 -> ShareUtils.shareAsEmail(AboutActivity.this, getString(R.string.about_system_info), systemInfo, null, R.string.about_system_info_send_chooser));
             logcat.setOnClickListener(view13 -> DebugUtils.createLogcat(AboutActivity.this));
             return view;
         }

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -129,7 +129,7 @@ public class DebugUtils {
     private static void shareLogfileAsEmail(@NonNull final Activity activity, final String additionalMessage, final File file) {
         final String systemInfo = SystemInformation.getSystemInformation(activity);
         final String emailText = additionalMessage == null ? systemInfo : additionalMessage + "\n\n" + systemInfo;
-        ShareUtils.shareAsEMail(activity, activity.getString(R.string.about_system_info), emailText, file, R.string.about_system_info_send_chooser);
+        ShareUtils.shareAsEmail(activity, activity.getString(R.string.about_system_info), emailText, file, R.string.about_system_info_send_chooser);
     }
 
 

--- a/main/src/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/cgeo/geocaching/utils/ShareUtils.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 public class ShareUtils {
 
     public static final String CHROME_PACKAGE_NAME = "com.android.chrome";
-    public static final String TYPE_CGEO_SUPPORT_EMAIL = "message/rfc822";
+    public static final String TYPE_EMAIL = "message/rfc822";
     public static final String TYPE_TEXT = "text/plain";
 
     private ShareUtils() {
@@ -41,17 +41,13 @@ public class ShareUtils {
         shareInternal(context, "*/*", null, null, file, titleResourceId);
     }
 
-    public static void shareAsGCSupportEmail(final Context context, final String subject, final String body, @Nullable final File file, @StringRes final int titleResourceId) {
-        shareInternal(context, TYPE_CGEO_SUPPORT_EMAIL, subject, body, file, titleResourceId);
-    }
-
-    public static void shareAsEMail(final Context context, final String subject, final String body, @Nullable final File file, @StringRes final int titleResourceId) {
+    public static void shareAsEmail(final Context context, final String subject, final String body, @Nullable final File file, @StringRes final int titleResourceId) {
         shareAsEmail(context, subject, body, file, titleResourceId, null);
     }
 
     public static void shareAsEmail(final Context context, final String subject, final String body, @Nullable final File file, @StringRes final int titleResourceId, final String receiver) {
         final String usedReceiver = receiver == null ? context.getString(R.string.support_mail) : receiver;
-        final Intent intent = createShareIntentInternal(context, TYPE_CGEO_SUPPORT_EMAIL, subject, body, file, usedReceiver);
+        final Intent intent = createShareIntentInternal(context, TYPE_EMAIL, subject, body, file, usedReceiver);
         shareInternal(context, intent, titleResourceId);
     }
 
@@ -85,9 +81,7 @@ public class ShareUtils {
             if (StringUtils.isNotBlank(body)) {
                 intent.putExtra(Intent.EXTRA_TEXT, body);
             }
-            if (mimeType.equals(TYPE_CGEO_SUPPORT_EMAIL)) {
-                intent.putExtra(Intent.EXTRA_EMAIL, new String[]{context.getString(R.string.support_mail)});
-            } else if (StringUtils.isNotBlank(receiver)) {
+            if (StringUtils.isNotBlank(receiver)) {
                 intent.putExtra(Intent.EXTRA_EMAIL, new String[]{receiver});
             }
             if (null != file) {


### PR DESCRIPTION
#9471 and #9495 had introduced the same feature, once at master and once at release. I should have rather targeted #9471 to release, then there wouldn't have been merge conflicts at all...  Sorry for that and thanks @moving-bits for stepping through merge hell!

This PR merges the duplicated methods and provides some cleanup...