### PR TITLE
Set individual permissions titles in wizard

### DIFF
--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -140,12 +140,12 @@ public class InstallWizardActivity extends AppCompatActivity {
                 break;
             }
             case WIZARD_PERMISSIONS_STORAGE:
-                title.setText(R.string.wizard_permissions_title);
+                title.setText(R.string.wizard_status_storage_permission);
                 text.setText(R.string.storage_permission_request_explanation);
                 setNavigation(this::gotoPrevious, 0, null, 0, this::requestStorage, 0);
                 break;
             case WIZARD_PERMISSIONS_LOCATION:
-                title.setText(R.string.wizard_permissions_title);
+                title.setText(R.string.wizard_status_location_permission);
                 text.setText(R.string.location_permission_request_explanation);
                 setNavigation(this::gotoPrevious, 0, null, 0, this::requestLocation, 0);
                 break;


### PR DESCRIPTION
Set individual titles for location and storage permissions in the wizard. (See https://github.com/cgeo/cgeo-guide/issues/25#issuecomment-814691333)

Existing strings are reused, so no need to wait for new translations here.

![image](https://user-images.githubusercontent.com/3754370/113832564-054a4800-9789-11eb-994e-1199761260b3.png).![image](https://user-images.githubusercontent.com/3754370/113832586-0a0efc00-9789-11eb-9548-ab5ca39d96ab.png)
