### PR TITLE
fixes for internal routing engine

### DIFF
--- a/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
+++ b/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
@@ -32,7 +32,7 @@ public class InternalRoutingService extends Service {
 
             // c:geo uses default profile mapping:
             if (mode.equals("motorcar")) {
-                worker.profileName = isFast ? "car-fast" : "moped";
+                worker.profileName = isFast ? "car-fast" : "car-eco";
             } else if (mode.equals("bicycle")) {
                 worker.profileName = isFast ? "fastbike" : "trekking";
             } else if (mode.equals("foot")) {

--- a/main/src/cgeo/geocaching/brouter/core/RoutingContext.java
+++ b/main/src/cgeo/geocaching/brouter/core/RoutingContext.java
@@ -131,16 +131,11 @@ public final class RoutingContext {
         return name;
     }
 
-    private void setModel(final String className) {
-        if (className == null) {
-            pm = new StdModel();
-        } else {
-            try {
-                final Class clazz = Class.forName(className);
-                pm = (OsmPathModel) clazz.newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException("Cannot create path-model: " + e);
-            }
+    private void setModel(final boolean useKinematicModel) {
+        try {
+            pm = useKinematicModel ? new KinematicModel() : new StdModel();
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot create path-model: " + e);
         }
         initModel();
     }
@@ -162,7 +157,7 @@ public final class RoutingContext {
     public void readGlobalConfig() {
         final BExpressionContext expctxGlobal = expctxWay; // just one of them...
 
-        setModel(expctxGlobal.modelClass);
+        setModel(expctxGlobal.useKinematicModel);
 
         downhillcostdiv = (int) expctxGlobal.getVariableValue("downhillcost", 0.f);
         downhillcutoff = (int) (expctxGlobal.getVariableValue("downhillcutoff", 0.f) * 10000);

--- a/main/src/cgeo/geocaching/brouter/expressions/BExpressionContext.java
+++ b/main/src/cgeo/geocaching/brouter/expressions/BExpressionContext.java
@@ -26,7 +26,7 @@ import java.util.TreeMap;
 public abstract class BExpressionContext implements IByteArrayUnifier {
     private static final String CONTEXT_TAG = "---context:";
     private static final String MODEL_TAG = "---model:";
-    public String modelClass;
+    public boolean useKinematicModel;
     public BExpressionMetaData meta;
     private String context;
     private boolean inOurContext = false;
@@ -759,7 +759,8 @@ public abstract class BExpressionContext implements IByteArrayUnifier {
             if (token.startsWith(CONTEXT_TAG)) {
                 inOurContext = token.substring(CONTEXT_TAG.length()).equals(context);
             } else if (token.startsWith(MODEL_TAG)) {
-                modelClass = token.substring(MODEL_TAG.length()).trim();
+                // no need to parse the name, as c:geo will only support the builtin model class (also prevents class injection)
+                useKinematicModel = true;
             } else if (inOurContext) {
                 return token;
             }


### PR DESCRIPTION
- fix mapping for "motorcar-short" to "car-eco" (used in original storageconfig) instead of "moped" (as mentioned in the readme)
- restrict config to use either StdModel or internal KinematicModel only instead of user-supplied class name