### PR TITLE
edit map behavior strings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1130,8 +1130,8 @@
     <string name="internal_goto_targets_description">This cache stores your recent \"Go to\" targets. It is automatically created once you have used the \"Go to\" function in the main menu. The coordinates entered there will be stored into waypoints of this cache. If you do no longer need these coordinates you can safely delete this cache or any of its waypoints. Also you can move the cache to any other list of your choice.</string>
     <string name="init_longtap_map">Long tap on map</string>
     <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache)</string>
-    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings - Map - Map behavior</string>
-    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings - Map - Map behavior</string>
+    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings → Map → Map behavior</string>
+    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings → Map → Map behavior</string>
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>


### PR DESCRIPTION
We had used the `>` character also at other places in our strings to direct users to a settings sub menu, so it would be consistent to use them here as well. 

Example:
`"Settings" > "Logging"` in the offline counter one time message

While I'm quite sure that we should use the `>` instead of `-` I'm wondering if we also want to use quotation marks here...?