### PR TITLE
Integrate SAF base folder query into wizard

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -842,7 +842,7 @@
 
     <!-- Content Storage -->
     <string name="contentstorage_grantaccess_dialog_title">Grant access for data storage</string>
-    <string name="contentstorage_grantaccess_dialog_msg_basedir_html"><![CDATA[<p>c:geo needs a local folder to store data like GPX files, backups and field notes. Latest with Android 11 the permission to use this folder needs to be explicitely granted by the user. Therefore c:geo from now on uses this new method to store your data.</p><p>In the following dialog, please select or create such a folder on your device. If you upgraded c:geo from a previous version, select the existing folder "cgeo" on root level of your device storage.</p>]]></string>
+    <string name="contentstorage_grantaccess_dialog_msg_basedir_html">c:geo needs a local folder to store data like GPX files, backups and field notes. Latest with Android 11 the permission to use this folder needs to be explicitely granted by the user. Therefore c:geo from now on uses this new method to store your data.\n\nIn the following dialog, please select or create such a folder on your device. If you upgraded c:geo from a previous version, select the existing folder "cgeo" on root level of your device storage.</string>
     <string name="contentstorage_selectfolder_dialog_title">Change Folder %s</string>
     <string name="contentstorage_selectfolder_dialog_msg_html_folderdata"><![CDATA[<p>The folder %s is currently set to \'%s\' and contains %d file(s) and %d subfolder(s).</p>]]></string>
     <string name="contentstorage_selectfolder_dialog_msg_html_defaultfolder"><![CDATA[<p>You may choose to use the default folder \'%s\' or pick a user-defined folder.</p>]]></string>
@@ -2087,6 +2087,7 @@
     <string name="wizard_outro_error">Incomplete configuration\nNot all parts of c:geo will work as expected!</string>
     <string name="wizard_permissions_title">Set app permissions</string>
     <string name="wizard_permissions_intro">c:geo needs certain permissions on your device to work correctly.\nI will explain more details in the next steps.</string>
+    <string name="wizard_basefolder_request_explanation">c:geo needs a local folder to store data like GPX files, backups and field notes. Select or create such a folder in the next step.\nIf you upgraded c:geo from a previous version, select the existing folder \"cgeo\" on root level of your device storage.</string>
     <string name="wizard_platforms_title">Configure services</string>
     <string name="wizard_platforms_intro">To find geocaches with c:geo you need an account for a geocaching service supported by c:geo.\nSelect the desired service below to either login with your existing account or create a new account.</string>
     <string name="wizard_platforms_gc">geocaching.com</string>
@@ -2102,6 +2103,7 @@
     <string name="wizard_status_title">Configuration status</string>
     <string name="wizard_status_storage_permission">Storage permission</string>
     <string name="wizard_status_location_permission">Location permission</string>
+    <string name="wizard_status_basefolder">Base folder</string>
     <string name="wizard_status_platform">Geocaching services</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -85,7 +85,7 @@ public class ContentStorageActivityHelper {
 
         final PersistableFolder folder = PersistableFolder.BASE;
 
-        if (folder.isUserDefined() && ContentStorage.get().ensureAndAdjustFolder(folder)) {
+        if (baseFolderIsSet()) {
             //everything is as we want it
             return;
         }
@@ -103,6 +103,11 @@ public class ContentStorageActivityHelper {
             .create();
         dialog.show();
         Dialogs.makeLinksClickable(dialog);
+    }
+
+    public static boolean baseFolderIsSet() {
+        final PersistableFolder folder = PersistableFolder.BASE;
+        return folder.isUserDefined() && ContentStorage.get().ensureAndAdjustFolder(folder);
     }
 
     /** Asks user to select a folder for single-time-usage (location and permission is not persisted) */
@@ -193,7 +198,7 @@ public class ContentStorageActivityHelper {
             return false;
         }
         if (runningIntentData == null) {
-            // this is not an error! It might mean that activity was requested by another instance of the Helper (thus usind same requestCodes)
+            // this is not an error! It might mean that activity was requested by another instance of the Helper (thus using same requestCodes)
             // -> signal that result was NOT handled
             return false;
         }


### PR DESCRIPTION
@eddiemuc 
Works in general, but I'm facing two issues, therefore setting "WIP" label for now:
- In `InstallWizardActivity.requestBaseFolder()` I've tried calling `selectPersistableFolder()` with a callback. But the callback got called only on selecting "cancel", not on "ok". (So I changed the code to work without callback, but it's sort of a hack.)
- This may be related to my second, more important issue: Even if I select a folder and grant access to it, my selection does not get persisted. In wizard's summary the entry is still shown as error, and in the `MainActivity` the base folder check will open.
- Strange thing: If I select the very same base folder coming from `MainActivity` it get's persisted. So what is the difference?

@eddiemuc
Do you have an idea what I'm missing here?