### PR TITLE
set back arrow in map downloader to return to map (fix #10327)

### DIFF
--- a/main/src/cgeo/geocaching/downloader/MapDownloadSelectorActivity.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloadSelectorActivity.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -311,6 +312,15 @@ public class MapDownloadSelectorActivity extends AbstractActionBarActivity {
             Dialogs.message(this, R.string.downloadmap_no_updates_found);
             new MapListTask(this, current.mapBase, "").execute();
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        // close the downloader on pressing the back arrow
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
## Description
- Currently the back arrow in the map downloader closes both the map downloader an the map. c:geo returns to the main screen.
- PR configures the back arrow to just close the map downloader (and by this return to the map)
