### PR TITLE
set LC 'active' info in services summary (rel. to #10477)

### DIFF
--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -282,7 +282,6 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
         getPreference(R.string.pref_connectorLCActive).setOnPreferenceChangeListener(this);
         setWebsite(R.string.pref_fakekey_lc_website, LCConnector.getInstance().getHost());
-        getPreference(R.string.preference_screen_lc).setSummary(getServiceSummary(Settings.isLCConnectorActive()));
         initLCServicePreference(Settings.isGCConnectorActive());
 
         getPreference(R.string.pref_connectorSUActive).setOnPreferenceChangeListener(this);
@@ -303,7 +302,9 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
     }
 
     private void initLCServicePreference(final boolean gcConnectorActive) {
-        getPreference(R.string.pref_connectorLCActive).setEnabled(gcConnectorActive && Settings.isGCPremiumMember());
+        final boolean isActiveGCPM = gcConnectorActive && Settings.isGCPremiumMember();
+        getPreference(R.string.preference_screen_lc).setSummary(getServiceSummary(Settings.isLCConnectorActive() && isActiveGCPM));
+        getPreference(R.string.pref_connectorLCActive).setEnabled(isActiveGCPM);
     }
 
     private void setWebsite(final int preferenceKey, final String urlOrHost) {


### PR DESCRIPTION
## Description
- update the "active" display in services summary for LC connector according to the _effective_ state of LC connector
- active == true, if LC connector is active + GC connector is active + successful authorization as PM
- (see discussion in https://github.com/cgeo/cgeo/issues/10477#issuecomment-830838124 and following entries for details)
