### PR TITLE
cache icon selection + groups

### DIFF
--- a/main/res/layout/emojiselector.xml
+++ b/main/res/layout/emojiselector.xml
@@ -4,10 +4,29 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <!--
+    <LinearLayout
+        android:id="@+id/emoji_groups"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" />
+
+    -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/emoji_groups"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <View
+        android:id="@+id/emoji_group_separator"
+        style="@style/separator_horizontal"
+        android:layout_below="@id/emoji_groups" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/emoji_grid"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_below="@id/emoji_group_separator"/>
 
     <View
         android:id="@+id/emoji_grid_separator"

--- a/main/res/layout/emojiselector_item.xml
+++ b/main/res/layout/emojiselector_item.xml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal"
+    android:orientation="vertical"
     android:padding="5dp"
-    android:layout_width="40dp"
-    android:layout_height="40dp">
+    android:layout_width="60dp"
+    android:layout_height="60dp">
 
     <TextView
         android:id="@+id/info_text"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:textSize="24sp"
         android:gravity="center"/>
 
-</LinearLayout>
+    <View
+        android:id="@+id/separator"
+        style="@style/separator_horizontal"
+        android:layout_alignParentBottom="true"
+        android:visibility="invisible" />
+</RelativeLayout>

--- a/main/src/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/cgeo/geocaching/utils/EmojiUtils.java
@@ -29,48 +29,110 @@ import androidx.recyclerview.widget.RecyclerView;
 
 public class EmojiUtils {
 
+    // list of emojis supported by the EmojiPopup
+    // should be supported by the Android API level we have set as minimum (currently API 21 = Android 5)
+    // for a list of supported Unicode standards by API level see https://developer.android.com/guide/topics/resources/internationalization
+    // for characters by Unicode version see https://unicode.org/emoji/charts-5.0/full-emoji-list.html (v5.0)
+
+    private static final EmojiSet[] symbols = {
+        // category symbols
+        new EmojiSet(0x2764, new int[]{
+            /* hearts */        0x2764, 0x1f499, 0x1f49a, 0x1f49b, 0x1f49c, 0x1f9e1, 0x1f49c, 0x1f5a4,
+            /* events */        0x1f383, 0x1f380,
+            /* office */        0x1f4c6,
+            /* warning */       0x26d4, 0x1f6d1, 0x2622,
+            /* av-symbol */     0x1f506,
+            /* other-symbol */  0x2b55, 0x2714, 0x2716, 0x274c, 0x203c, 0x2049, 0x2753, 0x2757,
+            /* geometric */     0x1f536, 0x1f537, 0x26aa, 0x26ab, 0x1f534, 0x1f535,
+            /* flags */         0x1f3c1, 0x1f6a9, 0x1f3f4, 0x1f3f3
+        }),
+        // category places
+        new EmojiSet(0x1f5fa, new int[]{
+            /* globe */         0x1f30d, 0x1f30e, 0x1f30f,
+            /* geographic */    0x1f3d4, 0x1f3d6, 0x1f3dc, 0x1f3dd, 0x1f3de,
+            /* buildings */     0x1f3e0, 0x1f3e2, 0x1f3da, 0x1f3e5, 0x1f3f0, 0x16cf,
+            /* other */         0x26f2, 0x2668, 0x1f3ad, 0x1f3a8,
+            /* plants */        0x1f332, 0x1f333, 0x1f334, 0x1f335, 0x1f340,
+            /* transport */     0x1f682, 0x1f68d, 0x1f695, 0x1f6b2, 0x1f697, 0x2693, 0x26f5, 0x2708, 0x1f680,
+            /* transp.-sign */  0x267f, 0x1f6bb
+        }),
+        // category food
+        new EmojiSet(0x1f968, new int[]{
+            /* fruits */        0x1f34a, 0x1f34b, 0x1f34d, 0x1f34e, 0x1f34f, 0x1f95d, 0x1f336, 0x1f344,
+            /* other */         0x1f968, 0x1f354, 0x1f355,
+            /* drink */         0x1f964, 0x2615, 0x1f37a
+        }),
+        // category activity
+        new EmojiSet(0x1f3c3, new int[]{
+            /* person-sport */  0x26f7, 0x1f3c4, 0x1f6a3, 0x1f3ca, 0x1f6b4
+
+        }),
+        // category people
+        new EmojiSet(0x1f600, new int[]{
+            /* smileys */       0x1f600, 0x1f60d, 0x1f641, 0x1f621, 0x1f47b,
+            /* people */        0x1f466, 0x1f467, 0x1f468, 0x1f469, 0x1f474, 0x1f475
+        }),
+
+    };
+
+    private static class EmojiSet {
+        public int tabSymbol;
+        public int[] symbols;
+
+        EmojiSet(final int tabSymbol, final int[] symbols) {
+            this.tabSymbol = tabSymbol;
+            this.symbols = symbols;
+        }
+    }
+
     private EmojiUtils() {
         // utility class
     }
 
     public static void selectEmojiPopup(final Activity activity, final int currentValue, @DrawableRes final int defaultRes, final Action1<Integer> setNewCacheIcon) {
 
+        final EmojiViewAdapter groupsAdapter;
         final EmojiViewAdapter gridAdapter;
         final EmojiViewAdapter lruAdapter;
 
         // calc sizes
-        final Pair<Integer, Integer> markerDimensions = DisplayUtils.getDrawableDimensions(activity.getResources(), R.drawable.marker_oc);
+        final Pair<Integer, Integer> markerDimensions = DisplayUtils.getDrawableDimensions(activity.getResources(), R.drawable.ic_menu_filter);
         final int markerAvailable = (int) (markerDimensions.second * 0.6);
-        final int markerFontsize = DisplayUtils.calculateMaxFontsize(35, 10, 100, markerAvailable);
-
-        // data to populate the emoji selector with
-        // !! those values are for testing purposes only currently !!
-        // @todo: set actual list of characters to be supported
-        final int[] emojiList = new int[50];
-        for (int i = 0; i < 50; i++) {
-            emojiList[i] = 0x1f334 + i;
-        }
-        final int[] lru = EmojiLRU.getLRU();
+        final int markerFontsize = DisplayUtils.calculateMaxFontsize(35, 10, 150, markerAvailable);
 
         final View dialogView = activity.getLayoutInflater().inflate(R.layout.emojiselector, null);
-
-        final int maxCols = DisplayUtils.calculateNoOfColumns(activity, 40);
-        final RecyclerView emojiGrid = dialogView.findViewById(R.id.emoji_grid);
-        emojiGrid.setLayoutManager(new GridLayoutManager(activity, maxCols));
-        final RecyclerView emojiLru = dialogView.findViewById(R.id.emoji_lru);
-        emojiLru.setLayoutManager(new GridLayoutManager(activity, maxCols));
-
         final View customTitle = activity.getLayoutInflater().inflate(R.layout.dialog_title_button_button, null);
         final AlertDialog dialog = Dialogs.newBuilder(activity)
             .setView(dialogView)
             .setCustomTitle(customTitle)
             .create();
 
-        gridAdapter = new EmojiViewAdapter(activity, emojiList, newCacheIcon -> onItemSelected(dialog, setNewCacheIcon, newCacheIcon));
-        emojiGrid.setAdapter(gridAdapter);
+        final int maxCols = DisplayUtils.calculateNoOfColumns(activity, 60);
+        final RecyclerView emojiGridView = dialogView.findViewById(R.id.emoji_grid);
+        emojiGridView.setLayoutManager(new GridLayoutManager(activity, maxCols));
+        gridAdapter = new EmojiViewAdapter(activity, symbols[0].symbols, currentValue, false, newCacheIcon -> onItemSelected(dialog, setNewCacheIcon, newCacheIcon));
+        emojiGridView.setAdapter(gridAdapter);
 
-        lruAdapter = new EmojiViewAdapter(activity, lru, newCacheIcon -> onItemSelected(dialog, setNewCacheIcon, newCacheIcon));
-        emojiLru.setAdapter(lruAdapter);
+        final RecyclerView emojiGroupView = dialogView.findViewById(R.id.emoji_groups);
+        emojiGroupView.setLayoutManager(new GridLayoutManager(activity, symbols.length));
+        final int[] emojiGroups = new int[symbols.length];
+        for (int i = 0; i < symbols.length; i++) {
+            emojiGroups[i] = symbols[i].tabSymbol;
+        }
+        groupsAdapter = new EmojiViewAdapter(activity, emojiGroups, symbols[0].tabSymbol, true, newgroup -> {
+            for (EmojiSet symbol : symbols) {
+                if (symbol.tabSymbol == newgroup) {
+                    gridAdapter.setData(symbol.symbols);
+                }
+            }
+        });
+        emojiGroupView.setAdapter(groupsAdapter);
+
+        final RecyclerView emojiLruView = dialogView.findViewById(R.id.emoji_lru);
+        emojiLruView.setLayoutManager(new GridLayoutManager(activity, maxCols));
+        final int[] lru = EmojiLRU.getLRU();
+        lruAdapter = new EmojiViewAdapter(activity, lru, 0, false, newCacheIcon -> onItemSelected(dialog, setNewCacheIcon, newCacheIcon));
+        emojiLruView.setAdapter(lruAdapter);
 
         ((TextView) customTitle.findViewById(R.id.dialog_title_title)).setText(R.string.cache_menu_set_cache_icon);
 
@@ -100,22 +162,31 @@ public class EmojiUtils {
         dialog.show();
     }
 
-    private static void onItemSelected(final AlertDialog dialog, final Action1<Integer> setNewCacheIcon, final int newCacheIcon) {
+    private static void onItemSelected(final AlertDialog dialog, final Action1<Integer> callback, final int selectedValue) {
         dialog.dismiss();
-        EmojiLRU.add(newCacheIcon);
-        setNewCacheIcon.call(newCacheIcon);
+        EmojiLRU.add(selectedValue);
+        callback.call(selectedValue);
     }
 
     private static class EmojiViewAdapter extends RecyclerView.Adapter<EmojiViewAdapter.ViewHolder> {
 
-        private final int[] data;
+        private int[] data;
         private final LayoutInflater inflater;
-        private final Action1<Integer> setNewCacheIcon;
+        private final Action1<Integer> callback;
+        private int currentValue = 0;
+        private final boolean highlightCurrent;
 
-        EmojiViewAdapter(final Context context, final int[] data, final Action1<Integer> setNewCacheIcon) {
+        EmojiViewAdapter(final Context context, final int[] data, final int currentValue, final boolean hightlightCurrent, final Action1<Integer> callback) {
             this.inflater = LayoutInflater.from(context);
+            this.setData(data);
+            this.currentValue = currentValue;
+            this.highlightCurrent = hightlightCurrent;
+            this.callback = callback;
+        }
+
+        public void setData(final int[] data) {
             this.data = data;
-            this.setNewCacheIcon = setNewCacheIcon;
+            notifyDataSetChanged();
         }
 
         @Override
@@ -128,7 +199,16 @@ public class EmojiUtils {
         @Override
         public void onBindViewHolder(@NonNull final EmojiViewAdapter.ViewHolder holder, final int position) {
             holder.tv.setText(new String(Character.toChars(data[position])));
-            holder.bind(data[position], setNewCacheIcon);
+            if (highlightCurrent) {
+                holder.sep.setVisibility(currentValue == data[position] ? View.VISIBLE : View.INVISIBLE);
+            }
+            holder.itemView.setOnClickListener(v -> {
+                currentValue = data[position];
+                callback.call(currentValue);
+                if (highlightCurrent) {
+                    notifyDataSetChanged();
+                }
+            });
         }
 
         @Override
@@ -138,16 +218,15 @@ public class EmojiUtils {
 
         public static class ViewHolder extends RecyclerView.ViewHolder {
             protected TextView tv;
+            protected View sep;
 
             ViewHolder(final View itemView) {
                 super(itemView);
                 tv = itemView.findViewById(R.id.info_text);
-            }
-
-            public void bind(final int item, final Action1<Integer> setNewCacheIcon) {
-                itemView.setOnClickListener(v -> setNewCacheIcon.call(item));
+                sep = itemView.findViewById(R.id.separator);
             }
         }
+
     }
 
     /**


### PR DESCRIPTION
Implements a first version of characters for the custom icon selector according to the discussion in #9717:

- enlarge icon display
- implement a standard set of selectable chars (WIP)
- display them in categories in the selector

I've chosen the following categories:
- symbols
- places
- foot
- activity
- people

and assigned a couple of icons to each category (although not yet complete, but you get the impression).

I've taken all symbols from the Unicode v5.0 list, which, according to Google's own documentation should be supported even on API 21 devices. (But, at least in the emulator, are not. I need to check whether I can detect this at runtime and skip such icons.)

Here's a screenshot from current implementation:

![image](https://user-images.githubusercontent.com/3754370/103937543-29b26c00-5129-11eb-87a4-7d04aa32d36f.png)

The popup is divided into four sections:
- title bar (title and buttons for reset and ok)
- category selector (5 categories, active is marked)
- symbol selector
- lru list (last up to 10 symbols)

