### PR TITLE
BRouter integration: add tests for integrated brouter

### DIFF
--- a/main/src/cgeo/geocaching/brouter/codec/StatCoderContext.java
+++ b/main/src/cgeo/geocaching/brouter/codec/StatCoderContext.java
@@ -68,12 +68,30 @@ public final class StatCoderContext extends BitCoderContext {
     }
 
     /**
+     * encode an unsigned integer with some of of least significant bits
+     * considered noisy
+     *
+     * @see #decodeNoisyNumber
+     */
+    public void encodeNoisyNumber(int value, final int noisybits) {
+        if (value < 0) {
+            throw new IllegalArgumentException("encodeVarBits expects positive value");
+        }
+        if (noisybits > 0) {
+            final int mask = 0xffffffff >>> (32 - noisybits);
+            encodeBounded(mask, value & mask);
+            value >>= noisybits;
+        }
+        encodeVarBits(value);
+    }
+
+    /**
      * decode an unsigned integer with some of of least significant bits
      * considered noisy
      *
      * @see #encodeNoisyNumber
      */
-    public int decodeNoisyNumber(int noisybits) {
+    public int decodeNoisyNumber(final int noisybits) {
         final int value = decodeBits(noisybits);
         return value | (decodeVarBits() << noisybits);
     }
@@ -84,7 +102,7 @@ public final class StatCoderContext extends BitCoderContext {
      *
      * @see #decodeNoisyDiff
      */
-    public void encodeNoisyDiff(int value, int noisybits) {
+    public void encodeNoisyDiff(int value, final int noisybits) {
         if (noisybits > 0) {
             value += 1 << (noisybits - 1);
             final int mask = 0xffffffff >>> (32 - noisybits);
@@ -149,11 +167,58 @@ public final class StatCoderContext extends BitCoderContext {
     }
 
     /**
+     * encode an integer-array making use of the fact that it is sorted. This is
+     * done, starting with the most significant bit, by recursively encoding the
+     * number of values with the current bit being 0. This yields an number of
+     * bits per value that only depends on the typical distance between subsequent
+     * values and also benefits
+     *
      * @param values  the array to encode
      * @param offset  position in this array where to start
      * @param subsize number of values to encode
+     * @param nextbit bitmask with the most significant bit set to 1
+     * @param mask    should be 0
+     */
+    public void encodeSortedArray(final int[] values, final int offset, final int subsize, int nextbit, int mask) {
+        if (subsize == 1) { // last-choice shortcut
+            while (nextbit != 0) {
+                encodeBit((values[offset] & nextbit) != 0);
+                nextbit >>= 1;
+            }
+        }
+        if (nextbit == 0) {
+            return;
+        }
+
+        final int data = mask & values[offset];
+        mask |= nextbit;
+
+        // count 0-bit-fraction
+        int i = offset;
+        final int end = subsize + offset;
+        for (; i < end; i++) {
+            if ((values[i] & mask) != data) {
+                break;
+            }
+        }
+        final int size1 = i - offset;
+        final int size2 = subsize - size1;
+
+        encodeBounded(subsize, size1);
+        if (size1 > 0) {
+            encodeSortedArray(values, offset, size1, nextbit >> 1, mask);
+        }
+        if (size2 > 0) {
+            encodeSortedArray(values, i, size2, nextbit >> 1, mask);
+        }
+    }
+
+    /**
+     * @param values     the array to encode
+     * @param offset     position in this array where to start
+     * @param subsize    number of values to encode
      * @param nextbitpos bitmask with the most significant bit set to 1
-     * @param value   should be 0
+     * @param value      should be 0
      */
     public void decodeSortedArray(final int[] values, int offset, int subsize, final int nextbitpos, int value) {
         if (subsize == 1) { // last-choice shortcut

--- a/main/src/cgeo/geocaching/brouter/util/DenseLongMap.java
+++ b/main/src/cgeo/geocaching/brouter/util/DenseLongMap.java
@@ -1,0 +1,202 @@
+package cgeo.geocaching.brouter.util;
+
+import java.util.ArrayList;
+
+/**
+ * Special Memory efficient Map to map a long-key to
+ * a "small" value (some bits only) where it is expected
+ * that the keys are dense, so that we can use more or less
+ * a simple array as the best-fit data model (except for
+ * the 32-bit limit of arrays!)
+ * <p>
+ * Target application are osm-node ids which are in the
+ * range 0...3 billion and basically dense (=only few
+ * nodes deleted)
+ *
+ * @author ab
+ */
+public class DenseLongMap {
+    private ArrayList<byte[]> blocklist = new ArrayList<byte[]>(4096);
+
+    private int blocksize; // bytes per bitplane in one block
+    private int blocksizeBits;
+    private long blocksizeBitsMask;
+    private int maxvalue = 254; // fixed due to 8 bit lookup table
+    private int[] bitplaneCount = new int[8];
+    private long putCount = 0L;
+    private long getCount = 0L;
+
+    /**
+     * Creates a DenseLongMap for the default block size
+     * ( 512 bytes per bitplane, covering a key range of 4096 keys )
+     * Note that one value range is limited to 0..254
+     */
+    public DenseLongMap() {
+        this(512);
+    }
+
+    /**
+     * Creates a DenseLongMap for the given block size
+     *
+     * @param blocksize bytes per bit-plane
+     */
+    public DenseLongMap(final int blocksize) {
+        int bits = 4;
+        while (bits < 28 && (1 << bits) != blocksize) {
+            bits++;
+        }
+        if (bits == 28) {
+            throw new RuntimeException("not a valid blocksize: " + blocksize + " ( expected 1 << bits with bits in (4..27) )");
+        }
+        blocksizeBits = bits + 3;
+        blocksizeBitsMask = (1L << blocksizeBits) - 1;
+        this.blocksize = blocksize;
+    }
+
+
+    public void put(final long key, final int value) {
+        putCount++;
+
+        if (value < 0 || value > maxvalue) {
+            throw new IllegalArgumentException("value out of range (0.." + maxvalue + "): " + value);
+        }
+
+        final int blockn = (int) (key >> blocksizeBits);
+        final int offset = (int) (key & blocksizeBitsMask);
+
+        byte[] block = blockn < blocklist.size() ? blocklist.get(blockn) : null;
+
+        int valuebits = 1;
+        if (block == null) {
+            block = new byte[sizeForBits(valuebits)];
+            bitplaneCount[0]++;
+
+            while (blocklist.size() < blockn + 1) {
+                blocklist.add(null);
+            }
+            blocklist.set(blockn, block);
+        } else {
+            // check how many bitplanes we have from the arraysize
+            while (sizeForBits(valuebits) < block.length) {
+                valuebits++;
+            }
+        }
+        int headersize = 1 << valuebits;
+
+        final byte v = (byte) (value + 1); // 0 is reserved (=unset)
+
+        // find the index in the lookup table or the first entry
+        int idx = 1;
+        while (idx < headersize) {
+            if (block[idx] == 0) {
+                block[idx] = v; // create new entry
+            }
+            if (block[idx] == v) {
+                break;
+            }
+            idx++;
+        }
+        if (idx == headersize) {
+            block = expandBlock(block, valuebits);
+            block[idx] = v; // create new entry
+            blocklist.set(blockn, block);
+            valuebits++;
+            headersize = 1 << valuebits;
+        }
+
+        final int bitmask = 1 << (offset & 0x7);
+        final int invmask = bitmask ^ 0xff;
+        int probebit = 1;
+        int blockidx = (offset >> 3) + headersize;
+
+        for (int i = 0; i < valuebits; i++) {
+            if ((idx & probebit) != 0) {
+                block[blockidx] |= bitmask;
+            } else {
+                block[blockidx] &= invmask;
+            }
+            probebit <<= 1;
+            blockidx += blocksize;
+        }
+    }
+
+
+    private int sizeForBits(final int bits) {
+        // size is lookup table + datablocks
+        return (1 << bits) + blocksize * bits;
+    }
+
+    private byte[] expandBlock(final byte[] block, final int valuebits) {
+        bitplaneCount[valuebits]++;
+        final byte[] newblock = new byte[sizeForBits(valuebits + 1)];
+        final int headersize = 1 << valuebits;
+        System.arraycopy(block, 0, newblock, 0, headersize); // copy header
+        System.arraycopy(block, headersize, newblock, 2 * headersize, block.length - headersize); // copy data
+        return newblock;
+    }
+
+    public int getInt(final long key) {
+        // bit-stats on first get
+        if (getCount++ == 0L) {
+            System.out.println("**** DenseLongMap stats ****");
+            System.out.println("putCount=" + putCount);
+            for (int i = 0; i < 8; i++) {
+                System.out.println(i + "-bitplanes=" + bitplaneCount[i]);
+            }
+            System.out.println("****************************");
+        }
+
+    /* actual stats for the 30x45 raster and 512 blocksize with filtered nodes:
+     *
+     **** DenseLongMap stats ****
+     putCount=858518399
+     0-bitplanes=783337
+     1-bitplanes=771490
+     2-bitplanes=644578
+     3-bitplanes=210767
+     4-bitplanes=439
+     5-bitplanes=0
+     6-bitplanes=0
+     7-bitplanes=0
+     *
+     * This is a total of 1,2 GB
+     * (1.234.232.832+7.381.126+15.666.740 for body/header/object-overhead )
+    */
+
+        if (key < 0) {
+            return -1;
+        }
+        final int blockn = (int) (key >> blocksizeBits);
+        final int offset = (int) (key & blocksizeBitsMask);
+
+        final byte[] block = blockn < blocklist.size() ? blocklist.get(blockn) : null;
+
+        if (block == null) {
+            return -1;
+        }
+
+        // check how many bitplanes we have from the arrayzize
+        int valuebits = 1;
+        while (sizeForBits(valuebits) < block.length) {
+            valuebits++;
+        }
+        final int headersize = 1 << valuebits;
+
+        final int bitmask = 1 << (offset & 7);
+        int probebit = 1;
+        int blockidx = (offset >> 3) + headersize;
+        int idx = 0; // 0 is reserved (=unset)
+
+        for (int i = 0; i < valuebits; i++) {
+            if ((block[blockidx] & bitmask) != 0) {
+                idx |= probebit;
+            }
+            probebit <<= 1;
+            blockidx += blocksize;
+        }
+
+        // lookup that value in the lookup header
+        return ((256 + block[idx]) & 0xff) - 1;
+    }
+
+}

--- a/main/src/cgeo/geocaching/brouter/util/MixCoderDataInputStream.java
+++ b/main/src/cgeo/geocaching/brouter/util/MixCoderDataInputStream.java
@@ -1,0 +1,125 @@
+/**
+ * DataInputStream for decoding fast-compact encoded number sequences
+ *
+ * @author ab
+ */
+package cgeo.geocaching.brouter.util;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+
+public final class MixCoderDataInputStream extends DataInputStream {
+    private int lastValue;
+    private int repCount;
+    private int diffshift;
+
+    private int bits; // bits left in buffer
+    private int b; // buffer word
+
+    private static final int[] vl_values = BitCoderContext.vl_values;
+    private static final int[] vl_length = BitCoderContext.vl_length;
+
+    public MixCoderDataInputStream(final InputStream is) {
+        super(is);
+    }
+
+    public int readMixed() throws IOException {
+        if (repCount == 0) {
+            final boolean negative = decodeBit();
+            final int d = decodeVarBits() + diffshift;
+            repCount = decodeVarBits() + 1;
+            lastValue += negative ? -d : d;
+            diffshift = 1;
+        }
+        repCount--;
+        return lastValue;
+    }
+
+    public boolean decodeBit() throws IOException {
+        fillBuffer();
+        final boolean value = (b & 1) != 0;
+        b >>>= 1;
+        bits--;
+        return value;
+    }
+
+    public int decodeVarBits2() throws IOException {
+        int range = 0;
+        while (!decodeBit()) {
+            range = 2 * range + 1;
+        }
+        return range + decodeBounded(range);
+    }
+
+    /**
+     * decode an integer in the range 0..max (inclusive).
+     *
+     * @see #encodeBounded
+     */
+    public int decodeBounded(final int max) throws IOException {
+        int value = 0;
+        int im = 1; // integer mask
+        while ((value | im) <= max) {
+            if (decodeBit()) {
+                value |= im;
+            }
+            im <<= 1;
+        }
+        return value;
+    }
+
+
+    /**
+     * @see #encodeVarBits
+     */
+
+    public int decodeVarBits() throws IOException {
+        fillBuffer();
+        final int b12 = b & 0xfff;
+        final int len = vl_length[b12];
+        if (len <= 12) {
+            b >>>= len;
+            bits -= len;
+            return vl_values[b12]; // full value lookup
+        }
+        if (len <= 23) { // // only length lookup
+            final int len2 = len >> 1;
+            b >>>= len2 + 1;
+            int mask = 0xffffffff >>> (32 - len2);
+            mask += b & mask;
+            b >>>= len2;
+            bits -= len;
+            return mask;
+        }
+        if ((b & 0xffffff) != 0) {
+            // here we just know len in [25..47]
+            // ( fillBuffer guarantees only 24 bits! )
+            b >>>= 12;
+            final int len3 = 1 + (vl_length[b & 0xfff] >> 1);
+            b >>>= len3;
+            final int len2 = 11 + len3;
+            bits -= len2 + 1;
+            fillBuffer();
+            int mask = 0xffffffff >>> (32 - len2);
+            mask += b & mask;
+            b >>>= len2;
+            bits -= len2;
+            return mask;
+        }
+        return decodeVarBits2(); // no chance, use the slow one
+    }
+
+    private void fillBuffer() throws IOException {
+        while (bits < 24) {
+            final int nextByte = read();
+
+            if (nextByte != -1) {
+                b |= (nextByte & 0xff) << bits;
+            }
+            bits += 8;
+        }
+    }
+
+}

--- a/main/src/cgeo/geocaching/brouter/util/MixCoderDataOutputStream.java
+++ b/main/src/cgeo/geocaching/brouter/util/MixCoderDataOutputStream.java
@@ -1,0 +1,114 @@
+/**
+ * DataOutputStream for fast-compact encoding of number sequences
+ *
+ * @author ab
+ */
+package cgeo.geocaching.brouter.util;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+public final class MixCoderDataOutputStream extends DataOutputStream {
+    private int lastValue;
+    private int lastLastValue;
+    private int repCount;
+    private int diffshift;
+
+    private int bm = 1; // byte mask (write mode)
+    private int b = 0;
+
+    public static int[] diffs = new int[100];
+    public static int[] counts = new int[100];
+
+    public MixCoderDataOutputStream(final OutputStream os) {
+        super(os);
+    }
+
+    public void writeMixed(final int v) throws IOException {
+        if (v != lastValue && repCount > 0) {
+            int d = lastValue - lastLastValue;
+            lastLastValue = lastValue;
+
+            encodeBit(d < 0);
+            if (d < 0) {
+                d = -d;
+            }
+            encodeVarBits(d - diffshift);
+            encodeVarBits(repCount - 1);
+
+            if (d < 100) {
+                diffs[d]++;
+            }
+            if (repCount < 100) {
+                counts[repCount]++;
+            }
+
+            diffshift = 1;
+            repCount = 0;
+        }
+        lastValue = v;
+        repCount++;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        final int v = lastValue;
+        writeMixed(v + 1);
+        lastValue = v;
+        repCount = 0;
+        if (bm > 1) {
+            writeByte((byte) b); // flush bit-coding
+        }
+    }
+
+    public void encodeBit(final boolean value) throws IOException {
+        if (bm == 0x100) {
+            writeByte((byte) b);
+            bm = 1;
+            b = 0;
+        }
+        if (value) {
+            b |= bm;
+        }
+        bm <<= 1;
+    }
+
+    public void encodeVarBits(int value) throws IOException {
+        int range = 0;
+        while (value > range) {
+            encodeBit(false);
+            value -= range + 1;
+            range = 2 * range + 1;
+        }
+        encodeBit(true);
+        encodeBounded(range, value);
+    }
+
+    public void encodeBounded(int max, final int value) throws IOException {
+        int im = 1; // integer mask
+        while (im <= max) {
+            if (bm == 0x100) {
+                writeByte((byte) b);
+                bm = 1;
+                b = 0;
+            }
+            if ((value & im) != 0) {
+                b |= bm;
+                max -= im;
+            }
+            bm <<= 1;
+            im <<= 1;
+        }
+    }
+
+    public static void stats() {
+        for (int i = 1; i < 100; i++) {
+            System.out.println("diff[" + i + "] = " + diffs[i]);
+        }
+        for (int i = 1; i < 100; i++) {
+            System.out.println("counts[" + i + "] = " + counts[i]);
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/codec/LinkedListContainerTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/codec/LinkedListContainerTest.java
@@ -1,0 +1,41 @@
+package cgeo.geocaching.brouter.codec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LinkedListContainerTest {
+    @Test
+    public void linkedListTest1() {
+        final int nlists = 553;
+
+        final LinkedListContainer llc = new LinkedListContainer(nlists, null);
+
+        for (int ln = 0; ln < nlists; ln++) {
+            for (int i = 0; i < 10; i++) {
+                llc.addDataElement(ln, ln * i);
+            }
+        }
+
+        for (int i = 0; i < 10; i++) {
+            for (int ln = 0; ln < nlists; ln++) {
+                llc.addDataElement(ln, ln * i);
+            }
+        }
+
+        for (int ln = 0; ln < nlists; ln++) {
+            final int cnt = llc.initList(ln);
+            Assert.assertTrue("list size test", cnt == 20);
+
+            for (int i = 19; i >= 0; i--) {
+                final int data = llc.getDataElement();
+                Assert.assertTrue("data value test", data == ln * (i % 10));
+            }
+        }
+
+        try {
+            llc.getDataElement();
+            Assert.fail("no more elements expected");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/codec/StatCoderContextTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/codec/StatCoderContextTest.java
@@ -1,0 +1,108 @@
+package cgeo.geocaching.brouter.codec;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StatCoderContextTest {
+    @Test
+    public void noisyVarBitsEncodeDecodeTest() {
+        final byte[] ab = new byte[40000];
+        StatCoderContext ctx = new StatCoderContext(ab);
+        for (int noisybits = 1; noisybits < 12; noisybits++) {
+            for (int i = 0; i < 1000; i++) {
+                ctx.encodeNoisyNumber(i, noisybits);
+            }
+        }
+        ctx.closeAndGetEncodedLength();
+        ctx = new StatCoderContext(ab);
+
+        for (int noisybits = 1; noisybits < 12; noisybits++) {
+            for (int i = 0; i < 1000; i++) {
+                final int value = ctx.decodeNoisyNumber(noisybits);
+                if (value != i) {
+                    Assert.fail("value mismatch: noisybits=" + noisybits + " i=" + i + " value=" + value);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void noisySignedVarBitsEncodeDecodeTest() {
+        final byte[] ab = new byte[80000];
+        StatCoderContext ctx = new StatCoderContext(ab);
+        for (int noisybits = 0; noisybits < 12; noisybits++) {
+            for (int i = -1000; i < 1000; i++) {
+                ctx.encodeNoisyDiff(i, noisybits);
+            }
+        }
+        ctx.closeAndGetEncodedLength();
+        ctx = new StatCoderContext(ab);
+
+        for (int noisybits = 0; noisybits < 12; noisybits++) {
+            for (int i = -1000; i < 1000; i++) {
+                final int value = ctx.decodeNoisyDiff(noisybits);
+                if (value != i) {
+                    Assert.fail("value mismatch: noisybits=" + noisybits + " i=" + i + " value=" + value);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void predictedValueEncodeDecodeTest() {
+        final byte[] ab = new byte[80000];
+        StatCoderContext ctx = new StatCoderContext(ab);
+        for (int value = -100; value < 100; value += 5) {
+            for (int predictor = -200; predictor < 200; predictor += 7) {
+                ctx.encodePredictedValue(value, predictor);
+            }
+        }
+        ctx.closeAndGetEncodedLength();
+        ctx = new StatCoderContext(ab);
+
+        for (int value = -100; value < 100; value += 5) {
+            for (int predictor = -200; predictor < 200; predictor += 7) {
+                final int decodedValue = ctx.decodePredictedValue(predictor);
+                if (value != decodedValue) {
+                    Assert.fail("value mismatch: value=" + value + " predictor=" + predictor + " decodedValue=" + decodedValue);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void sortedArrayEncodeDecodeTest() {
+        final Random rand = new Random();
+        final int size = 1000000;
+        final int[] values = new int[size];
+        for (int i = 0; i < size; i++) {
+            values[i] = rand.nextInt() & 0x0fffffff;
+        }
+        values[5] = 175384; // force collision
+        values[8] = 175384;
+
+        values[15] = 275384; // force neighbours
+        values[18] = 275385;
+
+        Arrays.sort(values);
+
+        final byte[] ab = new byte[3000000];
+        StatCoderContext ctx = new StatCoderContext(ab);
+        ctx.encodeSortedArray(values, 0, size, 0x08000000, 0);
+
+        ctx.closeAndGetEncodedLength();
+        ctx = new StatCoderContext(ab);
+
+        final int[] decodedValues = new int[size];
+        ctx.decodeSortedArray(decodedValues, 0, size, 27, 0);
+
+        for (int i = 0; i < size; i++) {
+            if (values[i] != decodedValues[i]) {
+                Assert.fail("mismatch at i=" + i + " " + values[i] + "<>" + decodedValues[i]);
+            }
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/core/OsmNodeNamedTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/core/OsmNodeNamedTest.java
@@ -1,0 +1,115 @@
+package cgeo.geocaching.brouter.core;
+
+import cgeo.geocaching.brouter.util.CheapRulerHelper;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class OsmNodeNamedTest {
+    public static int toOsmLon(final double lon) {
+        return (int) ((lon + 180.) / CheapRulerHelper.ILATLNG_TO_LATLNG + 0.5);
+    }
+
+    public static int toOsmLat(final double lat) {
+        return (int) ((lat + 90.) / CheapRulerHelper.ILATLNG_TO_LATLNG + 0.5);
+    }
+
+    @Test
+    public void testDistanceWithinRadius() {
+        // Segment ends
+        int lon1;
+        int lat1;
+        int lon2;
+        int lat2;
+        // Circle definition
+        final OsmNodeNamed node = new OsmNodeNamed();
+        // Center
+        node.ilon = toOsmLon(2.334243);
+        node.ilat = toOsmLat(48.824017);
+        // Radius
+        node.radius = 30;
+
+        // Check distance within radius is correctly computed if the segment passes through the center
+        lon1 = toOsmLon(2.332559);
+        lat1 = toOsmLat(48.823822);
+        lon2 = toOsmLon(2.335018);
+        lat2 = toOsmLat(48.824105);
+        double totalSegmentLength = CheapRulerHelper.distance(lon1, lat1, lon2, lat2);
+        assertEquals(
+            "Works for segment aligned with the nogo center",
+            2 * node.radius,
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.01 * (2 * node.radius)
+        );
+
+        // Check distance within radius is correctly computed for a given circle
+        node.ilon = toOsmLon(2.33438);
+        node.ilat = toOsmLat(48.824275);
+        assertEquals(
+            "Works for a segment with no particular properties",
+            27.5,
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.1 * 27.5
+        );
+
+        // Check distance within radius is the same if we reverse start and end point
+        assertEquals(
+            "Works if we switch firs and last point",
+            node.distanceWithinRadius(lon2, lat2, lon1, lat1, totalSegmentLength),
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.01
+        );
+
+        // Check distance within radius is correctly computed if a point is inside the circle
+        lon2 = toOsmLon(2.334495);
+        lat2 = toOsmLat(48.824045);
+        totalSegmentLength = CheapRulerHelper.distance(lon1, lat1, lon2, lat2);
+        assertEquals(
+            "Works if last point is within the circle",
+            17,
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.1 * 17
+        );
+
+        lon1 = toOsmLon(2.334495);
+        lat1 = toOsmLat(48.824045);
+        lon2 = toOsmLon(2.335018);
+        lat2 = toOsmLat(48.824105);
+        totalSegmentLength = CheapRulerHelper.distance(lon1, lat1, lon2, lat2);
+        assertEquals(
+            "Works if first point is within the circle",
+            9,
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.1 * 9
+        );
+
+        lon1 = toOsmLon(2.33427);
+        lat1 = toOsmLat(48.82402);
+        lon2 = toOsmLon(2.334587);
+        lat2 = toOsmLat(48.824061);
+        totalSegmentLength = CheapRulerHelper.distance(lon1, lat1, lon2, lat2);
+        assertEquals(
+            "Works if both points are within the circle",
+            25,
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.1 * 25
+        );
+
+        // Check distance within radius is correctly computed if both points are on
+        // the same side of the center.
+        // Note: the only such case possible is with one point outside and one
+        // point within the circle, as we expect the segment to have a non-empty
+        // intersection with the circle.
+        lon1 = toOsmLon(2.332559);
+        lat1 = toOsmLat(48.823822);
+        lon2 = toOsmLon(2.33431);
+        lat2 = toOsmLat(48.824027);
+        totalSegmentLength = CheapRulerHelper.distance(lon1, lat1, lon2, lat2);
+        assertEquals(
+            "Works if both points are on the same side of the circle center",
+            5,
+            node.distanceWithinRadius(lon1, lat1, lon2, lat2, totalSegmentLength),
+            0.1 * 5
+        );
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/core/OsmNogoPolygonTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/core/OsmNogoPolygonTest.java
@@ -1,0 +1,209 @@
+/**********************************************************************************************
+ Copyright (C) 2018 Norbert Truchsess norbert.truchsess@t-online.de
+ **********************************************************************************************/
+package cgeo.geocaching.brouter.core;
+
+import cgeo.geocaching.brouter.util.CheapRulerHelper;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OsmNogoPolygonTest {
+
+    private static final int OFFSET_X = 11000000;
+    private static final int OFFSET_Y = 50000000;
+    private static final double[] lons = {1.0, 1.0, 0.5, 0.5, 1.0, 1.0, -1.1, -1.0};
+    private static final double[] lats = {-1.0, -0.1, -0.1, 0.1, 0.1, 1.0, 1.1, -1.0};
+    private static OsmNogoPolygon polygon;
+    private static OsmNogoPolygon polyline;
+
+    public static int toOsmLon(final double lon, final int offsetX) {
+        return (int) ((lon + 180.) * 1000000. + 0.5) + offsetX; // see ServerHandler.readPosition()
+    }
+
+    public static int toOsmLat(final double lat, final int offsetY) {
+        return (int) ((lat + 90.) * 1000000. + 0.5) + offsetY;
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        polygon = new OsmNogoPolygon(true);
+        for (int i = 0; i < lons.length; i++) {
+            polygon.addVertex(toOsmLon(lons[i], OFFSET_X), toOsmLat(lats[i], OFFSET_Y));
+        }
+        polyline = new OsmNogoPolygon(false);
+        for (int i = 0; i < lons.length; i++) {
+            polyline.addVertex(toOsmLon(lons[i], OFFSET_X), toOsmLat(lats[i], OFFSET_Y));
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // empty
+    }
+
+    @Test
+    public void testCalcBoundingCircle() {
+        final double[] lonlat2m = CheapRulerHelper.getLonLatToMeterScales(polygon.ilat);
+        final double dlon2m = lonlat2m[0];
+        final double dlat2m = lonlat2m[1];
+
+        polygon.calcBoundingCircle();
+        double r = polygon.radius;
+        for (int i = 0; i < lons.length; i++) {
+            final double dpx = (toOsmLon(lons[i], OFFSET_X) - polygon.ilon) * dlon2m;
+            final double dpy = (toOsmLat(lats[i], OFFSET_Y) - polygon.ilat) * dlat2m;
+            final double r1 = Math.sqrt(dpx * dpx + dpy * dpy);
+            final double diff = r - r1;
+            assertTrue("i: " + i + " r(" + r + ") >= r1(" + r1 + ")", diff >= 0);
+        }
+        polyline.calcBoundingCircle();
+        r = polyline.radius;
+        for (int i = 0; i < lons.length; i++) {
+            final double dpx = (toOsmLon(lons[i], OFFSET_X) - polyline.ilon) * dlon2m;
+            final double dpy = (toOsmLat(lats[i], OFFSET_Y) - polyline.ilat) * dlat2m;
+            final double r1 = Math.sqrt(dpx * dpx + dpy * dpy);
+            final double diff = r - r1;
+            assertTrue("i: " + i + " r(" + r + ") >= r1(" + r1 + ")", diff >= 0);
+        }
+    }
+
+    @Test
+    public void testIsWithin() {
+        final double[] plons = {0.0, 0.5, 1.0, -1.5, -0.5, 1.0, 1.0, 0.5, 0.5, 0.5};
+        final double[] plats = {0.0, 1.5, 0.0, 0.5, -1.5, -1.0, -0.1, -0.1, 0.0, 0.1};
+        final boolean[] within = {true, false, false, false, false, true, true, true, true, true};
+
+        for (int i = 0; i < plons.length; i++) {
+            assertEquals("(" + plons[i] + "," + plats[i] + ")", within[i], polygon.isWithin(toOsmLon(plons[i], OFFSET_X), toOsmLat(plats[i], OFFSET_Y)));
+        }
+    }
+
+    @Test
+    public void testIntersectsPolygon() {
+        final double[] p0lons = {0.0, 1.0, -0.5, 0.5, 0.7, 0.7, 0.7, -1.5, -1.5, 0.0};
+        final double[] p0lats = {0.0, 0.0, 0.5, 0.5, 0.5, 0.05, 0.05, -1.5, 0.2, 0.0};
+        final double[] p1lons = {0.0, 1.0, 0.5, 1.0, 0.7, 0.7, 0.7, -0.5, -0.2, 0.5};
+        final double[] p1lats = {0.0, 0.0, 0.5, 0.5, -0.5, -0.5, -0.05, -0.5, 1.5, -1.5};
+        final boolean[] within = {false, false, false, true, true, true, false, true, true, true};
+
+        for (int i = 0; i < p0lons.length; i++) {
+            assertEquals("(" + p0lons[i] + "," + p0lats[i] + ")-(" + p1lons[i] + "," + p1lats[i] + ")", within[i], polygon.intersects(toOsmLon(p0lons[i], OFFSET_X), toOsmLat(p0lats[i], OFFSET_Y), toOsmLon(p1lons[i], OFFSET_X), toOsmLat(p1lats[i], OFFSET_Y)));
+        }
+    }
+
+    @Test
+    public void testIntersectsPolyline() {
+        final double[] p0lons = {0.0, 1.0, -0.5, 0.5, 0.7, 0.7, 0.7, -1.5, -1.5, 0.0};
+        final double[] p0lats = {0.0, 0.0, 0.5, 0.5, 0.5, 0.05, 0.05, -1.5, 0.2, 0.0};
+        final double[] p1lons = {0.0, 1.0, 0.5, 1.0, 0.7, 0.7, 0.7, -0.5, -0.2, 0.5};
+        final double[] p1lats = {0.0, 0.0, 0.5, 0.5, -0.5, -0.5, -0.05, -0.5, 1.5, -1.5};
+        final boolean[] within = {false, false, false, true, true, true, false, true, true, false};
+
+        for (int i = 0; i < p0lons.length; i++) {
+            assertEquals("(" + p0lons[i] + "," + p0lats[i] + ")-(" + p1lons[i] + "," + p1lats[i] + ")", within[i], polyline.intersects(toOsmLon(p0lons[i], OFFSET_X), toOsmLat(p0lats[i], OFFSET_Y), toOsmLon(p1lons[i], OFFSET_X), toOsmLat(p1lats[i], OFFSET_Y)));
+        }
+    }
+
+    @Test
+    public void testBelongsToLine() {
+        assertTrue(OsmNogoPolygon.isOnLine(10, 10, 10, 10, 10, 20));
+        assertTrue(OsmNogoPolygon.isOnLine(10, 10, 10, 10, 20, 10));
+        assertTrue(OsmNogoPolygon.isOnLine(10, 10, 20, 10, 10, 10));
+        assertTrue(OsmNogoPolygon.isOnLine(10, 10, 10, 20, 10, 10));
+        assertTrue(OsmNogoPolygon.isOnLine(10, 15, 10, 10, 10, 20));
+        assertTrue(OsmNogoPolygon.isOnLine(15, 10, 10, 10, 20, 10));
+        assertTrue(OsmNogoPolygon.isOnLine(10, 10, 10, 10, 20, 30));
+        assertTrue(OsmNogoPolygon.isOnLine(20, 30, 10, 10, 20, 30));
+        assertTrue(OsmNogoPolygon.isOnLine(15, 20, 10, 10, 20, 30));
+        assertFalse(OsmNogoPolygon.isOnLine(11, 11, 10, 10, 10, 20));
+        assertFalse(OsmNogoPolygon.isOnLine(11, 11, 10, 10, 20, 10));
+        assertFalse(OsmNogoPolygon.isOnLine(15, 21, 10, 10, 20, 30));
+        assertFalse(OsmNogoPolygon.isOnLine(15, 19, 10, 10, 20, 30));
+        assertFalse(OsmNogoPolygon.isOnLine(0, -10, 10, 10, 20, 30));
+        assertFalse(OsmNogoPolygon.isOnLine(30, 50, 10, 10, 20, 30));
+    }
+
+    @Test
+    public void testDistanceWithinPolygon() {
+        // Testing polygon
+        final double[] lons = {2.333523, 2.333432, 2.333833, 2.333983, 2.334815, 2.334766};
+        final double[] lats = {48.823778, 48.824091, 48.82389, 48.824165, 48.824232, 48.82384};
+        final OsmNogoPolygon polygon = new OsmNogoPolygon(true);
+        for (int i = 0; i < lons.length; i++) {
+            polygon.addVertex(toOsmLon(lons[i], 0), toOsmLat(lats[i], 0));
+        }
+        final OsmNogoPolygon polyline = new OsmNogoPolygon(false);
+        for (int i = 0; i < lons.length; i++) {
+            polyline.addVertex(toOsmLon(lons[i], 0), toOsmLat(lats[i], 0));
+        }
+
+        // Check with a segment with a single intersection with the polygon
+        int lon1 = toOsmLon(2.33308732509613, 0);
+        int lat1 = toOsmLat(48.8238790443901, 0);
+        int lon2 = toOsmLon(2.33378201723099, 0);
+        int lat2 = toOsmLat(48.8239585098974, 0);
+        assertEquals(
+            "Should give the correct length for a segment with a single intersection",
+            17.5,
+            polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+            0.05 * 17.5
+        );
+
+        // Check with a segment crossing multiple times the polygon
+        lon2 = toOsmLon(2.33488172292709, 0);
+        lat2 = toOsmLat(48.8240891862353, 0);
+        assertEquals(
+            "Should give the correct length for a segment with multiple intersections",
+            85,
+            polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+            0.05 * 85
+        );
+
+        // Check that it works when a point is within the polygon
+        lon2 = toOsmLon(2.33433187007904, 0);
+        lat2 = toOsmLat(48.8240238480664, 0);
+        assertEquals(
+            "Should give the correct length when last point is within the polygon",
+            50,
+            polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+            0.05 * 50
+        );
+        lon1 = toOsmLon(2.33433187007904, 0);
+        lat1 = toOsmLat(48.8240238480664, 0);
+        lon2 = toOsmLon(2.33488172292709, 0);
+        lat2 = toOsmLat(48.8240891862353, 0);
+        assertEquals(
+            "Should give the correct length when first point is within the polygon",
+            35,
+            polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+            0.05 * 35
+        );
+
+        lon1 = toOsmLon(2.333523, 0);
+        lat1 = toOsmLat(48.823778, 0);
+        lon2 = toOsmLon(2.333432, 0);
+        lat2 = toOsmLat(48.824091, 0);
+        assertEquals(
+            "Should give the correct length if the segment overlaps with an edge of the polygon",
+            CheapRulerHelper.distance(lon1, lat1, lon2, lat2),
+            polygon.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+            0.05 * CheapRulerHelper.distance(lon1, lat1, lon2, lat2)
+        );
+
+        lon1 = toOsmLon(2.333523, 0);
+        lat1 = toOsmLat(48.823778, 0);
+        lon2 = toOsmLon(2.3334775, 0);
+        lat2 = toOsmLat(48.8239345, 0);
+        assertEquals(
+            "Should give the correct length if the segment overlaps with a polyline",
+            CheapRulerHelper.distance(lon1, lat1, lon2, lat2),
+            polyline.distanceWithinPolygon(lon1, lat1, lon2, lat2),
+            0.05 * CheapRulerHelper.distance(lon1, lat1, lon2, lat2)
+        );
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/BitCoderContextTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/BitCoderContextTest.java
@@ -1,0 +1,53 @@
+package cgeo.geocaching.brouter.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BitCoderContextTest {
+    @Test
+    public void varBitsEncodeDecodeTest() {
+        final byte[] ab = new byte[581969];
+        BitCoderContext ctx = new BitCoderContext(ab);
+        for (int i = 0; i < 31; i++) {
+            ctx.encodeVarBits((1 << i) + 3);
+        }
+        for (int i = 0; i < 100000; i += 13) {
+            ctx.encodeVarBits(i);
+        }
+        ctx.closeAndGetEncodedLength();
+        ctx = new BitCoderContext(ab);
+
+        for (int i = 0; i < 31; i++) {
+            final int value = ctx.decodeVarBits();
+            final int v0 = (1 << i) + 3;
+            Assert.assertTrue("value mismatch value=" + value + "v0=" + v0, v0 == value);
+        }
+        for (int i = 0; i < 100000; i += 13) {
+            final int value = ctx.decodeVarBits();
+            Assert.assertTrue("value mismatch i=" + i + "v=" + value, value == i);
+        }
+    }
+
+    @Test
+    public void boundedEncodeDecodeTest() {
+        final byte[] ab = new byte[581969];
+        BitCoderContext ctx = new BitCoderContext(ab);
+        for (int max = 1; max < 1000; max++) {
+            for (int val = 0; val <= max; val++) {
+                ctx.encodeBounded(max, val);
+            }
+        }
+        ctx.closeAndGetEncodedLength();
+
+        ctx = new BitCoderContext(ab);
+
+        for (int max = 1; max < 1000; max++) {
+            for (int val = 0; val <= max; val++) {
+                final int valDecoded = ctx.decodeBounded(max);
+                if (valDecoded != val) {
+                    Assert.fail("mismatch at max=" + max + " " + valDecoded + "<>" + val);
+                }
+            }
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/ByteDataIOTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/ByteDataIOTest.java
@@ -1,0 +1,21 @@
+package cgeo.geocaching.brouter.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteDataIOTest {
+    @Test
+    public void varLengthEncodeDecodeTest() {
+        final byte[] ab = new byte[4000];
+        final ByteDataWriter w = new ByteDataWriter(ab);
+        for (int i = 0; i < 1000; i++) {
+            w.writeVarLengthUnsigned(i);
+        }
+        final ByteDataReader r = new ByteDataReader(ab);
+
+        for (int i = 0; i < 1000; i++) {
+            final int value = r.readVarLengthUnsigned();
+            Assert.assertTrue("value mismatch", value == i);
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/CheapAngleMeterTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/CheapAngleMeterTest.java
@@ -1,0 +1,120 @@
+package cgeo.geocaching.brouter.util;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class CheapAngleMeterTest {
+    public static int toOsmLon(final double lon) {
+        return (int) ((lon + 180.) / CheapRulerHelper.ILATLNG_TO_LATLNG + 0.5);
+    }
+
+    public static int toOsmLat(final double lat) {
+        return (int) ((lat + 90.) / CheapRulerHelper.ILATLNG_TO_LATLNG + 0.5);
+    }
+
+    @Test
+    public void testCalcAngle() {
+        final CheapAngleMeter am = new CheapAngleMeter();
+        // Segment ends
+        int lon0;
+        int lat0;
+        int lon1;
+        int lat1;
+        int lon2;
+        int lat2;
+
+        lon0 = toOsmLon(2.317126);
+        lat0 = toOsmLat(48.817927);
+        lon1 = toOsmLon(2.317316);
+        lat1 = toOsmLat(48.817978);
+        lon2 = toOsmLon(2.317471);
+        lat2 = toOsmLat(48.818043);
+        assertEquals(
+            "Works for an angle between -pi/4 and pi/4",
+            -10.,
+            am.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+            0.05 * 10.
+        );
+
+        lon0 = toOsmLon(2.317020662874013);
+        lat0 = toOsmLat(48.81799440182911);
+        lon1 = toOsmLon(2.3169460585876327);
+        lat1 = toOsmLat(48.817812421536644);
+        lon2 = lon0;
+        lat2 = lat0;
+        assertEquals(
+            "Works for an angle between 3*pi/4 and 5*pi/4",
+            180.,
+            am.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+            0.05 * 180.
+        );
+
+        lon0 = toOsmLon(2.317112);
+        lat0 = toOsmLat(48.817802);
+        lon1 = toOsmLon(2.317632);
+        lat1 = toOsmLat(48.817944);
+        lon2 = toOsmLon(2.317673);
+        lat2 = toOsmLat(48.817799);
+        assertEquals(
+            "Works for an angle between -3*pi/4 and -pi/4",
+            100.,
+            am.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+            0.1 * 100.
+        );
+
+        lon0 = toOsmLon(2.317128);
+        lat0 = toOsmLat(48.818072);
+        lon1 = toOsmLon(2.317532);
+        lat1 = toOsmLat(48.818108);
+        lon2 = toOsmLon(2.317497);
+        lat2 = toOsmLat(48.818264);
+        assertEquals(
+            "Works for an angle between pi/4 and 3*pi/4",
+            -100.,
+            am.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2),
+            0.1 * 100.
+        );
+    }
+
+    @Test
+    public void testCalcAngle2() {
+        final CheapAngleMeter am = new CheapAngleMeter();
+        final int lon1 = 8500000;
+        final int lat1 = 49500000;
+
+        final double[] lonlat2m = CheapRulerHelper.getLonLatToMeterScales(lat1);
+        final double lon2m = lonlat2m[0];
+        final double lat2m = lonlat2m[1];
+
+        for (double afrom = -175.; afrom < 180.; afrom += 10.) {
+            final double sf = Math.sin(afrom * Math.PI / 180.);
+            final double cf = Math.cos(afrom * Math.PI / 180.);
+
+            final int lon0 = (int) (0.5 + lon1 - cf * 150. / lon2m);
+            final int lat0 = (int) (0.5 + lat1 - sf * 150. / lat2m);
+
+            for (double ato = -177.; ato < 180.; ato += 10.) {
+                final double st = Math.sin(ato * Math.PI / 180.);
+                final double ct = Math.cos(ato * Math.PI / 180.);
+
+                final int lon2 = (int) (0.5 + lon1 + ct * 250. / lon2m);
+                final int lat2 = (int) (0.5 + lat1 + st * 250. / lat2m);
+
+                double a1 = afrom - ato;
+                if (a1 > 180.) {
+                    a1 -= 360.;
+                }
+                if (a1 < -180.) {
+                    a1 += 360.;
+                }
+                final double a2 = am.calcAngle(lon0, lat0, lon1, lat1, lon2, lat2);
+                final double c1 = Math.cos(a1 * Math.PI / 180.);
+                final double c2 = am.getCosAngle();
+
+                assertEquals("angle mismatch for afrom=" + afrom + " ato=" + ato, a1, a2, 0.2);
+                assertEquals("cosinus mismatch for afrom=" + afrom + " ato=" + ato, c1, c2, 0.001);
+            }
+        }
+    }
+
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/CompactMapTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/CompactMapTest.java
@@ -1,0 +1,61 @@
+package cgeo.geocaching.brouter.util;
+
+import java.util.HashMap;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CompactMapTest {
+    @Test
+    public void hashMapComparisonTest() {
+        hashMapComparison(0, 1);
+        hashMapComparison(1, 1);
+        hashMapComparison(2, 2);
+        hashMapComparison(3, 3);
+        hashMapComparison(4, 4);
+        hashMapComparison(5, 5);
+        hashMapComparison(7, 10);
+        hashMapComparison(8, 10);
+        hashMapComparison(10000, 20000);
+        Assert.assertTrue(true);
+    }
+
+    private void hashMapComparison(final int mapsize, final int trycount) {
+        final Random rand = new Random(12345);
+        final HashMap<Long, String> hmap = new HashMap<Long, String>();
+        CompactLongMap<String> cmapSlow = new CompactLongMap<String>();
+        CompactLongMap<String> cmapFast = new CompactLongMap<String>();
+
+        for (int i = 0; i < mapsize; i++) {
+            final String s = "" + i;
+            final long k = mapsize < 10 ? i : rand.nextInt(20000);
+            final Long kk = new Long(k);
+
+            if (!hmap.containsKey(kk)) {
+                hmap.put(kk, s);
+                cmapSlow.put(k, s);
+                cmapFast.fastPut(k, s);
+            }
+        }
+
+        for (int i = 0; i < trycount * 2; i++) {
+            if (i == trycount) {
+                cmapSlow = new FrozenLongMap<String>(cmapSlow);
+                cmapFast = new FrozenLongMap<String>(cmapFast);
+            }
+            final long k = mapsize < 10 ? i : rand.nextInt(20000);
+            final Long kk = new Long(k);
+            final String s = hmap.get(kk);
+
+            final boolean contained = hmap.containsKey(kk);
+            Assert.assertTrue("containsKey missmatch (slow)", contained == cmapSlow.contains(k));
+            Assert.assertTrue("containsKey missmatch (fast)", contained == cmapFast.contains(k));
+
+            if (contained) {
+                Assert.assertEquals("object missmatch (fast)", s, cmapFast.get(k));
+                Assert.assertEquals("object missmatch (slow)", s, cmapSlow.get(k));
+            }
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/DenseLongMapTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/DenseLongMapTest.java
@@ -1,0 +1,101 @@
+package cgeo.geocaching.brouter.util;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DenseLongMapTest {
+    @Test
+    public void hashMapComparisonTest() {
+        hashMapComparison(100000, 100000, 100000);
+        hashMapComparison(100000, 100000, 13000000);
+        Assert.assertTrue(true);
+    }
+
+    private void hashMapComparison(final int mapsize, final int trycount, final long keyrange) {
+        final Random rand = new Random(12345);
+        final HashMap<Long, Integer> hmap = new HashMap<Long, Integer>();
+        final DenseLongMap dmap = new DenseLongMap(512);
+
+        for (int i = 0; i < mapsize; i++) {
+            final int value = i % 255;
+            final long k = (long) (rand.nextDouble() * keyrange);
+            final Long kk = new Long(k);
+
+            hmap.put(kk, new Integer(value));
+            dmap.put(k, value); // duplicate puts allowed!
+        }
+
+        for (int i = 0; i < trycount; i++) {
+            final long k = (long) (rand.nextDouble() * keyrange);
+            final Long kk = new Long(k);
+            final Integer vv = hmap.get(kk);
+            final int hvalue = vv == null ? -1 : vv.intValue();
+            final int dvalue = dmap.getInt(k);
+
+            if (hvalue != dvalue) {
+                Assert.fail("value missmatch for key " + k + " hashmap=" + hvalue + " densemap=" + dvalue);
+            }
+        }
+    }
+
+    @Test
+    public void oneBitTest() {
+        final int keyrange = 300000;
+        final int mapputs = 100000;
+        final int trycount = 100000;
+
+        final Random rand = new Random(12345);
+        final HashSet<Long> hset = new HashSet<Long>();
+
+        final DenseLongMap dmap = new DenseLongMap(512);
+        for (int i = 0; i < mapputs; i++) {
+            final long k = (long) (rand.nextDouble() * keyrange);
+            hset.add(new Long(k));
+            dmap.put(k, 0);
+        }
+        for (int i = 0; i < trycount; i++) {
+            final long k = (long) (rand.nextDouble() * keyrange);
+            final boolean hcontains = hset.contains(new Long(k));
+            final boolean dcontains = dmap.getInt(k) == 0;
+
+            if (hcontains != dcontains) {
+                Assert.fail("value missmatch for key " + k + " hashset=" + hcontains + " densemap=" + dcontains);
+            }
+        }
+    }
+
+    // @Test - memory test disabled for load reasons
+    public void memoryUsageTest() {
+        final int keyrange = 32000000;
+        final int mapputs = keyrange * 2;
+
+        final Random rand = new Random(12345);
+        final DenseLongMap dmap = new DenseLongMap(6);
+
+        System.gc();
+        final long mem1 = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+        for (int i = 0; i < mapputs; i++) {
+            final int value = i % 63;
+            final long k = (long) (rand.nextDouble() * keyrange);
+            dmap.put(k, value);
+        }
+
+        System.gc();
+        final long mem2 = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+        final long memusage = mem2 - mem1;
+
+        if (memusage > (keyrange / 8) * 7) {
+            Assert.fail("memory usage too high: " + memusage + " for keyrange " + keyrange);
+        }
+
+        // need to use the map again for valid memory measure
+        Assert.assertTrue("out of range test", dmap.getInt(-1) == -1);
+    }
+
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/MixCoderTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/MixCoderTest.java
@@ -1,0 +1,55 @@
+package cgeo.geocaching.brouter.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MixCoderTest {
+    @Test
+    public void mixEncodeDecodeTest() throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        MixCoderDataOutputStream mco = new MixCoderDataOutputStream(baos);
+        MixCoderDataInputStream mci = null;
+
+        for (; ; ) {
+            final Random rnd = new Random(1234);
+            for (int i = 0; i < 1500; i++) {
+                checkEncodeDecode(rnd.nextInt(3800), mco, mci);
+            }
+            for (int i = 0; i < 1500; i++) {
+                checkEncodeDecode(rnd.nextInt(35), mco, mci);
+            }
+            for (int i = 0; i < 1500; i++) {
+                checkEncodeDecode(0, mco, mci);
+            }
+            for (int i = 0; i < 1500; i++) {
+                checkEncodeDecode(1000, mco, mci);
+            }
+
+            if (mco != null) {
+                mco.close();
+                mco = null;
+                mci = new MixCoderDataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+            } else {
+                break;
+            }
+        }
+        Assert.assertTrue(true);
+    }
+
+    private void checkEncodeDecode(final int v, final MixCoderDataOutputStream mco, final MixCoderDataInputStream mci) throws IOException {
+        if (mco != null) {
+            mco.writeMixed(v);
+        }
+        if (mci != null) {
+            final long vv = mci.readMixed();
+            if (vv != v) {
+                Assert.assertTrue("value mismatch: v=" + v + " vv=" + vv, false);
+            }
+        }
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/SortedHeapTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/SortedHeapTest.java
@@ -1,0 +1,59 @@
+package cgeo.geocaching.brouter.util;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SortedHeapTest {
+    @Test
+    public void sortedHeapTest1() {
+        final SortedHeap<String> sh = new SortedHeap<String>();
+        final Random rnd = new Random();
+        for (int i = 0; i < 100000; i++) {
+            int val = rnd.nextInt(1000000);
+            sh.add(val, "" + val);
+            val = rnd.nextInt(1000000);
+            sh.add(val, "" + val);
+            sh.popLowestKeyValue();
+        }
+
+        int cnt = 0;
+        int lastval = 0;
+        for (; ; ) {
+            final String s = sh.popLowestKeyValue();
+            if (s == null) {
+                break;
+            }
+            cnt++;
+            final int val = Integer.parseInt(s);
+            Assert.assertTrue("sorting test", val >= lastval);
+            lastval = val;
+        }
+        Assert.assertTrue("total count test", cnt == 100000);
+
+    }
+
+    @Test
+    public void sortedHeapTest2() {
+        final SortedHeap<String> sh = new SortedHeap<String>();
+        for (int i = 0; i < 100000; i++) {
+            sh.add(i, "" + i);
+        }
+
+        int cnt = 0;
+        int expected = 0;
+        for (; ; ) {
+            final String s = sh.popLowestKeyValue();
+            if (s == null) {
+                break;
+            }
+            cnt++;
+            final int val = Integer.parseInt(s);
+            Assert.assertTrue("sequence test", val == expected);
+            expected++;
+        }
+        Assert.assertTrue("total count test", cnt == 100000);
+
+    }
+}

--- a/tests/src-android/cgeo/geocaching/brouter/util/StringUtilsTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/util/StringUtilsTest.java
@@ -1,0 +1,24 @@
+package cgeo.geocaching.brouter.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+    private static final String[] raw = new String[]{"hallo", "is 1<2 ?", "or 4>5 ?", "or 1<>2 ?", "\"hi\" 'there'"};
+    private static final String[] xml = new String[]{"hallo", "is 1&lt;2 ?", "or 4&gt;5 ?", "or 1&lt;&gt;2 ?", "&quot;hi&quot; &apos;there&apos;"};
+    private static final String[] jsn = new String[]{"hallo", "is 1<2 ?", "or 4>5 ?", "or 1<>2 ?", "\\\"hi\\\" \\'there\\'"};
+
+    @Test
+    public void xmlEncodingTest() {
+        for (int i = 0; i < raw.length; i++) {
+            Assert.assertEquals("xml encoding mismatch for raw: " + raw[i], xml[i], StringUtils.escapeXml10(raw[i]));
+        }
+    }
+
+    @Test
+    public void jsonEncodingTest() {
+        for (int i = 0; i < raw.length; i++) {
+            Assert.assertEquals("json encoding mismatch for raw: " + raw[i], jsn[i], StringUtils.escapeJson(raw[i]));
+        }
+    }
+}


### PR DESCRIPTION
Migrate the tests from original BRouter to c:geo-integrated BRouter.

One test is missing yet - `EncodeDecodeTest` - which should be adapted to SAF first. I'll open a separate issue for that.