### PR TITLE
Introduce swipe to refresh gesture for cache details (fix #8888, fix #9880)

### DIFF
--- a/main/res/layout/cachedetail_activity.xml
+++ b/main/res/layout/cachedetail_activity.xml
@@ -2,21 +2,28 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="?background_color"
     android:orientation="vertical"
-    tools:context=".CacheDetailActivity" >
+    tools:context=".CacheDetailActivity">
 
-    <androidx.viewpager.widget.ViewPager
-        android:id="@+id/viewpager"
-        android:layout_width="fill_parent"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1">
+
+            <androidx.viewpager.widget.ViewPager
+                android:id="@+id/viewpager"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <com.viewpagerindicator.TitlePageIndicator
         android:id="@+id/pager_indicator"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/actionbar_background"
         app:footerColor="#ff888888"

--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/detailScroll"
     android:layout_width="fill_parent"
@@ -175,4 +175,4 @@
         </LinearLayout>
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
@@ -412,4 +412,4 @@
         </LinearLayout>
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/main/res/layout/cachedetail_images_page.xml
+++ b/main/res/layout/cachedetail_images_page.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
@@ -14,4 +14,4 @@
         android:orientation="vertical" >
     </LinearLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/main/res/layout/cachedetail_inventory_page.xml
+++ b/main/res/layout/cachedetail_inventory_page.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/list"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:cacheColorHint="?background_color"
     android:clipToPadding="false"
+    android:nestedScrollingEnabled="true"
     android:scrollbarStyle="outsideOverlay"
     tools:context=".CacheDetailActivity$InventoryViewCreator" />

--- a/main/res/layout/cachedetail_waypoints_page.xml
+++ b/main/res/layout/cachedetail_waypoints_page.xml
@@ -12,7 +12,8 @@
     android:footerDividersEnabled="false"
     android:headerDividersEnabled="false"
     android:listSelector="?background_color"
+    android:nestedScrollingEnabled="true"
     android:scrollbarStyle="outsideOverlay"
-    tools:context=".CacheDetailActivity$WaypointsViewCreator" >
+    tools:context=".CacheDetailActivity$WaypointsViewCreator">
 
 </ListView>

--- a/main/res/layout/logs_page.xml
+++ b/main/res/layout/logs_page.xml
@@ -11,8 +11,9 @@
     android:footerDividersEnabled="false"
     android:headerDividersEnabled="false"
     android:listSelector="?background_color"
+    android:nestedScrollingEnabled="true"
     android:scrollbarStyle="outsideOverlay"
     tools:context=".log.LogsViewCreator"
-    tools:listitem="@layout/logs_item" >
+    tools:listitem="@layout/logs_item">
 
 </ListView>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -142,7 +142,6 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
-import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.TextView.BufferType;
 import android.widget.Toast;
@@ -153,6 +152,7 @@ import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.core.view.MenuItemCompat;
+import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.FragmentManager;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -1003,6 +1003,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         }
     }
 
+    @Override
+    public void pullToRefreshActionTrigger() {
+        refreshCache();
+    }
+
     private void refreshCache() {
         if (progress.isShowing()) {
             showToast(res.getString(R.string.err_detail_still_working));
@@ -1115,20 +1120,23 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
     /**
      * Creator for details-view.
+     *
+     * TODO: Extract inner class to own file for a better overview. Same might apply to all other view creators.
      */
-    public class DetailsViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
+    public class DetailsViewCreator extends AbstractCachingPageViewCreator<NestedScrollView> {
         // Reference to the details list and favorite line, so that the helper-method can access them without an additional argument
         private LinearLayout detailsList;
         private ImmutablePair<RelativeLayout, TextView> favoriteLine;
 
         @Override
-        public ScrollView getDispatchedView(final ViewGroup parentView) {
+        @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"}) // splitting up that method would not help improve readability
+        public NestedScrollView getDispatchedView(final ViewGroup parentView) {
             if (cache == null) {
                 // something is really wrong
                 return null;
             }
 
-            view = (ScrollView) getLayoutInflater().inflate(R.layout.cachedetail_details_page, parentView, false);
+            view = (NestedScrollView) getLayoutInflater().inflate(R.layout.cachedetail_details_page, parentView, false);
 
             detailsList = view.findViewById(R.id.details_list);
             final CacheDetailsCreator details = new CacheDetailsCreator(CacheDetailActivity.this, detailsList);
@@ -1589,7 +1597,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
      */
     protected ActionMode currentActionMode;
 
-    protected class DescriptionViewCreator extends AbstractCachingPageViewCreator<ScrollView> {
+    protected class DescriptionViewCreator extends AbstractCachingPageViewCreator<NestedScrollView> {
 
         @BindView(R.id.personalnote) protected TextView personalNoteView;
         @BindView(R.id.description) protected IndexOutOfBoundsAvoidingTextView descView;
@@ -1597,13 +1605,14 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         private int maxPersonalNotesChars = 0;
 
         @Override
-        public ScrollView getDispatchedView(final ViewGroup parentView) {
+        @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"}) // splitting up that method would not help improve readability
+        public NestedScrollView getDispatchedView(final ViewGroup parentView) {
             if (cache == null) {
                 // something is really wrong
                 return null;
             }
 
-            view = (ScrollView) getLayoutInflater().inflate(R.layout.cachedetail_description_page, parentView, false);
+            view = (NestedScrollView) getLayoutInflater().inflate(R.layout.cachedetail_description_page, parentView, false);
             ButterKnife.bind(this, view);
 
             // cache short description
@@ -2123,29 +2132,28 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             }
 
             view = (RecyclerView) getLayoutInflater().inflate(R.layout.cachedetail_inventory_page, parentView, false);
-            final RecyclerView recyclerView = view.findViewById(R.id.list);
 
             // TODO: fix layout, then switch back to Android-resource and delete copied one
             // this copy is modified to respect the text color
-            RecyclerViewProvider.provideRecyclerView(CacheDetailActivity.this, recyclerView, true, true);
+            RecyclerViewProvider.provideRecyclerView(CacheDetailActivity.this, view, true, true);
             cache.mergeInventory(genericTrackables, processedBrands);
             final TrackableListAdapter adapterTrackables = new TrackableListAdapter(cache.getInventory(), trackable -> TrackableActivity.startActivity(CacheDetailActivity.this, trackable.getGuid(), trackable.getGeocode(), trackable.getName(), cache.getGeocode(), trackable.getBrand().getId()));
-            recyclerView.setAdapter(adapterTrackables);
+            view.setAdapter(adapterTrackables);
             cache.mergeInventory(genericTrackables, processedBrands);
 
             return view;
         }
     }
 
-    private class ImagesViewCreator extends AbstractCachingPageViewCreator<View> {
+    private class ImagesViewCreator extends AbstractCachingPageViewCreator<NestedScrollView> {
 
         @Override
-        public View getDispatchedView(final ViewGroup parentView) {
+        public NestedScrollView getDispatchedView(final ViewGroup parentView) {
             if (cache == null) {
                 return null; // something is really wrong
             }
 
-            view = getLayoutInflater().inflate(R.layout.cachedetail_images_page, parentView, false);
+            view = (NestedScrollView) getLayoutInflater().inflate(R.layout.cachedetail_images_page, parentView, false);
             if (imagesList == null && isCurrentPage(Page.IMAGES)) {
                 loadCacheImages();
             }


### PR DESCRIPTION
As discussed in #8888 and #9880 this implements a pull-to-refresh gesture to refresh cache details. I've chosen a relative high threshold for pull down refresh - tests will show whether this distance is too large/small or just right. This is difficult to estimate on the emulator...