### PR TITLE
installation wizard: skip some screens in migration mode

### DIFF
--- a/main/src/cgeo/geocaching/SplashActivity.java
+++ b/main/src/cgeo/geocaching/SplashActivity.java
@@ -16,9 +16,11 @@ class SplashActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         final Intent intent;
-        if (Settings.getLastChangelogChecksum() == 0 || !ContentStorageActivityHelper.baseFolderIsSet()) {
+        final boolean firstInstall = Settings.getLastChangelogChecksum() == 0;
+        if (firstInstall || !ContentStorageActivityHelper.baseFolderIsSet()) {
             // new install or base folder missing => run installation wizard
             intent = new Intent(this, InstallWizardActivity.class);
+            intent.putExtra(InstallWizardActivity.BUNDLE_MIGRATION, !firstInstall);
         } else {
             // otherwise regular startup
             intent = new Intent(this, MainActivity.class);


### PR DESCRIPTION
As discussed somewhere in the depths of #9872: Skip "services" and "advanced" screens in configuration wizard when in migration mode. Migration mode is entered on startup if "SAF base folder" is not set.

We may want to discuss whether to adapt some texts on wizard's opening and final screens when in migration mode.
