### PR TITLE
allow sorting also when in selection mode

### DIFF
--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -303,7 +303,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
     }
 
     public void forceSort() {
-        if (CollectionUtils.isEmpty(list) || selectMode) {
+        if (CollectionUtils.isEmpty(list)) {
             return;
         }
 
@@ -331,9 +331,6 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
     private void updateSortByDistance() {
         if (CollectionUtils.isEmpty(list)) {
-            return;
-        }
-        if (selectMode) {
             return;
         }
         if ((System.currentTimeMillis() - lastSort) <= PAUSE_BETWEEN_LIST_SORT) {


### PR DESCRIPTION
fixes #4507 and partly #6672

It looks like this was explicitly introduced, but I can't find a reason for it. All my resorting tests work fine, also when in selection mode. Looking at the history, it is there since 2012. I have read through some issues linked in the old commit messages but it seems like as there was no real reason, so let's remove it...