### PR TITLE
Rename LC connector and adjust info text (fix #10473)

### DIFF
--- a/main/res/values/changelog_master.xml
+++ b/main/res/values/changelog_master.xml
@@ -6,7 +6,7 @@
 
 <h4>Connectors:</h4>
 <ul>
-<li>New: Added connector for Adventure Lab Caches - To activate it go to Settings => Services => Labs.geocaching.com</li>
+<li>New: Added connector for Adventure Lab Caches - To activate it go to Settings => Services => Geocaching.com Adventure Lab</li>
 </ul>
 
 <h4>Cache details:</h4>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -535,7 +535,7 @@
     <string name="settings_gc_description">Authorize c:geo with geocaching.com to search for caches.</string>
     <string name="settings_ec_description">Authorize c:geo with extremcaching.com to search for caches and access/filter your found caches.</string>
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
-    <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Requires an activated \"Geocaching.com\" service. Available to \"Geocaching.com\" premium members only.)</string>
+    <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)</string>
     <string name="settings_activate_oc">Activate</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>
     <string name="init_oc_de_description">Authorize c:geo with opencaching.de to search for caches and access/filter your found caches.</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -188,7 +188,7 @@
     <string translatable="false" name="caches_map_locus">Locus</string>
     <string translatable="false" name="settings_title_gc">Geocaching.com</string>
     <string translatable="false" name="settings_title_ec">Extremcaching.com</string>
-    <string translatable="false" name="settings_title_lc">Labs.geocaching.com</string>
+    <string translatable="false" name="settings_title_lc">Geocaching.com Adventure Lab</string>
     <string translatable="false" name="init_oc">Opencaching.de</string>
     <string translatable="false" name="auth_ocde">opencaching.de</string>
     <string translatable="false" name="init_oc_pl">Opencaching.pl</string>


### PR DESCRIPTION
## Description
- Renames the LC connector to "Geocaching.com Adventure Lab" (I've chosen this variant to emphasize the relationship to the GC connector)
- Swaps the two info text parts (see screenshot) to make it a bit clearer

![image](https://user-images.githubusercontent.com/3754370/116298198-6f5c7880-a79c-11eb-964e-c697755f2e72.png)
