### PR TITLE
Add option to user-select one of the integrated translations instead of auto-select by system-default

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -52,7 +52,12 @@ android {
         // include only those language resources from libraries which we actively maintain ourselves in the translation project at https://crowdin.com/project/cgeo
         // not yet enough translations (~50%): "is","iw"(="he"),"lb","uk","zh","zh-rTW"
         // activated for testing: "uk"
-        resConfigs "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr","uk"
+        def locales = [ "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr","uk" ]
+
+        // needed for in-app language selector
+        buildConfigField "String[]", "TRANSLATION_ARRAY", "new String[]{\""+locales.join("\",\"")+"\"}"
+
+        resConfigs locales
     }
 
     // signing is handled via private.properties

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -61,7 +61,7 @@
     <string translatable="false" name="pref_skin">skin</string>
     <string translatable="false" name="pref_transparentBackground">transparentBackground</string>
     <string translatable="false" name="pref_showaddress">showaddress</string>
-    <string translatable="false" name="pref_useenglish">useenglish</string>
+    <string translatable="false" name="old_pref_useenglish">useenglish</string>
     <string translatable="false" name="pref_units_imperial">units</string>
     <string translatable="false" name="pref_ratingwanted">ratingwanted</string>
     <string translatable="false" name="pref_friendlogswanted">friendlogswanted</string>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -269,4 +269,6 @@
     <string translatable="false" name="pref_compacticon_off">off</string>
     <string translatable="false" name="pref_compacticon_on">manual</string>
     <string translatable="false" name="pref_compacticon_auto">auto</string>
+
+    <string translatable="false" name="pref_userLocale">userLocale</string>
 </resources>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -270,5 +270,5 @@
     <string translatable="false" name="pref_compacticon_on">manual</string>
     <string translatable="false" name="pref_compacticon_auto">auto</string>
 
-    <string translatable="false" name="pref_userLocale">userLocale</string>
+    <string translatable="false" name="pref_selected_language">selectedLanguage</string>
 </resources>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -599,8 +599,9 @@
     <string name="init_summary_address">Show address instead of coordinates on main screen</string>
     <string name="init_useenglish">Use English</string>
     <string name="init_summary_useenglish">Use English language for c:geo (restart required). Overrides the next setting.</string>
-    <string name="init_userlocale">Locale for translation</string>
-    <string name="init_summary_userlocale">Enter an ISO language identifier for app-specific language setting, e. g. \"de\" for German. Leave empty to use system setting. (Restart required)</string>
+    <string name="init_select_language">Select language</string>
+    <string name="init_summary_select_language">Select in-app language (requires restart)\n</string>
+    <string name="init_use_default_language">Use default language</string>
     <string name="init_category_exclude">Exclude caches</string>
     <string name="init_exclude">Exclude Own and Found</string>
     <string name="init_summary_exclude">Exclude caches you own or have found</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -597,8 +597,6 @@
     <string name="init_summary_transparentBackground">Use transparent background (restart required)</string>
     <string name="init_address">Show Address</string>
     <string name="init_summary_address">Show address instead of coordinates on main screen</string>
-    <string name="init_useenglish">Use English</string>
-    <string name="init_summary_useenglish">Use English language for c:geo (restart required). Overrides the next setting.</string>
     <string name="init_select_language">Select language</string>
     <string name="init_summary_select_language">Select in-app language (requires restart)\n</string>
     <string name="init_use_default_language">Use default language</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -598,7 +598,9 @@
     <string name="init_address">Show Address</string>
     <string name="init_summary_address">Show address instead of coordinates on main screen</string>
     <string name="init_useenglish">Use English</string>
