### PR TITLE
option to use individual cache markers (fix #9523)

### DIFF
--- a/main/res/layout/dialog_title_button_button.xml
+++ b/main/res/layout/dialog_title_button_button.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/dialog_title_title"
+        style="@style/action_bar_title"
+        android:ellipsize="marquee"
+        android:layout_width="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true" />
+
+    <ImageButton
+        android:id="@+id/dialog_button1"
+        style="@style/button_small"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_toLeftOf="@id/dialog_button2"
+        android:layout_centerVertical="true"
+        android:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/dialog_button2"
+        style="@style/button_small"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:visibility="gone" />
+
+</RelativeLayout>

--- a/main/res/layout/emojiselector.xml
+++ b/main/res/layout/emojiselector.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/emoji_grid"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <View
+        android:id="@+id/emoji_grid_separator"
+        style="@style/separator_horizontal"
+        android:layout_below="@id/emoji_grid" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/emoji_lru"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/emoji_grid_separator"/>
+
+</RelativeLayout>

--- a/main/res/layout/emojiselector_item.xml
+++ b/main/res/layout/emojiselector_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:padding="5dp"
+    android:layout_width="40dp"
+    android:layout_height="40dp">
+
+    <TextView
+        android:id="@+id/info_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"/>
+
+</LinearLayout>

--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -154,4 +154,9 @@
         android:title="@string/clear_goto_history_title"
         android:visible="false">
     </item>
+    <item
+        android:id="@+id/menu_set_cache_icon"
+        android:title="@string/cache_menu_set_cache_icon"
+        android:visible="false">
+    </item>
 </menu>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1036,6 +1036,8 @@
     <string name="menu_caches">Manage caches</string>
     <string name="cache_menu_event">Add to calendar</string>
     <string name="cache_menu_extract_waypoints">Extract waypoints</string>
+    <string name="cache_menu_set_cache_icon">Set cache icon</string>
+    <string name="cache_icon_updated">Cache icon updated</string>
     <string name="cache_menu_details">Details</string>
     <string name="cache_menu_refresh">Refresh</string>
     <string name="cache_menu_share">Share cache</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -80,6 +80,7 @@ import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.ColorUtils;
 import cgeo.geocaching.utils.CryptUtils;
 import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
@@ -668,6 +669,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         menu.findItem(R.id.menu_checker).setVisible(cache != null && StringUtils.isNotEmpty(CheckerUtils.getCheckerUrl(cache)));
         menu.findItem(R.id.menu_extract_waypoints).setVisible(cache != null && !isUDC);
         menu.findItem(R.id.menu_clear_goto_history).setVisible(cache != null && cache.isGotoHistoryUDC());
+        menu.findItem(R.id.menu_set_cache_icon).setVisible(cache != null && cache.isOffline());
         menuItemToggleWaypointsFromNote = menu.findItem(R.id.menu_toggleWaypointsFromNote);
         menuItemToggleWaypointsFromNote.setVisible(cache != null);
         setMenuPreventWaypointsFromNote(cache != null && cache.isPreventWaypointsFromNote());
@@ -748,12 +750,21 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             NavigationAppFactory.onMenuItemSelected(item, this, cache);
         } else if (menuItem == R.id.menu_tts_toggle) {
             SpeechService.toggleService(this, cache.getCoords());
+        } else if (menuItem == R.id.menu_set_cache_icon) {
+            EmojiUtils.selectEmojiPopup(this, cache.getAssignedEmoji(), cache.getType().markerId, this::setCacheIcon);
         } else if (LoggingUI.onMenuItemSelected(item, this, cache, null)) {
             refreshOnResume = true;
         } else {
             return super.onOptionsItemSelected(item);
         }
         return true;
