### PR TITLE
show toast on missing routing data (fix #8562)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -615,6 +615,7 @@
     <string name="init_brouterProfileBike">\"Bike\" profile</string>
     <string name="init_brouterProfileCar">\"Car\" profile</string>
     <string name="brouter_recalculating">Recalculating route in background…</string>
+    <string name="brouter_missing_data">Open BRouter to download missing routing data (%s)</string>
     <string name="init_summary_brouterShowBothDistances">If routing is active: Show the straight distance in addition to the calculated route length.</string>
     <string name="init_useInternalRouting">Use internal routing</string>
     <string name="init_summary_useInternalRouting">Use c:geo internal routing to be able to use automatic routing data downloading and other functions</string>


### PR DESCRIPTION
## Description
Show a toast on missing routing data for users of (external) BRouter.
Message is shown once per session per routing tile (e. g. "W5_N30.rd5")

(Users of internal routing engine can configure c:geo to offer automatic download for missing routing tiles, which we do not support for external BRouter - therefore this info message.)