### PR TITLE
support opening geochecker via webview

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -86,6 +86,7 @@ import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.SimpleDisposableHandler;
 import cgeo.geocaching.utils.SimpleHandler;
 import cgeo.geocaching.utils.TextUtils;
@@ -716,7 +717,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         } else if (menuItem == R.id.menu_gcvote) {
             showVoteDialog();
         } else if (menuItem == R.id.menu_checker) {
-            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(CheckerUtils.getCheckerUrl(cache))));
+            ShareUtils.openUrl(this, CheckerUtils.getCheckerUrl(cache), true);
         } else if (menuItem == R.id.menu_challenge_checker) {
             startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://project-gc.com/Challenges/" + cache.getGeocode())));
         } else if (menuItem == R.id.menu_ignore) {


### PR DESCRIPTION
Avoids "loops back into c:geo" when using "Open Geochecker"

![grafik](https://user-images.githubusercontent.com/64581222/116975404-e4114480-acbf-11eb-957f-ea4efdf26ceb.png)

fixes #10526