### PR TITLE
add info on LC preconditions + move LC close to GC in settings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -535,7 +535,7 @@
     <string name="settings_gc_description">Authorize c:geo with geocaching.com to search for caches.</string>
     <string name="settings_ec_description">Authorize c:geo with extremcaching.com to search for caches and access/filter your found caches.</string>
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
-    <string name="settings_lc_description">Include Adventure Lab caches on the map.</string>
+    <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Requires an activated \"Geocaching.com\" service. Available to \"Geocaching.com\" premium members only.)</string>
     <string name="settings_activate_oc">Activate</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>
     <string name="init_oc_de_description">Authorize c:geo with opencaching.de to search for caches and access/filter your found caches.</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -64,6 +64,32 @@
             </PreferenceScreen>
 
             <PreferenceScreen
+                android:key="@string/preference_screen_lc"
+                android:title="@string/settings_title_lc" >
+
+                <PreferenceCategory android:title="@string/settings_settings"
+                    android:layout="@layout/preference_category" >
+                    <CheckBoxPreference
+                        android:defaultValue="false"
+                        android:key="@string/pref_connectorLCActive"
+                        android:title="@string/settings_activate_lc" />
+                    <cgeo.geocaching.settings.TextPreference
+                        android:layout="@layout/text_preference"
+                        android:text="@string/settings_lc_description" />
+                </PreferenceCategory>
+
+                <PreferenceCategory android:title="@string/settings_information"
+                    android:layout="@layout/preference_category" >
+                    <Preference
+                        android:key="@string/pref_fakekey_lc_website"
+                        android:title="@string/settings_open_website" />
+                    <cgeo.geocaching.settings.CapabilitiesPreference
+                        android:title="@string/settings_features"
+                        app:connector="LC" />
+                </PreferenceCategory>
+            </PreferenceScreen>
+
+            <PreferenceScreen
                 android:key="@string/preference_screen_ocde"
                 android:title="@string/init_oc" >
                 <PreferenceCategory android:title="@string/settings_settings"
@@ -321,33 +347,6 @@
                     <cgeo.geocaching.settings.CapabilitiesPreference
                         android:title="@string/settings_features"
                         app:connector="SU" />
-                </PreferenceCategory>
-            </PreferenceScreen>
-
-            <PreferenceScreen
-                android:key="@string/preference_screen_lc"
-                android:title="@string/settings_title_lc" >
-
-                <PreferenceCategory android:title="@string/settings_settings"
-                    android:layout="@layout/preference_category" >
-                    <CheckBoxPreference
-                        android:defaultValue="false"
-                        android:key="@string/pref_connectorLCActive"
-                        android:title="@string/settings_activate_lc" />
-                    <cgeo.geocaching.settings.TextPreference
-                        android:dependency="@string/pref_connectorLCActive"
-                        android:layout="@layout/text_preference"
-                        android:text="@string/settings_lc_description" />
-                </PreferenceCategory>
-
-                <PreferenceCategory android:title="@string/settings_information"
-                    android:layout="@layout/preference_category" >
-                    <Preference
-                        android:key="@string/pref_fakekey_lc_website"
-                        android:title="@string/settings_open_website" />
-                    <cgeo.geocaching.settings.CapabilitiesPreference
-                        android:title="@string/settings_features"
-                        app:connector="LC" />
                 </PreferenceCategory>
             </PreferenceScreen>
         </PreferenceCategory>


### PR DESCRIPTION
## Description
- adds some explanation about preconditions for LC availability (rel. to #10477)
- moves LC connector in settings directly beneath GC connector
- LC info text is never greyed-out, even if connector is not active

![image](https://user-images.githubusercontent.com/3754370/116141362-db75a880-a6d8-11eb-8010-7e9d810ef3f2.png).![image](https://user-images.githubusercontent.com/3754370/116141388-e3cde380-a6d8-11eb-8282-b5a323d1a060.png)
