### PR TITLE
remove duplicates in package names

### DIFF
--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -201,7 +201,6 @@
     <string translatable="false" name="notification_channel_id">c:geo notification channel</string>
 
     <!-- link data to WhereYouGo - must be according to WhereYouGo configuration in their AndroidManifest.xml -->
-    <string translatable="false" name="whereyougo_package">menion.android.whereyougo</string>
     <string translatable="false" name="whereyougo_action_Mapsforge">"menion.android.whereyougo.maps.mapsforge.MapsforgeActivity"</string>
 
     <!-- WhereYouGo helper - must be the same values as in WhereYouGo -->
@@ -209,8 +208,17 @@
     <string translatable="false" name="cgeo_queryMapFile_actionParam">forceAndFeedback</string>
 
     <!-- play store ids -->
-    <string translatable="false" name="chirpwolf_package">de.wolffire.chirpwolf</string>
-    <string translatable="false" name="brouter_package">btools.routingapp</string>
+    <string translatable="false" name="package_whereyougo">menion.android.whereyougo</string>
+    <string translatable="false" name="package_chirpwolf">de.wolffire.chirpwolf</string>
+    <string translatable="false" name="package_brouter">btools.routingapp</string>
+    <string translatable="false" name="package_cgeo_contacts">cgeo.contacts</string>
+    <string translatable="false" name="package_pquery">org.pquery</string>
+    <string translatable="false" name="package_google_translate">com.google.android.apps.translate</string>
+    <string translatable="false" name="package_gpsstatus">com.eclipsim.gpsstatus2</string>
+    <string translatable="false" name="package_bluetoothgps">googoo.android.btgps</string>
+    <string translatable="false" name="package_gpslocker">com.silentlexx.gpslock</string>
+    <string translatable="false" name="package_barcode_scanner">com.google.zxing.client.android</string>
+    <string translatable="false" name="package_locus">menion.android.locus</string>
 
     <!-- map server urls -->
     <string translatable="false" name="mapserver_osm_v5">https://ftp-stud.hs-esslingen.de/pub/Mirrors/download.mapsforge.org/maps/v5/</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1530,14 +1530,14 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         CacheDetailActivity.this.startActivity(intent);
                     } else {
-                        ProcessUtils.openMarket(CacheDetailActivity.this, getString(R.string.whereyougo_package));
+                        ProcessUtils.openMarket(CacheDetailActivity.this, getString(R.string.package_whereyougo));
                     }
                 });
             }
         }
 
         private void updateChirpWolfBox() {
-            final Intent chirpWolf = ProcessUtils.getLaunchIntent(getString(R.string.chirpwolf_package));
+            final Intent chirpWolf = ProcessUtils.getLaunchIntent(getString(R.string.package_chirpwolf));
             final String compare = CacheAttribute.WIRELESSBEACON.getValue(true);
             boolean isEnabled = false;
             for (String current : cache.getAttributes()) {
@@ -1554,12 +1554,12 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 final ImageButton buttonCW = view.findViewById(R.id.send_to_chirp);
                 buttonCW.setOnClickListener(v -> {
                     // re-check installation state, might have changed since creating the view
-                    final Intent chirpWolf2 = ProcessUtils.getLaunchIntent(getString(R.string.chirpwolf_package));
+                    final Intent chirpWolf2 = ProcessUtils.getLaunchIntent(getString(R.string.package_chirpwolf));
                     if (null != chirpWolf2) {
                         chirpWolf2.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         CacheDetailActivity.this.startActivity(chirpWolf2);
                     } else {
-                        ProcessUtils.openMarket(CacheDetailActivity.this, getString(R.string.chirpwolf_package));
+                        ProcessUtils.openMarket(CacheDetailActivity.this, getString(R.string.package_chirpwolf));
                     }
                 });
             }

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -77,7 +77,7 @@ public class InstallWizardActivity extends AppCompatActivity {
         setNavigation(this::basicConfiguration, 0, null, 0, this::finishWizard, R.string.finish);
 
         findViewById(R.id.wizard_offlinemaps).setOnClickListener(v -> startActivityForResult(new Intent(this, MapDownloadSelectorActivity.class), MapDownloadUtils.REQUEST_CODE));
-        findViewById(R.id.wizard_brouter).setOnClickListener(v -> ProcessUtils.openMarket(this, getString(R.string.brouter_package)));
+        findViewById(R.id.wizard_brouter).setOnClickListener(v -> ProcessUtils.openMarket(this, getString(R.string.package_brouter)));
         findViewById(R.id.wizard_services).setOnClickListener(v -> SettingsActivity.openForScreen(R.string.preference_screen_services, this));
         findViewById(R.id.wizard_restore).setOnClickListener(v -> SettingsActivity.openForScreen(R.string.preference_screen_backup, this));
     }

--- a/main/src/cgeo/geocaching/apps/cache/WhereYouGoApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/WhereYouGoApp.java
@@ -55,6 +55,6 @@ public class WhereYouGoApp extends AbstractGeneralApp {
     }
 
     public static boolean isWhereYouGoInstalled() {
-        return null != ProcessUtils.getLaunchIntent(getString(R.string.whereyougo_package));
+        return null != ProcessUtils.getLaunchIntent(getString(R.string.package_whereyougo));
     }
 }

