### PR TITLE
Detect special case source == target in folder migration dialog

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -891,6 +891,7 @@
     <string name="folder_move_finished_title">Folder content was moved</string>
     <string name="folder_copy_finished_dialog_message">Content of folder %1$s was copied to %2$s.\n\n%3$s of %4$s and %5$s of %6$s were processed.</string>
     <string name="folder_move_finished_dialog_message">Content of folder %1$s was moved to %2$s.\n\n%3$s of %4$s and %5$s of %6$s were processed.</string>
+    <string name="folder_copy_move_not_necessary_dialog_message">Folder %1$s can be used without further migration.</string>
     <string name="folder_copy_move_finished_dialog_message_failure">The operation failed with code %1$s while processing file %2$s.</string>
     <string name="folder_move_finished_dialog_tap">Tap \'ok\' to finalize the folder change.</string>
 

--- a/main/src/cgeo/geocaching/storage/FolderUtils.java
+++ b/main/src/cgeo/geocaching/storage/FolderUtils.java
@@ -170,6 +170,7 @@ public class FolderUtils {
         Dialogs.newBuilder(activity)
             .setTitle(activity.getString(move ? R.string.folder_move_finished_title : R.string.folder_copy_finished_title))
             .setMessage(message)
+            .setCancelable(false)
             .setPositiveButton(android.R.string.ok, (dd, pp) -> {
                 dd.dismiss();
                 if (callback != null) {
@@ -188,19 +189,25 @@ public class FolderUtils {
     @NotNull
     private String getCopyAllDoneMessage(final Activity activity, final CopyResult copyResult, final Folder source, final Folder target, final boolean move) {
 
-        final String filesCopied = copyResult.filesCopied < 0 ? "-" : "" + copyResult.filesCopied;
-        final String filesTotal = copyResult.filesInSource < 0 ? "-" : plurals(activity, R.plurals.file_count, copyResult.filesInSource);
-        final String foldersCopied = copyResult.dirsCopied < 0 ? "-" : "" + copyResult.dirsCopied;
-        final String foldersTotal = copyResult.dirsInSource < 0 ? "-" : plurals(activity, R.plurals.folder_count, copyResult.dirsInSource);
+        String message;
+        if (copyResult.status == CopyResultStatus.OK && copyResult.filesCopied == 0 && copyResult.dirsCopied == 0) {
+            message = activity.getString(R.string.folder_copy_move_not_necessary_dialog_message, target.toUserDisplayableString());
+        } else {
 
-        String message =
-            activity.getString(move ? R.string.folder_move_finished_dialog_message : R.string.folder_copy_finished_dialog_message,
-                source.toUserDisplayableString(), target.toUserDisplayableString(),
-                filesCopied, filesTotal, foldersCopied, foldersTotal);
+            final String filesCopied = copyResult.filesCopied < 0 ? "-" : "" + copyResult.filesCopied;
+            final String filesTotal = copyResult.filesInSource < 0 ? "-" : plurals(activity, R.plurals.file_count, copyResult.filesInSource);
+            final String foldersCopied = copyResult.dirsCopied < 0 ? "-" : "" + copyResult.dirsCopied;
+            final String foldersTotal = copyResult.dirsInSource < 0 ? "-" : plurals(activity, R.plurals.folder_count, copyResult.dirsInSource);
 
-        if (copyResult.status != CopyResultStatus.OK) {
-            message += "\n\n" + activity.getString(R.string.folder_copy_move_finished_dialog_message_failure, copyResult.status.toString(),
-                copyResult.failedFile == null ? "---" : UriUtils.toUserDisplayableString(copyResult.failedFile.uri));
+            message =
+                activity.getString(move ? R.string.folder_move_finished_dialog_message : R.string.folder_copy_finished_dialog_message,
+                    source.toUserDisplayableString(), target.toUserDisplayableString(),
+                    filesCopied, filesTotal, foldersCopied, foldersTotal);
+
+            if (copyResult.status != CopyResultStatus.OK) {
+                message += "\n\n" + activity.getString(R.string.folder_copy_move_finished_dialog_message_failure, copyResult.status.toString(),
+                    copyResult.failedFile == null ? "---" : UriUtils.toUserDisplayableString(copyResult.failedFile.uri));
+            }
         }
 
         message += "\n\n" + activity.getString(R.string.folder_move_finished_dialog_tap);


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/64581222/107153246-b6d92280-696c-11eb-8b0c-d673f2f70a67.png)

@eddiemuc There was a status code NOTHING_TO_COPY which was removed in b2e7130240a6e9230b5597c6dced17e164b16305? Why was it deleted, and can we re-add it? That would simplify the if statement and would provide the option to easily change the dialog title as well...

---
Unrelated to this PR but came me in mind while writing the PR description: Shouldn't folder paths end with "/"?