### PR TITLE
set 'vote' menu entry to greyed out, if connector inactive

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -681,7 +681,9 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                 menu.findItem(R.id.menu_challenge_checker).setVisible(((PgcChallengeCheckerCapability) connector).isChallengeCache(cache));
             }
             if (connector instanceof IVotingCapability) {
-                menu.findItem(R.id.menu_gcvote).setVisible(((IVotingCapability) connector).supportsVoting(cache));
+                final MenuItem menuItemGCVote = menu.findItem(R.id.menu_gcvote);
+                menuItemGCVote.setVisible(((IVotingCapability) connector).supportsVoting(cache));
+                menuItemGCVote.setEnabled(Settings.isRatingWanted() && Settings.isGCVoteLoginValid());
             }
         }
         return super.onPrepareOptionsMenu(menu);


### PR DESCRIPTION
Related to https://github.com/cgeo/cgeo/discussions/9692:

Grey out the "vote" menu entry in cache details when either the GCVote connector is disabled or credentials are incomplete.
(It is already hidden when the current cache does not support GCVote.)