### PR TITLE
correctly unescape HTML characters when parsing PM-only caches

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -463,10 +463,10 @@ public final class GCParser {
                     cache.setDisabled(true);
                 }
             }
-            cache.setName(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_CACHENAME, true, ""));
+            cache.setName(TextUtils.stripHtml(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_CACHENAME, true, "")));
             cache.setGeocode(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_GEOCODE, true, ""));
-            cache.setOwnerDisplayName(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_OWNER, true, ""));
-            cache.setOwnerUserId(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_OWNER, true, "")); // set owner display name also as user id, as it's better than nothing ;-)
+            cache.setOwnerDisplayName(TextUtils.stripHtml(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_OWNER, true, "")));
+            cache.setOwnerUserId(TextUtils.stripHtml(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_OWNER, true, ""))); // set owner display name also as user id, as it's better than nothing ;-)
             cache.setDifficulty(Float.parseFloat(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_DIFFICULTY, true, "0")));
             cache.setTerrain(Float.parseFloat(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_TERRAIN, true, "0")));
             cache.setSize(CacheSize.getById(TextUtils.getMatch(pageIn, GCConstants.PATTERN_PREMIUMONLY_SIZE, true, CacheSize.NOT_CHOSEN.id)));


### PR DESCRIPTION
Posted in https://github.com/cgeo/cgeo/issues/9583#issue-774084772
> I do also see strange cache titles (e.g. for GC5G596) as presumably c:geo cannot resolve the unicode characters as it cannot open the PM cache.

Indeed, I forgot to unescape html characters while implementing the parsing for PM-only caches... This is now fixed with this PR!