### PR TITLE
remove outdated function

### DIFF
--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -32,7 +32,6 @@ import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapDownloadUtils;
-import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ShareUtils;
 
 import android.R.string;
@@ -243,7 +242,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         final Preference preference = getPreference(preferenceKey);
         preference.setOnPreferenceClickListener(preference1 -> {
             final String url = StringUtils.startsWith(urlOrHost, "http") ? urlOrHost : "http://" + urlOrHost;
-            ProcessUtils.openUri(url, SettingsActivity.this);
+            ShareUtils.openUrl(SettingsActivity.this, url);
             return true;
         });
     }

--- a/main/src/cgeo/geocaching/utils/ProcessUtils.java
+++ b/main/src/cgeo/geocaching/utils/ProcessUtils.java
@@ -1,13 +1,10 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
-import cgeo.geocaching.R;
-import cgeo.geocaching.activity.ActivityMixin;
 
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -121,16 +118,7 @@ public final class ProcessUtils {
         } catch (final RuntimeException ignored) {
             // market not available, fall back to browser
             final String uri = "https://play.google.com/store/apps/details?id=" + packageName;
-            openUri(uri, activity);
-        }
-    }
-
-    public static void openUri(@NonNull final String uri, @NonNull final Activity activity) {
-        try {
-            activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(uri)));
-        } catch (final ActivityNotFoundException e) {
-            Log.e("Cannot find suitable activity", e);
-            ActivityMixin.showToast(activity, R.string.err_application_no);
+            ShareUtils.openUrl(activity, uri);
         }
     }
 

--- a/main/src/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/cgeo/geocaching/utils/ShareUtils.java
@@ -131,6 +131,7 @@ public class ShareUtils {
 
     }
 
+    /* Opens a URL in browser, in the registered default application or if activated by the user in the settings with customTabs */
     public static void openUrl(final Context context, final String url, final boolean forceIntentChooser) {
         if (StringUtils.isBlank(url)) {
             return;


### PR DESCRIPTION
We currently have two identical functions used for opening a URL in browser:

- `ShareUtils.openUrl(Context, String)`
- `ProcessUtils.openUri(String, Activity)`

While `ShareUtils.openUrl` has optional custom tabs support and is used at most places the equivalent in `ProcessUtils ` has fallen into oblivion and is to be removed herewith...