### PR TITLE
use dark title color in UDC popup

### DIFF
--- a/main/res/layout/dialog_title_button_button.xml
+++ b/main/res/layout/dialog_title_button_button.xml
@@ -6,7 +6,7 @@
 
     <TextView
         android:id="@+id/dialog_title_title"
-        style="@style/action_bar_title"
+        style="@style/action_bar_title_popup"
         android:ellipsize="marquee"
         android:layout_width="wrap_content"
         android:layout_alignParentStart="true"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -96,6 +96,10 @@
         <item name="android:text">c:geo</item>
     </style>
 
+    <style name="action_bar_title_popup" parent="action_bar_title">
+        <item name="android:textColor">@color/just_black</item>
+    </style>
+
     <!-- button: full width -->
     <style name="button_full" parent="button">
         <item name="android:layout_width">fill_parent</item>


### PR DESCRIPTION
## Description
With the recent addition of setting a cache icon directly in the map's "create UDC" popup, the title is no longer visible when using light theme. This PR defines an adapted style which uses black title color for this popup.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/117548360-e283ab80-b034-11eb-8145-b3f015e6d96f.png)|![image](https://user-images.githubusercontent.com/3754370/117548364-e7485f80-b034-11eb-979c-111d1929f7ad.png)|
