### PR TITLE
Request SAF permissions on settings backup restore (fix #10105)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -694,6 +694,7 @@
     <string name="init_backup_settings_restore">Restore settings</string>
     <string name="settings_readingerror">Error reading settings</string>
     <string name="settings_restart">c:geo needs to be restarted now to bring loaded settings into effect</string>
+    <string name="settings_folder_changed">Setting for folder \"%1$s\" has changed to \"%2$s\".\n\nTap \"%3$s\" to keep current setting for this folder.\n\nTap \"%4$s\" to set the old folder. You will be asked to regrant c:geo access to that folder in that case.</string>
 
     <string name="settings_info_offline_maps_title">Info on Offline Maps</string>
     <string name="settings_info_offline_maps">c:geo supports maps for offline use. You can obtain maps from different providers or even create your own maps (from OSM data). First you have to select the folder in which offline maps are to be stored.</string>

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -199,7 +199,7 @@ public class InstallWizardActivity extends AppCompatActivity {
                     DataStore.resetNewlyCreatedDatabase();
                     final BackupUtils backupUtils = new BackupUtils(this);
                     if (BackupUtils.hasBackup(BackupUtils.newestBackupFolder())) {
-                        backupUtils.restore(BackupUtils.newestBackupFolder());
+                        backupUtils.restore(BackupUtils.newestBackupFolder(), getContentStorageHelper());
                     } else {
                         backupUtils.selectBackupDirIntent(getContentStorageHelper());
                     }

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -663,7 +663,7 @@ public class MainActivity extends AbstractActionBarActivity {
                         .setPositiveButton(getString(android.R.string.yes), (dialog, id) -> {
                             dialog.dismiss();
                             DataStore.resetNewlyCreatedDatabase();
-                            backupUtils.restore(BackupUtils.newestBackupFolder());
+                            backupUtils.restore(BackupUtils.newestBackupFolder(), getContentStorageHelper());
                         })
                         .setNegativeButton(getString(android.R.string.no), (dialog, id) -> {
                             dialog.cancel();

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1582,6 +1582,15 @@ public class Settings {
     }
 
     /**
+     * gets current setting for a persistable folder or null if unset
+     * should be called by BackupUtils.restoreInternal only
+     */
+    @Nullable
+    public static String getPersistableFolderRaw(@NonNull final PersistableFolder folder) {
+        return getString(folder.getPrefKeyId(), null);
+    }
+
+    /**
      * sets Uri for persistable uris. Can be set to null
      * should be called by PersistableUri class only
      */

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -420,7 +420,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
         final Preference restore = getPreference(R.string.pref_fakekey_preference_restore);
         restore.setOnPreferenceClickListener(preference -> {
-            backupUtils.restore(BackupUtils.newestBackupFolder());
+            backupUtils.restore(BackupUtils.newestBackupFolder(), contentStorageHelper);
             return true;
         });
 

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
- * Important: this class will oly work if you incorporate {@link #onActivityResult(int, int, Intent)}
+ * Important: this class will only work if you incorporate {@link #onActivityResult(int, int, Intent)}
  * into the {@link Activity#onActivityResult(int, int, Intent)} method of the using application!
  * TODO: once Activity ResultAPI is available -> refactor! Watch #9349
  */
@@ -132,6 +132,11 @@ public class ContentStorageActivityHelper {
     /** Simplified form of selectPersistableFolder without initial dialog */
     public void migratePersistableFolder(final PersistableFolder folder, final Consumer<PersistableFolder> callback) {
         selectFolderInternal(REQUEST_CODE_SELECT_FOLDER_PERSISTED, folder, null, CopyChoice.ASK_IF_DIFFERENT, callback);
+    }
+
+    /** Simplified form of selectPersistableFolder used on settings' restore */
+    public void restorePersistableFolder(final PersistableFolder folder, final Uri newUri, final Consumer<PersistableFolder> callback) {
+        selectFolderInternal(REQUEST_CODE_SELECT_FOLDER_PERSISTED, folder, newUri, CopyChoice.ASK_IF_DIFFERENT, callback);
     }
 
     /**

--- a/main/src/cgeo/geocaching/storage/PersistableFolder.java
+++ b/main/src/cgeo/geocaching/storage/PersistableFolder.java
@@ -117,6 +117,10 @@ public enum PersistableFolder {
         return ContentStorage.get().getUriForFolder(getFolder());
     }
 
+    public Uri getUriForFolder(final Folder folder) {
+        return ContentStorage.get().getUriForFolder(folder);
+    }
+
     public Folder getDefaultFolder() {
         return this.defaultFolder;
     }


### PR DESCRIPTION
On settings restore: Check if any of the `PersistableFolder` settings in the to-be-restored file differs from current settings and request access grant for those.

For every `PersistableFolder` with a different setting a popup will show while restoring settings, asking the user to either keep the existing value or restoring the old value, and starting SAF grant process in the latter case:

![image](https://user-images.githubusercontent.com/3754370/110993999-67758000-8378-11eb-9435-5ba4c8a162a1.png)
