### PR TITLE
use Dialogs.newBuilder for correct theming

### DIFF
--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -9,13 +9,13 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.view.View;
 import android.widget.ListView;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import java.lang.ref.WeakReference;
 import java.text.Collator;
@@ -107,9 +107,7 @@ public final class StoredList extends AbstractList {
             }
 
             final Activity activity = activityRef.get();
-            final AlertDialog.Builder builder = new AlertDialog.Builder(activity,
-                    Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert
-            );
+            final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
             builder.setTitle(res.getString(titleId));
             builder.setMultiChoiceItems(listTitles, selectedItems, new MultiChoiceClickListener(lists, selectedListIds));
             builder.setPositiveButton(android.R.string.ok, new OnOkClickListener(selectedListIds, runAfterwards, listNameMemento));


### PR DESCRIPTION
I switched from the androidx support library to the normal `android.app.AlertDialog` class to make use of our `Dialogs.newBuilder` function which fixes #9328 implicitly. 

I would guess using the support library is just a relict from the beginnings of c:geo and isn't needed anymore. However, lets target it to `master` to first see if nothing gets broken...