### PR TITLE
library updates

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -281,7 +281,7 @@ dependencies {
 
     // SpotBugs (successor of FindBugs)
     implementation 'net.jcip:jcip-annotations:1.0'
-    implementation 'com.github.spotbugs:spotbugs-annotations:4.2.0'
+    implementation 'com.github.spotbugs:spotbugs-annotations:4.2.1'
 
     // GeographicLib
     implementation 'net.sf.geographiclib:GeographicLib-Java:1.51'

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@
  * Enterprise plugin replaces Build scan plugin from gradle 6, see https://docs.gradle.com/enterprise/gradle-plugin/
  */
 plugins {
-    id 'com.gradle.enterprise' version '3.5.1'
+    id 'com.gradle.enterprise' version '3.5.2'
 }
 
 // Make the root project name independent of the directory name where we checked out the repository.


### PR DESCRIPTION
- gradle 6.8.1 to 6.8.2, see https://docs.gradle.org/6.8.2/release-notes.html and https://services.gradle.org/fixed-issues/6.8.2

- Gradle Enterprise Plugin 3.5.1 to 3.5.2, see https://docs.gradle.com/enterprise/gradle-plugin/#release_history

- spotbugs-annotations 4.2.0 to 4.2.1, see https://github.com/spotbugs/spotbugs/blob/4.2.1/CHANGELOG.md