### PR TITLE
configure dependabot and changes in result of dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
       # Ignore some updates to the apache 'commons-io' package
       # commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
       - dependency-name: "commons-io:commons-io"
+      # Ignore some updates to the 'assertj' package
+      # Ignore only new versions for >= 3.x
+      - dependency-name: "org.assertj:assertj-core"
+        versions: ["3.x"]

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,9 @@ allprojects {
                             selection.reject('Release candidate')
                         }
 
-                        // https://github.com/joel-costigliola/assertj-core/issues/345
+                        // see https://assertj.github.io/doc/#assertj-core-android
+                        // AssertJ Core 3.x is compatible with Android API Level 26+, except for soft assertions and assumptions.
+                        // AssertJ Core 2.x is Android compatible with Android API Level 26+ and API Level < 26 except for Path assertions.
                         if (selection.candidate.group == 'org.assertj' && selection.candidate.module == 'assertj-core' && selection.candidate.version.substring(0,1).toInteger() > 2) {
                             selection.reject("assertj 3.x or higher requires Java 7 SE classes not available in Android")
                         }

--- a/build.gradle
+++ b/build.gradle
@@ -109,9 +109,9 @@ allprojects {
                 // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
                 force 'com.google.guava:guava:26.0-jre'
 
-                // force this version because of bug in gradle 4.1.0 (referencing 4.1.0-alpha01-6193524)
-                // TODO check after gradle update
-                force 'com.android.tools.build:aapt2-proto:4.1.0-6503028'
+                // force this version because of conflict to our resolutionStrategy from lint-gradle 4.1.2 (referencing 4.1.0-alpha01-6193524)
+                // TODO check after gradle update (gradlew :main:lintBasicDebug)
+                force 'com.android.tools.build:aapt2-proto:4.1.1-6503028'
             }
         }
     }


### PR DESCRIPTION
- dependabot configure assertj restriction
- make description for the assertj gradle restriction clearer
- remove fix for gradle plugin problem, it is no more necessary
