### PR TITLE
recognize mapsource change in settings without restart (fix #10407)

### DIFF
--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -182,6 +182,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         }
         pref.setEntries(entries);
         pref.setEntryValues(values);
+        pref.setOnPreferenceChangeListener(this);
     }
 
     private void initNavigationMenuPreferences() {


### PR DESCRIPTION
## Description
Add an onChangeListener to the map source preference in settings to recognize a mapsource change without having the need to restart c:geo
