### PR TITLE
rename wizard 'skip' and add info/confirmation dialog (fix #9977)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2147,6 +2147,8 @@
     <string name="wizard_status_location_permission">Location permission</string>
     <string name="wizard_status_basefolder">Base folder</string>
     <string name="wizard_status_platform">Geocaching services</string>
+    <string name="wizard_not_now">Not now</string>
+    <string name="wizard_skip_wizard_warning">c:geo might not work as expected until configuration is completed. Depending on the missing configuration c:geo might not be able to read/store data like offline maps, geocaches, logfiles etc.\n\nWhenever you feel ready to finalize setup, either choose \"Configuration wizard\" in main menu or restart c:geo.</string>
 
     <!-- default actions in dialogs -->
     <string name="previous">Previous</string>

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -130,7 +130,7 @@ public class InstallWizardActivity extends AppCompatActivity {
             case WIZARD_START: {
                 title.setText(mode == WizardMode.WIZARDMODE_MIGRATION ? R.string.wizard_migration_title : R.string.wizard_welcome_title);
                 text.setText(mode == WizardMode.WIZARDMODE_RETURNING ? R.string.wizard_intro_returning : mode == WizardMode.WIZARDMODE_MIGRATION ? R.string.wizard_intro_migration : R.string.wizard_intro);
-                setNavigation(this::finishWizard, R.string.skip, null, 0, this::gotoNext, 0);
+                setNavigation(this::skipWizard, R.string.wizard_not_now, null, 0, this::gotoNext, 0);
                 break;
             }
             case WIZARD_PERMISSIONS: {
@@ -320,6 +320,10 @@ public class InstallWizardActivity extends AppCompatActivity {
             || (step == WizardStep.WIZARD_PLATFORMS && mode == WizardMode.WIZARDMODE_MIGRATION)
             || (step == WizardStep.WIZARD_ADVANCED && mode == WizardMode.WIZARDMODE_MIGRATION)
             ;
+    }
+
+    private void skipWizard() {
+        Dialogs.confirmPositiveNegativeNeutral(this, getString(R.string.wizard), getString(R.string.wizard_skip_wizard_warning), getString(android.R.string.ok), getString(R.string.back), "", (dialog, which) -> finishWizard(), (dialog, which) -> updateDialog(), null);
     }
 
     private void finishWizard() {


### PR DESCRIPTION
- renamed "skip" to "not now" on opening screen
- pressing the button will show an explanation + confirmation dialog with "back" and "ok" options

example (show for migration, but is similar in the first installation variant):
![image](https://user-images.githubusercontent.com/3754370/108639195-942e2a00-7493-11eb-8a83-d075d301e074.png).![image](https://user-images.githubusercontent.com/3754370/108639207-9abca180-7493-11eb-988d-6e8cc656b3f8.png)
