### PR TITLE
fix calling external routing service (fix #10281)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -742,7 +742,7 @@
             android:label="@string/tts_service" >
         </service>
         <service
-            android:name=".brouter.BRouterService"
+            android:name=".brouter.InternalRoutingService"
             android:exported="false"
             android:enabled="true"
             android:process=":brouter_service">

--- a/main/src/btools/routingapp/IBRouterService.aidl
+++ b/main/src/btools/routingapp/IBRouterService.aidl
@@ -1,30 +1,22 @@
-package cgeo.geocaching.brouter;
+package btools.routingapp;
 
 interface IBRouterService {
-
     //param params--> Map of params:
+    //  "pathToFileResult"-->String with the path to where the result must be saved, including file name and extension
+    //                    -->if null, the track is passed via the return argument
     //  "maxRunningTime"-->String with a number of seconds for the routing timeout, default = 60
-    //  "v"-->[motorcar|bicycle|foot]
-    //  "fast"-->[0|1]
-    //  "lats"-->double[] array of latitudes; 2 values at least.
-    //  "lons"-->double[] array of longitudes; 2 values at least.
-    //
     //  "turnInstructionFormat"-->String selecting the format for turn-instructions values: osmand, locus
     //  "trackFormat"-->[kml|gpx] default = gpx
+    //  "lats"-->double[] array of latitudes; 2 values at least.
+    //  "lons"-->double[] array of longitudes; 2 values at least.
     //  "nogoLats"-->double[] array of nogo latitudes; may be null.
     //  "nogoLons"-->double[] array of nogo longitudes; may be null.
     //  "nogoRadi"-->double[] array of nogo radius in meters; may be null.
-    //
-    //return null if all ok and no path given, the track if ok and path given, an error message if it was wrong
-    //
-    //call in a background thread, heavy task!
-
-    // standard BRouter parameters NOT supported by c:geo
-    // --------------------------------------------------
-    //  "pathToFileResult"-->String with the path to where the result must be saved, including file name and extension
-    //                    -->if null, the track is passed via the return argument
+    //  "fast"-->[0|1]
+    //  "v"-->[motorcar|bicycle|foot]
     //  "remoteProfile"--> (String), net-content of a profile. If remoteProfile != null, v+fast are ignored
-    //  "acceptCompressedFormat"
+    //return null if all ok and no path given, the track if ok and path given, an error message if it was wrong
+    //call in a background thread, heavy task!
 
     String getTrackFromParams(in Bundle params);
 }

--- a/main/src/cgeo/geocaching/brouter/IInternalRoutingService.aidl
+++ b/main/src/cgeo/geocaching/brouter/IInternalRoutingService.aidl
@@ -1,0 +1,30 @@
+package cgeo.geocaching.brouter;
+
+interface IInternalRoutingService {
+
+    //param params--> Map of params:
+    //  "maxRunningTime"-->String with a number of seconds for the routing timeout, default = 60
+    //  "v"-->[motorcar|bicycle|foot]
+    //  "fast"-->[0|1]
+    //  "lats"-->double[] array of latitudes; 2 values at least.
+    //  "lons"-->double[] array of longitudes; 2 values at least.
+    //
+    //  "turnInstructionFormat"-->String selecting the format for turn-instructions values: osmand, locus
+    //  "trackFormat"-->[kml|gpx] default = gpx
+    //  "nogoLats"-->double[] array of nogo latitudes; may be null.
+    //  "nogoLons"-->double[] array of nogo longitudes; may be null.
+    //  "nogoRadi"-->double[] array of nogo radius in meters; may be null.
+    //
+    //return null if all ok and no path given, the track if ok and path given, an error message if it was wrong
+    //
+    //call in a background thread, heavy task!
+
+    // standard BRouter parameters NOT supported by c:geo internal service
+    // -------------------------------------------------------------------
+    //  "pathToFileResult"-->String with the path to where the result must be saved, including file name and extension
+    //                    -->if null, the track is passed via the return argument
+    //  "remoteProfile"--> (String), net-content of a profile. If remoteProfile != null, v+fast are ignored
+    //  "acceptCompressedFormat"
+
+    String getTrackFromParams(in Bundle params);
+}

--- a/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
+++ b/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
@@ -11,9 +11,9 @@ import android.os.IBinder;
 
 import java.util.ArrayList;
 
-public class BRouterService extends Service {
+public class InternalRoutingService extends Service {
 
-    private final IBRouterService.Stub myBRouterServiceStub = new IBRouterService.Stub() {
+    private final IInternalRoutingService.Stub myBRouterServiceStub = new IInternalRoutingService.Stub() {
         @Override
         public String getTrackFromParams(final Bundle params) {
             final BRouterWorker worker = new BRouterWorker();

--- a/main/src/cgeo/geocaching/maps/routing/AbstractServiceConnection.java
+++ b/main/src/cgeo/geocaching/maps/routing/AbstractServiceConnection.java
@@ -1,0 +1,40 @@
+package cgeo.geocaching.maps.routing;
+
+import android.content.ComponentName;
+import android.content.ServiceConnection;
+import android.os.Bundle;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+class AbstractServiceConnection implements ServiceConnection {
+    protected android.os.IInterface routingService;
+    private Runnable onServiceConnectedCallback = null;
+
+    AbstractServiceConnection (final @Nullable Runnable onServiceConnectedCallback) {
+        this.onServiceConnectedCallback = onServiceConnectedCallback;
+    }
+
+    @Override
+    public void onServiceConnected(final ComponentName className, final IBinder service) {
+        if (null != onServiceConnectedCallback) {
+            onServiceConnectedCallback.run();
+        }
+    }
+
+    @Override
+    public void onServiceDisconnected(final ComponentName className) {
+        this.onServiceConnectedCallback = null;
+        routingService = null;
+    }
+
+    public boolean isConnected() {
+        return routingService != null;
+    }
+
+    @Nullable
+    public String getTrackFromParams(final Bundle params) {
+        return null;
+    }
+
+}

--- a/main/src/cgeo/geocaching/maps/routing/InternalServiceConnection.java
+++ b/main/src/cgeo/geocaching/maps/routing/InternalServiceConnection.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.maps.routing;
 
+import cgeo.geocaching.brouter.IInternalRoutingService;
+
 import android.content.ComponentName;
 import android.os.Bundle;
 import android.os.IBinder;
@@ -7,18 +9,16 @@ import android.os.RemoteException;
 
 import androidx.annotation.Nullable;
 
-import btools.routingapp.IBRouterService;
+public class InternalServiceConnection extends AbstractServiceConnection {
 
-public class BRouterServiceConnection extends AbstractServiceConnection {
-
-    BRouterServiceConnection (final @Nullable Runnable onServiceConnectedCallback) {
+    InternalServiceConnection (final @Nullable Runnable onServiceConnectedCallback) {
         super(onServiceConnectedCallback);
     }
 
     @Override
     public void onServiceConnected(final ComponentName className, final IBinder service) {
         super.onServiceConnected(className, service);
-        routingService = IBRouterService.Stub.asInterface(service);
+        routingService = IInternalRoutingService.Stub.asInterface(service);
     }
 
     @Override
@@ -28,9 +28,10 @@ public class BRouterServiceConnection extends AbstractServiceConnection {
         }
 
         try {
-            return ((IBRouterService) routingService).getTrackFromParams(params);
+            return ((IInternalRoutingService) routingService).getTrackFromParams(params);
         } catch (final RemoteException e) {
             return null;
         }
     }
+
 }


### PR DESCRIPTION
Untangling the IDL files for external and internal `BRouterService` (the latter now being called `InternalRoutingService`), but based on a common `AbstractServiceConnection` to preserve a standardized usage pattern for `Routing`.