### PR TITLE
More logical order in menu "History track"

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -119,12 +119,12 @@
                 android:title="@string/map_trail_show">
             </item>
             <item
-                android:id="@+id/menu_export_trailhistory"
-                android:title="@string/export_trailhistory_title">
-            </item>
-            <item
                 android:id="@+id/menu_trail_hide"
                 android:title="@string/map_trail_hide">
+            </item>
+            <item
+                android:id="@+id/menu_export_trailhistory"
+                android:title="@string/export_trailhistory_title">
             </item>
             <item
                 android:id="@+id/menu_clear_trailhistory"


### PR DESCRIPTION
After this change, we will always have three items in the menu:
1. Show / Hide
2. Export
3. Clean

Now it is illogical:
1. Show
2. Export
3. Clean

and
1. Export
2. Hide
3. Clean