### PR TITLE
make login pages more user-friendly (fix #9818)

### DIFF
--- a/main/res/layout/authorization_activity.xml
+++ b/main/res/layout/authorization_activity.xml
@@ -14,30 +14,16 @@
 
         <TextView
             android:id="@+id/auth_1"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            style="@style/authorization_text"
             android:layout_marginBottom="20dip"
-            android:layout_marginLeft="10dip"
-            android:layout_marginRight="10dip"
-            android:drawableLeft="@drawable/cgeo"
+            android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
-            android:gravity="left|center_vertical"
-            android:textColor="?text_color"
-            android:textSize="14sp"
             tools:text="Auth text 1"/>
 
         <TextView
             android:id="@+id/auth_2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            style="@style/authorization_text"
             android:layout_marginBottom="5dip"
-            android:layout_marginLeft="10dip"
-            android:layout_marginRight="10dip"
-            android:gravity="left|center_vertical"
-            android:textColor="?text_color"
-            android:textSize="14sp"
             tools:text="Auth text 2"/>
 
         <Button
@@ -45,6 +31,17 @@
             style="@style/button_full"
             android:layout_margin="7dip"
             tools:text="start"/>
+
+        <View
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            style="@style/separator_horizontal" />
+
+        <TextView
+            android:id="@+id/auth_3"
+            style="@style/authorization_text"
+            android:layout_marginBottom="5dip"
+            tools:text="Auth text 3"/>
 
         <Button
             android:id="@+id/register"

--- a/main/res/layout/authorization_credentials_activity.xml
+++ b/main/res/layout/authorization_credentials_activity.xml
@@ -13,30 +13,16 @@
 
         <TextView
             android:id="@+id/auth_1"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            style="@style/authorization_text"
             android:layout_marginBottom="20dip"
-            android:layout_marginLeft="10dip"
-            android:layout_marginRight="10dip"
             android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
-            android:gravity="left|center_vertical"
-            android:textColor="?text_color"
-            android:textSize="14sp"
             tools:text="Auth text 1"/>
 
         <TextView
             android:id="@+id/auth_2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            style="@style/authorization_text"
             android:layout_marginBottom="5dip"
-            android:layout_marginLeft="10dip"
-            android:layout_marginRight="10dip"
-            android:gravity="left|center_vertical"
-            android:textColor="?text_color"
-            android:textSize="14sp"
             tools:text="Auth text 2"/>
 
         <EditText
@@ -60,6 +46,17 @@
             style="@style/button_full"
             android:layout_margin="7dip"
             tools:text="check"/>
+
+        <View
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            style="@style/separator_horizontal" />
+
+        <TextView
+            android:id="@+id/auth_3"
+            style="@style/authorization_text"
+            android:layout_marginBottom="5dip"
+            tools:text="Auth text 3"/>
 
         <Button
             android:id="@+id/register"

--- a/main/res/layout/authorization_token_activity.xml
+++ b/main/res/layout/authorization_token_activity.xml
@@ -13,30 +13,16 @@
 
         <TextView
             android:id="@+id/auth_1"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            style="@style/authorization_text"
             android:layout_marginBottom="20dip"
-            android:layout_marginLeft="10dip"
-            android:layout_marginRight="10dip"
-            android:drawableLeft="@drawable/cgeo"
+            android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
-            android:gravity="left|center_vertical"
-            android:textColor="?text_color"
-            android:textSize="14sp"
             tools:text="Auth text 1"/>
 
         <TextView
             android:id="@+id/auth_2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            style="@style/authorization_text"
             android:layout_marginBottom="5dip"
-            android:layout_marginLeft="10dip"
-            android:layout_marginRight="10dip"
-            android:gravity="left|center_vertical"
-            android:textColor="?text_color"
-            android:textSize="14sp"
             tools:text="Auth text 2"/>
 
         <EditText
@@ -60,6 +46,17 @@
             style="@style/button_full"
             android:layout_margin="7dip"
             tools:text="start"/>
+
+        <View
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            style="@style/separator_horizontal" />
+
+        <TextView
+            android:id="@+id/auth_3"
+            style="@style/authorization_text"
+            android:layout_marginBottom="5dip"
+            tools:text="Auth text 3"/>
 
         <Button
             android:id="@+id/register"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -858,7 +858,8 @@
 
     <!-- auth credentials -->
     <string name="auth_credentials_explain_short">The following process will allow <b>c:geo</b> to access %s.</string>
-    <string name="auth_credentials_explain_long">Filling your credentials and pressing the \"Check authentication\" button will start the process. This process will connect to %s and validate your credentials. That\'s all.</string>
+    <string name="auth_credentials_explain_long">If you already have an account please enter your account credentials for %s below:</string>
+    <string name="auth_register_explain">If you do not yet have an account click below to be directed to the service\'s webpage to create an account. Make sure to use the method with username and password to create an account as c:geo does not support login via Google/Apple/Facebook. After account creation validation of your email address might be needed before you can use the login with c:geo.</string>
 
     <!-- auth token -->
     <string name="auth_token_explain_short">The following process will allow <b>c:geo</b> to access %s.</string>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -408,7 +408,7 @@
         <item name="android:layout_marginTop">-4dp</item>
     </style>
 
-    <!-- map distance info style -->
+    <!-- map distance info styles -->
     <style name="map_distanceinfo_no_background">
         <item name="android:paddingTop">0dp</item>
         <item name="android:paddingLeft">4dp</item>
@@ -423,11 +423,9 @@
         <item name="android:visibility">gone</item>
         <item name="android:maxLines">1</item>
     </style>
-
     <style name="map_distanceinfo" parent="map_distanceinfo_no_background">
         <item name="android:background">@drawable/icon_bcg</item>
     </style>
-
     <style name="map_distanceinfo_supersize" parent="map_distanceinfo">
         <item name="android:layout_marginLeft">-2dp</item>
         <item name="android:textSize">72sp</item>
@@ -436,7 +434,54 @@
         <item name="android:gravity">center_horizontal</item>
     </style>
 
-    <!-- about c:geo contributors style -->
+    <!-- splash screen style -->
+    <style name="SplashScreenTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@drawable/splashscreen_background</item>
+        <item name="android:windowActivityTransitions">false</item>
+    </style>
+
+    <!-- authorization styles -->
+    <style name="authorization_text">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_gravity">left|center_vertical</item>
+        <item name="android:layout_marginLeft">10dip</item>
+        <item name="android:layout_marginRight">10dip</item>
+        <item name="android:gravity">left|center_vertical</item>
+        <item name="android:textColor">?text_color</item>
+        <item name="android:textSize">16sp</item>
+    </style>
+
+    <!-- installation wizard styles -->
+    <style name="InstallationWizardMarginsLR">
+        <item name="android:layout_marginLeft">16dp</item>
+        <item name="android:layout_marginRight">16dp</item>
+    </style>
+    <style name="InstallationWizardButtonFull" parent="InstallationWizardMarginsLR">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_centerHorizontal">true</item>
+        <item name="android:layout_marginTop">12dp</item>
+    </style>
+    <style name="InstallationWizardButtonFooter" parent="InstallationWizardMarginsLR">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_alignParentBottom">true</item>
+        <item name="android:padding">12dp</item>
+        <item name="android:layout_marginBottom">12dp</item>
+    </style>
+    <style name="InstallationWizardTextViewBase" parent="InstallationWizardMarginsLR">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_centerHorizontal">true</item>
+        <item name="android:layout_marginTop">16dp</item>
+    </style>
+    <style name="InstallationWizardTextViewAdvanced" parent="InstallationWizardTextViewBase">
+        <item name="android:textSize">16sp</item>
+    </style>
+
+    <!-- about pages styles -->
     <style name="about_contributors">
         <item name="android:layout_gravity">left</item>
         <item name="android:layout_margin">7dip</item>
@@ -446,47 +491,6 @@
         <item name="android:textColorLink">?text_color_link</item>
         <item name="android:textSize">14sp</item>
     </style>
-
-    <!-- splash screen style -->
-    <style name="SplashScreenTheme" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:windowBackground">@drawable/splashscreen_background</item>
-        <item name="android:windowActivityTransitions">false</item>
-    </style>
-
-    <!-- installation wizard styles -->
-    <style name="InstallationWizardMarginsLR">
-        <item name="android:layout_marginLeft">16dp</item>
-        <item name="android:layout_marginRight">16dp</item>
-    </style>
-
-    <style name="InstallationWizardButtonFull" parent="InstallationWizardMarginsLR">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_centerHorizontal">true</item>
-        <item name="android:layout_marginTop">12dp</item>
-    </style>
-
-    <style name="InstallationWizardButtonFooter" parent="InstallationWizardMarginsLR">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_alignParentBottom">true</item>
-        <item name="android:padding">12dp</item>
-        <item name="android:layout_marginBottom">12dp</item>
-    </style>
-
-    <style name="InstallationWizardTextViewBase" parent="InstallationWizardMarginsLR">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:gravity">center</item>
-        <item name="android:layout_centerHorizontal">true</item>
-        <item name="android:layout_marginTop">16dp</item>
-    </style>
-
-    <style name="InstallationWizardTextViewAdvanced" parent="InstallationWizardTextViewBase">
-        <item name="android:textSize">16sp</item>
-    </style>
-
-    <!-- about pages styles -->
     <style name="about_info_title">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
@@ -509,4 +513,5 @@
         <item name="android:paddingLeft">3dip</item>
         <item name="android:textColorLink">?text_color_link</item>
     </style>
+
 </resources>

--- a/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
@@ -62,6 +62,7 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
     @BindView(R.id.register) protected Button registerButton;
     @BindView(R.id.auth_1) protected TextView auth1;
     @BindView(R.id.auth_2) protected TextView auth2;
+    @BindView(R.id.auth_3) protected TextView auth3;
     private ProgressDialog requestTokenDialog = null;
     private ProgressDialog changeTokensDialog = null;
 
@@ -147,6 +148,7 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
 
         auth1.setText(getAuthExplainShort());
         auth2.setText(getAuthExplainLong());
+        auth3.setText(getAuthRegisterExplain());
 
         final ImmutablePair<String, String> tempToken = getTempTokens();
         oAtoken = tempToken.left;
@@ -404,6 +406,10 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
 
     private String getAuthAuthorize() {
         return res.getString(R.string.auth_authorize);
+    }
+
+    protected String getAuthRegisterExplain() {
+        return res.getString(R.string.auth_register_explain);
     }
 
     protected String getAuthRegister() {

--- a/main/src/cgeo/geocaching/activity/TokenAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/activity/TokenAuthorizationActivity.java
@@ -51,6 +51,7 @@ public abstract class TokenAuthorizationActivity extends AbstractActivity {
     @BindView(R.id.register) protected Button registerButton;
     @BindView(R.id.auth_1) protected TextView auth1;
     @BindView(R.id.auth_2) protected TextView auth2;
+    @BindView(R.id.auth_3) protected TextView auth3;
     @BindView(R.id.username) protected EditText usernameEditText;
     @BindView(R.id.password) protected EditText passwordEditText;
 
@@ -105,6 +106,7 @@ public abstract class TokenAuthorizationActivity extends AbstractActivity {
 
         auth1.setText(getAuthExplainShort());
         auth2.setText(getAuthExplainLong());
+        auth3.setText(getAuthRegisterExplain());
 
         startButton.setText(getAuthAuthorize());
         startButton.setOnClickListener(new StartListener(this));
@@ -282,6 +284,10 @@ public abstract class TokenAuthorizationActivity extends AbstractActivity {
 
     protected String getAuthAuthorize() {
         return res.getString(R.string.auth_authorize);
+    }
+
+    protected String getAuthRegisterExplain() {
+        return res.getString(R.string.auth_register_explain);
     }
 
     protected String getAuthRegister() {

--- a/main/src/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
@@ -39,6 +39,7 @@ public abstract class AbstractCredentialsAuthorizationActivity extends AbstractA
     @BindView(R.id.register) protected Button registerButton;
     @BindView(R.id.auth_1) protected TextView auth1;
     @BindView(R.id.auth_2) protected TextView auth2;
+    @BindView(R.id.auth_3) protected TextView auth3;
     @BindView(R.id.username) protected EditText usernameEditText;
     @BindView(R.id.password) protected EditText passwordEditText;
 
@@ -56,6 +57,7 @@ public abstract class AbstractCredentialsAuthorizationActivity extends AbstractA
 
         auth1.setText(getAuthExplainShort());
         auth2.setText(getAuthExplainLong());
+        auth3.setText(getAuthRegisterExplain());
 
         checkButton.setText(getAuthCheck());
         checkButton.setOnClickListener(new CheckListener());
@@ -181,6 +183,10 @@ public abstract class AbstractCredentialsAuthorizationActivity extends AbstractA
 
     protected String getAuthCheckAgain() {
         return res.getString(R.string.auth_check_again);
+    }
+
+    protected String getAuthRegisterExplain() {
+        return res.getString(R.string.auth_register_explain);
     }
 
     protected String getAuthRegister() {


### PR DESCRIPTION
Updated the different login / authentication pages:
- enlarged font size to 16sp
- added divider and spacing between login/start button and create button
- shortened explanation for gc.com authentication
- added explanation for create
- updated image for all login pages still using the old c:geo logo

![image](https://user-images.githubusercontent.com/3754370/105553041-201e2c00-5d05-11eb-9946-0fcc88954548.png).![image](https://user-images.githubusercontent.com/3754370/105553062-24e2e000-5d05-11eb-8589-942239e1f0ba.png)
