### PR TITLE
fix #9849: set modified coordinates for originalEmptyCoordinates on import

### DIFF
--- a/main/src/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/cgeo/geocaching/export/GpxSerializer.java
@@ -200,7 +200,7 @@ public final class GpxSerializer {
             gpx.text("true");
             gpx.endTag(NS_CGEO, "userdefined");
         }
-        if (waypoint.getCoords() == null || waypoint.isOriginalCoordsEmpty()) {
+        if (waypoint.isOriginalCoordsEmpty()) {
             gpx.startTag(NS_CGEO, "originalCoordsEmpty");
             gpx.text("true");
             gpx.endTag(NS_CGEO, "originalCoordsEmpty");

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -310,11 +310,9 @@ abstract class GPXParser extends FileParser {
                         // there is no lookup code in gpx file
 
                         if (wptEmptyCoordinates) {
-                            waypoint.setCoords(null);
                             waypoint.setOriginalCoordsEmpty(true);
-                        } else {
-                            waypoint.setCoords(cache.getCoords());
                         }
+                        waypoint.setCoords(cache.getCoords());
 
                         waypoint.updateNoteAndUserNote(cache.getDescription());
 

--- a/tests/res/raw/ocddd2_empty_coord.gpx
+++ b/tests/res/raw/ocddd2_empty_coord.gpx
@@ -131,4 +131,16 @@
         <cgeo:userdefined>true</cgeo:userdefined>
         <cgeo:originalCoordsEmpty>true</cgeo:originalCoordsEmpty>
     </wpt>
+    <wpt lat="0.0" lon="0.0">
+        <name>02</name>
+        <cmt>Ttt</cmt>
+        <desc>Wegpunkt 5</desc>
+        <sym>Question to Answer</sym>
+        <type>Waypoint|Question to Answer</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
+        <cgeo:userdefined>true</cgeo:userdefined>
+        <cgeo:originalCoordsEmpty>true</cgeo:originalCoordsEmpty>
+    </wpt>
 </gpx>

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -209,6 +209,18 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(cache.getWaypoints()).hasSize(14);
     }
 
+    public void testWaypointParsingEmptyCoords() {
+        final Geocache cache = parseCache(R.raw.gc366bq);
+        int countEmptyCoords = 0;
+        for (final Waypoint wp : cache.getWaypoints()
+             ) {
+            if (wp.isOriginalCoordsEmpty()) {
+                countEmptyCoords++;
+            }
+        }
+        assertThat(countEmptyCoords).isEqualTo(1);
+    }
+
     public static void testNoteParsingWaypointTypes() {
         final Geocache cache = new Geocache();
         cache.setWaypoints(new ArrayList<>(), false);

--- a/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
+++ b/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
@@ -190,6 +190,7 @@ public class GpxSerializerTest extends AbstractResourceInstrumentationTestCase {
             final int cacheResource = R.raw.gc31j2h;
             final Geocache cache = loadCacheFromResource(cacheResource);
             final Waypoint waypoint = new Waypoint("WP", WaypointType.FINAL, false);
+            waypoint.setOriginalCoordsEmpty(true);
             cache.addOrChangeWaypoint(waypoint, true);
 
             final String gpxFromCache = getGPXFromCache(geocode);

--- a/tests/src-android/cgeo/geocaching/files/GPXImporterTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXImporterTest.java
@@ -113,8 +113,9 @@ public class GPXImporterTest extends AbstractResourceInstrumentationTestCase {
 
         final List<Waypoint> waypointList = cache.getWaypoints();
         assertThat(waypointList).isNotNull();
-        assertThat(waypointList).as("Number of imported waypoints").hasSize(4);
-        assertThat(waypointList.get(3).getCoords()).as("Empty Coordinates").isNull();
+        assertThat(waypointList).as("Number of imported waypoints").hasSize(5);
+        assertThat(waypointList.get(3).getCoords()).as("Not empty coordinates").isNotNull();
+        assertThat(waypointList.get(4).getCoords()).as("Empty coordinates").isNull();
     }
 
     public void testImportGpxWithWaypoints() throws IOException {


### PR DESCRIPTION
Waypoints with empty coordinates are getting exported with #8409. 
Unfortunately the cache-coordinates were set to null, if originalCoords were empty.
