### PR TITLE
fix #10009: make explicit when caches are deleted completey in cache lists

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -371,6 +371,8 @@
     <string name="caches_nearby">Nearby</string>
     <string name="caches_remove_all">Remove all</string>
     <string name="caches_remove_selected">Remove selected</string>
+    <string name="caches_remove_all_completely">Delete all from device</string>
+    <string name="caches_remove_selected_completely">Delete selected from device</string>
     <string name="caches_delete_events">Delete past events</string>
     <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>
     <string name="caches_upload_modifiedcoords_warning">Do you want to upload modified coordinates for all (selected) caches and overwrite the existing coordinates on the server? This cannot be undone.</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -751,7 +751,10 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setVisibleEnabled(menu, R.id.menu_remove_from_history, isHistory, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_remove_from_history, R.string.cache_remove_from_history, R.string.cache_clear_history);
             if (isOffline || type == CacheListType.HISTORY) { // only offline list
-                setMenuItemLabel(menu, R.id.menu_drop_caches, R.string.caches_remove_selected, R.string.caches_remove_all);
+                final boolean removeFromDevice = removeWillDeleteFromDevice(listId);
+                setMenuItemLabel(menu, R.id.menu_drop_caches,
+                    removeFromDevice ? R.string.caches_remove_selected_completely : R.string.caches_remove_selected,
+                    removeFromDevice ? R.string.caches_remove_all_completely : R.string.caches_remove_all);
                 setMenuItemLabel(menu, R.id.menu_refresh_stored, R.string.caches_refresh_selected, R.string.caches_refresh_all);
                 setMenuItemLabel(menu, R.id.menu_move_to_list, R.string.caches_move_selected, R.string.caches_move_all);
                 setMenuItemLabel(menu, R.id.menu_copy_to_list, R.string.caches_copy_selected, R.string.caches_copy_all);
@@ -1412,6 +1415,10 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         }
     }
 
+    public static boolean removeWillDeleteFromDevice(final int listId) {
+        return listId == PseudoList.ALL_LIST.id || listId == PseudoList.HISTORY_LIST.id || listId == StoredList.TEMPORARY_LIST.id;
+    }
+
     private static final class DeleteCachesFromListCommand extends AbstractCachesCommand {
 
         private final LastPositionHelper lastPositionHelper;
@@ -1438,8 +1445,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             }
         }
 
-        private boolean appliesToAllLists() {
-            return listId == PseudoList.ALL_LIST.id || listId == PseudoList.HISTORY_LIST.id || listId == StoredList.TEMPORARY_LIST.id;
+        public boolean appliesToAllLists() {
+            return removeWillDeleteFromDevice(listId);
         }
 
         @Override


### PR DESCRIPTION
fix #10009: make explicit when caches are deleted completey in cache lists

If we are in a user-defined list, cache menu remove entries is unchanged:
![image](https://user-images.githubusercontent.com/6909759/107881594-40e13800-6ee5-11eb-825d-2e13aaf424a6.png)


If we are in a "special" list (All, Temporaray, History) then labels for remove-entries are different:
![image](https://user-images.githubusercontent.com/6909759/107881624-6ff7a980-6ee5-11eb-9e68-55c0b4e38394.png)
