### PR TITLE
add hylly suomi map & themes (fix #10511)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2126,6 +2126,8 @@
     <string name="mapserver_openandromaps_themes_info">Detailed map theme, built for \"OpenAndroMaps\" maps</string>
     <string name="mapserver_freizeitkarte_info">Detailed maps, require one of the \"freizeitkarte\" map themes.</string>
     <string name="mapserver_freizeitkarte_themes_info">Detailed map theme, built for \"Freizeitkarte\" maps</string>
+    <string name="mapserver_hylly_info">Detailed maps for Finland, require one of the \"Hylly\" map themes</string>
+    <string name="mapserver_hylly_themes_info">Detailed map theme, built for \"Hylly\" maps</string>
     <string name="brouter_info">Offline routing service</string>
 
     <!-- history track -->

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -276,6 +276,16 @@
     <string translatable="false" name="mapserver_freizeitkarte_themes_name">Freizeitkarte Themes</string>
     <string translatable="false" name="mapserver_freizeitkarte_themes_downloadurl">http://download.freizeitkarte-osm.de/android/2012/</string>
 
+    <string translatable="false" name="mapserver_hylly_name">Hylly</string>
+    <string translatable="false" name="mapserver_hylly_updatecheckurl">https://kartat.hylly.org/</string>
+    <string translatable="false" name="mapserver_hylly_downloadurl">https://kartat-dl.hylly.org/</string>
+    <string translatable="false" name="mapserver_hylly_likeiturl">https://kartat.hylly.org/</string>
+    <string translatable="false" name="mapserver_hylly_projecturl">https://kartat.hylly.org/</string>
+
+    <string translatable="false" name="mapserver_hylly_themes_name">Hylly Themes</string>
+    <string translatable="false" name="mapserver_hylly_themes_updatecheckurl">https://kartat.hylly.org/</string>
+    <string translatable="false" name="mapserver_hylly_themes_downloadurl">https://kartat-dl.hylly.org/</string>
+
     <string translatable="false" name="brouter_name">BRouter</string>
     <string translatable="false" name="brouter_downloadurl">http://brouter.de/brouter/segments4/</string>
     <string translatable="false" name="brouter_projecturl">https://www.brouter.de/brouter/</string>

--- a/main/src/cgeo/geocaching/downloader/AbstractThemeDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractThemeDownloader.java
@@ -1,0 +1,28 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
+import cgeo.geocaching.models.Download;
+import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.UriUtils;
+
+import android.net.Uri;
+
+import androidx.annotation.StringRes;
+
+abstract class AbstractThemeDownloader extends AbstractDownloader {
+
+    AbstractThemeDownloader(final Download.DownloadType offlineMapType, final @StringRes int mapBase, final @StringRes int mapSourceName, final @StringRes int mapSourceInfo, final @StringRes int projectUrl, final @StringRes int likeItUrl) {
+        super(offlineMapType, mapBase, mapSourceName, mapSourceInfo, projectUrl, likeItUrl, PersistableFolder.OFFLINE_MAP_THEMES);
+        this.forceExtension = FileUtils.ZIP_FILE_EXTENSION;
+    }
+
+    @Override
+    protected void onSuccessfulReceive(final Uri result) {
+        //resync
+        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
+        //set map theme
+        RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));
+    }
+
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarteThemes.java
@@ -3,12 +3,9 @@ package cgeo.geocaching.downloader;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.files.InvalidXMLCharacterFilterReader;
-import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
 import cgeo.geocaching.models.Download;
-import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
-import cgeo.geocaching.utils.UriUtils;
 
 import android.net.Uri;
 import android.sax.Element;
@@ -26,12 +23,11 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.SAXException;
 
