### PR TITLE
set "on long tap" option default to true + add OneTimeMessage (fix #9615)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1129,6 +1129,8 @@
     <string name="internal_goto_targets_description">This cache stores your recent \"Go to\" targets. It is automatically created once you have used the \"Go to\" function in the main menu. The coordinates entered there will be stored into waypoints of this cache. If you do no longer need these coordinates you can safely delete this cache or any of its waypoints. Also you can move the cache to any other list of your choice.</string>
     <string name="init_longtap_map">Long tap on map</string>
     <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache)</string>
+    <string name="onetime_info_longtap_disabled">Long tap on map is disabled currently.\n\nActivate in settings for creating individual routes and user-defined caches.\n\nSee Settings - Map - Map behavior</string>
+    <string name="onetime_info_longtap_enabled">Long tap on map is enabled currently.\n\nBy long tapping on map you can create individual routes and user-defined caches.\n\nTo disable see Settings - Map - Map behavior</string>
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1129,8 +1129,8 @@
     <string name="internal_goto_targets_description">This cache stores your recent \"Go to\" targets. It is automatically created once you have used the \"Go to\" function in the main menu. The coordinates entered there will be stored into waypoints of this cache. If you do no longer need these coordinates you can safely delete this cache or any of its waypoints. Also you can move the cache to any other list of your choice.</string>
     <string name="init_longtap_map">Long tap on map</string>
     <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache)</string>
-    <string name="onetime_info_longtap_disabled">Long tap on map is disabled currently.\n\nActivate in settings for creating individual routes and user-defined caches.\n\nSee Settings - Map - Map behavior</string>
-    <string name="onetime_info_longtap_enabled">Long tap on map is enabled currently.\n\nBy long tapping on map you can create individual routes and user-defined caches.\n\nTo disable see Settings - Map - Map behavior</string>
+    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings - Map - Map behavior</string>
+    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings - Map - Map behavior</string>
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -27,8 +27,6 @@
     </integer-array>
 
     <string translatable="false" name="settings_gc_legal_note_url">https://www.geocaching.com/account/documents/termsofuse</string>
-    <string translatable="false" name="settings_offline_maps_url">https://manual.cgeo.org/en/offlinemaps</string>
-    <string translatable="false" name="settings_themes_url">https://manual.cgeo.org/en/offlinemaps</string>
     <string translatable="false" name="settings_send2cgeo_url">https://send2.cgeo.org/</string>
     <string translatable="false" name="settings_facebook_login_url">https://faq.cgeo.org/#facebook-login</string>
 
@@ -36,6 +34,10 @@
     <string translatable="false" name="map_attribution_openstreetmapde_html"><![CDATA[© <a href="https://openstreetmap.de/">OpenStreetMap DE</a>, map data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>]]></string>
     <string translatable="false" name="map_attribution_cyclosm_html"><![CDATA[© <a href="https://www.cyclosm.org/">CyclOSM</a>, map data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>]]></string>
 
+    <!-- links to manual pages -->
+    <string translatable="false" name="manual_url_settings_offline_maps">https://manual.cgeo.org/en/offlinemaps</string>
+    <string translatable="false" name="manual_url_settings_themes">https://manual.cgeo.org/en/offlinemaps</string>
+    <string translatable="false" name="manual_url_mapbehavior">https://manual.cgeo.org/en/mainmenu/settings#map_behavior</string>
 
     <!-- contributors -->
     <string translatable="false" name="contributors_carnero">carnero</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -565,7 +565,7 @@
             <cgeo.geocaching.settings.InfoPreference
                 android:text="@string/settings_info_offline_maps"
                 android:title="@string/settings_info_offline_maps_title"
-                app:url="@string/settings_offline_maps_url"
+                app:url="@string/manual_url_settings_offline_maps"
                 app:urlButton="@string/settings_goto_url_button" />
             <cgeo.geocaching.settings.InfoPreferenceMap
                 android:text="@string/downloadmap_info"
