### PR TITLE
replace ButterKnife for caches & trackables (rel. to #9232)

### DIFF
--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.AbstractViewPagerActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableTrackingCode;
+import cgeo.geocaching.databinding.TrackableDetailsViewBinding;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogTrackableActivity;
@@ -43,7 +44,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.DrawableRes;
@@ -59,8 +59,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -415,22 +413,14 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
     }
 
     public class DetailsViewCreator extends AbstractCachingPageViewCreator<NestedScrollView> {
-
-        @BindView(R.id.goal_box) protected LinearLayout goalBox;
-        @BindView(R.id.goal) protected TextView goalTextView;
-        @BindView(R.id.details_box) protected LinearLayout detailsBox;
-        @BindView(R.id.details) protected TextView detailsTextView;
-        @BindView(R.id.image_box) protected LinearLayout imageBox;
-        @BindView(R.id.details_list) protected LinearLayout detailsList;
-        @BindView(R.id.image) protected LinearLayout imageView;
-
+        private TrackableDetailsViewBinding binding;
         @Override
         @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"}) // splitting up that method would not help improve readability
         public NestedScrollView getDispatchedView(final ViewGroup parentView) {
-            view = (NestedScrollView) getLayoutInflater().inflate(R.layout.trackable_details_view, parentView, false);
-            ButterKnife.bind(this, view);
+            binding = TrackableDetailsViewBinding.inflate(getLayoutInflater(), parentView, false);
+            view = binding.getRoot();
 
-            final CacheDetailsCreator details = new CacheDetailsCreator(TrackableActivity.this, detailsList);
+            final CacheDetailsCreator details = new CacheDetailsCreator(TrackableActivity.this, binding.detailsList);
 
             // action bar icon
             if (StringUtils.isNotBlank(trackable.getIconUrl())) {
@@ -560,26 +550,26 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
             // trackable goal
             if (StringUtils.isNotBlank(HtmlUtils.extractText(trackable.getGoal()))) {
-                goalBox.setVisibility(View.VISIBLE);
-                goalTextView.setVisibility(View.VISIBLE);
-                goalTextView.setText(HtmlCompat.fromHtml(trackable.getGoal(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(geocode, true, false, goalTextView, false), null), TextView.BufferType.SPANNABLE);
-                goalTextView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
-                addContextMenu(goalTextView);
+                binding.goalBox.setVisibility(View.VISIBLE);
+                binding.goal.setVisibility(View.VISIBLE);
+                binding.goal.setText(HtmlCompat.fromHtml(trackable.getGoal(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(geocode, true, false, binding.goal, false), null), TextView.BufferType.SPANNABLE);
+                binding.goal.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
+                addContextMenu(binding.goal);
             }
 
             // trackable details
             if (StringUtils.isNotBlank(HtmlUtils.extractText(trackable.getDetails()))) {
-                detailsBox.setVisibility(View.VISIBLE);
-                detailsTextView.setVisibility(View.VISIBLE);
-                detailsTextView.setText(HtmlCompat.fromHtml(trackable.getDetails(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(geocode, true, false, detailsTextView, false), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
-                detailsTextView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
-                addContextMenu(detailsTextView);
+                binding.detailsBox.setVisibility(View.VISIBLE);
+                binding.details.setVisibility(View.VISIBLE);
+                binding.details.setText(HtmlCompat.fromHtml(trackable.getDetails(), HtmlCompat.FROM_HTML_MODE_LEGACY, new HtmlImage(geocode, true, false, binding.details, false), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+                binding.details.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
+                addContextMenu(binding.details);
             }
 
             // trackable image
             if (StringUtils.isNotBlank(trackable.getImage())) {
-                imageBox.setVisibility(View.VISIBLE);
-                final ImageView trackableImage = (ImageView) inflater.inflate(R.layout.trackable_image, imageView, false);
+                binding.imageBox.setVisibility(View.VISIBLE);
+                final ImageView trackableImage = (ImageView) inflater.inflate(R.layout.trackable_image, binding.image, false);
 
                 trackableImage.setImageResource(R.drawable.image_not_loaded);
                 trackableImage.setClickable(true);
@@ -587,7 +577,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
                 AndroidRxUtils.bindActivity(TrackableActivity.this, new HtmlImage(geocode, true, false, false).fetchDrawable(trackable.getImage())).subscribe(trackableImage::setImageDrawable);
 
-                imageView.addView(trackableImage);
+                binding.image.addView(trackableImage);
             }
             return view;
         }

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.ui;
 
 import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.CacheslistItemBinding;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.filter.IFilter;
 import cgeo.geocaching.list.AbstractList;
@@ -33,7 +34,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
-import android.widget.ImageView;
 import android.widget.SectionIndexer;
 import android.widget.TextView;
 
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import butterknife.BindView;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -118,18 +117,9 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
      *
      */
     public static class ViewHolder extends AbstractViewHolder {
-        @BindView(R.id.checkbox) protected CheckBox checkbox;
-        @BindView(R.id.log_status_mark) protected ImageView logStatusMark;
-        @BindView(R.id.text_icon) protected ImageView textIcon;
-        @BindView(R.id.text) protected TextView text;
-        @BindView(R.id.distance) protected DistanceView distance;
-        @BindView(R.id.favorite) protected TextView favorite;
-        @BindView(R.id.info) protected TextView info;
-        @BindView(R.id.inventory) protected TextView inventory;
-        @BindView(R.id.direction) protected CompassMiniView direction;
-        @BindView(R.id.dirimg) protected ImageView dirImg;
         private CacheListType cacheListType;
         public Geocache cache = null;
+        public CacheslistItemBinding binding;
 
         public ViewHolder(final View view) {
             super(view);
@@ -388,17 +378,17 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
     public static void updateViewHolder(final ViewHolder holder, final Geocache cache, final Resources res) {
         if (cache.isFound() && cache.isLogOffline()) {
-            holder.logStatusMark.setImageResource(R.drawable.mark_green_orange);
+            holder.binding.logStatusMark.setImageResource(R.drawable.mark_green_orange);
         } else if (cache.isFound()) {
-            holder.logStatusMark.setImageResource(R.drawable.mark_green_more);
+            holder.binding.logStatusMark.setImageResource(R.drawable.mark_green_more);
         } else if (cache.isLogOffline()) {
-            holder.logStatusMark.setImageResource(R.drawable.mark_orange);
+            holder.binding.logStatusMark.setImageResource(R.drawable.mark_orange);
         } else if (cache.isDNF()) {
-            holder.logStatusMark.setImageResource(R.drawable.mark_red);
+            holder.binding.logStatusMark.setImageResource(R.drawable.mark_red);
         } else {
-            holder.logStatusMark.setImageResource(R.drawable.mark_transparent);
+            holder.binding.logStatusMark.setImageResource(R.drawable.mark_transparent);
         }
-        holder.textIcon.setImageDrawable(MapMarkerUtils.getCacheMarker(res, cache, holder.cacheListType).getDrawable());
+        holder.binding.textIcon.setImageDrawable(MapMarkerUtils.getCacheMarker(res, cache, holder.cacheListType).getDrawable());
     }
 
     @Override
@@ -418,9 +408,10 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
         final ViewHolder holder;
         if (v == null) {
-            v = inflater.inflate(R.layout.cacheslist_item, parent, false);
-
+            final CacheslistItemBinding temp = CacheslistItemBinding.inflate(inflater, parent, false);
+            v = temp.getRoot();
             holder = new ViewHolder(v);
+            holder.binding = temp;
         } else {
             holder = (ViewHolder) v.getTag();
         }
@@ -433,77 +424,77 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
         v.setOnLongClickListener(touchListener);
         v.setOnTouchListener(touchListener);
 
-        holder.checkbox.setVisibility(selectMode ? View.VISIBLE : View.GONE);
-        holder.checkbox.setChecked(cache.isStatusChecked());
-        holder.checkbox.setOnClickListener(new SelectionCheckBoxListener(cache));
+        holder.binding.checkbox.setVisibility(selectMode ? View.VISIBLE : View.GONE);
+        holder.binding.checkbox.setChecked(cache.isStatusChecked());
+        holder.binding.checkbox.setOnClickListener(new SelectionCheckBoxListener(cache));
 
-        distances.add(holder.distance);
-        holder.distance.setContent(cache.getCoords());
-        compasses.add(holder.direction);
-        holder.direction.setTargetCoords(cache.getCoords());
+        distances.add(holder.binding.distance);
+        holder.binding.distance.setContent(cache.getCoords());
+        compasses.add(holder.binding.direction);
+        holder.binding.direction.setTargetCoords(cache.getCoords());
 
         if (cache.isDisabled() || cache.isArchived() || CalendarUtils.isPastEvent(cache)) { // strike
-            holder.text.setPaintFlags(holder.text.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+            holder.binding.text.setPaintFlags(holder.binding.text.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
         } else {
-            holder.text.setPaintFlags(holder.text.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
+            holder.binding.text.setPaintFlags(holder.binding.text.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
         }
         if (cache.isArchived()) { // red color
-            holder.text.setTextColor(ContextCompat.getColor(getContext(), R.color.archived_cache_color));
+            holder.binding.text.setTextColor(ContextCompat.getColor(getContext(), R.color.archived_cache_color));
         } else {
-            holder.text.setTextColor(ContextCompat.getColor(getContext(), lightSkin ? R.color.text_light : R.color.text_dark));
+            holder.binding.text.setTextColor(ContextCompat.getColor(getContext(), lightSkin ? R.color.text_light : R.color.text_dark));
         }
 
-        holder.text.setText(cache.getName(), TextView.BufferType.NORMAL);
+        holder.binding.text.setText(cache.getName(), TextView.BufferType.NORMAL);
         holder.cacheListType = cacheListType;
         updateViewHolder(holder, cache, res);
 
         final int inventorySize = cache.getInventoryItems();
         if (inventorySize > 0) {
-            holder.inventory.setText(String.format(Locale.getDefault(), "%d", inventorySize));
-            holder.inventory.setVisibility(View.VISIBLE);
+            holder.binding.inventory.setText(String.format(Locale.getDefault(), "%d", inventorySize));
+            holder.binding.inventory.setVisibility(View.VISIBLE);
         } else {
-            holder.inventory.setVisibility(View.GONE);
+            holder.binding.inventory.setVisibility(View.GONE);
         }
 
         if (cache.getDistance() != null) {
-            holder.distance.setDistance(cache.getDistance());
+            holder.binding.distance.setDistance(cache.getDistance());
         }
 
         if (cache.getCoords() != null && coords != null) {
-            holder.distance.update(coords);
+            holder.binding.distance.update(coords);
         }
 
         // only show the direction if this is enabled in the settings
         if (isLiveList) {
             if (cache.getCoords() != null) {
-                holder.direction.setVisibility(View.VISIBLE);
-                holder.dirImg.setVisibility(View.GONE);
-                holder.direction.updateAzimuth(azimuth);
+                holder.binding.direction.setVisibility(View.VISIBLE);
+                holder.binding.dirimg.setVisibility(View.GONE);
+                holder.binding.direction.updateAzimuth(azimuth);
                 if (coords != null) {
-                    holder.direction.updateCurrentCoords(coords);
+                    holder.binding.direction.updateCurrentCoords(coords);
                 }
             } else if (cache.getDirection() != null) {
-                holder.direction.setVisibility(View.VISIBLE);
-                holder.dirImg.setVisibility(View.GONE);
-                holder.direction.updateAzimuth(azimuth);
-                holder.direction.updateHeading(cache.getDirection());
+                holder.binding.direction.setVisibility(View.VISIBLE);
+                holder.binding.dirimg.setVisibility(View.GONE);
+                holder.binding.direction.updateAzimuth(azimuth);
+                holder.binding.direction.updateHeading(cache.getDirection());
             } else if (StringUtils.isNotBlank(cache.getDirectionImg())) {
-                holder.dirImg.setVisibility(View.INVISIBLE);
-                holder.direction.setVisibility(View.GONE);
+                holder.binding.dirimg.setVisibility(View.INVISIBLE);
+                holder.binding.direction.setVisibility(View.GONE);
                 DirectionImage.fetchDrawable(cache.getDirectionImg()).observeOn(AndroidSchedulers.mainThread()).subscribe(bitmapDrawable -> {
                     if (cache == holder.cache) {
-                        holder.dirImg.setImageDrawable(bitmapDrawable);
-                        holder.dirImg.setVisibility(View.VISIBLE);
+                        holder.binding.dirimg.setImageDrawable(bitmapDrawable);
+                        holder.binding.dirimg.setVisibility(View.VISIBLE);
                     }
                 });
             } else {
-                holder.dirImg.setVisibility(View.GONE);
-                holder.direction.setVisibility(View.GONE);
+                holder.binding.dirimg.setVisibility(View.GONE);
+                holder.binding.direction.setVisibility(View.GONE);
             }
         }
 
         final int favCount = cache.getFavoritePoints();
-        holder.favorite.setText(Formatter.formatFavCount(favCount));
+        holder.binding.favorite.setText(Formatter.formatFavCount(favCount));
 
         int favoriteBack;
         // set default background, neither vote nor rating may be available
@@ -520,12 +511,12 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
         } else if (rating > 0.0) {
             favoriteBack = RATING_BACKGROUND[0];
         }
-        holder.favorite.setBackgroundResource(favoriteBack);
+        holder.binding.favorite.setBackgroundResource(favoriteBack);
 
         if (isHistory() && cache.getVisitedDate() > 0) {
-            holder.info.setText(Formatter.formatCacheInfoHistory(cache));
+            holder.binding.info.setText(Formatter.formatCacheInfoHistory(cache));
         } else {
-            holder.info.setText(Formatter.formatCacheInfoLong(cache));
+            holder.binding.info.setText(Formatter.formatCacheInfoLong(cache));
         }
 
         // optionally show list infos
@@ -538,7 +529,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
                 }
             }
             if (!infos.isEmpty()) {
-                holder.info.append("\n" + StringUtils.join(infos, Formatter.SEPARATOR));
+                holder.binding.info.append("\n" + StringUtils.join(infos, Formatter.SEPARATOR));
             }
         }
 

--- a/main/src/cgeo/geocaching/ui/TrackableListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/TrackableListAdapter.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.ui;
 
-import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.TrackableItemBinding;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.ui.recyclerview.AbstractRecyclerViewHolder;
 import cgeo.geocaching.utils.TextUtils;
@@ -9,15 +9,11 @@ import android.graphics.Paint;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.List;
-
-import butterknife.BindView;
 
 public class TrackableListAdapter extends RecyclerView.Adapter<TrackableListAdapter.ViewHolder> {
 
@@ -29,8 +25,7 @@ public class TrackableListAdapter extends RecyclerView.Adapter<TrackableListAdap
     @NonNull private final TrackableClickListener trackableClickListener;
 
     protected static final class ViewHolder extends AbstractRecyclerViewHolder {
-        @BindView(R.id.trackable_image_brand) ImageView imageBrand;
-        @BindView(R.id.trackable_name) TextView name;
+        public TrackableItemBinding binding;
 
         ViewHolder(final View view) {
             super(view);
@@ -50,8 +45,9 @@ public class TrackableListAdapter extends RecyclerView.Adapter<TrackableListAdap
     @Override
     @NonNull
     public ViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
-        final View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.trackable_item, parent, false);
-        final ViewHolder viewHolder = new ViewHolder(view);
+        final TrackableItemBinding temp = TrackableItemBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+        final ViewHolder viewHolder = new ViewHolder(temp.getRoot());
+        viewHolder.binding = temp;
         viewHolder.itemView.setOnClickListener(view1 -> trackableClickListener.onTrackableClicked(trackables.get(viewHolder.getAdapterPosition())));
         return viewHolder;
     }
@@ -60,10 +56,10 @@ public class TrackableListAdapter extends RecyclerView.Adapter<TrackableListAdap
     public void onBindViewHolder(final ViewHolder holder, final int position) {
         final Trackable trackable = trackables.get(position);
 
-        holder.imageBrand.setImageResource(trackable.getIconBrand());
-        holder.name.setText(TextUtils.stripHtml(trackable.getName()));
+        holder.binding.trackableImageBrand.setImageResource(trackable.getIconBrand());
+        holder.binding.trackableName.setText(TextUtils.stripHtml(trackable.getName()));
         if (trackable.isMissing()) {
-            holder.name.setPaintFlags(holder.name.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+            holder.binding.trackableName.setPaintFlags(holder.binding.trackableName.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
         }
     }
 


### PR DESCRIPTION
Another step towards the viewbinding migration needed for the next Gradle version (and due to ButterKnife being discontinued). It changes ButterKnife @BindView to Android's viewbindings for the cache details, caches list, trackable details and trackables lists activities.