### PR TITLE
fix #9305: export and import UDC with empty coordinates

### DIFF
--- a/main/src/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/cgeo/geocaching/export/GpxSerializer.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.export;
 
 import cgeo.geocaching.connector.gc.GCUtils;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
@@ -110,14 +111,16 @@ public final class GpxSerializer {
             if (cache == null) {
                 continue;
             }
+
+            final boolean isInternal = InternalConnector.getInstance().canHandle(cache.getGeocode());
             final Geopoint coords = cache.getCoords();
-            if (coords == null) {
+            if (coords == null && !isInternal) {
                 // Export would be invalid without coordinates.
                 continue;
             }
             gpx.startTag(NS_GPX, "wpt");
-            gpx.attribute("", "lat", Double.toString(coords.getLatitude()));
-            gpx.attribute("", "lon", Double.toString(coords.getLongitude()));
+            gpx.attribute("", "lat", Double.toString(coords == null ? 0 : coords.getLatitude()));
+            gpx.attribute("", "lon", Double.toString(coords == null ? 0 : coords.getLongitude()));
 
             final Date hiddenDate = cache.getHiddenDate();
             if (hiddenDate != null) {

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.tc.TerraCachingLogType;
 import cgeo.geocaching.connector.tc.TerraCachingType;
 import cgeo.geocaching.enumerations.CacheAttribute;
@@ -929,10 +930,13 @@ abstract class GPXParser extends FileParser {
     }
 
     private boolean isValidForImport() {
-        if (StringUtils.isBlank(cache.getGeocode())) {
+        final String geocode = cache.getGeocode();
+        if (StringUtils.isBlank(geocode)) {
             return false;
         }
-        if (cache.getCoords() == null) {
+
+        final boolean isInternal = InternalConnector.getInstance().canHandle(geocode);
+        if (cache.getCoords() == null && !isInternal) {
             return false;
         }
         final boolean valid = (type == null && subtype == null && sym == null)

--- a/tests/res/raw/zz1000.gpx
+++ b/tests/res/raw/zz1000.gpx
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.0" creator="c:geo - http://www.cgeo.org/" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0/1 http://www.groundspeak.com/cache/1/0/1/cache.xsd http://www.gsak.net/xmlv1/6 http://www.gsak.net/xmlv1/6/gsak.xsd" xmlns="http://www.topografix.com/GPX/1/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:groundspeak="http://www.groundspeak.com/cache/1/0/1" xmlns:gsak="http://www.gsak.net/xmlv1/6" xmlns:cgeo="http://www.cgeo.org/wptext/1/0">
+  <wpt lat="0.0" lon="0.0">
+    <name>ZZ1000</name>
+    <desc>Test</desc>
+    <urlname>Test</urlname>
+    <sym>Geocache</sym>
+    <type>Geocache|User defined cache</type>
+    <groundspeak:cache id="" available="True" archived="False">
+      <groundspeak:name>Test</groundspeak:name>
+      <groundspeak:placed_by>You</groundspeak:placed_by>
+      <groundspeak:owner></groundspeak:owner>
+      <groundspeak:type>User defined cache</groundspeak:type>
+      <groundspeak:container>Unknown</groundspeak:container>
+      <groundspeak:difficulty>0</groundspeak:difficulty>
+      <groundspeak:terrain>0</groundspeak:terrain>
+      <groundspeak:country></groundspeak:country>
+      <groundspeak:state></groundspeak:state>
+      <groundspeak:short_description html="False"></groundspeak:short_description>
+      <groundspeak:long_description html="False">This is a user-defined cache</groundspeak:long_description>
+      <groundspeak:encoded_hints></groundspeak:encoded_hints>
+    </groundspeak:cache>
+    <gsak:wptExtension>
+      <gsak:Watch>false</gsak:Watch>
+      <gsak:IsPremium>false</gsak:IsPremium>
+      <gsak:FavPoints>-1</gsak:FavPoints>
+      <gsak:GcNote></gsak:GcNote>
+    </gsak:wptExtension>
+  </wpt>
+</gpx>

--- a/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
+++ b/tests/src-android/cgeo/geocaching/export/GpxSerializerTest.java
@@ -184,6 +184,20 @@ public class GpxSerializerTest extends AbstractResourceInstrumentationTestCase {
         assertEqualTags(imported, exported, "groundspeak:date");
     }
 
+    public void testUserDefinedCacheEmpty() throws IOException, ParserException {
+        final String geocode = "ZZ1000";
+        try {
+            final int cacheResource = R.raw.zz1000;
+            final Geocache cache = loadCacheFromResource(cacheResource);
+            assertThat(cache.getCoords()).isNull();
+
+            final String gpxFromCache = getGPXFromCache(geocode);
+            assertThat(gpxFromCache).contains("<wpt lat=\"0.0\" lon=\"0.0\">");
+        } finally {
+            DataStore.removeCache(geocode, LoadFlags.REMOVE_ALL);
+        }
+    }
+
     public void testWaypointEmpty() throws IOException, ParserException {
         final String geocode = "GC31J2H";
         try {


### PR DESCRIPTION
Empty coordinates are only valid for export / import if geocode is valid for InternalConnector (e.g. user-defined-cache)
(fix #9305)

