### PR TITLE
avoid forgotten accuracy circles in GMv2 (fix #9552)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapObjectsQueue.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapObjectsQueue.java
@@ -130,9 +130,11 @@ public class GoogleMapObjectsQueue {
             final long time = System.currentTimeMillis();
             MapObjectOptions options;
             while ((options = requestedToAdd.poll()) != null) {
-                final Object drawn = options.addToGoogleMap(googleMap);
-                drawnBy.put(drawn, options);
-                drawObjects.put(options, drawn);
+                if (!drawObjects.containsKey(options)) {
+                    final Object drawn = options.addToGoogleMap(googleMap);
+                    drawnBy.put(drawn, options);
+                    drawObjects.put(options, drawn);
+                }
                 if (System.currentTimeMillis() - time >= TIME_MAX) {
                     // removing and adding markers are time costly operations and we dont want to block UI thread
                     runOnUIThread(this);


### PR DESCRIPTION
Check if object to be drawn is already in map of drawn objects. If yes, do not draw the same object again.