### PR TITLE
fix availability/connected check for routing connection (fix #10503)

### DIFF
--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -482,7 +482,7 @@ public class InstallWizardActivity extends AppCompatActivity {
     }
 
     private static boolean broutertilesFolderNeedsMigration() {
-        return Settings.isBrouterAutoTileDownloads() && PersistableFolder.ROUTING_TILES.isLegacy() && Routing.isInstalled();
+        return Settings.isBrouterAutoTileDownloads() && PersistableFolder.ROUTING_TILES.isLegacy() && Routing.isExternalRoutingInstalled();
     }
 
     private void requestBroutertilesfolder() {

--- a/main/src/cgeo/geocaching/maps/routing/AbstractServiceConnection.java
+++ b/main/src/cgeo/geocaching/maps/routing/AbstractServiceConnection.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.maps.routing;
 
+import cgeo.geocaching.utils.Log;
+
 import android.content.ComponentName;
 import android.content.ServiceConnection;
 import android.os.Bundle;
@@ -17,6 +19,7 @@ class AbstractServiceConnection implements ServiceConnection {
 
     @Override
     public void onServiceConnected(final ComponentName className, final IBinder service) {
+        Log.d("connection to brouter established");
         if (null != onServiceConnectedCallback) {
             onServiceConnectedCallback.run();
         }
@@ -24,6 +27,7 @@ class AbstractServiceConnection implements ServiceConnection {
 
     @Override
     public void onServiceDisconnected(final ComponentName className) {
+        Log.d("connection to brouter disconnected");
         this.onServiceConnectedCallback = null;
         routingService = null;
     }

--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -67,7 +67,7 @@ public final class Routing {
             REGISTERED_CALLBACKS.put(callbackKey, onServiceConnectedCallback);
         }
 
-        if (routingServiceConnection != null && routingServiceConnection.isConnected()) {
+        if (isConnected()) {
             //already connected
             return;
         }
@@ -82,10 +82,7 @@ public final class Routing {
         }
 
         if (!getContext().bindService(intent, routingServiceConnection, Context.BIND_AUTO_CREATE)) {
-            routingServiceConnection = null;
-            Log.d("Connecting brouter failed");
-        } else {
-            Log.d("brouter connected");
+            Log.d("Connecting brouter: bindService failed or delayed");
         }
     }
 
@@ -107,7 +104,7 @@ public final class Routing {
 
         if (connectCount <= 0) {
             connectCount = 0;
-            if (routingServiceConnection != null && routingServiceConnection.isConnected()) {
+            if (isConnected()) {
                 getContext().unbindService(routingServiceConnection);
                 routingServiceConnection = null;
 
@@ -298,15 +295,23 @@ public final class Routing {
         timeLastUpdate = 0;
     }
 
+    /** Are we currently connected to any routing service (internal/external)? */
+    public static boolean isConnected() {
+        return routingServiceConnection != null && routingServiceConnection.isConnected();
+    }
+
+    /** Is any routing service available (internal/external) */
     public static boolean isAvailable() {
-        return routingServiceConnection != null;
+        return isConnected() || Settings.useInternalRouting() || isExternalRoutingInstalled();
     }
 
-    public static boolean isInstalled() {
-        return ProcessUtils.isInstalled(getPackageName());
+    /** Is external routing app installed? */
+    public static boolean isExternalRoutingInstalled() {
+        return ProcessUtils.isInstalled(getExternalRoutingPackageName());
     }
 
-    public static String getPackageName() {
+    /** Get Android package name for external routing app */
+    public static String getExternalRoutingPackageName() {
         return getContext().getString(R.string.package_brouter);
     }
 }

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
-import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.playservices.GooglePlayServices;
 import cgeo.geocaching.sensors.MagnetometerAndAccelerometerProvider;
 import cgeo.geocaching.sensors.OrientationProvider;
@@ -109,7 +108,7 @@ public final class SystemInformation {
         if (GCConnector.getInstance().isActive()) {
             body.append("\n- Geocaching.com date format: ").append(Settings.getGcCustomDate());
         }
-        body.append("\n- Routing: ").append(Settings.useInternalRouting() ? "internal" : "external").append(" / connection available: ").append(Routing.isAvailable()).append(" / BRouter installed: ").append(ProcessUtils.isInstalled(context.getString(R.string.package_brouter)));
+        body.append("\n- Routing: ").append(Settings.useInternalRouting() ? "internal" : "external").append(" / BRouter installed: ").append(ProcessUtils.isInstalled(context.getString(R.string.package_brouter)));
         appendAddons(body);
 
         body.append("\n")


### PR DESCRIPTION
## Description
- do not throw away the connection variable, if connection could not be established in `bindService` directly (allow asynchronicity)
- distinguish between "is currently connected" and "is generally available" checks
- label the corresponding functions more clearly
