### PR TITLE
Remove some relics from the time of Eclipse

### DIFF
--- a/main/project/findbugs/exclusions.xml
+++ b/main/project/findbugs/exclusions.xml
@@ -47,7 +47,7 @@
 	    <Class name="~.*Test"/>
 	</Match>
 
-	<!-- To many false positives here. The same issue will also be found by Eclipse locally, so we should be fine. -->
+	<!-- To many false positives here. The same issue will also be found by Android Studio locally, so we should be fine. -->
 	<Match>
 	    <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
 	</Match>

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -248,7 +248,6 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
         } else {
             title = StringUtils.isNotBlank(geocode) ? geocode : res.getString(R.string.cache);
         }
-        assert title != null; // help Eclipse null analysis
         setCacheTitleBar(title, type);
     }
 

--- a/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
@@ -218,7 +218,6 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
 
                 int status = STATUS_ERROR;
                 if (StringUtils.isNotBlank(line)) {
-                    assert line != null;
                     final MatcherWrapper paramsMatcher1 = new MatcherWrapper(PARAMS_PATTERN_1, line);
                     if (paramsMatcher1.find()) {
                         oAtoken = paramsMatcher1.group(1);

--- a/main/src/cgeo/geocaching/apps/AbstractApp.java
+++ b/main/src/cgeo/geocaching/apps/AbstractApp.java
@@ -38,7 +38,6 @@ public abstract class AbstractApp implements App {
         if (intent == null) {
             return false;
         }
-        assert intent != null; // eclipse issue
         return ProcessUtils.isIntentAvailable(intent);
     }
 

--- a/main/src/cgeo/geocaching/apps/navi/OsmAndApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/OsmAndApp.java
@@ -65,7 +65,6 @@ public class OsmAndApp extends AbstractPointNavigationApp {
         stringBuilder.append(ADD_MAP_MARKER);
         if (CollectionUtils.isNotEmpty(parameters)) {
             stringBuilder.append('?');
-            assert parameters != null; // avoid eclipse warning
             stringBuilder.append(parameters.toString());
         }
         return new Intent(Intent.ACTION_VIEW, Uri.parse(stringBuilder.toString()));

--- a/main/src/cgeo/geocaching/connector/ec/ECLogin.java
+++ b/main/src/cgeo/geocaching/connector/ec/ECLogin.java
@@ -66,8 +66,6 @@ public class ECLogin extends AbstractLogin {
             return StatusCode.CONNECTION_FAILED_EC; // no login page
         }
 
-        assert loginData != null;
-
         if (loginData.contains("Wrong username or password")) { // hardcoded in English
             Log.i("Failed to log in Extremcaching.com as " + credentials.getUserName() + " because of wrong username/password");
             return StatusCode.WRONG_LOGIN_DATA; // wrong login
@@ -98,7 +96,6 @@ public class ECLogin extends AbstractLogin {
             Log.e("ECLogin.getLoginStatus: No or empty data given");
             return false;
         }
-        assert data != null;
 
         final Application application = CgeoApplication.getInstance();
         setActualStatus(application.getString(R.string.init_login_popup_ok));

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -245,7 +245,6 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
             search.setError(StatusCode.CACHE_NOT_FOUND);
             return search;
         }
-        assert page != null;
 
         final SearchResult searchResult = GCParser.parseCache(page, handler);
 

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -189,7 +189,6 @@ public class GCLogin extends AbstractLogin {
                 // FIXME: should it be CONNECTION_FAILED to match the first attempt?
                 return StatusCode.COMMUNICATION_ERROR; // no login page
             }
-            assert loginData != null;  // Caught above
 
             if (getLoginStatus(loginData)) {
                 if (switchToEnglish(loginData) && retry) {
@@ -287,7 +286,6 @@ public class GCLogin extends AbstractLogin {
             Log.w("Login.checkLogin: No page given");
             return false;
         }
-        assert page != null;
 
         setActualStatus(CgeoApplication.getInstance().getString(R.string.init_login_popup_ok));
 
@@ -402,7 +400,6 @@ public class GCLogin extends AbstractLogin {
     private static void setHomeLocation() {
         retrieveHomeLocation().subscribe(homeLocationStr -> {
             if (StringUtils.isNotBlank(homeLocationStr) && !StringUtils.equals(homeLocationStr, Settings.getHomeLocation())) {
-                assert homeLocationStr != null;
                 Log.i("Setting home location to " + homeLocationStr);
                 Settings.setHomeLocation(homeLocationStr);
             }

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -288,7 +288,6 @@ public final class GCParser {
             }
 
             if (StringUtils.isNotBlank(inventoryPre)) {
-                assert inventoryPre != null;
                 final MatcherWrapper matcherTbsInside = new MatcherWrapper(GCConstants.PATTERN_SEARCH_TRACKABLESINSIDE, inventoryPre);
                 while (matcherTbsInside.find()) {
                     if (matcherTbsInside.group(1) != null &&
@@ -960,7 +959,6 @@ public final class GCParser {
             Log.w("GCParser.searchByAny: No data from server");
             return null;
         }
-        assert page != null;
 
         final String fullUri = uri + "?" + paramsWithF;
         final SearchResult searchResult = parseSearch(fullUri, page);
@@ -1060,7 +1058,6 @@ public final class GCParser {
             Log.w("GCParser.searchTrackable: No data from server");
             return null;
         }
-        assert page != null;
 
         final Trackable trackable = parseTrackable(page, geocode);
         if (trackable == null) {

--- a/main/src/cgeo/geocaching/log/LogEntry.java
+++ b/main/src/cgeo/geocaching/log/LogEntry.java
@@ -457,7 +457,6 @@ public class LogEntry implements Parcelable {
      */
     public CharSequence getImageTitles() {
         final List<String> titles = new ArrayList<>(5);
-        assert logImages != null; // make compiler happy
         for (final Image image : logImages) {
             if (StringUtils.isNotBlank(image.getTitle())) {
                 titles.add(HtmlUtils.extractText(image.getTitle()));

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -453,7 +453,7 @@ public class Geocache implements IWaypoint {
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
-        assert hidden != null; // Eclipse compiler issue
+        assert hidden != null; // Android Studio compiler issue
         return hidden.compareTo(cal.getTime()) < 0;
     }
 

--- a/main/src/cgeo/geocaching/sensors/GeoData.java
+++ b/main/src/cgeo/geocaching/sensors/GeoData.java
@@ -101,7 +101,6 @@ public class GeoData extends Location {
         final String homeLocationStr = Settings.getHomeLocation();
         if (StringUtils.isNotBlank(homeLocationStr)) {
             try {
-                assert homeLocationStr != null;
                 final Geopoint homeLocation = new Geopoint(homeLocationStr);
                 Log.i("No last known location available, using home location");
                 final Location initialLocation = new Location(HOME_PROVIDER);

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -64,7 +64,6 @@ public class CgeoApplicationTest extends CGeoTestCase {
     public static void testSearchTrackable() {
         final Trackable tb = GCParser.searchTrackable("TB2J1VZ", null, null);
         assertThat(tb).isNotNull();
-        assert tb != null; // eclipse bug
         // fix data
         assertThat(tb.getGuid()).isEqualTo("aefffb86-099f-444f-b132-605436163aa8");
         assertThat(tb.getGeocode()).isEqualTo("TB2J1VZ");

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -62,7 +62,6 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(result.getCount()).isEqualTo(1);
         final Geocache cache = result.getFirstCacheFromResult(LoadFlags.LOAD_CACHE_OR_DB);
         assertThat(cache).isNotNull();
-        assert cache != null; // eclipse bug
         assertThat(cache.getName()).isEqualTo(cacheName);
     }
 
@@ -111,7 +110,6 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
                 final SearchResult searchResult = GCParser.parseAndSaveCacheFromText(mockedCache.getData(), null);
                 final Geocache parsedCache = searchResult.getFirstCacheFromResult(LoadFlags.LOAD_CACHE_OR_DB);
                 assertThat(parsedCache).isNotNull();
-                assert parsedCache != null;  // To keep editors happy
                 assertThat(StringUtils.isNotBlank(mockedCache.getMockedDataUser())).isTrue();
                 // Workaround for issue #3777
                 if (mockedCache.getGeocode().equals("GC3XX5J") && Settings.getUserName().equals("mucek4")) {
@@ -181,7 +179,6 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         final String page = requestHtmlPage(cache.getGeocode(), null, "n");
         final Geocache cache2 = GCParser.parseAndSaveCacheFromText(page, null).getFirstCacheFromResult(LOAD_CACHE_ONLY);
         assertThat(cache2).isNotNull();
-        assert cache2 != null; // eclipse bug
         assertThat(cache2.hasUserModifiedCoords()).isTrue();
         assertThat(cache2.getCoords()).isEqualTo(new Geopoint("N51 21.544", "E07 02.566"));
         // delete coordinates
@@ -190,7 +187,6 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         final String page2 = requestHtmlPage(cache.getGeocode(), null, "n");
         final Geocache cache3 = GCParser.parseAndSaveCacheFromText(page2, null).getFirstCacheFromResult(LOAD_CACHE_ONLY);
         assertThat(cache3).isNotNull();
-        assert cache3 != null; // eclipse bug
         assertThat(cache3.hasUserModifiedCoords()).isFalse();
     }
 

--- a/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
@@ -19,7 +19,6 @@ public class OkapiClientTest extends CGeoTestCase {
         final String geoCode = "OU0331";
         Geocache cache = OkapiClient.getCache(geoCode);
         assertThat(cache).as("Cache from OKAPI").isNotNull();
-        assert cache != null; // eclipse null analysis
         assertThat(cache.getGeocode()).isEqualTo(geoCode);
         assertThat(cache.getName()).isEqualTo("Oshkosh Municipal Tank");
         assertThat(cache.isDetailed()).isTrue();
@@ -38,7 +37,6 @@ public class OkapiClientTest extends CGeoTestCase {
         final String geoCode = "OC1234";
         final Geocache cache = OkapiClient.getCache(geoCode);
         assertThat(cache).overridingErrorMessage("You must have a valid OKAPI key installed for running this test (but you do not need to set credentials in the app).").isNotNull();
-        assert cache != null; // eclipse null analysis
         assertThat(cache.getName()).isEqualTo("Wupper-Schein");
     }
 
@@ -64,7 +62,6 @@ public class OkapiClientTest extends CGeoTestCase {
         removeCacheCompletely(geoCode);
         final Geocache cache = OkapiClient.getCache(geoCode);
         assertThat(cache).as("Cache from OKAPI").isNotNull();
-        assert cache != null; // eclipse null analysis
         assertThat(cache.getLogCounts().get(LogType.WILL_ATTEND)).isGreaterThan(0);
     }
 
@@ -128,7 +125,6 @@ public class OkapiClientTest extends CGeoTestCase {
             }
         }
         assertThat(logWithImage).isNotNull();
-        assert logWithImage != null; // eclipse null analysis
         assertThat(logWithImage.getLogImages()).isNotEmpty();
     }
 

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyConnectorTest.java
@@ -60,7 +60,6 @@ public class GeokretyConnectorTest extends AbstractResourceInstrumentationTestCa
     public void testSearchTrackable() throws Exception {
         final Trackable geokret = GeokretyConnector.searchTrackable("GKB580");
         assertThat(geokret).isNotNull();
-        assert geokret != null;
         assertThat(geokret.getBrand()).isEqualTo(TrackableBrand.GEOKRETY);
         assertThat(geokret.getName()).isEqualTo("c:geo One");
         assertThat(geokret.getDetails()).isEqualTo("GeoKret for the c:geo project :)<br />DO NOT MOVE");

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
@@ -27,7 +27,6 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
 
         final List<Trackable> trackables = GeokretyParser.parse(new InputSource(getResourceStream(R.raw.geokret141_xml)));
         assertThat(trackables).hasSize(2);
-        assert trackables != null;
 
         // Check first GK in list
         final Trackable trackable1 = trackables.get(0);
@@ -49,7 +48,6 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
     public void testParseResponse() throws Exception {
         final ImmutablePair<Integer, List<String>> response1 = GeokretyParser.parseResponse(getFileContent(R.raw.geokret142_xml));
         assertThat(response1).isNotNull();
-        assert response1 != null;
         assertThat(response1.getLeft()).isNotNull();
         assertThat(response1.getLeft()).isEqualTo(0);
         assertThat(response1.getRight()).isNotNull();
@@ -59,7 +57,6 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
 
         final ImmutablePair<Integer, List<String>> response2 = GeokretyParser.parseResponse(getFileContent(R.raw.geokret143_xml));
         assertThat(response2).isNotNull();
-        assert response2 != null;
         assertThat(response2.getLeft()).isNotNull();
         assertThat(response2.getLeft()).isEqualTo(27334);
         assertThat(response2.getRight()).isNotNull();
@@ -67,7 +64,6 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
 
         final ImmutablePair<Integer, List<String>> response3 = GeokretyParser.parseResponse(getFileContent(R.raw.geokret144_xml));
         assertThat(response3).isNotNull();
-        assert response3 != null;
         assertThat(response3.getLeft()).isNotNull().isEqualTo(0);
         assertThat(response3.getRight()).isNotNull().hasSize(2);
         assertThat(response3.getRight().get(0)).isEqualTo("Wrong secid");
@@ -90,7 +86,6 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
 
         final List<Trackable> trackables = GeokretyParser.parse(new InputSource(getResourceStream(R.raw.geokret146_xml)));
         assertThat(trackables).hasSize(1);
-        assert trackables != null;
 
         final Trackable trackable1 = trackables.get(0);
         assertThat(trackable1).isNotNull();
@@ -107,7 +102,6 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
     public void testParseDescription() throws Exception {
         final List<Trackable> trackables = GeokretyParser.parse(new InputSource(getResourceStream(R.raw.geokret145_xml)));
         assertThat(trackables).hasSize(1);
-        assert trackables != null;
 
         // Check first GK in list
         final Trackable trackable1 = trackables.get(0);

--- a/tests/src-android/cgeo/geocaching/connector/trackable/TravelBugConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/TravelBugConnectorTest.java
@@ -32,14 +32,12 @@ public class TravelBugConnectorTest extends TestCase {
     public static void testOnlineSearchBySecretCode() {
         final Trackable trackable = getConnector().searchTrackable("GST9HV", null, null);
         assertThat(trackable).isNotNull();
-        assert trackable != null;
         assertThat(trackable.getName()).isEqualTo("Deutschland");
     }
 
     public static void testOnlineSearchByPublicCode() {
         final Trackable trackable = getConnector().searchTrackable("TB4JD36", null, null);
         assertThat(trackable).isNotNull();
-        assert trackable != null;
         assertThat(trackable.getName()).isEqualTo("Mein Kilometerzähler");
     }
 

--- a/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
@@ -219,7 +219,6 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(wp.getWaypointType()).isEqualTo(WaypointType.PARKING);
         Geopoint waypointCoords = wp.getCoords();
         assertThat(waypointCoords).isNotNull();
-        assert waypointCoords != null; // eclipse null analysis
         assertEquals(49.317517, waypointCoords.getLatitude(), 0.000001);
         assertEquals(8.545083, waypointCoords.getLongitude(), 0.000001);
 
@@ -232,7 +231,6 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(wp.getWaypointType()).isEqualTo(WaypointType.STAGE);
         waypointCoords = wp.getCoords();
         assertThat(waypointCoords).isNotNull();
-        assert waypointCoords != null; // eclipse null analysis
         assertEquals(49.317500, waypointCoords.getLatitude(), 0.000001);
         assertEquals(8.545100, waypointCoords.getLongitude(), 0.000001);
     }
@@ -403,7 +401,6 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
         final List<Geocache> caches = readGPX10(R.raw.tc2012);
         final Geocache mystery = getCache(caches, "U017");
         assertThat(mystery).isNotNull();
-        assert mystery != null;
         assertThat(mystery.getType()).isEqualTo(CacheType.MYSTERY);
     }
 

--- a/tests/src-android/cgeo/test/Compare.java
+++ b/tests/src-android/cgeo/test/Compare.java
@@ -30,7 +30,6 @@ public abstract class Compare {
         assertThat(actual.getFavoritePoints()).as(cacheStr + "fav points").isGreaterThanOrEqualTo(expected.getFavoritePoints());
         final Date hiddenDate = actual.getHiddenDate();
         assertThat(hiddenDate).isNotNull();
-        assert hiddenDate != null; // silence the eclipse compiler in the next line
         assertThat(hiddenDate).as(cacheStr + " hidden date").isEqualTo(expected.getHiddenDate());
         assertThat(actual.isPremiumMembersOnly()).as(cacheStr + "premium only").isEqualTo(expected.isPremiumMembersOnly());
 

--- a/tests/src-android/cgeo/watchdog/WatchdogTest.java
+++ b/tests/src-android/cgeo/watchdog/WatchdogTest.java
@@ -66,7 +66,6 @@ public class WatchdogTest extends CGeoTestCase {
 
         final Geocache geocache = searchResult.getFirstCacheFromResult(LoadFlags.LOAD_CACHE_OR_DB);
         assertThat(geocache).isNotNull();
-        assert geocache != null; // Eclipse null analysis weakness
         assertThat(geocache.getGeocode()).isEqualTo(geocode);
     }
 


### PR DESCRIPTION
There were many null analysis assertions in the code which are not necessary anymore when using Android Studio. Lint has complained that this condition must always be true and should be removed, which is done with this PR...