### PR TITLE
avoid lint warning `UnusedResources` for non english strings.xml

### DIFF
--- a/main/lint.xml
+++ b/main/lint.xml
@@ -49,5 +49,6 @@
         <ignore path="res/drawable-mdpi/attribute_maintenance.png" />
         <ignore path="res/*/ic_launcher_round.xml" />
         <ignore path="res/values/vpi__colors.xml" />
+        <ignore path="res/values-*/strings.xml" />
     </issue>
 </lint>


### PR DESCRIPTION
Hide these warnings - the next complete update from crowdin will update the files accordingly.
Don´t hide in the english strings.xml.