### PR TITLE
add support for mf-v4-map scheme for downloading map files (fix #9918)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -880,6 +880,16 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="cgeo.geocaching.MainActivity" />
         </activity>
+        <activity
+            android:name=".settings.MapDownloaderReceiverSchemeMap"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="mf-v4-map" />
+            </intent-filter>
+        </activity>
         <activity android:name=".maps.mapsforge.v6.RenderThemeSettings" />
 
         <!-- fileprovider to be able to share files -->

--- a/main/src/cgeo/geocaching/settings/MapDownloaderReceiverSchemeMap.java
+++ b/main/src/cgeo/geocaching/settings/MapDownloaderReceiverSchemeMap.java
@@ -1,0 +1,39 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.models.OfflineMap;
+import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MapDownloadUtils;
+
+import android.net.Uri;
+import android.os.Bundle;
+
+/* Receives a download URL via "mf-v4-map" scheme, e. g. from openandromaps.org */
+class MapDownloaderReceiverSchemeMap extends AbstractActivity {
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTheme();
+
+        final Uri uri = getIntent().getData();
+        final String host = uri.getHost();
+        final String path = uri.getPath();
+        Log.i("MapDownloaderReceiverSchemeMap: host=" + host + ", path=" + path);
+
+        // check for OpenAndroMaps
+        if (host.equals("download.openandromaps.org") && path.startsWith("/mapsV4/") && path.endsWith(".zip")) {
+            // remap Uri to their ftp server
+            final Uri newUri = Uri.parse(getString(R.string.mapserver_openandromaps_downloadurl) + path.substring(8));
+            MapDownloadUtils.triggerDownload(this, OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_OPENANDROMAPS.id, newUri, "", System.currentTimeMillis(), this::callback);
+        } else {
+            // generic map download
+            Log.w("MapDownloaderReceiverSchemeMap: Received map download intent from unknown source: " + uri.toString());
+            finish();
+        }
+    }
+
+    public void callback() {
+        finish();
+    }
+}


### PR DESCRIPTION
In addition to using the integrated MapDownloader you may now come from the OpenAndroMaps homepage and click on their "Install others" button to trigger download and installation of a map file:

![image](https://user-images.githubusercontent.com/3754370/106379981-b27e9980-63af-11eb-9a48-f784ad81ba42.png)
