### PR TITLE
move offline routing settings to navigation (fix #10502)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -510,8 +510,8 @@
     <string name="confirm_data_dir_move">Moving the geocache data might take a really long time, depending on your device and the amount of data.</string>
 
     <string name="settings_title_basicmembers">Options for Basic Members</string>
-    <string name="settings_title_navigation">Navigation</string>
-    <string name="settings_summary_navigation">Choose preferred navigation methods and select external navigation apps.</string>
+    <string name="settings_title_navigation">Routing / Navigation</string>
+    <string name="settings_summary_navigation">Configure offline routing, choose preferred navigation methods and select external navigation apps.</string>
     <string name="settings_title_system">System</string>
     <string name="settings_summary_system">System specific settings and debugging options.</string>
     <string name="settings_title_navigation_menu">Navigation Menu</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -640,72 +640,6 @@
                 android:entryValues="@array/maprotationValues" />
         </PreferenceCategory>
 
-        <PreferenceCategory android:title="@string/settings_title_offline_routing" android:summary="@string/settings_summary_offline_routing"
-            android:layout="@layout/preference_category">
-            <Preference
-                android:selectable="false"
-                android:key="@string/pref_fakekey_brouterDistanceThresholdTitle"
-                android:summary="@string/init_brouterThreshold_description"
-                android:title="@string/init_brouterThreshold" />
-            <cgeo.geocaching.settings.ProximityPreference
-                android:key="@string/pref_brouterDistanceThreshold"
-                app:min="1"
-                app:max="@integer/brouter_threshold_max"
-                android:defaultValue="@integer/brouter_threshold_default"
-                app:highRes="false" />
-
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_brouterShowBothDistances"
-                android:summary="@string/init_summary_brouterShowBothDistances"
-                android:title="@string/init_brouterShowBothDistances" />
-
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_useInternalRouting"
-                android:summary="@string/init_summary_useInternalRouting"
-                android:title="@string/init_useInternalRouting" />
-
-            <Preference
-                android:key="@string/pref_persistablefolder_routingtiles"
-                android:title="@string/init_brouter_directory_description"
-                android:dependency="@string/pref_useInternalRouting" />
-
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_brouterAutoTileDownloads"
-                android:summary="@string/init_brouterAutoTileDownloads_description"
-                android:dependency="@string/pref_useInternalRouting"
-                android:title="@string/init_autoDownloads" />
-
-            <Preference
-                android:selectable="false"
-                android:summary="@string/init_updateinterval_description"
-                android:title="@string/init_updateinterval_title"
-                android:dependency="@string/pref_brouterAutoTileDownloads" />
-            <cgeo.geocaching.settings.SeekbarPreference
-                android:key="@string/pref_brouterAutoTileDownloadsInterval"
-                app:min="0"
-                app:max="@integer/brouter_updateinterval_max"
-                android:defaultValue="@integer/brouter_updateinterval_default"
-                android:dependency="@string/pref_brouterAutoTileDownloads" />
-
-            <ListPreference
-                android:dialogTitle="@string/init_brouterProfileWalk"
-                android:key="@string/pref_brouterProfileWalk"
-                android:title="@string/init_brouterProfileWalk" />
-            <ListPreference
-                android:dialogTitle="@string/init_brouterProfileBike"
-                android:key="@string/pref_brouterProfileBike"
-                android:title="@string/init_brouterProfileBike" />
-            <ListPreference
-                android:defaultValue="car-eco.brf"
-                android:dialogTitle="@string/init_brouterProfileCar"
-                android:key="@string/pref_brouterProfileCar"
-                android:title="@string/init_brouterProfileCar" />
-
-        </PreferenceCategory>
-
         <PreferenceCategory android:title="@string/settings_title_waypoints"
             android:layout="@layout/preference_category" >
             <Preference
@@ -1019,6 +953,72 @@
         android:icon="?attr/settings_arrow"
         android:title="@string/settings_title_navigation"
         android:summary="@string/settings_summary_navigation" >
+
+        <PreferenceCategory android:title="@string/settings_title_offline_routing" android:summary="@string/settings_summary_offline_routing"
+            android:layout="@layout/preference_category">
+            <Preference
+                android:selectable="false"
+                android:key="@string/pref_fakekey_brouterDistanceThresholdTitle"
+                android:summary="@string/init_brouterThreshold_description"
+                android:title="@string/init_brouterThreshold" />
+            <cgeo.geocaching.settings.ProximityPreference
+                android:key="@string/pref_brouterDistanceThreshold"
+                app:min="1"
+                app:max="@integer/brouter_threshold_max"
+                android:defaultValue="@integer/brouter_threshold_default"
+                app:highRes="false" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_brouterShowBothDistances"
+                android:summary="@string/init_summary_brouterShowBothDistances"
+                android:title="@string/init_brouterShowBothDistances" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_useInternalRouting"
+                android:summary="@string/init_summary_useInternalRouting"
+                android:title="@string/init_useInternalRouting" />
+
+            <Preference
+                android:key="@string/pref_persistablefolder_routingtiles"
+                android:title="@string/init_brouter_directory_description"
+                android:dependency="@string/pref_useInternalRouting" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="@string/pref_brouterAutoTileDownloads"
+                android:summary="@string/init_brouterAutoTileDownloads_description"
+                android:dependency="@string/pref_useInternalRouting"
+                android:title="@string/init_autoDownloads" />
+
+            <Preference
+                android:selectable="false"
+                android:summary="@string/init_updateinterval_description"
+                android:title="@string/init_updateinterval_title"
+                android:dependency="@string/pref_brouterAutoTileDownloads" />
+            <cgeo.geocaching.settings.SeekbarPreference
+                android:key="@string/pref_brouterAutoTileDownloadsInterval"
+                app:min="0"
+                app:max="@integer/brouter_updateinterval_max"
+                android:defaultValue="@integer/brouter_updateinterval_default"
+                android:dependency="@string/pref_brouterAutoTileDownloads" />
+
+            <ListPreference
+                android:dialogTitle="@string/init_brouterProfileWalk"
+                android:key="@string/pref_brouterProfileWalk"
+                android:title="@string/init_brouterProfileWalk" />
+            <ListPreference
+                android:dialogTitle="@string/init_brouterProfileBike"
+                android:key="@string/pref_brouterProfileBike"
+                android:title="@string/init_brouterProfileBike" />
+            <ListPreference
+                android:defaultValue="car-eco.brf"
+                android:dialogTitle="@string/init_brouterProfileCar"
+                android:key="@string/pref_brouterProfileCar"
+                android:title="@string/init_brouterProfileCar" />
+
+        </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/init_default_navigation_tool"
             android:layout="@layout/preference_category" >

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -197,6 +197,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         initBackupButtons();
         initDbLocationPreference();
         initMapPreferences();
+        initOfflineRoutingPreferences();
         initGeoDirPreferences();
         initDebugPreference();
         initForceOrientationSensorPreference();
@@ -594,14 +595,6 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     }
 
     private void initMapPreferences() {
-        getPreference(R.string.pref_useInternalRouting).setOnPreferenceChangeListener((preference, newValue) -> {
-            updateRoutingPrefs(!Settings.useInternalRouting());
-            return true;
-        });
-        updateRoutingPrefs(Settings.useInternalRouting());
-
-        updateRoutingProfilesPrefs();
-
         getPreference(R.string.pref_bigSmileysOnMap).setOnPreferenceChangeListener((preference, newValue) -> {
             setResult(RESTART_NEEDED);
             return true;
@@ -611,6 +604,15 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             RenderThemeHelper.changeSyncSetting(this, (newValue instanceof Boolean) ? ((Boolean) newValue).booleanValue() : false, changedValue -> {
                 ((CheckBoxPreference) getPreference(R.string.pref_renderthemefolder_synctolocal)).setChecked(changedValue);
         }));
+    }
+
+    private void initOfflineRoutingPreferences() {
+        getPreference(R.string.pref_useInternalRouting).setOnPreferenceChangeListener((preference, newValue) -> {
+            updateRoutingPrefs(!Settings.useInternalRouting());
+            return true;
+        });
+        updateRoutingPrefs(Settings.useInternalRouting());
+        updateRoutingProfilesPrefs();
     }
 
     private void updateRoutingProfilesPrefs() {


### PR DESCRIPTION
## Description
- moves the "offline routing" block from map settings to navigation settings
- renames "Navigation" to "Offline routing / Navigation" and adapts its description

