### PR TITLE
More ugly lc fixes (Fixes #10601)

### DIFF
--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -90,7 +90,7 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             details = new CacheDetailsCreator(getActivity(), binding.waypointDetailsList);
 
             //Waypoint geocode
-            details.add(R.string.cache_geocode, waypoint.getPrefix() + waypoint.getGeocode().substring(2));
+            details.add(R.string.cache_geocode, waypoint.getPrefix() + waypoint.getShortGeocode().substring(2));
             waypointDistance = details.addDistance(waypoint, waypointDistance);
             final String note = waypoint.getNote();
             if (StringUtils.isNotBlank(note)) {


### PR DESCRIPTION
There are still occurences in the code where the long "geocode" associated with Adventure Lab Caches hit the surface. This PR tries to fix them one after another. 

At this time, the waypoint popup gets fixed.