### PR TITLE
Support comma in formula

### DIFF
--- a/tests/src/cgeo/geocaching/calculator/FormulaParserTest.java
+++ b/tests/src/cgeo/geocaching/calculator/FormulaParserTest.java
@@ -64,6 +64,18 @@ public class FormulaParserTest {
     }
 
     @Test
+    public void testBlankAddedByAutocorrectionDot() {
+        final FormulaParser formulaParser = new FormulaParser();
+        assertThat(formulaParser.parseLatitude("N 49° 56. ABC")).isNotBlank();
+    }
+
+    @Test
+    public void testBlankAddedByAutocorrectionComma() {
+        final FormulaParser formulaParser = new FormulaParser();
+        assertThat(formulaParser.parseLatitude("N 49° 56, ABC")).isNotBlank();
+    }
+
+    @Test
     public void testParseFullCoordinatesWithFormula() {
         final FormulaParser formulaParser = new FormulaParser();
         final FormulaWrapper parsedFullCoordinates = formulaParser.parse(WaypointParser.PARSING_COORD_FORMULA_PLAIN + " N  AB° 48.[B+C-A]^2  E (B%C)°  38.(D+F)*2 | a = 2) test");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Fixes unrecognized parsed formula in personal note, if it contains comma instead of dots
Export of the formula will be with comma, because it uses the current locale.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #10588 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
use same input-preparing as in GeopointParser to convert comma to dot. Only dots are allowed in the regular expression.