-    <string name="init_summary_useenglish">Use English language for c:geo (Restart needed)</string>
+    <string name="init_summary_useenglish">Use English language for c:geo (restart required). Overrides the next setting.</string>
+    <string name="init_userlocale">Locale for translation</string>
+    <string name="init_summary_userlocale">Enter an ISO language identifier for app-specific language setting, e. g. \"de\" for German. Leave empty to use system setting. (Restart required)</string>
     <string name="init_category_exclude">Exclude caches</string>
     <string name="init_exclude">Exclude Own and Found</string>
     <string name="init_summary_exclude">Exclude caches you own or have found</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -495,6 +495,11 @@
             android:key="@string/pref_useenglish"
             android:summary="@string/init_summary_useenglish"
             android:title="@string/init_useenglish" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="@string/pref_userLocale"
+            android:title="@string/init_userlocale"
+            android:summary="@string/init_summary_userlocale" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_units_imperial"

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -495,11 +495,9 @@
             android:key="@string/pref_useenglish"
             android:summary="@string/init_summary_useenglish"
             android:title="@string/init_useenglish" />
-        <EditTextPreference
-            android:defaultValue=""
-            android:key="@string/pref_userLocale"
-            android:title="@string/init_userlocale"
-            android:summary="@string/init_summary_userlocale" />
+        <ListPreference
+            android:key="@string/pref_selected_language"
+            android:title="@string/init_select_language" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_units_imperial"

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -490,11 +490,6 @@
             android:key="@string/pref_plainLogs"
             android:summary="@string/init_summary_plain_logs"
             android:title="@string/init_plain_logs" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/pref_useenglish"
-            android:summary="@string/init_summary_useenglish"
-            android:title="@string/init_useenglish" />
         <ListPreference
             android:key="@string/pref_selected_language"
             android:title="@string/init_select_language" />

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.network.AndroidBeam;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.EditUtils;
 import cgeo.geocaching.utils.HtmlUtils;
