### PR TITLE
fix #10123: make themes folder sync configurable

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -171,6 +171,7 @@
     <string translatable="false" name="pref_includefoundstatus">includefoundstatus</string>
     <string translatable="false" name="pref_cleartrailafterexportstatus">cleartrailafterexportstatus</string>
     <string translatable="false" name="pref_renderthemefile">renderthemefile</string>
+    <string translatable="false" name="pref_renderthemefolder_synctolocal">renderthemefolder_synctolocal</string>
     <string translatable="false" name="pref_logImageScale">logImageScale</string>
     <string translatable="false" name="pref_ocde_tokensecret">ocde_tokensecret</string>
     <string translatable="false" name="pref_ocde_tokenpublic">ocde_tokenpublic</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -698,7 +698,7 @@
     <string name="settings_info_offline_maps_title">Info on Offline Maps</string>
     <string name="settings_info_offline_maps">c:geo supports maps for offline use. You can obtain maps from different providers or even create your own maps (from OSM data). First you have to select the folder in which offline maps are to be stored.</string>
     <string name="settings_info_themes_title">Info on Map Themes</string>
-    <string name="settings_info_themes">c:geo supports custom themes for offline maps. These can be used to change the color style of the map (e.g. to have a nightview map) or to highlight certain objects like cycle paths or height lines within the map.</string>
+    <string name="settings_info_themes">c:geo supports custom themes for offline maps. These can be used to change the color style of the map (e.g. to have a nightview map) or to highlight certain objects like cycle paths or height lines within the map.\n\nWorking with non-zipped map themes might decrease map viewer opening performance. In this case, the theme folder may optionally be synchronized to an app-private local folder for faster access (at the cost of some storage space).</string>
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="init_local_file_system">Local File System</string>
     <string name="init_base_directory_description">Base folder for public local data</string>
@@ -852,13 +852,13 @@
 
     <!-- Content Storage -->
     <string name="contentstorage_selectfolder_dialog_title">Change Folder %s</string>
-    <string name="contentstorage_selectfolder_dialog_msg_folderdata">The folder %1$s is currently set to \'%2$s\' and contains %3$s and %4$s.</string>
+    <string name="contentstorage_selectfolder_dialog_msg_folderdata">The folder %1$s is currently set to \'%2$s\', contains %3$s and %4$s and has a total size of %5$s.</string>
     <string name="contentstorage_selectfolder_dialog_msg_defaultfolder">You may choose to use the default folder \'%s\' or pick a user-defined folder.</string>
     <string name="contentstorage_selectfolder_dialog_choice_nocopy">Do nothing</string>
     <string name="contentstorage_selectfolder_dialog_choice_copy">Copy all content</string>
     <string name="contentstorage_selectfolder_dialog_choice_move">Move all content</string>
     <string name="contentstorage_selectfolder_dialog_choice_justselect">No further action</string>
-    <string name="contentstorage_selectfolder_dialog_choice">You selected a different folder than currently stored. How do you want to proceed?\n\nSelect folder and</string>
+    <string name="contentstorage_selectfolder_dialog_choice">You selected a different folder than currently stored. The current folder contains %1$s, %2$s and has a size of %3$s. How do you want to proceed?\n\nSelect folder and</string>
     <string name="contentstorage_folder_selection_aborted">Aborting folder selection, folder is \'%s\'</string>
     <string name="contentstorage_folder_selection_success">Folder set to \'%s\'</string>
     <string name="contentstorage_file_selection_aborted">Aborting file selection</string>
@@ -1339,6 +1339,10 @@
     <string name="map_showwp_parking">Parking waypoints</string>
     <string name="map_showwp_visited">Visited waypoints</string>
     <string name="map_show_track">Show GPX track/route</string>
+    <string name="init_renderthemefolder_synctolocal">Synchronize themes to app-private folder</string>
+    <string name="init_summary_renderthemefolder_synctolocal">This option may improve map viewer opening performance at the cost of some device storage space.</string>
+    <string name="init_renderthemefolder_synctolocal_dialog_title">Turn on theme folder synchronization</string>
+    <string name="init_renderthemefolder_synctolocal_dialog_message">This will permanently synchronize the content of the Map Theme folder into an app-private folder for faster file access.\n\nYour map Theme Folder \'%s\' has currently %s, %s and a size of %s.\n\nDo you want to turn on folder synchronization?</string>
     <string name="init_hidewp">Hide waypoints</string>
     <string name="init_summary_hidewp_original">Hide original waypoints on the map</string>
     <string name="init_summary_hidewp_parking">Hide parking waypoints on the map</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -582,6 +582,11 @@
             <Preference
                 android:key="@string/pref_persistablefolder_offlinemapthemes"
                 android:title="@string/init_rendertheme_folder" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_renderthemefolder_synctolocal"
