### PR TITLE
add automatic update check for maps and themes (fix #10354)

### DIFF
--- a/main/res/menu/main_activity_options.xml
+++ b/main/res/menu/main_activity_options.xml
@@ -42,6 +42,20 @@
         app:showAsAction="ifRoom">
     </item>
     <item
+        android:title="@string/menu_update"
+        app:showAsAction="ifRoom">
+        <menu>
+            <item
+                android:id="@+id/menu_update_routingdata"
+                android:title="@string/menu_update_routingdata">
+            </item>
+            <item
+                android:id="@+id/menu_update_mapdata"
+                android:title="@string/menu_update_mapdata">
+            </item>
+        </menu>
+    </item>
+    <item
         android:id="@+id/menu_helpers"
         android:icon="@drawable/ic_menu_shopping"
         android:title="@string/menu_helpers"

--- a/main/res/values/numbers.xml
+++ b/main/res/values/numbers.xml
@@ -11,6 +11,8 @@
     <integer name="brouter_threshold_max">120</integer>
     <integer name="brouter_updateinterval_default">30</integer>
     <integer name="brouter_updateinterval_max">366</integer>
+    <integer name="map_updateinterval_default">30</integer>
+    <integer name="map_updateinterval_max">366</integer>
     <integer name="waypoint_threshold_default">10</integer>
     <integer name="waypoint_threshold_max">200</integer>
     <integer name="proximitynotification_distance_max">1000</integer>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -164,6 +164,9 @@
     <string translatable="false" name="pref_usecompass">usecompass</string>
     <string translatable="false" name="pref_mapfile">mfmapfile</string>
     <string translatable="false" name="pref_mapdownloader_source">mapdownloader_source</string>
+    <string translatable="false" name="pref_mapAutoDownloads">mapAutoDownloads</string>
+    <string translatable="false" name="pref_mapAutoDownloadsInterval">mapAutoDownloadsInterval</string>
+    <string translatable="false" name="pref_mapAutoDownloadsLastCheck">mapAutoDownloadsLastCheck</string>
     <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>
     <string translatable="false" name="pref_memberstatus">memberstatus</string>
     <string translatable="false" name="pref_coordinputformat">coordinputformat</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -604,8 +604,9 @@
     <string name="init_brouterThreshold">Calculate route</string>
     <string name="init_brouterThreshold_description">Maximum distance up to which offline routing will calculate a route.</string>
     <string name="init_brouterShowBothDistances">Show straight distance</string>
-    <string name="init_brouterAutoTileDownloads">Automatic download</string>
+    <string name="init_autoDownloads">Automatic download</string>
     <string name="init_brouterAutoTileDownloads_description">Automatically offer to download missing routing tile data.</string>
+    <string name="init_mapAutoDownloads_description">Automatically check for update of map and theme files. (Valid only for files you have downloaded with the integrated downloader.)</string>
     <string name="init_brouterProfileWalk">\"Walk\" profile</string>
     <string name="init_brouterProfileBike">\"Bike\" profile</string>
     <string name="init_brouterProfileCar">\"Car\" profile</string>
@@ -705,8 +706,8 @@
     <string name="init_base_directory_description">Base folder for public local data</string>
     <string name="init_map_directory_description">Folder with offline maps</string>
     <string name="init_brouter_directory_description">Folder with BRouter routing data</string>
-    <string name="init_brouter_updateinterval_title">Update interval</string>
-    <string name="init_brouter_updateinterval_description">Reminds you every x days for an update check</string>
+    <string name="init_updateinterval_title">Update interval</string>
+    <string name="init_updateinterval_description">Reminds you every x days for an update check</string>
     <string name="init_gpx_importexportdir">GPX Folder</string>
     <string name="init_dataDir">Select data folder</string>
     <string name="init_dataDir_note">You may choose to store the additional data for geocaches (spoilers, log images, …) on your external storage (emulated or real external SD card depending on your device).</string>
@@ -2101,6 +2102,7 @@
     <string name="downloadtile_title">Missing routing data</string>
     <string name="downloadtile_info">c:geo cannot calculate the requested route as there is some routing data file missing. Do you want to download missing routing data?</string>
     <string name="tileupdate_info">Do you want to check for updates of downloaded routing data files?</string>
+    <string name="mapupdate_info">Do you want to check for updates of map and theme files?</string>
     <string name="no_updates_found">No updates found</string>
     <string name="updates_check">Updates check</string>
     <string name="mapserver_mapsforge_info">Basic maps, no map themes required</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -302,6 +302,9 @@
     <string name="menu_helpers">Utility programs</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_backup">Backup / restore</string>
+    <string name="menu_update">Update</string>
+    <string name="menu_update_routingdata">Routing data</string>
+    <string name="menu_update_mapdata">Map data</string>
     <string name="menu_history">History</string>
     <string name="menu_filter">Filter</string>
     <string name="menu_scan_geo">Scan geocode</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -571,6 +571,24 @@
                 android:text="@string/downloadmap_info"
                 android:title="@string/downloadmap_title"
                 app:urlButton="@string/downloadmap_choose" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_mapAutoDownloads"
+                android:summary="@string/init_mapAutoDownloads_description"
+                android:title="@string/init_autoDownloads" />
+            <Preference
+                android:selectable="false"
+                android:summary="@string/init_updateinterval_description"
+                android:title="@string/init_updateinterval_title"
+                android:dependency="@string/pref_mapAutoDownloads" />
+            <cgeo.geocaching.settings.SeekbarPreference
+                android:key="@string/pref_mapAutoDownloadsInterval"
+                app:min="0"
+                app:max="@integer/map_updateinterval_max"
+                android:defaultValue="@integer/map_updateinterval_default"
+                android:dependency="@string/pref_mapAutoDownloads" />
+
             <Preference
                 android:key="@string/pref_persistablefolder_offlinemaps"
                 android:title="@string/init_map_directory_description" />
@@ -632,12 +650,12 @@
                 android:key="@string/pref_brouterAutoTileDownloads"
                 android:summary="@string/init_brouterAutoTileDownloads_description"
                 android:dependency="@string/pref_useInternalRouting"
-                android:title="@string/init_brouterAutoTileDownloads" />
+                android:title="@string/init_autoDownloads" />
 
             <Preference
                 android:selectable="false"
-                android:summary="@string/init_brouter_updateinterval_description"
-                android:title="@string/init_brouter_updateinterval_title"
+                android:summary="@string/init_updateinterval_description"
+                android:title="@string/init_updateinterval_title"
                 android:dependency="@string/pref_brouterAutoTileDownloads" />
             <cgeo.geocaching.settings.SeekbarPreference
                 android:key="@string/pref_brouterAutoTileDownloadsInterval"

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -549,6 +549,7 @@ public class MainActivity extends AbstractActionBarActivity {
         super.onPrepareOptionsMenu(menu);
         menu.findItem(R.id.menu_wizard).setVisible(!InstallWizardActivity.isConfigurationOk(this));
         menu.findItem(R.id.menu_pocket_queries).setVisible(Settings.isGCConnectorActive() && Settings.isGCPremiumMember());
+        menu.findItem(R.id.menu_update_routingdata).setEnabled(Settings.useInternalRouting());
         return true;
     }
 
@@ -577,6 +578,10 @@ public class MainActivity extends AbstractActionBarActivity {
             if (Settings.isGCPremiumMember()) {
                 startActivity(new Intent(this, PocketQueryListActivity.class));
             }
+        } else if (id == R.id.menu_update_routingdata) {
+            DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, this::returnFromTileUpdateCheck);
+        } else if (id == R.id.menu_update_mapdata) {
+            DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, this::returnFromMapUpdateCheck);
         } else {
             return super.onOptionsItemSelected(item);
         }

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -345,6 +345,7 @@ public class MainActivity extends AbstractActionBarActivity {
         OneTimeDialogs.nextStatus();
 
         checkForRoutingTileUpdates();
+        checkForMapUpdates();
     }
 
     @Override
