### PR TITLE
make distance layout more flexible (fix #7489)

### DIFF
--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -9,36 +9,45 @@
         android:id="@+id/target"
         android:layout_alignParentTop="true"
         android:layout_alignParentLeft="true"
+        android:layout_toLeftOf="@id/distances"
         android:layout_marginLeft="-2dp"
-        android:layout_marginRight="97dp"
+        android:layout_marginRight="2dp"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
         android:layout_width="wrap_content"
+        android:ellipsize="end"
         style="@style/map_distanceinfo"
         android:gravity="left" />
 
-    <TextView
-        android:id="@+id/distance1"
+    <LinearLayout
+        android:id="@+id/distances"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
-        android:layout_alignParentRight="true"
-        android:layout_width="95dp"
-        style="@style/map_distanceinfo" />
+        android:padding="0dp"
+        android:layout_margin="0dp"
+        android:orientation="vertical"
+        android:gravity="right"
+        android:background="@drawable/icon_bcg">
 
-    <TextView
-        android:id="@+id/distance2"
-        android:layout_marginTop="0dp"
-        android:layout_below="@id/distance1"
-        android:layout_alignParentRight="true"
-        android:layout_width="95dp"
-        style="@style/map_distanceinfo" />
+        <TextView
+            android:id="@+id/distance1"
+            android:layout_width="wrap_content"
+            style="@style/map_distanceinfo_no_background" />
 
-    <TextView
-        android:id="@+id/distance3"
-        android:layout_marginTop="0dp"
-        android:layout_below="@id/distance2"
-        android:layout_alignParentRight="true"
-        android:layout_width="95dp"
-        style="@style/map_distanceinfo" />
+        <TextView
+            android:id="@+id/distance2"
+            android:layout_marginTop="0dp"
+            android:layout_width="wrap_content"
+            style="@style/map_distanceinfo_no_background" />
+
+        <TextView
+            android:id="@+id/distance3"
+            android:layout_marginTop="0dp"
+            android:layout_width="wrap_content"
+            style="@style/map_distanceinfo_no_background" />
+    </LinearLayout>
 
     <TextView
         android:id="@+id/distanceSupersize"
@@ -46,6 +55,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_alignParentTop="true"
+        android:ellipsize="end"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="64sp"
         app:autoSizeMaxTextSize="120sp"
@@ -56,11 +66,13 @@
         android:id="@+id/targetSupersize"
         android:layout_alignParentTop="true"
         android:layout_alignParentLeft="true"
+        android:layout_toLeftOf="@id/distance1Supersize"
         android:layout_marginLeft="-2dp"
-        android:layout_marginRight="97dp"
+        android:layout_marginRight="2dp"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
         android:layout_width="wrap_content"
+        android:ellipsize="end"
         style="@style/map_distanceinfo_no_background"
         android:gravity="left" />
 
@@ -68,7 +80,7 @@
         android:id="@+id/distance1Supersize"
         android:layout_alignParentTop="true"
         android:layout_alignParentRight="true"
-        android:layout_width="95dp"
+        android:layout_width="wrap_content"
         style="@style/map_distanceinfo_no_background" />
 
     <TextView
@@ -76,7 +88,7 @@
         android:layout_marginTop="10dp"
         android:layout_below="@id/distanceSupersize"
         android:layout_alignParentRight="true"
-        android:layout_width="95dp"
+        android:layout_width="wrap_content"
         style="@style/map_distanceinfo" />
 
 </RelativeLayout>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -414,7 +414,6 @@
         <item name="android:paddingLeft">4dp</item>
         <item name="android:paddingRight">4dp</item>
         <item name="android:layout_height">28dp</item>
-        <item name="android:ellipsize">end</item>
         <item name="android:gravity">right</item>
         <item name="android:lines">1</item>
         <item name="android:textColor">@color/text_icon</item>


### PR DESCRIPTION
Instead of using a fixed with for the distance infos on the right:
Uses maximum available space for target cache title, limited only by the width of the widest distance info.

![image](https://user-images.githubusercontent.com/3754370/107126193-a498af00-68ae-11eb-9a6f-d773b4dafb9a.png)
