### PR TITLE
Migrate last missing brouter test (fix #10279)

### DIFF
--- a/tests/src-android/cgeo/geocaching/brouter/expressions/EncodeDecodeTest.java
+++ b/tests/src-android/cgeo/geocaching/brouter/expressions/EncodeDecodeTest.java
@@ -1,0 +1,46 @@
+package cgeo.geocaching.brouter.expressions;
+
+import cgeo.geocaching.brouter.util.DefaultFilesUtils;
+import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.storage.PersistableFolder;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EncodeDecodeTest {
+
+    @Test
+    public void encodeDecodeTest() {
+        // make sure profile files exist
+        DefaultFilesUtils.checkDefaultFiles();
+
+        // create routing context and load profile
+        final BExpressionMetaData meta = new BExpressionMetaData();
+        final BExpressionContextWay expctxWay = new BExpressionContextWay(meta);
+        meta.readMetaData();
+        final ContentStorage.FileInformation fi = ContentStorage.get().getFileInfo(PersistableFolder.ROUTING_BASE.getFolder(), "trekking.brf");
+        expctxWay.parseFile(fi.uri, "global");
+
+        final String[] tags = { "highway=residential",  "oneway=yes",  "reversedirection=yes" };
+
+        // encode the tags into 64 bit description word
+        final int[] lookupData = expctxWay.createNewLookupData();
+        for (String arg : tags) {
+            final int idx = arg.indexOf('=');
+            if (idx < 0) {
+                throw new IllegalArgumentException("bad argument (should be <tag>=<value>): " + arg);
+            }
+            final String key = arg.substring(0, idx);
+            final String value = arg.substring(idx + 1);
+
+            expctxWay.addLookupValue(key, value, lookupData);
+        }
+        final byte[] description = expctxWay.encode(lookupData);
+
+        // calculate the cost factor from that description
+        expctxWay.evaluate(true, description); // true = "reversedirection=yes"  (not encoded in description anymore)
+
+        final float costfactor = expctxWay.getCostfactor();
+        Assert.assertTrue("costfactor mismatch", Math.abs(costfactor - 5.15) < 0.00001);
+    }
+}


### PR DESCRIPTION
## Description
Since SAF-migration for internal routing engine is complete, we can now add the last missing test from the original BRouter test suite.
