### PR TITLE
clean up old configuration

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -87,11 +87,6 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/maps_api2_key" />
 
-        <!-- required by Google Maps SDK version 16 and below if targeted to SDK 28 or above -->
-        <uses-library
-            android:name="org.apache.http.legacy"
-            android:required="false" />
-
         <!-- support also very wide screen devices. https://developer.android.com/guide/practices/screens_support.html#MaxAspectRatio -->
         <meta-data
             android:name="android.max_aspect"

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -30,16 +30,6 @@
 
 # Android -----------------------------------------------------------------------------------------
 
-# Our build contains a legacy http client jar without any good reason
-# https://code.google.com/p/android/issues/detail?id=194513
--dontnote android.net.http.SslCertificate
--dontnote android.net.http.SslError
--dontnote android.net.http.SslCertificate$DName
--dontnote org.apache.http.conn.scheme.SocketFactory
--dontnote org.apache.http.conn.scheme.HostNameResolver
--dontnote org.apache.http.conn.ConnectTimeoutException
--dontnote org.apache.http.params.HttpParams
-
 -keep class androidx.appcompat.widget.ShareActionProvider { <init>(...); }
 
 # Apache commons ----------------------------------------------------------------------------------
@@ -74,12 +64,6 @@
 # AssertJ -----------------------------------------------------------------------------------------
 # ignore all things in AssertJ, as long as tests are generally running fine
 -dontnote org.assertj.core.internal.**
-
-# Butter Knife ------------------------------------------------------------------------------------
-
-# Butter knife recommended settings from website, see http://jakewharton.github.io/butterknife/
--dontwarn butterknife.internal.**
--keep class **$$ViewInjector { *; }
 
 # Jackson XML -------------------------------------------------------------------------------------
 
@@ -135,7 +119,7 @@
 
 # Unsorted ----------------------------------------------------------------------------------------
 
--dontwarn  org.springframework.**
+-dontwarn org.springframework.**
 -dontwarn org.tukaani.xz.**
 
 -keepclasseswithmembers class * {


### PR DESCRIPTION
- remove no more necessary "org.apache.http.legacy" from Android Manifest
- remove no more necessary "butterknife.*", "android.net.http.*" and "org.apache.http.*" from proguard config