### PR TITLE
make compact icon buttons same width in map quick settings

### DIFF
--- a/main/res/layout/map_settings_dialog.xml
+++ b/main/res/layout/map_settings_dialog.xml
@@ -34,29 +34,33 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="6dip"
                 android:text="@string/map_dot_mode" />
-            <Button
-                android:id="@+id/compacticon_off"
-                style="@style/button_small"
+            <LinearLayout
                 android:layout_width="wrap_content"
-                android:layout_height="40dp"
+                android:layout_height="wrap_content"
+                android:padding="0dp"
+                android:layout_margin="0dp"
                 android:layout_below="@id/compacticon_title"
-                android:text="@string/switch_off" />
-            <Button
-                android:id="@+id/compacticon_auto"
-                style="@style/button_small"
-                android:layout_width="wrap_content"
-                android:layout_height="40dp"
-                android:layout_below="@id/compacticon_title"
-                android:layout_toRightOf="@id/compacticon_off"
-                android:text="@string/switch_auto" />
-            <Button
-                android:id="@+id/compacticon_on"
-                style="@style/button_small"
-                android:layout_width="wrap_content"
-                android:layout_height="40dp"
-                android:layout_below="@id/compacticon_title"
-                android:layout_toRightOf="@id/compacticon_auto"
-                android:text="@string/switch_on" />
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/compacticon_off"
+                    style="@style/button_small"
+                    android:layout_height="40dp"
+                    android:layout_weight="1"
+                    android:text="@string/switch_off" />
+                <Button
+                    android:id="@+id/compacticon_auto"
+                    style="@style/button_small"
+                    android:layout_height="40dp"
+                    android:layout_weight="1"
+                    android:text="@string/switch_auto" />
+                <Button
+                    android:id="@+id/compacticon_on"
+                    style="@style/button_small"
+                    android:layout_height="40dp"
+                    android:layout_weight="1"
+                    android:text="@string/switch_on" />
+            </LinearLayout>
         </RelativeLayout>
         <RelativeLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Currently the "compact icon mode" buttons in map quick settings popup look like this for OSM:

![image](https://user-images.githubusercontent.com/3754370/107140767-a7ce8200-6924-11eb-9b6f-62c0de55f68b.png)

Google Maps do a better job here, although they share the popup's layout definition.

This PR changes the layout for compact icon mode buttons to look balanced for both maps:

![image](https://user-images.githubusercontent.com/3754370/107140791-c896d780-6924-11eb-977a-e970bf10a165.png).![image](https://user-images.githubusercontent.com/3754370/107140793-cd5b8b80-6924-11eb-9f2c-ec5c9b4a8822.png)
