### PR TITLE
retain prevWptFromNotes and assignedEmoji on cache reload (fix #9736)

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -361,6 +361,14 @@ public class Geocache implements IWaypoint {
             reliableLatLon = other.reliableLatLon;
         }
 
+        if (!preventWaypointsFromNote) {
+            preventWaypointsFromNote = other.preventWaypointsFromNote;
+        }
+
+        if (assignedEmoji == 0) {
+            assignedEmoji = other.assignedEmoji;
+        }
+
         this.eventTimeMinutes = null; // will be recalculated if/when necessary
         return isEqualTo(other);
     }


### PR DESCRIPTION
- retains the stored value for assigned custom icon on cache reload (fix #9736)
- retains the stored value for "prevent waypoints from note" on cache reload (IIRC that's hidden somewhere in some comment, does not have its own issue)

Both are settings which are c:geo-internal, cannot be taken from a downloaded geocache page, and therefore got lost in the past.