### PR TITLE
Request error description from user for problem report

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -475,7 +475,7 @@
 
     <string name="debug_user_error_report_title">Report a problem</string>
     <string name="debug_user_error_errortext">An unexpected problem has occured which we would request you to report to us:</string>
-    <string name="debug_user_error_explain_options_html"><![CDATA[<p>Help us fixing c:geo problems by reporting them via email with system information and c:geo logfile included. More contact options can be found at <i>About c:geo</i></p>]]></string>
+    <string name="debug_user_error_explain_options_html"><![CDATA[<p>Help us fixing c:geo problems by reporting them via email with system information and c:geo logfile included. Please do also include a detailed error description with your mail. Other contact options can be found at <i>About c:geo</i></p>]]></string>
 
     <!-- settings -->
     <string name="settings_title_open_settings">Open settings?</string>


### PR DESCRIPTION
We should include, that the user shall also provide a description of the error.
Otherwise I assume we might get a lot of mails with sysinfo and logfiles but without additional details.