### PR TITLE
fix #10413: make contentstorageactivityhelper state-aware, replace lambda callbacks with activity-restore-stable code

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.network.AndroidBeam;
-import cgeo.geocaching.storage.ContentStorageActivityHelper;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.ClipboardUtils;
@@ -52,8 +51,6 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
     private final CompositeDisposable resumeDisposable = new CompositeDisposable();
 
     private final String logToken = "[" + this.getClass().getName() + "]";
-
-    private ContentStorageActivityHelper contentStorageHelper = null; //lazy initalized
 
     protected AbstractActivity() {
         this(false);
@@ -279,21 +276,6 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
             return;
         }
         setCacheTitleBar(cache);
-    }
-
-    protected ContentStorageActivityHelper getContentStorageHelper() {
-        if (this.contentStorageHelper == null) {
-            this.contentStorageHelper = new ContentStorageActivityHelper(this);
-        }
-        return this.contentStorageHelper;
-    }
-
-    @Override
-    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (this.contentStorageHelper != null) {
-            this.contentStorageHelper.onActivityResult(requestCode, resultCode, data);
-        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.interfaces.CachesOverlayItemImpl;
 import cgeo.geocaching.maps.interfaces.MapActivityImpl;
 import cgeo.geocaching.maps.interfaces.MapViewImpl;
@@ -99,11 +100,20 @@ public abstract class AbstractMap {
         //
     }
 
+    public void centerOnPosition(final double latitude, final double longitude, final Viewport viewport) {
+        //
+    }
+
+
     public void reloadIndividualRoute() {
         //
     }
 
-    @Nullable
+    public void clearIndividualRoute() {
+        //
+    }
+
+     @Nullable
     public Geocache getCurrentTargetCache() {
         if (StringUtils.isNotBlank(targetGeocode)) {
             return DataStore.loadCache(targetGeocode, LoadFlags.LOAD_CACHE_OR_DB);

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -830,8 +830,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         } else if (id == R.id.menu_compass) {
             menuCompass();
         } else if (!HistoryTrackUtils.onOptionsItemSelected(activity, id, () -> mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null), this::clearTrailHistory)
-            && !this.trackUtils.onOptionsItemSelected(id, tracks, this::setTracks, this::centerOnPosition)
-            && !this.individualRouteUtils.onOptionsItemSelected(id, individualRoute, this::clearIndividualRoute, this::reloadIndividualRoute, this::centerOnPosition, this::setTarget)
+            && !this.trackUtils.onOptionsItemSelected(id, tracks)
+            && !this.individualRouteUtils.onOptionsItemSelected(id, individualRoute, this::centerOnPosition, this::setTarget)
             && !MapDownloaderUtils.onOptionsItemSelected(activity, id)) {
             final MapSource mapSource = MapProviderFactory.getMapSource(id);
             if (mapSource != null) {
@@ -886,7 +886,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         this.trackUtils.showTrackInfo(tracks);
     }
 
-    private void centerOnPosition(final double latitude, final double longitude, final Viewport viewport) {
+    @Override
+    public void centerOnPosition(final double latitude, final double longitude, final Viewport viewport) {
         followMyLocation = false;
         switchMyLocationButton();
         mapView.zoomToBounds(viewport, new GoogleGeoPoint(new LatLng(latitude, longitude)));
@@ -905,7 +906,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         ActivityMixin.showToast(activity, res.getString(R.string.map_trailhistory_cleared));
     }
 
-    private void clearIndividualRoute() {
+    @Override
+    public void clearIndividualRoute() {
         individualRoute.clearRoute(overlayPositionAndScale);
         overlayPositionAndScale.repaintRequired();
         ActivityMixin.invalidateOptionsMenu(activity);

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -34,11 +34,13 @@ import org.apache.commons.lang3.StringUtils;
 
 public class GoogleMapActivity extends Activity implements MapActivityImpl, FilteredActivity {
 
+    private static final String STATE_INDIVIDUAlROUTEUTILS = "indrouteutils";
+    private static final String STATE_TRACKUTILS = "trackutils";
 
     private final AbstractMap mapBase;
 
-    private final TrackUtils trackUtils = new TrackUtils(this);
-    private final IndividualRouteUtils individualRouteUtils = new IndividualRouteUtils(this);
+    private TrackUtils trackUtils = null;
+    private IndividualRouteUtils individualRouteUtils = null;
 
     public GoogleMapActivity() {
         mapBase = new CGeoMap(this);
@@ -68,11 +70,17 @@ public class GoogleMapActivity extends Activity implements MapActivityImpl, Filt
     @Override
     protected void onCreate(final Bundle icicle) {
         mapBase.onCreate(icicle);
+        individualRouteUtils = new IndividualRouteUtils(this, icicle == null ? null : icicle.getBundle(STATE_INDIVIDUAlROUTEUTILS),
+            mapBase::clearIndividualRoute, mapBase::reloadIndividualRoute);
+        trackUtils = new TrackUtils(this, icicle == null ? null : icicle.getBundle(STATE_TRACKUTILS),
+            mapBase::setTracks, mapBase::centerOnPosition);
     }
 
     @Override
     protected void onSaveInstanceState(@NonNull final Bundle outState) {
         mapBase.onSaveInstanceState(outState);
+        outState.putBundle(STATE_INDIVIDUAlROUTEUTILS, individualRouteUtils.getState());
+        outState.putBundle(STATE_TRACKUTILS, trackUtils.getState());
     }
 
     @Override
@@ -223,7 +231,7 @@ public class GoogleMapActivity extends Activity implements MapActivityImpl, Filt
             */
         }
         this.trackUtils.onActivityResult(requestCode, resultCode, data);
-        this.individualRouteUtils.onActivityResult(requestCode, resultCode, data, mapBase::reloadIndividualRoute);
+        this.individualRouteUtils.onActivityResult(requestCode, resultCode, data);
         MapDownloaderUtils.onActivityResult(this, requestCode, resultCode, data);
     }
 

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -12,6 +12,9 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.provider.DocumentsContract;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -23,8 +26,11 @@ import androidx.annotation.StringRes;
 import androidx.core.util.Consumer;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 
@@ -35,48 +41,119 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
  */
 public class ContentStorageActivityHelper {
 
-    //use a globally unique request code to mix-in with Activity.onActivityResult. (This will no longer be neccessary with Activity Result API)
-    //code must be positive (>0) and <=65535 (restriction of SDK21)
-    private static final int REQUEST_CODE_SELECT_FOLDER = 59371; //this is a random number
-    private static final int REQUEST_CODE_SELECT_FOLDER_PERSISTED = 59372;
 
-    private static final int REQUEST_CODE_SELECT_FILE = 59373;
-    private static final int REQUEST_CODE_SELECT_FILE_MULTIPLE = 59374;
-    private static final int REQUEST_CODE_SELECT_FILE_PERSISTED = 59375;
+    public enum SelectAction {
+        //use globally unique request codes to mix-in with Activity.onActivityResult. (This will no longer be neccessary with Activity Result API)
+        //code must be positive (>0) and <=65535 (restriction of SDK21)
+        SELECT_FOLDER(59371, Folder.class),
+        SELECT_FOLDER_PERSISTED(59372, PersistableFolder.class),
+        SELECT_FILE(59373, Uri.class),
+        SELECT_FILE_MULTIPLE(59374, List.class),
+        SELECT_FILE_PERSISTED(59375, PersistableUri.class);
+
+        public final int requestCode;
+        public final Class<?> callbackParameterClass;
+
+        SelectAction(final int requestCode, final Class<?> callbackParameterClass) {
+            this.requestCode = requestCode;
+            this.callbackParameterClass = callbackParameterClass;
+        }
+
+        public static SelectAction getByRequestCode(final int requestCode) {
+            for (SelectAction a : values()) {
+                if (a.requestCode == requestCode) {
+                    return a;
+                }
+            }
+            return null;
+        }
+
+    }
 
     private final Activity activity;
+    private final Map<SelectAction, Consumer<Object>> selectActionCallbacks = new HashMap<>();
 
     private enum CopyChoice { ASK_IF_DIFFERENT, GO_BACK, DO_NOTHING, COPY, MOVE }
 
     //stores intermediate data of a running intent by return code. (This will no longer be neccessary with Activity Result API)
-    private IntentData<?> runningIntentData;
+    private IntentData runningIntentData;
 
-    private static class IntentData<T> {
-        public final Consumer<T> callback; //for all requests
+    private static class IntentData implements Parcelable {
+        public final SelectAction action;
 
-        public final PersistableFolder folder; //for REQUEST_CODE_GRANT_FOLDER_URI_ACCESS
-        public final CopyChoice copyChoice; //for REQUEST_CODE_GRANT_FOLDER_URI_ACCESS
+        public final PersistableFolder folder; //for SelectAction.GRANT_FOLDER_URI_ACCESS
+        public final CopyChoice copyChoice; //for SelectAction.GRANT_FOLDER_URI_ACCESS
 
-        public final PersistableUri persistedDocUri; // for REQUEST_CODE_SELECT_FILE_PERSISTED
+        public final PersistableUri persistedDocUri; // for SelectAction.SELECT_FILE_PERSISTED
 
-        IntentData(final PersistableFolder folder, final CopyChoice copyChoice, final Consumer<T> callback) {
-            this(folder, copyChoice, null, callback);
+        IntentData(final PersistableFolder folder, final CopyChoice copyChoice, final SelectAction action) {
+            this(folder, copyChoice, null, action);
         }
 
-        IntentData(final PersistableUri persistedDocUri, final Consumer<T> callback) {
-            this(null, null, persistedDocUri, callback);
+        IntentData(final PersistableUri persistedDocUri, final SelectAction action) {
+            this(null, null, persistedDocUri, action);
         }
 
-        IntentData(final PersistableFolder folder, final CopyChoice copyChoice, final PersistableUri persistedDocUri, final Consumer<T> callback) {
+        IntentData(final PersistableFolder folder, final CopyChoice copyChoice, final PersistableUri persistedDocUri, final SelectAction action) {
             this.folder = folder;
-            this.callback = callback;
+            this.action = action;
             this.copyChoice = copyChoice;
             this.persistedDocUri = persistedDocUri;
         }
+
+        protected IntentData(final Parcel in) {
+            this.folder = EnumUtils.getEnum(PersistableFolder.class, in.readString());
+            this.action = EnumUtils.getEnum(SelectAction.class, in.readString());
+            this.copyChoice = EnumUtils.getEnum(CopyChoice.class, in.readString());
+            this.persistedDocUri = EnumUtils.getEnum(PersistableUri.class, in.readString());
+        }
+
+        public static final Creator<IntentData> CREATOR = new Creator<IntentData>() {
+            @Override
+            public IntentData createFromParcel(final Parcel in) {
+                return new IntentData(in);
+            }
+
+            @Override
+            public IntentData[] newArray(final int size) {
+                return new IntentData[size];
+            }
+        };
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(final Parcel dest, final int flags) {
+            dest.writeString(folder == null ? null : folder.name());
+            dest.writeString(action == null ? null : action.name());
+            dest.writeString(copyChoice == null ? null : copyChoice.name());
+            dest.writeString(persistedDocUri == null ? null : persistedDocUri.name());
+        }
     }
 
-    public ContentStorageActivityHelper(final Activity activity) {
+    public ContentStorageActivityHelper(final Activity activity, final Bundle state) {
         this.activity = activity;
+        if (state != null) {
+            runningIntentData = state.getParcelable("state");
+        }
+    }
+
+    public Bundle getState() {
+        final Bundle state = new Bundle();
+        state.putParcelable("state", runningIntentData);
+        return state;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> ContentStorageActivityHelper addSelectActionCallback(final SelectAction action, final Class<T> clazz, final Consumer<T> callback) {
+        if (!action.callbackParameterClass.isAssignableFrom(clazz)) {
+            throw new IllegalArgumentException("Callback for action '" + action + "' must be of type " + action.callbackParameterClass + ", found " + clazz);
+        }
+        this.selectActionCallbacks.put(action, (Consumer<Object>) callback);
+        return this;
     }
 
     public static boolean baseFolderIsSet() {
@@ -84,18 +161,20 @@ public class ContentStorageActivityHelper {
         return folder.isUserDefined() && ContentStorage.get().ensureFolder(folder);
     }
 
-    /** Asks user to select a folder for single-time-usage (location and permission is not persisted) */
-    public void selectFolder(@Nullable final Uri startUri, final Consumer<Folder> callback) {
-        selectFolderInternal(REQUEST_CODE_SELECT_FOLDER, null, startUri, null, callback);
+    /** Asks user to select a folder for single-time-usage (location and permission is not persisted)
+     *  if a callback for action {@link SelectAction#SELECT_FOLDER} is registered, it will be called after selection has finished
+     * */
+    public void selectFolder(@Nullable final Uri startUri) {
+        selectFolderInternal(SelectAction.SELECT_FOLDER, null, startUri, null);
     }
 
     /**
      * Starts user selection of a new Location for the given persisted folder.
      * Persisted folder handling is a bit more complex and involved e.g. optional copying from previous location and provides a default-option to user
+     * if a callback for action {@link SelectAction#SELECT_FOLDER_PERSISTED} is registered, it will be called after selection has finished
      * @param folder folder to request a new place from user
-     * @param callback called after user changed the uri. Callback is always called, even if user cancelled or error occured
      */
-    public void selectPersistableFolder(final PersistableFolder folder, final Consumer<PersistableFolder> callback) {
+    public void selectPersistableFolder(final PersistableFolder folder) {
 
         final ImmutableTriple<String, String, String> folderInfo = getInternationalizedFolderInfoStrings(folder.getFolder());
 
@@ -110,18 +189,18 @@ public class ContentStorageActivityHelper {
             .setMessage(folderData + (folder.isUserDefined() ? "\n\n" + defaultFolder : ""))
             .setPositiveButton(R.string.persistablefolder_pickfolder, (d, p) -> {
                 d.dismiss();
-                selectFolderInternal(REQUEST_CODE_SELECT_FOLDER_PERSISTED, folder, null, CopyChoice.ASK_IF_DIFFERENT, callback);
+                selectFolderInternal(SelectAction.SELECT_FOLDER_PERSISTED, folder, null, CopyChoice.ASK_IF_DIFFERENT);
                 })
             .setNegativeButton(android.R.string.cancel, (d, p) -> {
                 d.dismiss();
-                finalizePersistableFolderSelection(false, folder, null, callback);
+                finalizePersistableFolderSelection(false, folder, null, SelectAction.SELECT_FOLDER_PERSISTED);
             });
 
             //only allow default selection if folder is currently NOT at default
             if (folder.isUserDefined()) {
                 dialog.setNeutralButton(R.string.persistablefolder_usedefault, (d, p) -> {
                     d.dismiss();
-                    continuePersistableFolderSelectionCheckFoldersAreEqual(folder, null, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION, CopyChoice.ASK_IF_DIFFERENT, callback);
+                    continuePersistableFolderSelectionCheckFoldersAreEqual(folder, null, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION, CopyChoice.ASK_IF_DIFFERENT, SelectAction.SELECT_FOLDER_PERSISTED);
                 });
             }
 
@@ -129,44 +208,50 @@ public class ContentStorageActivityHelper {
     }
 
     /** Simplified form of selectPersistableFolder without initial dialog */
-    public void migratePersistableFolder(final PersistableFolder folder, final Consumer<PersistableFolder> callback) {
-        selectFolderInternal(REQUEST_CODE_SELECT_FOLDER_PERSISTED, folder, null, CopyChoice.ASK_IF_DIFFERENT, callback);
+    public void migratePersistableFolder(final PersistableFolder folder) {
+        selectFolderInternal(SelectAction.SELECT_FOLDER_PERSISTED, folder, null, CopyChoice.ASK_IF_DIFFERENT);
     }
 
     /** Simplified form of selectPersistableFolder used on settings' restore */
-    public void restorePersistableFolder(final PersistableFolder folder, final Uri newUri, final Consumer<PersistableFolder> callback) {
-        selectFolderInternal(REQUEST_CODE_SELECT_FOLDER_PERSISTED, folder, newUri, CopyChoice.ASK_IF_DIFFERENT, callback);
+    public void restorePersistableFolder(final PersistableFolder folder, final Uri newUri) {
+        selectFolderInternal(SelectAction.SELECT_FOLDER_PERSISTED, folder, newUri, CopyChoice.ASK_IF_DIFFERENT);
     }
 
     /**
      * Asks user to select a file for single usage (e.g. to import something into c:geo
+     * if a callback for action {@link SelectAction#SELECT_FILE} is registered, it will be called after selection has finished
      * @param type mime type, used for intent search
      * @param startUri hint for intent where to start search
-     * @param callback called when user made selection. If user aborts search, callback is called with value null
      */
-    public void selectFile(@Nullable final String type, @Nullable final Uri startUri, final Consumer<Uri> callback) {
-        selectFilesInternal(type, startUri, REQUEST_CODE_SELECT_FILE, null, callback);
+    public void selectFile(@Nullable final String type, @Nullable final Uri startUri) {
+        selectFilesInternal(type, startUri, SelectAction.SELECT_FILE, null);
     }
 
-    /** Asks user to select multiple files at once */
-    public void selectMultipleFiles(@Nullable final String type, @Nullable final Uri startUri, final Consumer<List<Uri>> callback) {
-        selectFilesInternal(type, startUri, REQUEST_CODE_SELECT_FILE_MULTIPLE, null, callback);
+    /**
+     * Asks user to select multiple files at once
+     * if a callback for action {@link SelectAction#SELECT_FILE_MULTIPLE} is registered, it will be called after selection has finished
+     * */
+    public void selectMultipleFiles(@Nullable final String type, @Nullable final Uri startUri) {
+        selectFilesInternal(type, startUri, SelectAction.SELECT_FILE_MULTIPLE, null);
     }
 
-    /** Asks user to select a new location for a persisted uri (used e.g. for Track file). Permission is persisted as well. */
-    public void selectPersistableUri(@NonNull final PersistableUri persistedDocUri, final Consumer<Uri> callback) {
-        selectFilesInternal(persistedDocUri.getMimeType(), persistedDocUri.getUri(), REQUEST_CODE_SELECT_FILE_PERSISTED, persistedDocUri, callback);
+    /**
+     * Asks user to select a new location for a persisted uri (used e.g. for Track file). Permission is persisted as well.
+     * if a callback for action {@link SelectAction#SELECT_FILE_PERSISTED} is registered, it will be called after selection has finished
+     * */
+    public void selectPersistableUri(@NonNull final PersistableUri persistedDocUri) {
+        selectFilesInternal(persistedDocUri.getMimeType(), persistedDocUri.getUri(), SelectAction.SELECT_FILE_PERSISTED, persistedDocUri);
     }
 
     /** Simplified form of selectPersistableUri used on settings' restore */
-    public void restorePersistableUri(final PersistableUri persistableUri, final Uri newUri, final Consumer<Uri> callback) {
-        selectFilesInternal(persistableUri.getMimeType(), newUri, REQUEST_CODE_SELECT_FILE_PERSISTED, persistableUri, callback);
+    public void restorePersistableUri(final PersistableUri persistableUri, final Uri newUri) {
+        selectFilesInternal(persistableUri.getMimeType(), newUri, SelectAction.SELECT_FILE_PERSISTED, persistableUri);
     }
 
     /** You MUST include in {@link Activity#onActivityResult(int, int, Intent)} of using Activity */
     public boolean onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
-        if (requestCode != REQUEST_CODE_SELECT_FOLDER && requestCode != REQUEST_CODE_SELECT_FOLDER_PERSISTED &&
-            requestCode != REQUEST_CODE_SELECT_FILE && requestCode != REQUEST_CODE_SELECT_FILE_MULTIPLE && requestCode != REQUEST_CODE_SELECT_FILE_PERSISTED) {
+        final SelectAction action = SelectAction.getByRequestCode(requestCode);
+        if (action == null) {
             return false;
         }
         if (runningIntentData == null) {
@@ -179,17 +264,17 @@ public class ContentStorageActivityHelper {
 
             final boolean resultOk = resultCode == Activity.RESULT_OK && intent != null;
 
-            switch (requestCode) {
-                case REQUEST_CODE_SELECT_FOLDER:
+            switch (action) {
+                case SELECT_FOLDER:
                     handleResultFolderSelection(intent, resultOk);
                     break;
-                case REQUEST_CODE_SELECT_FOLDER_PERSISTED:
+                case SELECT_FOLDER_PERSISTED:
                     handleResultPersistableFolderSelection(intent, resultOk);
                     break;
-                case REQUEST_CODE_SELECT_FILE:
-                case REQUEST_CODE_SELECT_FILE_MULTIPLE:
-                case REQUEST_CODE_SELECT_FILE_PERSISTED:
-                    handleResultSelectFiles(requestCode, intent, resultOk);
+                case SELECT_FILE:
+                case SELECT_FILE_MULTIPLE:
+                case SELECT_FILE_PERSISTED:
+                    handleResultSelectFiles(action, intent, resultOk);
                     break;
                 default: //for codacy
                     break;
@@ -201,7 +286,7 @@ public class ContentStorageActivityHelper {
         }
     }
 
-    private void selectFilesInternal(@Nullable final String type, @Nullable final Uri startUri, final int requestCode, final PersistableUri docUri, final Consumer<?> callback) {
+    private void selectFilesInternal(@Nullable final String type, @Nullable final Uri startUri, final SelectAction action, final PersistableUri docUri) {
         // call for document tree dialog
         final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
@@ -210,18 +295,18 @@ public class ContentStorageActivityHelper {
             // Attribute is supported starting SDK26 / O
             intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, startUri);
         }
-        if (requestCode == REQUEST_CODE_SELECT_FILE_MULTIPLE) {
+        if (action == SelectAction.SELECT_FILE_MULTIPLE) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         }
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION  |
             (docUri == null ? 0 : Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION));
 
-        runningIntentData = new IntentData<>(docUri, callback);
+        runningIntentData = new IntentData(docUri, action);
 
-        this.activity.startActivityForResult(intent, requestCode);
+        this.activity.startActivityForResult(intent, action.requestCode);
     }
 
-    private void selectFolderInternal(final int requestCode, final PersistableFolder folder, final Uri startUri, final CopyChoice copyChoice, final Consumer<?> callback) {
+    private void selectFolderInternal(final SelectAction action, final PersistableFolder folder, final Uri startUri, final CopyChoice copyChoice) {
 
         // call for document tree dialog
         final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
@@ -238,13 +323,13 @@ public class ContentStorageActivityHelper {
             intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, realStartUri);
         }
 
-        runningIntentData = new IntentData<>(folder, copyChoice, callback);
+        runningIntentData = new IntentData(folder, copyChoice, action);
 
-        this.activity.startActivityForResult(intent, requestCode);
+        this.activity.startActivityForResult(intent, action.requestCode);
     }
 
 
-    private void handleResultSelectFiles(final int requestCode, final Intent intent, final boolean resultOk) {
+    private void handleResultSelectFiles(final SelectAction action, final Intent intent, final boolean resultOk) {
         final List<Uri> selectedUris = new ArrayList<>();
         if (!resultOk || intent == null) {
             report(true, R.string.contentstorage_file_selection_aborted);
@@ -275,40 +360,26 @@ public class ContentStorageActivityHelper {
             }
         }
 
-        if (runningIntentData.callback != null) {
-            switch (requestCode) {
-                case REQUEST_CODE_SELECT_FILE_MULTIPLE:
-                    ((Consumer<List<Uri>>) runningIntentData.callback).accept(selectedUris);
-                    break;
-                default:
-                    ((Consumer<Uri>) runningIntentData.callback).accept(selectedUris.isEmpty() ? null : selectedUris.get(0));
-                    break;
-            }
-        }
+        callCallback(action, action == SelectAction.SELECT_FILE_MULTIPLE ? selectedUris : selectedUris.isEmpty() ? null : selectedUris.get(0));
     }
 
     private void handleResultFolderSelection(final Intent intent, final boolean resultOk) {
         final Uri uri = !resultOk || intent == null ? null : intent.getData();
         final Folder folder = uri == null ? null : Folder.fromDocumentUri(uri);
 
-        final Consumer<Folder> callback = (Consumer<Folder>) runningIntentData.callback;
-
         if (uri == null) {
             report(true, R.string.contentstorage_folder_selection_aborted, "---");
         } else {
             report(true, R.string.contentstorage_folder_selection_success, uri);
         }
-        if (callback != null) {
-            callback.accept(folder);
-        }
+        callCallback(SelectAction.SELECT_FOLDER, folder);
     }
 
     private void handleResultPersistableFolderSelection(final Intent intent, final boolean resultOk) {
         final Uri uri = !resultOk || intent == null ? null : intent.getData();
         final PersistableFolder folder = runningIntentData.folder;
-        final Consumer<PersistableFolder> callback = (Consumer<PersistableFolder>) runningIntentData.callback;
         if (uri == null) {
-            finalizePersistableFolderSelection(false, folder, null, callback);
+            finalizePersistableFolderSelection(false, folder, null, runningIntentData.action);
         } else {
             final int flags = Intent.FLAG_GRANT_READ_URI_PERMISSION | (runningIntentData.folder.needsWrite() ? Intent.FLAG_GRANT_WRITE_URI_PERMISSION : 0);
             activity.getContentResolver().takePersistableUriPermission(uri, flags);
@@ -317,9 +388,9 @@ public class ContentStorageActivityHelper {
             //Test if access is really working!
             final Folder target = Folder.fromDocumentUri(uri);
             if (!ContentStorage.get().ensureFolder(target, runningIntentData.folder.needsWrite(), true)) {
-                finalizePersistableFolderSelection(false, folder, null, callback);
+                finalizePersistableFolderSelection(false, folder, null, runningIntentData.action);
             } else {
-                continuePersistableFolderSelectionCheckFoldersAreEqual(folder, uri, flags, runningIntentData.copyChoice, callback);
+                continuePersistableFolderSelectionCheckFoldersAreEqual(folder, uri, flags, runningIntentData.copyChoice, runningIntentData.action);
             }
         }
     }
@@ -332,7 +403,7 @@ public class ContentStorageActivityHelper {
         ContentStorage.get().refreshUriPermissionCache();
     }
 
-    private void continuePersistableFolderSelectionCheckFoldersAreEqual(final PersistableFolder folder, final Uri targetUri, final int flags, final CopyChoice copyChoice, final Consumer<PersistableFolder> callback) {
+    private void continuePersistableFolderSelectionCheckFoldersAreEqual(final PersistableFolder folder, final Uri targetUri, final int flags, final CopyChoice copyChoice, final SelectAction action) {
         final Folder before = folder.getFolder();
         if (copyChoice == CopyChoice.ASK_IF_DIFFERENT && before != null && !FolderUtils.get().foldersAreEqual(before, Folder.fromDocumentUri(targetUri))) {
 
@@ -350,52 +421,50 @@ public class ContentStorageActivityHelper {
                 .setTitle(activity.getString(R.string.contentstorage_selectfolder_dialog_title, folder.toUserDisplayableName()))
                 .setPositiveButton(android.R.string.ok, (d, p) -> {
                     d.dismiss();
-                    continuePersistableFolderSelectionCopyMove(folder, targetUri, cc[0], callback);
+                    continuePersistableFolderSelectionCopyMove(folder, targetUri, cc[0], action);
                 })
                 .setNegativeButton(android.R.string.cancel, (d, p) -> {
                     d.dismiss();
                     releaseGrant(targetUri, flags);
-                    finalizePersistableFolderSelection(false, folder, null, callback);
+                    finalizePersistableFolderSelection(false, folder, null, action);
                 })
                 .setNeutralButton(R.string.back, (d, p) -> {
                     d.dismiss();
                     releaseGrant(targetUri, flags);
-                    migratePersistableFolder(folder, callback);
+                    migratePersistableFolder(folder);
                 })
                 .create()
                 .show();
         } else {
-            continuePersistableFolderSelectionCopyMove(folder, targetUri, runningIntentData.copyChoice == CopyChoice.ASK_IF_DIFFERENT ? CopyChoice.DO_NOTHING : runningIntentData.copyChoice, callback);
+            continuePersistableFolderSelectionCopyMove(folder, targetUri, runningIntentData.copyChoice == CopyChoice.ASK_IF_DIFFERENT ? CopyChoice.DO_NOTHING : runningIntentData.copyChoice, action);
         }
     }
 
-    private void continuePersistableFolderSelectionCopyMove(final PersistableFolder folder, final Uri targetUri, final CopyChoice copyChoice, final Consumer<PersistableFolder> callback) {
+    private void continuePersistableFolderSelectionCopyMove(final PersistableFolder folder, final Uri targetUri, final CopyChoice copyChoice, final SelectAction action) {
         final Folder before = folder.getFolder();
         if (copyChoice.equals(CopyChoice.DO_NOTHING) || FolderUtils.FolderInfo.EMPTY_FOLDER.equals(FolderUtils.get().getFolderInfo(before))) {
             //nothing to copy/move
-            finalizePersistableFolderSelection(true, folder, targetUri, callback);
+            finalizePersistableFolderSelection(true, folder, targetUri, action);
         } else {
 
             //perform copy or move
             final Folder target = targetUri == null ? folder.getDefaultFolder() : Folder.fromDocumentUri(targetUri);
             FolderUtils.get().copyAllAsynchronousWithGui(activity, folder.getFolder(), target, copyChoice.equals(CopyChoice.MOVE), copyResult -> {
                 if (copyResult != null) {
-                    finalizePersistableFolderSelection(true, folder, targetUri, callback);
+                    finalizePersistableFolderSelection(true, folder, targetUri, action);
                 }
             });
         }
     }
 
-    private void finalizePersistableFolderSelection(final boolean success, final PersistableFolder folder, final Uri selectedUri, final Consumer<PersistableFolder> callback) {
+    private void finalizePersistableFolderSelection(final boolean success, final PersistableFolder folder, final Uri selectedUri, final SelectAction action) {
         if (success) {
             ContentStorage.get().setUserDefinedFolder(folder, Folder.fromDocumentUri(selectedUri), true);
             report(false, R.string.contentstorage_folder_selection_success, folder);
         } else {
             report(true, R.string.contentstorage_folder_selection_aborted, folder);
         }
-        if (callback != null) {
-            callback.accept(folder);
-        }
+        callCallback(action, folder);
     }
 
     private void report(final boolean isWarning, @StringRes final int messageId, final Object ... params) {
@@ -408,6 +477,13 @@ public class ContentStorageActivityHelper {
     private static ImmutableTriple<String, String, String> getInternationalizedFolderInfoStrings(final Folder folder) {
         final FolderUtils.FolderInfo folderInfo = FolderUtils.get().getFolderInfo(folder, -1);
         return folderInfo.getUserDisplayableFolderInfoStrings();
+    }
+
+    private void callCallback(final SelectAction action, final Object parameter) {
+        final Consumer<Object> callback = (Consumer<Object>) this.selectActionCallbacks.get(action);
+        if (callback != null) {
+            callback.accept(parameter);
+        }
     }
 
 }


### PR DESCRIPTION
fixes #10413 

ContentStorageActivityHelper was not state-aware and thus not able to "survive" a "destroy/resume" cycle of the using activity. This was fixed.

Umfortunately, Lambda callback design is not possible in this state-aware design any more, thus it was replaced by code with preassigned actions independent of exchanged activity class. Unfortunately this also meant redesign of all classes using ContentStorageActivityHelper, specifically BackupUtils, TrackingUtils and IndividualRouteUtils had to be made state-aware as well. 

@fm-sys Unfortunatly BackupUtils had to be changed quite a bit, thus I would appreciate your review. Especially the "regrantAccess" logic was tricky, to re-enable the "cycle" logic even if corresponding activity anchor is recreated I had to store state in the utils class.