### PR TITLE
add toasts for remove waypoints button (fix #9656)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -950,6 +950,8 @@
     <string name="cache_personal_note_edit">Edit</string>
     <string name="cache_personal_note_storewaypoints">Add/Update Waypoints</string>
     <string name="cache_personal_note_removewaypoints">Remove Waypoints</string>
+    <string name="cache_personal_note_removedwaypoints">Removed waypoints</string>
+    <string name="cache_personal_note_removewaypoints_nowaypoints">No waypoints found to remove</string>
     <string name="cache_personal_note_storewaypoints_success">Waypoints were added to personal note</string>
     <string name="cache_personal_note_storewaypoints_success_limited">Waypoints were added to note but had to be shortened (max personal note size: %1$d)</string>
     <string name="cache_personal_note_storewaypoints_failed">Waypoints could not be stored in note due to size limits (max personal note size: %1$d)</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2614,12 +2614,13 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (newNote != null) {
             setNewPersonalNote(newNote);
         }
+        showShortToast(note.equals(newNote) ? R.string.cache_personal_note_removewaypoints_nowaypoints : R.string.cache_personal_note_removedwaypoints);
     }
 
     public void storeWaypointsInPersonalNote(final Geocache cache, final int maxPersonalNotesChars) {
         final String note = cache.getPersonalNote() == null ? "" : cache.getPersonalNote();
 
-        //only uer modified waypoints
+        //only user modified waypoints
         final List<Waypoint> userModifiedWaypoints = new ArrayList<>();
         for (Waypoint w : cache.getWaypoints()) {
             if (w.isUserModified()) {


### PR DESCRIPTION
Adds toasts for the "remove waypoints" button. Now all four combinations are covered:
- synch waypoints: waypoints were added to PN / no storable waypoints found
- remove waypoints: removed waypoints / no waypoints found to remove
