### PR TITLE
avoid crash when starting google maps navigation (fix #10550)

### DIFF
--- a/main/res/layout/cacheslist_item_select.xml
+++ b/main/res/layout/cacheslist_item_select.xml
@@ -5,7 +5,6 @@
     android:id="@+id/one_cache"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:background="?background_color"
     tools:context=".maps.mapsforge.v6.NewMap" >
 
     <!-- cache name and icon -->

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -215,6 +215,7 @@
 
     <style name="Dialog_Alert" parent="@style/Theme.AppCompat.Dialog.Alert">
         <item name="text_color">@color/text_dark</item>
+        <item name="text_color_grey">@color/text_grey_dark</item>
         <item name="buttonBarButtonStyle">@style/button_borderless</item>
         <item name="background">?android:attr/selectableItemBackground</item>
         <item name="colorAccent">@color/colorAccent</item>
@@ -224,6 +225,7 @@
 
     <style name="Dialog_Alert_light" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
         <item name="text_color">@color/text_light</item>
+        <item name="text_color_grey">@color/text_grey_light</item>
         <item name="buttonBarButtonStyle">@style/button_borderless</item>
         <item name="background">?android:attr/selectableItemBackground</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/main/src/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/cgeo/geocaching/activity/ActivityMixin.java
@@ -55,10 +55,7 @@ public final class ActivityMixin {
     }
 
     private static int getThemeId() {
-        if (Settings.isLightSkin()) {
-            return R.style.light;
-        }
-        return R.style.dark;
+        return Settings.isLightSkin() ? R.style.light : R.style.dark;
     }
 
     public static void setTheme(final Activity activity) {
@@ -70,11 +67,7 @@ public final class ActivityMixin {
     }
 
     public static int getDialogTheme() {
-        // Light theme dialogs don't work on Android Api < 11
-        if (Settings.isLightSkin()) {
-            return R.style.popup_light;
-        }
-        return R.style.popup_dark;
+        return Settings.isLightSkin() ? R.style.popup_light : R.style.popup_dark;
     }
 
     /**

--- a/main/src/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
@@ -87,8 +87,9 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
          * show a selection of all parking places and the cache itself, when using the navigation for driving
          */
         private void selectDriveTarget(final Context context, final ArrayList<IWaypoint> targets) {
-            final LayoutInflater inflater = LayoutInflater.from(context);
-            final ListAdapter adapter = new ArrayAdapter<IWaypoint>(context, R.layout.cacheslist_item_select, targets) {
+            final Context themeContext = Dialogs.newContextThemeWrapper(context);
+            final LayoutInflater inflater = LayoutInflater.from(themeContext);
+            final ListAdapter adapter = new ArrayAdapter<IWaypoint>(themeContext, R.layout.cacheslist_item_select, targets) {
                 @Override
                 public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
 

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -847,11 +847,11 @@ public final class Dialogs {
         builder.create().show();
     }
 
-    public static AlertDialog.Builder newBuilder(final Activity activity) {
-        return new AlertDialog.Builder(new ContextThemeWrapper(activity, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert));
+    public static AlertDialog.Builder newBuilder(final Context context) {
+        return new AlertDialog.Builder(newContextThemeWrapper(context));
     }
 
-    public static AlertDialog.Builder newBuilder(final Context context) {
-        return new AlertDialog.Builder(new ContextThemeWrapper(context, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert));
+    public static ContextThemeWrapper newContextThemeWrapper(final Context context) {
+        return new ContextThemeWrapper(context, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert);
     }
 }

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -180,8 +180,7 @@ public class BackupUtils {
         }
 
         // We are using ContextThemeWrapper to prevent crashes caused by missing attribute definitions when starting the dialog from MainActivity
-        final Context c = new ContextThemeWrapper(activityContext, Settings.isLightSkin() ? R.style.Dialog_Alert_light : R.style.Dialog_Alert);
-        final View content = LayoutInflater.from(c).inflate(R.layout.restore_dialog, null);
+        final View content = LayoutInflater.from(Dialogs.newContextThemeWrapper(activityContext)).inflate(R.layout.restore_dialog, null);
         final CheckBox databaseCheckbox = content.findViewById(R.id.database_check_box);
         final CheckBox settingsCheckbox = content.findViewById(R.id.settings_check_box);
         final TextView warningText = content.findViewById(R.id.warning);


### PR DESCRIPTION
I hope we can refactor the base theme of cgeo rather soon, so that such kind of fixes aren't necessary anymore! 

Here we have another dialog which can be shown from one activity but not from another :-/

Anyway, a compromise of omitting attributes and adding them to the dialog theme, makes the "google maps navigation dialog" working fine...


---
The background in the dialog (uses the same resource file) never looked good anyway (which is also solved implicitly):

![grafik](https://user-images.githubusercontent.com/64581222/117455521-8d1da080-af47-11eb-9227-928f671ba85e.png)

---

On the way, I've done some small cleanup, which makes usage of ContextThemeWrapper easier...