### PR TITLE
add application/gpx to accepted MIME types (fix #10309)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -373,6 +373,7 @@
                 <data android:mimeType="application/x-zip-compressed" />
                 <data android:mimeType="application/x-zip" />
                 <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/gpx" />
                 <data android:pathPattern=".*\\.gpx" />
                 <data android:pathPattern=".*\\.zip" />
                 <data android:pathPattern=".*\\.ggz" />


### PR DESCRIPTION
I've targeted this to `release`, but if we want to test it a bit, we can retarget it to `master` as well.