### PR TITLE
apply colorAccent to Google Maps

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -55,11 +55,15 @@
     <style name="cgeo_gmap" parent="@android:style/Theme.DeviceDefault">
         <item name="text_color">@color/text_dark</item>
         <item name="button">@drawable/action_button_dark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
     </style>
 
     <style name="cgeo_gmap_light" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
         <item name="text_color">@color/text_light</item>
         <item name="button">@drawable/action_button_light</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
     </style>
 
     <style name="cgeo.base" parent="@style/Theme.AppCompat">


### PR DESCRIPTION
applies to menu headline as well as to check boxes and radio items in menus

![image](https://user-images.githubusercontent.com/3754370/101532295-a1f40900-3994-11eb-8de5-7679fc31f740.png)

And will, after merging to master, also apply for the map quick settings popup:

![image](https://user-images.githubusercontent.com/3754370/101532360-b6380600-3994-11eb-9ac6-cc82dc0b8f86.png)
