### PR TITLE
enable writing of own log files

### DIFF
--- a/main/src/cgeo/geocaching/utils/FileNameCreator.java
+++ b/main/src/cgeo/geocaching/utils/FileNameCreator.java
@@ -11,11 +11,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class FileNameCreator {
 
     public static final FileNameCreator DEFAULT = new FileNameCreator("cgeo-file", "txt");
-//    public static final FileNameCreator DEFAULT_TEXT = new FileNameCreator("file", "txt");
-//    public static final FileNameCreator DEFAULT_BINARY = new FileNameCreator("file", "bin");
 
     public static final FileNameCreator OFFLINE_MAPS = new FileNameCreator("mapfile", "map");
     public static final FileNameCreator LOGFILE = new FileNameCreator("logcat", "txt");
+    public static final FileNameCreator LOGFILE_SELF_WRITTEN = new FileNameCreator("cgeo-log-%s", "txt");
     public static final FileNameCreator MEMORY_DUMP = new FileNameCreator("cgeo_dump", "hprof");
     public static final FileNameCreator GPX_EXPORT = new FileNameCreator("export", "gpx");
     public static final FileNameCreator INDIVIDUAL_ROUTE_NOSUFFIX = new FileNameCreator("route", null);


### PR DESCRIPTION
enable writing of own log files

Introduces a new option `logging.logfile` in `log-properties.txt`. If set to a value x, a log file will be written by c:geo (in addition to logging to logcat) into the logfiles directory.

