### PR TITLE
auto-focus UDC create input field

### DIFF
--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -268,13 +268,14 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
         }));
 
         Dialogs.newBuilder(context)
-                .setCustomTitle(titleViewBinding.getRoot())
-                .setView(editText)
-                .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
-                    final String geocode = createCache(context, editText.getText().toString(), null, temporaryCache.getAssignedEmoji(), geopoint, listId);
-                    CacheDetailActivity.startActivity(context, geocode);
-                })
-                .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> dialog.cancel())
-                .show();
+            .setCustomTitle(titleViewBinding.getRoot())
+            .setView(editText)
+            .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
+                final String geocode = createCache(context, editText.getText().toString(), null, temporaryCache.getAssignedEmoji(), geopoint, listId);
+                CacheDetailActivity.startActivity(context, geocode);
+            })
+            .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> dialog.cancel())
+            .show();
+        editText.requestFocus();
     }
 }


### PR DESCRIPTION
## Description
On long tap on the map the "Create UDC" popup will open. Currently the actual input field is hard to see, as there is no visual indicator for it. This PR automatically sets the focus to the input field, so that you get the blinking cursor as indicator.