### PR TITLE
fix Geocache.findWaypoint() no null-check for Prefix and Coordinates

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1590,6 +1590,7 @@ public class Geocache implements IWaypoint {
      *            the id of the waypoint to look for
      * @return waypoint or {@code null}
      */
+    @Nullable
     public Waypoint getWaypointById(final int id) {
         for (final Waypoint waypoint : waypoints) {
             if (waypoint.getId() == id) {
@@ -1606,6 +1607,7 @@ public class Geocache implements IWaypoint {
      *            the prefix of the waypoint to look for
      * @return waypoint or {@code null}
      */
+    @Nullable
     public Waypoint getWaypointByPrefix(final String prefix) {
         for (final Waypoint waypoint : waypoints) {
             if (waypoint.getPrefix().equals(prefix)) {
@@ -1652,7 +1654,8 @@ public class Geocache implements IWaypoint {
         return changed;
     }
 
-    private Waypoint findWaypoint(final Waypoint searchWp) {
+    @Nullable
+    private Waypoint findWaypoint(@NonNull final Waypoint searchWp) {
         //try to match prefix
         final String searchWpPrefix = searchWp.getPrefix();
         if (!StringUtils.isBlank(searchWpPrefix)) {
@@ -2101,6 +2104,7 @@ public class Geocache implements IWaypoint {
         ActivityMixin.showToast(activity, StringUtils.defaultIfBlank(hint, activity.getString(R.string.cache_hint_not_available)));
     }
 
+    @NonNull
     public GeoitemRef getGeoitemRef() {
         return new GeoitemRef(getGeocode(), getCoordType(), getGeocode(), 0, getName(), getType().markerId);
     }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1654,10 +1654,10 @@ public class Geocache implements IWaypoint {
 
     private Waypoint findWaypoint(final Waypoint searchWp) {
         //try to match prefix
-        final String prefix = searchWp.getPrefix();
-        if (null != prefix) {
+        final String searchWpPrefix = searchWp.getPrefix();
+        if (!StringUtils.isBlank(searchWpPrefix)) {
             for (final Waypoint waypoint : waypoints) {
-                if (!StringUtils.isBlank(prefix) && !StringUtils.isBlank(waypoint.getPrefix()) && prefix.equals(waypoint.getPrefix())) {
+                if (searchWpPrefix.equals(waypoint.getPrefix())) {
                     return waypoint;
                 }
             }
@@ -1674,14 +1674,14 @@ public class Geocache implements IWaypoint {
                     return waypoint;
                 }
             }
-            return null;
         }
 
-        //try to match name if prefix and coords are null
+        //try to match name if prefix is empty and coords are not equal
         final String searchWpName = searchWp.getName();
+        final String searchWpType = searchWp.getWaypointType().getL10n();
         if (!StringUtils.isBlank(searchWpName)) {
             for (final Waypoint waypoint : waypoints) {
-                if (searchWpName.equals(waypoint.getName()) && searchWp.getWaypointType().getL10n().equals(waypoint.getWaypointType().getL10n())) {
+                if (searchWpName.equals(waypoint.getName()) && searchWpType.equals(waypoint.getWaypointType().getL10n())) {
                     return waypoint;
                 }
             }

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -384,7 +384,7 @@ public class Waypoint implements IWaypoint {
         final ImmutablePair<String, String> parsedNameAndPrefix = parseNameAndPrefix(wordsBefore, wpType);
         String name = parsedNameAndPrefix.getLeft();
         final String prefix = parsedNameAndPrefix.getRight();
-        if (name == null) {
+        if (StringUtils.isBlank(name)) {
             name = namePrefix + " " + count;
         }
 
@@ -411,16 +411,16 @@ public class Waypoint implements IWaypoint {
     }
 
     /**
-     * try to parse a name out of given words. If not possible, null is returned
+     * try to parse a name out of given words. If not possible, empty is returned
      */
     @NonNull
     private static ImmutablePair<String, String> parseNameAndPrefix(final String[] words, final WaypointType wpType) {
         if (words.length == 0 || !words[0].startsWith(PARSING_NAME_PRAEFIX)) {
-            return new ImmutablePair<>(null, null);
+            return new ImmutablePair<>("", "");
         }
         //first word handling
         String name = words[0].substring(PARSING_NAME_PRAEFIX.length());
-        String prefix = null;
+        String prefix = "";
         final int idx = name.indexOf(PARSING_PREFIX_CLOSE);
         if (idx > 0 && name.startsWith(PARSING_PREFIX_OPEN)) {
             prefix = name.substring(PARSING_PREFIX_OPEN.length(), idx).trim();
@@ -436,7 +436,7 @@ public class Waypoint implements IWaypoint {
                 name += words[i];
             }
         }
-        return new ImmutablePair<>(StringUtils.isBlank(name) ? null : name.trim(), prefix);
+        return new ImmutablePair<>(StringUtils.isBlank(name) ? "" : name.trim(), prefix);
     }
 
     private static boolean useWordForParsedName(final String word, final boolean isLast, final WaypointType wpType) {

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -70,12 +70,20 @@ public class GeocacheTest extends CGeoTestCase {
         assertWaypointsParsed("Test N51 13.888 E007 03.444", wpList);
     }
 
+    public final void testUpdateWaypointsFromNoteSingleLine() {
+        final List<Waypoint> wpList = new ArrayList<>();
+        wpList.add(createWaypointWithUserNote(new Geopoint("N51 13.888 E007 03.444"), "", "", "Test N51 13.233 E007 03.444 Test N51 09.123 E007 03.444", WaypointType.OWN));
+        wpList.add(createWaypointWithUserNote(new Geopoint("N51 13.233 E007 03.444"), "", "", "Test N51 09.123 E007 03.444", WaypointType.OWN));
+        wpList.add(createWaypointWithUserNote(new Geopoint("N51 09.123 E007 03.444"), "", "", "", WaypointType.OWN));
+        assertWaypointsParsed("Test N51 13.888 E007 03.444 Test N51 13.233 E007 03.444 Test N51 09.123 E007 03.444",  wpList);
+    }
+
     public final void testUpdateWaypointsFromNote() {
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "", "", "", WaypointType.OWN));
         wpList.add(new Waypoint("", new Geopoint("N51 13.233 E007 03.444"), "", "", "", WaypointType.OWN));
         wpList.add(new Waypoint("", new Geopoint("N51 09.123 E007 03.444"), "", "", "", WaypointType.OWN));
-        assertWaypointsParsed("Test N51 13.888 E007 03.444 Test N51 13.233 E007 03.444 Test N51 09.123 E007 03.444",  wpList);
+        assertWaypointsParsed("Test N51 13.888 E007 03.444 \nTest N51 13.233 E007 03.444 \nTest N51 09.123 E007 03.444",  wpList);
     }
 
     /**
@@ -86,7 +94,7 @@ public class GeocacheTest extends CGeoTestCase {
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "", "", "", WaypointType.OWN));
         wpList.add(new Waypoint("", new Geopoint("N51 13.233 E007 03.444"), "", "", "", WaypointType.OWN));
-        assertWaypointsParsed("Test N51 13.888 E007 03.444 Test N51 13.233 E007 03.444 Test N51 13.888 E007 03.444", wpList);
+        assertWaypointsParsed("Test N51 13.888 E007 03.444 \nTest N51 13.233 E007 03.444 \nTest N51 13.888 E007 03.444", wpList);
     }
 
     public final void testUpdateWaypointsWithEmptyCoordsFromNote() {
@@ -120,21 +128,27 @@ public class GeocacheTest extends CGeoTestCase {
     }
 
     /**
-     * The new waypoints are not contained in the cache.
-     * So expected size is 3.
+     * Waypoint with coordinates exist. Update waypointlist from note.
+     * The first waypoint has auto generated name and coordinates.
+     * The second waypoint has auto generated name and empty coordinates.
+     * So expected size is 3:
+     * - existing waypoint with original coordinates.
+     * - new waypoint with auto generated name and coordinates.
+     * - new waypoint with auto generated name and with empty coordinates.
      */
-    public final void testUpdateExistingWaypointsWithEmptyCoordsFromNoteAddWaypoint() {
+    public final void testUpdateExistingWaypointFromNote() {
         final Geocache cache = new Geocache();
         final String geocode = "Test" + System.nanoTime();
         cache.setGeocode(geocode);
         cache.setCoords(new Geopoint(40.0, 8.0));
         final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
-        userWaypoint.setCoords(new Geopoint(42.0, 10.0));
+        final Geopoint userWpGeopoint = new Geopoint(42.0, 10.0);
+        userWaypoint.setCoords(userWpGeopoint);
         cache.addOrChangeWaypoint(userWaypoint, false);
         saveFreshCacheToDB(cache);
 
         final List<Waypoint> wpList = new ArrayList<>();
-        wpList.add(new Waypoint("", new Geopoint(42.0, 10.0), "Test", "", "", WaypointType.OWN));
+        wpList.add(new Waypoint("", userWpGeopoint, "Test", "", "", WaypointType.OWN));
         wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "Personal note 1", "", "", WaypointType.OWN));
         wpList.add(new Waypoint("", null, "Personal note 2", "", "", WaypointType.OWN));
         assertWaypointsParsed(cache, "Test N51 13.888 E007 03.444\nTest (NO-COORD)", wpList);
@@ -143,31 +157,59 @@ public class GeocacheTest extends CGeoTestCase {
     }
 
     /**
-     * The second waypoint has same name but empty coordinates.
-     * So expected size is 2.
+     * Waypoint with coordinates exist. Update waypointlist from note.
+     * The  waypoint has same name like the existing waypoint but empty coordinates.
+     * So expected size is 1:
+     * - existing waypoint with original coordinates.
      */
-    public final void testUpdateExistingWaypointWithEmptyCoordsFromNoteWithSameNameAndCoordinates() {
+    public final void testUpdateExistingWaypointFromNoteWithSameNameAndEmptyCoords() {
         final Geocache cache = new Geocache();
         final String geocode = "Test" + System.nanoTime();
         cache.setGeocode(geocode);
         cache.setCoords(new Geopoint(40.0, 8.0));
         final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
-        userWaypoint.setCoords(new Geopoint(42.0, 10.0));
+        final Geopoint userWpGeopoint = new Geopoint(42.0, 10.0);
+        userWaypoint.setCoords(userWpGeopoint);
         cache.addOrChangeWaypoint(userWaypoint, false);
         saveFreshCacheToDB(cache);
 
         final List<Waypoint> wpList = new ArrayList<>();
-        wpList.add(new Waypoint("", new Geopoint(42.0, 10.0), "Test", "", "", WaypointType.OWN));
-        wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "Personal note 1", "", "", WaypointType.OWN));
+        wpList.add(new Waypoint("", userWpGeopoint, "Test", "", "", WaypointType.OWN));
         // wpList.add(new Waypoint("", null, "Test", "", "", WaypointType.OWN));
-        assertWaypointsParsed(cache, "Test N51 13.888 E007 03.444\n@Test (NO-COORD)", wpList);
+        assertWaypointsParsed(cache, "@Test (NO-COORD)", wpList);
 
         removeCacheCompletely(geocode);
     }
 
     /**
-     * The second waypoint has same name and empty coordinates.
-     * So expected size is 2.
+     * Waypoint with coordinates exist. Update waypointlist from note.
+     * The  waypoint has same name like the existing waypoint and a note and new coordinates.
+     * So expected size is 1:
+     * - existing waypoint with original coordinates and new note.
+     */
+    public final void testUpdateExistingWaypointFromNoteWithSameNameAndCoords() {
+        final Geocache cache = new Geocache();
+        final String geocode = "Test" + System.nanoTime();
+        cache.setGeocode(geocode);
+        cache.setCoords(new Geopoint(40.0, 8.0));
+        final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
+        final Geopoint userWpGeopoint = new Geopoint(42.0, 10.0);
+        userWaypoint.setCoords(userWpGeopoint);
+        cache.addOrChangeWaypoint(userWaypoint, false);
+        saveFreshCacheToDB(cache);
+
+        final List<Waypoint> wpList = new ArrayList<>();
+        wpList.add(createWaypointWithUserNote(userWpGeopoint, "Test", "", "NewNote", WaypointType.OWN));
+        assertWaypointsParsed(cache, "@Test N51 13.888 E007 03.444 \"NewNote\"", wpList);
+
+        removeCacheCompletely(geocode);
+    }
+
+    /**
+     * Waypoint with empty coordinates exist. Update waypointlist from note.
+     * The  waypoint has same name like the existing waypoint and a note and new coordinates.
+     * So expected size is 1:
+     * - existing waypoint with new coordinates and original note.
      */
     public final void testUpdateExistingWaypointWithEmptyCoordsFromNoteWithSameName() {
         final Geocache cache = new Geocache();
@@ -176,20 +218,23 @@ public class GeocacheTest extends CGeoTestCase {
         cache.setCoords(new Geopoint(40.0, 8.0));
         final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
         userWaypoint.setCoords(null);
+        userWaypoint.setUserNote("UserNote");
         cache.addOrChangeWaypoint(userWaypoint, false);
         saveFreshCacheToDB(cache);
 
         final List<Waypoint> wpList = new ArrayList<>();
-        wpList.add(new Waypoint("", null, "Test", "", "", WaypointType.OWN));
-        wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "Personal note 1", "", "", WaypointType.OWN));
-        assertWaypointsParsed(cache, "Test N51 13.888 E007 03.444\n@Test (NO-COORD)", wpList);
+        wpList.add(createWaypointWithUserNote(new Geopoint("N51 13.888 E007 03.444"), "Test", "", "UserNote", WaypointType.OWN));
+        assertWaypointsParsed(cache, "@Test N51 13.888 E007 03.444 \"NewNote\"", wpList);
 
         removeCacheCompletely(geocode);
     }
 
     /**
-     * The second waypoint has same name and empty coordinates, but different type.
-     * So expected size is 3.
+     * Waypoint with empty coordinates exist. Update waypointlist from note.
+     * The  waypoint has same name like the existing waypoint, new coordinates and different type.
+     * So expected size is 2:
+     * - existing waypoint with empty coordinates.
+     * - new waypoint with new coordinates.
      */
     public final void testUpdateExistingWaypointWithEmptyCoordsFromNoteWithSameNameDifferentType() {
         final Geocache cache = new Geocache();
@@ -203,11 +248,93 @@ public class GeocacheTest extends CGeoTestCase {
 
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(new Waypoint("", null, "Test", "", "", WaypointType.OWN));
-        wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "Personal note 1", "", "", WaypointType.OWN));
         wpList.add(new Waypoint("", null, "Test", "", "", WaypointType.FINAL));
-        assertWaypointsParsed(cache, "Test N51 13.888 E007 03.444\n@Test (F) (NO-COORD)", wpList);
+        assertWaypointsParsed(cache, "@Test (F) (NO-COORD)", wpList);
 
         removeCacheCompletely(geocode);
+    }
+
+    /**
+     * Waypoint with coordinates exist. Update waypointlist from note.
+     * The waypoint has same prefix, but different name and coordinates.
+     * So expected size is 1:
+     * - existing waypoint with original name and coordinates.
+     */
+    public final void testUpdateExistingWaypointFromNoteWithSamePrefix() {
+        final Geocache cache = new Geocache();
+        final String geocode = "Test" + System.nanoTime();
+        cache.setGeocode(geocode);
+        cache.setCoords(new Geopoint(40.0, 8.0));
+        final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
+        final Geopoint userWpGeopoint = new Geopoint(42.0, 10.0);
+        userWaypoint.setCoords(userWpGeopoint);
+        userWaypoint.setPrefix("S1");
+        cache.addOrChangeWaypoint(userWaypoint, false);
+        saveFreshCacheToDB(cache);
+
+        final List<Waypoint> wpList = new ArrayList<>();
+        wpList.add(new Waypoint("", userWpGeopoint, "Test", "S1", "", WaypointType.OWN));
+        assertWaypointsParsed(cache, "@[S1]ModTest N51 13.888 E007 03.444", wpList);
+
+        removeCacheCompletely(geocode);
+    }
+
+    /**
+     * Waypoint with empty coordinates exist. Update waypointlist from note.
+     * The waypoint has same prefix, but different name and coordinates.
+     * So expected size is 1:
+     * - existing waypoint with original name, but new coordinates.
+     */
+    public final void testUpdateExistingWaypointWithEmptyCoordsFromNoteWithSamePrefix() {
+        final Geocache cache = new Geocache();
+        final String geocode = "Test" + System.nanoTime();
+        cache.setGeocode(geocode);
+        cache.setCoords(new Geopoint(40.0, 8.0));
+        final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
+        userWaypoint.setCoords(null);
+        userWaypoint.setPrefix("S1");
+        cache.addOrChangeWaypoint(userWaypoint, false);
+        saveFreshCacheToDB(cache);
+
+        final List<Waypoint> wpList = new ArrayList<>();
+        wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "Test", "S1", "", WaypointType.OWN));
+        assertWaypointsParsed(cache, "@[S1]ModTest N51 13.888 E007 03.444", wpList);
+
+        removeCacheCompletely(geocode);
+    }
+
+    /**
+     * Waypoint with empty coordinates exist. Update waypointlist from note.
+     * The waypoint has prefix which does not exist, but name of existing waypoint.
+     * So expected size is 2:
+     * - existing waypoint unchanged
+     * - new waypoint with prefix is added.
+     */
+    public final void testUpdateExistingWaypointWithEmptyCoordsFromNoteWithNewPrefix() {
+        final Geocache cache = new Geocache();
+        final String geocode = "Test" + System.nanoTime();
+        cache.setGeocode(geocode);
+        cache.setCoords(new Geopoint(40.0, 8.0));
+        final Waypoint userWaypoint = new Waypoint("Test", WaypointType.OWN, true);
+        userWaypoint.setCoords(null);
+        cache.addOrChangeWaypoint(userWaypoint, false);
+        saveFreshCacheToDB(cache);
+
+        final List<Waypoint> wpList = new ArrayList<>();
+        wpList.add(new Waypoint("", null, "Test", "", "", WaypointType.OWN));
+        wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "Test", "S1", "", WaypointType.OWN));
+        assertWaypointsParsed(cache, "@[S1]Test N51 13.888 E007 03.444", wpList);
+
+        removeCacheCompletely(geocode);
+    }
+
+    private static Waypoint createWaypointWithUserNote(final Geopoint point, final String name, final String prefix, final String userNote, final WaypointType type) {
+        final Waypoint newWaypoint = new Waypoint("", point, name, prefix, "", type);
+        newWaypoint.setUserNote(userNote);
+        if (prefix.isEmpty()) {
+            newWaypoint.setUserDefined();
+        }
+        return newWaypoint;
     }
 
     private void assertWaypointsParsed(final String note, final List<Waypoint> expectedWaypoints) {
@@ -233,11 +360,13 @@ public class GeocacheTest extends CGeoTestCase {
             final Waypoint waypoint = waypoints.get(i);
             final Waypoint expectedWaypoint = expectedWpIterator.next();
             assertThat(waypoint.getCoords()).isEqualTo(expectedWaypoint.getCoords());
+            final String wpNote = expectedWaypoint.getUserNote();
             String wpName = expectedWaypoint.getName();
             if (wpName == null || wpName.isEmpty()) {
                 wpName = CgeoApplication.getInstance().getString(R.string.cache_personal_note) + " " + (i + 1);
             }
             assertThat(waypoint.getName()).isEqualTo(wpName);
+            assertThat(waypoint.getUserNote()).isEqualTo(wpNote);
         }
     }
 

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -64,12 +64,20 @@ public class GeocacheTest extends CGeoTestCase {
         assertThat(cache.getGeocode()).isEqualTo("GC1234");
     }
 
+    /**
+     * The waypoint with valid coordinates.
+     * Waypoint should be extracted, so expected size is 1.
+     */
     public final void testUpdateWaypointFromNote() {
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "", "", "", WaypointType.OWN));
         assertWaypointsParsed("Test N51 13.888 E007 03.444", wpList);
     }
 
+    /**
+     * Waypoints in a single line with valid coordinates.
+     * Waypoints should be extracted, but the user-note contains the following text, so expected size is 3 with different user-notes.
+     */
     public final void testUpdateWaypointsFromNoteSingleLine() {
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(createWaypointWithUserNote(new Geopoint("N51 13.888 E007 03.444"), "", "", "Test N51 13.233 E007 03.444 Test N51 09.123 E007 03.444", WaypointType.OWN));
@@ -78,6 +86,10 @@ public class GeocacheTest extends CGeoTestCase {
         assertWaypointsParsed("Test N51 13.888 E007 03.444 Test N51 13.233 E007 03.444 Test N51 09.123 E007 03.444",  wpList);
     }
 
+    /**
+     * Waypoints in different lines with valid coordinates.
+     * Waypoints should be extracted, the user-note does not contain the following text, so expected size is 3 with empty user-notes.
+     */
     public final void testUpdateWaypointsFromNote() {
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "", "", "", WaypointType.OWN));
@@ -97,6 +109,10 @@ public class GeocacheTest extends CGeoTestCase {
         assertWaypointsParsed("Test N51 13.888 E007 03.444 \nTest N51 13.233 E007 03.444 \nTest N51 13.888 E007 03.444", wpList);
     }
 
+    /**
+     * The second waypoint has empty coordinates.
+     * Waypoint with empty coordinates should be created, so expected size is 2.
+     */
     public final void testUpdateWaypointsWithEmptyCoordsFromNote() {
         final List<Waypoint> wpList = new ArrayList<>();
         wpList.add(new Waypoint("", new Geopoint("N51 13.888 E007 03.444"), "", "", "", WaypointType.OWN));


### PR DESCRIPTION
Prefix should never be null. So if prefix is empty, no check for matching coordinate or name was done.
For coordinates: if searchWp has coordinates, no check for matching name was done, if no waypoint with matching coordinates was found.

The fix removes the wrong return null statement for coordinates and the useless null check for prefix.
- remove useless null-check for prefix
- set empty prefix instead of null
- if searchwaypoint does have coordinates and no waypoint is found, look for waypoint with same name
- add more testcases


Replaces PR #10343