### PR TITLE
adapt login regexp to yet another website change (rel. to #10440)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -81,7 +81,7 @@ public final class GCConstants {
     static final Pattern PATTERN_CACHES_FOUND_LOGIN_PAGE = Pattern.compile("\"findCount\": ([0-9]*)\\s*\\}];\\s*<\\/script>");
 
     static final Pattern PATTERN_AVATAR_IMAGE_SERVERPARAMETERS = Pattern.compile("\"(https?:\\/\\/(img(?:cdn)?\\.geocaching\\.com|[^>\\\"]+\\.cloudfront\\.net)\\/avatar\\/[0-9a-f-]+\\.(" + IMAGE_FORMATS + "))\\\"");
-    static final Pattern PATTERN_LOGIN_NAME_LOGIN_PAGE = Pattern.compile("<script type=\"text\\/javascript\">\\s*var dataLayer = \\[\\{\\s*\"username\": \"([^\"]*)\"");
+    static final Pattern PATTERN_LOGIN_NAME_LOGIN_PAGE = Pattern.compile("\\swindow(?>\\.|\\[')headerSettings(?>'\\])?\\s*=\\s*\\{[\\S\\s]*\"username\":\\s*\"([^\"]*)\",?[\\S\\s]*\\}");
 
     // Patterns for parsing trackables
 


### PR DESCRIPTION
Adapt to yet another cascade of changes on their login pages, changing the check from `dataLayer` to `headerSettings`. Current expression will now also work with either `window.varname` and `window['varname']` way of declaring, and with `username` being the last var or not.