### PR TITLE
merge old cache logs on importing GPX/PQ (fix #9524)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -420,7 +420,7 @@ public final class GCParser {
         final SearchResult result = new SearchResult(parsed.left);
         if (parsed.left == StatusCode.NO_ERROR) {
             result.addAndPutInCache(Collections.singletonList(parsed.right));
-            DataStore.saveLogs(parsed.right.getGeocode(), getLogs(parseUserToken(page), Logs.ALL).blockingIterable());
+            DataStore.saveLogs(parsed.right.getGeocode(), getLogs(parseUserToken(page), Logs.ALL).blockingIterable(), true);
         }
         return result;
     }
@@ -1815,7 +1815,7 @@ public final class GCParser {
                     mergeFriendsLogs(logEntries, specialLogEntries);
                     return logEntries;
                 }).cache();
-        mergedLogs.subscribe(logEntries -> DataStore.saveLogs(cache.getGeocode(), logEntries));
+        mergedLogs.subscribe(logEntries -> DataStore.saveLogs(cache.getGeocode(), logEntries, true));
         if (cache.isFound() || cache.isDNF()) {
             ownLogs.subscribe(logEntry -> {
                 if (logEntry.getType().isFoundLog() || (!cache.isFound() && cache.isDNF() && logEntry.getType() == LogType.DIDNT_FIND_IT)) {

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -544,7 +544,7 @@ final class OkapiClient {
             cache.setDetailedUpdatedNow();
             // save full detailed caches
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
-            DataStore.saveLogs(cache.getGeocode(), parseLogs((ArrayNode) response.path(CACHE_LATEST_LOGS), cache.getGeocode()));
+            DataStore.saveLogs(cache.getGeocode(), parseLogs((ArrayNode) response.path(CACHE_LATEST_LOGS), cache.getGeocode()), true);
         } catch (ClassCastException | NullPointerException e) {
             Log.e("OkapiClient.parseCache", e);
         }

--- a/main/src/cgeo/geocaching/connector/su/SuParser.java
+++ b/main/src/cgeo/geocaching/connector/su/SuParser.java
@@ -187,7 +187,7 @@ public class SuParser {
         // save full detailed caches
         DataStore.saveCache(cache, EnumSet.of(LoadFlags.SaveFlag.DB));
         if (data.has(CACHE_LATEST_LOGS)) {
-            DataStore.saveLogs(cache.getGeocode(), parseLogs((ArrayNode) data.path(CACHE_LATEST_LOGS)));
+            DataStore.saveLogs(cache.getGeocode(), parseLogs((ArrayNode) data.path(CACHE_LATEST_LOGS)), true);
         }
         return cache;
     }

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -266,7 +266,7 @@ abstract class GPXParser extends FileParser {
                     // finally store the cache in the database
                     result.add(geocode);
                     DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
-                    DataStore.saveLogs(cache.getGeocode(), logs);
+                    DataStore.saveLogs(cache.getGeocode(), logs, false);
 
                     // avoid the cachecache using lots of memory for caches which the user did not actually look at
                     DataStore.removeCache(geocode, EnumSet.of(RemoveFlag.CACHE));

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -797,7 +797,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
                         final LogEntry logProblem = logBuilder.setLog(getString(reportProblem.get().textId)).setLogImages(Collections.emptyList()).setLogType(reportProblem.get().logType).build();
                         newLogs.add(0, logProblem);
                     }
-                    DataStore.saveLogs(cache.getGeocode(), newLogs);
+                    DataStore.saveLogs(cache.getGeocode(), newLogs, true);
 
                     // update offline log in DB
                     cache.clearOfflineLog();

--- a/tests/src-android/cgeo/geocaching/export/ExportTest.java
+++ b/tests/src-android/cgeo/geocaching/export/ExportTest.java
@@ -44,7 +44,7 @@ public class ExportTest extends CGeoTestCase {
                 .setLog("Smile: \ud83d\ude0a")
                 .build();
         DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
-        DataStore.saveLogs(cache.getGeocode(), Collections.singletonList(log));
+        DataStore.saveLogs(cache.getGeocode(), Collections.singletonList(log), true);
         assertCanExport(cache);
     }
 

--- a/tests/src-android/cgeo/geocaching/storage/DataStoreTest.java
+++ b/tests/src-android/cgeo/geocaching/storage/DataStoreTest.java
@@ -189,7 +189,7 @@ public class DataStoreTest extends CGeoTestCase {
         final List<LogEntry> logs = new ArrayList<>();
         logs.add(new LogEntry.Builder().setDate(new Date().getTime() - MILLISECONDS_PER_DAY * 3).setLog("testlog").setLogType(LogType.NOTE).setServiceLogId("pid").build());
         logs.add(new LogEntry.Builder().setDate(new Date().getTime() - MILLISECONDS_PER_DAY * 2).setLog("testlog2").setLogType(LogType.NOTE).build());
-        DataStore.saveLogs(ARTIFICIAL_GEOCODE, logs);
+        DataStore.saveLogs(ARTIFICIAL_GEOCODE, logs, true);
 
         final List<LogEntry> logsLoadeded = DataStore.loadLogs(ARTIFICIAL_GEOCODE);
 

--- a/tests/src-android/cgeo/geocaching/storage/DataStoreTestHelpers.java
+++ b/tests/src-android/cgeo/geocaching/storage/DataStoreTestHelpers.java
@@ -51,7 +51,7 @@ public class DataStoreTestHelpers extends CGeoTestCase  {
 
         for (int i = 0; i < ARTIFICAL_GEOCACHES_COUNT; i++) {
             final String geocode = dummyCaches.get(i).getGeocode();
-            DataStore.saveLogs(geocode, createDummyLogsForCache(geocode, 30));
+            DataStore.saveLogs(geocode, createDummyLogsForCache(geocode, 30), true);
         }
     }
 


### PR DESCRIPTION
Solves #9524, but also merges old logs on importing from other GPX files or updating a cache using the connector.
Merging is done by per-log deleting old logs from same author, same date, same type before storing the new logs.