### PR TITLE
make backup/restore buttons look like buttons (fix #9486)

### DIFF
--- a/main/res/layout/preference_button.xml
+++ b/main/res/layout/preference_button.xml
@@ -6,10 +6,9 @@
     android:orientation="vertical"
     android:descendantFocusability="blocksDescendants">
     <TextView android:id="@android:id/title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        style="@style/button"
+        style="@style/button_full"
         android:layout_marginLeft="18dp"
+        android:layout_marginRight="18dp"
         android:layout_marginTop="10dp"
         android:textSize="16sp"
         android:clickable="false" />

--- a/main/res/layout/preference_button.xml
+++ b/main/res/layout/preference_button.xml
@@ -1,0 +1,22 @@
+<!-- Layout used for buttons in preferences -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:descendantFocusability="blocksDescendants">
+    <TextView android:id="@android:id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/button"
+        android:layout_marginLeft="18dp"
+        android:layout_marginTop="10dp"
+        android:textSize="16sp"
+        android:clickable="false" />
+    <TextView android:id="@android:id/summary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="18dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp" />
+</LinearLayout>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -210,6 +210,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert</item>
         <item name="text_color">@color/text_dark</item>
+        <item name="button">@drawable/action_button_dark</item>
     </style>
 
     <style name="settings.light" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
@@ -228,6 +229,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert_light</item>
         <item name="text_color">@color/text_light</item>
+        <item name="button">@drawable/action_button_light</item>
     </style>
 
     <style name="Dialog_Alert" parent="@style/Theme.AppCompat.Dialog.Alert">

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -1121,17 +1121,20 @@
                 android:summary="@string/init_backup_logins_summary" />
             <Preference
                 android:key="@string/pref_fakekey_preference_backup"
-                android:title="@string/init_backup_now" />
+                android:title="@string/init_backup_now"
+                android:layout="@layout/preference_button" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_restore_title"
             android:layout="@layout/preference_category">
             <Preference
                 android:key="@string/pref_fakekey_preference_restore"
-                android:title="@string/init_backup_start_restore" />
+                android:title="@string/init_backup_start_restore"
+                android:layout="@layout/preference_button" />
             <Preference
                 android:key="@string/pref_fakekey_preference_restore_dirselect"
-                android:title="@string/init_backup_restore_different_backup" />
+                android:title="@string/init_backup_restore_different_backup"
+                android:layout="@layout/preference_button" />
         </PreferenceCategory>
     </PreferenceScreen>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3754370/101998941-1651e380-3cd8-11eb-95e1-a2ec4480b112.png)

If we want to make other texts in preferences look like buttons as well, we only need to add the `android:layout="@layout/preference_button"` in the appropriate places of `main/res/xml/preferences.xml` now.

"title" is required and used as button label, "summary" is supported additionally (to be display below the button).
The only thing that might be irritating a bit at first is that not only the button is clickable, but the whole preference line (as is the case with all preferences).