### PR TITLE
generify handling of URL opening

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -162,7 +162,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
             } else {
                 binding.changelogMaster.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
             }
-            binding.changelogGithub.setOnClickListener(v -> startUrl("https://github.com/cgeo/cgeo/releases"));
+            binding.changelogGithub.setOnClickListener(v -> ShareUtils.openUrl(AboutActivity.this, "https://github.com/cgeo/cgeo/releases"));
             binding.changelogMaster.setText(LiUtils.formatHTML(getString(R.string.changelog_master)));
             binding.changelogRelease.setText(LiUtils.formatHTML(getString(R.string.changelog_release)));
 
@@ -267,11 +267,7 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
     }
 
     public final void setClickListener(final View view, final String url) {
-        view.setOnClickListener(v -> startUrl(url));
-    }
-
-    private void startUrl(final String url) {
-        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        view.setOnClickListener(v -> ShareUtils.openUrl(this, url));
     }
 
     @Override

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -86,6 +86,7 @@ import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.SimpleDisposableHandler;
 import cgeo.geocaching.utils.SimpleHandler;
 import cgeo.geocaching.utils.TextUtils;
@@ -718,7 +719,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
         } else if (menuItem == R.id.menu_checker) {
             startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(CheckerUtils.getCheckerUrl(cache))));
         } else if (menuItem == R.id.menu_challenge_checker) {
-            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://project-gc.com/Challenges/" + cache.getGeocode())));
+            ShareUtils.openUrl(this, "https://project-gc.com/Challenges/" + cache.getGeocode());
         } else if (menuItem == R.id.menu_ignore) {
             ignoreCache();
         } else if (menuItem == R.id.menu_extract_waypoints) {

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -81,6 +81,7 @@ import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.annotation.SuppressLint;
@@ -264,7 +265,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         });
         dialog.setPositiveButton(res.getString(R.string.license_show), (dialog12, id) -> {
             Cookies.clearCookies();
-            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.geocaching.com/software/agreement.aspx?ID=0")));
+            ShareUtils.openUrl(this, "https://www.geocaching.com/software/agreement.aspx?ID=0");
         });
 
         final AlertDialog alert = dialog.create();

--- a/main/src/cgeo/geocaching/StatusFragment.java
+++ b/main/src/cgeo/geocaching/StatusFragment.java
@@ -5,10 +5,9 @@ import cgeo.geocaching.network.StatusUpdater;
 import cgeo.geocaching.network.StatusUpdater.Status;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ShareUtils;
 
-import android.content.Intent;
 import android.content.res.Resources;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -64,7 +63,7 @@ public class StatusFragment extends Fragment {
                     statusGroup.setVisibility(View.VISIBLE);
 
                     if (status.url != null) {
-                        statusGroup.setOnClickListener(v -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(status.url))));
+                        statusGroup.setOnClickListener(v -> ShareUtils.openUrl(this.getContext(), status.url));
                     } else {
                         statusGroup.setClickable(false);
                     }

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -465,7 +465,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
             if (logDate != null && logType != null) {
                 final Uri uri = new Uri.Builder().scheme("https").authority("www.geocaching.com").path("/track/log.aspx").encodedQuery("LUID=" + trackable.getLogGuid()).build();
                 final TextView logView = details.add(R.string.trackable_status, res.getString(R.string.trackable_found, logType.getL10n(), Formatter.formatDate(logDate.getTime()))).right;
-                logView.setOnClickListener(v -> startActivity(new Intent(Intent.ACTION_VIEW, uri)));
+                logView.setOnClickListener(v -> ShareUtils.openUrl(TrackableActivity.this, uri.toString()));
             }
 
             // trackable owner
@@ -581,7 +581,7 @@ public class TrackableActivity extends AbstractViewPagerActivity<TrackableActivi
 
                 trackableImage.setImageResource(R.drawable.image_not_loaded);
                 trackableImage.setClickable(true);
-                trackableImage.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(trackable.getImage()))));
+                trackableImage.setOnClickListener(view -> ShareUtils.openUrl(TrackableActivity.this, trackable.getImage()));
 
                 AndroidRxUtils.bindActivity(TrackableActivity.this, new HtmlImage(geocode, true, false, false).fetchDrawable(trackable.getImage())).subscribe(trackableImage::setImageDrawable);
 

--- a/main/src/cgeo/geocaching/helper/UsefulAppsActivity.java
+++ b/main/src/cgeo/geocaching/helper/UsefulAppsActivity.java
@@ -4,9 +4,8 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.ui.recyclerview.RecyclerViewProvider;
 import cgeo.geocaching.utils.ProcessUtils;
+import cgeo.geocaching.utils.ShareUtils;
 
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.recyclerview.widget.RecyclerView;
@@ -38,7 +37,7 @@ public final class UsefulAppsActivity extends AbstractActionBarActivity {
         view.setAdapter(new HelperAppAdapter(this, HELPER_APPS, helperApp -> {
             final String packageName = getString(helperApp.packageNameResId);
             if (packageName.startsWith("http")) {
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(packageName)));
+                ShareUtils.openUrl(this, packageName);
             } else {
                 ProcessUtils.openMarket(UsefulAppsActivity.this, packageName);
             }

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
@@ -18,10 +19,8 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
-import android.content.Intent;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
-import android.net.Uri;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -600,7 +599,7 @@ public final class Dialogs {
         }
 
         if (StringUtils.isNotBlank(moreInfoURL)) {
-            builder.setNeutralButton(R.string.more_information, (dialog, which) -> context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(moreInfoURL))));
+            builder.setNeutralButton(R.string.more_information, (dialog, which) -> ShareUtils.openUrl(context, moreInfoURL));
         }
 
         if (cancellable) {


### PR DESCRIPTION
While working on #10526 I noticed that we use the "old" way of opening URL's at quite a few places. In the background the method does exactly the same, except if the optional setting "use chrome webview" is activated, which is the reason, why usage of `ShareUtils` should be preferred...