### PR TITLE
Optimize nearby results for ALC #10557

### DIFF
--- a/main/src/cgeo/geocaching/connector/lc/LCApi.java
+++ b/main/src/cgeo/geocaching/connector/lc/LCApi.java
@@ -79,7 +79,7 @@ final class LCApi {
             return Collections.emptyList();
         }
         final Parameters params = new Parameters("skip", "0");
-        params.add("take", "100");
+        params.add("take", "20");
         params.add("radiusMeters", "10000");
         params.add("origin.latitude", String.valueOf(center.getLatitude()));
         params.add("origin.longitude", String.valueOf(center.getLongitude()));


### PR DESCRIPTION
see #10557 for the associated discussion. In a nutshell: LC connector returned 100 caches hardcoded while other connectors returned only 20 which caused an unbalanced result on the map (LCs dominated). Now I am adjusting to `take=20` to be on par. 