### PR TITLE
use correct title color in UDC popup / emoji chooser

### DIFF
--- a/main/res/layout/dialog_title_button_button.xml
+++ b/main/res/layout/dialog_title_button_button.xml
@@ -6,11 +6,12 @@
 
     <TextView
         android:id="@+id/dialog_title_title"
-        style="@style/action_bar_title_popup"
+        style="@style/action_bar_title"
         android:ellipsize="marquee"
         android:layout_width="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
+        android:textColor="?text_color"
         android:layout_toStartOf="@+id/dialog_button_wrapper"/>
 
     <LinearLayout

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -96,10 +96,6 @@
         <item name="android:text">c:geo</item>
     </style>
 
-    <style name="action_bar_title_popup" parent="action_bar_title">
-        <item name="android:textColor">@color/just_black</item>
-    </style>
-
     <!-- button: full width -->
     <style name="button_full" parent="button">
         <item name="android:layout_width">fill_parent</item>


### PR DESCRIPTION
Follow up of #10562

Fixes dark text color in dark theme:
![grafik](https://user-images.githubusercontent.com/64581222/117554026-5766dd80-b055-11eb-8c8c-a6aa1184c23d.png)
