### PR TITLE
catch SecurityException on receiving download (fix #10246)

### DIFF
--- a/main/src/cgeo/geocaching/downloader/ReceiveMapFileActivity.java
+++ b/main/src/cgeo/geocaching/downloader/ReceiveMapFileActivity.java
@@ -83,7 +83,7 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                             }
                         }
                     }
-                } catch (IOException e) {
+                } catch (IOException | SecurityException e) {
                     // ignore ZIP errors
                 }
                 // if no ZIP file: continue with copying the file
@@ -209,6 +209,9 @@ public class ReceiveMapFileActivity extends AbstractActivity {
                 } else {
                     status = doCopy(inputStream, outputUri);
                 }
+            } catch (SecurityException e) {
+                Log.e("SecurityException on receiving map file: " + e.getMessage());
+                return CopyStates.FILENOTFOUND_EXCEPTION;
             } catch (FileNotFoundException e) {
                 return CopyStates.FILENOTFOUND_EXCEPTION;
             } finally {
@@ -217,7 +220,6 @@ public class ReceiveMapFileActivity extends AbstractActivity {
 
             // clean up and refresh available map list
             if (!cancelled.get()) {
-                status = CopyStates.SUCCESS;
                 try {
                     getContentResolver().delete(uri, null, null);
                 } catch (IllegalArgumentException iae) {


### PR DESCRIPTION
- catch SecurityException on receiving download (fix #10246)
- also removes false "SUCCESS" state overriding IOException state