### PR TITLE
Related to #9466: Only use k-factor above 9999 favorite points

### DIFF
--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -226,7 +226,7 @@ public final class Formatter {
 
     @NonNull
     public static String formatFavCount(final int favCount) {
-        return favCount >= 1000 ? (favCount / 1000) + "k" : favCount >= 0 ? Integer.toString(favCount) : "?";
+        return favCount >= 10000 ? (favCount / 1000) + "k" : favCount >= 0 ? Integer.toString(favCount) : "?";
     }
 
     @NonNull


### PR DESCRIPTION
Only shorten favpoints beginning with 10k, because:
- That was my original proposal in #9466 (only had a typo in my proposal there)
- There is a higher probability to have several caches with >999 fav points in an area, so you can still compare the exact numbers on list. Caches with >9999 are more rare, so for most users it will be rare to see those on lists (as of today)
- There is enough room for 4 digits but not for 5
