### PR TITLE
optimize/update imports and tasks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
       # Ignore only new versions for >= 3.x
       - dependency-name: "org.assertj:assertj-core"
         versions: ["3.x"]
+      # Ignore updates to the 'guava' package
+      # found no way to instead integrate listenablefuture/9999.0-empty-to-avoid-conflict-with-guava
+      - dependency-name: "com.google.guava:guava"

--- a/build.gradle
+++ b/build.gradle
@@ -122,14 +122,7 @@ allprojects {
  */
 subprojects {
     repositories {
-        // = mavenCentral()
-        maven {
-            url 'https://repo1.maven.org/maven2'
-            // for undobar
-            metadataSources {
-                artifact()
-            }
-        }
+        mavenCentral()
         jcenter()
         // viewpager fork
         maven {

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -277,7 +277,7 @@ dependencies {
 
     // SpotBugs (successor of FindBugs)
     implementation 'net.jcip:jcip-annotations:1.0'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.1.4'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.2.0'
 
     // GeographicLib
     implementation 'net.sf.geographiclib:GeographicLib-Java:1.51'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -502,10 +502,12 @@ android.applicationVariants.all { variant ->
 }
 
 // run device and non device tests together with one task. also fixes the bug that gradle optimizes tests away in repeated runs
-// FIXME: This uses eager task creation API. Found no way to configure a set of dependsOn with the new API.
-tasks.create(name: "testDebug", dependsOn: [ "testBasicDebugUnitTest", "connectedBasicDebugAndroidTest" ]) {
-    group 'cgeo'
+// This uses eager task creation API.
+tasks.create('testDebug') {
+    group 'verification'
     description "Tests the debug build both with device-dependent and device-independent tests."
+
+    dependsOn 'testBasicDebugUnitTest', 'connectedBasicDebugAndroidTest'
 }
 
 /*
@@ -591,6 +593,9 @@ tasks.whenTaskAdded { theTask ->
 apply plugin: 'checkstyle'
 
 tasks.register('checkstyle', Checkstyle) {
+    group 'verification'
+    description 'Check code standard'
+
     configFile file("${project.rootDir}/checkstyle.xml")
     source 'src'
     source '../tests/src'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@
  * Enterprise plugin replaces Build scan plugin from gradle 6, see https://docs.gradle.com/enterprise/gradle-plugin/
  */
 plugins {
-    id 'com.gradle.enterprise' version '3.4.1'
+    id 'com.gradle.enterprise' version '3.5.1'
 }
 
 // Make the root project name independent of the directory name where we checked out the repository.


### PR DESCRIPTION
-  Update the gradle enterprise plugin
   see https://docs.gradle.com/enterprise/gradle-plugin/#release_history

- Update the spotbugs-annotations plugin 
  see https://github.com/spotbugs/spotbugs/blob/master/CHANGELOG.md#420---2020-11-28
  Btw, this was not covered by dependabot.

 - found no way to really skip the downgrade of com.google.guava:guava-26.0-jre
   dependabot should close the #9760

- remove unused undobar source

- optimize gradle task: testDebug

- optimize gradle task: checkstyle 
- 