### PR TITLE
display extra explanation for LC caches (fix #10472)

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -44,6 +44,25 @@
                 android:indeterminateOnly="true" />
         </RelativeLayout>
 
+        <!-- Extra description -->
+
+        <RelativeLayout style="@style/separator_horizontal_layout">
+            <View style="@style/separator_horizontal" />
+            <TextView
+                android:id="@+id/extra_description_title"
+                style="@style/separator_horizontal_headline" />
+        </RelativeLayout>
+
+        <TextView
+            android:id="@+id/extra_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dip"
+            android:layout_marginBottom="12dip"
+            android:textSize="14sp"
+            android:visibility="gone"
+            />
+
         <!-- Hint and spoiler-images box -->
 
         <LinearLayout

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -536,6 +536,7 @@
     <string name="settings_ec_description">Authorize c:geo with extremcaching.com to search for caches and access/filter your found caches.</string>
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
     <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)\n\nChanging this setting requires a restart.</string>
+    <string name="lc_default_description">This is a geocaching.com Adventure Lab Cache. Adventures can only be played with the Groundspeak Adventure Lab App. Tap on the Adventure Lab icon on the \"Details\" page to open/install the Adventure Lab App for this adventure from there.\nIf you don\'t want to see Adenture Lab caches on your map and search, you can deactivate using the \"settings\" menu - Services - Geocaching.com Adventure Lab</string>
     <string name="settings_activate_oc">Activate</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>
     <string name="init_oc_de_description">Authorize c:geo with opencaching.de to search for caches and access/filter your found caches.</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -20,6 +20,7 @@ import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.connector.capability.PgcChallengeCheckerCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
 import cgeo.geocaching.connector.internal.InternalConnector;
+import cgeo.geocaching.connector.lc.LCConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.databinding.CachedetailDescriptionPageBinding;
@@ -1647,6 +1648,21 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
             if (StringUtils.isNotBlank(cache.getDescription()) || cache.supportsDescriptionchange()) {
                 loadLongDescription(parentView);
             }
+
+            // extra description
+            final String geocode = cache.getGeocode();
+            boolean hasExtraDescription = LCConnector.getInstance().canHandle(geocode); // could be generalized, but currently it's only LC
+            if (hasExtraDescription) {
+                final IConnector conn = ConnectorFactory.getConnector(geocode);
+                if (conn != null) {
+                    binding.extraDescriptionTitle.setText(conn.getName());
+                    binding.extraDescription.setText(conn.getExtraDescription());
+                } else {
+                    hasExtraDescription = false;
+                }
+            }
+            binding.extraDescriptionTitle.setVisibility(hasExtraDescription ? View.VISIBLE : View.GONE);
+            binding.extraDescription.setVisibility(hasExtraDescription ? View.VISIBLE : View.GONE);
 
             // cache personal note
             setPersonalNote(binding.personalnote, binding.personalnoteButtonSeparator, cache.getPersonalNote());

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -104,6 +104,11 @@ public abstract class AbstractConnector implements IConnector {
     }
 
     @Override
+    public String getExtraDescription() {
+        return "";
+    }
+
+    @Override
     public boolean supportsSettingFoundState() {
         return false;
     }

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -99,6 +99,12 @@ public interface IConnector {
      */
     boolean supportsDescriptionchange();
 
+
+    /**
+     * Shall an extra description be displayed on cache detail page?
+     */
+    String getExtraDescription();
+
     /**
      * enable/disable changing found state of a cache
      */

--- a/main/src/cgeo/geocaching/connector/lc/LCConnector.java
+++ b/main/src/cgeo/geocaching/connector/lc/LCConnector.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.connector.lc;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.AbstractConnector;
@@ -32,8 +33,11 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     @NonNull
     private static final Pattern PATTERN_LC_CODE = Pattern.compile("LC[-\\w]+", Pattern.CASE_INSENSITIVE);
 
+    private final String name;
+
     private LCConnector() {
         // singleton
+        name = CgeoApplication.getInstance().getString(R.string.settings_title_lc);
     }
 
     /**
@@ -62,7 +66,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     @NonNull
     public String getName() {
-        return "labs.geocaching.com";
+        return name;
     }
 
     @Override
@@ -75,6 +79,11 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     @NonNull
     public String getHost() {
         return "labs.geocaching.com";
+    }
+
+    @Override
+    public String getExtraDescription() {
+        return CgeoApplication.getInstance().getString(R.string.lc_default_description);
     }
 
     @Override


### PR DESCRIPTION
## Description
Displays an extra description for LC caches on cache description page. Text is being displayed in a separate block beneath the cache's description:

![image](https://user-images.githubusercontent.com/3754370/116459084-a9458180-a865-11eb-8d70-9a07232256cb.png)