@@ -438,6 +439,22 @@ public class MainActivity extends AbstractActionBarActivity {
     private void returnFromTileUpdateCheck(final boolean updateCheckAllowed) {
         if (updateCheckAllowed) {
             Settings.setBrouterAutoTileDownloadsLastCheckInS(System.currentTimeMillis() / 1000);
+        }
+    }
+
+    private void checkForMapUpdates() {
+        if (Settings.isMapAutoDownloads()) {
+            final long now = System.currentTimeMillis() / 1000;
+            final int interval = Settings.getMapAutoDownloadsInterval();
+            if ((Settings.getMapAutoDownloadsLastCheckInS() + (interval * 24 * 60 * 60)) <= now) {
+                DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, R.string.mapupdate_info, this::returnFromMapUpdateCheck);
+            }
+        }
+    }
+
+    private void returnFromMapUpdateCheck(final boolean updateCheckAllowed) {
+        if (updateCheckAllowed) {
+            Settings.setMapAutoDownloadsLastCheckInS(System.currentTimeMillis() / 1000);
         }
     }
 

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -146,7 +146,7 @@ public class DownloaderUtils {
     }
 
     /**
-     * aks user whether to check for updates
+     * ask user whether to check for updates
      * if yes: checks whether updates are available for the type specified
      *      if yes: ask user to download them all
      *              if yes: trigger download(s)
@@ -157,6 +157,12 @@ public class DownloaderUtils {
             new CheckForDownloadsTask(activity, title, type).execute();
             callback.call(true);
         }, dialog -> callback.call(false));
+    }
+
+    // same as checkForUpdatesAndDownloadAll above, but without question
+    public static void checkForUpdatesAndDownloadAll(final Activity activity, final Download.DownloadType type, @StringRes final int title, final Action1<Boolean> callback) {
+        new CheckForDownloadsTask(activity, title, type).execute();
+        callback.call(true);
     }
 
     private static class CheckForDownloadsTask extends AsyncTaskWithProgressText<Void, List<Download>> {

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -174,7 +174,15 @@ public class DownloaderUtils {
         @Override
         protected List<Download> doInBackgroundInternal(final Void[] none) {
             final List<Download> result = new ArrayList<>();
-            final ArrayList<CompanionFileUtils.DownloadedFileData> existingFiles = CompanionFileUtils.availableOfflineMaps(currentType);
+            final ArrayList<CompanionFileUtils.DownloadedFileData> existingFiles = new ArrayList<>();
+            if (currentType.equals(Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED)) {
+                final ArrayList<Download.DownloadTypeDescriptor> typeDescriptors =  Download.DownloadType.getOfflineMapTypes();
+                for (Download.DownloadTypeDescriptor typeDescriptor : typeDescriptors) {
+                    existingFiles.addAll(CompanionFileUtils.availableOfflineMaps(typeDescriptor.type));
+                }
+            } else {
+                existingFiles.addAll(CompanionFileUtils.availableOfflineMaps(currentType));
+            }
 
             for (CompanionFileUtils.DownloadedFileData existingFile : existingFiles) {
                 final Download download = checkForUpdate(existingFile);

--- a/main/src/cgeo/geocaching/models/Download.java
+++ b/main/src/cgeo/geocaching/models/Download.java
@@ -82,6 +82,7 @@ public class Download {
 
     public enum DownloadType {
         // id values must not be changed as they are referenced in the database & download companion files
+        DOWNLOADTYPE_ALL_MAPRELATED(0),         // virtual entry
         DOWNLOADTYPE_MAP_MAPSFORGE(1),
         DOWNLOADTYPE_MAP_OPENANDROMAPS(2),
         DOWNLOADTYPE_THEME_OPENANDROMAPS(3),

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -978,6 +978,22 @@ public class Settings {
         return getInt(R.string.pref_mapdownloader_source, Download.DownloadType.DOWNLOADTYPE_MAP_MAPSFORGE.id);
     }
 
+    public static boolean isMapAutoDownloads() {
+        return getBoolean(R.string.pref_mapAutoDownloads, false);
+    }
+
+    public static int getMapAutoDownloadsInterval() {
+        return getInt(R.string.pref_mapAutoDownloadsInterval, 30);
+    }
+
+    public static long getMapAutoDownloadsLastCheckInS() {
+        return getLong(R.string.pref_mapAutoDownloadsLastCheck, 0);
+    }
+
+    public static void setMapAutoDownloadsLastCheckInS(final long lastCheck) {
+        putLong(R.string.pref_mapAutoDownloadsLastCheck, lastCheck);
+    }
+
     public static void setPqShowDownloadableOnly(final boolean showDownloadableOnly) {
         putBoolean(R.string.pref_pqShowDownloadableOnly, showDownloadableOnly);
     }


### PR DESCRIPTION
Adds an automatic update check for map and theme files downloaded with the integrated downloader

![image](https://user-images.githubusercontent.com/3754370/115105498-a68e8680-9f5f-11eb-8655-8aec7fe1ffb1.png)

Also adds an menu option to manually trigger update checks for either routing tile data or map data (new menu "Update" in main menu with two sub options).