### PR TITLE
Extends the OneTimeDialogs framework

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -183,7 +183,7 @@ public class MainActivity extends AbstractActionBarActivity {
                         connectorInfo.setOnClickListener(v -> SettingsActivity.openForScreen(R.string.preference_screen_services, activity));
 
                         if (offlineFoundsAvailable) {
-                            Dialogs.basicOneTimeMessage((Activity) getContext(), OneTimeDialogs.DialogType.EXPLAIN_OFFLINE_FOUND_COUNTER, OneTimeDialogs.DialogStatus.DIALOG_SHOW);
+                            Dialogs.basicOneTimeMessage((Activity) getContext(), OneTimeDialogs.DialogType.EXPLAIN_OFFLINE_FOUND_COUNTER);
                         }
                     }
                 });
@@ -786,6 +786,11 @@ public class MainActivity extends AbstractActionBarActivity {
             final long lastChecksum = Settings.getLastChangelogChecksum();
             final long checksum = TextUtils.checksum(getString(R.string.changelog_master) + getString(R.string.changelog_release));
             Settings.setLastChangelogChecksum(checksum);
+
+            if (lastChecksum == 0) {
+                // initialize oneTimeMessages after fresh install
+                OneTimeDialogs.initializeOnFreshInstall();
+            }
 
             if (lastChecksum == 0) {
                 // show starting page after install

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -606,7 +606,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         AndroidBeam.disable(activity);
 
-        Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS, OneTimeDialogs.DialogStatus.DIALOG_SHOW);
+        Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
     }
 
     public void toggleRouteItem(final IWaypoint item) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -321,7 +321,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true));
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 
-        Dialogs.basicOneTimeMessage(this, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS, OneTimeDialogs.DialogStatus.DIALOG_SHOW);
+        Dialogs.basicOneTimeMessage(this, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
     }
 
     private void postZoomToViewport(final Viewport viewport) {

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -200,7 +200,7 @@ public class BackupUtils extends Activity {
 
         final File[] dirs = getDirsToRemove(Settings.allowedBackupsNumber());
         if (dirs != null) {
-            Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, OneTimeDialogs.DialogStatus.DIALOG_SHOW, activityContext.getString(R.string.init_backup_backup), activityContext.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs[dirs.length - 1])), true, null, () -> {
+            Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, activityContext.getString(R.string.init_backup_backup), activityContext.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs[dirs.length - 1])), true, null, () -> {
                 LocalStorage.deleteFilesOrDirectories(dirs);
                 backupInternal(runAfterwards);
             });


### PR DESCRIPTION
Extends the OneTimeDialogs framework so that dialogs can also be displayed only for new or updating users.

I have configured the existing OneTimeDialogs like this:
- explain offline found counter --> all users
- database overwrite notice --> of course also all users
- map quick settings --> only upgrading users


also see https://github.com/cgeo/cgeo/pull/9597#issuecomment-751507462

Sorry, but this PR will lead to one minor merge conflict, when merging it back to master. Unfortunately unavoidable...