### PR TITLE
Sys info lang

### DIFF
--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -102,7 +102,7 @@ public class ContentStorageActivityHelper {
         //create the message;
         final String folderData = activity.getString(R.string.contentstorage_selectfolder_dialog_msg_folderdata,
             folder.toUserDisplayableName(), folder.toUserDisplayableValue(), folderInfo.left, folderInfo.middle, folderInfo.right);
-        final String defaultFolder = activity.getString(R.string.contentstorage_selectfolder_dialog_msg_defaultfolder, folder.getDefaultFolder().toUserDisplayableString(true));
+        final String defaultFolder = activity.getString(R.string.contentstorage_selectfolder_dialog_msg_defaultfolder, folder.getDefaultFolder().toUserDisplayableString(true, false));
 
         final AlertDialog.Builder dialog = Dialogs.newBuilder(activity);
         dialog

--- a/main/src/cgeo/geocaching/storage/Folder.java
+++ b/main/src/cgeo/geocaching/storage/Folder.java
@@ -127,14 +127,14 @@ public class Folder {
     /** Returns a representation of this folder's location fit to show to an end user. This value is volatile if this folder's type is volatile (e.g. {@link FolderType#PERSISTABLE_FOLDER}) */
     @NonNull
     public String toUserDisplayableString() {
-        return toUserDisplayableString(false);
+        return toUserDisplayableString(false, false);
     }
 
     @NonNull
-    public String toUserDisplayableString(final boolean addLegacyFlag) {
+    public String toUserDisplayableString(final boolean addLegacyFlag, final boolean forceEnglish) {
         String result = "";
         if (addLegacyFlag && getBaseType() == Folder.FolderType.FILE) {
-            result += "[" + (CgeoApplication.getInstance() == null ? "Legacy" :
+            result += "[" + (CgeoApplication.getInstance() == null || forceEnglish ? "Legacy" :
                 CgeoApplication.getInstance().getApplicationContext().getString(R.string.persistablefolder_legacy)) + "]";
         }
         result += UriUtils.toUserDisplayableString(getBaseUri(), getSubdirsToBase());

--- a/main/src/cgeo/geocaching/storage/PersistableFolder.java
+++ b/main/src/cgeo/geocaching/storage/PersistableFolder.java
@@ -158,10 +158,16 @@ public enum PersistableFolder {
     /** Returns a representation of this folder's location fit to show to an end user */
     @NonNull
     public String toUserDisplayableValue() {
-        String result = getFolder().toUserDisplayableString(true);
+        return toUserDisplayableValue(false);
+    }
+
+    /** Returns a representation of this folder's location fit to show to an end user */
+    @NonNull
+    public String toUserDisplayableValue(final boolean forceEnglish) {
+        String result = getFolder().toUserDisplayableString(true, forceEnglish);
 
         result += " (";
-        if (CgeoApplication.getInstance() == null) {
+        if (forceEnglish || CgeoApplication.getInstance() == null) {
             //this codepath is only chosen if no translation is available (e.g. in local unit tests)
             result += isUserDefined() ? "User-Defined" : "Default";
         } else {
@@ -183,7 +189,7 @@ public enum PersistableFolder {
 
     @Override
     public String toString() {
-        return name() + ": " + toUserDisplayableValue() + "[" + getFolder() + "]";
+        return name() + ": " + toUserDisplayableValue(true) + "[" + getFolder() + "]";
     }
 
 }

--- a/main/src/cgeo/geocaching/utils/LocalizationUtils.java
+++ b/main/src/cgeo/geocaching/utils/LocalizationUtils.java
@@ -6,10 +6,14 @@ import cgeo.geocaching.storage.Folder;
 import cgeo.geocaching.storage.PersistableFolder;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
+
+import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -93,6 +97,17 @@ public final class LocalizationUtils {
         return new ImmutablePair<>(getStringWithFallback(messageId, fallback, paramsForUser), getStringWithFallback(messageId, fallback, paramsForLog));
     }
 
+    @NonNull
+    public static String getEnglishString(final Context context, @StringRes final int resId) {
+        final Configuration configuration = getEnglishConfiguration(context);
+        return context.createConfigurationContext(configuration).getResources().getString(resId);
+    }
 
+    @NonNull
+    private static Configuration getEnglishConfiguration(final Context context) {
+        final Configuration configuration = new Configuration(context.getResources().getConfiguration());
+        configuration.setLocale(new Locale("en"));
+        return configuration;
+    }
 
 }

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -98,9 +98,9 @@ public final class SystemInformation {
             .append("\n- OSM multi-threading: ").append(Settings.hasOSMMultiThreading()).append(" / threads: ").append(Settings.getMapOsmThreads())
             .append("\n- Global filter: ").append(Settings.getCacheType().pattern)
             .append("\n- Last backup: ").append(BackupUtils.hasBackup(BackupUtils.newestBackupFolder()) ? BackupUtils.getNewestBackupDateTime() : "never")
-            .append("\n- Routing mode: ").append(context.getString(Settings.getRoutingMode().infoResId));
-            appendMapSourceInformation(body, context);
-            body
+            .append("\n- Routing mode: ").append(LocalizationUtils.getEnglishString(context, Settings.getRoutingMode().infoResId));
+        appendMapSourceInformation(body, context);
+        body
             .append("\n")
             .append("\nServices:")
             .append("\n-------");
@@ -195,9 +195,10 @@ public final class SystemInformation {
             return;
         }
         final ImmutablePair<String, Boolean> mapAtts = source.calculateMapAttribution(ctx);
-        body.append(source.getName()).append("\n  - Id: ").append(source.getId())
-            .append("\n  - Atts: ").append(mapAtts == null ? "none" : mapAtts.left)
-            .append("\n  - Theme: ").append(Settings.getSelectedMapRenderTheme());
+        body.append(source.getName()) // unfortunately localized but an English string would require large refactoring. The sourceId provides an unlocalized and unique identifier.
+                .append("\n  - Id: ").append(source.getId())
+                .append("\n  - Atts: ").append(mapAtts == null ? "none" :  HtmlUtils.extractText(mapAtts.left).replace("\n", " / "))
+                .append("\n  - Theme: ").append(StringUtils.isBlank(Settings.getSelectedMapRenderTheme()) ? "none" : Settings.getSelectedMapRenderTheme());
     }
 
 
@@ -219,7 +220,7 @@ public final class SystemInformation {
                 if (connector instanceof ILogin) {
                     final ILogin login = (ILogin) connector;
                     connectors.append(": ").append(login.isLoggedIn() ? "Logged in" : "Not logged in")
-                            .append(" (").append(login.getLoginStatusString()).append(')');
+                            .append(" (").append(login.getLoginStatusString() /* unfortunately localized but an English string would require large refactoring */).append(')');
                     if (login.getName().equals("geocaching.com") && login.isLoggedIn()) {
                         connectors.append(" / ").append(Settings.getGCMemberStatus());
                     }


### PR DESCRIPTION
- Use unlocalized (english) values
- Add hint that value is localized (at places where an english value isn't easily possible)
- Avoid html styling tags for attribution text

fix #10410