### PR TITLE
restart c:geo after language change automatically when leaving settings

### DIFF
--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -861,6 +861,10 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             final ListPreference listPreference = (ListPreference) preference;
             final int index = listPreference.findIndexOfValue(stringValue);
 
+            if (isPreference(preference, R.string.pref_selected_language)) {
+                setResult(RESTART_NEEDED);
+            }
+
             // Set the summary to reflect the new value.
             preference.setSummary(
                     index >= 0

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -161,6 +161,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         initDefaultNavigationPreferences();
         initBackupButtons();
         initDbLocationPreference();
+        initMapPreferences();
         initGeoDirPreferences();
         initDebugPreference();
         initForceOrientationSensorPreference();
@@ -552,6 +553,13 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         final ListPreference selectedLanguage = (ListPreference) getPreference(R.string.pref_selected_language);
         selectedLanguage.setEntries(entries);
         selectedLanguage.setEntryValues(entryValues);
+    }
+
+    private void initMapPreferences() {
+        getPreference(R.string.pref_bigSmileysOnMap).setOnPreferenceChangeListener((preference, newValue) -> {
+            setResult(RESTART_NEEDED);
+            return true;
+        });
     }
 
     private void initGeoDirPreferences() {


### PR DESCRIPTION
I first thought about restarting c:geo directly after changing the language setting, but then I decided against it. With this implementation c:geo will be restarted automatically when leaving the settings activity. Therefore, it's easier to change it back if you accidentally select the wrong one...

...and the same is done for the "bigSmileys" option too.