### PR TITLE
Add freizeitkarte maps to downloader (rel. to #7529)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2098,6 +2098,7 @@
     <string name="mapserver_mapsforge_info">Basic maps, no map themes required</string>
     <string name="mapserver_openandromaps_info">Detailed maps, require map theme \"Elevate\"</string>
     <string name="mapserver_elevate_info">Detailed map theme</string>
+    <string name="mapserver_freizeitkarte_info">Detailed maps, require one of the \"freizeitkarte\" map themes.</string>
 
     <!-- history track -->
     <string name="map_clear_trailhistory">Clear history track</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -233,7 +233,7 @@
     <string translatable="false" name="mapserver_openandromaps_likeiturl">https://www.openandromaps.org/projektkosten</string>
     <string translatable="false" name="mapserver_openandromaps_projecturl">https://www.openandromaps.org/</string>
 
-    <string translatable="false" name="mapserver_elevate_name">Elevate Theme</string>
+    <string translatable="false" name="mapserver_elevate_name">OpenAndroMaps Theme</string>
     <string translatable="false" name="mapserver_elevate_downloadurl">https://www.openandromaps.org/wp-content/users/tobias/</string>
     <string translatable="false" name="mapserver_elevate_updatecheckurl">https://www.openandromaps.org/kartenlegende/elevation-hike-theme</string>
 
@@ -241,6 +241,8 @@
     <string translatable="false" name="mapserver_freizeitkarte_downloadurl">http://repository.freizeitkarte-osm.de/repository_freizeitkarte_android.xml</string>
     <string translatable="false" name="mapserver_freizeitkarte_likeiturl">https://www.freizeitkarte-osm.de/android/de/impressum.html</string>
     <string translatable="false" name="mapserver_freizeitkarte_projecturl">https://www.freizeitkarte-osm.de/android/en/</string>
+
+    <string translatable="false" name="mapserver_freizeitkarte_themes_name">Freizeitkarte Themes</string>
 
     <!-- c:geo mail subject for problem reports -->
     <string translatable="false" name="mailsubject_problem_report">c:geo problem report</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -237,6 +237,11 @@
     <string translatable="false" name="mapserver_elevate_downloadurl">https://www.openandromaps.org/wp-content/users/tobias/</string>
     <string translatable="false" name="mapserver_elevate_updatecheckurl">https://www.openandromaps.org/kartenlegende/elevation-hike-theme</string>
 
+    <string translatable="false" name="mapserver_freizeitkarte_name">Freizeitkarte</string>
+    <string translatable="false" name="mapserver_freizeitkarte_downloadurl">http://repository.freizeitkarte-osm.de/repository_freizeitkarte_android.xml</string>
+    <string translatable="false" name="mapserver_freizeitkarte_likeiturl">https://www.freizeitkarte-osm.de/android/de/impressum.html</string>
+    <string translatable="false" name="mapserver_freizeitkarte_projecturl">https://www.freizeitkarte-osm.de/android/en/</string>
+
     <!-- c:geo mail subject for problem reports -->
     <string translatable="false" name="mailsubject_problem_report">c:geo problem report</string>
 </resources>

--- a/main/src/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -14,6 +14,8 @@ import androidx.annotation.StringRes;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
+
 public abstract class AbstractDownloader {
     public OfflineMap.OfflineMapType offlineMapType;
     public Uri mapBase;
@@ -62,6 +64,25 @@ public abstract class AbstractDownloader {
                     list.add(offlineMap);
                 }
             }
+        }
+    }
+
+    // do any cleanup on filename?
+    protected String toVisibleFilename(final String filename) {
+        return filename;
+    }
+
+    // infix a certain string into the filename?
+    protected String toInfixedString(final String filename, final String infix) {
+        if (StringUtils.isNotBlank(infix)) {
+            if (StringUtils.isNotBlank(forceExtension)) {
+                final int extPos = filename.indexOf(forceExtension);
+                return extPos == -1 ? filename + infix : filename.substring(0, extPos) + infix + forceExtension;
+            } else {
+                return filename + infix;
+            }
+        } else {
+            return filename;
         }
     }
 

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
@@ -1,0 +1,110 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
+import cgeo.geocaching.models.OfflineMap;
+import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.Log;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.sax.Element;
+import android.sax.RootElement;
+import android.util.Xml;
+
+import androidx.annotation.NonNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xml.sax.SAXException;
+
+public class MapDownloaderFreizeitkarte extends AbstractMapDownloader {
+
+    private static final MapDownloaderFreizeitkarte INSTANCE = new MapDownloaderFreizeitkarte();
+
+    private MapDownloaderFreizeitkarte() {
+        super (OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_FREIZEITKARTE, R.string.mapserver_freizeitkarte_downloadurl, R.string.mapserver_freizeitkarte_name, R.string.mapserver_freizeitkarte_info, R.string.mapserver_freizeitkarte_projecturl, R.string.mapserver_freizeitkarte_likeiturl);
+    }
+
+    private static class FZKParser {
+        // temporary data per entry
+        private String url;
+        private long size;
+        private String description;
+        private String dateInfo;
+
+        private void parse(@NonNull final String page, final List<OfflineMap> result, final OfflineMap.OfflineMapType offlineMapType) {
+            final RootElement root = new RootElement("", "Freizeitkarte");
+            final Element map = root.getChild("", "Map");
+            map.setStartElementListener(attr -> {
+                url = "";
+                size = 0;
+                description = "";
+                dateInfo = "";
+            });
+            map.getChild("", "Url").setEndTextElementListener(body -> url = body);
+            map.getChild("", "Size").setEndTextElementListener(body -> size = Long.parseLong(body));
+            map.getChild("", "DescriptionEnglish").setEndTextElementListener(body -> description = body);
+            map.getChild("", "MapsforgeDateOfCreation").setEndTextElementListener(body -> dateInfo = body);
+            map.setEndElementListener(() -> {
+                if (StringUtils.isNotBlank(url) && StringUtils.isNotBlank(dateInfo)) {
+                    result.add(new OfflineMap(description, Uri.parse(url), false, dateInfo.substring(0, 10), Formatter.formatBytes(size), offlineMapType));
+                }
+            });
+
+            try {
+                final BufferedReader reader = new BufferedReader(new StringReader(page));
+                Xml.parse(new InvalidXMLCharacterFilterReader(reader), root.getContentHandler());
+            } catch (final SAXException | IOException e) {
+                Log.e("Cannot parse freizeitkarte XML: " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<OfflineMap> list, final String page) {
+        new FZKParser().parse(page, list, offlineMapType);
+    }
+
+    @Override
+    protected OfflineMap checkUpdateFor(final String page, final String remoteUrl, final String remoteFilename) {
+        final List<OfflineMap> list = new ArrayList<>();
+        new FZKParser().parse(page, list, offlineMapType);
+        for (OfflineMap map : list) {
+            if (map.getUri().getLastPathSegment().equals(remoteFilename)) {
+                return map;
+            }
+        }
+        return null;
+    }
+
+    // Freizeitkarte uses a repository, need to map here to its fixed address
+    @Override
+    protected String getUpdatePageUrl(final String downloadPageUrl) {
+        return CgeoApplication.getInstance().getString(R.string.mapserver_freizeitkarte_downloadurl);
+    }
+
+    @Override
+    protected String toVisibleFilename(final String filename) {
+        return toInfixedString(CompanionFileUtils.getDisplayName((filename.startsWith("Freizeitkarte_") ? filename.substring(14) : filename).toLowerCase()), " (FZK)");
+    }
+
+    @Override
+    protected void onFollowup(final Activity activity, final Runnable callback) {
+        // @todo: check whether one of the theme files exist in theme folder and ask whether user wants to download it as well, if it does not exist yet
+        // FZK theme downloading needs to be implemented first
+        callback.run();
+    }
+
+    @NonNull
+    public static MapDownloaderFreizeitkarte getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
@@ -1,0 +1,101 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
+import cgeo.geocaching.models.OfflineMap;
+import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.Log;
+
+import android.net.Uri;
+import android.sax.Element;
+import android.sax.RootElement;
+import android.util.Xml;
+
+import androidx.annotation.NonNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xml.sax.SAXException;
+
+public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
+    private static final MapDownloaderFreizeitkarteThemes INSTANCE = new MapDownloaderFreizeitkarteThemes();
+
+    private MapDownloaderFreizeitkarteThemes() {
+        super(OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, R.string.mapserver_freizeitkarte_downloadurl, R.string.mapserver_freizeitkarte_themes_name, R.string.mapserver_freizeitkarte_info, R.string.mapserver_freizeitkarte_projecturl, R.string.mapserver_freizeitkarte_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
+        this.forceExtension = ".zip";
+    }
+
+    private static class FZKParser {
+        // temporary data per entry
+        private String url;
+        private long size;
+        private String description;
+
+        private void parse(@NonNull final String page, final List<OfflineMap> result, final OfflineMap.OfflineMapType offlineMapType) {
+            final RootElement root = new RootElement("", "Freizeitkarte");
+            final Element theme = root.getChild("", "Theme");
+            theme.setStartElementListener(attr -> {
+                url = "";
+                size = 0;
+                description = "";
+            });
+            theme.getChild("", "Url").setEndTextElementListener(body -> url = body);
+            theme.getChild("", "Size").setEndTextElementListener(body -> size = Long.parseLong(body));
+            theme.getChild("", "DescriptionEnglish").setEndTextElementListener(body -> description = body);
+            theme.setEndElementListener(() -> {
+                if (StringUtils.isNotBlank(url)) {
+                    result.add(new OfflineMap(description, Uri.parse(url), false, "", Formatter.formatBytes(size), offlineMapType));
+                }
+            });
+
+            try {
+                final BufferedReader reader = new BufferedReader(new StringReader(page));
+                Xml.parse(new InvalidXMLCharacterFilterReader(reader), root.getContentHandler());
+            } catch (final SAXException | IOException e) {
+                Log.e("Cannot parse freizeitkarte XML: " + e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<OfflineMap> list, final String page) {
+        new FZKParser().parse(page, list, offlineMapType);
+    }
+
+    @Override
+    protected OfflineMap checkUpdateFor(final String page, final String remoteUrl, final String remoteFilename) {
+        final List<OfflineMap> list = new ArrayList<>();
+        new FZKParser().parse(page, list, offlineMapType);
+        for (OfflineMap map : list) {
+            if (map.getUri().getLastPathSegment().equals(remoteFilename)) {
+                return map;
+            }
+        }
+        return null;
+    }
+
+    // Freizeitkarte uses a repository, need to map here to its fixed address
+    @Override
+    protected String getUpdatePageUrl(final String downloadPageUrl) {
+        return CgeoApplication.getInstance().getString(R.string.mapserver_freizeitkarte_downloadurl);
+    }
+
+    @Override
+    protected void onSuccessfulReceive(final Uri result) {
+        // @todo: Set downloaded theme as current theme
+        // requires SAF migration of themes to be implemented first
+    }
+
+    @NonNull
+    public static MapDownloaderFreizeitkarteThemes getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -58,6 +58,12 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     }
 
     @Override
+    protected String toVisibleFilename(final String filename) {
+        final int posInfix = filename.indexOf("_oam.osm.");
+        return toInfixedString(posInfix == -1 ? filename : filename.substring(0, posInfix) + filename.substring(posInfix + 8), " (OAM)");
+    }
+
+    @Override
     protected void onFollowup(final Activity activity, final Runnable callback) {
         // check whether Elevate.zip exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
         boolean themeFound = false;

--- a/main/src/cgeo/geocaching/downloader/ReceiveMapFileActivity.java
+++ b/main/src/cgeo/geocaching/downloader/ReceiveMapFileActivity.java
@@ -75,10 +75,7 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                         String filename = ze.getName();
                         final int posExt = filename.lastIndexOf('.');
                         if (posExt != -1 && (StringUtils.equalsIgnoreCase(FileUtils.MAP_FILE_EXTENSION, filename.substring(posExt)))) {
-                            final int posInfix = filename.indexOf("_oam.osm.");
-                            if (posInfix != -1) {
-                                filename = filename.substring(0, posInfix) + filename.substring(posInfix + 8);
-                            }
+                            filename = downloader.toVisibleFilename(filename);
                             // found map file within zip
                             if (guessFilename(filename)) {
                                 handleMapFile(this,  true, ze.getName());

--- a/main/src/cgeo/geocaching/models/OfflineMap.java
+++ b/main/src/cgeo/geocaching/models/OfflineMap.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.downloader.AbstractDownloader;
 import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.downloader.MapDownloaderElevate;
+import cgeo.geocaching.downloader.MapDownloaderFreizeitkarte;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
 import cgeo.geocaching.utils.CalendarUtils;
@@ -81,7 +82,8 @@ public class OfflineMap {
         // id values must not be changed as they are referenced in the database & download companion files
         MAP_DOWNLOAD_TYPE_MAPSFORGE(1),
         MAP_DOWNLOAD_TYPE_OPENANDROMAPS(2),
-        MAP_DOWNLOAD_TYPE_ELEVATE(3);
+        MAP_DOWNLOAD_TYPE_ELEVATE(3),
+        MAP_DOWNLOAD_TYPE_FREIZEITKARTE(4);
 
         public final int id;
         public static final int DEFAULT = MAP_DOWNLOAD_TYPE_MAPSFORGE.id;
@@ -112,6 +114,7 @@ public class OfflineMap {
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_MAPSFORGE, MapDownloaderMapsforge.getInstance(), R.string.mapserver_mapsforge_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_OPENANDROMAPS, MapDownloaderOpenAndroMaps.getInstance(), R.string.mapserver_openandromaps_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_ELEVATE, MapDownloaderElevate.getInstance(), R.string.mapserver_elevate_name));
+                offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE, MapDownloaderFreizeitkarte.getInstance(), R.string.mapserver_freizeitkarte_name));
             }
         }
     }

--- a/main/src/cgeo/geocaching/models/OfflineMap.java
+++ b/main/src/cgeo/geocaching/models/OfflineMap.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.downloader.AbstractDownloader;
 import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.downloader.MapDownloaderElevate;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarte;
+import cgeo.geocaching.downloader.MapDownloaderFreizeitkarteThemes;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
 import cgeo.geocaching.utils.CalendarUtils;
@@ -83,7 +84,8 @@ public class OfflineMap {
         MAP_DOWNLOAD_TYPE_MAPSFORGE(1),
         MAP_DOWNLOAD_TYPE_OPENANDROMAPS(2),
         MAP_DOWNLOAD_TYPE_ELEVATE(3),
-        MAP_DOWNLOAD_TYPE_FREIZEITKARTE(4);
+        MAP_DOWNLOAD_TYPE_FREIZEITKARTE(4),
+        MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES(5);
 
         public final int id;
         public static final int DEFAULT = MAP_DOWNLOAD_TYPE_MAPSFORGE.id;
@@ -115,6 +117,7 @@ public class OfflineMap {
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_OPENANDROMAPS, MapDownloaderOpenAndroMaps.getInstance(), R.string.mapserver_openandromaps_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_ELEVATE, MapDownloaderElevate.getInstance(), R.string.mapserver_elevate_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE, MapDownloaderFreizeitkarte.getInstance(), R.string.mapserver_freizeitkarte_name));
+                offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, MapDownloaderFreizeitkarteThemes.getInstance(), R.string.mapserver_freizeitkarte_themes_name));
             }
         }
     }


### PR DESCRIPTION
This is part 1: adding "freizeitkarte" maps to the downloader.

Next parts will be adding "freizeitkarte" themes to the downloader, and auto-downloading fzk-theme after downloading a fzk map. Keeping the "WIP" label until that is included as well.