### PR TITLE
Fix wrong default value for proximity-preferences (fix #10598)

### DIFF
--- a/main/src/cgeo/geocaching/settings/SeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/SeekbarPreference.java
@@ -129,12 +129,13 @@ public class SeekbarPreference extends Preference {
     @Override
     protected void onSetInitialValue(final boolean restoreValue, final Object defaultValue) {
         final int defValue = null != defaultValue ? (Integer) defaultValue : this.defaultValue;
-        startProgress = valueToProgress(restoreValue ? getPersistedInt(defValue) : defValue);
+        final int defaultProgress = valueToProgress(restoreValue ? getPersistedInt(defValue) : defValue);
+        startProgress = defaultProgress < minProgress ? minProgress : Math.min(defaultProgress, maxProgress);
     }
 
     @Override
     protected Object onGetDefaultValue(final TypedArray a, final int index) {
-        return valueToProgress(a.getInt(index, defaultValue));
+        return a.getInt(index, defaultValue);
     }
 
     @Override


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
Fix wrong default value for proximity-preferences:
* avoid doubled conversion of the value, 'onGetDefaultValue' should return the default value, which is in this case the integer metric value (default value in the preferences.xml is defined as metric distance) and not the internal integer progress value.
* check for min/max on setting default-value


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#10598

