### PR TITLE
Fix: Enable editing of imported waypoints with empty coordinates (fix #6915)

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -311,10 +311,12 @@ abstract class GPXParser extends FileParser {
                         waypoint.setLookup("---");
                         // there is no lookup code in gpx file
 
-                        if (wptEmptyCoordinates) {
+                        waypoint.setCoords(cache.getCoords());
+
+                        // user defined waypoint does not have original empty coordinates
+                        if (wptEmptyCoordinates || (!waypoint.isUserDefined() && null == waypoint.getCoords())) {
                             waypoint.setOriginalCoordsEmpty(true);
                         }
-                        waypoint.setCoords(cache.getCoords());
 
                         final WaypointUserNoteCombiner wpCombiner = new WaypointUserNoteCombiner(waypoint);
                         wpCombiner.updateNoteAndUserNote(cache.getDescription());

--- a/tests/res/raw/ocddd2_empty_coord.gpx
+++ b/tests/res/raw/ocddd2_empty_coord.gpx
@@ -121,26 +121,57 @@
     </wpt>
     <wpt lat="48.885" lon="9.174999999999999">
         <name>01</name>
-        <cmt>Ttt</cmt>
+        <cmt>Coordinates are modified. No orginial coordinates for user defined wp.</cmt>
         <desc>Wegpunkt 4</desc>
         <sym>Question to Answer</sym>
         <type>Waypoint|Question to Answer</type>
         <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
             <gsak:Parent>OCDDD2</gsak:Parent>
+            <gsak:Child_ByGSAK>true</gsak:Child_ByGSAK>
         </gsak:wptExtension>
         <cgeo:userdefined>true</cgeo:userdefined>
-        <cgeo:originalCoordsEmpty>true</cgeo:originalCoordsEmpty>
     </wpt>
     <wpt lat="0.0" lon="0.0">
         <name>02</name>
-        <cmt>Ttt</cmt>
-        <desc>Wegpunkt 5</desc>
+        <cmt>Original coordinates for user defined wp are empty.</cmt>
+        <desc>Original Empty User</desc>
+        <sym>Question to Answer</sym>
+        <type>Waypoint|Question to Answer</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+            <gsak:Child_ByGSAK>true</gsak:Child_ByGSAK>
+        </gsak:wptExtension>
+        <cgeo:userdefined>true</cgeo:userdefined>
+    </wpt>
+    <wpt lat="0.0" lon="0.0">
+        <name>03</name>
+        <cmt>Original coordinates are empty.</cmt>
+        <desc>Original Empty</desc>
         <sym>Question to Answer</sym>
         <type>Waypoint|Question to Answer</type>
         <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
             <gsak:Parent>OCDDD2</gsak:Parent>
         </gsak:wptExtension>
-        <cgeo:userdefined>true</cgeo:userdefined>
+    </wpt>
+    <wpt lat="48.885" lon="9.174999999999999">
+        <name>04</name>
+        <cmt>Coordinates are modified. Original coordinates are empty.</cmt>
+        <desc>Original Empty Modified</desc>
+        <sym>Question to Answer</sym>
+        <type>Waypoint|Question to Answer</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
         <cgeo:originalCoordsEmpty>true</cgeo:originalCoordsEmpty>
     </wpt>
+    <wpt lat="" lon="">
+        <name>05</name>
+        <cmt>Original coordinates are blank.</cmt>
+        <desc>Original Blank</desc>
+        <sym>Question to Answer</sym>
+        <type>Waypoint|Question to Answer</type>
+        <gsak:wptExtension xmlns:gsak="http://www.gsak.net/xmlv1/4">
+            <gsak:Parent>OCDDD2</gsak:Parent>
+        </gsak:wptExtension>
+    </wpt>    
 </gpx>

--- a/tests/src-android/cgeo/geocaching/files/GPXImporterTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXImporterTest.java
@@ -114,9 +114,12 @@ public class GPXImporterTest extends AbstractResourceInstrumentationTestCase {
 
         final List<Waypoint> waypointList = cache.getWaypoints();
         assertThat(waypointList).isNotNull();
-        assertThat(waypointList).as("Number of imported waypoints").hasSize(5);
+        assertThat(waypointList).as("Number of imported waypoints").hasSize(8);
         assertThat(waypointList.get(3).getCoords()).as("Not empty coordinates").isNotNull();
         assertThat(waypointList.get(4).getCoords()).as("Empty coordinates").isNull();
+        assertThat(waypointList.get(5).getCoords()).as("Empty coordinates").isNull();
+        assertThat(waypointList.get(6).getCoords()).as("Not empty coordinates").isNotNull();
+        assertThat(waypointList.get(7).getCoords()).as("Blank coordinates").isNull();
     }
 
     public void testImportGpxWithWaypoints() throws IOException {

--- a/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
@@ -124,8 +124,48 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
 
         final List<Waypoint> waypointList = cache.getWaypoints();
         assertThat(waypointList).isNotNull();
-        assertThat(waypointList).hasSize(2);
-        assertThat(waypointList.get(1).getCoords()).isNull();
+        assertThat(waypointList).as("Number of imported waypoints").hasSize(2);
+
+        final Waypoint wpEmpty = waypointList.get(1);
+        assertThat(wpEmpty.getCoords()).as("Empty coordinates").isNull();
+        assertThat(wpEmpty.isUserDefined()).as("UserDefined").isFalse();
+        assertThat(wpEmpty.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isTrue();
+    }
+
+
+    public void testOCddd2WptsEmptyCoord() throws IOException, ParserException {
+        removeCacheCompletely("OCDDD2");
+        final List<Geocache> caches = readGPX10(R.raw.ocddd2, R.raw.ocddd2_empty_coord);
+        assertThat(caches).hasSize(1);
+        final Geocache cache = caches.get(0);
+
+        final List<Waypoint> waypointList = cache.getWaypoints();
+        assertThat(waypointList).isNotNull();
+        assertThat(waypointList).as("Number of imported waypoints").hasSize(8);
+
+        final Waypoint wpNotEmpty = waypointList.get(3);
+        assertThat(wpNotEmpty.getCoords()).as("Not empty coordinates").isNotNull();
+        assertThat(wpNotEmpty.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isFalse();
+
+        final Waypoint wpEmptyUser = waypointList.get(4);
+        assertThat(wpEmptyUser.getCoords()).as("Empty coordinates").isNull();
+        assertThat(wpEmptyUser.isUserDefined()).as("UserDefined").isTrue();
+        assertThat(wpEmptyUser.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isFalse();
+
+        final Waypoint wpEmptyOwner = waypointList.get(5);
+        assertThat(wpEmptyOwner.getCoords()).as("Empty coordinates").isNull();
+        assertThat(wpEmptyOwner.isUserDefined()).as("UserDefined").isFalse();
+        assertThat(wpEmptyOwner.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isTrue();
+
+        final Waypoint wpEmptyOwnerModfied = waypointList.get(6);
+        assertThat(wpEmptyOwnerModfied.getCoords()).as("Not empty coordinates").isNotNull();
+        assertThat(wpEmptyOwnerModfied.isUserDefined()).as("UserDefined").isFalse();
+        assertThat(wpEmptyOwnerModfied.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isTrue();
+
+        final Waypoint wpBlank = waypointList.get(7);
+        assertThat(wpBlank.getCoords()).as("Blank coordinates").isNull();
+        assertThat(wpBlank.isUserDefined()).as("UserDefined").isFalse();
+        assertThat(wpBlank.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isTrue();
     }
 
     private static void checkWaypointType(final Collection<Geocache> caches, final String geocode, final int wpIndex, final WaypointType waypointType) {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
Set `original coordinates empty` for imported gpx (e.g. GSAK, not exported via c:geo) for waypoint with 0/0
Otherwise coordinates of owner defined waypoints with empty coordinates could not be assigned

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #6915

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Only with the flag original coordinates empty set, the user can edit pre-defined waypoints with empty coordinates.
In some cases (e.g. gpx exported from GSAK) the flag is not set: the flag is only set, if the cgeo-extension is contained in the gpx.