@@ -577,7 +577,7 @@
             <cgeo.geocaching.settings.InfoPreference
                 android:text="@string/settings_info_themes"
                 android:title="@string/settings_info_themes_title"
-                app:url="@string/settings_themes_url"
+                app:url="@string/manual_url_settings_themes"
                 app:urlButton="@string/settings_goto_url_button" />
             <Preference
                 android:key="@string/pref_renderthemepath"

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -54,7 +54,6 @@ import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
@@ -610,7 +609,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         AndroidBeam.disable(activity);
 
-        Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
+        MapUtils.showMapOneTimeMessages(activity);
     }
 
     public void toggleRouteItem(final IWaypoint item) {

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.maps;
 
+import android.app.Activity;
+
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.WaypointType;
@@ -7,6 +9,8 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.storage.extension.OneTimeDialogs;
+import cgeo.geocaching.ui.dialog.Dialogs;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -62,4 +66,9 @@ public class MapUtils {
         }
         caches.removeAll(removeList);
     }
+
+    public static void showMapOneTimeMessages(final Activity activity) {
+        Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
+    }
+
 }

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -1,7 +1,5 @@
 package cgeo.geocaching.maps;
 
-import android.app.Activity;
-
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.WaypointType;
@@ -11,6 +9,8 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.dialog.Dialogs;
+
+import android.app.Activity;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -67,8 +67,10 @@ public class MapUtils {
         caches.removeAll(removeList);
     }
 
+    // one-time messages to be shown for maps
     public static void showMapOneTimeMessages(final Activity activity) {
         Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
+        Dialogs.basicOneTimeMessage(activity, Settings.isLongTapOnMapActivated() ? OneTimeDialogs.DialogType.MAP_LONG_TAP_ENABLED : OneTimeDialogs.DialogType.MAP_LONG_TAP_DISABLED);
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -56,7 +56,6 @@ import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -27,6 +27,7 @@ import cgeo.geocaching.maps.MapOptions;
 import cgeo.geocaching.maps.MapProviderFactory;
 import cgeo.geocaching.maps.MapSettingsUtils;
 import cgeo.geocaching.maps.MapState;
+import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.mapsforge.AbstractMapsforgeMapSource;
@@ -326,7 +327,7 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true));
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 
-        Dialogs.basicOneTimeMessage(this, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
+        MapUtils.showMapOneTimeMessages(this);
     }
 
     private void postZoomToViewport(final Viewport viewport) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1095,7 +1095,7 @@ public class Settings {
     }
 
     public static boolean isLongTapOnMapActivated() {
-        return getBoolean(R.string.pref_longTapOnMapActivated, false);
+        return getBoolean(R.string.pref_longTapOnMapActivated, true);
     }
 
     public static boolean isUseTwitter() {

--- a/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -23,7 +23,9 @@ public class OneTimeDialogs extends DataStore.DBExtension {
 
         EXPLAIN_OFFLINE_FOUND_COUNTER(R.string.settings_information, R.string.feature_info_offline_counter, DefaultBehavior.SHOW_ALWAYS),
         DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS),
-        MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE);
+        MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE),
+        MAP_LONG_TAP_DISABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_disabled, DefaultBehavior.SHOW_ALWAYS),
+        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS);
 
         public final Integer messageTitle;
         public final Integer messageText;

--- a/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.storage.extension;
 import cgeo.geocaching.R;
 import cgeo.geocaching.storage.DataStore;
 
