### PR TITLE
update authorization activity icon

### DIFF
--- a/main/res/layout/authorization_credentials_activity.xml
+++ b/main/res/layout/authorization_credentials_activity.xml
@@ -19,7 +19,7 @@
             android:layout_marginBottom="20dip"
             android:layout_marginLeft="10dip"
             android:layout_marginRight="10dip"
-            android:drawableLeft="@drawable/cgeo"
+            android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
             android:gravity="left|center_vertical"
             android:textColor="?text_color"


### PR DESCRIPTION
While working on a different issue I stumbled upon authorization activity still using the old c:geo icon => updated it

![image](https://user-images.githubusercontent.com/3754370/103156252-fe359600-47a6-11eb-8035-7b997e39712c.png)
