### PR TITLE
add option to export individual route as track (fix #10516)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -178,6 +178,11 @@
                 android:visible="false">
             </item>
             <item
+                android:id="@+id/menu_export_individual_route_as_track"
+                android:title="@string/map_export_individual_route_as_track"
+                android:visible="false">
+            </item>
+            <item
                 android:id="@+id/menu_clear_individual_route"
                 android:title="@string/map_clear_individual_route"
                 android:visible="false">

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1992,7 +1992,8 @@
     <string name="individual_route_error_toggling_waypoint">error toggling waypoint</string>
     <string name="individual_route_error_single_waypoint_mode">Not available in single waypoint mode</string>
     <string name="map_sort_individual_route">Sort individual route</string>
-    <string name="map_export_individual_route">Export individual route</string>
+    <string name="map_export_individual_route">Export as route</string>
+    <string name="map_export_individual_route_as_track">Export as track</string>
     <string name="map_load_individual_route">Load individual route</string>
     <string name="map_load_individual_route_confirm">Overwrite existing route?</string>
     <string name="map_autotarget_individual_route">Set route start as target</string>

--- a/main/src/cgeo/geocaching/utils/FileNameCreator.java
+++ b/main/src/cgeo/geocaching/utils/FileNameCreator.java
@@ -18,6 +18,7 @@ public class FileNameCreator {
     public static final FileNameCreator MEMORY_DUMP = new FileNameCreator("cgeo_dump", "hprof");
     public static final FileNameCreator GPX_EXPORT = new FileNameCreator("export", "gpx");
     public static final FileNameCreator INDIVIDUAL_ROUTE_NOSUFFIX = new FileNameCreator("route", null);
+    public static final FileNameCreator INDIVIDUAL_TRACK_NOSUFFIX = new FileNameCreator("track", null);
     public static final FileNameCreator TRAIL_HISTORY = new FileNameCreator("trail", "gpx");
 
     public static final FileNameCreator OFFLINE_LOG_IMAGE = new FileNameCreator("cgeo-image-%s", "jpg");

--- a/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
+++ b/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
@@ -54,6 +54,7 @@ public class IndividualRouteUtils {
         menu.findItem(R.id.menu_sort_individual_route).setVisible(isVisible);
         menu.findItem(R.id.menu_center_on_route).setVisible(isVisible);
         menu.findItem(R.id.menu_export_individual_route).setVisible(isVisible);
+        menu.findItem(R.id.menu_export_individual_route_as_track).setVisible(isVisible);
         menu.findItem(R.id.menu_clear_individual_route).setVisible(isVisible);
         menu.findItem(R.id.menu_clear_targets).setVisible(targetIsSet || Settings.isAutotargetIndividualRoute());
         menu.findItem(R.id.menu_autotarget_individual_route).setVisible(true).setChecked(Settings.isAutotargetIndividualRoute());
@@ -62,8 +63,10 @@ public class IndividualRouteUtils {
     /**
      * Check if selected menu entry is regarding individual routes
      *
-     * @param activity calling activity
      * @param id       menu entry id
+     * @param route    current route
+     * @param centerOnPosition  method to call to center on route
+     * @param setTarget         method to call on set target
      * @return true, if selected menu entry is individual route related and consumed / false else
      */
     public boolean onOptionsItemSelected(final int id, final IndividualRoute route, final Route.CenterOnPosition centerOnPosition, final Action2<Geopoint, String> setTarget) {
@@ -78,7 +81,9 @@ public class IndividualRouteUtils {
         } else if (id == R.id.menu_center_on_route) {
             route.setCenter(centerOnPosition);
         } else if (id == R.id.menu_export_individual_route) {
-            new IndividualRouteExport(activity, route);
+            new IndividualRouteExport(activity, route, false);
+        } else if (id == R.id.menu_export_individual_route_as_track) {
+            new IndividualRouteExport(activity, route, true);
         } else if (id == R.id.menu_clear_individual_route) {
             Dialogs.confirm(activity, R.string.map_clear_individual_route, R.string.map_clear_individual_route_confirm, (dialog, which) -> {
                 clearIndividualRoute.run();


### PR DESCRIPTION
## Description
- adds option "Export as track" to individual route menu on map
- renames option "Export individual route" to "Export as route" in individual route menu on map
- default filename for export as track is prefixed with "track" instead of "route"
- exported track has one track segment per waypoint of the individual route
