### PR TITLE
optimize names for new waypoints (related to #9041)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -60,6 +60,14 @@
     <string name="wp_waypoint">Reference Point</string>
     <string name="wp_original">Original Coordinates</string>
 
+    <!-- waypoints short names for new waypoints -->
+    <string name="wpnew_final">Final</string>
+    <string name="wpnew_stage">Stage</string>
+    <string name="wpnew_pkg">Parking</string>
+    <string name="wpnew_trailhead">Via</string>
+    <string name="wpnew_waypoint">Marker</string>
+    <string name="wpnew_original">Original</string>
+
     <!-- logs -->
     <string name="log_found">Found it</string>
     <string name="log_dnf">Didn\'t find it</string>

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -218,7 +218,9 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
 
         final List<String> wayPointTypes = new ArrayList<>();
         for (final WaypointType wpt : WaypointType.ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL) {
-            wayPointTypes.add(wpt.getL10n());
+            if (!wayPointTypes.contains(wpt.getNameForNewWaypoint())) {
+                wayPointTypes.add(wpt.getNameForNewWaypoint());
+            }
         }
         final ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, wayPointTypes);
         waypointName.setAdapter(adapter);

--- a/main/src/cgeo/geocaching/enumerations/WaypointType.java
+++ b/main/src/cgeo/geocaching/enumerations/WaypointType.java
@@ -3,7 +3,9 @@ package cgeo.geocaching.enumerations;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,14 +23,14 @@ import org.apache.commons.lang3.StringUtils;
  * Enum listing waypoint types
  */
 public enum WaypointType {
-    FINAL("flag", "f", "Final Location", R.string.wp_final, R.drawable.waypoint_flag, 3, R.drawable.dot_waypoint_flag),
-    OWN("own", "o", "Own", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 5, R.drawable.dot_waypoint),
-    PARKING("pkg", "p", "Parking Area", R.string.wp_pkg, R.drawable.waypoint_pkg, -1, R.drawable.dot_waypoint_pkg),
-    PUZZLE("puzzle", "x", "Virtual Stage", R.string.wp_puzzle, R.drawable.waypoint_puzzle, 2, R.drawable.dot_waypoint),
-    STAGE("stage", "s", "Physical Stage", R.string.wp_stage, R.drawable.waypoint_stage, 2, R.drawable.dot_waypoint),
-    TRAILHEAD("trailhead", "t", "Trailhead", R.string.wp_trailhead, R.drawable.waypoint_trailhead, 1, R.drawable.dot_waypoint),
-    WAYPOINT("waypoint", "w", "Reference Point", R.string.wp_waypoint, R.drawable.waypoint_waypoint, 2, R.drawable.dot_waypoint_reference),
-    ORIGINAL("original", "h", "Original Coordinates", R.string.wp_original, R.drawable.waypoint_waypoint, 4, R.drawable.dot_waypoint_reference);
+    FINAL("flag", "f", "Final Location", R.string.wp_final, R.string.wpnew_final, R.drawable.waypoint_flag, 3, R.drawable.dot_waypoint_flag),
+    OWN("own", "o", "Own", R.string.wp_waypoint, R.string.wpnew_waypoint, R.drawable.waypoint_waypoint, 5, R.drawable.dot_waypoint),
+    PARKING("pkg", "p", "Parking Area", R.string.wp_pkg, R.string.wpnew_pkg, R.drawable.waypoint_pkg, -1, R.drawable.dot_waypoint_pkg),
+    PUZZLE("puzzle", "x", "Virtual Stage", R.string.wp_puzzle, R.string.wpnew_stage, R.drawable.waypoint_puzzle, 2, R.drawable.dot_waypoint),
+    STAGE("stage", "s", "Physical Stage", R.string.wp_stage, R.string.wpnew_stage, R.drawable.waypoint_stage, 2, R.drawable.dot_waypoint),
+    TRAILHEAD("trailhead", "t", "Trailhead", R.string.wp_trailhead, R.string.wpnew_trailhead, R.drawable.waypoint_trailhead, 1, R.drawable.dot_waypoint),
+    WAYPOINT("waypoint", "w", "Reference Point", R.string.wp_waypoint, R.string.wpnew_waypoint, R.drawable.waypoint_waypoint, 2, R.drawable.dot_waypoint_reference),
+    ORIGINAL("original", "h", "Original Coordinates", R.string.wp_original, R.string.wpnew_original, R.drawable.waypoint_waypoint, 4, R.drawable.dot_waypoint_reference);
 
     @NonNull
     public static final List<WaypointType> ALL_TYPES = orderedWaypointTypes(false);
@@ -38,21 +40,23 @@ public enum WaypointType {
     @NonNull
     public final String id;
 
-    public final String shortId;
+    public final String shortId;        // for personal notes
 
     @NonNull
     public final String gpx;
-    public final int stringId;
+    public final int stringId;          // regular type identifier
+    public final int stringIdNewWpt;    // default name for new waypoints
     public final int markerId;
 
     public final int order;
     public final int dotMarkerId;
 
-    WaypointType(@NonNull final String id, @NonNull final String shortId, @NonNull final String gpx, final int stringId, final int markerId, final int order, final int dotMarkerId) {
+    WaypointType(@NonNull final String id, @NonNull final String shortId, @NonNull final String gpx, @StringRes final int stringId, @StringRes final int stringIdNewWpt, @DrawableRes final int markerId, final int order, @DrawableRes final int dotMarkerId) {
         this.id = id;
         this.shortId = shortId;
         this.gpx = gpx;
         this.stringId = stringId;
+        this.stringIdNewWpt = stringIdNewWpt;
         this.markerId = markerId;
         this.order = order;
         this.dotMarkerId = dotMarkerId;
@@ -106,6 +110,15 @@ public enum WaypointType {
             return name();
         }
         return CgeoApplication.getInstance().getBaseContext().getString(stringId);
+    }
+
+    @NonNull
+    public final String getNameForNewWaypoint() {
+        //enable local unit testing
+        if (CgeoApplication.getInstance() == null) {
+            return name();
+        }
+        return CgeoApplication.getInstance().getBaseContext().getString(stringIdNewWpt);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1645,7 +1645,7 @@ public class Geocache implements IWaypoint {
             if (!StringUtils.isBlank(searchWpName)) {
                 final String wpName = waypoint.getName();
                 final WaypointType wpType = waypoint.getWaypointType();
-                if (searchWpName.equals(wpName) && searchWp.getWaypointType().getL10n().equals(wpType.getL10n())) {
+                if (searchWpName.equals(wpName) && (searchWp.getWaypointType().getNameForNewWaypoint().equals(wpType.getNameForNewWaypoint()) || searchWp.getWaypointType().getL10n().equals(wpType.getL10n()))) {
                     return waypoint;
                 }
             }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1645,7 +1645,7 @@ public class Geocache implements IWaypoint {
             if (!StringUtils.isBlank(searchWpName)) {
                 final String wpName = waypoint.getName();
                 final WaypointType wpType = waypoint.getWaypointType();
-                if (searchWpName.equals(wpName) && (searchWp.getWaypointType().getNameForNewWaypoint().equals(wpType.getNameForNewWaypoint()) || searchWp.getWaypointType().getL10n().equals(wpType.getL10n()))) {
+                if (searchWpName.equals(wpName) && searchWp.getWaypointType().getL10n().equals(wpType.getL10n())) {
                     return waypoint;
                 }
             }

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.location.GeopointWrapper;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.MatcherWrapper;
 import cgeo.geocaching.utils.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -704,9 +705,18 @@ public class Waypoint implements IWaypoint {
         }
         // for other types add an index by default, which is highest found index + 1
         int max = 0;
-        for (int i = 0; i < 30; i++) {
-            if (wpNames.contains(type.getL10n() + " " + i) || wpNames.contains(type.getNameForNewWaypoint() + " " + i)) {
-                max = i;
+        final Pattern p = Pattern.compile("[^0-9]*([0-9]*)");
+        for (String wpName : wpNames) {
+            final MatcherWrapper match = new MatcherWrapper(p, wpName);
+            while (match.find()) {
+                try {
+                    final int i = Integer.parseInt(match.group(1));
+                    if (i > max) {
+                        max = i;
+                    }
+                } catch (NumberFormatException e) {
+                    // ignore
+                }
             }
         }
         return type.getNameForNewWaypoint() + " " + (max + 1);

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -479,7 +479,7 @@ public class Waypoint implements IWaypoint {
             }
         }
         for (final WaypointType wpType : WaypointType.ALL_TYPES) {
-            if (lowerInput.contains(wpType.getL10n().toLowerCase(Locale.getDefault()))) {
+            if (lowerInput.contains(wpType.getNameForNewWaypoint().toLowerCase(Locale.getDefault())) || lowerInput.contains(wpType.getL10n().toLowerCase(Locale.getDefault()))) {
                 return wpType;
             }
         }
@@ -699,17 +699,17 @@ public class Waypoint implements IWaypoint {
             wpNames.add(waypoint.getName());
         }
         // try final and trailhead without index
-        if ((type == WaypointType.FINAL || type == WaypointType.TRAILHEAD) && !wpNames.contains(type.getL10n())) {
-            return type.getL10n();
+        if ((type == WaypointType.FINAL || type == WaypointType.TRAILHEAD) && !wpNames.contains(type.getL10n()) && !wpNames.contains(type.getNameForNewWaypoint())) {
+            return type.getNameForNewWaypoint();
         }
         // for other types add an index by default, which is highest found index + 1
         int max = 0;
         for (int i = 0; i < 30; i++) {
-            if (wpNames.contains(type.getL10n() + " " + i)) {
+            if (wpNames.contains(type.getL10n() + " " + i) || wpNames.contains(type.getNameForNewWaypoint() + " " + i)) {
                 max = i;
             }
         }
-        return type.getL10n() + " " + (max + 1);
+        return type.getNameForNewWaypoint() + " " + (max + 1);
     }
 
     /**

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -480,7 +480,14 @@ public class Waypoint implements IWaypoint {
             }
         }
         for (final WaypointType wpType : WaypointType.ALL_TYPES) {
-            if (lowerInput.contains(wpType.getNameForNewWaypoint().toLowerCase(Locale.getDefault())) || lowerInput.contains(wpType.getL10n().toLowerCase(Locale.getDefault()))) {
+            // check the old, longer waypoint names first (to not interfere with the shortened versions)
+            if (lowerInput.contains(wpType.getL10n().toLowerCase(Locale.getDefault()))) {
+                return wpType;
+            }
+        }
+        for (final WaypointType wpType : WaypointType.ALL_TYPES) {
+            // then check the new, shortened versions
+            if (lowerInput.contains(wpType.getNameForNewWaypoint().toLowerCase(Locale.getDefault()))) {
                 return wpType;
             }
         }


### PR DESCRIPTION
Optimizes name handling for new waypoints:
- uses a short name for new waypoints (as described in https://github.com/cgeo/cgeo/issues/9041#issuecomment-697926825, "new WP default name")
- counter for new waypoints is no longer wp type-specific, but "global" (within this cache)
- detecting the highest given number is no longer limited to 30 but done with a regular expression, so if a wp is named "Stage 47", the next waypoint will get index 48.
- for comparison old + new name scheme are used to stay compatible

I did not swap the order of name and number, as this would either create confusion or require a migration of the existing waypoints. Let's see, if the shortened default names are sufficient for visibility in window titles already.