### PR TITLE
colorize map quick settings checkboxes for Google Maps

### DIFF
--- a/main/res/layout/map_settings_item.xml
+++ b/main/res/layout/map_settings_item.xml
@@ -28,6 +28,7 @@
         android:layout_width="30dp"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
-        android:layout_centerVertical="true"/>
+        android:layout_centerVertical="true"
+        android:theme="@style/checkbox"/>
 
 </RelativeLayout>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -32,6 +32,7 @@
 
     <style name="checkbox" parent="@android:style/Widget.CompoundButton.CheckBox">
         <item name="android:textColor">?text_color</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
     </style>
 
     <style name="checkbox_full" parent="checkbox">


### PR DESCRIPTION
I found a way to colorize the check boxes in Google Maps' quick settings popup:

![image](https://user-images.githubusercontent.com/3754370/101527912-e7add300-398e-11eb-8518-f42f8f3dbbef.png)

(Still searching for the menus' headline and check boxes, though.)