### PR TITLE
restrict avatar size

### DIFF
--- a/main/src/cgeo/geocaching/settings/CredentialsPreference.java
+++ b/main/src/cgeo/geocaching/settings/CredentialsPreference.java
@@ -120,6 +120,9 @@ public class CredentialsPreference extends AbstractClickablePreference {
         frame.setVisibility(View.VISIBLE);
         frame.addView(iconView);
 
+        final LinearLayout.LayoutParams param = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1.5f);
+        frame.setLayoutParams(param);
+
         return preferenceView;
     }
 


### PR DESCRIPTION
Tries to fix the oversized avatar image (#10369) by limiting their relative column width.

@Lineflyer 
Not sure if this works reliably, as I cannot reproduce the issue. Can you cross-check?
