### PR TITLE
disable transitions for splashscreen

### DIFF
--- a/main/src/cgeo/geocaching/SplashActivity.java
+++ b/main/src/cgeo/geocaching/SplashActivity.java
@@ -15,7 +15,7 @@ class SplashActivity extends AppCompatActivity {
         // continue by starting MainActivity and finishing this one
         final Intent main = new Intent(this, MainActivity.class);
         main.putExtras(getIntent());
-        startActivity(main);
+        startActivity(main, null);
         finish();
     }
 


### PR DESCRIPTION
c:geo did not have set any transitions for `SplashActivity` calling `MainActivity`, but there seem to some system-specific default transitions. This PR sets the activity options to null, which should disable any transition.

@Lineflyer @SammysHP 
Regarding #9563 and #9392: As I can reproduce neither of it in my test environment - can you cross-check with this PR on the devices where those issues occurred? Thanks.