### PR TITLE
short LC names and conditional D/T texts (Fixes 10583)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1789,7 +1789,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             final int distance = (int) (1000 * coord.distanceTo(item.getCoords()));
             if (distance > 0 && distance < minDistance) {
                 minDistance = distance;
-                name = item.getGeocode() + " " + item.getName();
+                name = item.getShortGeocode() + " " + item.getName();
             }
         }
         // check waypoints

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -788,7 +788,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer {
         this.targetView = new TargetView((TextView) findViewById(R.id.target), (TextView) findViewById(R.id.targetSupersize), StringUtils.EMPTY, StringUtils.EMPTY);
         final Geocache target = getCurrentTargetCache();
         if (target != null) {
-            targetView.setTarget(target.getGeocode(), target.getName());
+            targetView.setTarget(target.getShortGeocode(), target.getName());
         }
 
         // resume location access
@@ -1375,6 +1375,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer {
 
                     final StringBuilder text = new StringBuilder(item.getShortItemCode());
                     final String geocode = item.getGeocode();
+                    final String shortgeocode = item.getShortGeocode();
                     if (StringUtils.isNotEmpty(geocode)) {
                         final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
                         if (cache != null && item.getType() == CoordinatesType.CACHE) {
@@ -1382,7 +1383,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer {
                         } else {
                             tv.setCompoundDrawablesWithIntrinsicBounds(item.getMarkerId(), 0, 0, 0);
                             if (item.getType() == CoordinatesType.WAYPOINT) {
-                                text.append(Formatter.SEPARATOR).append(geocode);
+                                text.append(Formatter.SEPARATOR).append(shortgeocode);
                                 if (cache != null) {
                                     text.append(Formatter.SEPARATOR).append(cache.getName());
                                 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -404,7 +404,7 @@ public abstract class AbstractCachesOverlay {
                 final int distance = (int) (1000f * cacheCoords.distanceTo(coord));
                 if (distance > 0 && distance < minDistance) {
                     minDistance = distance;
-                    name = cache.getGeocode() + " " + cache.getName();
+                    name = cache.getShortGeocode() + " " + cache.getName();
                 }
                 final List<Waypoint> waypoints = cache.getWaypoints();
                 for (final Waypoint waypoint : waypoints) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/GeoitemRef.java
@@ -76,6 +76,11 @@ public class GeoitemRef implements Parcelable {
         return geocode;
     }
 
+    @NonNull
+    public String getShortGeocode() {
+        return generateShortGeocode(geocode);
+    }
+
     public int getId() {
         return id;
     }

--- a/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -88,7 +88,7 @@ public class RouteSortActivity extends AbstractActivity {
                 final TextView title = v.findViewById(R.id.title);
                 final TextView detail = v.findViewById(R.id.detail);
                 if (null == data && cacheOrWaypointType) {
-                    title.setText(routeItem.getGeocode());
+                    title.setText(routeItem.getShortGeocode());
                     detail.setText(R.string.route_item_not_yet_loaded);
                 } else {
                     title.setText(null == data ? "" : data.getName());

--- a/main/src/cgeo/geocaching/models/RouteItem.java
+++ b/main/src/cgeo/geocaching/models/RouteItem.java
@@ -7,9 +7,12 @@ import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.MatcherWrapper;
+import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -126,6 +129,11 @@ public class RouteItem implements Parcelable {
 
     public String getGeocode() {
         return cacheGeocode;
+    }
+
+    @NonNull
+    public String getShortGeocode() {
+        return generateShortGeocode(cacheGeocode);
     }
 
     public String getIdentifier() {

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -329,7 +329,14 @@ public final class Formatter {
 
     @NonNull
     public static String formatMapSubtitle(final Geocache cache) {
-        return "D " + formatDT(cache.getDifficulty()) + SEPARATOR + "T " + formatDT(cache.getTerrain()) + SEPARATOR + cache.getShortGeocode();
+        String title = "";
+        if (cache.hasDifficulty()) {
+            title += "D " + formatDT(cache.getDifficulty()) + SEPARATOR;
+        }
+        if (cache.hasTerrain()) {
+            title += "T " + formatDT(cache.getDifficulty()) + SEPARATOR;
+        }
+        return title + cache.getShortGeocode();
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/cgeo/geocaching/utils/Formatter.java
@@ -334,7 +334,7 @@ public final class Formatter {
             title += "D " + formatDT(cache.getDifficulty()) + SEPARATOR;
         }
         if (cache.hasTerrain()) {
-            title += "T " + formatDT(cache.getDifficulty()) + SEPARATOR;
+            title += "T " + formatDT(cache.getTerrain()) + SEPARATOR;
         }
         return title + cache.getShortGeocode();
     }


### PR DESCRIPTION
Lots of description here: #10583

A word on "conditional D/T" texts: LC caches don't have D/T ratings. When the cache object is instantiated, the respective properties are left uninitialized. In various views this did the job and no D/T related strings were shown, however, in Map view when a target was set, `D 0.0 . T 0.0 .....` was shown. This PR addresses that bug in addition to showing short LC  code as reported in the referenced issue.