### PR TITLE
create UDC: offer "use current list" (if available) (fix #10427)

### DIFF
--- a/main/res/layout/udc_create.xml
+++ b/main/res/layout/udc_create.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="3dip">
+
+    <EditText
+        android:id="@+id/name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/cache_name"
+        android:inputType="text|none" />
+
+    <CheckBox
+        android:id="@+id/givenList"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/create_internal_cache_currentlist" />
+</LinearLayout>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -144,6 +144,7 @@
     <string translatable="false" name="pref_debug">debug</string>
     <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
     <string translatable="false" name="pref_longTapOnMapActivated">pref_longTapCreateUDC</string>
+    <string translatable="false" name="pref_createUDCuseGivenList">createUDCuseGivenList</string>
     <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
     <!-- preferences used internally -->
     <string translatable="false" name="pref_temp_twitter_token_secret">temp-token-secret</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1277,6 +1277,7 @@
 
     <string name="create_internal_cache">Create user-defined cache</string>
     <string name="create_internal_cache_short">New cache</string>
+    <string name="create_internal_cache_currentlist">Use current list</string>
     <string name="internal_cache_default_name">User defined cache #%1$d</string>
     <string name="internal_cache_default_description">This is a user-defined cache</string>
     <string name="internal_cache_default_owner">You</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -938,7 +938,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             deletePastEvents();
             invalidateOptionsMenuCompatible();
         } else if (menuItem == R.id.menu_create_internal_cache) {
-            InternalConnector.interactiveCreateCache(this, coords, StoredList.getConcreteList(listId));
+            InternalConnector.interactiveCreateCache(this, coords, StoredList.getConcreteList(listId), false);
         } else if (menuItem == R.id.menu_clear_offline_logs) {
             clearOfflineLogs();
             invalidateOptionsMenuCompatible();
@@ -1691,7 +1691,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         // apply filter settings (if there's a filter)
         final SearchResult searchToUse = getFilteredSearch();
-        DefaultMap.startActivitySearch(this, searchToUse, title);
+        DefaultMap.startActivitySearch(this, searchToUse, title, listId);
     }
 
     private void refreshCurrentList() {

--- a/main/src/cgeo/geocaching/apps/cachelist/InternalCacheListMap.java
+++ b/main/src/cgeo/geocaching/apps/cachelist/InternalCacheListMap.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.apps.cachelist;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.apps.AbstractApp;
+import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.maps.DefaultMap;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
@@ -34,6 +35,6 @@ class InternalCacheListMap extends AbstractApp implements CacheListApp {
 
     @Override
     public void invoke(@NonNull final List<Geocache> caches, @NonNull final Activity activity, @NonNull final SearchResult search) {
-        DefaultMap.startActivitySearch(activity, cls != null ? cls : Settings.getMapProvider().getMapClass(), search, null);
+        DefaultMap.startActivitySearch(activity, cls != null ? cls : Settings.getMapProvider().getMapClass(), search, null, StoredList.TEMPORARY_LIST.id);
     }
 }

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -598,6 +598,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             savedInstanceState.remove(BUNDLE_MAP_STATE);
         }
         mapView.onCreate(savedInstanceState);
+        mapView.setListId(mapOptions.fromList);
 
         mapView.onMapReady(() -> initializeMap(trailHistory));
 

--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -51,12 +51,12 @@ public final class DefaultMap {
         startActivityGeoCode(fromActivity, getDefaultMapClass(), geocode);
     }
 
