### PR TITLE
change 'more' link for map themes (rel. to #10224)

### DIFF
--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -36,7 +36,7 @@
 
     <!-- links to manual pages -->
     <string translatable="false" name="manual_url_settings_offline_maps">https://manual.cgeo.org/en/offlinemaps</string>
-    <string translatable="false" name="manual_url_settings_themes">https://manual.cgeo.org/en/offlinemaps</string>
+    <string translatable="false" name="faq_url_settings_themes">https://faq.cgeo.org/#theme-slow</string>
     <string translatable="false" name="manual_url_mapbehavior">https://manual.cgeo.org/en/mainmenu/settings#map_behavior</string>
 
     <!-- contributors -->

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -577,7 +577,7 @@
             <cgeo.geocaching.settings.InfoPreference
                 android:text="@string/settings_info_themes"
                 android:title="@string/settings_info_themes_title"
-                app:url="@string/manual_url_settings_themes"
+                app:url="@string/faq_url_settings_themes"
                 app:urlButton="@string/settings_goto_url_button" />
             <Preference
                 android:key="@string/pref_persistablefolder_offlinemapthemes"


### PR DESCRIPTION
related to #10224: Change link behind "more" on themes info to point to FAQ entry about syncing