### PR TITLE
un-distort custom images on map

### DIFF
--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -11,6 +11,7 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.DisplayMetrics;
+import android.util.Pair;
 import android.view.WindowManager;
 
 import androidx.annotation.DrawableRes;
@@ -52,9 +53,10 @@ public class DisplayUtils {
      * @param resToFitIn - resource to check
      * @return actual height
      */
-    public static int getDrawableHeight(final Resources res, @DrawableRes final int resToFitIn) {
+    public static Pair<Integer, Integer> getDrawableDimensions(final Resources res, @DrawableRes final int resToFitIn) {
         final Bitmap calc = BitmapFactory.decodeResource(res, resToFitIn);
-        return calc.getHeight();
+        return new Pair<>(calc.getWidth(), calc.getHeight());
+
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/cgeo/geocaching/utils/EmojiUtils.java
@@ -15,6 +15,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,8 +39,8 @@ public class EmojiUtils {
         final EmojiViewAdapter lruAdapter;
 
         // calc sizes
-        final int markerHeight = DisplayUtils.getDrawableHeight(activity.getResources(), R.drawable.marker_oc);
-        final int markerAvailable = (int) (markerHeight * 0.6);
+        final Pair<Integer, Integer> markerDimensions = DisplayUtils.getDrawableDimensions(activity.getResources(), R.drawable.marker_oc);
+        final int markerAvailable = (int) (markerDimensions.second * 0.6);
         final int markerFontsize = DisplayUtils.calculateMaxFontsize(35, 10, 100, markerAvailable);
 
         // data to populate the emoji selector with
@@ -79,7 +80,7 @@ public class EmojiUtils {
         if (currentValue == -1) {
             button2.setImageResource(R.drawable.ic_menu_mark);
         } else if (currentValue != 0) {
-            button2.setImageDrawable(getEmojiDrawable(activity.getResources(), markerHeight, markerAvailable, markerFontsize, currentValue));
+            button2.setImageDrawable(getEmojiDrawable(activity.getResources(), markerDimensions, markerAvailable, markerFontsize, currentValue));
         } else if (defaultRes != 0) {
             button2.setImageResource(defaultRes);
         }
@@ -152,20 +153,20 @@ public class EmojiUtils {
     /**
      * builds a drawable the size of a marker with a given text
      * @param res - the resources to use
-     * @param bitmapSize - actual size of the bitmap to place the text in
+     * @param bitmapDimensions - actual size (width/height) of the bitmap to place the text in
      * @param availableSize - available size
      * @param fontsize - fontsize to use
      * @param emoji codepoint of the emoji to display
      * @return drawable bitmap with text on it
      */
-    public static BitmapDrawable getEmojiDrawable(final Resources res, final int bitmapSize, final int availableSize, final int fontsize, final int emoji) {
+    public static BitmapDrawable getEmojiDrawable(final Resources res, final Pair<Integer, Integer> bitmapDimensions, final int availableSize, final int fontsize, final int emoji) {
         final String text = new String(Character.toChars(emoji));
         final TextPaint tPaint = new TextPaint();
         tPaint.setTextSize(fontsize);
-        final Bitmap bm = Bitmap.createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ARGB_8888);
+        final Bitmap bm = Bitmap.createBitmap(bitmapDimensions.first, bitmapDimensions.second, Bitmap.Config.ARGB_8888);
         final Canvas canvas = new Canvas(bm);
         final StaticLayout lsLayout = new StaticLayout(text, tPaint, availableSize, Layout.Alignment.ALIGN_CENTER, 1, 0, false);
-        final int deltaTopLeft = (int) (0.3 * (bitmapSize - availableSize));
+        final int deltaTopLeft = (int) (0.4 * (bitmapDimensions.first - availableSize));
         canvas.translate(deltaTopLeft, deltaTopLeft + (int) ((availableSize - lsLayout.getHeight()) / 2));
         lsLayout.draw(canvas);
         canvas.save();

--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -21,6 +21,7 @@ import cgeo.geocaching.utils.builders.InsetsBuilder;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.util.Pair;
 import android.util.SparseArray;
 
 import androidx.annotation.NonNull;
@@ -41,7 +42,7 @@ public final class MapMarkerUtils {
     private static Boolean listsRead = false;
 
     private static final SparseArray<CacheMarker> overlaysCache = new SparseArray<>();
-    private static int markerHeight = 0;
+    private static Pair<Integer, Integer> markerDimensions = null;
     private static int markerAvailable = 0;
     private static int markerFontsize = 0;
 
@@ -238,12 +239,12 @@ public final class MapMarkerUtils {
         final int mainMarkerId = getMainMarkerId(cache, cacheListType);
         final boolean doubleSize = showBigSmileys(cacheListType) && mainMarkerId != cache.getType().markerId;
         if (useEmoji > 0 && !doubleSize) {
-            if (markerHeight == 0) {
-                markerHeight = DisplayUtils.getDrawableHeight(res, R.drawable.marker_oc);
-                markerAvailable = (int) (markerHeight * 0.6);
+            if (markerDimensions == null) {
+                markerDimensions = DisplayUtils.getDrawableDimensions(res, R.drawable.marker_oc);
+                markerAvailable = (int) (markerDimensions.first * 0.6);
                 markerFontsize = DisplayUtils.calculateMaxFontsize(35, 10, 100, markerAvailable);
             }
-            insetsBuilder.withInset(new InsetBuilder(EmojiUtils.getEmojiDrawable(res, markerHeight, markerAvailable, markerFontsize, useEmoji)));
+            insetsBuilder.withInset(new InsetBuilder(EmojiUtils.getEmojiDrawable(res, markerDimensions, markerAvailable, markerFontsize, useEmoji)));
         } else {
             insetsBuilder.withInset(new InsetBuilder(mainMarkerId, VERTICAL.CENTER, HORIZONTAL.CENTER, doubleSize));
         }
@@ -274,7 +275,6 @@ public final class MapMarkerUtils {
         if (markerId > 0) {
             insetsBuilder.withInset(new InsetBuilder(ListMarker.getResDrawable(markerId), VERTICAL.CENTER, HORIZONTAL.LEFT));
         }
-
         markerId = (assignedMarkers >> ListMarker.MAX_BITS_PER_MARKER) & ListMarker.BITMASK;
         if (markerId > 0) {
             insetsBuilder.withInset(new InsetBuilder(ListMarker.getResDrawable(markerId), VERTICAL.CENTER, HORIZONTAL.RIGHT));


### PR DESCRIPTION
Currently a custom icon gets distorted (stretched horizontally) when drawn on the map, caused by the assumption of the underlying map markers being a square (which they aren't). This PR fixes that by handling height and width separately.