### PR TITLE
enhance user experience on receiving download (rel. to #10615)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2081,6 +2081,7 @@
 
     <!-- ReceiveDownloadActivity -->
     <string name="receivedownload_intenttitle">Receive file</string>
+    <string name="receivedownload_receiving_file">Receiving file \"%s\"</string>
     <string name="receivedownload_success">File successfully stored as \"%s\"</string>
     <string name="receivedownload_error">Error while receiving file</string>
     <string name="receivedownload_error_io_exception">I/O error while receiving file. Is your folder \"%s\" writable?</string>
@@ -2088,7 +2089,7 @@
     <string name="receivedownload_alreadyexists">A file with this name already exists. Overwrite existing file or save new file under a different name?</string>
     <string name="receivedownload_option_overwrite">Overwrite</string>
     <string name="receivedownload_option_differentname">Different name</string>
-    <string name="receivedownload_kb_copied">%d kB copied</string>
+    <string name="receivedownload_amount_copied">%s copied</string>
     <string name="receivedownload_cancelled">File transfer cancelled</string>
 
     <!-- Download map preference and menu entry -->


### PR DESCRIPTION
## Description
- tries to fix issue #10615
- fixes a full scan on opening the zip (will now stop after first found map file)
- uses `BufferedOutput`
- avoids flooding UI with progress messages (zip had been updating in chunks of mostly less than 1k!, thus very frequently)
- outputs the processed size in K/M/G etc.

## Additional context
I'm not sure if that really fixes the original issue, but in several tests c:geo now stays responsive (where we had ANR before) on starting to transfer a downloaded file, and while the system's download manager took more than 10 minutes for a 590 MB file to download, unzipping to app. 700 MB and transferring it to c:geo was done in about 50s in the emulator.

@gcey:
Do you have a chance to test this build when it's compiled, to check whether it fixes the problem you described in #10615?