### PR TITLE
fix: saf accept spaces in foldernames

### DIFF
--- a/main/src/cgeo/geocaching/storage/Folder.java
+++ b/main/src/cgeo/geocaching/storage/Folder.java
@@ -303,7 +303,7 @@ public class Folder {
         final List<String> result = new ArrayList<>();
         for (String token : names.split("/")) {
             if (!StringUtils.isBlank(token)) {
-                result.add(token.replaceAll("[^a-zA-Z0-9-_.]", "-").trim());
+                result.add(token.trim());
             }
         }
         return result;

--- a/tests/src-android/cgeo/geocaching/storage/ContentStorageTest.java
+++ b/tests/src-android/cgeo/geocaching/storage/ContentStorageTest.java
@@ -129,6 +129,22 @@ public class ContentStorageTest extends CGeoTestCase {
         assertThat(ContentStorage.get().delete(uri2)).isTrue();
     }
 
+    public void testFileStrangeNames()  {
+        final Folder folder = createTestFolder(Folder.FolderType.FILE, "strangeNames");
+        ContentStorage.get().ensureFolder(folder, true);
+
+        final File dir = new File(folder.getUri().getPath());
+        final File f1 = new File(dir, "a b c");
+        f1.mkdirs();
+
+        FolderUtils.get().getFolderInfo(folder);
+
+        final List<ContentStorage.FileInformation> files = ContentStorage.get().list(folder);
+
+        assertThat(files).hasSize(1);
+        assertThat(files.get(0).name).isEqualTo("a b c");
+    }
+
     public void testFileCopyAll() {
         performCopyAll(Folder.FolderType.FILE, Folder.FolderType.FILE);
     }


### PR DESCRIPTION
fixes: saf duplicates folder names with spaces in it.
With fix SAF will accept spaces in foldernames

I am currently unable to find the issue where this was found, but I guess the fix is needed anyway...