### PR TITLE
unify design of different export functionalities

### DIFF
--- a/main/res/layout/gpx_export_fragment.xml
+++ b/main/res/layout/gpx_export_fragment.xml
@@ -17,9 +17,4 @@
         android:paddingBottom="20dp"
         android:paddingLeft="8dp"/>
 
-    <CheckBox
-        android:id="@+id/share"
-        style="@style/checkbox_full"
-        android:text="@string/init_share_after_export" />
-
 </LinearLayout>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -776,6 +776,7 @@
     <string name="init_create_memory_dump">Create memory dump</string>
     <string name="init_memory_dump">Memory dump</string>
     <string name="init_memory_dumped">Memory dumped to %s</string>
+    <string name="init_please_wait">Please wait…</string>
     <string name="init_hardware_acceleration_title">Hardware accelerated rendering</string>
     <string name="init_hardware_acceleration_note">Hardware acceleration renders graphical elements faster on the screen. However on some devices the Android operating system contains bugs and some text may appear blurred (notably bold characters). Disable hardware acceleration if this happens to you.</string>
     <string name="init_hardware_acceleration">Enable hardware acceleration</string>

--- a/main/src/cgeo/geocaching/export/FieldNoteExport.java
+++ b/main/src/cgeo/geocaching/export/FieldNoteExport.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AsyncTaskWithProgress;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ShareUtils;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -169,10 +170,10 @@ public class FieldNoteExport extends AbstractExport {
         protected void onPostExecuteInternal(final Boolean result) {
             if (activity != null) {
                 final Context nonNullActivity = activity;
-                if (result) {
+                if (result && exportFile != null) {
                     Settings.setFieldnoteExportDate(System.currentTimeMillis());
 
-                    ActivityMixin.showToast(activity, getName() + ' ' + nonNullActivity.getString(R.string.export_exportedto) + ": " + exportFile.toString());
+                    ShareUtils.shareFileOrDismissDialog(activity, exportFile, "text/plain", R.string.export, getName() + " " + nonNullActivity.getString(R.string.export_exportedto) + ": " + exportFile.toString());
 
                     if (upload) {
                         ActivityMixin.showToast(activity, nonNullActivity.getString(R.string.export_fieldnotes_upload_success));

--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -83,14 +83,10 @@ public class GpxExport extends AbstractExport {
         final TextView text = layout.findViewById(R.id.info);
         text.setText(activity.getString(R.string.export_confirm_message, Settings.getGpxExportDir(), fileName));
 
-        final CheckBox shareOption = layout.findViewById(R.id.share);
-        shareOption.setChecked(Settings.getShareAfterExport());
-
         final CheckBox includeFoundStatus = layout.findViewById(R.id.include_found_status);
         includeFoundStatus.setChecked(Settings.getIncludeFoundStatus());
 
         builder.setPositiveButton(R.string.export, (dialog, which) -> {
-            Settings.setShareAfterExport(shareOption.isChecked());
             Settings.setIncludeFoundStatus(includeFoundStatus.isChecked());
             dialog.dismiss();
             new ExportTask(activity).execute(geocodes);
@@ -158,10 +154,7 @@ public class GpxExport extends AbstractExport {
             final Activity activityLocal = activity;
             if (activityLocal != null) {
                 if (exportFile != null) {
-                    ActivityMixin.showToast(activityLocal, getName() + ' ' + activityLocal.getString(R.string.export_exportedto) + ": " + exportFile.toString());
-                    if (Settings.getShareAfterExport()) {
-                        ShareUtils.share(activityLocal, exportFile, "application/xml", R.string.export_gpx_to);
-                    }
+                        ShareUtils.shareFileOrDismissDialog(activityLocal, exportFile, "application/xml", R.string.export, getName() + ' ' + activityLocal.getString(R.string.export_exportedto) + ": " + exportFile.toString());
                 } else {
                     ActivityMixin.showToast(activityLocal, activityLocal.getString(R.string.export_failed));
                 }

--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.text.InputFilter;
 import android.view.View;
-import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -74,14 +73,10 @@ public class IndividualRouteExport {
         final TextView text = layout.findViewById(R.id.info);
         text.setText(activity.getString(R.string.export_confirm_message, Settings.getGpxExportDir(), filename + FileUtils.GPX_FILE_EXTENSION));
 
-        final CheckBox shareOption = layout.findViewById(R.id.share);
-        shareOption.setChecked(Settings.getShareAfterExport());
-
         builder
             .setPositiveButton(R.string.export, (dialog, which) -> {
                 final String temp = StringUtils.trim(editFilename.getText().toString());
                 filename = (StringUtils.isNotBlank(temp) ? temp : filename) + FileUtils.GPX_FILE_EXTENSION;
-                Settings.setShareAfterExport(shareOption.isChecked());
                 dialog.dismiss();
                 new Export(activity).execute(route.getSegments());
             })
@@ -165,10 +160,7 @@ public class IndividualRouteExport {
         protected void onPostExecuteInternal(final File exportFile) {
             if (null != activity) {
                 if (null != exportFile) {
-                    ActivityMixin.showToast(activity, String.format(activity.getString(R.string.export_individualroute_success), exportFile.toString()));
-                    if (Settings.getShareAfterExport()) {
-                        ShareUtils.share(activity, exportFile, "application/xml", R.string.export_gpx_to);
-                    }
+                    ShareUtils.shareFileOrDismissDialog(activity, exportFile, "application/xml", R.string.export, String.format(activity.getString(R.string.export_individualroute_success), exportFile.toString()));
                 } else {
                     ActivityMixin.showToast(activity, activity.getString(R.string.export_failed));
                 }

--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -55,14 +55,10 @@ public class TrailHistoryExport {
         final TextView text = layout.findViewById(R.id.info);
         text.setText(activity.getString(R.string.export_confirm_message, Settings.getGpxExportDir(), filename));
 
-        final CheckBox shareOption = layout.findViewById(R.id.share);
-        shareOption.setChecked(Settings.getShareAfterExport());
-
         final CheckBox clearAfterExport = layout.findViewById(R.id.clear_trailhistory_after_export);
         clearAfterExport.setChecked(Settings.getClearTrailAfterExportStatus());
 
         builder.setPositiveButton(R.string.export, (dialog, which) -> {
-            Settings.setShareAfterExport(shareOption.isChecked());
             Settings.setClearTrailAfterExportStatus(clearAfterExport.isChecked());
             dialog.dismiss();
             new Export(activity, clearTrailHistory).execute(DataStore.loadTrailHistoryAsArray());
@@ -155,10 +151,7 @@ public class TrailHistoryExport {
         protected void onPostExecuteInternal(final File exportFile) {
             if (null != activity) {
                 if (null != exportFile) {
-                    ActivityMixin.showToast(activity, String.format(activity.getString(R.string.export_trailhistory_success), exportFile.toString()));
-                    if (Settings.getShareAfterExport()) {
-                        ShareUtils.share(activity, exportFile, "application/xml", R.string.export_gpx_to);
-                    }
+                    ShareUtils.shareFileOrDismissDialog(activity, exportFile, "application/xml", R.string.export, String.format(activity.getString(R.string.export_trailhistory_success), exportFile.toString()));
                     if (Settings.getClearTrailAfterExportStatus()) {
                         clearTrailHistory.run();
                     }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1212,13 +1212,6 @@ public class Settings {
         putString(R.string.pref_dataDir, extDir);
     }
 
-    public static boolean getShareAfterExport() {
-        return getBoolean(R.string.pref_shareafterexport, true);
-    }
-
-    public static void setShareAfterExport(final boolean shareAfterExport) {
-        putBoolean(R.string.pref_shareafterexport, shareAfterExport);
-    }
     public static boolean getIncludeFoundStatus() {
         return getBoolean(R.string.pref_includefoundstatus, true);
     }

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -669,7 +669,7 @@ public final class Dialogs {
      * @param neutralListener
      *            listener for neutral button
      */
-    public static void messageNeutral(final Activity context, final String msg, final int neutralTextButton, final OnClickListener neutralListener) {
+    public static void messageNeutral(final Context context, final String msg, final int neutralTextButton, final OnClickListener neutralListener) {
         messageNeutral(context, null, msg, neutralTextButton, neutralListener);
     }
 
@@ -687,7 +687,7 @@ public final class Dialogs {
      * @param neutralListener
      *            listener of the neutral button
      */
-    public static AlertDialog.Builder messageNeutral(final Activity context, @Nullable final String title, final String msg, final int neutralTextButton, final OnClickListener neutralListener) {
+    public static AlertDialog.Builder messageNeutral(final Context context, @Nullable final String title, final String msg, final int neutralTextButton, final OnClickListener neutralListener) {
         final AlertDialog.Builder builder = newBuilder(context);
         final AlertDialog dialog = builder.setMessage(msg)
             .setPositiveButton(android.R.string.ok, null)
@@ -698,7 +698,6 @@ public final class Dialogs {
             dialog.setTitle(title);
         }
 
-        dialog.setOwnerActivity(context);
         dialog.show();
         return builder;
     }

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -8,6 +8,8 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -34,15 +36,17 @@ public class DebugUtils {
     }
 
     public static void createMemoryDump(@NonNull final Context context) {
-        try {
-            final File file = FileUtils.getUniqueNamedLogfile("cgeo_dump", "hprof");
-            android.os.Debug.dumpHprofData(file.getPath());
-            Toast.makeText(context, context.getString(R.string.init_memory_dumped, file.getAbsolutePath()),
-                    Toast.LENGTH_LONG).show();
-            ShareUtils.share(context, file, R.string.init_memory_dump);
-        } catch (final IOException e) {
-            Log.e("createMemoryDump", e);
-        }
+        Toast.makeText(context, R.string.init_please_wait, Toast.LENGTH_LONG).show();
+        final File file = FileUtils.getUniqueNamedLogfile("cgeo_dump", "hprof");
+
+        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                try {
+                    android.os.Debug.dumpHprofData(file.getPath());
+                } catch (IOException e) {
+                    Log.e("createMemoryDump", e);
+                }
+                ShareUtils.shareFileOrDismissDialog(context, file, "*/*", R.string.init_memory_dump, context.getString(R.string.init_memory_dumped, file.getAbsolutePath()));
+                }, 1000);
     }
 
     public static void askUserToReportProblem(@NonNull final Activity context, @Nullable final String errorMsg) {

--- a/main/src/cgeo/geocaching/utils/MapUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapUtils.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -20,7 +19,7 @@ public final class MapUtils {
     }
 
     public static void showInvalidMapfileMessage(final Context context) {
-        Dialogs.messageNeutral((Activity) context, context.getString(R.string.warn_invalid_mapfile), R.string.more_information, (dialog, which) -> {
+        Dialogs.messageNeutral(context, context.getString(R.string.warn_invalid_mapfile), R.string.more_information, (dialog, which) -> {
             final Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.addCategory(Intent.CATEGORY_BROWSABLE);
             intent.setDataAndType(Uri.parse(context.getString(R.string.settings_offline_maps_url)), "text/html");

--- a/main/src/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/cgeo/geocaching/utils/ShareUtils.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.ShareBroadcastReceiver;
+import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
@@ -33,12 +34,16 @@ public class ShareUtils {
         // utility class
     }
 
-    public static void share(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int titleResourceId) {
-        shareInternal(context, mimeType, null, null, file, titleResourceId);
+    /**
+     * Standard message box + additional share button for file sharing
+     */
+    public static void shareFileOrDismissDialog(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int title, final String msg) {
+        Dialogs.messageNeutral(context, context.getString(title), msg, R.string.cache_share_field,
+            (dialog, which) -> share(context, file, mimeType, title));
     }
 
-    public static void share(final Context context, @NonNull final File file, @StringRes final int titleResourceId) {
-        shareInternal(context, "*/*", null, null, file, titleResourceId);
+    public static void share(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int titleResourceId) {
+        shareInternal(context, mimeType, null, null, file, titleResourceId);
     }
 
     public static void shareAsEmail(final Context context, final String subject, final String body, @Nullable final File file, @StringRes final int titleResourceId) {

--- a/main/src/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/cgeo/geocaching/utils/ShareUtils.java
@@ -39,10 +39,10 @@ public class ShareUtils {
      */
     public static void shareFileOrDismissDialog(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int title, final String msg) {
         Dialogs.messageNeutral(context, context.getString(title), msg, R.string.cache_share_field,
-            (dialog, which) -> share(context, file, mimeType, title));
+            (dialog, which) -> shareInternal(context, file, mimeType, title));
     }
 
-    public static void share(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int titleResourceId) {
+    private static void shareInternal(final Context context, @NonNull final File file, @NonNull final String mimeType, @StringRes final int titleResourceId) {
         shareInternal(context, mimeType, null, null, file, titleResourceId);
     }
 


### PR DESCRIPTION
I'm on the go to unify the design of all different export functionalities, to have a consistent UX...

GPX export for example has IMHO two main problems:
- "Open share menu after GPX export" may not be clear for everyone, and you have to decide in advance on something that will only be relevant later on
- The toast "GPX exported to: ..." is way too quick, so it has happened to me several times that I had to repeat the export, because I had too little time to remember the file name

Therefore, it makes sense to use the same UI as we already have for backup and logfiles:

![grafik](https://user-images.githubusercontent.com/64581222/103017992-c3ccbe80-4544-11eb-90ec-951b0f8dd781.png)

To avoid additional clicks, can we possibly avoid the following pop-up completely. Is there a real reason why you should not include the found status? We can either move the function to the settings or remove it completely. I am in favor of variant two, because in my opinion c:geo already has far too many settings options and tries to please everyone. (PS: [That](https://github.com/cgeo/cgeo/pull/5835) was the PR where it was added)

![grafik](https://user-images.githubusercontent.com/64581222/103017961-b6173900-4544-11eb-9b0e-a571d1a620bb.png)
