### PR TITLE
BRouter integration: more code cleanup & fixes

### DIFF
--- a/main/src/cgeo/geocaching/brouter/BRouterConstants.java
+++ b/main/src/cgeo/geocaching/brouter/BRouterConstants.java
@@ -8,6 +8,8 @@ public class BRouterConstants {
     public static final String BROUTER_PROFILE_BIKE_DEFAULT = "trekking.brf";
     public static final String BROUTER_PROFILE_CAR_DEFAULT = "car-eco.brf";
 
+    public static final String BROUTER_TILE_FILEEXTENSION = ".rd5";
+
     private BRouterConstants() {
         // utility class
     }

--- a/main/src/cgeo/geocaching/brouter/BRouterWorker.java
+++ b/main/src/cgeo/geocaching/brouter/BRouterWorker.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 public class BRouterWorker {
     // public String baseDir;
-    public String segmentDir;
     public String profileFilename;
     public String rawTrackPath;
     public List<OsmNodeNamed> waypoints;
@@ -49,7 +48,7 @@ public class BRouterWorker {
 
         waypoints = readPositions(params);
 
-        final RoutingEngine cr = new RoutingEngine(segmentDir, waypoints, rc);
+        final RoutingEngine cr = new RoutingEngine(waypoints, rc);
         cr.doRun(maxRunningTime);
 
         // store new reference track if any

--- a/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
+++ b/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
@@ -1,14 +1,15 @@
 package cgeo.geocaching.brouter;
 
 import cgeo.geocaching.brouter.util.DefaultFilesUtils;
+import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Service;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.IBinder;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import org.apache.commons.lang3.StringUtils;
@@ -20,22 +21,16 @@ public class InternalRoutingService extends Service {
         public String getTrackFromParams(final Bundle params) {
             final BRouterWorker worker = new BRouterWorker();
 
-            final String baseDir = Environment.getExternalStorageDirectory().getAbsolutePath() + "/cgeo/routing";
-
-            // should be:
-            // final Folder base = PersistableFolder.ROUTING_BASE.getFolder();
-            // worker.segmentDir = PersistableFolder.ROUTING_TILES.getFolder();
-
-            final String fast = params.getString("fast");
-            final boolean isFast = "1".equals(fast) || "true".equals(fast) || "yes".equals(fast);
-            final String mode = params.getString("v");
-
             worker.profileFilename = params.getString("profile");
             if (StringUtils.isBlank(worker.profileFilename)) {
                 return ""; // cannot calculate a route without a profile
             }
 
-            worker.rawTrackPath = baseDir + "/" + mode + "_rawtrack.dat";
+            final String mode = params.getString("v");
+            worker.rawTrackPath = getApplicationContext().getFilesDir().getAbsolutePath() + "/routing/";
+            FileUtils.mkdirs(new File(worker.rawTrackPath));
+            worker.rawTrackPath += mode + "_rawtrack.dat";
+
             worker.nogoList = new ArrayList<>();
 
             try {

--- a/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
+++ b/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
@@ -21,7 +21,6 @@ public class InternalRoutingService extends Service {
             final BRouterWorker worker = new BRouterWorker();
 
             final String baseDir = Environment.getExternalStorageDirectory().getAbsolutePath() + "/cgeo/routing";
-            worker.segmentDir = baseDir + "/segments4/";
 
             // should be:
             // final Folder base = PersistableFolder.ROUTING_BASE.getFolder();

--- a/main/src/cgeo/geocaching/brouter/core/RoutingEngine.java
+++ b/main/src/cgeo/geocaching/brouter/core/RoutingEngine.java
@@ -21,7 +21,6 @@ public class RoutingEngine extends Thread {
     protected List<MatchedWaypoint> matchedWaypoints;
     protected OsmTrack foundTrack = new OsmTrack();
     protected String errorMessage = null;
-    protected String segmentDir;
     protected RoutingContext routingContext;
     private NodesCache nodesCache;
     private final SortedHeap<OsmPath> openSet = new SortedHeap<OsmPath>();
@@ -31,7 +30,6 @@ public class RoutingEngine extends Thread {
     private static final int MAXNODES_ISLAND_CHECK = 500;
     private final OsmNodePairSet islandNodePairs = new OsmNodePairSet(MAXNODES_ISLAND_CHECK);
     private OsmTrack foundRawTrack = null;
-    private int alternativeIndex = 0;
     private volatile boolean terminated;
     private OsmTrack guideTrack;
     private OsmPathElement matchPath;
@@ -40,9 +38,7 @@ public class RoutingEngine extends Thread {
 
     private final boolean directWeaving = !Boolean.getBoolean("disableDirectWeaving");
 
-    public RoutingEngine(final String segmentDir,
-                         final List<OsmNodeNamed> waypoints, final RoutingContext rc) {
-        this.segmentDir = segmentDir;
+    public RoutingEngine(final List<OsmNodeNamed> waypoints, final RoutingContext rc) {
         this.waypoints = waypoints;
         this.routingContext = rc;
 
@@ -354,7 +350,7 @@ public class RoutingEngine extends Thread {
         }
         final long maxmem = routingContext.memoryclass * 1024L * 1024L; // in MB
 
-        nodesCache = new NodesCache(segmentDir, routingContext.expctxWay, maxmem, nodesCache, detailed);
+        nodesCache = new NodesCache(routingContext.expctxWay, maxmem, nodesCache, detailed);
         islandNodePairs.clearTempPairs();
     }
 

--- a/main/src/cgeo/geocaching/brouter/mapaccess/NodesCache.java
+++ b/main/src/cgeo/geocaching/brouter/mapaccess/NodesCache.java
@@ -15,7 +15,6 @@ import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.Log;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -30,7 +29,6 @@ public final class NodesCache implements Closeable {
     public String firstFileAccessName;
     private final BExpressionContextWay expCtxWay;
     private final int lookupVersion;
-    private final int lookupMinorVersion;
     private String currentFileName;
     private final HashMap<String, PhysicalFile> fileCache;
     private final DataBuffers dataBuffers;
@@ -55,7 +53,6 @@ public final class NodesCache implements Closeable {
         this.nodesMap.maxmem = (2L * maxmem) / 3L;
         this.expCtxWay = ctxWay;
         this.lookupVersion = ctxWay.meta.lookupVersion;
-        this.lookupMinorVersion = ctxWay.meta.lookupMinorVersion;
         this.detailed = detailed;
 
         if (ctxWay != null) {
@@ -322,7 +319,7 @@ public final class NodesCache implements Closeable {
 
         PhysicalFile ra = null;
         if (!fileCache.containsKey(filenameBase)) {
-            final ContentStorage.FileInformation fi = ContentStorage.get().getFileInfo(PersistableFolder.ROUTING_TILES.getFolder(), filenameBase + ".rd5");
+            final ContentStorage.FileInformation fi = ContentStorage.get().getFileInfo(PersistableFolder.ROUTING_TILES.getFolder(), filenameBase + BRouterConstants.BROUTER_TILE_FILEEXTENSION);
             if (fi != null && !fi.isDirectory) {
                 currentFileName = fi.name;
 
@@ -350,7 +347,9 @@ public final class NodesCache implements Closeable {
     @Override
     public void close() {
         for (PhysicalFile f : fileCache.values()) {
-            f.close();
+            if (f != null) {
+                f.close();
+            }
         }
     }
 }

--- a/main/src/cgeo/geocaching/brouter/mapaccess/NodesCache.java
+++ b/main/src/cgeo/geocaching/brouter/mapaccess/NodesCache.java
@@ -5,6 +5,7 @@
  */
 package cgeo.geocaching.brouter.mapaccess;
 
+import cgeo.geocaching.brouter.BRouterConstants;
 import cgeo.geocaching.brouter.codec.DataBuffers;
 import cgeo.geocaching.brouter.codec.MicroCache;
 import cgeo.geocaching.brouter.codec.WaypointMatcher;
@@ -27,7 +28,6 @@ public final class NodesCache implements Closeable {
     public WaypointMatcher waypointMatcher;
     public boolean firstFileAccessFailed = false;
     public String firstFileAccessName;
-    private final File segmentDir;
     private final BExpressionContextWay expCtxWay;
     private final int lookupVersion;
     private final int lookupMinorVersion;
@@ -49,9 +49,8 @@ public final class NodesCache implements Closeable {
 
     private final boolean directWeaving = !Boolean.getBoolean("disableDirectWeaving");
 
-    public NodesCache(final String segmentDir, final BExpressionContextWay ctxWay, final long maxmem, final NodesCache oldCache, final boolean detailed) {
+    public NodesCache(final BExpressionContextWay ctxWay, final long maxmem, final NodesCache oldCache, final boolean detailed) {
         this.maxmemtiles = maxmem / 8;
-        this.segmentDir = new File(segmentDir);
         this.nodesMap = new OsmNodesMap();
         this.nodesMap.maxmem = (2L * maxmem) / 3L;
         this.expCtxWay = ctxWay;
@@ -65,10 +64,6 @@ public final class NodesCache implements Closeable {
 
         firstFileAccessFailed = false;
         firstFileAccessName = null;
-
-        if (!this.segmentDir.isDirectory()) {
-            throw new RuntimeException("segment directory " + segmentDir + " does not exist");
-        }
 
         if (oldCache != null) {
             fileCache = oldCache.fileCache;
@@ -323,7 +318,7 @@ public final class NodesCache implements Closeable {
         final String slat = lat < 0 ? "S" + (-lat) : "N" + lat;
         final String filenameBase = slon + "_" + slat;
 
-        currentFileName = filenameBase + ".rd5";
+        currentFileName = filenameBase + BRouterConstants.BROUTER_TILE_FILEEXTENSION;
 
         PhysicalFile ra = null;
         if (!fileCache.containsKey(filenameBase)) {

--- a/main/src/cgeo/geocaching/downloader/BRouterTileDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/BRouterTileDownloader.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.downloader;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.brouter.BRouterConstants;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.CalendarUtils;
@@ -26,7 +27,7 @@ public class BRouterTileDownloader extends AbstractDownloader {
         super(Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.brouter_downloadurl, R.string.brouter_name, R.string.brouter_info, R.string.brouter_projecturl, 0, PersistableFolder.ROUTING_TILES);
         overwrite = true; // silently overwrite already existing files
         useCompanionFiles = false; // use single uri, and no companion files
-        forceExtension = ".rd5";
+        forceExtension = BRouterConstants.BROUTER_TILE_FILEEXTENSION;
     }
 
     @Override


### PR DESCRIPTION
- removes some more unused code (segmentDir, ...), vars and unused/unsupported parameters ("fast")
- uses static var for file extension
- moves rawtrack files to app-internal folder (fixes #10400)
- fixes error in `PhysicalFile` when routing tile file did not exist
