### PR TITLE
support description edit for UDC (fix #9713)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1088,6 +1088,8 @@
     <string name="cache_name">Name</string>
     <string name="cache_name_set">Set cachename</string>
     <string name="cache_name_updated">Cachename updated</string>
+    <string name="cache_description_set">Set cache description</string>
+    <string name="cache_description_updated">Cache description updated</string>
     <string name="cache_type">Type</string>
     <string name="cache_size">Size</string>
     <string name="cache_distance">Distance</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -118,6 +118,7 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
+import android.text.method.ScrollingMovementMethod;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ClickableSpan;
 import android.text.style.ForegroundColorSpan;
@@ -132,6 +133,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -1598,8 +1600,8 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             }
 
             // long description
-            if (StringUtils.isNotBlank(cache.getDescription())) {
-                loadLongDescription();
+            if (StringUtils.isNotBlank(cache.getDescription()) || cache.supportsDescriptionchange()) {
+                loadLongDescription(parentView);
             }
 
             // cache personal note
@@ -1716,11 +1718,42 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             }));
         }
 
-        private void loadLongDescription() {
+        private void loadLongDescription(final ViewGroup parentView) {
             loadingView.setVisibility(View.VISIBLE);
 
             final String longDescription = cache.getDescription();
             loadDescription(longDescription, descView, loadingView);
+
+            if (cache.supportsDescriptionchange()) {
+                descView.setOnClickListener(v -> {
+                    final Context context = parentView.getContext();
+                    final EditText editText = new EditText(context);
+                    editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+                    editText.setImeOptions(EditorInfo.IME_FLAG_NO_ENTER_ACTION);
+                    editText.setSingleLine(false);
+                    editText.setLines(5);
+                    editText.setMaxLines(10);
+                    editText.setVerticalScrollBarEnabled(true);
+                    editText.setMovementMethod(ScrollingMovementMethod.getInstance());
+                    editText.setScrollBarStyle(View.SCROLLBARS_INSIDE_INSET);
+                    editText.setText(cache.getDescription());
+                    Dialogs.moveCursorToEnd(editText);
+
+                    Dialogs.newBuilder(context)
+                        .setTitle(R.string.cache_description_set)
+                        .setView(editText)
+                        .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
+                            descView.setText(editText.getText().toString());
+                            cache.setDescription(editText.getText().toString());
+                            DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
+                            Toast.makeText(context, R.string.cache_description_updated, Toast.LENGTH_SHORT).show();
+                        })
+                        .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })
+                        .show()
+                    ;
+                });
+            }
+
         }
 
         private void warnPersonalNoteExceedsLimit() {

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -93,7 +93,13 @@ public abstract class AbstractConnector implements IConnector {
         return new NoLoggingManager();
     }
 
+    @Override
     public boolean supportsNamechange() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsDescriptionchange() {
         return false;
     }
 

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -94,6 +94,12 @@ public interface IConnector {
     boolean supportsNamechange();
 
     /**
+     * enable/disable changing the description of a cache
+     *
+     */
+    boolean supportsDescriptionchange();
+
+    /**
      * Get host name of the connector server for dynamic loading of data.
      *
      */

--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -126,6 +126,11 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     @Override
+    public boolean supportsDescriptionchange() {
+        return true;
+    }
+
+    @Override
     public SearchResult searchByGeocode(@Nullable final String geocode, @Nullable final String guid, final DisposableHandler handler) {
 
         DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_loadpage);

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -773,6 +773,10 @@ public class Geocache implements IWaypoint {
         return getConnector().supportsNamechange();
     }
 
+    public boolean supportsDescriptionchange() {
+        return getConnector().supportsDescriptionchange();
+    }
+
     private String getShareSubject() {
         final StringBuilder subject = new StringBuilder("Geocache ");
         subject.append(geocode);


### PR DESCRIPTION
Simple text editor field for a quick change of UDC description:

![image](https://user-images.githubusercontent.com/3754370/103944909-a39c2280-5134-11eb-816b-b0eb8e57a2ae.png)

Can be enabled on a per-connector base, default is "not supported".
