### PR TITLE
force show internal storage on SAF folder selection (fix #10639)

### DIFF
--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -94,6 +94,18 @@ public class Intents {
     private static final String PREFIX_INTERNAL = "cgeo.geocaching.intent.internal.";
     public static final String INTENT_CACHE_CHANGED = PREFIX_INTERNAL + "cache-changed";
 
+    /**
+     * To be used together with {@link android.content.Intent#ACTION_OPEN_DOCUMENT_TREE}
+     *
+     * The value is decide whether to show advance mode or not.
+     * If the value is true, the local/device storage root must be
+     * visible in DocumentsUI. Otherwise it depends on the users preference.
+     *
+     * This is a system internal Api, which is not officially supported and not accessible from outside. Therefore, we need to define it ourselves.
+     * Anyway, the usage of it should be uncritical. The worst thing which could happen is that the EXTRA is simply ignored.
+     */
+    public static final String EXTRA_SHOW_ADVANCED = "android.provider.extra.SHOW_ADVANCED";
+
     private Intents() {
         // Do not instantiate
     }

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.storage;
 
+import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -314,6 +315,9 @@ public class ContentStorageActivityHelper {
             (folder == null || folder.needsWrite() ? Intent.FLAG_GRANT_WRITE_URI_PERMISSION : 0) |
             (folder != null ? Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION : 0));
         Uri realStartUri = startUri != null ? startUri : (folder != null ? folder.getUri() : null);
+
+        // show internal storage
+        intent.putExtra(Intents.EXTRA_SHOW_ADVANCED, true);
 
         if (realStartUri != null && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (UriUtils.isFileUri(realStartUri)) {


### PR DESCRIPTION
Although this seems kind of hacky, it actually works... ;-)

Furthermore, the usage of it should be uncritical. The worst thing which could happen is that the EXTRA is simply ignored is new/some android versions.