### PR TITLE
make downloader test more flexible (fix #10553)

### DIFF
--- a/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
@@ -150,13 +150,13 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         final List<Download> list = getList(BRouterTileDownloader.getInstance(), CgeoApplication.getInstance().getString(R.string.brouter_downloadurl));
 
         // number of tiles
-        assertThat(list.size()).isEqualTo(1120);
+        assertThat(list.size()).isBetween(1115, 1130);
 
         // number of dirs found
         assertThat(count(list, true)).isEqualTo(0);
 
         // number of non-dirs found
-        assertThat(count(list, false)).isEqualTo(1120);
+        assertThat(count(list, false)).isEqualTo(list.size());
 
         // check one named entry
         final Download d = findByName(list, "E5_N50.rd5");


### PR DESCRIPTION
## Description
make downloader tests more flexible:
- accept a range for routing tiles between 1115 and 1130 (currently: 1121)
- test "non-dirs found" against `list.size()` instead of a specific number
- target this update to `release` to catch those tests as well
