### PR TITLE
remove 'refresh' menu entry in cache details

### DIFF
--- a/main/res/menu/cache_options.xml
+++ b/main/res/menu/cache_options.xml
@@ -48,13 +48,6 @@
         app:showAsAction="ifRoom">
     </item>
     <item
-        android:id="@+id/menu_refresh"
-        android:icon="@drawable/ic_menu_refresh"
-        android:title="@string/cache_offline_refresh"
-        android:visible="false"
-        app:showAsAction="ifRoom">
-    </item>
-    <item
         android:id="@+id/menu_share_from_popup"
         android:title="@string/cache_menu_share"
         android:visible="false">

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -666,7 +666,6 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         if (cache != null) {
             // top level menu items
             menu.findItem(R.id.menu_tts_toggle).setVisible(!cache.isGotoHistoryUDC());
-            menu.findItem(R.id.menu_refresh).setVisible(cache.supportsRefresh());
             menu.findItem(R.id.menu_checker).setVisible(StringUtils.isNotEmpty(CheckerUtils.getCheckerUrl(cache)));
             if (connector instanceof PgcChallengeCheckerCapability) {
                 menu.findItem(R.id.menu_challenge_checker).setVisible(((PgcChallengeCheckerCapability) connector).isChallengeCache(cache));


### PR DESCRIPTION
Since we have this nice "pull to refresh" feature in cache details we do not need the "refresh" menu entry any longer