### PR TITLE
restrict auto-downloading of tile data to internal routing service

### DIFF
--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -218,7 +218,7 @@ public final class Routing {
         }
 
         // missing routing data?
-        if (gpx.startsWith("datafile ") && gpx.endsWith(" not found") && Settings.isBrouterAutoTileDownloads() && !PersistableFolder.ROUTING_TILES.isLegacy()) {
+        if (gpx.startsWith("datafile ") && gpx.endsWith(" not found") && Settings.useInternalRouting() && Settings.isBrouterAutoTileDownloads() && !PersistableFolder.ROUTING_TILES.isLegacy()) {
             synchronized (requestedTileFiles) {
                 String filename = gpx.substring(9);
                 final int pos = filename.indexOf(" ");


### PR DESCRIPTION
As agreed upon somewhere in our discussion about BRouter integration this PR restricts the check for missing routing tile data to the internal routing service to avoid the (depending on Android system version) pretty complicated configuration necessary for external BRouter and auto-tile-downloader to work together - and the support effort which would come with that probably.