### PR TITLE
shortened ALC LC-codes issue_#10387

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -162,7 +162,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         final String cacheSize = cache.showSize() ? " (" + cache.getSize().getL10n() + ")" : "";
         details.add(R.string.cache_type, cacheType + cacheSize);
 
-        details.add(R.string.cache_geocode, cache.getGeocode());
+        details.add(R.string.cache_geocode, cache.getShortGeocode());
         details.addCacheState(cache);
 
         cacheDistance = details.addDistance(cache, cacheDistance);

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1171,7 +1171,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
             details.add(R.string.cache_type, cache.getType().getL10n());
             details.addSize(cache);
-            addContextMenu(details.add(R.string.cache_geocode, cache.getGeocode()).right);
+            addContextMenu(details.add(R.string.cache_geocode, cache.getShortGeocode()).right);
             details.addCacheState(cache);
 
             cacheDistanceView = details.addDistance(cache, cacheDistanceView);

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1025,7 +1025,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         }
         final Geocache cache = adapter.getItem(adapterInfo.position);
 
-        menu.setHeaderTitle(StringUtils.defaultIfBlank(cache.getName(), cache.getGeocode()));
+        menu.setHeaderTitle(StringUtils.defaultIfBlank(cache.getName(), cache.getShortGeocode()));
 
         contextMenuGeocode = cache.getGeocode();
 

