### PR TITLE
replace ButterKnife for several more files (rel. to #9232)

### DIFF
--- a/main/res/layout/filter_activity.xml
+++ b/main/res/layout/filter_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/filter_activity_viewroot"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"

--- a/main/res/layout/mapdownloader_activity.xml
+++ b/main/res/layout/mapdownloader_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/mapdownloader_activity_viewroot"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"

--- a/main/src/cgeo/geocaching/address/AddressListAdapter.java
+++ b/main/src/cgeo/geocaching/address/AddressListAdapter.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.address;
 import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.AddresslistItemBinding;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.sensors.Sensors;
@@ -9,8 +10,6 @@ import android.location.Address;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -18,7 +17,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.List;
 
-import butterknife.BindView;
 import org.apache.commons.lang3.StringUtils;
 
 class AddressListAdapter extends RecyclerView.Adapter<AddressListAdapter.AddressListHolder> {
@@ -28,13 +26,11 @@ class AddressListAdapter extends RecyclerView.Adapter<AddressListAdapter.Address
     @NonNull private final AddressClickListener clickListener;
 
     protected static final class AddressListHolder extends AbstractRecyclerViewHolder {
-
-        @BindView(R.id.label) TextView label;
-        @BindView(R.id.distance) TextView distance;
-        @BindView(R.id.mapIcon) ImageView mapIcon;
+        private final AddresslistItemBinding binding;
 
         AddressListHolder(final View itemView) {
             super(itemView);
+            binding = AddresslistItemBinding.bind(itemView);
         }
     }
 
@@ -55,15 +51,15 @@ class AddressListAdapter extends RecyclerView.Adapter<AddressListAdapter.Address
         final View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.addresslist_item, parent, false);
         final AddressListHolder viewHolder = new AddressListHolder(view);
         viewHolder.itemView.setOnClickListener(view1 -> clickListener.onClickAddress(addresses.get(viewHolder.getAdapterPosition())));
-        viewHolder.mapIcon.setOnClickListener(v -> clickListener.onClickMapIcon(addresses.get(viewHolder.getAdapterPosition())));
+        viewHolder.binding.mapIcon.setOnClickListener(v -> clickListener.onClickMapIcon(addresses.get(viewHolder.getAdapterPosition())));
         return viewHolder;
     }
 
     @Override
     public void onBindViewHolder(final AddressListHolder holder, final int position) {
         final Address address = addresses.get(position);
-        holder.label.setText(getAddressText(address));
-        holder.distance.setText(getDistanceText(address));
+        holder.binding.label.setText(getAddressText(address));
+        holder.binding.distance.setText(getDistanceText(address));
     }
 
     private CharSequence getDistanceText(final Address address) {

--- a/main/src/cgeo/geocaching/connector/gc/PocketQueryListAdapter.java
+++ b/main/src/cgeo/geocaching/connector/gc/PocketQueryListAdapter.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector.gc;
 
 import cgeo.geocaching.CacheListActivity;
 import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.PocketqueryItemBinding;
 import cgeo.geocaching.models.PocketQuery;
 import cgeo.geocaching.ui.recyclerview.AbstractRecyclerViewHolder;
 import cgeo.geocaching.utils.Formatter;
@@ -9,26 +10,20 @@ import cgeo.geocaching.utils.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
-
-import butterknife.BindView;
 
 class PocketQueryListAdapter extends RecyclerView.Adapter<PocketQueryListAdapter.ViewHolder> {
 
     @NonNull private final PocketQueryListActivity activity;
 
     protected static final class ViewHolder extends AbstractRecyclerViewHolder {
-        @BindView(R.id.label) TextView label;
-        @BindView(R.id.download) Button download;
-        @BindView(R.id.cachelist) Button cachelist;
-        @BindView(R.id.info) TextView info;
+        private final PocketqueryItemBinding binding;
 
         ViewHolder(final View view) {
             super(view);
+            binding = PocketqueryItemBinding.bind(view);
         }
     }
 
@@ -46,10 +41,10 @@ class PocketQueryListAdapter extends RecyclerView.Adapter<PocketQueryListAdapter
     public ViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
         final View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.pocketquery_item, parent, false);
         final ViewHolder viewHolder = new ViewHolder(view);
-        viewHolder.cachelist.setOnClickListener(view1 -> CacheListActivity.startActivityPocket(view1.getContext(), activity.getQueries().get(viewHolder.getAdapterPosition())));
-        viewHolder.cachelist.setVisibility(activity.onlyDownloadable() ? View.GONE : View.VISIBLE);
+        viewHolder.binding.cachelist.setOnClickListener(view1 -> CacheListActivity.startActivityPocket(view1.getContext(), activity.getQueries().get(viewHolder.getAdapterPosition())));
+        viewHolder.binding.cachelist.setVisibility(activity.onlyDownloadable() ? View.GONE : View.VISIBLE);
 
-        viewHolder.download.setOnClickListener(v -> {
+        viewHolder.binding.download.setOnClickListener(v -> {
             final PocketQuery pocketQuery = activity.getQueries().get(viewHolder.getAdapterPosition());
             if (activity.onlyDownloadable()) {
                 activity.returnResult(pocketQuery);
@@ -64,9 +59,9 @@ class PocketQueryListAdapter extends RecyclerView.Adapter<PocketQueryListAdapter
     @Override
     public void onBindViewHolder(final ViewHolder holder, final int position) {
         final PocketQuery pocketQuery = activity.getQueries().get(position);
-        holder.download.setVisibility(pocketQuery.isDownloadable() ? View.VISIBLE : View.GONE);
-        holder.label.setText(pocketQuery.getName());
-        holder.info.setText(Formatter.formatPocketQueryInfo(pocketQuery));
+        holder.binding.download.setVisibility(pocketQuery.isDownloadable() ? View.VISIBLE : View.GONE);
+        holder.binding.label.setText(pocketQuery.getName());
+        holder.binding.info.setText(Formatter.formatPocketQueryInfo(pocketQuery));
     }
 
 }

--- a/main/src/cgeo/geocaching/filter/FilterActivity.java
+++ b/main/src/cgeo/geocaching/filter/FilterActivity.java
@@ -2,14 +2,13 @@ package cgeo.geocaching.filter;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
+import cgeo.geocaching.databinding.FilterActivityBinding;
 import cgeo.geocaching.filter.FilterRegistry.FactoryEntry;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.widget.ExpandableListView;
-import android.widget.LinearLayout;
 import android.widget.SimpleExpandableListAdapter;
 
 import androidx.annotation.NonNull;
@@ -20,8 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.OptionsItem;
 import org.androidannotations.annotations.OptionsMenu;
@@ -39,14 +36,12 @@ public class FilterActivity extends AbstractActionBarActivity {
     private static final String KEY_FILTER_NAME = "filterName";
     private static final String KEY_FILTER_GROUP_NAME = "filterGroupName";
 
-    @BindView(R.id.filterList) protected ExpandableListView filterList;
-    @BindView(R.id.filters) protected LinearLayout filtersContainer;
+    private FilterActivityBinding binding;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState, R.layout.filter_activity);
-        ButterKnife.bind(this);
-
+        binding = FilterActivityBinding.bind(findViewById(R.id.filter_activity_viewroot));
         createListAdapter();
     }
 
@@ -66,8 +61,8 @@ public class FilterActivity extends AbstractActionBarActivity {
                         new String[] { KEY_FILTER_NAME, "CHILD_NAME" },
                         new int[] { android.R.id.text1 }
                 );
-        filterList.setAdapter(adapter);
-        filterList.setOnChildClickListener((parent, v, groupPosition, childPosition, id) -> {
+        binding.filterList.setAdapter(adapter);
+        binding.filterList.setOnChildClickListener((parent, v, groupPosition, childPosition, id) -> {
             setFilterResult(groupPosition, childPosition);
             return true;
         });

--- a/main/src/cgeo/geocaching/helper/HelperAppAdapter.java
+++ b/main/src/cgeo/geocaching/helper/HelperAppAdapter.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.helper;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.compatibility.Compatibility;
+import cgeo.geocaching.databinding.UsefulappsItemBinding;
 import cgeo.geocaching.ui.recyclerview.AbstractRecyclerViewHolder;
 
 import android.content.Context;
@@ -9,8 +10,6 @@ import android.content.res.Resources;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.core.text.HtmlCompat;
@@ -19,8 +18,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.Arrays;
 import java.util.List;
 
-import butterknife.BindView;
-
 final class HelperAppAdapter extends RecyclerView.Adapter<HelperAppAdapter.ViewHolder> {
 
     @NonNull private final List<HelperApp> helperApps;
@@ -28,12 +25,11 @@ final class HelperAppAdapter extends RecyclerView.Adapter<HelperAppAdapter.ViewH
     @NonNull private final Context context;
 
     protected static final class ViewHolder extends AbstractRecyclerViewHolder {
-        @BindView(R.id.title) protected TextView title;
-        @BindView(R.id.image) protected ImageView image;
-        @BindView(R.id.description) protected TextView description;
+        private final UsefulappsItemBinding binding;
 
         ViewHolder(final View rowView) {
             super(rowView);
+            binding = UsefulappsItemBinding.bind(rowView);
         }
     }
 
@@ -64,9 +60,9 @@ final class HelperAppAdapter extends RecyclerView.Adapter<HelperAppAdapter.ViewH
     public void onBindViewHolder(final ViewHolder holder, final int position) {
         final HelperApp app = helperApps.get(position);
         final Resources resources = context.getResources();
-        holder.title.setText(resources.getString(app.titleId));
-        holder.image.setImageDrawable(Compatibility.getDrawable(resources, app.iconId));
-        holder.description.setText(HtmlCompat.fromHtml(resources.getString(app.descriptionId), HtmlCompat.FROM_HTML_MODE_LEGACY));
+        holder.binding.title.setText(resources.getString(app.titleId));
+        holder.binding.image.setImageDrawable(Compatibility.getDrawable(resources, app.iconId));
+        holder.binding.description.setText(HtmlCompat.fromHtml(resources.getString(app.descriptionId), HtmlCompat.FROM_HTML_MODE_LEGACY));
     }
 
 }


### PR DESCRIPTION
Getting closer... Another step towards the viewbinding migration needed for the next Gradle version (and due to ButterKnife being discontinued). It changes ButterKnife @BindView to Android's viewbindings for filter / map downloader / address list / pocket query list and helper apps activities.