### PR TITLE
do not reset last viewport on every location cycle (related to #9374)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/StoredCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/StoredCachesOverlay.java
@@ -67,12 +67,12 @@ public class StoredCachesOverlay extends AbstractCachesOverlay {
                 if (moved) {
 
                     previousZoom = zoomNow;
+                    previousViewport = viewportNow;
                     overlay.load();
                     overlay.refreshed();
                 } else if (!previousViewport.equals(viewportNow)) {
                     overlay.updateTitle();
                 }
-                previousViewport = viewportNow;
             } catch (final Exception e) {
                 Log.w("StoredCachesOverlay.startLoadtimer.start", e);
             }


### PR DESCRIPTION
reverts part of an unnecessary change introduced by #8389

See https://github.com/cgeo/cgeo/issues/9374#issuecomment-761205884 for more info.

