### PR TITLE
show toast only if individual route or track loaded (fix #9594)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -846,7 +846,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     private void routingModeChanged(final RoutingMode newValue) {
         Settings.setRoutingMode(newValue);
-        Toast.makeText(activity, R.string.brouter_recalculating, Toast.LENGTH_SHORT).show();
+        if ((null != manualRoute && manualRoute.getNumSegments() > 0) || null != tracks) {
+            Toast.makeText(activity, R.string.brouter_recalculating, Toast.LENGTH_SHORT).show();
+        }
         manualRoute.reloadRoute(overlayPositionAndScale);
         if (null != tracks) {
             try {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -464,7 +464,9 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
 
     private void routingModeChanged(final RoutingMode newValue) {
         Settings.setRoutingMode(newValue);
-        Toast.makeText(this, R.string.brouter_recalculating, Toast.LENGTH_SHORT).show();
+        if ((null != manualRoute && manualRoute.getNumSegments() > 0) || null != tracks) {
+            Toast.makeText(this, R.string.brouter_recalculating, Toast.LENGTH_SHORT).show();
+        }
         manualRoute.reloadRoute(routeLayer);
         if (null != tracks) {
             try {


### PR DESCRIPTION
Show "recalculating route" on map quick settings close only, if routing mode has changed and either individual route is configured and/or GPX track/route has been loaded.