### PR TITLE
More lint fixes

### DIFF
--- a/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
+++ b/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
@@ -15,7 +15,7 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:baselineAligned="false">
 
             <LinearLayout

--- a/main/res/layout/authorization_activity.xml
+++ b/main/res/layout/authorization_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
@@ -16,9 +15,9 @@
             android:id="@+id/auth_1"
             style="@style/authorization_text"
             android:layout_marginBottom="20dip"
-            android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
-            tools:text="Auth text 1"/>
+            tools:text="Auth text 1"
+            app:drawableLeftCompat="@drawable/cgeo_actionbar_squircle" />
 
         <TextView
             android:id="@+id/auth_2"

--- a/main/res/layout/authorization_credentials_activity.xml
+++ b/main/res/layout/authorization_credentials_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
@@ -15,9 +14,9 @@
             android:id="@+id/auth_1"
             style="@style/authorization_text"
             android:layout_marginBottom="20dip"
-            android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
-            tools:text="Auth text 1"/>
+            tools:text="Auth text 1"
+            app:drawableLeftCompat="@drawable/cgeo_actionbar_squircle" />
 
         <TextView
             android:id="@+id/auth_2"

--- a/main/res/layout/authorization_token_activity.xml
+++ b/main/res/layout/authorization_token_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
@@ -15,9 +14,9 @@
             android:id="@+id/auth_1"
             style="@style/authorization_text"
             android:layout_marginBottom="20dip"
-            android:drawableLeft="@drawable/cgeo_actionbar_squircle"
             android:drawablePadding="15dip"
-            tools:text="Auth text 1"/>
+            tools:text="Auth text 1"
+            app:drawableLeftCompat="@drawable/cgeo_actionbar_squircle" />
 
         <TextView
             android:id="@+id/auth_2"

--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/detailScroll"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
@@ -83,11 +82,10 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:layout_marginTop="6dip"
-                android:drawableLeft="?log_img_icon"
                 android:drawablePadding="3dip"
                 android:text="@string/cache_menu_spoilers"
                 android:textColor="?text_color"
-                android:textSize="14sp" />
+                android:textSize="14sp" app:drawableLeftCompat="?log_img_icon" />
         </LinearLayout>
 
         <!-- Personal note box -->

--- a/main/res/layout/coordinates_equations.xml
+++ b/main/res/layout/coordinates_equations.xml
@@ -15,7 +15,7 @@
 
     <LinearLayout
         android:id="@+id/VariablesScrollpane"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:padding="6dp" >

--- a/main/res/layout/logs_item.xml
+++ b/main/res/layout/logs_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    android:layout_width="match_parent"
+<LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto" android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     xmlns:android="http://schemas.android.com/apk/res/android">
@@ -80,10 +79,10 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left|top"
                 android:layout_marginTop="3dip"
-                android:drawableLeft="?log_img_icon"
                 android:drawablePadding="3dip"
                 android:textColor="?text_color"
-                android:textSize="14sp"/>
+                android:textSize="14sp"
+                app:drawableLeftCompat="?log_img_icon" />
         </LinearLayout>
 
     </RelativeLayout>

--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -34,7 +34,8 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoFindOnMap">
+                android:onClick="cgeoFindOnMap"
+                tools:ignore="UseCompoundDrawables">
 
                 <ImageView
                     android:id="@+id/map"
@@ -47,7 +48,8 @@
             </LinearLayout>
 
             <LinearLayout
-                style="@style/icon_mainscreen_cell">
+                style="@style/icon_mainscreen_cell"
+                tools:ignore="UseCompoundDrawables">
 
                 <ImageView
                     android:id="@+id/nearest"
@@ -72,7 +74,8 @@
                     android:textIsSelectable="false" />
 
                 <LinearLayout
-                    style="@style/icon_mainscreen_cell_counter">
+                    style="@style/icon_mainscreen_cell_counter"
+                    tools:ignore="UseCompoundDrawables">
 
                     <ImageView
                         android:id="@+id/search_offline"
@@ -91,7 +94,8 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoSearch">
+                android:onClick="cgeoSearch"
+                tools:ignore="UseCompoundDrawables">
 
                 <ImageView
                     android:id="@+id/advanced_button"
@@ -105,7 +109,8 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoPoint">
+                android:onClick="cgeoPoint"
+                tools:ignore="UseCompoundDrawables">
 
                 <ImageView
                     android:id="@+id/any_button"
@@ -119,7 +124,8 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
-                android:onClick="cgeoFilter">
+                android:onClick="cgeoFilter"
+                tools:ignore="UseCompoundDrawables">
 
                 <ImageView
                     android:id="@+id/filter_button"

--- a/main/res/layout/mapdownloader_item.xml
+++ b/main/res/layout/mapdownloader_item.xml
@@ -23,7 +23,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="@drawable/ic_menu_save"
             android:gravity="left|center_vertical"
-            android:text="@null"/>
+            android:text="@null"
+            tools:ignore="ButtonStyle" />
 
         <Button
             android:id="@+id/retrieve"
@@ -31,7 +32,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="@android:drawable/ic_menu_search"
             android:gravity="left|center_vertical"
-            android:text="@null"/>
+            android:text="@null"
+            tools:ignore="ButtonStyle" />
     </LinearLayout>
 
     <TextView

--- a/main/res/layout/pocketquery_item.xml
+++ b/main/res/layout/pocketquery_item.xml
@@ -23,7 +23,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="@drawable/ic_menu_save"
             android:gravity="left|center_vertical"
-            android:text="@null"/>
+            android:text="@null"
+            tools:ignore="ButtonStyle" />
 
         <Button
             android:id="@+id/cachelist"
@@ -31,7 +32,8 @@
             android:layout_height="wrap_content"
             android:drawableLeft="@android:drawable/ic_menu_search"
             android:gravity="left|center_vertical"
-            android:text="@null"/>
+            android:text="@null"
+            tools:ignore="ButtonStyle" />
     </LinearLayout>
 
     <TextView


### PR DESCRIPTION
## Description
Another bunch of lint fixes:
- use compound drawables (on mainscreen, ignore)
- use `app:drawableLeftCompat` instead of `android:drawableLeft`
- adjust layout width/height options for some calculator elements
- button borders for action buttons in pocket queries and downloader (ignore/keep)