+    }
+
+    private void setCacheIcon(final int newCacheIcon) {
+        cache.setAssignedEmoji(newCacheIcon);
+        DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
+        Toast.makeText(this, R.string.cache_icon_updated, Toast.LENGTH_SHORT).show();
+        notifyDataSetChanged();
     }
 
     private void ignoreCache() {

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -108,6 +108,8 @@ public class Geocache implements IWaypoint {
     private String ownerDisplayName = "";
     private String ownerGuid = "";
     private String ownerUserId = "";
+    private int assignedEmoji = 0;
+
     @Nullable
     private Date hidden = null;
     /**
@@ -1254,6 +1256,10 @@ public class Geocache implements IWaypoint {
         this.ownerGuid = ownerGuid;
     }
 
+    public void setAssignedEmoji(final int assignedEmoji) {
+        this.assignedEmoji = assignedEmoji;
+    }
+
     public void setOwnerUserId(final String ownerUserId) {
         this.ownerUserId = ownerUserId;
     }
@@ -2085,5 +2091,9 @@ public class Geocache implements IWaypoint {
     @NonNull
     public Comparator<? super Waypoint> getWaypointComparator() {
         return isGotoHistoryUDC() ? Waypoint.WAYPOINT_ID_COMPARATOR : Waypoint.WAYPOINT_COMPARATOR;
+    }
+
+    public int getAssignedEmoji() {
+        return assignedEmoji;
     }
 }

--- a/main/src/cgeo/geocaching/storage/extension/EmojiLRU.java
+++ b/main/src/cgeo/geocaching/storage/extension/EmojiLRU.java
@@ -1,0 +1,47 @@
+package cgeo.geocaching.storage.extension;
+
+import cgeo.geocaching.storage.DataStore;
+
+import java.util.ArrayList;
+import java.util.ListIterator;
+
+public class EmojiLRU extends DataStore.DBExtension {
+
+    private static final DataStore.DBExtensionType type = DataStore.DBExtensionType.DBEXTENSION_EMOJILRU;
+    public static final int MAX_LRU_LENGTH = 10;
+
+    private EmojiLRU(final DataStore.DBExtension copyFrom) {
+        super(copyFrom);
+    }
+
+    public static void add(final int character) {
+        final String key = String.valueOf(character);
+        removeAll(type, key);
+        add(type, key, 0, 0, 0, 0, "", "", "", "");
+    }
+
+    /**
+     * returns a list of max MAX_LRU_LENGTH LRU elements
+     * LRU list is truncated in db after MAX_LRU_LENGTH automatically
+     * @return LRU list, in reverse chronological order
+     */
+    public static int[] getLRU() {
+        final ArrayList<DataStore.DBExtension> storedValues = getAll(type, null);
+        if (storedValues.isEmpty()) {
+            return new int[] {};
+        }
+
+        final int[] result = new int[Math.min(storedValues.size(), MAX_LRU_LENGTH)];
+        int arrayPos = 0;
+        for (ListIterator<DataStore.DBExtension> iterator = storedValues.listIterator(storedValues.size()); iterator.hasPrevious();) {
+            final DataStore.DBExtension element = iterator.previous();
+            if (arrayPos < MAX_LRU_LENGTH) {
+                result[arrayPos++] = Integer.parseInt(element.getKey());
+            } else {
+                removeAll(type, element.getKey());
+            }
+        }
+        return result;
+    }
+
+}

--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -3,9 +3,17 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.CgeoApplication;
 
 import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Point;
+import android.text.Layout;
+import android.text.StaticLayout;
+import android.text.TextPaint;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
+
+import androidx.annotation.DrawableRes;
 
 public class DisplayUtils {
 
@@ -32,4 +40,60 @@ public class DisplayUtils {
         return metrics;
     }
 
+    public static int calculateNoOfColumns(final Context context, final float columnWidthDp) {
+        final DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        final float screenWidthDp = displayMetrics.widthPixels / displayMetrics.density;
+        return (int) (screenWidthDp / columnWidthDp + 0.5);
+    }
+
+    /**
+     * get actual height of given drawable resource
+     * @param res - resources to load from
+     * @param resToFitIn - resource to check
+     * @return actual height
+     */
+    public static int getDrawableHeight(final Resources res, @DrawableRes final int resToFitIn) {
+        final Bitmap calc = BitmapFactory.decodeResource(res, resToFitIn);
+        return calc.getHeight();
+    }
+
+    /**
+     * calculate maximum font size a text can use to fit into given size
+     * @param initialFontsize - font size to start tests with
+     * @param minFontsize - minimum font size to return
+     * @param maxFontsize - maximum font size to use
+     * @param availableSize - available space for text
+     * @return maximum font size within given ranges
+     */
+    public static int calculateMaxFontsize(final int initialFontsize, final int minFontsize, final int maxFontsize, final int availableSize) {
+        int fontsize = initialFontsize;
+        final TextPaint tPaint = new TextPaint();
+
+        int height = getTextHeight(tPaint, initialFontsize, availableSize);
+        if (height > availableSize) {
+            while (height > availableSize && fontsize > minFontsize) {
+                fontsize--;
+                height = getTextHeight(tPaint, fontsize, availableSize);
+            }
+        } else {
+            while (height < availableSize && fontsize < maxFontsize) {
+                fontsize++;
+                height = getTextHeight(tPaint, fontsize, availableSize);
+            }
+        }
+        return fontsize;
+    }
+
+    /**
+     * returns the height a text in the given fontSize would use
+     * @param tPaint - paint object
+     * @param fontSize - font size to use
+     * @param availableSize - available size for layout
+     * @return actual size
+     */
+    public static int getTextHeight(final TextPaint tPaint, final int fontSize, final int availableSize) {
+        tPaint.setTextSize(fontSize);
+        final StaticLayout lsLayout = new StaticLayout("}", tPaint, availableSize, Layout.Alignment.ALIGN_CENTER, 1, 0, false);
+        return lsLayout.getHeight();
+    }
 }

--- a/main/src/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/cgeo/geocaching/utils/EmojiUtils.java
@@ -1,0 +1,170 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.storage.extension.EmojiLRU;
+import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.utils.functions.Action1;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.text.Layout;
+import android.text.StaticLayout;
+import android.text.TextPaint;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.TextView;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class EmojiUtils {
+
+    private EmojiUtils() {
+        // utility class
+    }
+
+    public static void selectEmojiPopup(final Activity activity, final int currentValue, @DrawableRes final int defaultRes, final Action1<Integer> setNewCacheIcon) {
+
+        final EmojiViewAdapter gridAdapter;
+        final EmojiViewAdapter lruAdapter;
+
+        // calc sizes
+        final int markerHeight = DisplayUtils.getDrawableHeight(activity.getResources(), R.drawable.marker_oc);
+        final int markerAvailable = (int) (markerHeight * 0.6);
+        final int markerFontsize = DisplayUtils.calculateMaxFontsize(35, 10, 100, markerAvailable);
+
+        // data to populate the emoji selector with
+        // !! those values are for testing purposes only currently !!
+        // @todo: set actual list of characters to be supported
+        final int[] emojiList = new int[50];
+        for (int i = 0; i < 50; i++) {
+            emojiList[i] = 0x1f334 + i;
+        }
+        final int[] lru = EmojiLRU.getLRU();
+
+        final View dialogView = activity.getLayoutInflater().inflate(R.layout.emojiselector, null);
+
+        final int maxCols = DisplayUtils.calculateNoOfColumns(activity, 40);
+        final RecyclerView emojiGrid = dialogView.findViewById(R.id.emoji_grid);
+        emojiGrid.setLayoutManager(new GridLayoutManager(activity, maxCols));
+        final RecyclerView emojiLru = dialogView.findViewById(R.id.emoji_lru);
+        emojiLru.setLayoutManager(new GridLayoutManager(activity, maxCols));
+
+        final View customTitle = activity.getLayoutInflater().inflate(R.layout.dialog_title_button_button, null);
+        final AlertDialog dialog = Dialogs.newBuilder(activity)
+            .setView(dialogView)
+            .setCustomTitle(customTitle)
+            .create();
+
+        gridAdapter = new EmojiViewAdapter(activity, emojiList, newCacheIcon -> onItemSelected(dialog, setNewCacheIcon, newCacheIcon));
+        emojiGrid.setAdapter(gridAdapter);
+
+        lruAdapter = new EmojiViewAdapter(activity, lru, newCacheIcon -> onItemSelected(dialog, setNewCacheIcon, newCacheIcon));
+        emojiLru.setAdapter(lruAdapter);
+
+        ((TextView) customTitle.findViewById(R.id.dialog_title_title)).setText(R.string.cache_menu_set_cache_icon);
+
+        // right button displays current value; clicking simply closes the dialog
+        final ImageButton button2 = customTitle.findViewById(R.id.dialog_button2);
+        button2.setVisibility(View.VISIBLE);
+        if (currentValue != 0) {
+            button2.setImageDrawable(getEmojiDrawable(activity.getResources(), markerHeight, markerAvailable, markerFontsize, currentValue));
+        } else if (defaultRes != 0) {
+            button2.setImageResource(defaultRes);
+        }
+        button2.setOnClickListener(v -> dialog.dismiss());
+
+        // left button displays default value (if different from current value)
+        if (currentValue != 0 && defaultRes != 0) {
+            final ImageButton button1 = customTitle.findViewById(R.id.dialog_button1);
+            button1.setVisibility(View.VISIBLE);
+            button1.setImageResource(defaultRes);
+            button1.setOnClickListener(v -> setNewCacheIcon.call(0));
+        }
+
+        dialog.show();
+    }
+
+    private static void onItemSelected(final AlertDialog dialog, final Action1<Integer> setNewCacheIcon, final int newCacheIcon) {
+        dialog.dismiss();
+        EmojiLRU.add(newCacheIcon);
+        setNewCacheIcon.call(newCacheIcon);
+    }
+
+    private static class EmojiViewAdapter extends RecyclerView.Adapter<EmojiViewAdapter.ViewHolder> {
+
+        private final int[] data;
+        private final LayoutInflater inflater;
+        private final Action1<Integer> setNewCacheIcon;
+
+        EmojiViewAdapter(final Context context, final int[] data, final Action1<Integer> setNewCacheIcon) {
+            this.inflater = LayoutInflater.from(context);
+            this.data = data;
+            this.setNewCacheIcon = setNewCacheIcon;
+        }
+
+        @Override
+        @NonNull
+        public EmojiViewAdapter.ViewHolder onCreateViewHolder(@NonNull final ViewGroup parent, final int viewType) {
+            final View view = inflater.inflate(R.layout.emojiselector_item, parent, false);
+            return new EmojiViewAdapter.ViewHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull final EmojiViewAdapter.ViewHolder holder, final int position) {
+            holder.tv.setText(new String(Character.toChars(data[position])));
+            holder.bind(data[position], setNewCacheIcon);
+        }
+
+        @Override
+        public int getItemCount() {
+            return data.length;
+        }
+
+        public static class ViewHolder extends RecyclerView.ViewHolder {
+            protected TextView tv;
+
+            ViewHolder(final View itemView) {
+                super(itemView);
+                tv = itemView.findViewById(R.id.info_text);
+            }
+
+            public void bind(final int item, final Action1<Integer> setNewCacheIcon) {
+                itemView.setOnClickListener(v -> setNewCacheIcon.call(item));
+            }
+        }
+    }
+
+    /**
+     * builds a drawable the size of a marker with a given text
+     * @param res - the resources to use
+     * @param bitmapSize - actual size of the bitmap to place the text in
+     * @param availableSize - available size
+     * @param fontsize - fontsize to use
+     * @param emoji codepoint of the emoji to display
+     * @return drawable bitmap with text on it
+     */
+    public static BitmapDrawable getEmojiDrawable(final Resources res, final int bitmapSize, final int availableSize, final int fontsize, final int emoji) {
+        final String text = new String(Character.toChars(emoji));
+        final TextPaint tPaint = new TextPaint();
+        tPaint.setTextSize(fontsize);
+        final Bitmap bm = Bitmap.createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ARGB_8888);
+        final Canvas canvas = new Canvas(bm);
+        final StaticLayout lsLayout = new StaticLayout(text, tPaint, availableSize, Layout.Alignment.ALIGN_CENTER, 1, 0, false);
+        final int deltaTopLeft = (int) (0.3 * (bitmapSize - availableSize));
+        canvas.translate(deltaTopLeft, deltaTopLeft + (int) ((availableSize - lsLayout.getHeight()) / 2));
+        lsLayout.draw(canvas);
+        canvas.save();
+        canvas.restore();
+        return new BitmapDrawable(res, bm);
+    }
+}


### PR DESCRIPTION
Allows using unicode characters as cache markers on a per-cache base.
Fixes #9523 and gives a mitigation for other issues requesting to set individual cache icons without the hassle of handling user-selected image files, and without blowing c:geo's APK size.

- New menu entry in cache menu "Select cache icon"
- opens a popup where you can select an "icon" (= unicode character) from a given list (*)
- at the bottom of this popup a "recently used" list builds (max. 10 entries)
- you can reset the chosen icon to default in this popup
- the selected "icon" is used as cache marker on the map (and other places)
- on the map it uses the usual insets, and the "squared" white background (the same that is used for OC caches and UDC)
- "big smileys" option has precedence over the user-selected icon
- map cache markers with individual cache icons are using the marker cache (as the regular markers do)
- db migration adds a single field (int) to the cache table, and sets all existing caches to "default marker" (= 0)

For screenshots see https://github.com/cgeo/cgeo/issues/9523#issuecomment-753641788 and https://github.com/cgeo/cgeo/issues/9523#issuecomment-753669988.

(*) The list of characters supported currently is for demonstration purposes only, the list has to finalized yet.