### PR TITLE
Skip unnecessary update checks directly after activating auto-download checks

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -444,18 +444,14 @@ public class MainActivity extends AbstractActionBarActivity {
     }
 
     private void checkForRoutingTileUpdates() {
-        if (Settings.useInternalRouting() && Settings.isBrouterAutoTileDownloads() && !PersistableFolder.ROUTING_TILES.isLegacy()) {
-            final long now = System.currentTimeMillis() / 1000;
-            final int interval = Settings.getBrouterAutoTileDownloadsInterval();
-            if ((Settings.getBrouterAutoTileDownloadsLastCheckInS() + (interval * 24 * 60 * 60)) <= now) {
-                DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, this::returnFromTileUpdateCheck);
-            }
+        if (Settings.useInternalRouting() && Settings.isBrouterAutoTileDownloads() && !PersistableFolder.ROUTING_TILES.isLegacy() && Settings.brouterAutoTileDownloadsNeedUpdate()) {
+            DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, this::returnFromTileUpdateCheck);
         }
     }
 
     private void returnFromTileUpdateCheck(final boolean updateCheckAllowed) {
         if (updateCheckAllowed) {
-            Settings.setBrouterAutoTileDownloadsLastCheckInS(System.currentTimeMillis() / 1000);
+            Settings.setBrouterAutoTileDownloadsLastCheck();
         }
     }
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -456,18 +456,14 @@ public class MainActivity extends AbstractActionBarActivity {
     }
 
     private void checkForMapUpdates() {
-        if (Settings.isMapAutoDownloads()) {
-            final long now = System.currentTimeMillis() / 1000;
-            final int interval = Settings.getMapAutoDownloadsInterval();
-            if ((Settings.getMapAutoDownloadsLastCheckInS() + (interval * 24 * 60 * 60)) <= now) {
-                DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, R.string.mapupdate_info, this::returnFromMapUpdateCheck);
-            }
+        if (Settings.isMapAutoDownloads() && Settings.mapAutoDownloadsNeedUpdate()) {
+            DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, R.string.mapupdate_info, this::returnFromMapUpdateCheck);
         }
     }
 
     private void returnFromMapUpdateCheck(final boolean updateCheckAllowed) {
         if (updateCheckAllowed) {
-            Settings.setMapAutoDownloadsLastCheckInS(System.currentTimeMillis() / 1000);
+            Settings.setMapAutoDownloadsLastCheck();
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1107,16 +1107,19 @@ public class Settings {
         return getBoolean(R.string.pref_brouterAutoTileDownloads, false);
     }
 
-    public static int getBrouterAutoTileDownloadsInterval() {
-        return getInt(R.string.pref_brouterAutoTileDownloadsInterval, 30);
+    public static boolean brouterAutoTileDownloadsNeedUpdate() {
+        final long lastCheck = getLong(R.string.pref_brouterAutoTileDownloadsLastCheck, 0);
+        if (lastCheck == 0) {
+            setBrouterAutoTileDownloadsLastCheck();
+            return false;
+        }
+        final long now = System.currentTimeMillis() / 1000;
+        final int interval = getInt(R.string.pref_brouterAutoTileDownloadsInterval, 30);
+        return ((lastCheck + (interval * 24 * 60 * 60)) <= now);
     }
 
-    public static long getBrouterAutoTileDownloadsLastCheckInS() {
-        return getLong(R.string.pref_brouterAutoTileDownloadsLastCheck, 0);
-    }
-
-    public static void setBrouterAutoTileDownloadsLastCheckInS(final long lastCheck) {
-        putLong(R.string.pref_brouterAutoTileDownloadsLastCheck, lastCheck);
+    public static void setBrouterAutoTileDownloadsLastCheck() {
+        putLong(R.string.pref_brouterAutoTileDownloadsLastCheck, System.currentTimeMillis() / 1000);
     }
 
     public static String getRoutingProfile() {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -986,16 +986,19 @@ public class Settings {
         return getBoolean(R.string.pref_mapAutoDownloads, false);
     }
 
-    public static int getMapAutoDownloadsInterval() {
-        return getInt(R.string.pref_mapAutoDownloadsInterval, 30);
+    public static boolean mapAutoDownloadsNeedUpdate() {
+        final long lastCheck = getLong(R.string.pref_mapAutoDownloadsLastCheck, 0);
+        if (lastCheck == 0) {
+            setMapAutoDownloadsLastCheck();
+            return false;
+        }
+        final long now = System.currentTimeMillis() / 1000;
+        final int interval = getInt(R.string.pref_mapAutoDownloadsInterval, 30);
+        return (lastCheck + (interval * 24 * 60 * 60)) <= now;
     }
 
-    public static long getMapAutoDownloadsLastCheckInS() {
-        return getLong(R.string.pref_mapAutoDownloadsLastCheck, 0);
-    }
-
-    public static void setMapAutoDownloadsLastCheckInS(final long lastCheck) {
-        putLong(R.string.pref_mapAutoDownloadsLastCheck, lastCheck);
+    public static void setMapAutoDownloadsLastCheck() {
+        putLong(R.string.pref_mapAutoDownloadsLastCheck, System.currentTimeMillis() / 1000);
     }
 
     public static void setPqShowDownloadableOnly(final boolean showDownloadableOnly) {
@@ -1115,7 +1118,7 @@ public class Settings {
         }
         final long now = System.currentTimeMillis() / 1000;
         final int interval = getInt(R.string.pref_brouterAutoTileDownloadsInterval, 30);
-        return ((lastCheck + (interval * 24 * 60 * 60)) <= now);
+        return (lastCheck + (interval * 24 * 60 * 60)) <= now;
     }
 
     public static void setBrouterAutoTileDownloadsLastCheck() {


### PR DESCRIPTION
## Description
Happens for both brouter tiles and maps/themes.

PR fixes this by checking whether the "last check" value is already set or not. If not (meaning: first start after activating the respective update option) remember the current date/time as "last checked" and return silently. Otherwise: Check date/time and act accordingly. Fixes #10606.
