### PR TITLE
hide cache submenus in popup (fix #9825)

### DIFF
--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -37,10 +37,20 @@
         app:showAsAction="ifRoom">
     </item>
     <item
+        android:id="@+id/menu_caches_around_from_popup"
+        android:title="@string/cache_menu_around"
+        android:visible="false">
+    </item>
+    <item
         android:id="@+id/menu_show_in_browser"
         android:icon="@drawable/ic_menu_info_details"
         android:title="@string/cache_menu_browser"
         app:showAsAction="ifRoom">
+    </item>
+    <item
+        android:id="@+id/menu_share_from_popup"
+        android:title="@string/cache_menu_share"
+        android:visible="false">
     </item>
     <item
         android:id="@+id/menu_checker"
@@ -61,8 +71,10 @@
         android:visible="false">
     </item>
     <item
+        android:id="@+id/menu_waypoints"
         android:title="@string/cache_waypoints"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_delete_userdefined_waypoints"
@@ -91,7 +103,8 @@
     <item
         android:id="@+id/menu_export"
         android:title="@string/share_export"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_share"
@@ -108,8 +121,10 @@
         </menu>
     </item>
     <item
+        android:id="@+id/menu_advanced"
         android:title="@string/cache_advanced"
-        app:showAsAction="never">
+        app:showAsAction="never"
+        android:visible="false">
         <menu>
             <item
                 android:id="@+id/menu_calendar"

--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -113,7 +113,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
 
     protected void showPopup(final View view) {
         final android.widget.PopupMenu popupMenu = new android.widget.PopupMenu(getActivity(), view);
-        CacheMenuHandler.addMenuItems(new MenuInflater(getActivity()), popupMenu.getMenu(), cache);
+        CacheMenuHandler.addMenuItems(new MenuInflater(getActivity()), popupMenu.getMenu(), cache, true);
         popupMenu.setOnMenuItemClickListener(
                 AbstractDialogFragment.this::onMenuItemClick
         );
@@ -226,14 +226,14 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
     @Override
     public void onCreateOptionsMenu(@NonNull final Menu menu, @NonNull final MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        CacheMenuHandler.addMenuItems(inflater, menu, cache);
+        CacheMenuHandler.addMenuItems(inflater, menu, cache, false);
 
     }
 
     @Override
     public void onCreateContextMenu(@NonNull final ContextMenu menu, @NonNull final View v, final ContextMenu.ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
-        CacheMenuHandler.addMenuItems(new MenuInflater(getActivity()), menu, cache);
+        CacheMenuHandler.addMenuItems(new MenuInflater(getActivity()), menu, cache, false);
         for (int i = 0; i < menu.size(); i++) {
             final MenuItem m = menu.getItem(i);
             m.setOnMenuItemClickListener(this);
@@ -268,7 +268,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         super.onPrepareOptionsMenu(menu);
 
         try {
-            CacheMenuHandler.onPrepareOptionsMenu(menu, cache);
+            CacheMenuHandler.onPrepareOptionsMenu(menu, cache, false);
             LoggingUI.onPrepareOptionsMenu(menu, cache);
         } catch (final RuntimeException ignored) {
             // nothing

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -661,32 +661,42 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         final IConnector connector = null != cache ? ConnectorFactory.getConnector(cache) : null;
         final boolean isUDC = null != connector && connector.equals(InternalConnector.getInstance());
 
-        CacheMenuHandler.onPrepareOptionsMenu(menu, cache);
+        CacheMenuHandler.onPrepareOptionsMenu(menu, cache, false);
         LoggingUI.onPrepareOptionsMenu(menu, cache);
-        menu.findItem(R.id.menu_tts_toggle).setVisible(cache != null && !cache.isGotoHistoryUDC());
-        menu.findItem(R.id.menu_edit_fieldnote).setVisible(true);
-        menu.findItem(R.id.menu_delete_userdefined_waypoints).setVisible(cache != null && cache.isOffline() && cache.hasUserdefinedWaypoints());
-        menu.findItem(R.id.menu_checker).setVisible(cache != null && StringUtils.isNotEmpty(CheckerUtils.getCheckerUrl(cache)));
-        menu.findItem(R.id.menu_extract_waypoints).setVisible(cache != null && !isUDC);
-        menu.findItem(R.id.menu_clear_goto_history).setVisible(cache != null && cache.isGotoHistoryUDC());
-        menu.findItem(R.id.menu_set_cache_icon).setVisible(cache != null && cache.isOffline());
-        menuItemToggleWaypointsFromNote = menu.findItem(R.id.menu_toggleWaypointsFromNote);
-        setMenuPreventWaypointsFromNote(cache != null && cache.isPreventWaypointsFromNote());
-        menuItemToggleWaypointsFromNote.setVisible(cache != null && !cache.isGotoHistoryUDC());
-        menu.findItem(R.id.menu_export).setVisible(cache != null);
         if (cache != null) {
-            if (connector instanceof IgnoreCapability) {
-                menu.findItem(R.id.menu_ignore).setVisible(((IgnoreCapability) connector).canIgnoreCache(cache));
-            }
+            // top level menu items
+            menu.findItem(R.id.menu_tts_toggle).setVisible(!cache.isGotoHistoryUDC());
+            menu.findItem(R.id.menu_checker).setVisible(StringUtils.isNotEmpty(CheckerUtils.getCheckerUrl(cache)));
             if (connector instanceof PgcChallengeCheckerCapability) {
                 menu.findItem(R.id.menu_challenge_checker).setVisible(((PgcChallengeCheckerCapability) connector).isChallengeCache(cache));
             }
+            menu.findItem(R.id.menu_edit_fieldnote).setVisible(true);
+
+            // submenu waypoints
+            menu.findItem(R.id.menu_delete_userdefined_waypoints).setVisible(cache.isOffline() && cache.hasUserdefinedWaypoints());
+            menu.findItem(R.id.menu_extract_waypoints).setVisible(!isUDC);
+            menu.findItem(R.id.menu_clear_goto_history).setVisible(cache.isGotoHistoryUDC());
+            menuItemToggleWaypointsFromNote = menu.findItem(R.id.menu_toggleWaypointsFromNote);
+            setMenuPreventWaypointsFromNote(cache.isPreventWaypointsFromNote());
+            menuItemToggleWaypointsFromNote.setVisible(!cache.isGotoHistoryUDC());
+            menu.findItem(R.id.menu_waypoints).setVisible(true);
+
+            // submenu share / export
+            menu.findItem(R.id.menu_export).setVisible(true);
+
+            // submenu advanced
             if (connector instanceof IVotingCapability) {
                 final MenuItem menuItemGCVote = menu.findItem(R.id.menu_gcvote);
                 menuItemGCVote.setVisible(((IVotingCapability) connector).supportsVoting(cache));
                 menuItemGCVote.setEnabled(Settings.isRatingWanted() && Settings.isGCVoteLoginValid());
             }
+            if (connector instanceof IgnoreCapability) {
+                menu.findItem(R.id.menu_ignore).setVisible(((IgnoreCapability) connector).canIgnoreCache(cache));
+            }
+            menu.findItem(R.id.menu_set_cache_icon).setVisible(cache.isOffline());
+            menu.findItem(R.id.menu_advanced).setVisible(cache.getCoords() != null);
         }
+
         return super.onPrepareOptionsMenu(menu);
     }
 

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -60,13 +60,13 @@ public final class CacheMenuHandler extends AbstractUIFactory {
                 return true;
             }
             return false;
-        } else if (menuItem == R.id.menu_caches_around) {
+        } else if (menuItem == R.id.menu_caches_around || menuItem == R.id.menu_caches_around_from_popup) {
             activityInterface.cachesAround();
             return true;
         } else if (menuItem == R.id.menu_show_in_browser) {
             cache.openInBrowser(activity);
             return true;
-        } else if (menuItem == R.id.menu_share) {
+        } else if (menuItem == R.id.menu_share || menuItem == R.id.menu_share_from_popup) {
             cache.shareCache(activity, res);
             return true;
         } else if (menuItem == R.id.menu_calendar) {
@@ -76,31 +76,32 @@ public final class CacheMenuHandler extends AbstractUIFactory {
         return false;
     }
 
-    public static void onPrepareOptionsMenu(final Menu menu, final Geocache cache) {
+    public static void onPrepareOptionsMenu(final Menu menu, final Geocache cache, final boolean fromPopup) {
         if (cache == null) {
             return;
         }
         final boolean hasCoords = cache.getCoords() != null;
+        // top level menu items
         menu.findItem(R.id.menu_default_navigation).setVisible(hasCoords);
+        menu.findItem(R.id.menu_default_navigation).setTitle(NavigationAppFactory.getDefaultNavigationApplication().getName());
         menu.findItem(R.id.menu_navigate).setVisible(hasCoords);
-        menu.findItem(R.id.menu_share).setVisible(!InternalConnector.getInstance().canHandle(cache.getGeocode()));
-        menu.findItem(R.id.menu_caches_around).setVisible(hasCoords && cache.supportsCachesAround());
-        menu.findItem(R.id.menu_calendar).setVisible(cache.canBeAddedToCalendar());
         menu.findItem(R.id.menu_log_visit).setVisible(cache.supportsLogging() && !Settings.getLogOffline());
         menu.findItem(R.id.menu_log_visit_offline).setVisible(cache.supportsLogging() && Settings.getLogOffline());
-
-        menu.findItem(R.id.menu_default_navigation).setTitle(NavigationAppFactory.getDefaultNavigationApplication().getName());
-
         // some connectors don't support URL - we don't need "open in browser" for those caches
         menu.findItem(R.id.menu_show_in_browser).setVisible(cache.getUrl() != null);
+        // submenu share / export
+        menu.findItem(fromPopup ? R.id.menu_share_from_popup : R.id.menu_share).setVisible(!InternalConnector.getInstance().canHandle(cache.getGeocode()));
+        // submenu advanced
+        menu.findItem(R.id.menu_calendar).setVisible(cache.canBeAddedToCalendar());
+        menu.findItem(fromPopup ? R.id.menu_caches_around_from_popup : R.id.menu_caches_around).setVisible(hasCoords && cache.supportsCachesAround());
     }
 
-    public static void addMenuItems(final MenuInflater inflater, final Menu menu, final Geocache cache) {
+    public static void addMenuItems(final MenuInflater inflater, final Menu menu, final Geocache cache, final boolean fromPopup) {
         inflater.inflate(R.menu.cache_options, menu);
-        onPrepareOptionsMenu(menu, cache);
+        onPrepareOptionsMenu(menu, cache, fromPopup);
     }
 
     public static void addMenuItems(final Activity activity, final Menu menu, final Geocache cache) {
-        addMenuItems(activity.getMenuInflater(), menu, cache);
+        addMenuItems(activity.getMenuInflater(), menu, cache, false);
     }
 }


### PR DESCRIPTION
- do not show cache detail submenus in map cache popup
- but show entries "share" and "caches around" (if applicable) as top level menu items in popup