-public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
+public class MapDownloaderFreizeitkarteThemes extends AbstractThemeDownloader {
     private static final MapDownloaderFreizeitkarteThemes INSTANCE = new MapDownloaderFreizeitkarteThemes();
 
     private MapDownloaderFreizeitkarteThemes() {
-        super(Download.DownloadType.DOWNLOADTYPE_THEME_FREIZEITKARTE, R.string.mapserver_freizeitkarte_downloadurl, R.string.mapserver_freizeitkarte_themes_name, R.string.mapserver_freizeitkarte_themes_info, R.string.mapserver_freizeitkarte_projecturl, R.string.mapserver_freizeitkarte_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
-        this.forceExtension = ".zip";
+        super(Download.DownloadType.DOWNLOADTYPE_THEME_FREIZEITKARTE, R.string.mapserver_freizeitkarte_downloadurl, R.string.mapserver_freizeitkarte_themes_name, R.string.mapserver_freizeitkarte_themes_info, R.string.mapserver_freizeitkarte_projecturl, R.string.mapserver_freizeitkarte_likeiturl);
     }
 
     private static class FZKParser {
@@ -87,14 +83,6 @@ public class MapDownloaderFreizeitkarteThemes extends AbstractDownloader {
     @Override
     protected String getUpdatePageUrl(final String downloadPageUrl) {
         return CgeoApplication.getInstance().getString(R.string.mapserver_freizeitkarte_downloadurl);
-    }
-
-    @Override
-    protected void onSuccessfulReceive(final Uri result) {
-        //resync
-        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
-        //set map theme
-        RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderHylly.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderHylly.java
@@ -1,0 +1,63 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Download;
+import cgeo.geocaching.utils.MatcherWrapper;
+
+import android.app.Activity;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class MapDownloaderHylly extends AbstractMapDownloader {
+    private static final Pattern PATTERN_MAP = Pattern.compile("href=\"(https:\\/\\/kartat-dl\\.hylly\\.org\\/(\\d{4}-\\d\\d-\\d\\d)\\/(mtk_suomi\\.map))\">mtk_suomi.map<\\/a>\\s*<\\/td>\\s*<td>(\\d+\\.\\d+ GB)<\\/td>"); // 1:url, 2:date yyyy-MM-dd, 3:file name, 4:size (string)
+    private static final String[] THEME_FILES = {"peruskartta.zip"};
+    private static final MapDownloaderHylly INSTANCE = new MapDownloaderHylly();
+
+    private MapDownloaderHylly() {
+        super (Download.DownloadType.DOWNLOADTYPE_MAP_HYLLY, R.string.mapserver_hylly_updatecheckurl, R.string.mapserver_hylly_name, R.string.mapserver_hylly_info, R.string.mapserver_hylly_projecturl, R.string.mapserver_hylly_likeiturl);
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<Download> list, final String page) {
+        final MatcherWrapper matchMap = new MatcherWrapper(PATTERN_MAP, page);
+        while (matchMap.find()) {
+            final Download offlineMap = new Download(matchMap.group(3), Uri.parse(matchMap.group(1)), false, matchMap.group(2), matchMap.group(4), offlineMapType);
+            list.add(offlineMap);
+        }
+    }
+
+    @Override
+    protected Download checkUpdateFor(final String page, final String remoteUrl, final String remoteFilename) {
+        final MatcherWrapper matchMap = new MatcherWrapper(PATTERN_MAP, page);
+        while (matchMap.find()) {
+            final String filename = matchMap.group(3);
+            if (filename.equals(remoteFilename)) {
+                return new Download(matchMap.group(3), Uri.parse(remoteUrl + "/" + filename), false, matchMap.group(2), matchMap.group(4), offlineMapType);
+            }
+        }
+        return null;
+    }
+
+    // hylly uses different servers for update check and download, need to map here
+    @Override
+    protected String getUpdatePageUrl(final String downloadPageUrl) {
+        return CgeoApplication.getInstance().getString(R.string.mapserver_hylly_updatecheckurl);
+    }
+
+
+    @Override
+    protected void onFollowup(final Activity activity, final Runnable callback) {
+        // check whether theme file exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
+        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_hylly_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY, callback);
+    }
+
+    @NonNull
+    public static MapDownloaderHylly getInstance() {
+        return INSTANCE;
+    }
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderHyllyThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderHyllyThemes.java
@@ -1,0 +1,54 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Download;
+import cgeo.geocaching.utils.MatcherWrapper;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class MapDownloaderHyllyThemes extends AbstractThemeDownloader {
+    private static final Pattern PATTERN_MAP = Pattern.compile("href=\"(https:\\/\\/kartat-dl\\.hylly\\.org\\/(\\d{4}-\\d\\d-\\d\\d)\\/([\\w ]+\\.zip))\">[\\w ]+kartta\\.zip<\\/a>"); // 1:url, 2:date yyyy-MM-dd, 3:file name, 4:size (string)
+    private static final MapDownloaderHyllyThemes INSTANCE = new MapDownloaderHyllyThemes();
+
+    private MapDownloaderHyllyThemes() {
+        super (Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY, R.string.mapserver_hylly_themes_updatecheckurl, R.string.mapserver_hylly_themes_name, R.string.mapserver_hylly_themes_info, R.string.mapserver_hylly_projecturl, R.string.mapserver_hylly_likeiturl);
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<Download> list, final String page) {
+        final MatcherWrapper matchMap = new MatcherWrapper(PATTERN_MAP, page);
+        while (matchMap.find()) {
+            final Download offlineMap = new Download(matchMap.group(3), Uri.parse(matchMap.group(1)), false, matchMap.group(2), "", offlineMapType);
+            list.add(offlineMap);
+        }
+    }
+
+    @Override
+    protected Download checkUpdateFor(final String page, final String remoteUrl, final String remoteFilename) {
+        final MatcherWrapper matchMap = new MatcherWrapper(PATTERN_MAP, page);
+        while (matchMap.find()) {
+            final String filename = matchMap.group(3);
+            if (filename.equals(remoteFilename)) {
+                return new Download(matchMap.group(3), Uri.parse(remoteUrl + "/" + filename), false, matchMap.group(2), "", offlineMapType);
+            }
+        }
+        return null;
+    }
+
+    // hylly uses different servers for update check and download, need to map here
+    @Override
+    protected String getUpdatePageUrl(final String downloadPageUrl) {
+        return CgeoApplication.getInstance().getString(R.string.mapserver_hylly_updatecheckurl);
+    }
+
+    @NonNull
+    public static MapDownloaderHyllyThemes getInstance() {
+        return INSTANCE;
+    }
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
@@ -2,11 +2,8 @@ package cgeo.geocaching.downloader;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
-import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
 import cgeo.geocaching.models.Download;
-import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.MatcherWrapper;
-import cgeo.geocaching.utils.UriUtils;
 
 import android.net.Uri;
 
@@ -15,14 +12,13 @@ import androidx.annotation.NonNull;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class MapDownloaderOpenAndroMapsThemes extends AbstractDownloader {
+public class MapDownloaderOpenAndroMapsThemes extends AbstractThemeDownloader {
 
     private static final Pattern PATTERN_LAST_UPDATED_DATE = Pattern.compile("<a href=\"https:\\/\\/www\\.openandromaps\\.org\\/wp-content\\/users\\/tobias\\/version\\.txt\">[0-9]\\.[0-9]\\.[0-9]<\\/a><\\/strong>, ([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{2}) ");
     private static final MapDownloaderOpenAndroMapsThemes INSTANCE = new MapDownloaderOpenAndroMapsThemes();
 
     private MapDownloaderOpenAndroMapsThemes() {
-        super(Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS, R.string.mapserver_openandromaps_themes_updatecheckurl, R.string.mapserver_openandromaps_themes_name, R.string.mapserver_openandromaps_themes_info, R.string.mapserver_openandromaps_projecturl, R.string.mapserver_openandromaps_likeiturl, PersistableFolder.OFFLINE_MAP_THEMES);
-        this.forceExtension = ".zip";
+        super(Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS, R.string.mapserver_openandromaps_themes_updatecheckurl, R.string.mapserver_openandromaps_themes_name, R.string.mapserver_openandromaps_themes_info, R.string.mapserver_openandromaps_projecturl, R.string.mapserver_openandromaps_likeiturl);
     }
 
     @Override
@@ -54,16 +50,6 @@ public class MapDownloaderOpenAndroMapsThemes extends AbstractDownloader {
             return result.endsWith("/") ? result : result + "/";
         }
         return downloadPageUrl;
-    }
-
-    @Override
-    protected void onSuccessfulReceive(final Uri result) {
-
-        //resync
-        RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
-
-        //set map theme
-        RenderThemeHelper.setSelectedMapThemeDirect(UriUtils.getLastPathSegment(result));
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMap.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMap.java
@@ -20,11 +20,15 @@ class MapDownloaderReceiverSchemeMap extends AbstractActivity {
         final String path = uri.getPath();
         Log.i("MapDownloaderReceiverSchemeMap: host=" + host + ", path=" + path);
 
-        // check for OpenAndroMaps
         if (host.equals("download.openandromaps.org") && path.startsWith("/mapsV4/") && path.endsWith(".zip")) {
+            // check for OpenAndroMaps - mf-v4-map://download.openandromaps.org/mapsV4/Germany/bayern.zip
             // remap Uri to their ftp server
             final Uri newUri = Uri.parse(getString(R.string.mapserver_openandromaps_downloadurl) + path.substring(8));
             DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_MAP_OPENANDROMAPS.id, newUri, "", "", System.currentTimeMillis(), this::callback);
+        } else if (host.equals("kartat-dl.hylly.org") && path.endsWith("/mtk_suomi.map")) {
+            // check for Hylly maps - mf-v4-map://kartat-dl.hylly.org/2021-04-25/mtk_suomi.map
+            final Uri newUri = Uri.parse("https://" + host + path);
+            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_MAP_HYLLY.id, newUri, "", "", System.currentTimeMillis(), this::callback);
         } else {
             // generic map download
             Log.w("MapDownloaderReceiverSchemeMap: Received map download intent from unknown source: " + uri.toString());

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMapTheme.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMapTheme.java
@@ -20,11 +20,15 @@ class MapDownloaderReceiverSchemeMapTheme extends AbstractActivity {
         final String path = uri.getPath();
         Log.i("MapDownloaderReceiverSchemeMapTheme: host=" + host + ", path=" + path);
 
-        // check for OpenAndroMaps
         if (host.equals("download.openandromaps.org") && path.startsWith("/themes/") && path.endsWith(".zip")) {
+            // check for OpenAndroMaps
             // no remapping, as they have themes only on their homepage, not on their ftp site
             final Uri newUri = Uri.parse(getString(R.string.mapserver_openandromaps_themes_downloadurl) + path.substring(8));
             DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS.id, newUri, "", "", System.currentTimeMillis(), this::callback);
+        } else if (host.equals("kartat-dl.hylly.org") && path.endsWith("kartta.zip")) {
+            // check for Hylly map themes - mf-theme://kartat-dl.hylly.org/2021-04-25/peruskartta.zip
+            final Uri newUri = Uri.parse("https://" + host + path);
+            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY.id, newUri, "", "", System.currentTimeMillis(), this::callback);
         } else {
             // generic map theme download - not yet supported
             Log.w("MapDownloaderReceiverSchemeMapTheme: Received map theme download intent from unknown source: " + uri.toString());

--- a/main/src/cgeo/geocaching/models/Download.java
+++ b/main/src/cgeo/geocaching/models/Download.java
@@ -7,6 +7,8 @@ import cgeo.geocaching.downloader.BRouterTileDownloader;
 import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarte;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarteThemes;
+import cgeo.geocaching.downloader.MapDownloaderHylly;
+import cgeo.geocaching.downloader.MapDownloaderHyllyThemes;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
@@ -88,6 +90,8 @@ public class Download {
         DOWNLOADTYPE_THEME_OPENANDROMAPS(3),
         DOWNLOADTYPE_MAP_FREIZEITKARTE(4),
         DOWNLOADTYPE_THEME_FREIZEITKARTE(5),
+        DOWNLOADTYPE_MAP_HYLLY(6),
+        DOWNLOADTYPE_THEME_HYLLY(7),
 
         DOWNLOADTYPE_BROUTER_TILES(90);
 
@@ -124,6 +128,8 @@ public class Download {
                 offlineMapTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_THEME_OPENANDROMAPS, MapDownloaderOpenAndroMapsThemes.getInstance(), R.string.mapserver_openandromaps_themes_name));
                 offlineMapTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_MAP_FREIZEITKARTE, MapDownloaderFreizeitkarte.getInstance(), R.string.mapserver_freizeitkarte_name));
                 offlineMapTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_THEME_FREIZEITKARTE, MapDownloaderFreizeitkarteThemes.getInstance(), R.string.mapserver_freizeitkarte_themes_name));
+                offlineMapTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_MAP_HYLLY, MapDownloaderHylly.getInstance(), R.string.mapserver_hylly_name));
+                offlineMapTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_THEME_HYLLY, MapDownloaderHyllyThemes.getInstance(), R.string.mapserver_hylly_themes_name));
 
                 // all other download types
                 downloadTypes.addAll(offlineMapTypes);


### PR DESCRIPTION
## Description
- adds hylly soumi map & themes to the map downloader
- including update check and auto-install
- also supports `mf-v4-map` and `mf-theme` schemes for direct install from website

|Soumi map|Available in downloader
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/116793463-26bbfc80-aac7-11eb-8391-31f244997f61.png)|![image](https://user-images.githubusercontent.com/3754370/116793468-33405500-aac7-11eb-8dff-c7f169d2703a.png)|
|Theme downloading|Update check|
|![image](https://user-images.githubusercontent.com/3754370/116793465-2d4a7400-aac7-11eb-9b85-a13c533f92cb.png)|![image](https://user-images.githubusercontent.com/3754370/116793472-3a676300-aac7-11eb-9bf9-05f284d3add8.png)|

