### PR TITLE
fix cancel on restoring multiple folders

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -692,7 +692,7 @@
     <string name="init_backup_settings_restore">Restore settings</string>
     <string name="settings_readingerror">Error reading settings</string>
     <string name="settings_restart">c:geo needs to be restarted now to bring loaded settings into effect</string>
-    <string name="settings_folder_changed">Setting for folder \"%1$s\" has changed to \"%2$s\".\n\nTap \"%3$s\" to keep current setting for this folder.\n\nTap \"%4$s\" to set the old folder. You will be asked to regrant c:geo access to that folder in that case.</string>
+    <string name="settings_folder_changed">Setting for folder \"%1$s\" will be restored to \"%2$s\".\n\nTap \"%3$s\" to keep current setting for this folder.\n\nTap \"%4$s\" to set the old folder. You will be asked to regrant c:geo access to that folder in that case.</string>
 
     <string name="settings_info_offline_maps_title">Info on Offline Maps</string>
     <string name="settings_info_offline_maps">c:geo supports maps for offline use. You can obtain maps from different providers or even create your own maps (from OSM data). First you have to select the folder in which offline maps are to be stored.</string>

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -212,7 +212,10 @@ public class BackupUtils {
                         regrantAccess(activityContext, contentStorageActivityHelper, currentFolderValues, restartNeeded, resultString);
                     });
                 },
-                d2 -> finishRestoreInternal(activityContext, restartNeeded, resultString));
+                d2 -> {
+                    currentFolderValues.remove(0);
+                    regrantAccess(activityContext, contentStorageActivityHelper, currentFolderValues, restartNeeded, resultString);
+                });
         } else {
             finishRestoreInternal(activityContext, restartNeeded, resultString);
         }


### PR DESCRIPTION
When you restore settings with multiple folders being different from current setting, and you selected "cancel" on one of them, c:geo did not ask you for the other diverging folders anymore during restore. This is fixed by this PR.

Also the dialog message is changed from "folder xxx has changed to yyy" to "folder xxx will be restored to yyy" to more accurately reflect what is happening.