### PR TITLE
correct imperial conversion in map settings (fix #10341)

### DIFF
--- a/main/src/cgeo/geocaching/location/IConversion.java
+++ b/main/src/cgeo/geocaching/location/IConversion.java
@@ -4,6 +4,8 @@ public interface IConversion {
     float MILES_TO_KILOMETER = 1.609344f;
     float FEET_TO_KILOMETER = 0.0003048f;
     float YARDS_TO_KILOMETER = 0.0009144f;
+    float FEET_TO_METER = 0.3048f;
+
     /**
      * Factor used to calculate distance from meters to foot;
      * <p>

--- a/main/src/cgeo/geocaching/settings/ProximityPreference.java
+++ b/main/src/cgeo/geocaching/settings/ProximityPreference.java
@@ -56,17 +56,17 @@ public class ProximityPreference extends SeekbarPreference {
 
     @Override
     protected String valueToShownValue(final int value) {
-        return Settings.useImperialUnits() ? String.format(Locale.getDefault(), "%.2f", value / ((highRes ? 1 : 1000) * IConversion.MILES_TO_KILOMETER)) : String.valueOf(value);
+        return Settings.useImperialUnits() ? String.format(Locale.getDefault(), "%.2f", value / (highRes ? IConversion.FEET_TO_METER : IConversion.MILES_TO_KILOMETER)) : String.valueOf(value);
     }
 
     @Override
     protected int shownValueToValue(final float shownValue) {
-        return Math.round(Settings.useImperialUnits() ? shownValue * (highRes ? 1 : 1000) * IConversion.MILES_TO_KILOMETER : shownValue);
+        return Math.round(Settings.useImperialUnits() ? shownValue * (highRes ? IConversion.FEET_TO_METER : IConversion.MILES_TO_KILOMETER) : shownValue);
     }
 
     @Override
     protected String getValueString(final int progress) {
-        return valueToShownValue(progressToValue(progress)) + (Settings.useImperialUnits() ? " mi" : (highRes ? " m" : " km"));
+        return valueToShownValue(progressToValue(progress)) + (Settings.useImperialUnits() ? (highRes ? " ft" : " mi") : (highRes ? " m" : " km"));
     }
 
 }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
use correct  conversion factor for imperial length for the proximity notification and max routing distance.

For proximity use ft as unit (meter in metric system), for max routing distance use yd as unit (km in metric system)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#10341
