### PR TITLE
never show configuration wizard as menu action

### DIFF
--- a/main/res/menu/main_activity_options.xml
+++ b/main/res/menu/main_activity_options.xml
@@ -27,7 +27,7 @@
         android:id="@+id/menu_wizard"
         android:icon="@drawable/ic_menu_preferences"
         android:title="@string/wizard"
-        app:showAsAction="ifRoom">
+        app:showAsAction="never">
     </item>
     <item
         android:id="@+id/menu_settings"


### PR DESCRIPTION
It is not really intuitive to have two identical icons with different meanings. As an unambiguous "configuration wizard icon" does not exist, it's the best to always hide the icon...

Before it was like this:
![grafik](https://user-images.githubusercontent.com/64581222/104092296-52e70f80-5283-11eb-8f24-64bf05ca8f67.png)
