### PR TITLE
better backup integration in installation wizard

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -655,6 +655,7 @@
     <string name="init_restore_restored">Restoration completed</string>
     <string name="init_backup_start_restore">Start restore</string>
     <string name="init_backup_restore_different_backup">Restore a different backup</string>
+    <string name="init_backup_restore_different_backup_explanation">Please select the folder that contains the backup you want to restore</string>
     <string name="init_backup_backup_history">Backup history</string>
     <string name="init_backup_history_length_title">Maximum stored backups</string>
     <string name="init_backup_history_length_summary">Decide how many backups should be kept. When the limit is reached, the oldest ones will be deleted automatically.</string>

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -15,9 +15,11 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.ContentStorageActivityHelper;
+import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.ProcessUtils;
 
 import android.Manifest;
@@ -189,7 +191,13 @@ public class InstallWizardActivity extends AppCompatActivity {
                 }, button2Info, R.string.wizard_advanced_brouter_info);
                 setButton(button3, R.string.wizard_advanced_restore_label, v -> {
                     setButtonToDone();
-                    SettingsActivity.openForScreen(R.string.preference_screen_backup, this);
+                    DataStore.resetNewlyCreatedDatabase();
+                    final BackupUtils backupUtils = new BackupUtils(this);
+                    if (BackupUtils.hasBackup(BackupUtils.newestBackupFolder())) {
+                        backupUtils.restore(BackupUtils.newestBackupFolder());
+                    } else {
+                        backupUtils.selectBackupDirIntent(getContentStorageHelper());
+                    }
                 }, button3Info, R.string.wizard_advanced_restore_info);
                 break;
             case WIZARD_END: {

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -58,7 +58,7 @@ import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
 
 
-public class BackupUtils extends Activity {
+public class BackupUtils {
     private static final String ATTRIBUTE_NAME = "name";
     private static final String ATTRIBUTE_VALUE = "value";
     private static final String TAG_MAP = "map";
@@ -74,6 +74,7 @@ public class BackupUtils extends Activity {
     /* Public methods containing question dialogs, etc */
 
     public void selectBackupDirIntent (final ContentStorageActivityHelper contentStorageHelper) {
+        Toast.makeText(activityContext, R.string.init_backup_restore_different_backup_explanation, Toast.LENGTH_LONG).show();
         contentStorageHelper.selectFolder(PersistableFolder.BACKUP.getUri(), this::restore);
     }
 
@@ -246,7 +247,7 @@ public class BackupUtils extends Activity {
             final InputStream file = ContentStorage.get().openForRead(getSettingsFile(backupDir).uri);
 
             // open shared prefs for writing
-            final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), MODE_PRIVATE);
+            final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), Context.MODE_PRIVATE);
             final SharedPreferences.Editor editor = prefs.edit();
 
             // parse xml
@@ -351,7 +352,7 @@ public class BackupUtils extends Activity {
     }
 
     private boolean createSettingsBackupInternal(final Folder backupDir, final Boolean fullBackup) {
-        final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), MODE_PRIVATE);
+        final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), Context.MODE_PRIVATE);
         final Map<String, ?> keys = prefs.getAll();
         final HashSet<String> ignoreKeys = new HashSet<>();
 

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.InstallWizardActivity;
 import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.BackupSeekbarPreference;
@@ -165,7 +166,7 @@ public class BackupUtils extends Activity {
                     resultString += activityContext.getString(R.string.init_restore_settings_failed);
                 }
             }
-            if (restartNeeded) {
+            if (restartNeeded && !(activityContext instanceof InstallWizardActivity)) {
                 Dialogs.confirmYesNo(activityContext, R.string.init_restore_restored, resultString + activityContext.getString(R.string.settings_restart), (dialog2, which2) -> ProcessUtils.restartApplication(activityContext));
             } else {
                 Dialogs.message(activityContext, R.string.init_restore_restored, resultString);


### PR DESCRIPTION
There was a bug that restoring a backup always returned "database is broken" when triggering restore via the installation wizard.
Also, the "cgeo needs to be restarted" dialog had disturbed the installation workflow. 

Both ones are fixed in this PR. Along the way, it will also save some clicks for restoring, as "restore" will now start the restore directly instead of redirecting to the settings first.