### PR TITLE
skip map companion files on map list build

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -16,6 +16,7 @@ import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.OfflineMapUtils;
 
 import android.app.Activity;
 import android.content.Context;
@@ -352,7 +353,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         final Resources resources = CgeoApplication.getInstance().getResources();
         final List<ImmutablePair<String, Uri>> offlineMaps =
             CollectionStream.of(getOfflineMaps())
-                .filter(fi -> !fi.isDirectory && isValidMapFile(fi.uri))
+                .filter(fi -> !fi.isDirectory && !fi.name.toLowerCase().endsWith(OfflineMapUtils.INFOFILE_SUFFIX) && isValidMapFile(fi.uri))
                 .map(fi -> new ImmutablePair<>(fi.name, fi.uri)).toList();
         if (offlineMaps.size() > 1) {
             registerMapSource(new OfflineMultiMapSource(offlineMaps, this, resources.getString(R.string.map_source_osm_offline_combined)));

--- a/main/src/cgeo/geocaching/utils/OfflineMapUtils.java
+++ b/main/src/cgeo/geocaching/utils/OfflineMapUtils.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class OfflineMapUtils {
 
-    private static final String INFOFILE_SUFFIX = "-cgeo.txt";
+    public static final String INFOFILE_SUFFIX = "-cgeo.txt";
 
     private static final String PROP_PARSETYPE = "remote.parsetype";
     private static final String PROP_REMOTEPAGE = "remote.page";


### PR DESCRIPTION
Skip map companion files on building list of user-installed offline map files to avoid unnecessary opening and parsing of files.