### PR TITLE
Treat missing ellipsis character as lint error

### DIFF
--- a/main/lint.xml
+++ b/main/lint.xml
@@ -26,6 +26,8 @@
     <issue id="MissingTranslation" severity="ignore" />
     <!-- old translation will be deleted by the next crowdin import -->
     <issue id="ExtraTranslation" severity="ignore" />
+    <!-- treat non use of ellipsis character as error to avoid them on incoming translations -->
+    <issue id="TypographyEllipsis" severity="error" />
 
     <issue id="Registered" severity="ignore" />
     <issue id="RtlHardcoded" severity="ignore" />


### PR DESCRIPTION
Make build fail (as we stop on lint error now) if strings or incoming translations use `...` instead of the designates ellipsis character. This can currently not be forbidden/mitigated on Crowdin while translating and is an often made error made by translators.

Thus not detecting it will lead to more lint warning in the project (and more ugly strings).