+import androidx.annotation.StringRes;
 
 public class OneTimeDialogs extends DataStore.DBExtension {
 
@@ -21,20 +22,22 @@ public class OneTimeDialogs extends DataStore.DBExtension {
 
         // when an one time dialog gets removed/replaced, keep the old one in the enum anyway, so that we can be sure that the same name isn't used again in the future.
 
-        EXPLAIN_OFFLINE_FOUND_COUNTER(R.string.settings_information, R.string.feature_info_offline_counter, DefaultBehavior.SHOW_ALWAYS),
-        DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS),
-        MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE),
-        MAP_LONG_TAP_DISABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_disabled, DefaultBehavior.SHOW_ALWAYS),
-        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS);
+        EXPLAIN_OFFLINE_FOUND_COUNTER(R.string.settings_information, R.string.feature_info_offline_counter, DefaultBehavior.SHOW_ALWAYS, 0),
+        DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS, 0),
+        MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0),
+        MAP_LONG_TAP_DISABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_disabled, DefaultBehavior.SHOW_ALWAYS, 0),
+        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS, 0);
 
         public final Integer messageTitle;
         public final Integer messageText;
         public final DefaultBehavior defaultBehavior;
+        public final int moreInfoURLResId;
 
-        DialogType(final Integer messageTitle, final Integer messageText, final DefaultBehavior defaultBehavior) {
+        DialogType(final Integer messageTitle, final Integer messageText, final DefaultBehavior defaultBehavior, @StringRes final int moreInfoURLResId) {
             this.messageTitle = messageTitle;
             this.messageText = messageText;
             this.defaultBehavior = defaultBehavior;
+            this.moreInfoURLResId = moreInfoURLResId;
         }
     }
 

--- a/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -25,8 +25,8 @@ public class OneTimeDialogs extends DataStore.DBExtension {
         EXPLAIN_OFFLINE_FOUND_COUNTER(R.string.settings_information, R.string.feature_info_offline_counter, DefaultBehavior.SHOW_ALWAYS, 0),
         DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS, 0),
         MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0),
-        MAP_LONG_TAP_DISABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_disabled, DefaultBehavior.SHOW_ALWAYS, 0),
-        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS, 0);
+        MAP_LONG_TAP_DISABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_disabled, DefaultBehavior.SHOW_ALWAYS, R.string.manual_url_mapbehavior),
+        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS, R.string.manual_url_mapbehavior);
 
         public final Integer messageTitle;
         public final Integer messageText;

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -603,7 +603,7 @@ public final class Dialogs {
         }
 
         if (cancellable) {
-            builder.setNeutralButton(android.R.string.cancel, null);
+            builder.setNegativeButton(android.R.string.cancel, null);
         }
 
         builder.setIcon(ImageUtils.getTransparent1x1Drawable(context.getResources()));
