### PR TITLE
add toggle to pq list to display all/downloadable only

### DIFF
--- a/main/res/layout/pq_actionbar.xml
+++ b/main/res/layout/pq_actionbar.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal" >
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:gravity="left|center_horizontal"
+        style="@style/cgeo.ActionBarStyle.TitleTextStyle"
+        android:text="@string/menu_pocket_queries" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchAB"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/title"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:gravity="right"
+        android:text="@string/show_all" />
+</RelativeLayout>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -134,6 +134,7 @@
     <string translatable="false" name="pref_debug">debug</string>
     <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
     <string translatable="false" name="pref_longTapOnMapActivated">pref_longTapCreateUDC</string>
+    <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
     <!-- preferences used internally -->
     <string translatable="false" name="pref_temp_twitter_token_secret">temp-token-secret</string>
     <string translatable="false" name="pref_temp_twitter_token_public">temp-token-public</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2034,6 +2034,7 @@
     <string name="switch_default">(default)</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="show_all">Show all</string>
 
     <string name="routingmode_straight">Straight</string>
     <string name="routingmode_walk">Walk</string>

--- a/main/src/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
+++ b/main/src/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.models.PocketQuery;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.recyclerview.RecyclerViewProvider;
 import cgeo.geocaching.utils.AndroidRxUtils;
 
@@ -12,8 +13,11 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.SwitchCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
@@ -23,9 +27,12 @@ import org.apache.commons.collections4.CollectionUtils;
 
 public class PocketQueryListActivity extends AbstractActionBarActivity {
 
+    @NonNull private final List<PocketQuery> allPocketQueries = new ArrayList<>();
     @NonNull private final List<PocketQuery> pocketQueries = new ArrayList<>();
 
     private boolean onlyDownloadable = false;
+    private boolean fixed = false;
+    private SwitchCompat switchCompat = null;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -34,11 +41,28 @@ public class PocketQueryListActivity extends AbstractActionBarActivity {
         final Bundle extras = getIntent().getExtras();
         if (extras != null) {
             onlyDownloadable = extras.getBoolean(Intents.EXTRA_PQ_LIST_IMPORT);
+            if (onlyDownloadable) {
+                fixed = true;
+            }
+        } else {
+            onlyDownloadable = Settings.getPqShowDownloadableOnly();
         }
 
         final PocketQueryListAdapter adapter = new PocketQueryListAdapter(this);
         final RecyclerView view = RecyclerViewProvider.provideRecyclerView(this, R.id.pocketquery_list, true, true);
         view.setAdapter(adapter);
+
+        if (!fixed) {
+            final ActionBar bar = getSupportActionBar();
+            final View customView = getLayoutInflater().inflate(R.layout.pq_actionbar, null);
+            bar.setCustomView(customView);
+            bar.setDisplayShowCustomEnabled(true);
+
+            switchCompat = customView.findViewById(R.id.switchAB);
+            switchCompat.setVisibility(View.INVISIBLE);
+            switchCompat.setChecked(!Settings.getPqShowDownloadableOnly());
+            switchCompat.setOnCheckedChangeListener((a, b) -> checkSwitchState(adapter));
+        }
 
         final ProgressDialog waitDialog = ProgressDialog.show(this, getString(R.string.search_pocket_title), getString(R.string.search_pocket_loading), true, true);
         waitDialog.setCancelable(true);
@@ -48,26 +72,39 @@ public class PocketQueryListActivity extends AbstractActionBarActivity {
     private void loadInBackground(final PocketQueryListAdapter adapter, final ProgressDialog waitDialog) {
         AndroidRxUtils.bindActivity(this, GCParser.searchPocketQueryListObservable).subscribe(pocketQueryList -> {
             waitDialog.dismiss();
-            if (onlyDownloadable) {
-                for (final PocketQuery pq : pocketQueryList) {
-                    if (pq.isDownloadable()) {
-                        pocketQueries.add(pq);
-                    }
-                }
-            } else {
-                pocketQueries.addAll(pocketQueryList);
-            }
-
+            allPocketQueries.addAll(pocketQueryList);
             if (CollectionUtils.isEmpty(pocketQueryList)) {
                 ActivityMixin.showToast(PocketQueryListActivity.this, getString(R.string.warn_no_pocket_query_found));
                 finish();
             }
-
-            adapter.notifyItemRangeInserted(0, pocketQueryList.size());
+            fillAdapter(adapter);
+            if (!fixed) {
+                switchCompat.setVisibility(View.VISIBLE);
+            }
         }, e -> {
             ActivityMixin.showToast(PocketQueryListActivity.this, getString(R.string.err_read_pocket_query_list));
             finish();
         });
+    }
+
+    private void fillAdapter(final PocketQueryListAdapter adapter) {
+        pocketQueries.clear();
+        if (onlyDownloadable) {
+            for (final PocketQuery pq : allPocketQueries) {
+                if (pq.isDownloadable()) {
+                    pocketQueries.add(pq);
+                }
+            }
+        } else {
+            pocketQueries.addAll(allPocketQueries);
+        }
+        adapter.notifyDataSetChanged();
+    }
+
+    private void checkSwitchState(final PocketQueryListAdapter adapter) {
+        onlyDownloadable = !switchCompat.isChecked();
+        Settings.setPqShowDownloadableOnly(onlyDownloadable);
+        fillAdapter(adapter);
     }
 
     public static void startSubActivity(final Activity fromActivity, final int requestCode) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -965,6 +965,14 @@ public class Settings {
         return getInt(R.string.pref_maplanguage, MAP_LANGUAGE_DEFAULT);
     }
 
+    public static void setPqShowDownloadableOnly(final boolean showDownloadableOnly) {
+        putBoolean(R.string.pref_pqShowDownloadableOnly, showDownloadableOnly);
+    }
+
+    public static boolean getPqShowDownloadableOnly() {
+        return getBoolean(R.string.pref_pqShowDownloadableOnly, false);
+    }
+
     public static void setAnyCoordinates(final Geopoint coords) {
         if (coords != null) {
             putFloat(R.string.pref_anylatitude, (float) coords.getLatitude());


### PR DESCRIPTION
Add a toggle (switch) to the main screen's pq list to toggle display between "all" and "downloadable only":

![image](https://user-images.githubusercontent.com/3754370/108606564-0aab2900-73bb-11eb-9e9e-c2673eadb897.png).![image](https://user-images.githubusercontent.com/3754370/108606570-1696eb00-73bb-11eb-95f8-035d106c4527.png)

This makes live easier for people like me who have dozens of pq, but only very few of them active.

Toggle will be displayed on main screen's pq list only, not when coming from a cache list (as then the list is always filtered to "downloadable only"). The toggle's value gets remembered in the preferences. Default value is "show all" (as it is today's behavior).