@@ -132,6 +133,7 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         Log.v(logToken + ".onCreate(Bundle)");
+        ApplicationSettings.setLocale(this);
         super.onCreate(savedInstanceState);
         onCreateCommon();
     }

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -942,15 +942,13 @@ final class OkapiClient {
 
     /**
      * Return a pipe-separated list of preferred languages. English and the device default language (if different) will
-     * always be in the list. Forcing cgeo language to English will prefer English over the device default language.
+     * always be in the list. A user-set language will be first (if set).
      */
     @NonNull
     static String getPreferredLanguage() {
+        final String userLanguage = StringUtils.lowerCase(Settings.getApplicationLocale().getLanguage());
         final String defaultLanguage = StringUtils.defaultIfBlank(StringUtils.lowerCase(Locale.getDefault().getLanguage()), "en");
-        if ("en".equals(defaultLanguage)) {
-            return defaultLanguage;
-        }
-        return Settings.useEnglish() ? "en|" + defaultLanguage : defaultLanguage + "|en";
+        return userLanguage + (userLanguage.equals(defaultLanguage) ? "" : "|" + defaultLanguage) + ("en".equals(userLanguage) || "en".equals(defaultLanguage) ? "" : "|en");
     }
 
     private static void addFilterParams(@NonNull final Map<String, String> valueMap, @NonNull final OCApiConnector connector, final boolean my) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -58,6 +58,7 @@ import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
+import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.Formatter;
@@ -531,6 +532,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
+        ApplicationSettings.setLocale(this.getActivity());
         super.onCreate(savedInstanceState);
 
         // class init

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -58,6 +58,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
+import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.Formatter;
@@ -213,6 +214,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
+        ApplicationSettings.setLocale(this);
         super.onCreate(savedInstanceState);
 
         Log.d("NewMap: onCreate");

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1561,11 +1561,16 @@ public class Settings {
 
     /**
      * Return the locale that should be used to display information to the user.
+     * Precedence is useEnglish > userLocale > defaultLocale
      *
-     * @return either the system locale or an English one, depending on the settings
+     * @return either English locale, user-defined locale or system default locale, depending on the settings
      */
     public static Locale getApplicationLocale() {
-        return Settings.useEnglish() ? Locale.ENGLISH : Locale.getDefault();
+        if (Settings.useEnglish()) {
+            return Locale.ENGLISH;
+        }
+        final String userLocale = Settings.getString(R.string.pref_userLocale, "");
+        return StringUtils.isNotBlank(userLocale) ? new Locale(userLocale, "") : Locale.getDefault();
     }
 
     public static void setRoutingMode(@NonNull final RoutingMode mode) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -175,7 +175,7 @@ public class Settings {
             e.putInt(getKey(R.string.pref_version), prefsV0.getInt(getKey(R.string.pref_version), 0));
             e.putBoolean(getKey(R.string.pref_ratingwanted), prefsV0.getBoolean(getKey(R.string.pref_ratingwanted), true));
             e.putBoolean(getKey(R.string.pref_friendlogswanted), prefsV0.getBoolean(getKey(R.string.pref_friendlogswanted), true));
-            e.putBoolean(getKey(R.string.pref_useenglish), prefsV0.getBoolean(getKey(R.string.pref_useenglish), false));
+            e.putBoolean(getKey(R.string.old_pref_useenglish), prefsV0.getBoolean(getKey(R.string.old_pref_useenglish), false));
             e.putBoolean(getKey(R.string.pref_usecompass), prefsV0.getInt(getKey(R.string.pref_usecompass), 1) != 0);
             e.putBoolean(getKey(R.string.pref_trackautovisit), prefsV0.getBoolean(getKey(R.string.pref_trackautovisit), false));
             e.putBoolean(getKey(R.string.pref_sigautoinsert), prefsV0.getBoolean(getKey(R.string.pref_sigautoinsert), false));
@@ -680,11 +680,11 @@ public class Settings {
     }
 
     public static boolean useEnglish() {
-        return getBoolean(R.string.pref_useenglish, false);
+        return getBoolean(R.string.old_pref_useenglish, false);
     }
 
     public static void setUseEnglish(final boolean useEnglish) {
-        putBoolean(R.string.pref_useenglish, useEnglish);
+        putBoolean(R.string.old_pref_useenglish, useEnglish);
     }
 
     public static boolean isShowAddress() {
@@ -1561,15 +1561,13 @@ public class Settings {
 
     /**
      * Return the locale that should be used to display information to the user.
-     * Precedence is useEnglish > userLocale > defaultLocale
+     * Includes migration from the old "useEnglish" preference
+     * Precedence is userLocale > useEnglish > defaultLocale
      *
-     * @return either English locale, user-defined locale or system default locale, depending on the settings
+     * @return either user-defined locale or system default locale, depending on the settings
      */
     public static Locale getApplicationLocale() {
-        if (Settings.useEnglish()) {
-            return Locale.ENGLISH;
-        }
-        final String selectedLanguage = Settings.getString(R.string.pref_selected_language, "");
+        final String selectedLanguage = Settings.getString(R.string.pref_selected_language, Settings.getBoolean(R.string.old_pref_useenglish, false) ? "en" : "");
         return StringUtils.isNotBlank(selectedLanguage) ? new Locale(selectedLanguage, "") : Locale.getDefault();
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1569,8 +1569,8 @@ public class Settings {
         if (Settings.useEnglish()) {
             return Locale.ENGLISH;
         }
-        final String userLocale = Settings.getString(R.string.pref_userLocale, "");
-        return StringUtils.isNotBlank(userLocale) ? new Locale(userLocale, "") : Locale.getDefault();
+        final String selectedLanguage = Settings.getString(R.string.pref_selected_language, "");
+        return StringUtils.isNotBlank(selectedLanguage) ? new Locale(selectedLanguage, "") : Locale.getDefault();
     }
 
     public static void setRoutingMode(@NonNull final RoutingMode mode) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -679,14 +679,6 @@ public class Settings {
                 GCConstants.DEFAULT_GC_DATE);
     }
 
-    public static boolean useEnglish() {
-        return getBoolean(R.string.old_pref_useenglish, false);
-    }
-
-    public static void setUseEnglish(final boolean useEnglish) {
-        putBoolean(R.string.old_pref_useenglish, useEnglish);
-    }
-
     public static boolean isShowAddress() {
         return getBoolean(R.string.pref_showaddress, true);
     }
@@ -1567,8 +1559,16 @@ public class Settings {
      * @return either user-defined locale or system default locale, depending on the settings
      */
     public static Locale getApplicationLocale() {
-        final String selectedLanguage = Settings.getString(R.string.pref_selected_language, Settings.getBoolean(R.string.old_pref_useenglish, false) ? "en" : "");
+        final String selectedLanguage = getUserLanguage();
         return StringUtils.isNotBlank(selectedLanguage) ? new Locale(selectedLanguage, "") : Locale.getDefault();
+    }
+
+    public static String getUserLanguage() {
+        return getString(R.string.pref_selected_language, Settings.getBoolean(R.string.old_pref_useenglish, false) ? "en" : "");
+    }
+
+    public static void putUserLanguage(final String language) {
+        putString(R.string.pref_selected_language, language);
     }
 
     public static void setRoutingMode(@NonNull final RoutingMode mode) {

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -539,12 +539,14 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     private void initLanguagePreferences() {
         final String[] entries = new String[BuildConfig.TRANSLATION_ARRAY.length + 1];
         final String[] entryValues = new String[BuildConfig.TRANSLATION_ARRAY.length + 1];
+        final Locale currentLocale = Settings.getApplicationLocale();
 
         entries[0] = getString(R.string.init_use_default_language);
         entryValues[0] = "";
         for (int i = 0; i < BuildConfig.TRANSLATION_ARRAY.length; i++) {
-            entries[1 + i] = BuildConfig.TRANSLATION_ARRAY[i];
             entryValues[1 + i] = BuildConfig.TRANSLATION_ARRAY[i];
+            final Locale l = new Locale(BuildConfig.TRANSLATION_ARRAY[i], "");
+            entries[1 + i] = BuildConfig.TRANSLATION_ARRAY[i] + " (" + l.getDisplayLanguage(currentLocale) + ")";
         }
 
         final ListPreference selectedLanguage = (ListPreference) getPreference(R.string.pref_selected_language);

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.FileUtils;
@@ -115,7 +116,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
-        // Set light skin in preferences only for devices > 2.x, it doesn't work under 2.x
+        ApplicationSettings.setLocale(this);
         setTheme(Settings.isLightSkin() ? R.style.settings_light : R.style.settings);
         super.onCreate(savedInstanceState);
 

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.settings;
 
+import cgeo.geocaching.BuildConfig;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
@@ -179,7 +180,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                 R.string.pref_mapDirectory, R.string.pref_defaultNavigationTool,
                 R.string.pref_defaultNavigationTool2, R.string.pref_webDeviceName,
                 R.string.pref_fakekey_preference_backup, R.string.pref_twitter_cache_message,
-                R.string.pref_twitter_trackable_message, R.string.pref_ec_icons }) {
+                R.string.pref_twitter_trackable_message, R.string.pref_ec_icons, R.string.pref_selected_language }) {
             bindSummaryToStringValue(k);
         }
         bindGeocachingUserToGCVoteuser();
@@ -536,11 +537,27 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     }
 
     private void initLanguagePreferences() {
+        // use English
         final Preference p = getPreference(R.string.pref_useenglish);
         p.setOnPreferenceChangeListener((preference, newValue) -> {
             setResult(RESTART_NEEDED);
             return true;
         });
+
+        // language selector
+        final String[] entries = new String[BuildConfig.TRANSLATION_ARRAY.length + 1];
+        final String[] entryValues = new String[BuildConfig.TRANSLATION_ARRAY.length + 1];
+
+        entries[0] = getString(R.string.init_use_default_language);
+        entryValues[0] = "";
+        for (int i = 0; i < BuildConfig.TRANSLATION_ARRAY.length; i++) {
+            entries[1 + i] = BuildConfig.TRANSLATION_ARRAY[i];
+            entryValues[1 + i] = BuildConfig.TRANSLATION_ARRAY[i];
+        }
+
+        final ListPreference selectedLanguage = (ListPreference) getPreference(R.string.pref_selected_language);
+        selectedLanguage.setEntries(entries);
+        selectedLanguage.setEntryValues(entryValues);
     }
 
     private void initGeoDirPreferences() {
@@ -853,7 +870,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             // Set the summary to reflect the new value.
             preference.setSummary(
                     index >= 0
-                            ? listPreference.getEntries()[index]
+                            ? (isPreference(preference, R.string.pref_selected_language) ? getString(R.string.init_summary_select_language) : "") + listPreference.getEntries()[index]
                             : null);
         } else if (isPreference(preference, R.string.pref_fakekey_preference_restore)) {
             final String textRestore;

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -537,14 +537,6 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     }
 
     private void initLanguagePreferences() {
-        // use English
-        final Preference p = getPreference(R.string.pref_useenglish);
-        p.setOnPreferenceChangeListener((preference, newValue) -> {
-            setResult(RESTART_NEEDED);
-            return true;
-        });
-
-        // language selector
         final String[] entries = new String[BuildConfig.TRANSLATION_ARRAY.length + 1];
         final String[] entryValues = new String[BuildConfig.TRANSLATION_ARRAY.length + 1];
 

--- a/main/src/cgeo/geocaching/utils/ApplicationSettings.java
+++ b/main/src/cgeo/geocaching/utils/ApplicationSettings.java
@@ -1,5 +1,10 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.settings.Settings;
+
+import android.app.Activity;
+import android.content.res.Configuration;
+
 /**
  * This utility class contains static settings that do not require a context or
  * an application. It may not depend or use any other package from c:geo.
@@ -23,6 +28,20 @@ public class ApplicationSettings {
         // There is currently no Android API to get the file name of the shared preferences. Let's hardcode
         // it without needing a CgeoApplication instance.
         return "cgeo.geocaching_preferences";
+    }
+
+
+    /**
+     * Sets a user-defined Locale for localized strings
+     *
+     * @param activity Activity to set the new locale for
+     */
+    public static void setLocale(final Activity activity) {
+        if (activity != null) {
+            final Configuration conf = activity.getResources().getConfiguration();
+            conf.setLocale(Settings.getApplicationLocale());
+            activity.getResources().updateConfiguration(conf, activity.getResources().getDisplayMetrics());
+        }
     }
 
 }

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -60,22 +60,19 @@ public final class SystemInformation {
                 .append("\nc:geo version: ").append(Version.getVersionName(context));
         appendGooglePlayServicesVersion(context, body);
         body
-                .append("\nLow power mode: ").append(Settings.useLowPowerMode() ? "active" : "inactive")
-                .append("\nCompass capabilities: ").append(Sensors.getInstance().hasCompassCapabilities() ? "yes" : "no")
-                .append("\nRotation vector sensor: ").append(presence(RotationProvider.hasRotationSensor(context)))
-                .append("\nOrientation sensor: ").append(presence(OrientationProvider.hasOrientationSensor(context)))
-                .append("\nMagnetometer & Accelerometer sensor: ").append(presence(MagnetometerAndAccelerometerProvider.hasMagnetometerAndAccelerometerSensors(context)))
-                .append("\nDirection sensor used: ").append(usedDirectionSensor)
-                .append("\nHide caches: ").append(hideCaches.isEmpty() ? "-" : hideCaches)
-                .append("\nHide waypoints: ").append(hideWaypoints.isEmpty() ? "-" : hideWaypoints)
-                .append("\nHW acceleration: ").append(Settings.useHardwareAcceleration() ? "enabled" : "disabled")
-                .append(" (").append(Settings.useHardwareAcceleration() == HwAccel.hwAccelShouldBeEnabled() ? "default state" : "manually changed").append(')')
-                .append("\nSystem language: ").append(Locale.getDefault());
-        if (Settings.useEnglish()) {
-            body.append(" (c:geo forced to English)");
-        }
-        body.append("\nSystem date format: ").append(Formatter.getShortDateFormat())
-                .append("\nDebug mode active: ").append(Settings.isDebug() ? "yes" : "no");
+            .append("\nLow power mode: ").append(Settings.useLowPowerMode() ? "active" : "inactive")
+            .append("\nCompass capabilities: ").append(Sensors.getInstance().hasCompassCapabilities() ? "yes" : "no")
+            .append("\nRotation vector sensor: ").append(presence(RotationProvider.hasRotationSensor(context)))
+            .append("\nOrientation sensor: ").append(presence(OrientationProvider.hasOrientationSensor(context)))
+            .append("\nMagnetometer & Accelerometer sensor: ").append(presence(MagnetometerAndAccelerometerProvider.hasMagnetometerAndAccelerometerSensors(context)))
+            .append("\nDirection sensor used: ").append(usedDirectionSensor)
+            .append("\nHide caches: ").append(hideCaches.isEmpty() ? "-" : hideCaches)
+            .append("\nHide waypoints: ").append(hideWaypoints.isEmpty() ? "-" : hideWaypoints)
+            .append("\nHW acceleration: ").append(Settings.useHardwareAcceleration() ? "enabled" : "disabled")
+            .append(" (").append(Settings.useHardwareAcceleration() == HwAccel.hwAccelShouldBeEnabled() ? "default state" : "manually changed").append(')')
+            .append("\nSystem language: ").append(Locale.getDefault()).append(" / user-defined language: ").append(Settings.getUserLanguage())
+            .append("\nSystem date format: ").append(Formatter.getShortDateFormat())
+            .append("\nDebug mode active: ").append(Settings.isDebug() ? "yes" : "no");
         appendDirectory(body, "\nSystem internal c:geo dir: ", LocalStorage.getInternalCgeoDirectory());
         appendDirectory(body, "\nUser storage c:geo dir: ", LocalStorage.getExternalPublicCgeoDirectory());
         appendDirectory(body, "\nGeocache data: ", LocalStorage.getGeocacheDataDirectory());

--- a/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
@@ -85,20 +85,20 @@ public class OkapiClientTest extends CGeoTestCase {
 
     public static void testPreferredLanguage() {
         final Locale savedLocale = Locale.getDefault();
-        final boolean useEnglish = Settings.useEnglish();
+        final String userLanguage = Settings.getUserLanguage();
         try {
-            Settings.setUseEnglish(false);
+            Settings.putUserLanguage("");
             Locale.setDefault(Locale.US);
             assertThat(OkapiClient.getPreferredLanguage()).isEqualTo("en");     // US, useEnglish = false
-            Settings.setUseEnglish(true);
+            Settings.putUserLanguage("en");
             assertThat(OkapiClient.getPreferredLanguage()).isEqualTo("en");     // US, useEnglish = true
             Locale.setDefault(Locale.GERMANY);
             assertThat(OkapiClient.getPreferredLanguage()).isEqualTo("en|de");  // DE, useEnglish = true
-            Settings.setUseEnglish(false);
+            Settings.putUserLanguage("");
             assertThat(OkapiClient.getPreferredLanguage()).isEqualTo("de|en");  // DE, useEnglish = false
         } finally {
             Locale.setDefault(savedLocale);
-            Settings.setUseEnglish(useEnglish);
+            Settings.putUserLanguage(userLanguage);
         }
     }
 


### PR DESCRIPTION
Adds an option to set c:geo's language independently from system language setting. Switches language on
- main screen
- settings activity
- map activities

accordingly.

Addresses #7991 ~and #9197~.

For now it's a proof-of-concept only. Language can be set by entering an ISO code (eg.: "de" for German) in "settings" - "appearance" - needs to be made more user-friendly later on.

![image](https://user-images.githubusercontent.com/3754370/102008733-f8fe3300-3d32-11eb-958f-0040aab590fd.png)![image](https://user-images.githubusercontent.com/3754370/102008626-49c15c00-3d32-11eb-8220-56906b3b6f8e.png)

Precedence is:
- "use English"
- user-defined locale (if "use English" is unchecked)
- system-default locale (if "use English" is unchecked and user-defined locale is empty)
