### PR TITLE
make sure map zoom level is within bounds on map source change

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -721,6 +721,14 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
             mapView.setZoomLevelMax(newLayer.getZoomLevelMax());
             mapView.setZoomLevelMin(newLayer.getZoomLevelMin());
 
+            // make sure map zoom level is within new zoom level boundaries
+            final int currentZoomLevel = mapView.getMapZoomLevel();
+            if (currentZoomLevel < newLayer.getZoomLevelMin()) {
+                mapView.setMapZoomLevel(newLayer.getZoomLevelMin());
+            } else if (currentZoomLevel > newLayer.getZoomLevelMax()) {
+                mapView.setMapZoomLevel(newLayer.getZoomLevelMax());
+            }
+
             final Layers layers = this.mapView.getLayerManager().getLayers();
             int index = 0;
             if (oldLayer != null) {


### PR DESCRIPTION
Checks whether current map zoom level is within zoom level bounds of selected OSM map source. Works for changes within OSM (offline/online) as well as from Google Maps to OSM.

see https://github.com/cgeo/cgeo/issues/9752#issuecomment-761805338