--- a/main/src/cgeo/geocaching/helper/HelperApp.java
+++ b/main/src/cgeo/geocaching/helper/HelperApp.java
@@ -1,19 +1,18 @@
 package cgeo.geocaching.helper;
 
-import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 final class HelperApp {
     final int titleId;
     final int descriptionId;
     final int iconId;
-    @NonNull
-    final String packageName;
+    final int packageNameResId;
 
-    HelperApp(final int title, final int description, final int icon, @NonNull final String packageName) {
+    HelperApp(final int title, final int description, final int icon, @StringRes final int packageNameResId) {
         this.titleId = title;
         this.descriptionId = description;
         this.iconId = icon;
-        this.packageName = packageName;
+        this.packageNameResId = packageNameResId;
     }
 
 }

--- a/main/src/cgeo/geocaching/helper/QueryMapFile.java
+++ b/main/src/cgeo/geocaching/helper/QueryMapFile.java
@@ -25,7 +25,7 @@ public class QueryMapFile extends Activity {
         if (forceAndFeedback || (mapFile != null && !"".equals(mapFile))) {
             try {
                 final Intent intent = new Intent(Intent.ACTION_SENDTO);
-                intent.setComponent(new ComponentName(getString(R.string.whereyougo_package), getString(R.string.whereyougo_action_Mapsforge)));
+                intent.setComponent(new ComponentName(getString(R.string.package_whereyougo), getString(R.string.whereyougo_action_Mapsforge)));
                 intent.putExtra(getString(R.string.cgeo_queryMapFile_resultParam), mapFile);
                 intent.putExtra(getString(R.string.cgeo_queryMapFile_actionParam), forceAndFeedback);
                 startActivity(intent);

--- a/main/src/cgeo/geocaching/helper/UsefulAppsActivity.java
+++ b/main/src/cgeo/geocaching/helper/UsefulAppsActivity.java
@@ -16,18 +16,18 @@ import butterknife.ButterKnife;
 public final class UsefulAppsActivity extends AbstractActionBarActivity {
 
     private static final HelperApp[] HELPER_APPS = {
-            new HelperApp(R.string.helper_sendtocgeo_title, R.string.helper_sendtocgeo_description, R.mipmap.ic_launcher_send2cgeo, "https://send2.cgeo.org"),
-            new HelperApp(R.string.helper_contacts_title, R.string.helper_contacts_description, R.mipmap.ic_launcher_contacts, "cgeo.contacts"),
-            new HelperApp(R.string.helper_brouter_title, R.string.helper_brouter_description, R.drawable.helper_brouter, "btools.routingapp"),
-            new HelperApp(R.string.helper_pocketquery_title, R.string.helper_pocketquery_description, R.drawable.helper_pocketquery, "org.pquery"),
-            new HelperApp(R.string.helper_google_translate_title, R.string.helper_google_translate_description, R.drawable.helper_google_translate, "com.google.android.apps.translate"),
-            new HelperApp(R.string.helper_where_you_go_title, R.string.helper_where_you_go_description, R.mipmap.ic_launcher_whereyougo, "menion.android.whereyougo"),
-            new HelperApp(R.string.helper_gpsstatus_title, R.string.helper_gpsstatus_description, R.drawable.helper_gpsstatus, "com.eclipsim.gpsstatus2"),
-            new HelperApp(R.string.helper_bluetoothgps_title, R.string.helper_bluetoothgps_description, R.drawable.helper_bluetoothgps, "googoo.android.btgps"),
-            new HelperApp(R.string.helper_gps_locker_title, R.string.helper_gps_locker_description, R.drawable.helper_gps_locker, "com.silentlexx.gpslock"),
-            new HelperApp(R.string.helper_barcode_title, R.string.helper_barcode_description, R.drawable.helper_barcode, "com.google.zxing.client.android"),
-            new HelperApp(R.string.helper_chirpwolf, R.string.helper_chirpwolf_description, R.drawable.helper_chirpwolf, "de.wolffire.chirpwolf"),
-            new HelperApp(R.string.helper_locus_title, R.string.helper_locus_description, R.drawable.helper_locus, "menion.android.locus"),
+            new HelperApp(R.string.helper_sendtocgeo_title, R.string.helper_sendtocgeo_description, R.mipmap.ic_launcher_send2cgeo, R.string.settings_send2cgeo_url),
+            new HelperApp(R.string.helper_contacts_title, R.string.helper_contacts_description, R.mipmap.ic_launcher_contacts, R.string.package_cgeo_contacts),
+            new HelperApp(R.string.helper_brouter_title, R.string.helper_brouter_description, R.drawable.helper_brouter, R.string.package_brouter),
+            new HelperApp(R.string.helper_pocketquery_title, R.string.helper_pocketquery_description, R.drawable.helper_pocketquery, R.string.package_pquery),
+            new HelperApp(R.string.helper_google_translate_title, R.string.helper_google_translate_description, R.drawable.helper_google_translate, R.string.package_google_translate),
+            new HelperApp(R.string.helper_where_you_go_title, R.string.helper_where_you_go_description, R.mipmap.ic_launcher_whereyougo, R.string.package_whereyougo),
+            new HelperApp(R.string.helper_gpsstatus_title, R.string.helper_gpsstatus_description, R.drawable.helper_gpsstatus, R.string.package_gpsstatus),
+            new HelperApp(R.string.helper_bluetoothgps_title, R.string.helper_bluetoothgps_description, R.drawable.helper_bluetoothgps, R.string.package_bluetoothgps),
+            new HelperApp(R.string.helper_gps_locker_title, R.string.helper_gps_locker_description, R.drawable.helper_gps_locker, R.string.package_gpslocker),
+            new HelperApp(R.string.helper_barcode_title, R.string.helper_barcode_description, R.drawable.helper_barcode, R.string.package_barcode_scanner),
+            new HelperApp(R.string.helper_chirpwolf, R.string.helper_chirpwolf_description, R.drawable.helper_chirpwolf, R.string.package_chirpwolf),
+            new HelperApp(R.string.helper_locus_title, R.string.helper_locus_description, R.drawable.helper_locus, R.string.package_locus),
     };
 
     @Override
@@ -38,10 +38,11 @@ public final class UsefulAppsActivity extends AbstractActionBarActivity {
 
         final RecyclerView view = RecyclerViewProvider.provideRecyclerView(this, R.id.apps_list, false, false);
         view.setAdapter(new HelperAppAdapter(this, HELPER_APPS, helperApp -> {
-            if (helperApp.packageName.startsWith("http")) {
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(helperApp.packageName)));
+            final String packageName = getString(helperApp.packageNameResId);
+            if (packageName.startsWith("http")) {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(packageName)));
             } else {
-                ProcessUtils.openMarket(UsefulAppsActivity.this, helperApp.packageName);
+                ProcessUtils.openMarket(UsefulAppsActivity.this, packageName);
             }
         }));
 


### PR DESCRIPTION
Refactoring:
- Some package names and URL had been stored twice in the app due to `HelperApp` requiring a string and other places requiring a resource id => refactored `HelperApp` to resource id
- Moved all package names to strings_not_translatable, removing duplicates along the way.
- Consistently named all Play Store package names starting with `package_` prefix.