-    public static void startActivitySearch(final Activity fromActivity, final Class<?> cls, final SearchResult search, final String title) {
-        new MapOptions(search, title).startIntent(fromActivity, cls);
+    public static void startActivitySearch(final Activity fromActivity, final Class<?> cls, final SearchResult search, final String title, final int fromList) {
+        new MapOptions(search, title, fromList).startIntent(fromActivity, cls);
     }
 
-    public static void startActivitySearch(final Activity fromActivity, final SearchResult search, final String title) {
-        startActivitySearch(fromActivity, getDefaultMapClass(), search, title);
+    public static void startActivitySearch(final Activity fromActivity, final SearchResult search, final String title, final int fromList) {
+        startActivitySearch(fromActivity, getDefaultMapClass(), search, title, fromList);
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/cgeo/geocaching/maps/MapOptions.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.settings.Settings;
 
@@ -26,6 +27,7 @@ public class MapOptions {
     public WaypointType waypointType;
     public MapState mapState;
     public String title;
+    public int fromList;
 
     public MapOptions(final Context context, @Nullable final Bundle extras) {
         if (extras != null) {
@@ -41,6 +43,7 @@ public class MapOptions {
             if (null != coords && null == waypointType) {
                 waypointType = WaypointType.WAYPOINT;
             }
+            fromList = extras.getInt(Intents.EXTRA_LIST_ID, StoredList.TEMPORARY_LIST.id);
         } else {
             mapMode = MapMode.LIVE;
             isStoredEnabled = true;
@@ -51,11 +54,12 @@ public class MapOptions {
         }
     }
 
-    public MapOptions(final SearchResult search, final String title) {
+    public MapOptions(final SearchResult search, final String title, final int fromList) {
         this.searchResult = search;
         this.title = title;
         this.mapMode = MapMode.LIST;
         this.isLiveEnabled = false;
+        this.fromList = fromList;
     }
 
     public MapOptions() {
@@ -97,6 +101,7 @@ public class MapOptions {
         intent.putExtra(Intents.EXTRA_WPTTYPE, waypointType);
         intent.putExtra(Intents.EXTRA_MAPSTATE, mapState);
         intent.putExtra(Intents.EXTRA_TITLE, title);
+        intent.putExtra(Intents.EXTRA_LIST_ID, fromList);
         return intent;
     }
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps.google.v2;
 import cgeo.geocaching.EditWaypointActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.internal.InternalConnector;
+import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.CGeoMap;
@@ -78,6 +79,8 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
     private WeakReference<PositionAndHistory> positionAndHistoryRef;
     private View root = null;
 
+    private int fromList = StoredList.TEMPORARY_LIST.id;
+
     public interface PostRealDistance {
         void postRealDistance (float realDistance);
     }
@@ -133,7 +136,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
                 if (null != cache) {
                     EditWaypointActivity.startActivityAddWaypoint(this.getContext(), cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
                 } else if (Settings.isLongTapOnMapActivated()) {
-                    InternalConnector.interactiveCreateCache(this.getContext(), new Geopoint(tapLatLong.latitude, tapLatLong.longitude), InternalConnector.UDC_LIST);
+                    InternalConnector.interactiveCreateCache(this.getContext(), new Geopoint(tapLatLong.latitude, tapLatLong.longitude), fromList, true);
                 }
             }
         });
@@ -164,6 +167,11 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
             mapReadyCallback = null;
         }
         redraw();
+    }
+
+    @Override
+    public void setListId(final int listId) {
+        fromList = listId;
     }
 
     private void recognizePositionChange() {

--- a/main/src/cgeo/geocaching/maps/interfaces/MapViewImpl.java
+++ b/main/src/cgeo/geocaching/maps/interfaces/MapViewImpl.java
@@ -87,6 +87,7 @@ public interface MapViewImpl<T extends CachesOverlayItemImpl> {
 
     void setOnTapListener(OnCacheTapListener listener);
 
+    void setListId(int listId);
 
     /* From Google MapView documentation:
      * Users of this class must forward all the life cycle methods from the Activity or Fragment

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -965,7 +965,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer {
         if (cache != null) {
             EditWaypointActivity.startActivityAddWaypoint(this, cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
         } else if (Settings.isLongTapOnMapActivated()) {
-            InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), InternalConnector.UDC_LIST);
+            InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), mapOptions.fromList, true);
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1169,6 +1169,14 @@ public class Settings {
         return getBoolean(R.string.pref_longTapOnMapActivated, true);
     }
 
+    public static boolean getCreateUDCuseGivenList() {
+        return getBoolean(R.string.pref_createUDCuseGivenList, false);
+    }
+
+    public static void setCreateUDCuseGivenList(final boolean createUDCuseGivenList) {
+        putBoolean(R.string.pref_createUDCuseGivenList, createUDCuseGivenList);
+    }
+
     public static boolean isUseTwitter() {
         return getBoolean(R.string.pref_twitter, false);
     }


### PR DESCRIPTION
## Description
When you are mapping a cache list using the map symbol, and create a UDC on that map, the dialog will now ask whether you want to store that UDC in the current list. If you don't check the checkbox, the new UDC will be stored in the UDC standard list.
The dialog remembers your selection.
If you are opening the map using a different way, no checkbox will be shown, and newly created UDC will be stored in the UDC standard list as before.
(UDC created from within a cache list will be stored in that list, as before.)

|mapping a cache list|any other way|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/117555189-44580b80-b05d-11eb-9d33-5a62a0cc772e.png)|![image](https://user-images.githubusercontent.com/3754370/117555191-49b55600-b05d-11eb-9346-fb60b47c9712.png)|
