### PR TITLE
fix #10070, #10082, #10080: synchronize map theme folder in background

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2157,6 +2157,10 @@
     <string name="wizard_not_now">Not now</string>
     <string name="wizard_skip_wizard_warning">c:geo might not work as expected until configuration is completed. Depending on the missing configuration c:geo might not be able to read/store data like offline maps, geocaches, logfiles etc.\n\nWhenever you feel ready to finalize setup, either choose \"Configuration wizard\" in main menu or restart c:geo.</string>
 
+    <!-- Map Theme helper -->
+    <string name="mapthemes_foldersync_finished_toast">%1$s folder synchronization finished after %2$s, %3$d of %4$s needed synchronization</string>
+
+
     <!-- default actions in dialogs -->
     <string name="previous">Previous</string>
     <string name="skip">Skip</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -335,7 +335,7 @@ public class MainActivity extends AbstractActionBarActivity {
         LocalStorage.migrateLocalStorage(this);
 
         //sync map Theme folder
-        RenderThemeHelper.resynchronizeMapThemeFolder(this);
+        RenderThemeHelper.resynchronizeMapThemeFolder();
 
         // reactivate dialogs which are set to show later
         OneTimeDialogs.nextStatus();

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
@@ -92,7 +92,7 @@ public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
     @Override
     protected void onSuccessfulReceive(final Uri result) {
         //resync
-        RenderThemeHelper.resynchronizeMapThemeFolder(null);
+        RenderThemeHelper.resynchronizeMapThemeFolder();
         //set map theme
         RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));
     }

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
@@ -60,7 +60,7 @@ public class MapDownloaderOpenAndroMapsThemes extends AbstractDownloader {
     protected void onSuccessfulReceive(final Uri result) {
 
         //resync
-        RenderThemeHelper.resynchronizeMapThemeFolder(null);
+        RenderThemeHelper.resynchronizeMapThemeFolder();
 
         //set map theme
         RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -387,7 +387,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                 contentStorageHelper.selectPersistableFolder(folder, f -> {
                     p.setSummary(f.toUserDisplayableValue());
                     if (PersistableFolder.OFFLINE_MAP_THEMES.equals(f)) {
-                        RenderThemeHelper.resynchronizeMapThemeFolder(this);
+                        RenderThemeHelper.resynchronizeMapThemeFolder();
                     }
                 });
                 return false;

--- a/main/src/cgeo/geocaching/storage/ContentStorage.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorage.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.FileNameCreator;
+import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.UriUtils;
 import static cgeo.geocaching.storage.Folder.CGEO_PRIVATE_FILES;
@@ -502,37 +503,10 @@ public class ContentStorage {
     private void reportProblem(@StringRes final int messageId, final Exception ex, final Object ... params) {
 
         //prepare params message
-        final ImmutablePair<String, String> messages = constructMessage(messageId, params);
+        final ImmutablePair<String, String> messages = LocalizationUtils.getMultiPurposeString(messageId, "ContentStorage", params);
         Log.w("ContentStorage: " + messages.right, ex);
         if (context != null) {
             ActivityMixin.showToast(context, messages.left);
         }
     }
-
-    /**
-     * Given a resource id and parameters to fill it, constructs one message fit fpr user display (left) and one for log file (right)
-     * Difference is that the one for the log file will contain more detailled information than that for the end user
-     */
-    public ImmutablePair<String, String> constructMessage(@StringRes final int messageId, final Object ... params) {
-        //prepare params message
-        final Object[] paramsForLog = new Object[params.length];
-        final Object[] paramsForUser = new Object[params.length];
-        for (int i = 0; i < params.length; i++) {
-            if (params[i] instanceof Folder) {
-                paramsForUser[i] = ((Folder) params[i]).toUserDisplayableString();
-                paramsForLog[i] = params[i] + "(" + getUriForFolder((Folder) params[i]) + ")";
-            } else if (params[i] instanceof PersistableFolder) {
-                paramsForUser[i] = ((PersistableFolder) params[i]).toUserDisplayableValue();
-                paramsForLog[i] = params[i] + "(" + getUriForFolder(((PersistableFolder) params[i]).getFolder()) + ")";
-            } else if (params[i] instanceof Uri) {
-                paramsForUser[i] = UriUtils.toUserDisplayableString((Uri) params[i]);
-                paramsForLog[i] = params[i];
-            } else {
-                paramsForUser[i] = params[i];
-                paramsForLog[i] = params[i];
-            }
-        }
-        return new ImmutablePair<>(context.getString(messageId, paramsForUser), context.getString(messageId, paramsForLog));
-    }
-
 }

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.storage;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.UriUtils;
 
@@ -12,16 +13,13 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.DocumentsContract;
-import android.text.Spanned;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
-import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.core.text.HtmlCompat;
 import androidx.core.util.Consumer;
 
 import java.util.ArrayList;
@@ -390,13 +388,9 @@ public class ContentStorageActivityHelper {
     }
 
     private void report(final boolean isWarning, @StringRes final int messageId, final Object ... params) {
-        final ImmutablePair<String, String> messages = ContentStorage.get().constructMessage(messageId, params);
+        final ImmutablePair<String, String> messages = LocalizationUtils.getMultiPurposeString(messageId, "CSActivityHelper", params);
         Log.log(isWarning ? Log.LogLevel.WARN : Log.LogLevel.INFO, messages.right);
         ActivityMixin.showToast(activity, messages.left);
-    }
-
-    private Spanned getHtml(@AnyRes final int id, final Object ... params) {
-        return HtmlCompat.fromHtml(activity.getString(id, params), HtmlCompat.FROM_HTML_MODE_LEGACY);
     }
 
 }

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -367,6 +367,14 @@ public final class Formatter {
         return String.format(Locale.getDefault(), "%.1f %sB", bytes / Math.pow(1024, exp), pre);
     }
 
+    public static String formatDuration(final long milliseconds) {
+        //currently only used for millisecond/second range, could be expanded to longer ranges later
+        if (milliseconds > 1000) {
+            return (milliseconds / 1000) + "." + (milliseconds % 1000) + "s";
+        }
+        return milliseconds + "ms";
+    }
+
     public static List<CharSequence> truncateCommonSubdir(@NonNull final List<CharSequence> directories) {
         if (directories.size() < 2) {
             return directories;

--- a/main/src/cgeo/geocaching/utils/LocalizationUtils.java
+++ b/main/src/cgeo/geocaching/utils/LocalizationUtils.java
@@ -1,0 +1,87 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.storage.Folder;
+import cgeo.geocaching.storage.PersistableFolder;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.annotation.PluralsRes;
+import androidx.annotation.StringRes;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+/**
+ * A set of static helper methods supporting localization/internationalization
+ * especially in areas where Code has no activity available to get a context from.
+ *
+ * All methods work also in unit-test environments (where there is no available context
+ */
+public final class LocalizationUtils {
+
+    private static final Context APPLICATION_CONTEXT =
+        CgeoApplication.getInstance() == null ? null : CgeoApplication.getInstance().getApplicationContext();
+
+    private LocalizationUtils() {
+        //Util class, no instance
+    }
+
+    public static boolean hasContext() {
+        return APPLICATION_CONTEXT != null;
+    }
+
+    public static String getString(@StringRes final int resId, final Object ... params) {
+        return getStringWithFallback(resId, null, params);
+    }
+
+    public static String getStringWithFallback(@StringRes final int resId, final String fallback, final Object ... params) {
+        if (APPLICATION_CONTEXT == null) {
+            return "(NoCtx)" + (fallback == null ? "" : fallback) + "[" + StringUtils.join(params, ";") + "]";
+        }
+        return APPLICATION_CONTEXT.getString(resId, params);
+    }
+
+    public static String getPlural(@PluralsRes final int pluralId, final int quantity) {
+        return getPlural(pluralId, quantity, "thing(s)");
+    }
+
+    public static String getPlural(@PluralsRes final int pluralId, final int quantity, final String fallback) {
+        if (APPLICATION_CONTEXT == null) {
+            return quantity + " " + fallback;
+        }
+        return CgeoApplication.getInstance().getApplicationContext().getResources().getQuantityString(pluralId, quantity, quantity);
+    }
+
+    /**
+     * Given a resource id and parameters to fill it, constructs one message fit for user display (left) and one for log file
+     * (right). Difference is that the one for the log file will contain more detailled information than that for the end user
+     */
+    public static ImmutablePair<String, String> getMultiPurposeString(@StringRes final int messageId, final String fallback, final Object ... params) {
+
+        //prepare params message
+        final Object[] paramsForLog = new Object[params.length];
+        final Object[] paramsForUser = new Object[params.length];
+        for (int i = 0; i < params.length; i++) {
+            if (params[i] instanceof Folder) {
+                paramsForUser[i] = ((Folder) params[i]).toUserDisplayableString();
+                paramsForLog[i] = params[i] + "(" + ContentStorage.get().getUriForFolder((Folder) params[i]) + ")";
+            } else if (params[i] instanceof PersistableFolder) {
+                paramsForUser[i] = ((PersistableFolder) params[i]).toUserDisplayableValue();
+                paramsForLog[i] = params[i] + "(" + ContentStorage.get().getUriForFolder(((PersistableFolder) params[i]).getFolder()) + ")";
+            } else if (params[i] instanceof Uri) {
+                paramsForUser[i] = UriUtils.toUserDisplayableString((Uri) params[i]);
+                paramsForLog[i] = params[i];
+            } else {
+                paramsForUser[i] = params[i];
+                paramsForLog[i] = params[i];
+            }
+        }
+        return new ImmutablePair<>(getStringWithFallback(messageId, fallback, paramsForUser), getStringWithFallback(messageId, fallback, paramsForLog));
+    }
+
+
+
+}

--- a/tests/src-android/cgeo/geocaching/storage/ContentStorageTest.java
+++ b/tests/src-android/cgeo/geocaching/storage/ContentStorageTest.java
@@ -409,7 +409,7 @@ public class ContentStorageTest extends CGeoTestCase {
         p.store(new FileOutputStream(new File(fileSimDir, folderSyncInfoFilename)), "test");
         writeToUri(Uri.fromFile(new File(fileSimDir, "ccc-ddd.txt")), fileSimContent);
 
-        FolderUtils.get().synchronizeFolder(sourceFolder, targetFolderFile, null);
+        FolderUtils.get().synchronizeFolder(sourceFolder, targetFolderFile, null, null);
 
         //check if source and target files are identical
         final List<ImmutablePair<ContentStorage.FileInformation, String>> targetFiles = FolderUtils.get().getAllFiles(targetFolder);


### PR DESCRIPTION
fix #10070: synchronize map theme folder in background

Synchronization of Map Themes is now done in the background, but still uses the same trigger points as before (on c:geo startup, on map theme folder change and after map theme download).

Instead of original GUI, user is informed via toast about map theme sync:

![image](https://user-images.githubusercontent.com/6909759/109389735-f365c180-790d-11eb-989c-2d8b14982631.png)

![image](https://user-images.githubusercontent.com/6909759/109389744-ffea1a00-790d-11eb-8069-2618802d3dd1.png)

This PR also includes LocalizationUtils for localization methods useful when not having an activity around (so one does not have to deal with CGeoApplication).

It also fixes #10080, because this was just a parameter to add.
