### PR TITLE
check glyph availability for custom icons

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -415,6 +415,8 @@
     <string name="caches_set_listmarker">Set list marker</string>
     <string name="caches_listmarker_none">No marker</string>
     <string name="caches_listmarker_selected">(selected)</string>
+    <string name="onetime_missing_unicode_title">Select emoji</string>
+    <string name="onetime_missing_unicode_info">Your Android version does not support automatic detection of icons supported - some characters may be missing</string>
 
     <!-- caches lists -->
     <string name="menu_lists">Manage lists</string>

--- a/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -26,7 +26,8 @@ public class OneTimeDialogs extends DataStore.DBExtension {
         DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS, 0),
         MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0),
         MAP_LONG_TAP_DISABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_disabled, DefaultBehavior.SHOW_ALWAYS, R.string.manual_url_mapbehavior),
-        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS, R.string.manual_url_mapbehavior);
+        MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS, R.string.manual_url_mapbehavior),
+        MISSING_UNICODE_CHARACTERS(R.string.onetime_missing_unicode_title, R.string.onetime_missing_unicode_info, DefaultBehavior.SHOW_ALWAYS, 0);
 
         public final Integer messageTitle;
         public final Integer messageText;


### PR DESCRIPTION
- Android 6+: Automatically removes unsupported characters from emoji selector
- Android 5: Shows a OneTimeMessage about not being able to auto-filter unsupported characters
- Selected icons for icon groups which are supported even on Android 5

Android 5:
![image](https://user-images.githubusercontent.com/3754370/104074314-10d0b600-5210-11eb-8669-4947650afc78.png).![image](https://user-images.githubusercontent.com/3754370/104074328-1b8b4b00-5210-11eb-9c7c-3d8e4afb5169.png)

Android 6 vs. Android 10:
![image](https://user-images.githubusercontent.com/3754370/104074350-2d6cee00-5210-11eb-8985-00f8a85551c4.png).![image](https://user-images.githubusercontent.com/3754370/104074364-3493fc00-5210-11eb-9cd6-564c59d93e5a.png)