+                android:summary="@string/init_summary_renderthemefolder_synctolocal"
+                android:title="@string/init_renderthemefolder_synctolocal" />
             <ListPreference
                 android:title="@string/settings_title_map_rotation"
                 android:summary="%s"

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -335,7 +335,7 @@ public class MainActivity extends AbstractActionBarActivity {
         LocalStorage.migrateLocalStorage(this);
 
         //sync map Theme folder
-        RenderThemeHelper.resynchronizeMapThemeFolder();
+        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
 
         // reactivate dialogs which are set to show later
         OneTimeDialogs.nextStatus();

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
@@ -92,7 +92,7 @@ public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
     @Override
     protected void onSuccessfulReceive(final Uri result) {
         //resync
-        RenderThemeHelper.resynchronizeMapThemeFolder();
+        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
         //set map theme
         RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));
     }

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
@@ -60,7 +60,7 @@ public class MapDownloaderOpenAndroMapsThemes extends AbstractDownloader {
     protected void onSuccessfulReceive(final Uri result) {
 
         //resync
-        RenderThemeHelper.resynchronizeMapThemeFolder();
+        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
 
         //set map theme
         RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1285,6 +1285,16 @@ public class Settings {
         putString(R.string.pref_renderthemefile, customRenderThemeFile);
     }
 
+    /** Shall SOLELY be used by {@link cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper}! */
+    public static boolean getSyncMapRenderThemeFolder() {
+        return getBoolean(R.string.pref_renderthemefolder_synctolocal, false);
+    }
+
+    /** Shall SOLELY be used by {@link cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper}! */
+    public static void setSyncMapRenderThemeFolder(final boolean syncMapRenderThemeFolder) {
+        putBoolean(R.string.pref_renderthemefolder_synctolocal, syncMapRenderThemeFolder);
+    }
+
     /**
      * @return true if plain text log wanted
      */

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -387,7 +387,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                 contentStorageHelper.selectPersistableFolder(folder, f -> {
                     p.setSummary(f.toUserDisplayableValue());
                     if (PersistableFolder.OFFLINE_MAP_THEMES.equals(f)) {
-                        RenderThemeHelper.resynchronizeMapThemeFolder();
+                        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
                     }
                 });
                 return false;
@@ -540,6 +540,11 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             setResult(RESTART_NEEDED);
             return true;
         });
+
+        getPreference(R.string.pref_renderthemefolder_synctolocal).setOnPreferenceChangeListener((preference, newValue) ->
+            RenderThemeHelper.changeSyncSetting(this, (newValue instanceof Boolean) ? ((Boolean) newValue).booleanValue() : false, changedValue -> {
+                ((CheckBoxPreference) getPreference(R.string.pref_renderthemefolder_synctolocal)).setChecked(changedValue);
+        }));
     }
 
     private void initGeoDirPreferences() {

--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -186,7 +186,7 @@ public final class LocalStorage {
     }
 
     @NonNull
-    public static File getMapThemeInternalDir() {
+    public static File getMapThemeInternalSyncDir() {
         final File dir =  new File(getInternalCgeoDirectory(), MAP_THEME_INTERNAL_DIR_NAME);
         dir.mkdirs();
         return dir;

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.playservices.GooglePlayServices;
 import cgeo.geocaching.sensors.MagnetometerAndAccelerometerProvider;
@@ -113,6 +114,7 @@ public final class SystemInformation {
         appendDirectory(body, "\n- System internal c:geo dir: ", LocalStorage.getInternalCgeoDirectory());
         appendDirectory(body, "\n- Legacy User storage c:geo dir: ", LocalStorage.getExternalPublicCgeoDirectory());
         appendDirectory(body, "\n- Geocache data: ", LocalStorage.getGeocacheDataDirectory());
+        appendDirectory(body, "\n- Internal theme sync (is turned " + (RenderThemeHelper.isThemeSynchronizationActive() ? "ON" : "off") + "): ", LocalStorage.getMapThemeInternalSyncDir());
         appendPublicFolders(body);
         body.append("\n- Map render theme path: ").append(Settings.getSelectedMapRenderTheme());
         appendPersistedDocumentUris(body);
@@ -165,11 +167,11 @@ public final class SystemInformation {
         body.append("\n- Public Folders: #").append(PersistableFolder.values().length);
         for (PersistableFolder folder : PersistableFolder.values()) {
             final boolean isAvailable = ContentStorage.get().ensureFolder(folder);
-            final ImmutablePair<Integer, Integer> files = FolderUtils.get().getFolderInfo(folder.getFolder());
+            final FolderUtils.FolderInfo folderInfo = FolderUtils.get().getFolderInfo(folder.getFolder());
             final ImmutablePair<Long, Long> freeSpace = FolderUtils.get().getDeviceInfo(folder.getFolder());
             body.append("\n- ").append(folder.toString())
                 .append(" (Uri: ").append(ContentStorage.get().getUriForFolder(folder.getFolder()))
-                .append(", Available:").append(isAvailable).append(", Files: ").append(files.left).append(", subdirs:").append(files.right)
+                .append(", Av:").append(isAvailable).append(", ").append(folderInfo)
                 .append(", free space: ").append(Formatter.formatBytes(freeSpace.left)).append(", files on device: ").append(freeSpace.right).append(")");
         }
     }


### PR DESCRIPTION
fix #10123: make themes folder sync configurable:

- Takes out the sync by default
- Make a new setting under map themes folder to turn it on or off
- Adjust explanatory text for map theme folder (there is already one in the settings for it, it also points to FAQs)
- Implements an absolute maximum sync file size (5MB) as well as an "exclude" file filter (will not sync Files with suffix map)
