### PR TITLE
allow TB special tracking code length 9

### DIFF
--- a/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -26,7 +26,7 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     /**
      * TB codes really start with TB1, there is no padding or minimum length
      */
-    private static final Pattern PATTERN_TB_CODE = Pattern.compile("(TB[0-9A-Z&&[^ILOSU]]+)|([0-9A-Z]{6})|([0-9]{5})", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_TB_CODE = Pattern.compile("(TB[0-9A-Z&&[^ILOSU]]+)|([0-9A-Z]{6})|([0-9]{3}[A-Z]{6})|([0-9]{5})", Pattern.CASE_INSENSITIVE);
 
     @Override
     public int getPreferenceActivity() {
@@ -35,6 +35,9 @@ public class TravelBugConnector extends AbstractTrackableConnector {
 
     @Override
     public boolean canHandleTrackable(@Nullable final String geocode) {
+        if (geocode == null) {
+            return false;
+        }
         return PATTERN_TB_CODE.matcher(geocode).matches();
     }
 

--- a/tests/src-android/cgeo/geocaching/connector/trackable/TravelBugConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/TravelBugConnectorTest.java
@@ -2,20 +2,25 @@ package cgeo.geocaching.connector.trackable;
 
 import cgeo.geocaching.models.Trackable;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class TravelBugConnectorTest extends TestCase {
+public class TravelBugConnectorTest {
 
-    public static void testCanHandleTrackable() {
+    @Test
+    public void testCanHandleTrackable() {
         assertThat(getConnector().canHandleTrackable("TB1234")).isTrue();
         assertThat(getConnector().canHandleTrackable("TB1")).isTrue();
         assertThat(getConnector().canHandleTrackable("TB123F")).isTrue();
         assertThat(getConnector().canHandleTrackable("TB123Z")).isTrue();
         assertThat(getConnector().canHandleTrackable("TB4JD36")).isTrue(); // existing TB, 5 specific characters
         assertThat(getConnector().canHandleTrackable("GK1234")).isTrue(); // valid secret code, even though this might be a geokrety
-        assertThat(getConnector().canHandleTrackable("GST9HV")).isTrue(); // existing secret code
-        assertThat(getConnector().canHandleTrackable("UNKNOWN")).isFalse();
+        assertThat(getConnector().canHandleTrackable("GST9HV")).isTrue(); // existing secret code 6 digits
+        assertThat(getConnector().canHandleTrackable("999MROVER")).isTrue(); // formatted for the special secret code 9 digits for TB5EFXK
+        assertThat(getConnector().canHandleTrackable("NOTBC")).isFalse(); // shorter than 6 digits
+        assertThat(getConnector().canHandleTrackable("UNKNOWN")).isFalse(); // longer than 6 / shorter than 8 digits
+        assertThat(getConnector().canHandleTrackable("NOTKNOWN")).isFalse(); // longer than 6 / shorter than 8 digits
+        assertThat(getConnector().canHandleTrackable("NOTRACKING")).isFalse(); // longer than 9 digits
 
         assertThat(getConnector().canHandleTrackable("GC1234")).isTrue();
         assertThat(getConnector().canHandleTrackable("GC1234", TrackableBrand.UNKNOWN)).isTrue(); // accepted as TB
@@ -23,19 +28,22 @@ public class TravelBugConnectorTest extends TestCase {
         assertThat(getConnector().canHandleTrackable("GC1234", TrackableBrand.GEOKRETY)).isFalse(); // Not a TB
     }
 
-    public static void testGetUrl() {
+    @Test
+    public void testGetUrl() {
         final Trackable trackable = new Trackable();
         trackable.setGeocode("TB2345");
         assertThat(getConnector().getUrl(trackable)).isEqualTo("https://www.geocaching.com//track/details.aspx?tracker=TB2345");
     }
 
-    public static void testOnlineSearchBySecretCode() {
+    @Test
+    public void testOnlineSearchBySecretCode() {
         final Trackable trackable = getConnector().searchTrackable("GST9HV", null, null);
         assertThat(trackable).isNotNull();
         assertThat(trackable.getName()).isEqualTo("Deutschland");
     }
 
-    public static void testOnlineSearchByPublicCode() {
+    @Test
+    public void testOnlineSearchByPublicCode() {
         final Trackable trackable = getConnector().searchTrackable("TB4JD36", null, null);
         assertThat(trackable).isNotNull();
         assertThat(trackable.getName()).isEqualTo("Mein Kilometerzähler");
@@ -45,7 +53,8 @@ public class TravelBugConnectorTest extends TestCase {
         return TravelBugConnector.getInstance();
     }
 
-    public static void testGetTrackableCodeFromUrl() throws Exception {
+    @Test
+    public void testGetTrackableCodeFromUrl() {
         assertThat(TravelBugConnector.getInstance().getTrackableCodeFromUrl("http://coord.info/TB1234")).isEqualTo("TB1234");
         assertThat(TravelBugConnector.getInstance().getTrackableCodeFromUrl("http://www.coord.info/TB1234")).isEqualTo("TB1234");
         assertThat(TravelBugConnector.getInstance().getTrackableCodeFromUrl("http://geocaching.com/track/details.aspx?tracker=TB1234")).isEqualTo("TB1234");
@@ -56,7 +65,8 @@ public class TravelBugConnectorTest extends TestCase {
         assertThat(TravelBugConnector.getInstance().getTrackableCodeFromUrl("http://www.coord.info/GC1234")).isEqualTo("GC1234");
     }
 
-    public static void testRecommendGeocode() throws Exception {
+    @Test
+    public void testRecommendGeocode() {
         assertThat(getConnector().recommendLogWithGeocode()).isFalse();
     }
 }


### PR DESCRIPTION
fixes #10192

- edit pattern to additional allow 9 digit tracking code formatted for logging of TB5EFXK
- more tests for 5 to 10 digits length
- fix a possible nullable problem
- switch test class to simple junit4 tests