### PR TITLE
Fixes for theme loading errors (fix #3302)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -604,7 +604,8 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         builder.setTitle(R.string.map_theme_select);
 
         builder.setSingleChoiceItems(names.toArray(new String[names.size()]), selectedItem, (dialog, newItem) -> {
-            if (newItem != selectedItem) {
+            // selected a new item - or: only default available
+            if (newItem != selectedItem || names.size() == 1) {
                 // Adjust index because of <default> selection
                 if (newItem > 0) {
                     Settings.setCustomRenderThemeFile(themeFiles[newItem - 1].getPath());

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -647,10 +647,12 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
                 Log.w("Failed to set render theme", e);
                 ActivityMixin.showApplicationToast(getString(R.string.err_rendertheme_file_unreadable));
                 rendererLayer.setXmlRenderTheme(InternalRenderTheme.OSMARENDER);
+                Settings.setCustomRenderThemeFile(StringUtils.EMPTY);
             } catch (final XmlPullParserException e) {
                 Log.w("render theme invalid", e);
                 ActivityMixin.showApplicationToast(getString(R.string.err_rendertheme_invalid));
                 rendererLayer.setXmlRenderTheme(InternalRenderTheme.OSMARENDER);
+                Settings.setCustomRenderThemeFile(StringUtils.EMPTY);
             }
         }
         tileCache.purge();


### PR DESCRIPTION
Fixes two errors on OSM custom theme loading:
- "Default" is now selectable and gets stored, even if no other theme is available
- On theme loading error map theme setting is reverted to "Default" (thus you won't get the loading error message any longer on subsequent map starts)
