### PR TITLE
set background color for downloader to fix light theme

### DIFF
--- a/main/res/layout/mapdownloader_activity.xml
+++ b/main/res/layout/mapdownloader_activity.xml
@@ -5,6 +5,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
+    android:background="?background_color"
     tools:context=".downloader.MapDownloadSelectorActivity" >
 
     <Button


### PR DESCRIPTION
## Description
- Currently header for map downloader is unreadable in light theme.
- This PR defines the background color to fix this.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/119186431-6481c480-ba78-11eb-97af-615cb9f325d1.png)|![image](https://user-images.githubusercontent.com/3754370/119186503-76636780-ba78-11eb-8db8-44ec46f4a38d.png)|