@@ -618,7 +618,7 @@ public final class Dialogs {
 
         if (cancellable) {
             checkbox.setOnClickListener(result -> {
-                final Button button = dialog.getButton(AlertDialog.BUTTON_NEUTRAL);
+                final Button button = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
                 button.setEnabled(!checkbox.isChecked());
             });
         }

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -17,8 +17,10 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
+import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -566,7 +568,7 @@ public final class Dialogs {
      * @param runAfterwards
      *            runnable (may be <tt>null</tt>) will be executed when ok button is clicked
      */
-    private static void internalOneTimeMessage(@NonNull final Activity context, @Nullable final String title, final String message, final OneTimeDialogs.DialogType dialogType, @Nullable final Observable<Drawable> iconObservable, final boolean cancellable, final Runnable runAfterwards) {
+    private static void internalOneTimeMessage(@NonNull final Activity context, @Nullable final String title, final String message, @Nullable final String moreInfoURL, final OneTimeDialogs.DialogType dialogType, @Nullable final Observable<Drawable> iconObservable, final boolean cancellable, final Runnable runAfterwards) {
         final View content = context.getLayoutInflater().inflate(R.layout.dialog_text_checkbox, null);
         final CheckBox checkbox = (CheckBox) content.findViewById(R.id.check_box);
         final TextView textView = (TextView) content.findViewById(R.id.message);
@@ -594,6 +596,10 @@ public final class Dialogs {
 
         if (title != null) {
             builder.setTitle(title);
+        }
+
+        if (StringUtils.isNotBlank(moreInfoURL)) {
+            builder.setNeutralButton(R.string.more_information, (dialog, which) -> context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(moreInfoURL))));
         }
 
         if (cancellable) {
@@ -632,7 +638,7 @@ public final class Dialogs {
 
         if (OneTimeDialogs.showDialog(dialogType)) {
             OneTimeDialogs.setStatus(dialogType, OneTimeDialogs.DialogStatus.DIALOG_HIDE, OneTimeDialogs.DialogStatus.DIALOG_SHOW);
-            internalOneTimeMessage(context, getString(dialogType.messageTitle), getString(dialogType.messageText), dialogType,
+            internalOneTimeMessage(context, getString(dialogType.messageTitle), getString(dialogType.messageText), dialogType.moreInfoURLResId > 0 ? getString(dialogType.moreInfoURLResId) : null, dialogType,
                 Observable.just(Objects.requireNonNull(ResourcesCompat.getDrawable(context.getResources(), R.drawable.ic_info_blue, context.getTheme()))), false, null);
         }
     }
@@ -644,9 +650,9 @@ public final class Dialogs {
      * @param dialogType
      *            used for storing the dialog status in the DB, title and message defined in the dialogType are ignored
      */
-    public static void advancedOneTimeMessage(final Activity context, final OneTimeDialogs.DialogType dialogType, final String title, final String message, final boolean cancellable, @Nullable final Observable<Drawable> iconObservable, @Nullable final Runnable runAfterwards) {
+    public static void advancedOneTimeMessage(final Activity context, final OneTimeDialogs.DialogType dialogType, final String title, final String message, final String moreInfoURL, final boolean cancellable, @Nullable final Observable<Drawable> iconObservable, @Nullable final Runnable runAfterwards) {
         if (OneTimeDialogs.showDialog(dialogType)) {
-            internalOneTimeMessage(context, title, message, dialogType, iconObservable, cancellable, runAfterwards);
+            internalOneTimeMessage(context, title, message, moreInfoURL, dialogType, iconObservable, cancellable, runAfterwards);
         } else if (runAfterwards != null) {
             runAfterwards.run();
         }

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -190,7 +190,7 @@ public class BackupUtils extends Activity {
 
         final File[] dirs = getDirsToRemove(Settings.allowedBackupsNumber());
         if (dirs != null) {
-            Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, activityContext.getString(R.string.init_backup_backup), activityContext.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs[dirs.length - 1])), true, null, () -> {
+            Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, activityContext.getString(R.string.init_backup_backup), activityContext.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs[dirs.length - 1])), null, true, null, () -> {
                 LocalStorage.deleteFilesOrDirectories(dirs);
                 backupInternal(runAfterwards);
             });

--- a/main/src/cgeo/geocaching/utils/MapUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapUtils.java
@@ -22,7 +22,7 @@ public final class MapUtils {
         Dialogs.messageNeutral(context, context.getString(R.string.warn_invalid_mapfile), R.string.more_information, (dialog, which) -> {
             final Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.addCategory(Intent.CATEGORY_BROWSABLE);
-            intent.setDataAndType(Uri.parse(context.getString(R.string.settings_offline_maps_url)), "text/html");
+            intent.setDataAndType(Uri.parse(context.getString(R.string.manual_url_settings_offline_maps)), "text/html");
             context.startActivity(intent);
         });
     }


### PR DESCRIPTION
- sets default for "on long tap" map option to true
- shows a OneTimeMessage on opening map, content depending on current setting (see screenshots)
- extends the OneTimeMessage framework to (optionally) support a "more information" URL (see screenshots)
- code deduplication: moves the existing map OneTimeMessage messages to `maps/MapUtils`

![image](https://user-images.githubusercontent.com/3754370/103539258-0329d200-4e98-11eb-9bb3-d8f0e204f9dc.png).![image](https://user-images.githubusercontent.com/3754370/103539265-08871c80-4e98-11eb-8c3b-7e35d73bb5b0.png)

"More information" will take to our user manual, map settings section.