### PR TITLE
optimize handling of wrongly detected tracking codes in global search

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -216,7 +216,7 @@
     <string name="err_tb_display">c:geo can\'t display the trackable you want. Is it really a trackable?</string>
     <string name="err_tb_details_open">c:geo can\'t open trackable details.</string>
     <string name="err_tb_not_loggable">This trackable isn\'t loggable.</string>
-    <string name="err_tb_find">c:geo can\'t find trackable</string>
+    <string name="err_tb_not_found">c:geo can\'t find trackable %s.</string>
     <string name="err_tb_find_that">c:geo can\'t find that trackable.</string>
     <string name="err_waypoint_cache_unknown">c:geo doesn\'t know to which cache you want to add a waypoint for.</string>
     <string name="err_waypoint_add_failed">c:geo failed to add your waypoint.</string>

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -153,6 +153,9 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
             final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
             trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, geocode.toUpperCase(Locale.US));
             trackablesIntent.putExtra(Intents.EXTRA_BRAND, trackableBrand.getId());
+            if (keywordSearch) { // keyword fallback, if desired by caller
+                trackablesIntent.putExtra(Intents.EXTRA_KEYWORD, query.trim());
+            }
             startActivity(trackablesIntent);
             return true;
         }

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -92,6 +92,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
     private ProgressDialog waitDialog = null;
     private CharSequence clickedItemText = null;
     private ImagesList imagesList = null;
+    private String fallbackKeywordSearch = null;
     private final CompositeDisposable createDisposables = new CompositeDisposable();
     private final CompositeDisposable geoDataDisposable = new CompositeDisposable();
     private static final GeoDirHandler locationUpdater = new GeoDirHandler() {
@@ -128,6 +129,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             geocache = extras.getString(Intents.EXTRA_GEOCACHE);
             brand = TrackableBrand.getById(extras.getInt(Intents.EXTRA_BRAND));
             trackingCode = extras.getString(Intents.EXTRA_TRACKING_CODE);
+            fallbackKeywordSearch = extras.getString(Intents.EXTRA_KEYWORD);
         }
 
         // try to get data from URI
@@ -289,10 +291,14 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
         if (trackable == null) {
             Dialogs.dismiss(waitDialog);
 
-            if (StringUtils.isNotBlank(geocode)) {
-                showToast(res.getString(R.string.err_tb_find) + " " + geocode + ".");
+            if (fallbackKeywordSearch != null) {
+                CacheListActivity.startActivityKeyword(this, fallbackKeywordSearch);
             } else {
-                showToast(res.getString(R.string.err_tb_find_that));
+                if (StringUtils.isNotBlank(geocode)) {
+                    showToast(res.getString(R.string.err_tb_find) + " " + geocode + ".");
+                } else {
+                    showToast(res.getString(R.string.err_tb_find_that));
+                }
             }
 
             finish();

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -295,7 +295,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
                 CacheListActivity.startActivityKeyword(this, fallbackKeywordSearch);
             } else {
                 if (StringUtils.isNotBlank(geocode)) {
-                    showToast(res.getString(R.string.err_tb_find) + " " + geocode + ".");
+                    showToast(res.getString(R.string.err_tb_not_found, geocode));
                 } else {
                     showToast(res.getString(R.string.err_tb_find_that));
                 }

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -203,7 +203,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
                     showProgress(false);
 
                     if (StringUtils.isNotBlank(geocode)) {
-                        showToast(res.getString(R.string.err_tb_find) + ' ' + geocode + '.');
+                        showToast(res.getString(R.string.err_tb_not_found, geocode));
                     } else {
                         showToast(res.getString(R.string.err_tb_find_that));
                     }


### PR DESCRIPTION

If no trackable with matching tracking code is found, execute online cache name search afterwards...

fixes #10258
fixes #5083
