### PR TITLE
Update the Locus integration

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -301,8 +301,7 @@ dependencies {
     implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
 
     // Locus Maps integration
-    //noinspection GradleDependency
-    implementation "com.asamm:locus-api-android:0.3.17"
+    implementation "com.asamm:locus-api-android:0.9.21"
 
     // Mapsforge new version
     def mapsforgeVersion = '0.14.0'


### PR DESCRIPTION
- Update the Locus integration to the 0.9.x series (refactoring Locus)
- Update the CacheType's
- Update the deprecated storage access for sending huge data to Locus (>1000 Caches)
  The old implementation should not work with Android 10 and 11 (not tested)
  (see https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory() )
  Migrate to `context.getExternalFilesDir()`, therefore changed the data file location:
    old path:
    `/storage/emulated/0/Android/data/menion.android.locus.api/files/showIn.locus`
    new path:
    `/storage/emulated/0/Android/data/cgeo.geocaching/files/showIn.locus`

@Lineflyer: Please test using devices with Android 10 and 11
@eddiemuc: Please check if this fits in the SAF implementation