### PR TITLE
add multithreaded map rendering for OSM (fix #9895)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -115,6 +115,8 @@
     <string translatable="false" name="pref_mapline_circlefillcolor">mapline_circlefillcolor</string>
     <string translatable="false" name="pref_mapline_accuracycirclecolor">mapline_accuracycirclecolor</string>
     <string translatable="false" name="pref_mapline_accuracycirclefillcolor">mapline_accuracycirclefillcolor</string>
+    <string translatable="false" name="pref_map_osm_multithreaded">map_osm_multithreaded</string>
+    <string translatable="false" name="pref_map_osm_threads">map_osm_threads</string>
     <string translatable="false" name="pref_showListsInCacheList">showListsInCacheList</string>
     <string translatable="false" name="pref_compactIconMode">compactIconMode</string>
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -806,6 +806,9 @@
     <string name="feature_favorite">Adding cache to favorites</string>
     <string name="feature_voting">Voting for caches</string>
     <string name="init_maplines_title">Map lines customization</string>
+    <string name="init_map_other">Other</string>
+    <string name="init_map_osm_multithreaded">Multi-threaded (OSM)</string>
+    <string name="init_summary_map_osm_multithreaded">Use multiple threads to render OpenStreetMap maps</string>
 
     <!-- proximity notification -->
     <string name="settings_title_proximityNotification">Proximity notification</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -806,6 +806,15 @@
                 app:defaultColor="@color/default_accuracycirclefillcolor"
                 app:showOpaquenessSlider="true" />
         </PreferenceCategory>
+
+        <PreferenceCategory android:title="@string/init_map_other"
+            android:layout="@layout/preference_category">
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_map_osm_multithreaded"
+                android:summary="@string/init_summary_map_osm_multithreaded"
+                android:title="@string/init_map_osm_multithreaded" />
+        </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -231,6 +231,10 @@ public class NewMap extends AbstractActionBarActivity implements XmlRenderThemeM
         this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         this.sharedPreferences.registerOnSharedPreferenceChangeListener(this);
 
+        // Support for multi-threaded map painting
+        Parameters.NUMBER_OF_THREADS = Settings.getMapOsmThreads();
+        Log.i("OSM #threads=" + Parameters.NUMBER_OF_THREADS);
+
         // Use fast parent tile rendering to increase performance when zooming in
         Parameters.PARENT_TILES_RENDERING = Parameters.ParentTilesRendering.SPEED;
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -821,6 +821,10 @@ public class Settings {
         return getInt(prefKeyId, getKeyInt(defaultValueKeyId));
     }
 
+    public static int getMapOsmThreads() {
+        return getBoolean(R.string.pref_map_osm_multithreaded, false) ? Math.max(1, getInt(R.string.pref_map_osm_threads, Math.min(Runtime.getRuntime().availableProcessors() + 1, 4))) : 1;
+    }
+
     public static int getCompactIconMode() {
         final String prefValue = getString(R.string.pref_compactIconMode, "");
         if (prefValue.equals(getKey(R.string.pref_compacticon_on))) {


### PR DESCRIPTION
For testing purposes only!

Set `NewMap` to 4 rendering threads (see #9895).
Fixed value, no user interface supplied, testing only.