### PR TITLE
replace viewpagerindicator by another one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,6 @@ allprojects {
 subprojects {
     repositories {
         mavenCentral()
-        // viewpager fork
-        maven {
-            url 'https://dl.bintray.com/alexeydanilov/maven'
-        }
         // Android Support libraries are now in an online Maven repository
         google()
         // integrate as last one - for versions by commit ID

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -403,9 +403,8 @@ dependencies {
     implementation 'androidx.browser:browser:1.3.0'
 
     // ViewPagerIndicator, view pager titles for cache details and similar view pager based activities
-    //             url 'https://dl.bintray.com/alexeydanilov/maven'
     // this is a fork of the original viewpager library
-    implementation 'com.viewpagerindicator:viewpagerindicator:2.4.3'
+    implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
 
     // Zxing barcode reader integration
     implementation 'com.google.zxing:android-integration:3.3.0'


### PR DESCRIPTION
## Description
As we are have no more access to the used viewpagerindicator fork let it replace by another one (until we replace it with a new solution).

## Related issues
fixes #10561
