### PR TITLE
switch map activities to AppCompatActivity (rel. to #9373)

### DIFF
--- a/main/res/layout/settings_toolbar.xml
+++ b/main/res/layout/settings_toolbar.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    app:theme="@style/dark"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?attr/actionBarSize"
+    app:navigationContentDescription="@string/abc_action_bar_up_description"
+    app:navigationIcon="?attr/homeAsUpIndicator"
+    style="@style/cgeo.ActionBarStyle"
+    />

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -171,7 +171,7 @@
         <item name="android:windowAnimationStyle">@android:style/Animation</item>
     </style>
 
-    <style name="settings" parent="@android:style/Theme.DeviceDefault">
+    <style name="settings" parent="dark">
         <item name="settings_cloud">@drawable/settings_cloud_white</item>
         <item name="settings_details">@drawable/settings_details_white</item>
         <item name="settings_eye">@drawable/settings_eye_white</item>
@@ -183,14 +183,14 @@
         <item name="settings_backup">@drawable/settings_backup_white</item>
         <item name="settings_info_icon">@drawable/settings_info_icon_white</item>
         <item name="settings_map_icon">@drawable/settings_map_white</item>
+
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert</item>
         <item name="text_color">@color/text_dark</item>
-        <item name="button">@drawable/action_button_dark</item>
     </style>
 
-    <style name="settings.light" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
+    <style name="settings.light" parent="light">
         <item name="settings_cloud">@drawable/settings_cloud_black</item>
         <item name="settings_details">@drawable/settings_details_black</item>
         <item name="settings_eye">@drawable/settings_eye_black</item>
@@ -202,11 +202,11 @@
         <item name="settings_backup">@drawable/settings_backup_black</item>
         <item name="settings_info_icon">@drawable/settings_info_icon_black</item>
         <item name="settings_map_icon">@drawable/settings_map_black</item>
+
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:alertDialogTheme">@style/Dialog_Alert_light</item>
         <item name="text_color">@color/text_light</item>
-        <item name="button">@drawable/action_button_light</item>
     </style>
 
     <style name="Dialog_Alert" parent="@style/Theme.AppCompat.Dialog.Alert">

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -55,20 +55,6 @@
         <item name="android:indeterminateProgressStyle" tools:ignore="NewApi">@style/cgeo.Widget.AppCompat.Base.ProgressBar.Medium</item>
     </style>
 
-    <style name="cgeo_gmap" parent="@android:style/Theme.DeviceDefault">
-        <item name="text_color">@color/text_dark</item>
-        <item name="button">@drawable/action_button_dark</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:colorAccent">@color/colorAccent</item>
-    </style>
-
-    <style name="cgeo_gmap_light" parent="@android:style/Theme.DeviceDefault.Light.DarkActionBar">
-        <item name="text_color">@color/text_light</item>
-        <item name="button">@drawable/action_button_light</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:colorAccent">@color/colorAccent</item>
-    </style>
-
     <style name="cgeo.base" parent="@style/Theme.AppCompat">
 
        <!-- For some reason we get a different text-size here (bug in abc?), explicitly set text styles -->

--- a/main/src/cgeo/geocaching/helper/QueryMapFile.java
+++ b/main/src/cgeo/geocaching/helper/QueryMapFile.java
@@ -3,17 +3,18 @@ package cgeo.geocaching.helper;
 import cgeo.geocaching.R;
 import cgeo.geocaching.storage.PersistableFolder;
 
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 /**
  * Helper activity for WhereYouGo to request the current mf map dir
  * Only returns if there is a map file set or forceAndFeedback=true
  */
-public class QueryMapFile extends Activity {
+public class QueryMapFile extends AppCompatActivity {
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -14,7 +14,6 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.storage.DataStore;
 
-import android.app.Activity;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.Menu;
@@ -22,6 +21,7 @@ import android.view.MenuItem;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -47,7 +47,7 @@ public abstract class AbstractMap {
         return mapActivity.getResources();
     }
 
-    public Activity getActivity() {
+    public AppCompatActivity getActivity() {
         return mapActivity.getActivity();
     }
 

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -70,7 +70,6 @@ import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TrackUtils;
 import static cgeo.geocaching.location.Viewport.containingGCliveCaches;
 
-import android.app.ActionBar;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -96,6 +95,8 @@ import android.widget.ViewSwitcher.ViewFactory;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -149,7 +150,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     // Those are initialized in onCreate() and will never be null afterwards
     private Resources res;
-    private Activity activity;
+    private AppCompatActivity activity;
     private MapItemFactory mapItemFactory;
     private final LeastRecentlyUsedSet<Geocache> caches = new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount());
     private final Progress progress = new Progress();
@@ -321,7 +322,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     @NonNull
     private ActionBar getActionBar() {
-        final ActionBar actionBar = activity.getActionBar();
+        final ActionBar actionBar = activity.getSupportActionBar();
         assert actionBar != null;
         return actionBar;
     }
@@ -575,7 +576,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         activity.setContentView(mapProvider.getMapLayoutId());
 
         // try to retrieve up indicator resId and forward it to popup
-        final TypedArray a = activity.getTheme().obtainStyledAttributes(R.style.cgeo_gmap, new int[] {R.attr.homeAsUpIndicator});
+        final TypedArray a = activity.getTheme().obtainStyledAttributes(R.style.cgeo, new int[] {R.attr.homeAsUpIndicator});
         final int upResId = a.getResourceId(0, 0);
         a.recycle();
         activity.findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(activity, manualRoute, this::onMapSettingsPopupFinished, this::routingModeChanged, this::compactIconModeChanged, upResId));

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -70,7 +70,6 @@ import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TrackUtils;
 import static cgeo.geocaching.location.Viewport.containingGCliveCaches;
 
-import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.res.Resources;

--- a/main/src/cgeo/geocaching/maps/MapActivity.java
+++ b/main/src/cgeo/geocaching/maps/MapActivity.java
@@ -2,14 +2,15 @@ package cgeo.geocaching.maps;
 
 import cgeo.geocaching.settings.Settings;
 
-import android.app.Activity;
 import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * This activity provides an entry point for external intent calls, and then forwards to the currently used map activity
  * implementation.
  */
-public class MapActivity extends Activity {
+public class MapActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -19,7 +19,6 @@ import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_OFF;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -29,10 +28,11 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class GoogleMapActivity extends Activity implements MapActivityImpl, FilteredActivity {
+public class GoogleMapActivity extends AppCompatActivity implements MapActivityImpl, FilteredActivity {
 
 
     private final AbstractMap mapBase;
@@ -45,11 +45,7 @@ public class GoogleMapActivity extends Activity implements MapActivityImpl, Filt
     }
 
     public void setTheme(final int resid) {
-        if (Settings.isLightSkin()) {
-            super.setTheme(R.style.cgeo_gmap_light);
-        } else {
-            super.setTheme(R.style.cgeo_gmap);
-        }
+        super.setTheme(Settings.isLightSkin() ? R.style.light : R.style.dark);
     }
 
     public TrackUtils getTrackUtils() {
@@ -61,7 +57,7 @@ public class GoogleMapActivity extends Activity implements MapActivityImpl, Filt
     }
 
     @Override
-    public Activity getActivity() {
+    public AppCompatActivity getActivity() {
         return this;
     }
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapProvider.java
@@ -8,8 +8,9 @@ import cgeo.geocaching.maps.interfaces.MapItemFactory;
 import cgeo.geocaching.maps.interfaces.MapProvider;
 import cgeo.geocaching.maps.interfaces.MapSource;
 
-import android.app.Activity;
 import android.content.res.Resources;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public final class GoogleMapProvider extends AbstractMapProvider {
 
@@ -40,7 +41,7 @@ public final class GoogleMapProvider extends AbstractMapProvider {
     }
 
     @Override
-    public Class<? extends Activity> getMapClass() {
+    public Class<? extends AppCompatActivity> getMapClass() {
         return GoogleMapActivity.class;
     }
 

--- a/main/src/cgeo/geocaching/maps/interfaces/MapActivityImpl.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapActivityImpl.java
@@ -3,12 +3,13 @@ package cgeo.geocaching.maps.interfaces;
 import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.TrackUtils;
 
-import android.app.Activity;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Defines the common functions of the provider-specific
@@ -18,7 +19,7 @@ public interface MapActivityImpl {
 
     Resources getResources();
 
-    Activity getActivity();
+    AppCompatActivity getActivity();
 
     void superOnCreate(Bundle savedInstanceState);
 

--- a/main/src/cgeo/geocaching/maps/interfaces/MapProvider.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapProvider.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.maps.interfaces;
 
-import android.app.Activity;
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Defines functions of a factory class to get implementation specific objects
@@ -10,7 +10,7 @@ public interface MapProvider {
 
     boolean isSameActivity(MapSource source1, MapSource source2);
 
-    Class<? extends Activity> getMapClass();
+    Class<? extends AppCompatActivity> getMapClass();
 
     int getMapViewId();
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -19,13 +19,13 @@ import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.TextUtils;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -87,7 +87,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
     }
 
     @Override
-    public Class<? extends Activity> getMapClass() {
+    public Class<? extends AppCompatActivity> getMapClass() {
         mapItemFactory = new MapsforgeMapItemFactory();
         return NewMap.class;
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -251,7 +251,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer {
         this.mapAttribution = findViewById(R.id.map_attribution);
 
         // try to retrieve up indicator resId and forward it to popup
-        final TypedArray a = getTheme().obtainStyledAttributes(R.style.cgeo_gmap, new int[] {R.attr.homeAsUpIndicator});
+        final TypedArray a = getTheme().obtainStyledAttributes(R.style.cgeo, new int[] {R.attr.homeAsUpIndicator});
         final int upResId = a.getResourceId(0, 0);
         a.recycle();
         findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(this, manualRoute, this::onMapSettingsPopupFinished, this::routingModeChanged, this::compactIconModeChanged, upResId));


### PR DESCRIPTION
Some preparations for #9373:
- rebase map activities to `AppCompatActivity`
- use cgeo-based theme for Google Maps (instead of `DeviceDefault`-based) (fix #7587)
- use cgeo-based theme for settings (instead of `DeviveDefault`-based)
- set toolbar for settings (fixes #5602)

Should also fix some theme problems with Google Maps and settings, e. g. #8783 (but that probably needs to be checked against physical devices).

Tested in the emulator against API 21, 23, 24 and 30.

Some screenshots for settings: (title bar adjusts to preferences screen)
![image](https://user-images.githubusercontent.com/3754370/108597365-f9e1bf80-7388-11eb-93bf-57e0f969b470.png).![image](https://user-images.githubusercontent.com/3754370/108597372-00703700-7389-11eb-9dd9-f60bd37671ee.png)
