### PR TITLE
fix coords sql for negative latitude/longitude

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -3377,8 +3377,8 @@ public class DataStore {
 
     public static String getCoordDiffExpression(@NonNull final Geopoint coords, @Nullable final String tableId) {
         final String tableExp = tableId == null ? "" : tableId + ".";
-        return "(ABS(" + tableExp + "latitude-" + String.format((Locale) null, "%.6f", coords.getLatitude()) +
-            ") + ABS(" + tableExp + "longitude-" + String.format((Locale) null, "%.6f", coords.getLongitude()) + "))";
+        return "(ABS(" + tableExp + "latitude - " + String.format((Locale) null, "%.6f", coords.getLatitude()) +
+            ") + ABS(" + tableExp + "longitude - " + String.format((Locale) null, "%.6f", coords.getLongitude()) + "))";
     }
 
     /** Retrieve all stored caches from DB */


### PR DESCRIPTION
## Description
The SQL build for a coordinates-based search will fail, if latitude and/or longitude are negative, as this leads to a double dash in the SQL, which will be interpreted as a comment. 

Something like this will be shown in the error log:

```
05-08 21:25:36.574 6321-6321/cgeo.geocaching E/SQLiteLog: (1) near "--122.084000))) ASC LIMIT 1000": syntax error
05-08 21:25:36.574 6321-6321/cgeo.geocaching E/cgeo: [main] DataStore.loadBatchOfStoredGeocodes
    android.database.sqlite.SQLiteException: near "--122.084000))) ASC LIMIT 1000": syntax error (code 1): , while compiling: SELECT geocode FROM cg_caches t WHERE (geocode IN (SELECT geocode FROM cg_caches_lists WHERE list_id =11)) ORDER BY ((ABS(t.latitude - 37.421998) + ABS(t.longitude --122.084000))) ASC LIMIT 1000
        at android.database.sqlite.SQLiteConnection.nativePrepareStatement(Native Method)
        at android.database.sqlite.SQLiteConnection.acquirePreparedStatement(SQLiteConnection.java:889)
        at android.database.sqlite.SQLiteConnection.prepare(SQLiteConnection.java:500)
        at android.database.sqlite.SQLiteSession.prepare(SQLiteSession.java:588)
        at android.database.sqlite.SQLiteProgram.<init>(SQLiteProgram.java:58)
        at android.database.sqlite.SQLiteQuery.<init>(SQLiteQuery.java:37)
        at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:44)
        at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1316)
        at android.database.sqlite.SQLiteDatabase.rawQuery(SQLiteDatabase.java:1255)
        at cgeo.geocaching.storage.DataStore.loadBatchOfStoredGeocodes(DataStore.java:3371)
        at cgeo.geocaching.storage.DataStore.getBatchOfStoredCaches(DataStore.java:4363)
        at cgeo.geocaching.CacheListActivity.onResume(CacheListActivity.java:671)
```
This PR fixes this by adding spaces after the "-" symbol.