### PR TITLE
some polishing for map downloader

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -155,6 +155,7 @@
     <string translatable="false" name="pref_version">version</string>
     <string translatable="false" name="pref_usecompass">usecompass</string>
     <string translatable="false" name="pref_mapfile">mfmapfile</string>
+    <string translatable="false" name="pref_mapdownloader_source">mapdownloader_source</string>
     <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>
     <string translatable="false" name="pref_memberstatus">memberstatus</string>
     <string translatable="false" name="pref_coordinputformat">coordinputformat</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2101,8 +2101,9 @@
     <string name="downloadmap_install_theme_info">Your downloaded map requires a special theme file. Do you want to download this as well?</string>
     <string name="mapserver_mapsforge_info">Basic maps, no map themes required</string>
     <string name="mapserver_openandromaps_info">Detailed maps, require map theme \"Elevate\"</string>
-    <string name="mapserver_elevate_info">Detailed map theme</string>
+    <string name="mapserver_openandromaps_themes_info">Detailed map theme, built for \"OpenAndroMaps\" maps</string>
     <string name="mapserver_freizeitkarte_info">Detailed maps, require one of the \"freizeitkarte\" map themes.</string>
+    <string name="mapserver_freizeitkarte_themes_info">Detailed map theme, built for \"Freizeitkarte\" maps</string>
 
     <!-- history track -->
     <string name="map_clear_trailhistory">Clear history track</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -233,9 +233,9 @@
     <string translatable="false" name="mapserver_openandromaps_likeiturl">https://www.openandromaps.org/projektkosten</string>
     <string translatable="false" name="mapserver_openandromaps_projecturl">https://www.openandromaps.org/</string>
 
-    <string translatable="false" name="mapserver_elevate_name">OpenAndroMaps Theme</string>
-    <string translatable="false" name="mapserver_elevate_downloadurl">https://www.openandromaps.org/wp-content/users/tobias/</string>
-    <string translatable="false" name="mapserver_elevate_updatecheckurl">https://www.openandromaps.org/kartenlegende/elevation-hike-theme</string>
+    <string translatable="false" name="mapserver_openandromaps_themes_name">OpenAndroMaps Theme</string>
+    <string translatable="false" name="mapserver_openandromaps_themes_downloadurl">https://www.openandromaps.org/wp-content/users/tobias/</string>
+    <string translatable="false" name="mapserver_openandromaps_themes_updatecheckurl">https://www.openandromaps.org/kartenlegende/elevation-hike-theme</string>
 
     <string translatable="false" name="mapserver_freizeitkarte_name">Freizeitkarte</string>
     <string translatable="false" name="mapserver_freizeitkarte_downloadurl">http://repository.freizeitkarte-osm.de/repository_freizeitkarte_android.xml</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -243,6 +243,7 @@
     <string translatable="false" name="mapserver_freizeitkarte_projecturl">https://www.freizeitkarte-osm.de/android/en/</string>
 
     <string translatable="false" name="mapserver_freizeitkarte_themes_name">Freizeitkarte Themes</string>
+    <string translatable="false" name="mapserver_freizeitkarte_themes_downloadurl">http://download.freizeitkarte-osm.de/android/2012/</string>
 
     <!-- c:geo mail subject for problem reports -->
     <string translatable="false" name="mailsubject_problem_report">c:geo problem report</string>

--- a/main/src/cgeo/geocaching/downloader/AbstractMapDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractMapDownloader.java
@@ -28,7 +28,6 @@ abstract class AbstractMapDownloader extends AbstractDownloader {
         MapsforgeMapProvider.getInstance().updateOfflineMaps(result);
     }
 
