### PR TITLE
don't allow canceling the "copy done" dialog via clicking outside

### DIFF
--- a/main/src/cgeo/geocaching/storage/FolderUtils.java
+++ b/main/src/cgeo/geocaching/storage/FolderUtils.java
@@ -170,6 +170,7 @@ public class FolderUtils {
         Dialogs.newBuilder(activity)
             .setTitle(activity.getString(move ? R.string.folder_move_finished_title : R.string.folder_copy_finished_title))
             .setMessage(message)
+            .setCancelable(false)
             .setPositiveButton(android.R.string.ok, (dd, pp) -> {
                 dd.dismiss();
                 if (callback != null) {


### PR DESCRIPTION
Since it would be quite inconvenient if someone accidentally cancel the folder migration after he had already moved all the files to the new location, we shouldn't allow canceling in the CopyAllDoneDialog...

closes #9978