### PR TITLE
remove some unused parameters & switch logging to c:geo logging

### DIFF
--- a/main/src/cgeo/geocaching/brouter/BRouterWorker.java
+++ b/main/src/cgeo/geocaching/brouter/BRouterWorker.java
@@ -49,8 +49,7 @@ public class BRouterWorker {
 
         waypoints = readPositions(params);
 
-        final RoutingEngine cr = new RoutingEngine(null, null, segmentDir, waypoints, rc);
-        cr.quite = true;
+        final RoutingEngine cr = new RoutingEngine(segmentDir, waypoints, rc);
         cr.doRun(maxRunningTime);
 
         // store new reference track if any


### PR DESCRIPTION
- removes outFileBase and logFileBase from `RoutingEngine` (as they are always `null` for internal routing engine)
- switches internal logging of `RoutingEngine` to c:geo logging routine (`Log.i()`)