### PR TITLE
switch LC connector active default to true (fix #10477)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -535,7 +535,7 @@
     <string name="settings_gc_description">Authorize c:geo with geocaching.com to search for caches.</string>
     <string name="settings_ec_description">Authorize c:geo with extremcaching.com to search for caches and access/filter your found caches.</string>
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
-    <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)</string>
+    <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)\n\nChanging this setting requires a restart.</string>
     <string name="settings_activate_oc">Activate</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>
     <string name="init_oc_de_description">Authorize c:geo with opencaching.de to search for caches and access/filter your found caches.</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -70,7 +70,7 @@
                 <PreferenceCategory android:title="@string/settings_settings"
                     android:layout="@layout/preference_category" >
                     <CheckBoxPreference
-                        android:defaultValue="false"
+                        android:defaultValue="true"
                         android:key="@string/pref_connectorLCActive"
                         android:title="@string/settings_activate_lc" />
                     <cgeo.geocaching.settings.TextPreference

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -492,7 +492,7 @@ public class Settings {
     }
 
     public static boolean isLCConnectorActive() {
-        return getBoolean(R.string.pref_connectorLCActive, false);
+        return getBoolean(R.string.pref_connectorLCActive, true);
     }
 
     public static void setLCConnectorActive(final boolean value) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -495,10 +495,6 @@ public class Settings {
         return getBoolean(R.string.pref_connectorLCActive, true);
     }
 
-    public static void setLCConnectorActive(final boolean value) {
-        putBoolean(R.string.pref_connectorLCActive, value);
-    }
-
     public static boolean isSUConnectorActive() {
         return getBoolean(R.string.pref_connectorSUActive, false);
     }


### PR DESCRIPTION
## Description
- sets default for LC connector to activated==true (fixes #10477)
- removes an unused LC method in Settings
- adds info about required restart to the preferences screen
