### PR TITLE
Allow backup of empty database (fix #10590)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -677,7 +677,7 @@
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>
-    <string name="init_backup_unnecessary">Database is empty, no backup necessary.</string>
+    <string name="init_backup_unnecessary">Database is empty, no backup necessary. Still create a backup?</string>
     <string name="init_backup_folder_exists_error">Unable to create a new backup folder. Did you already perform a backup in the last minute?</string>
     <string name="init_backup_no_backup_available">There is no backup file available.</string>
     <string name="backup_confirm_overwrite">This will delete your oldest existing backup folder from %s. \nDo you want to continue?</string>

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -348,10 +348,13 @@ public class BackupUtils {
         // avoid overwriting an existing backup with an empty database
         // (can happen directly after reinstalling the app)
         if (DataStore.getAllCachesCount() == 0) {
-            Toast.makeText(activityContext, R.string.init_backup_unnecessary, Toast.LENGTH_LONG).show();
-            return;
+            Dialogs.confirmYesNo(activityContext, R.string.init_backup_backup, R.string.init_backup_unnecessary, (dialog, which) -> backupStep2(runAfterwards));
+        } else {
+            backupStep2(runAfterwards);
         }
+    }
 
+    private void backupStep2(final Runnable runAfterwards) {
         final List<ContentStorage.FileInformation> dirs = getDirsToRemove(Settings.allowedBackupsNumber());
         if (dirs != null) {
             Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, activityContext.getString(R.string.init_backup_backup), activityContext.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs.get(dirs.size() - 1).dirLocation)), null, true, null, () -> {


### PR DESCRIPTION
## Description
- Currently no backups can be created if the database does not contain any caches. This had been implemented as a safety measure to not overwrite the (at that time) only existing backup with an empty one.
- Meanwhile we can have several backups at the same time, so the safety measure is no longer needed (in most cases, at least).
- As one might to backup the settings, allow creating a backup even when there are no caches to back up. But to be on the safe side, ask the user if she/he really wants to create a backup.

![image](https://user-images.githubusercontent.com/3754370/118037520-41675e80-b36e-11eb-93f2-a1c1542ad900.png)
