### PR TITLE
clean-up cache popup (fix #9578)

### DIFF
--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -147,7 +147,7 @@
         android:id="@+id/menu_toggleWaypointsFromNote"
         android:title="@string/cache_menu_preventWaypointsFromNote"
         app:showAsAction="ifRoom"
-        android:visible="true">
+        android:visible="false">
     </item>
     <item
         android:id="@+id/menu_clear_goto_history"

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -671,7 +671,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         menuItemToggleWaypointsFromNote = menu.findItem(R.id.menu_toggleWaypointsFromNote);
         menuItemToggleWaypointsFromNote.setVisible(cache != null);
         setMenuPreventWaypointsFromNote(cache != null && cache.isPreventWaypointsFromNote());
-        menu.findItem(R.id.menu_toggleWaypointsFromNote).setTitle(cache != null && cache.isPreventWaypointsFromNote() ? R.string.cache_menu_allowWaypointExtraction : R.string.cache_menu_preventWaypointsFromNote);
+        menu.findItem(R.id.menu_toggleWaypointsFromNote).setTitle(cache != null && cache.isPreventWaypointsFromNote() ? R.string.cache_menu_allowWaypointExtraction : R.string.cache_menu_preventWaypointsFromNote).setVisible(cache != null);
         menu.findItem(R.id.menu_export).setVisible(cache != null);
         if (cache != null) {
             if (connector instanceof IgnoreCapability) {

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -83,7 +83,6 @@ public final class CacheMenuHandler extends AbstractUIFactory {
         final boolean hasCoords = cache.getCoords() != null;
         menu.findItem(R.id.menu_default_navigation).setVisible(hasCoords);
         menu.findItem(R.id.menu_navigate).setVisible(hasCoords);
-        menu.findItem(R.id.menu_delete).setVisible(cache.isOffline());
         menu.findItem(R.id.menu_share).setVisible(!InternalConnector.getInstance().canHandle(cache.getGeocode()));
         menu.findItem(R.id.menu_caches_around).setVisible(hasCoords && cache.supportsCachesAround());
         menu.findItem(R.id.menu_calendar).setVisible(cache.canBeAddedToCalendar());


### PR DESCRIPTION
do not show 'delete' and 'prevent waypoints from note' entries in cache popup