### PR TITLE
lint fixes/Null checks

### DIFF
--- a/main/src/cgeo/geocaching/location/Geopoint.java
+++ b/main/src/cgeo/geocaching/location/Geopoint.java
@@ -51,6 +51,7 @@ public final class Geopoint implements ICoordinates, Parcelable {
      * @param lonE6 longitude in microdegrees
      * @param dummy ignored parameter
      */
+    @SuppressWarnings("unused")
     private Geopoint(final int latE6, final int lonE6, final Object dummy) {
         latitudeE6 = latE6;
         longitudeE6 = lonE6;
@@ -91,7 +92,7 @@ public final class Geopoint implements ICoordinates, Parcelable {
      * @param loc
      *            the Location to clone
      */
-    public Geopoint(final Location loc) {
+    public Geopoint(@NonNull final Location loc) {
         this(loc.getLatitude(), loc.getLongitude());
     }
 
@@ -101,7 +102,7 @@ public final class Geopoint implements ICoordinates, Parcelable {
      * @param in
      *            a Parcel to read the saved data from
      */
-    public Geopoint(final Parcel in) {
+    public Geopoint(@NonNull final Parcel in) {
         latitudeE6 = in.readInt();
         longitudeE6 = in.readInt();
     }
@@ -181,7 +182,10 @@ public final class Geopoint implements ICoordinates, Parcelable {
      * @throws GeopointException
      *             if there is an error in distance calculation
      */
-    public float distanceTo(@NonNull final ICoordinates point) {
+    public float distanceTo(final ICoordinates point) {
+        if (point == null) {
+            return 0.0f;
+        }
         final Geopoint otherCoords = point.getCoords();
         final GeodesicData g = Geodesic.WGS84.Inverse(getLatitude(), getLongitude(), otherCoords.getLatitude(), otherCoords.getLongitude(),
                 GeodesicMask.DISTANCE);
@@ -611,5 +615,4 @@ public final class Geopoint implements ICoordinates, Parcelable {
     public static boolean equalsFormatted(final Geopoint p1, final Geopoint p2, final GeopointFormatter.Format format) {
         return p1 == null ? p2 == null : p2 != null && p1.format(format).equals(p2.format(format));
     }
-
 }


### PR DESCRIPTION
fixes #10071
maybe helps #10307 (first NPE)

- add some NonNull attributes
- add unused atrribute, maxbe the method will later used
  (by the way in AS the lint message for "unused" is wrong and a known bug
- instead attribute NonNull for the distanceTo method (used 35 times in c:geo, but seldom checked) swich to explicit return a value 0f