--- a/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
+++ b/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
@@ -104,7 +104,7 @@ public class NavigateAnyPointActivity extends AbstractActionBarActivity {
 
                 if (null != item) {
                     title.setCompoundDrawablesWithIntrinsicBounds(item.getType().markerId, 0, 0, 0);
-                    detail.setText(item.getGeocode());
+                    detail.setText(item.getShortGeocode());
                 } else {
                     detail.setText(context.getString(R.string.create_internal_cache));
                 }

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -79,7 +79,7 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             if (StringUtils.isNotBlank(waypoint.getName())) {
                 setTitle(waypoint.getName());
             } else {
-                setTitle(waypoint.getGeocode());
+                setTitle(waypoint.getShortGeocode());
             }
 
 
@@ -94,11 +94,11 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             waypointDistance = details.addDistance(waypoint, waypointDistance);
             final String note = waypoint.getNote();
             if (StringUtils.isNotBlank(note)) {
-                details.addHtml(R.string.waypoint_note, note, waypoint.getGeocode());
+                details.addHtml(R.string.waypoint_note, note, waypoint.getShortGeocode());
             }
             final String userNote = waypoint.getUserNote();
             if (StringUtils.isNotBlank(userNote)) {
-                details.addHtml(R.string.waypoint_user_note, userNote, waypoint.getGeocode());
+                details.addHtml(R.string.waypoint_user_note, userNote, waypoint.getShortGeocode());
             }
 
             binding.toggleVisited.setChecked(waypoint.isVisited());

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -255,7 +255,7 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
      * change the titlebar icon and text to show the current geocache
      */
     protected void setCacheTitleBar(@NonNull final Geocache cache) {
-        setTitle(TextUtils.coloredCacheText(cache, cache.getName() + " (" + cache.getGeocode() + ")"));
+        setTitle(TextUtils.coloredCacheText(cache, cache.getName() + " (" + cache.getShortGeocode() + ")"));
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowHomeEnabled(true);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1373,7 +1373,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer {
                     final GeoitemRef item = getItem(position);
                     tv.setText(item.getName());
 
-                    final StringBuilder text = new StringBuilder(item.getItemCode());
+                    final StringBuilder text = new StringBuilder(item.getShortItemCode());
                     final String geocode = item.getGeocode();
                     if (StringUtils.isNotEmpty(geocode)) {
                         final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.utils.TextUtils;
+import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -64,7 +65,7 @@ public class GeoitemRef implements Parcelable {
 
     @NonNull
     public String getShortItemCode() {
-        return itemCode == null ? "" : (itemCode.length() > 8 ? itemCode.substring(0, 8) : itemCode);
+        return generateShortGeocode(itemCode);
     }
 
     public CoordinatesType getType() {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
@@ -62,6 +62,11 @@ public class GeoitemRef implements Parcelable {
         return itemCode;
     }
 
+    @NonNull
+    public String getShortItemCode() {
+        return itemCode == null ? "" : (itemCode.length() > 8 ? itemCode.substring(0, 8) : itemCode);
+    }
+
     public CoordinatesType getType() {
         return type;
     }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -51,6 +51,7 @@ import cgeo.geocaching.utils.LazyInitializedList;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
 import cgeo.geocaching.utils.ShareUtils;
+import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 
 import android.app.Activity;
 import android.content.Context;
@@ -88,6 +89,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+
 
 /**
  * Internal representation of a "cache"
@@ -641,7 +643,7 @@ public class Geocache implements IWaypoint {
 
     @NonNull
     public String getShortGeocode() {
-        return (geocode.length() <= 8) ? geocode : (geocode.substring(0, 8));
+       return generateShortGeocode(geocode);
     }
 
     /**

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -639,6 +639,11 @@ public class Geocache implements IWaypoint {
         return geocode;
     }
 
+    @NonNull
+    public String getShortGeocode() {
+        return (geocode.length() <= 8) ? geocode : (geocode.substring(0, 8));
+    }
+
     /**
      * @return displayed owner, might differ from the real owner
      */

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.MatcherWrapper;
+import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -204,7 +205,7 @@ public class Waypoint implements IWaypoint {
 
     @NonNull
     public String getShortGeocode() {
-        return (geocode.length() <= 8) ? geocode : (geocode.substring(0, 8));
+        return generateShortGeocode(geocode);
     }
 
     public void setGeocode(final String geocode) {

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -202,6 +202,11 @@ public class Waypoint implements IWaypoint {
         return geocode;
     }
 
+    @NonNull
+    public String getShortGeocode() {
+        return (geocode.length() <= 8) ? geocode : (geocode.substring(0, 8));
+    }
+
     public void setGeocode(final String geocode) {
         this.geocode = StringUtils.upperCase(geocode);
     }

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -183,7 +183,7 @@ public final class Formatter {
     public static String formatCacheInfoLong(final Geocache cache) {
         final List<String> infos = new ArrayList<>();
         if (StringUtils.isNotBlank(cache.getGeocode())) {
-            infos.add(cache.getGeocode());
+            infos.add(cache.getShortGeocode());
         }
 
         addShortInfos(cache, infos);
@@ -232,7 +232,7 @@ public final class Formatter {
     @NonNull
     public static String formatCacheInfoHistory(final Geocache cache) {
         final List<String> infos = new ArrayList<>(3);
-        infos.add(StringUtils.upperCase(cache.getGeocode()));
+        infos.add(StringUtils.upperCase(cache.getShortGeocode()));
         infos.add(formatDate(cache.getVisitedDate()));
         infos.add(formatTime(cache.getVisitedDate()));
         return StringUtils.join(infos, SEPARATOR);
@@ -327,7 +327,7 @@ public final class Formatter {
 
     @NonNull
     public static String formatMapSubtitle(final Geocache cache) {
-        return "D " + formatDT(cache.getDifficulty()) + SEPARATOR + "T " + formatDT(cache.getTerrain()) + SEPARATOR + cache.getGeocode();
+        return "D " + formatDT(cache.getDifficulty()) + SEPARATOR + "T " + formatDT(cache.getTerrain()) + SEPARATOR + cache.getShortGeocode();
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -26,6 +26,8 @@ import org.apache.commons.lang3.StringUtils;
 
 public final class Formatter {
 
+    private static final int SHORT_GEOCODE_MAX_LENGTH = 8;
+
     /** Text separator used for formatting texts */
     public static final String SEPARATOR = " · ";
     public static final int MINUTES_PER_DAY = 24 * 60;
@@ -397,11 +399,9 @@ public final class Formatter {
         return truncatedDirs;
     }
 
-    private static final int SHORT_GEOCODE_MAX_LENGTH = 8;
-
     @NonNull
     public static String generateShortGeocode(final String fullGeocode) {
-        return (fullGeocode.length() <= SHORT_GEOCODE_MAX_LENGTH) ? fullGeocode: (fullGeocode.substring(0, SHORT_GEOCODE_MAX_LENGTH) + "…");
+        return (fullGeocode.length() <= SHORT_GEOCODE_MAX_LENGTH) ? fullGeocode : (fullGeocode.substring(0, SHORT_GEOCODE_MAX_LENGTH) + "…");
     }
 
 }

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -397,4 +397,11 @@ public final class Formatter {
         return truncatedDirs;
     }
 
+    private static final int SHORT_GEOCODE_MAX_LENGTH = 8;
+
+    @NonNull
+    public static String generateShortGeocode(final String fullGeocode) {
+        return (fullGeocode.length() <= SHORT_GEOCODE_MAX_LENGTH) ? fullGeocode: (fullGeocode.substring(0, SHORT_GEOCODE_MAX_LENGTH) + "…");
+    }
+
 }


### PR DESCRIPTION
## Description
Adventure Lab Caches use a UUID for identification in the place where other geocaches use a GC-code aka geocode. The UUID is required as an addressing component when fetching data from the geocaching.com servers. The problem with the UUID: It  looks ugly at the UI and it cannot be memorized by the human brain for instance on a tour when one cacher says to another: "Hey what's the GC code for that cache over there ....".

This PR addresses the UI aspects of ALC-UUIDs in the place where a geocode is shown for other caches. There are three relevant scenarios, pls refer to https://github.com/cgeo/cgeo/issues/10387 for a more detailed discussion of these three cases and how they are addressed by this PR. In summary: One case is addressed by a modification in the respective layout.xml file ellipsizing the string, another case is addressed by a new method on cache objects: getShortGeocode() which truncates the geocode to 8 characters.

We should have a discussion whether "8" is an appropriate number as regular geocodes will get longer over time. At this time they are 7 characters long so it will take a very ong time until 8 characters lead to shortened strings even for non-ALC caches.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
https://github.com/cgeo/cgeo/issues/10387
