### PR TITLE
handle case that no file size can be specified while importing zipped GPX files

### DIFF
--- a/main/src/cgeo/geocaching/files/AbstractImportGpxZipThread.java
+++ b/main/src/cgeo/geocaching/files/AbstractImportGpxZipThread.java
@@ -8,6 +8,9 @@ import cgeo.geocaching.utils.TextUtils;
 
 import android.os.Handler;
 
+import androidx.annotation.StringRes;
+import androidx.core.util.Predicate;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 abstract class AbstractImportGpxZipThread extends AbstractImportGpxThread {
 
     public static final String ENCODING = "cp437"; // Geocaching.com used windows cp 437 encoding
+    private Collection<Geocache> caches = Collections.emptySet();
     private String gpxFileName = null;
 
     protected AbstractImportGpxZipThread(final int listId, final Handler importStepHandler, final DisposableHandler progressHandler) {
@@ -30,49 +34,75 @@ abstract class AbstractImportGpxZipThread extends AbstractImportGpxThread {
 
     @Override
     protected Collection<Geocache> doImport(final GPXParser parser) throws IOException, ParserException {
-        Collection<Geocache> caches = Collections.emptySet();
         // can't assume that GPX file comes before waypoint file in zip -> so we need two passes
-        // 1. parse GPX files
-        final ZipArchiveInputStream zisPass1 = new ZipArchiveInputStream(new BufferedInputStream(getInputStream()), ENCODING);
+        // 1. parse GPX files (all except waypoint files)
+        if (!parseZipFileGpxContent(parser, filename -> !StringUtils.endsWithIgnoreCase(filename, GPXImporter.WAYPOINTS_FILE_SUFFIX_AND_EXTENSION),
+                GPXImporter.IMPORT_STEP_READ_FILE, R.string.gpx_import_loading_caches_with_filename)) {
+            throw new ParserException("Imported ZIP does not contain a GPX file.");
+        }
+        // 2. parse only waypoint files
+        parseZipFileGpxContent(parser, filename -> StringUtils.endsWithIgnoreCase(filename, GPXImporter.WAYPOINTS_FILE_SUFFIX_AND_EXTENSION),
+                GPXImporter.IMPORT_STEP_READ_WPT_FILE, R.string.gpx_import_loading_waypoints_with_filename);
+        return caches;
+    }
+
+    /**
+     * parse the zip archive for GPX files which match the criteria given in the filename matcher
+     *
+     * @param parser the GPXParser object
+     * @param filenameMatcher pass true if the GPX file should be progressed in this run
+     * @param importStep the GPXImporter step
+     * @param stepText the description @StringRes which should be displayed
+     * @return true if at least one file is a GPX
+     */
+    private boolean parseZipFileGpxContent(final GPXParser parser, final Predicate<String> filenameMatcher, final int importStep, final @StringRes int stepText) throws IOException, ParserException {
+        final ZipArchiveInputStream zisPass = new ZipArchiveInputStream(new BufferedInputStream(getInputStream()), ENCODING);
         try {
             int acceptedFiles = 0;
             int ignoredFiles = 0;
-            for (ZipEntry zipEntry = zisPass1.getNextZipEntry(); zipEntry != null; zipEntry = zisPass1.getNextZipEntry()) {
+            for (ZipEntry zipEntry = zisPass.getNextZipEntry(); zipEntry != null; zipEntry = zisPass.getNextZipEntry()) {
                 gpxFileName = zipEntry.getName();
                 if (StringUtils.endsWithIgnoreCase(gpxFileName, FileUtils.GPX_FILE_EXTENSION)) {
-                    if (!StringUtils.endsWithIgnoreCase(gpxFileName, GPXImporter.WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
-                        importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_READ_FILE, R.string.gpx_import_loading_caches_with_filename, (int) zipEntry.getSize(), getSourceDisplayName()));
-                        caches = parser.parse(new NoCloseInputStream(zisPass1), progressHandler);
+                    if (filenameMatcher.test(gpxFileName)) {
+                        final long size = zipEntry.getSize();
+                        importStepHandler.sendMessage(importStepHandler.obtainMessage(importStep, stepText, (int) (size == -1 ? getZipFileSize(gpxFileName) : size), getSourceDisplayName()));
+                        caches = parser.parse(new NoCloseInputStream(zisPass), progressHandler);
                         acceptedFiles++;
                     }
                 } else {
                     ignoredFiles++;
                 }
             }
-            if (ignoredFiles > 0 && acceptedFiles == 0) {
-                throw new ParserException("Imported ZIP does not contain a GPX file.");
+            if (ignoredFiles == 0 || acceptedFiles > 0) {
+                return true;
             }
         } finally {
-            IOUtils.closeQuietly(zisPass1);
+            IOUtils.closeQuietly(zisPass);
         }
+        return false;
+    }
 
-        // 2. parse waypoint files
-        final InputStream inputStream = getInputStream();
-        final ZipArchiveInputStream zisPass2 = new ZipArchiveInputStream(new BufferedInputStream(inputStream), ENCODING);
+    /**
+     * Get the file size of a specific file inside the zip archive.
+     * It worth it to spend some extra time to gather the size so that we can visualize a progress while parsing afterwards.
+     * This method is rather time consuming, so don't call this if the size can also be found otherwise.
+     *
+     * @param filename the filename of the file inside the zip archive.
+     * @return the uncompressed size of the entry data
+     */
+    private long getZipFileSize(final String filename) throws IOException {
+        final ZipArchiveInputStream zisPass = new ZipArchiveInputStream(new BufferedInputStream(getInputStream()), ENCODING);
         try {
-            for (ZipEntry zipEntry = zisPass2.getNextZipEntry(); zipEntry != null; zipEntry = zisPass2.getNextZipEntry()) {
-                gpxFileName = zipEntry.getName();
-                if (StringUtils.endsWithIgnoreCase(gpxFileName, GPXImporter.WAYPOINTS_FILE_SUFFIX_AND_EXTENSION)) {
-                    importStepHandler.sendMessage(importStepHandler.obtainMessage(GPXImporter.IMPORT_STEP_READ_WPT_FILE, R.string.gpx_import_loading_waypoints_with_filename, (int) zipEntry.getSize(), gpxFileName));
-                    caches = parser.parse(new NoCloseInputStream(zisPass2), progressHandler);
+            for (ZipEntry zipEntry = zisPass.getNextZipEntry(); zipEntry != null; zipEntry = zisPass.getNextZipEntry()) {
+                if (filename.equals(zipEntry.getName())) {
+                    zisPass.getNextZipEntry(); // internally this read everything until the next entry. The file size is sometimes included at the end of the file entry, and is therefore only available if everything was read.
+                    return zipEntry.getSize();
                 }
             }
         } finally {
-            IOUtils.closeQuietly(zisPass2);
-            IOUtils.closeQuietly(inputStream);
+            IOUtils.closeQuietly(zisPass);
         }
-
-        return caches;
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
PR #10539 doesn't show the import progress while importing the GPX. 

After debugging, it seems that the file size is stored after the GPX file inside the ZIP. So to get the file size, the whole file needs to be streamed. Since nothing has to be done with the file content, this initial read-through is relatively quick and IMHO it definitely is worth it so that the progress can be displayed in the further processing. (Maybe 1-2 extra seconds, but in exchange the user knows in the following 20 seconds that the app has not got stuck but is still importing.) 

Furthermore, the entire file will be read only if the file size could not be found with the today's method, so it will not slow down existing functionality. The issue occurred to me when importing a bookmark list GPX-ZIP-file, but can occur with other (malformatted?!) ZIP files as well...