### PR TITLE
Indicate waypoint has calculated coordinates in waypoint list (rel #9899, #6833)

### DIFF
--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -84,6 +84,23 @@
         android:maxLines="1" />
 
     <TextView
+        android:id="@+id/calculate_coordinates"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:layout_marginLeft="12dp"
+        android:ellipsize="end"
+        android:focusable="false"
+        android:lines="1"
+        android:maxLines="1"
+        android:scrollHorizontally="true"
+        android:textColor="?text_color_headline"
+        android:textSize="14sp"
+        android:visibility="gone"
+        android:text="@string/waypoint_calculate_coordinates"
+        tools:visiblity="visible" />
+
+    <TextView
         android:id="@+id/note"
         android:autoLink="web|map"
         android:layout_width="fill_parent"

--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -84,7 +84,7 @@
         android:maxLines="1" />
 
     <TextView
-        android:id="@+id/calculate_coordinates"
+        android:id="@+id/calculated_coordinates"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="left"
@@ -97,7 +97,7 @@
         android:textColor="?text_color_headline"
         android:textSize="14sp"
         android:visibility="gone"
-        android:text="@string/waypoint_calculate_coordinates"
+        android:text="@string/waypoint_calculated_coordinates"
         tools:visiblity="visible" />
 
     <TextView

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1287,6 +1287,7 @@
     </array>
     <string name="waypoint_cache_coordinates">Cache coordinates</string>
     <string name="waypoint_calculate_coordinates">Calculate coordinates</string>
+    <string name="waypoint_calculated_coordinates">Calculated coordinates</string>
     <string name="waypoint_custom">Custom</string>
     <string name="waypoint_my_coordinates">My coordinates</string>
     <string name="waypoint_bearing">Bearing in °</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2011,18 +2011,18 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         protected void fillViewHolder(final View rowView, final WaypointViewHolder holder, final Waypoint wpt) {
             // coordinates
             final TextView coordinatesView = holder.binding.coordinates;
-            final TextView calculateCoordinatesView = holder.binding.calculateCoordinates;
+            final TextView calculatedCoordinatesView = holder.binding.calculatedCoordinates;
             final Geopoint coordinates = wpt.getCoords();
 
             if (coordinates != null) {
                 holder.setCoordinate(coordinates);
                 coordinatesView.setVisibility(View.VISIBLE);
-                calculateCoordinatesView.setVisibility(View.GONE);
+                calculatedCoordinatesView.setVisibility(View.GONE);
             } else {
                 coordinatesView.setVisibility(View.GONE);
                 // formula, if no coords
                 final String calcStateJson = wpt.getCalcStateJson();
-                calculateCoordinatesView.setVisibility(null != calcStateJson ? View.VISIBLE : View.GONE);
+                calculatedCoordinatesView.setVisibility(null != calcStateJson ? View.VISIBLE : View.GONE);
             }
 
             // info

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2011,12 +2011,18 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         protected void fillViewHolder(final View rowView, final WaypointViewHolder holder, final Waypoint wpt) {
             // coordinates
             final TextView coordinatesView = holder.binding.coordinates;
+            final TextView calculateCoordinatesView = holder.binding.calculateCoordinates;
             final Geopoint coordinates = wpt.getCoords();
+
             if (coordinates != null) {
                 holder.setCoordinate(coordinates);
                 coordinatesView.setVisibility(View.VISIBLE);
+                calculateCoordinatesView.setVisibility(View.GONE);
             } else {
                 coordinatesView.setVisibility(View.GONE);
+                // formula, if no coords
+                final String calcStateJson = wpt.getCalcStateJson();
+                calculateCoordinatesView.setVisibility(null != calcStateJson ? View.VISIBLE : View.GONE);
             }
 
             // info

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2013,17 +2013,11 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             final TextView coordinatesView = holder.binding.coordinates;
             final TextView calculatedCoordinatesView = holder.binding.calculatedCoordinates;
             final Geopoint coordinates = wpt.getCoords();
+            final String calcStateJson = wpt.getCalcStateJson();
 
-            if (coordinates != null) {
-                holder.setCoordinate(coordinates);
-                coordinatesView.setVisibility(View.VISIBLE);
-                calculatedCoordinatesView.setVisibility(View.GONE);
-            } else {
-                coordinatesView.setVisibility(View.GONE);
-                // formula, if no coords
-                final String calcStateJson = wpt.getCalcStateJson();
-                calculatedCoordinatesView.setVisibility(null != calcStateJson ? View.VISIBLE : View.GONE);
-            }
+            holder.setCoordinate(coordinates);
+            coordinatesView.setVisibility(null != coordinates ? View.VISIBLE : View.GONE);
+            calculatedCoordinatesView.setVisibility(null != calcStateJson ? View.VISIBLE : View.GONE);
 
             // info
             final String waypointInfo = Formatter.formatWaypointInfo(wpt);

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -483,7 +483,10 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
 
     @Override
     public void saveCalculatorState(final CalcState calcState) {
-        this.calcStateJson = calcState != null ? calcState.toJSON().toString() : null;
+        this.calcStateJson = null;
+        if (calcState != null && calcState.equations.size() > 0) {
+            this.calcStateJson = calcState.toJSON().toString();
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.utils.EditUtils;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -38,6 +39,7 @@ import android.widget.TextView;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -54,6 +56,7 @@ public class CoordinatesInputDialog extends DialogFragment {
 
     private EditText eLat, eLon;
     private Button bLat, bLon;
+    private Button bCalculate;
     private EditText eLatDeg, eLatMin, eLatSec, eLatSub;
     private EditText eLonDeg, eLonMin, eLonSec, eLonSub;
     private TextView tLatSep1, tLatSep2, tLatSep3;
@@ -149,9 +152,9 @@ public class CoordinatesInputDialog extends DialogFragment {
 
         final Spinner spinner = v.findViewById(R.id.spinnerCoordinateFormats);
         final ArrayAdapter<CharSequence> adapter =
-                ArrayAdapter.createFromResource(getActivity(),
-                        R.array.waypoint_coordinate_formats,
-                        android.R.layout.simple_spinner_item);
+            ArrayAdapter.createFromResource(getActivity(),
+                R.array.waypoint_coordinate_formats,
+                android.R.layout.simple_spinner_item);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinner.setAdapter(adapter);
         spinner.setSelection(Settings.getCoordInputFormat().ordinal());
@@ -179,6 +182,8 @@ public class CoordinatesInputDialog extends DialogFragment {
 
         orderedInputs = Arrays.asList(eLatDeg, eLatMin, eLatSec, eLatSub, eLonDeg, eLonMin, eLonSec, eLonSub);
 
+        bCalculate = v.findViewById(R.id.calculate);
+
         for (final EditText editText : orderedInputs) {
             editText.addTextChangedListener(new SwitchToNextFieldWatcher(editText));
             editText.setOnFocusChangeListener(new PadZerosOnFocusLostListener());
@@ -197,10 +202,10 @@ public class CoordinatesInputDialog extends DialogFragment {
         } else {
             buttonCache.setVisibility(View.GONE);
         }
-        final Button buttonCalculate = v.findViewById(R.id.calculate);
+
         if (getActivity() instanceof CalculateState) {
-            buttonCalculate.setOnClickListener(new CalculateListener());
-            buttonCalculate.setVisibility(View.VISIBLE);
+            bCalculate.setOnClickListener(new CalculateListener());
+            bCalculate.setVisibility(View.VISIBLE);
         }
 
         final Button buttonClear = v.findViewById(R.id.clear);
@@ -367,6 +372,15 @@ public class CoordinatesInputDialog extends DialogFragment {
 
         for (final EditText editText : orderedInputs) {
             setSize(editText);
+        }
+
+        if (getActivity() instanceof CalculateState) {
+            final CalculateState calculateState = (CalculateState) getActivity();
+            final CalcState theState = calculateState.fetchCalculatorState();
+
+            if (null != theState) {
+                bCalculate.setTypeface(null, Typeface.ITALIC);
+            }
         }
     }
 

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -39,7 +39,6 @@ import android.widget.TextView;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -182,8 +181,6 @@ public class CoordinatesInputDialog extends DialogFragment {
 
         orderedInputs = Arrays.asList(eLatDeg, eLatMin, eLatSec, eLatSub, eLonDeg, eLonMin, eLonSec, eLonSub);
 
-        bCalculate = v.findViewById(R.id.calculate);
-
         for (final EditText editText : orderedInputs) {
             editText.addTextChangedListener(new SwitchToNextFieldWatcher(editText));
             editText.setOnFocusChangeListener(new PadZerosOnFocusLostListener());
@@ -203,6 +200,7 @@ public class CoordinatesInputDialog extends DialogFragment {
             buttonCache.setVisibility(View.GONE);
         }
 
+        bCalculate = v.findViewById(R.id.calculate);
         if (getActivity() instanceof CalculateState) {
             bCalculate.setOnClickListener(new CalculateListener());
             bCalculate.setVisibility(View.VISIBLE);

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -377,6 +377,7 @@ public class CoordinatesInputDialog extends DialogFragment {
             final CalcState theState = calculateState.fetchCalculatorState();
 
             if (null != theState) {
+                bCalculate.setText(R.string.waypoint_calculated_coordinates);
                 bCalculate.setTypeface(null, Typeface.ITALIC);
             }
         }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
Show text "Calculate coordinates" in the waypoint list for the coordinates of a waypoint, if it has calculated coordinates.
CalcState is only saved, if it has equations / variables. 
![grafik](https://user-images.githubusercontent.com/70113341/116143989-162d1000-a6dc-11eb-9ddd-5210d0f86b24.png)

In the CoordinatesInputDialog the button "Calculate" has italic font, if already a formula is given (I can change this to bold / colored, ... ).
![grafik](https://user-images.githubusercontent.com/70113341/115969621-0bd50f80-a53e-11eb-96f6-11822eda359f.png)


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#6833 , #9899 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Because there is no way to delete the calcState of the waypoint, I added the logic, that a calcState is only set, if it has equations.
Probably it should be extended to "delete the calcState, if the coordinates get cleared by user". But I an not sure about this, so this could be an extra PR.

I am working on showing a icon in addition (like the "tick" for "visited" waypoints), but I am not yet satisfied with the look and feel of that icon, I am not sure, if it is visible enough on small screens (see https://github.com/cgeo/cgeo/issues/9899#issuecomment-782926595)