### PR TITLE
store cache to default list on found state change (if needed)

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -253,7 +253,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
 
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
-        if (CacheMenuHandler.onMenuItemSelected(item, this, cache, null)) {
+        if (CacheMenuHandler.onMenuItemSelected(item, this, cache, this::init)) {
             return true;
         }
         if (LoggingUI.onMenuItemSelected(item, getActivity(), cache, dialog -> init())) {

--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.apps.navi.NavigationSelectionActionProvider;
 import cgeo.geocaching.calendar.CalendarAdder;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
@@ -20,6 +21,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.Fragment;
+
+import java.util.Collections;
 
 /**
  * Shared menu handling for all activities having menu items related to a cache. <br>
@@ -89,6 +92,10 @@ public final class CacheMenuHandler extends AbstractUIFactory {
     private static void setFoundState(final Activity activity, final Geocache cache, final boolean foundState, final boolean dnfState, @Nullable final Runnable notifyDataSetChanged) {
         cache.setFound(foundState);
         cache.setDNF(dnfState);
+        if (!cache.isOffline()) {
+            // store to default list if not yet stored
+            cache.setLists(Collections.singleton(StoredList.STANDARD_LIST_ID));
+        }
         DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
         Toast.makeText(activity, R.string.cache_foundstate_updated, Toast.LENGTH_SHORT).show();
         if (notifyDataSetChanged != null) {
@@ -107,9 +114,9 @@ public final class CacheMenuHandler extends AbstractUIFactory {
         menu.findItem(R.id.menu_navigate).setVisible(hasCoords);
         menu.findItem(R.id.menu_log_visit).setVisible(cache.supportsLogging() && !Settings.getLogOffline());
         menu.findItem(R.id.menu_log_visit_offline).setVisible(cache.supportsLogging() && Settings.getLogOffline());
-        menu.findItem(R.id.menu_set_found).setVisible(cache.isOffline() && cache.supportsSettingFoundState() && !cache.isFound());
-        menu.findItem(R.id.menu_set_DNF).setVisible(cache.isOffline() && cache.supportsSettingFoundState() && !cache.isDNF());
-        menu.findItem(R.id.menu_reset_foundstate).setVisible(cache.isOffline() && cache.supportsSettingFoundState() && (cache.isFound() || cache.isDNF()));
+        menu.findItem(R.id.menu_set_found).setVisible(cache.supportsSettingFoundState() && !cache.isFound());
+        menu.findItem(R.id.menu_set_DNF).setVisible(cache.supportsSettingFoundState() && !cache.isDNF());
+        menu.findItem(R.id.menu_reset_foundstate).setVisible(cache.supportsSettingFoundState() && (cache.isFound() || cache.isDNF()));
         // some connectors don't support URL - we don't need "open in browser" for those caches
         menu.findItem(R.id.menu_show_in_browser).setVisible(cache.getUrl() != null);
         // submenu share / export


### PR DESCRIPTION
## Description
- always show found state change menu entries in cache popup, even if cache is not yet saved
- on selecting such a menu entry, store cache to default list, if cache is not yet stored offline
- fixes #10501

