### PR TITLE
adapt cache type detection to website change (rel. to #10421)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -50,7 +50,7 @@ public final class GCConstants {
     static final Pattern PATTERN_FOUND = Pattern.compile("logtypes/48/(" + StringUtils.join(LogType.foundLogTypes(), "|") + ").png\" id=\"ctl00_ContentBody_GeoNav_logTypeImage\"");
     static final Pattern PATTERN_DNF = Pattern.compile("logtypes/48/(" + LogType.DIDNT_FIND_IT.id + ").png\" id=\"ctl00_ContentBody_GeoNav_logTypeImage\"");
     static final Pattern PATTERN_OWNER_DISPLAYNAME = Pattern.compile("<div id=\"ctl00_ContentBody_mcd1\">[^<]+<a href=\"[^\"]+\">([^<]+)</a>");
-    static final Pattern PATTERN_TYPE = Pattern.compile("<a href=\"/seek/nearest.aspx\\?tx=([0-9a-f-]+)");
+    static final Pattern PATTERN_TYPE = Pattern.compile("<use xlink:href=\"/app/ui-icons/sprites/cache-types.svg#icon-([0-9a-f]+)");
     static final Pattern PATTERN_HIDDEN = Pattern.compile("ctl00_ContentBody_mcd2[^:]+:\\s*([^<]+?)<");
     static final Pattern PATTERN_HIDDENEVENT = Pattern.compile(":\\s*([0-9-/]+)\\s*<div id=\"calLinks\">", Pattern.DOTALL);
     static final Pattern PATTERN_IS_FAVORITE = Pattern.compile("<div id=\"pnlFavoriteCache\">"); // without 'class="hideMe"' inside the tag !

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -584,7 +584,7 @@ public final class GCParser {
         cache.setDNF(TextUtils.matches(page, GCConstants.PATTERN_DNF));
 
         // cache type
-        cache.setType(CacheType.getByGuid(TextUtils.getMatch(page, GCConstants.PATTERN_TYPE, true, cache.getType().id)));
+        cache.setType(CacheType.getByWaypointType(TextUtils.getMatch(page, GCConstants.PATTERN_TYPE, true, cache.getType().id)));
 
         // on watchlist
         cache.setOnWatchlist(TextUtils.matches(page, GCConstants.PATTERN_WATCHLIST));

--- a/tests/src/cgeo/geocaching/test/mock/GC1ZXX2.html
+++ b/tests/src/cgeo/geocaching/test/mock/GC1ZXX2.html
@@ -473,7 +473,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                 <div id="ctl00_ContentBody_mcd2">
                     Hidden
                     :
-                    16.10.2009
+                    2009-10-16
                     
                     
                 </div>

--- a/tests/src/cgeo/geocaching/test/mock/GC3FJ5F.html
+++ b/tests/src/cgeo/geocaching/test/mock/GC3FJ5F.html
@@ -481,7 +481,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                 <div id="ctl00_ContentBody_mcd2">
                     Hidden
                     :
-                    29.3.2012
+                    2012-03-29
                     
                     
                 </div>


### PR DESCRIPTION
## Description
Adapts our code to the website change of cache detail page regarding the cache type. It's now referenced using the waypoint type instead of the type guid.

## Related issues
related to #10421, but not completely fixing it, as there is also a change regarding the cache owner.
