### PR TITLE
fix #9808: remove outdated basedir check dialog (replaced by wizard)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -841,8 +841,6 @@
     <string name="sendToCgeo_no_registration">c:geo failed to download caches. Registration for send2cgeo expired. Please register in settings.</string>
 
     <!-- Content Storage -->
-    <string name="contentstorage_grantaccess_dialog_title">Grant access for data storage</string>
-    <string name="contentstorage_grantaccess_dialog_msg_basedir_html">c:geo needs a local folder to store data like GPX files, backups and field notes. Latest with Android 11 the permission to use this folder needs to be explicitely granted by the user. Therefore c:geo from now on uses this new method to store your data.\n\nIn the following dialog, please select or create such a folder on your device. If you upgraded c:geo from a previous version, select the existing folder "cgeo" on root level of your device storage.</string>
     <string name="contentstorage_selectfolder_dialog_title">Change Folder %s</string>
     <string name="contentstorage_selectfolder_dialog_msg_html_folderdata"><![CDATA[<p>The folder %s is currently set to \'%s\' and contains %d file(s) and %d subfolder(s).</p>]]></string>
     <string name="contentstorage_selectfolder_dialog_msg_html_defaultfolder"><![CDATA[<p>You may choose to use the default folder \'%s\' or pick a user-defined folder.</p>]]></string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -342,8 +342,6 @@ public class MainActivity extends AbstractActionBarActivity {
 
         confirmDebug();
 
-        getContentStorageHelper().checkBaseFolderAccess();
-
         // infobox "not logged in" with link to service config; display delayed by 10 seconds
         final Handler handler = new Handler();
         handler.postDelayed(this::checkLoggedIn, 10000);

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -80,31 +80,6 @@ public class ContentStorageActivityHelper {
         this.activity = activity;
     }
 
-    /** Check routine, should be called on c:geo startup to check whether base dir is set as wanted. */
-    public void checkBaseFolderAccess() {
-
-        final PersistableFolder folder = PersistableFolder.BASE;
-
-        if (baseFolderIsSet()) {
-            //everything is as we want it
-            return;
-        }
-
-        //ask/remind user to choose an explicit BASE dir, otherwise the default will be used
-        final AlertDialog dialog = Dialogs.newBuilder(activity)
-            .setTitle(R.string.contentstorage_grantaccess_dialog_title)
-            .setMessage(HtmlCompat.fromHtml(activity.getString(R.string.contentstorage_grantaccess_dialog_msg_basedir_html),
-                HtmlCompat.FROM_HTML_MODE_LEGACY))
-            .setPositiveButton(android.R.string.ok, (d, p) -> {
-                d.dismiss();
-                selectPersistableFolder(folder, null);
-            })
-            .setNegativeButton(android.R.string.cancel, (d, p) -> d.dismiss())
-            .create();
-        dialog.show();
-        Dialogs.makeLinksClickable(dialog);
-    }
-
     public static boolean baseFolderIsSet() {
         final PersistableFolder folder = PersistableFolder.BASE;
         return folder.isUserDefined() && ContentStorage.get().ensureAndAdjustFolder(folder);


### PR DESCRIPTION
fixes #9808
Removes outdated saf basedir check fialog on startup:
![image](https://user-images.githubusercontent.com/6909759/106393124-91409c00-63f5-11eb-973c-cc4e8e54cda4.png)


Because it has be replaced by wizard dialog:
![image](https://user-images.githubusercontent.com/6909759/106393121-86860700-63f5-11eb-9226-81bb7e818597.png)