-
     // check if any of the given file exists in the given path
     // if none exists: confirm to & download first
     protected void findOrDownload(final Activity activity, final String[] filenames, final String baseUrl, final OfflineMap.OfflineMapType offlineMapType, final Runnable callback) {

--- a/main/src/cgeo/geocaching/downloader/AbstractMapDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractMapDownloader.java
@@ -1,13 +1,19 @@
 package cgeo.geocaching.downloader;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.models.OfflineMap;
+import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.FileUtils;
 
+import android.app.Activity;
 import android.net.Uri;
 
 import androidx.annotation.StringRes;
+
+import java.util.List;
 
 abstract class AbstractMapDownloader extends AbstractDownloader {
 
@@ -20,6 +26,31 @@ abstract class AbstractMapDownloader extends AbstractDownloader {
     protected void onSuccessfulReceive(final Uri result) {
         // update offline maps
         MapsforgeMapProvider.getInstance().updateOfflineMaps(result);
+    }
+
+
+    // check if any of the given file exists in the given path
+    // if none exists: confirm to & download first
+    protected void findOrDownload(final Activity activity, final String[] filenames, final String baseUrl, final OfflineMap.OfflineMapType offlineMapType, final Runnable callback) {
+        boolean anyFileFound = false;
+        final List<ContentStorage.FileInformation> dirContent = ContentStorage.get().list(PersistableFolder.OFFLINE_MAP_THEMES);
+        for (ContentStorage.FileInformation fi : dirContent) {
+            for (String filename : filenames) {
+                if (fi.name.equals(filename)) {
+                    anyFileFound = true;
+                    break;
+                }
+            }
+        }
+
+        if (!anyFileFound) {
+                Dialogs.confirm(activity, activity.getString(R.string.downloadmap_install_theme_title), activity.getString(R.string.downloadmap_install_theme_info), activity.getString(android.R.string.ok), (d, w) -> {
+                final Uri newUri = Uri.parse(baseUrl + filenames[0]);
+                MapDownloaderUtils.triggerDownload(activity, offlineMapType.id, newUri, "", System.currentTimeMillis(), callback);
+            }, dialog -> callback.run());
+        } else {
+            callback.run();
+        }
     }
 
 }

--- a/main/src/cgeo/geocaching/downloader/MapDownloadSelectorActivity.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloadSelectorActivity.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.databinding.MapdownloaderItemBinding;
 import cgeo.geocaching.models.OfflineMap;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.recyclerview.AbstractRecyclerViewHolder;
 import cgeo.geocaching.ui.recyclerview.RecyclerViewProvider;
@@ -232,6 +233,13 @@ public class MapDownloadSelectorActivity extends AbstractActionBarActivity {
         final ArrayAdapter<OfflineMap.OfflineMapTypeDescriptor> spinnerAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, spinnerData);
         spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         binding.downloaderType.setAdapter(spinnerAdapter);
+
+        final OfflineMap.OfflineMapTypeDescriptor descriptor = OfflineMap.OfflineMapType.fromTypeId(Settings.getMapDownloaderSource());
+        if (descriptor != null) {
+            final int spinnerPosition = spinnerAdapter.getPosition(descriptor);
+            binding.downloaderType.setSelection(spinnerPosition);
+        }
+
         binding.downloaderType.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(final AdapterView<?> parent, final View view, final int position, final long id) {
@@ -277,6 +285,8 @@ public class MapDownloadSelectorActivity extends AbstractActionBarActivity {
                 finish();
             }
         });
+
+        Settings.setMapDownloaderSource(current.offlineMapType.id);
     }
 
     public List<OfflineMap> getQueries() {

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
@@ -26,6 +26,7 @@ import org.xml.sax.SAXException;
 
 public class MapDownloaderFreizeitkarte extends AbstractMapDownloader {
 
+    private static final String[] THEME_FILES = {"freizeitkarte-v5.zip", "fzk-outdoor-contrast-v5.zip", "fzk-outdoor-soft-v5.zip"};
     private static final MapDownloaderFreizeitkarte INSTANCE = new MapDownloaderFreizeitkarte();
 
     private MapDownloaderFreizeitkarte() {
@@ -97,9 +98,8 @@ public class MapDownloaderFreizeitkarte extends AbstractMapDownloader {
 
     @Override
     protected void onFollowup(final Activity activity, final Runnable callback) {
-        // @todo: check whether one of the theme files exist in theme folder and ask whether user wants to download it as well, if it does not exist yet
-        // FZK theme downloading needs to be implemented first
-        callback.run();
+        // check whether a FZK theme exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
+        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_freizeitkarte_themes_downloadurl), OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, callback);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
@@ -3,10 +3,12 @@ package cgeo.geocaching.downloader;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
+import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
 import cgeo.geocaching.models.OfflineMap;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.UriUtils;
 
 import android.net.Uri;
 import android.sax.Element;
@@ -89,8 +91,10 @@ public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
 
     @Override
     protected void onSuccessfulReceive(final Uri result) {
-        // @todo: Set downloaded theme as current theme
-        // requires SAF migration of themes to be implemented first
+        //resync
+        RenderThemeHelper.resynchronizeMapThemeFolder(null);
+        //set map theme
+        RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
@@ -30,7 +30,7 @@ public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
     private static final MapDownloaderFreizeitkarteThemes INSTANCE = new MapDownloaderFreizeitkarteThemes();
 
     private MapDownloaderFreizeitkarteThemes() {
-        super(OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, R.string.mapserver_freizeitkarte_downloadurl, R.string.mapserver_freizeitkarte_themes_name, R.string.mapserver_freizeitkarte_info, R.string.mapserver_freizeitkarte_projecturl, R.string.mapserver_freizeitkarte_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
+        super(OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, R.string.mapserver_freizeitkarte_downloadurl, R.string.mapserver_freizeitkarte_themes_name, R.string.mapserver_freizeitkarte_themes_info, R.string.mapserver_freizeitkarte_projecturl, R.string.mapserver_freizeitkarte_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
         this.forceExtension = ".zip";
     }
 

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -2,9 +2,6 @@ package cgeo.geocaching.downloader;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.OfflineMap;
-import cgeo.geocaching.storage.ContentStorage;
-import cgeo.geocaching.storage.PersistableFolder;
-import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.MatcherWrapper;
@@ -21,7 +18,7 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     private static final Pattern PATTERN_MAP = Pattern.compile("<a href=\"([A-Za-z0-9_-]+\\.zip)\">([A-Za-z0-9_-]+)\\.zip<\\/a>[ ]*([0-9]{2}-[A-Za-z]{3}-[0-9]{4}) [0-9]{2}:[0-9]{2}[ ]*([0-9]+)"); // 1:file name, 2:display name, 3:date DD-MMM-YYYY, 4:size (bytes)
     private static final Pattern PATTERN_DIR = Pattern.compile("<a href=\"([A-Z-a-z0-9]+\\/)\">([A-Za-z0-9]+)\\/<\\/a>");  // 1:file name, 2:display name
     private static final Pattern PATTERN_UP = Pattern.compile("<a href=\"(\\.\\.\\/)\">(\\.\\.)\\/<\\/a>"); // 1:relative dir, 2:..
-    private static final String ELEVATE_THEME = "Elevate.zip";
+    private static final String[] THEME_FILES = {"Elevate.zip"};
     private static final MapDownloaderOpenAndroMaps INSTANCE = new MapDownloaderOpenAndroMaps();
 
     private MapDownloaderOpenAndroMaps() {
@@ -66,23 +63,7 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     @Override
     protected void onFollowup(final Activity activity, final Runnable callback) {
         // check whether Elevate.zip exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
-        boolean themeFound = false;
-        final List<ContentStorage.FileInformation> mapDirContent = ContentStorage.get().list(PersistableFolder.OFFLINE_MAP_THEMES);
-        for (ContentStorage.FileInformation fi : mapDirContent) {
-            if (fi.name.equals(ELEVATE_THEME)) {
-                themeFound = true;
-                break;
-            }
-        }
-
-        if (!themeFound) {
-            Dialogs.confirm(activity, activity.getString(R.string.downloadmap_install_theme_title), activity.getString(R.string.downloadmap_install_theme_info), activity.getString(android.R.string.ok), (d, w) -> {
-                final Uri newUri = Uri.parse(activity.getString(R.string.mapserver_elevate_downloadurl) + ELEVATE_THEME);
-                MapDownloaderUtils.triggerDownload(activity, OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_ELEVATE.id, newUri, "", System.currentTimeMillis(), callback);
-            }, dialog -> callback.run());
-        } else {
-            callback.run();
-        }
+        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_elevate_downloadurl), OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_ELEVATE, callback);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -63,7 +63,7 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     @Override
     protected void onFollowup(final Activity activity, final Runnable callback) {
         // check whether Elevate.zip exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
-        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_elevate_downloadurl), OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_ELEVATE, callback);
+        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_openandromaps_themes_downloadurl), OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_OPENANDROMAPS_THEMES, callback);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
@@ -15,19 +15,19 @@ import androidx.annotation.NonNull;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class MapDownloaderElevate extends AbstractDownloader {
+public class MapDownloaderOpenAndroMapsThemes extends AbstractDownloader {
 
     private static final Pattern PATTERN_LAST_UPDATED_DATE = Pattern.compile("<a href=\"https:\\/\\/www\\.openandromaps\\.org\\/wp-content\\/users\\/tobias\\/version\\.txt\">[0-9]\\.[0-9]\\.[0-9]<\\/a><\\/strong>, ([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{2}) ");
-    private static final MapDownloaderElevate INSTANCE = new MapDownloaderElevate();
+    private static final MapDownloaderOpenAndroMapsThemes INSTANCE = new MapDownloaderOpenAndroMapsThemes();
 
-    private MapDownloaderElevate() {
-        super(OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_ELEVATE, R.string.mapserver_elevate_updatecheckurl, R.string.mapserver_elevate_name, R.string.mapserver_elevate_info, R.string.mapserver_openandromaps_projecturl, R.string.mapserver_openandromaps_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
+    private MapDownloaderOpenAndroMapsThemes() {
+        super(OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_OPENANDROMAPS_THEMES, R.string.mapserver_openandromaps_themes_updatecheckurl, R.string.mapserver_openandromaps_themes_name, R.string.mapserver_openandromaps_themes_info, R.string.mapserver_openandromaps_projecturl, R.string.mapserver_openandromaps_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
         this.forceExtension = ".zip";
     }
 
     @Override
     protected void analyzePage(final Uri uri, final List<OfflineMap> list, final String page) {
-        final OfflineMap file = checkUpdateFor(page, CgeoApplication.getInstance().getString(R.string.mapserver_elevate_downloadurl), "Elevate.zip");
+        final OfflineMap file = checkUpdateFor(page, CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_downloadurl), "Elevate.zip");
         if (file != null) {
             list.add(file);
         }
@@ -38,7 +38,7 @@ public class MapDownloaderElevate extends AbstractDownloader {
         final MatcherWrapper matchDate = new MatcherWrapper(PATTERN_LAST_UPDATED_DATE, page);
         if (matchDate.find()) {
             final String date = "20" + matchDate.group(3) + "-" + matchDate.group(2) + "-" + matchDate.group(1);
-            return new OfflineMap("Elevate", Uri.parse(CgeoApplication.getInstance().getString(R.string.mapserver_elevate_downloadurl) + "Elevate.zip"), false, date, "", offlineMapType);
+            return new OfflineMap("Elevate", Uri.parse(CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_downloadurl) + "Elevate.zip"), false, date, "", offlineMapType);
         }
         return null;
     }
@@ -47,8 +47,8 @@ public class MapDownloaderElevate extends AbstractDownloader {
     @Override
     protected String getUpdatePageUrl(final String downloadPageUrl) {
         final String compare = downloadPageUrl.endsWith("/") ? downloadPageUrl : downloadPageUrl + "/";
-        final String downloadUrl = CgeoApplication.getInstance().getString(R.string.mapserver_elevate_downloadurl);
-        final String updateUrl = CgeoApplication.getInstance().getString(R.string.mapserver_elevate_updatecheckurl);
+        final String downloadUrl = CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_downloadurl);
+        final String updateUrl = CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_updatecheckurl);
         if (compare.startsWith(downloadUrl)) {
             final String result = updateUrl + compare.substring(downloadUrl.length());
             return result.endsWith("/") ? result : result + "/";
@@ -67,7 +67,7 @@ public class MapDownloaderElevate extends AbstractDownloader {
     }
 
     @NonNull
-    public static MapDownloaderElevate getInstance() {
+    public static MapDownloaderOpenAndroMapsThemes getInstance() {
         return INSTANCE;
     }
 }

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMapTheme.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMapTheme.java
@@ -23,8 +23,8 @@ class MapDownloaderReceiverSchemeMapTheme extends AbstractActivity {
         // check for OpenAndroMaps
         if (host.equals("download.openandromaps.org") && path.startsWith("/themes/") && path.endsWith(".zip")) {
             // no remapping, as they have themes only on their homepage, not on their ftp site
-            final Uri newUri = Uri.parse(getString(R.string.mapserver_elevate_downloadurl) + path.substring(8));
-            MapDownloaderUtils.triggerDownload(this, OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_ELEVATE.id, newUri, "", System.currentTimeMillis(), this::callback);
+            final Uri newUri = Uri.parse(getString(R.string.mapserver_openandromaps_themes_downloadurl) + path.substring(8));
+            MapDownloaderUtils.triggerDownload(this, OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_OPENANDROMAPS_THEMES.id, newUri, "", System.currentTimeMillis(), this::callback);
         } else {
             // generic map theme download - not yet supported
             Log.w("MapDownloaderReceiverSchemeMapTheme: Received map theme download intent from unknown source: " + uri.toString());

--- a/main/src/cgeo/geocaching/models/OfflineMap.java
+++ b/main/src/cgeo/geocaching/models/OfflineMap.java
@@ -4,7 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.downloader.AbstractDownloader;
 import cgeo.geocaching.downloader.CompanionFileUtils;
-import cgeo.geocaching.downloader.MapDownloaderElevate;
+import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarte;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarteThemes;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
@@ -83,7 +83,7 @@ public class OfflineMap {
         // id values must not be changed as they are referenced in the database & download companion files
         MAP_DOWNLOAD_TYPE_MAPSFORGE(1),
         MAP_DOWNLOAD_TYPE_OPENANDROMAPS(2),
-        MAP_DOWNLOAD_TYPE_ELEVATE(3),
+        MAP_DOWNLOAD_TYPE_OPENANDROMAPS_THEMES(3),
         MAP_DOWNLOAD_TYPE_FREIZEITKARTE(4),
         MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES(5);
 
@@ -115,7 +115,7 @@ public class OfflineMap {
             if (offlineMapTypes.size() == 0) {
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_MAPSFORGE, MapDownloaderMapsforge.getInstance(), R.string.mapserver_mapsforge_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_OPENANDROMAPS, MapDownloaderOpenAndroMaps.getInstance(), R.string.mapserver_openandromaps_name));
-                offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_ELEVATE, MapDownloaderElevate.getInstance(), R.string.mapserver_elevate_name));
+                offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_OPENANDROMAPS_THEMES, MapDownloaderOpenAndroMapsThemes.getInstance(), R.string.mapserver_openandromaps_themes_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE, MapDownloaderFreizeitkarte.getInstance(), R.string.mapserver_freizeitkarte_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, MapDownloaderFreizeitkarteThemes.getInstance(), R.string.mapserver_freizeitkarte_themes_name));
             }

--- a/main/src/cgeo/geocaching/models/OfflineMap.java
+++ b/main/src/cgeo/geocaching/models/OfflineMap.java
@@ -4,11 +4,11 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.downloader.AbstractDownloader;
 import cgeo.geocaching.downloader.CompanionFileUtils;
-import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarte;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarteThemes;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
+import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
 import cgeo.geocaching.utils.CalendarUtils;
 
 import android.net.Uri;
@@ -119,6 +119,16 @@ public class OfflineMap {
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE, MapDownloaderFreizeitkarte.getInstance(), R.string.mapserver_freizeitkarte_name));
                 offlineMapTypes.add(new OfflineMapTypeDescriptor(MAP_DOWNLOAD_TYPE_FREIZEITKARTE_THEMES, MapDownloaderFreizeitkarteThemes.getInstance(), R.string.mapserver_freizeitkarte_themes_name));
             }
+        }
+
+        public static OfflineMapTypeDescriptor fromTypeId(final int id) {
+            buildOfflineMapTypesList();
+            for (OfflineMapTypeDescriptor descriptor : offlineMapTypes) {
+                if (descriptor.type.id == id) {
+                    return descriptor;
+                }
+            }
+            return null;
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -21,6 +21,7 @@ import cgeo.geocaching.maps.interfaces.MapProvider;
 import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
+import cgeo.geocaching.models.OfflineMap;
 import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.playservices.GooglePlayServices;
 import cgeo.geocaching.sensors.DirectionData;
@@ -962,6 +963,14 @@ public class Settings {
 
     public static int getMapLanguage() {
         return getInt(R.string.pref_maplanguage, MAP_LANGUAGE_DEFAULT);
+    }
+
+    public static void setMapDownloaderSource(final int source) {
+        putInt(R.string.pref_mapdownloader_source, source);
+    }
+
+    public static int getMapDownloaderSource() {
+        return getInt(R.string.pref_mapdownloader_source, OfflineMap.OfflineMapType.MAP_DOWNLOAD_TYPE_MAPSFORGE.id);
     }
 
     public static void setPqShowDownloadableOnly(final boolean showDownloadableOnly) {


### PR DESCRIPTION
some polishing for the map downloader:
- set downloaded Freizeitkarte (FZK) theme as current theme on successful download (last part to fix #7529)
- offer to download missing FZK theme after successful FZK map download
- make naming of maps' and themes' variables and classes consistent
- remember last selected type in map downloader
