### PR TITLE
rel to #9609: prepare offline log image migration to SAF

### DIFF
--- a/main/src/cgeo/geocaching/models/Image.java
+++ b/main/src/cgeo/geocaching/models/Image.java
@@ -95,18 +95,6 @@ public class Image implements Parcelable {
         }
 
         /**
-         * Set image from File.
-         *
-         * @param file
-         *          The image url from File
-         */
-        @NonNull
-        public Builder setUrl(@NonNull final File file) {
-            uri = Uri.fromFile(file);
-            return this;
-        }
-
-        /**
          * Set image from Image.
          *
          * @param image
@@ -338,20 +326,6 @@ public class Image implements Parcelable {
         return FileUtils.urlToFile(uri.toString());
     }
 
-    /**
-     * Check if the image exists locally.
-     * Return False if Image is not local.
-     * Todo: May check if we have a cached Image for remote Uri
-     *
-     * @return
-     *          True if image exists on local filesystem
-     */
-    public boolean existsLocal() {
-        if (!isLocalFile()) {
-            return false;
-        }
-        return new File(getPath()).exists();
-    }
 
     /**
      * Check if the image Uri is Empty.

--- a/tests/src-android/cgeo/geocaching/models/ImageTest.java
+++ b/tests/src-android/cgeo/geocaching/models/ImageTest.java
@@ -49,8 +49,8 @@ public class ImageTest extends CGeoTestCase {
     }
 
     public static void testFileConstructor() throws Exception {
-        final Image image1 = new Image.Builder().setUrl(FileUtils.urlToFile(FILE1)).build();
-        final Image image2 = new Image.Builder().setUrl(FileUtils.urlToFile(FILE2)).build();
+        final Image image1 = new Image.Builder().setUrl(Uri.fromFile(FileUtils.urlToFile(FILE1))).build();
+        final Image image2 = new Image.Builder().setUrl(Uri.fromFile(FileUtils.urlToFile(FILE2))).build();
 
         assertThat(image1).isNotEqualTo(Image.NONE);
         assertThat(image2).isNotEqualTo(Image.NONE);
@@ -116,12 +116,6 @@ public class ImageTest extends CGeoTestCase {
         assertThat(image2.isLocalFile()).isFalse();
         assertThat(image3.isLocalFile()).isTrue();
         assertThat(image4.isLocalFile()).isFalse();
-    }
-
-    public static void testLocalFile() throws Exception {
-        final Image image1 = new Image.Builder().setUrl(FILE1).build();
-
-        assertThat(image1.localFile()).isEqualTo(FileUtils.urlToFile(FILE1));
     }
 
     public static void testGetUrl() throws Exception {


### PR DESCRIPTION
This PR contains necessary refactorings in master before offline log images can be migrated to SAF.

Basically, ImageUtils and related classes are converted to use Uris & InputStreams instead of Files. Placeholder methods which will later converted to use SAF methods are marked accordingly with TODO tags. 