### PR TITLE
use different way of detecting view root (fix #9975)

### DIFF
--- a/main/res/layout/logcache_activity.xml
+++ b/main/res/layout/logcache_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/logcache_viewroot"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="?background_color"

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -207,7 +207,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         onCreate(savedInstanceState, R.layout.logcache_activity);
-        binding = LogcacheActivityBinding.bind(getWindow().getDecorView().findViewById(android.R.id.content));
+        binding = LogcacheActivityBinding.bind(findViewById(R.id.logcache_viewroot));
 
         date.init(binding.date, null, getSupportFragmentManager());
         logType.setTextView(binding.type).setDisplayMapper(LogType::getL10n);


### PR DESCRIPTION
`LogCacheActivity` (and some others) are a bit harder to tackle for the ButterKnife => viewbinding change. Using the regular approach with `Bindingclass.inflate()` did not work here, it constantly crashed, so I used the regular view creation and attached the viewbinding using the `bind` method. The way for finding the correct root view introduced with #9962 worked on my testing devices, but obviously not on all machines, so I switched to a different approach here, introducing an explicit id for the root view and querying it.