### PR TITLE
automatically download map themes (if necessary) (fix #10694)

### DIFF
--- a/main/src/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -93,15 +93,14 @@ public abstract class AbstractDownloader {
         }
     }
 
+    // extra file to download?
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+        return null;
+    }
+
     // default action to be started after having received and copied the downloaded file successfully
     protected void onSuccessfulReceive(final Uri result) {
         // default: nothing to do
-    }
-
-    // default followup action on UI thread after having received and copied the downloaded file successfully
-    protected void onFollowup(final Activity activity, final Runnable callback) {
-        // default: just continue with callback
-        callback.run();
     }
 
 }

--- a/main/src/cgeo/geocaching/downloader/AbstractMapDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractMapDownloader.java
@@ -5,10 +5,8 @@ import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
-import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.FileUtils;
 
-import android.app.Activity;
 import android.net.Uri;
 
 import androidx.annotation.StringRes;
@@ -32,27 +30,17 @@ abstract class AbstractMapDownloader extends AbstractDownloader {
     }
 
     // check if any of the given file exists in the given path
-    // if none exists: confirm to & download first
-    protected void findOrDownload(final Activity activity, final String[] filenames, final String baseUrl, final Download.DownloadType offlineMapType, final Runnable callback) {
-        boolean anyFileFound = false;
+    // if none exists: return descriptor for it
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final String[] filenames, final String baseUrl, final Download.DownloadType offlineMapType) {
         final List<ContentStorage.FileInformation> dirContent = ContentStorage.get().list(PersistableFolder.OFFLINE_MAP_THEMES);
         for (ContentStorage.FileInformation fi : dirContent) {
             for (String filename : filenames) {
                 if (fi.name.equals(filename)) {
-                    anyFileFound = true;
-                    break;
+                    return null;
                 }
             }
         }
-
-        if (!anyFileFound) {
-            Dialogs.confirm(activity, activity.getString(R.string.downloadmap_install_theme_title), activity.getString(R.string.downloadmap_install_theme_info), activity.getString(android.R.string.ok), (d, w) -> {
-                final Uri newUri = Uri.parse(baseUrl + filenames[0]);
-                DownloaderUtils.triggerDownload(activity, R.string.download_title, offlineMapType.id, newUri, "", "", System.currentTimeMillis(), callback);
-            }, dialog -> callback.run());
-        } else {
-            callback.run();
-        }
+        return new DownloaderUtils.DownloadDescriptor(filenames[0], Uri.parse(baseUrl + filenames[0]), offlineMapType.id);
     }
 
 }

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
@@ -99,9 +99,8 @@ public class MapDownloaderFreizeitkarte extends AbstractMapDownloader {
     }
 
     @Override
-    protected void onFollowup(final Activity activity, final Runnable callback) {
-        // check whether a FZK theme exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
-        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_freizeitkarte_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_FREIZEITKARTE, callback);
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+        return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_freizeitkarte_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_FREIZEITKARTE);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderHylly.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderHylly.java
@@ -50,11 +50,9 @@ public class MapDownloaderHylly extends AbstractMapDownloader {
         return CgeoApplication.getInstance().getString(R.string.mapserver_hylly_updatecheckurl);
     }
 
-
     @Override
-    protected void onFollowup(final Activity activity, final Runnable callback) {
-        // check whether theme file exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
-        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_hylly_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY, callback);
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+        return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_hylly_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -62,9 +62,8 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     }
 
     @Override
-    protected void onFollowup(final Activity activity, final Runnable callback) {
-        // check whether Elevate.zip exists in theme folder and ask whether user wants to download it as well, if it does not exist yet
-        findOrDownload(activity, THEME_FILES, activity.getString(R.string.mapserver_openandromaps_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS, callback);
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+        return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_openandromaps_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS);
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/downloader/ReceiveDownloadActivity.java
+++ b/main/src/cgeo/geocaching/downloader/ReceiveDownloadActivity.java
@@ -304,7 +304,7 @@ public class ReceiveDownloadActivity extends AbstractActivity {
                     result = getString(R.string.receivedownload_error);
                     break;
             }
-            Dialogs.message(context, getString(R.string.receivedownload_intenttitle), result, getString(android.R.string.ok), (dialog, button) -> downloader.onFollowup(activity, ReceiveDownloadActivity.this::doFinish));
+            Dialogs.message(context, getString(R.string.receivedownload_intenttitle), result, getString(android.R.string.ok), (dialog, button) -> doFinish());
         }
 
     }


### PR DESCRIPTION
## Description
- On downloading a map using the integrated downloader: automatically download theme file (if required and not yet installed)
- This replaces the (interactive) `onFollowup` method which was blocking using a background service for download.
