### PR TITLE
Add long-click-behaviour to waypoint-coordinates to copy coordinates as for cache-coordinates

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2250,6 +2250,10 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                         clickedItemText = Formatter.formatHiddenDate(cache);
                         buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_event), true);
                         menu.findItem(R.id.menu_calendar).setVisible(cache.canBeAddedToCalendar());
+                    } else if (viewId == R.id.coordinates) {
+                        clickedItemText = ((TextView) view1).getText();
+                        clickedItemText = GeopointFormatter.reformatForClipboard(clickedItemText);
+                        buildDetailsContextMenu(actionMode, menu, res.getString(R.string.cache_coordinates), true);
                     } else {
                         return false;
                     }


### PR DESCRIPTION
add long-click-behaviour to waypoint-coordinates to copy coordinates as for cache-coordinates (fix #6711)

If long click on the waypoint-coordinates open the copy-menu as for the cache-coordinates, should then the copy-entry in the menu be deleted?

