### PR TITLE
add application/gpx+xml to accepted MIME types

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -357,7 +357,7 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ggz" />
             </intent-filter>
 
-            <!-- intent filter for ZIP files -->
+            <!-- intent filter for local ZIP / GPX files -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -374,6 +374,7 @@
                 <data android:mimeType="application/x-zip" />
                 <data android:mimeType="application/octet-stream" />
                 <data android:mimeType="application/gpx" />
+                <data android:mimeType="application/gpx+xml" />
                 <data android:pathPattern=".*\\.gpx" />
                 <data android:pathPattern=".*\\.zip" />
                 <data android:pathPattern=".*\\.ggz" />


### PR DESCRIPTION
Similar issue as in #10309 which happened to me in my file manager. Locus is listed but c:geo isn't. See also issue #527 as a reference, in which the MIME type was suggested/~added~ as well years before.

![4 Size)](https://user-images.githubusercontent.com/64581222/114471588-2c71a100-9bf1-11eb-9d68-cfacbe9523de.jpg)