### PR TITLE
make auto-target available in map quick settings (fix #9521)

### DIFF
--- a/main/res/layout/map_settings_dialog.xml
+++ b/main/res/layout/map_settings_dialog.xml
@@ -58,8 +58,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
-        android:layout_marginBottom="8dp">
+        android:layout_marginRight="8dp">
         <TextView
             android:id="@+id/routing_title"
             android:layout_width="wrap_content"
@@ -98,4 +97,32 @@
             android:layout_toRightOf="@id/routing_bike"
             android:src="@drawable/routing_car" />
     </RelativeLayout>
+    <RelativeLayout
+        android:id="@+id/map_settings_autotarget_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:visibility="gone">
+        <TextView
+            android:id="@+id/map_settings_autotarget_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="6dip"
+            android:text="@string/individual_route" />
+        <CheckBox
+            android:id="@+id/map_settings_autotarget"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/map_autotarget_individual_route"
+            android:layout_below="@id/map_settings_autotarget_title" />
+    </RelativeLayout>
+
+
+
+    <View
+        android:id="@+id/spacer_bottom"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp" />
 </LinearLayout>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -565,7 +565,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
 
         activity.setContentView(mapProvider.getMapLayoutId());
-        activity.findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(activity, this::onMapSettingsPopupFinished, this::routingModeChanged, this::compactIconModeChanged));
+        activity.findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(activity, manualRoute, this::onMapSettingsPopupFinished, this::routingModeChanged, this::compactIconModeChanged));
 
         // If recreating from an obsolete map source, we may need a restart
         if (changeMapSource(Settings.getMapSource())) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -258,7 +258,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         setTitle();
         this.mapAttribution = findViewById(R.id.map_attribution);
 
-        findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(this, this::onMapSettingsPopupFinished, this::routingModeChanged, this::compactIconModeChanged));
+        findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(this, manualRoute, this::onMapSettingsPopupFinished, this::routingModeChanged, this::compactIconModeChanged));
 
         // prepare circular progress spinner
         spinner = (ProgressBar) findViewById(R.id.map_progressbar);

--- a/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
+++ b/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
@@ -70,9 +70,7 @@ public class IndividualRouteUtils {
                 ActivityMixin.invalidateOptionsMenu(activity);
             });
         } else if (id == R.id.menu_autotarget_individual_route) {
-            Settings.setAutotargetIndividualRoute(!Settings.isAutotargetIndividualRoute());
-            route.triggerTargetUpdate(!Settings.isAutotargetIndividualRoute());
-            ActivityMixin.invalidateOptionsMenu(activity);
+            setAutotargetIndividualRoute(activity, route, !Settings.isAutotargetIndividualRoute());
         } else if (id == R.id.menu_clear_targets) {
             if (setTarget != null) {
                 setTarget.call(null, null);
@@ -108,6 +106,12 @@ public class IndividualRouteUtils {
             return true;
         }
         return false;
+    }
+
+    public  static void setAutotargetIndividualRoute(final Activity activity, final ManualRoute route, final boolean newValue) {
+        Settings.setAutotargetIndividualRoute(newValue);
+        route.triggerTargetUpdate(!Settings.isAutotargetIndividualRoute());
+        ActivityMixin.invalidateOptionsMenu(activity);
     }
 
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3754370/101953456-a9b4e700-3bfa-11eb-91ad-c065deed7fa2.png)

@MagpieFourtyTwo
Currently the last section ("individual route" + checkbox) is only shown if either
- an individual route is defined and/or
- "auto target individual route" is activated

Or should we always show this part?
