### PR TITLE
optimize LC extra description box in cachedetails

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -44,24 +44,30 @@
                 android:indeterminateOnly="true" />
         </RelativeLayout>
 
-        <!-- Extra description -->
-
-        <RelativeLayout style="@style/separator_horizontal_layout">
-            <View style="@style/separator_horizontal" />
-            <TextView
-                android:id="@+id/extra_description_title"
-                style="@style/separator_horizontal_headline" />
-        </RelativeLayout>
-
-        <TextView
-            android:id="@+id/extra_description"
-            android:layout_width="match_parent"
+        <!-- Extra description box -->
+        <LinearLayout
+            android:id="@+id/extra_description_box"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dip"
             android:layout_marginBottom="12dip"
-            android:textSize="14sp"
+            android:orientation="vertical"
             android:visibility="gone"
-            />
+            tools:visibility="visible">
+
+            <RelativeLayout style="@style/separator_horizontal_layout">
+                <View style="@style/separator_horizontal" />
+                <TextView
+                    android:id="@+id/extra_description_title"
+                    style="@style/separator_horizontal_headline" />
+            </RelativeLayout>
+
+            <TextView
+                android:id="@+id/extra_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dip"
+                android:textSize="14sp" />
+        </LinearLayout>
 
         <!-- Hint and spoiler-images box -->
 
@@ -104,7 +110,8 @@
                 android:drawablePadding="3dip"
                 android:text="@string/cache_menu_spoilers"
                 android:textColor="?text_color"
-                android:textSize="14sp" app:drawableLeftCompat="?log_img_icon" />
+                android:textSize="14sp"
+                app:drawableLeftCompat="?log_img_icon" />
         </LinearLayout>
 
         <!-- Personal note box -->

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1661,8 +1661,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
                     hasExtraDescription = false;
                 }
             }
-            binding.extraDescriptionTitle.setVisibility(hasExtraDescription ? View.VISIBLE : View.GONE);
-            binding.extraDescription.setVisibility(hasExtraDescription ? View.VISIBLE : View.GONE);
+            binding.extraDescriptionBox.setVisibility(hasExtraDescription ? View.VISIBLE : View.GONE);
 
             // cache personal note
             setPersonalNote(binding.personalnote, binding.personalnoteButtonSeparator, cache.getPersonalNote());


### PR DESCRIPTION
#10499 has caused the side effect, that a duplicated separator line is displayed for all non-LC caches:

![Screenshot_20210504_091338](https://user-images.githubusercontent.com/64581222/116971252-942f7f00-acb9-11eb-9780-2b3c1e87c280.jpg)

This is fixed with this PR...