### PR TITLE
fix #9655: accomodate for legacy values in log image scale settings

### DIFF
--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1350,7 +1350,13 @@ public class Settings {
     }
 
     public static int getLogImageScale() {
-        return getInt(R.string.pref_logImageScale, -1);
+        final int scale = getInt(R.string.pref_logImageScale, -1);
+
+        //accomodate for legacy values which might be stored in preferences from former c:geo versions. See Issue #9655
+        if (scale < 0) {
+            return -1;
+        }
+        return scale < 512 ? 512 : scale;
     }
 
     public static void setLogImageScale(final int scale) {


### PR DESCRIPTION
fix #9655: accomodate for legacy values in log image scale settings