### PR TITLE
Move some strings to non translatable

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <string name="app_name">c:geo</string>
-
     <!-- basics -->
     <string name="cache">Cache</string>
     <string name="detail">Details</string>
@@ -163,8 +161,6 @@
     <string name="log_problem_archive_text">This geocacher reported that this geocache should be archived. A community volunteer reviewer has been notified.</string>
 
     <string name="log_image_scale_option_noscaling">No scaling</string>
-    <string name="log_image_scale_option_entry">%1$d x %2$d px</string>
-    <string name="log_image_scale_option_entry_noimage">%1$d px</string>
     <string name="log_image_info">%1$d x %2$d px, %3$s\nScaled/Compressed:\n%4$d x %5$d px, ~%6$s</string>
     <string name="log_image_titleprefix">Image</string>
 
@@ -294,7 +290,6 @@
     <string name="loc_fused">Fused</string>
     <string name="loc_low_power">Low-power</string>
     <string name="loc_home">Home coordinates</string>
-    <string name="loc_gps">GPS</string>
     <string name="loc_sat">Sat</string>
     <string name="loc_trying">Trying to Locate</string>
     <string name="loc_no_addr">Unknown address</string>
@@ -497,8 +492,6 @@
     <string name="settings_title_waypoints">Waypoints</string>
     <string name="settings_title_map_content">Map Content</string>
     <string name="settings_title_map_behavior">Map behavior</string>
-    <string name="settings_title_gpx">GPX</string>
-
     <string name="settings_title_data_dir">Geocache data folder</string>
     <string name="settings_title_data_dir_usage">Geocache data folder (%1$s used)</string>
     <string name="calculate_dataDir_title">Geocache data usage</string>
@@ -581,7 +574,6 @@
     <string name="init_signature_template_name">Name</string>
     <string name="init_signature_template_difficulty">Difficulty</string>
     <string name="init_signature_template_terrain">Terrain</string>
-    <string name="init_signature_template_url">URL</string>
     <string name="init_signature_template_log">Log text</string>
     <string name="init_signature_template_size">Size</string>
     <string name="init_signature_template_type">Type</string>
@@ -832,9 +824,6 @@
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>
-    <string name="map_source_osm_mapnik">OpenStreetMap.org</string>
-    <string name="map_source_osm_osmde">OpenStreetMap.de</string>
-    <string name="map_source_osm_cyclosm">CyclOSM</string>
     <string name="map_source_osm_offline">Offline</string>
     <string name="map_source_osm_offline_combined">Combined (Offline)</string>
     <string name="map_source_attribution_dialog_title">Map Attributions</string>
@@ -880,7 +869,6 @@
     <string name="persistablefolder_base">Base</string>
     <string name="persistablefolder_offline_maps">Offline Maps</string>
     <string name="persistablefolder_offline_maps_themes">Map Themes</string>
-    <string name="persistablefolder_gpx">GPX</string>
     <string name="persistablefolder_backup">Backup</string>
     <string name="persistablefolder_logfiles">Logfiles</string>
     <string name="persistablefolder_fieldnotes">Field Notes</string>
@@ -1112,7 +1100,6 @@
     <string name="cache_menu_sygic_drive">Sygic (Driving)</string>
     <string name="cache_menu_radar">Radar</string>
     <string name="cache_menu_map">Map</string>
-    <string name="cache_menu_rmaps">Rmaps</string>
     <string name="cache_menu_map_ext">Other external apps</string>
     <string name="cache_menu_streetview">Street View</string>
     <string name="cache_menu_browser">Open in browser</string>
@@ -1487,7 +1474,6 @@
     <string name="export_fieldnotes_upload_success">Upload to geocaching.com successful</string>
     <string name="export_fieldnotes_onlynew">Only since last export</string>
     <string name="export_fieldnotes_creating">Creating Field Notes…</string>
-    <string name="export_gpx">GPX</string>
     <string name="export_gpx_info">The GPX file will be exported to %1$s with the current date and time as its file name.</string>
     <string name="export_confirm_title">Exporting %1$s</string>
     <string name="export_confirm_message">To Path: %1$s\nFile Name: %2$s</string>
@@ -1936,8 +1922,6 @@
     <string name="init_low_disk_space_message">The geocache data folder is running low on storage space. This can cause malfunctions of c:geo. Please free up some space.</string>
     <string name="init_confirm_debug">c:geo is running in debug mode!</string>
     <string name="list_confirm_debug_message">The debug mode causes instabilities! Do you want to deactivate the debug mode?</string>
-    <string name="waypoint_latitude_null">N/S --° --.---</string>
-    <string name="waypoint_longitude_null">E/W --° --.---</string>
 
     <!-- permission handling -->
     <string name="close_app">Close app</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <string translatable="false" name="app_name">c:geo</string>
+
     <string-array translatable="false" name="waypoint_coordinate_formats">
         <item>@string/waypoint_coordinate_formats_plain</item>
         <item>DDD.DDDDD°</item>
@@ -25,7 +27,30 @@
         <item>800</item>
         <item>1024</item>
     </integer-array>
+    <string translatable="false" name="log_image_scale_option_entry">%1$d x %2$d px</string>
+    <string translatable="false" name="log_image_scale_option_entry_noimage">%1$d px</string>
 
+    <!-- location services -->
+    <string translatable="false" name="loc_gps">GPS</string>
+
+    <!-- Persistable Folders -->
+    <string translatable="false"  name="persistablefolder_gpx">GPX</string>
+
+    <!-- export -->
+    <string translatable="false" name="export_gpx">GPX</string>
+
+    <!-- map sources -->
+    <string translatable="false" name="map_source_osm_mapnik">OpenStreetMap.org</string>
+    <string translatable="false" name="map_source_osm_osmde">OpenStreetMap.de</string>
+    <string translatable="false" name="map_source_osm_cyclosm">CyclOSM</string>
+
+    <!-- calendar adder -->
+    <string translatable="false" name="waypoint_latitude_null">N/S --° --.---</string>
+    <string translatable="false" name="waypoint_longitude_null">E/W --° --.---</string>
+
+    <!-- settings -->
+    <string translatable="false" name="settings_title_gpx">GPX</string>
+    <string translatable="false" name="init_signature_template_url">URL</string>
     <string translatable="false" name="settings_gc_legal_note_url">https://www.geocaching.com/account/documents/termsofuse</string>
     <string translatable="false" name="settings_send2cgeo_url">https://send2.cgeo.org/</string>
     <string translatable="false" name="settings_facebook_login_url">https://faq.cgeo.org/#facebook-login</string>
@@ -142,6 +167,7 @@
     <!-- cache menu -->
     <string translatable="false" name="caches_map_mapswithme">Maps.me</string>
     <string translatable="false" name="cache_menu_mapswithme">Maps.me</string>
+    <string translatable="false" name="cache_menu_rmaps">Rmaps</string>
     <string translatable="false" name="faq_link"><a href="">faq.cgeo.org</a></string>
     <string translatable="false" name="website_link"><a href="">cgeo.org</a></string>
     <string translatable="false" name="twitter_link"><a href="">@android_GC</a></string>


### PR DESCRIPTION
Moving some strings into the non-translatable string file, as:
- Those does not contain translatable content (such as N° --.---..."
- Are own names and should not be translated (like Openstreetmap.org, Rmaps)
- Our app name should also not be fooled with on Crowdin

There have been occasions in the past where such strings have been translated and thus they are no longer correct (e.g. Rmaps to german Rkarten, Openstreetmap.de in spain to openstreetmap.es, etc.)

BTW:
This is my first PR which has been built locally on my machine before submitting it :) 