### PR TITLE
update gradle to version 4.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
 
         // un-mocking of portable Android classes
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
@@ -109,9 +109,9 @@ allprojects {
                 // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
                 force 'com.google.guava:guava:26.0-jre'
 
-                // force this version because of conflict to our resolutionStrategy from lint-gradle 4.1.2 (referencing 4.1.0-alpha01-6193524)
+                // force this version because of conflict to our resolutionStrategy from lint-gradle 4.1.3 (referencing 4.1.0-alpha01-6193524)
                 // TODO check after gradle update (gradlew :main:lintBasicDebug)
-                force 'com.android.tools.build:aapt2-proto:4.1.2-6503028'
+                force 'com.android.tools.build:aapt2-proto:4.1.3-6503028'
             }
         }
     }


### PR DESCRIPTION
checked also the aapt2-proto reference, is further necessary

Not yet useful release notes in https://androidstudio.googleblog.com/2021/03/android-studio-413-available.html
