### PR TITLE
make use of google translate in-app translation popup

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -167,6 +167,7 @@
 
 
     <!-- translation -->
+    <string name="translate">Translate</string>
     <string name="translate_to_sys_lang">Translate to %s</string>
     <string name="translate_to_english">Translate to English</string>
     <string name="translate_length_warning">Translation may fail with a large amount of text.</string>

--- a/main/src/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/LogsViewCreator.java
@@ -138,17 +138,28 @@ public abstract class LogsViewCreator extends AbstractCachingListViewPageViewCre
                     .addItem(activity.getString(R.string.copy_to_clipboard), R.drawable.ic_menu_copy, i -> {
                         ClipboardUtils.copyToClipboard(holder.binding.log.getText().toString());
                         activity.showToast(activity.getString(R.string.clipboard_copy_ok));
-                    })
-                    .addItem(R.string.context_share_as_text, R.drawable.ic_menu_share, it ->
-                            ShareUtils.sharePlainText(activity, holder.binding.log.getText().toString()))
-                    .addItem(activity.getString(R.string.translate_to_sys_lang, Locale.getDefault().getDisplayLanguage()),
-                            R.drawable.ic_menu_translate, it -> TranslationUtils.startActivityTranslate(activity, Locale.getDefault().getLanguage(), HtmlUtils.extractText(log.log)));
-            final boolean localeIsEnglish = StringUtils.equals(Locale.getDefault().getLanguage(), Locale.ENGLISH.getLanguage());
+                    });
 
-            if (!localeIsEnglish) {
-                ctxMenu.addItem(R.string.translate_to_english, R.drawable.ic_menu_translate, it ->
-                        TranslationUtils.startActivityTranslate(activity, Locale.ENGLISH.getLanguage(), HtmlUtils.extractText(log.log)));
+            // translation
+            if (TranslationUtils.supportsInAppTranslationPopup()) {
+                ctxMenu.addItem(R.string.translate, R.drawable.ic_menu_translate, it ->
+                        TranslationUtils.startInAppTranslationPopup(activity, HtmlUtils.extractText(log.log)));
+            } else {
+                ctxMenu.addItem(activity.getString(R.string.translate_to_sys_lang, Locale.getDefault().getDisplayLanguage()),
+                        R.drawable.ic_menu_translate, it -> TranslationUtils.startActivityTranslate(activity, Locale.getDefault().getLanguage(), HtmlUtils.extractText(log.log)));
+
+                final boolean localeIsEnglish = StringUtils.equals(Locale.getDefault().getLanguage(), Locale.ENGLISH.getLanguage());
+                if (!localeIsEnglish) {
+                    ctxMenu.addItem(R.string.translate_to_english, R.drawable.ic_menu_translate, it ->
+                            TranslationUtils.startActivityTranslate(activity, Locale.ENGLISH.getLanguage(), HtmlUtils.extractText(log.log)));
+                }
             }
+
+            // share
+            ctxMenu.addItem(R.string.context_share_as_text, R.drawable.ic_menu_share, it ->
+                    ShareUtils.sharePlainText(activity, holder.binding.log.getText().toString()));
+
+            // subclass specific entries
             extendContextMenu(ctxMenu, log).show();
         };
 

--- a/main/src/cgeo/geocaching/utils/TranslationUtils.java
+++ b/main/src/cgeo/geocaching/utils/TranslationUtils.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.network.Network;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -46,7 +47,7 @@ public final class TranslationUtils {
     }
 
     /**
-     * Send Intent for Google Translate. Can be caught by Google Translate App or browser.
+     * Send Intent for Google Translate. Should only be used if InAppTranslationPopup is not available.
      *
      * @param activity
      *            The activity starting the process
@@ -60,5 +61,23 @@ public final class TranslationUtils {
             ActivityMixin.showToast(activity, R.string.translate_length_warning);
         }
         activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(buildTranslationURI(toLang, text))));
+    }
+
+    public static boolean supportsInAppTranslationPopup() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && ProcessUtils.isLaunchable(TRANSLATION_APP);
+    }
+
+    public static void startInAppTranslationPopup(final Activity activity, final String text) {
+        if (!supportsInAppTranslationPopup()) {
+            return;
+        }
+
+        final Intent intent = new Intent();
+        intent.setType("text/plain");
+        intent.setAction(Intent.ACTION_PROCESS_TEXT);
+        intent.putExtra(Intent.EXTRA_PROCESS_TEXT, text);
+        intent.putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true);
+        intent.setPackage(TRANSLATION_APP);
+        activity.startActivity(intent);
     }
 }


### PR DESCRIPTION
The Google Translate App supports such cool "in-app translation popups" nowadays (appearance not configurable and dependents on the device):

![Screenshot_20210504_163744](https://user-images.githubusercontent.com/64581222/117030969-6faac580-ad00-11eb-8431-ecbff75a62fd.jpg) / ![grafik](https://user-images.githubusercontent.com/64581222/117029813-4fc6d200-acff-11eb-889a-df034a69b9da.png)  

---

Unfortunately (or maybe even fortunately to keep things simple ;-)) it doesn't allow configuring the target language, but since it remembers the last selected language(s) it is IMHO totally fine...

| before | after (if Translate App is installed) |
|-|-|
| ![grafik](https://user-images.githubusercontent.com/64581222/117031952-5f471a80-ad01-11eb-87cd-ac9b828a169b.png) | ![grafik](https://user-images.githubusercontent.com/64581222/117031930-59513980-ad01-11eb-9799-30513e199783.png) |

BTW, I also reordered the "share text" item, so the elements are in a more logical order.