### PR TITLE
String improvements based on Crowdin feedback

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -571,7 +571,7 @@
     <string name="settings_service_active">Active</string>
     <string name="settings_navigation_disabled">This app seems not to be installed</string>
     <string name="init_signature">Signature</string>
-    <string name="init_template_help">Placeholder strings like [NAME] will be expanded later when this template is used.</string>
+    <string name="init_template_help">Placeholder strings - like [NAME] - are filled with the designated text when the template is used.</string>
     <string name="init_signature_template_button">Insert Template</string>
     <string name="init_signature_template_date">Date</string>
     <string name="init_signature_template_time">Time</string>
@@ -1329,12 +1329,12 @@
     <string name="map_rotation">Map rotation</string>
     <string name="map_dot_mode">Use compact icons</string>
     <string name="map_show_circles">Show circles</string>
-    <string name="map_showc_ownfound">Show own/found caches</string>
-    <string name="map_showc_disabled">Show disabled caches</string>
-    <string name="map_showc_archived">Show archived caches</string>
-    <string name="map_showwp_original">Show original waypoints</string>
-    <string name="map_showwp_parking">Show parking waypoints</string>
-    <string name="map_showwp_visited">Show visited waypoints</string>
+    <string name="map_showc_ownfound">Own/found caches</string>
+    <string name="map_showc_disabled">Disabled caches</string>
+    <string name="map_showc_archived">Archived caches</string>
+    <string name="map_showwp_original">Original waypoints</string>
+    <string name="map_showwp_parking">Parking waypoints</string>
+    <string name="map_showwp_visited">Visited waypoints</string>
     <string name="map_show_track">Show GPX track/route</string>
     <string name="init_hidewp">Hide waypoints</string>
     <string name="init_summary_hidewp_original">Hide original waypoints on the map</string>
@@ -1353,10 +1353,10 @@
     <string name="map_gm_autorotation_disable">Disable map auto rotation?\n\nYou can enable it again using the Map rotation menu</string>
     <string name="quick_settings">Quick settings</string>
     <string name="quick_settings_info">Some map settings (Map settings, hide, routing) have been moved to the new \"Quick settings\" popup.\nYou can open this popup using the icon in the map\'s bottom center.</string>
-    <string name="map_show_in_map">Show in map</string>
+    <string name="map_show_in_map">Show on map:</string>
 
     <!-- search -->
-    <string name="search_bar_hint">Search for caches</string>
+    <string name="search_bar_hint">Search caches/trackables</string>
     <string name="search_bar_desc">Caches (geo code, keyword), Trackables (TB code)</string>
     <string name="search_coordinates">Coordinates</string>
     <string name="search_coordinates_button">Search by coordinates</string>


### PR DESCRIPTION
Taken from issues our translators opened on Crowdin:

- Map quick settings: 
  - "Show..." is obsolete as 1. the meaning is clear by the checkboxes and 2. there is a caption "Show in map". Also smaller strings might fit better.
  - The mentioned "Show in map" should be "Show on map" (grammar) and a double quote at the end is missing
- Search bar hint says "Search for caches" but you can also search trackables. Replace by "Search caches/trackables"
- More understandable explanation of signature templates
- 