### PR TITLE
fix: make routing folder preference dependent on internal routing

### DIFF
--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -625,7 +625,7 @@
             <Preference
                 android:key="@string/pref_persistablefolder_routingtiles"
                 android:title="@string/init_brouter_directory_description"
-                android:dependency="@string/pref_brouterAutoTileDownloads" />
+                android:dependency="@string/pref_useInternalRouting" />
 
             <CheckBoxPreference
                 android:defaultValue="false"


### PR DESCRIPTION
Since our decision that routing tile update should be available only to internal routing the dependency of the routing data folder preference should point to "use internal routing" instead of "use auto downloading"