### PR TITLE
support setting found state for LC connector (fix #10475)

### DIFF
--- a/main/src/cgeo/geocaching/connector/lc/LCConnector.java
+++ b/main/src/cgeo/geocaching/connector/lc/LCConnector.java
@@ -78,6 +78,11 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    public boolean supportsSettingFoundState() {
+        return true;
+    }
+
+    @Override
     public SearchResult searchByGeocode(@Nullable final String geocode, @Nullable final String guid, final DisposableHandler handler) {
         if (geocode == null) {
             return null;


### PR DESCRIPTION
## Description
Support setting state to "found", "did not find" or removing those states for the LC connector (in the same way we have it for UDC)
