### PR TITLE
introduce full changelog (rel. to #10701, part b)

### DIFF
--- a/main/res/raw/changelog_full.md
+++ b/main/res/raw/changelog_full.md
@@ -1,0 +1,89 @@
+# Full changelog
+This changelog contains all changes which are not intermediate developing steps. It is more detailed than the changelogs we publish in our releases.
+
+<!-- --------------------------------------------------------------------------------- --->
+
+## Next release (branch `release`)
+
+### Map
+- Fix: Theming error in downloader (light theme only)
+- Fix: Selected track/route file did not get persisted
+
+### Other
+
+<!-- --------------------------------------------------------------------------------- --->
+
+## Current development (branch `master`)
+
+### Advanced filtering system (experimental)
+- Introducing a new filtering system to c:geo, supporting flexible, combinable and storable filters
+- Available in both cache lists and map view
+- This is work in progress, stay tuned!
+- The old filter systems are still available (for the time being), but will be superseeded by the new system at some point in time.
+
+### Map
+- New: On creating a user-defined cache while displaying a map from a list: Offer user to store new cache in current list (instead of default list for user-defined caches)
+
+### Cache details
+- New: Make use of google translate in-app translation popup
+- New: Allow changing the assigned icon in cache details popup via long click (stored caches only)
+
+### Downloader
+- Change: Files downloaded successfully will automatically overwrite existing files having the same name
+- Change: If a map requires a certain theme which is not installed yet, c:geo will automatically download and install that theme as well
+
+### Other
+- New: Download bookmark lists from geocaching.com - see "Lists / pocket queries" in main menu
+- New: Ignore capability for geocaching.su
+- Change: Removed no longer maintained RMAPS navigation app
+
+<!-- --------------------------------------------------------------------------------- --->
+
+## 2021.05.20
+
+### Geocaching Services
+- New: Added connector for Adventure Lab Caches - Shows starting coords of Adventure Labs with basic info on map and searches (PM-only). Use the link on the cache details page to start the Adventure Lab app to play the Adventure.
+- [Tap for FAQ, known limitations and open issues for Adventure Lab Caches](https://www.cgeo.org/faq#ALC_PM)
+
+### Cache details
+- New: Long click on waypoint coordinates to copy coordinates
+- New: Export and import user defined caches with empty coordinates
+- New: Support changing found state for user-defined caches and Lab Adventures
+- New: Parse formula for waypoints in personal cache note
+- New: Added indicator for calculated coordinates in waypoint list
+
+### Map
+- New: Automatic check for updates of downloaded map and theme files (optional)
+- New: BRouter: Show info message on missing routing data
+- New: Export individual route as track (in addition to "Export as route")
+
+### Integrated routing engine
+- New: Integrated BRouter routing engine - you can now use either external BRouter app or the integrated routing engine
+- New: Integrated routing engine supports automatic download of missing routing tiles
+- New: Integrated routing engine supports automatic updates of downloaded routing tiles
+- New: Integrated routing engine supports selecting different routing profiles
+
+
+### Other
+- Fix: Failing login to geocaching.com caused by website changes
+- Change: "Sort individual route" automatically closes on saving and checks for unsaved changes on using the back arrow
+- Fix: A couple of theming issues, esp. aligned theming of Google Maps and settings to "rest of app"
+- Fix: Optimize global search: If no trackable with matching tracking code is found, execute online cache name search afterwards
+- Fix: Avoid avatar images being displayed too wide and pushing the "Update / remove authorization" functionalty aside
+- Fix: Fix conversion error in some distance settings for imperial units
+- Fix: Directory selected by user not taken over in wizard on older devices
+- Fix: Scan for map themes now run as background task on startup
+- Fix: Changing map source via settings being recognized after full restart only
+- Fix: Crash in "View settings" under certain conditions
+- Fix: Back arrow in map downloader returning to main screen
+- Fix: Avoid strange popup messages when attaching image to log
+- Fix: Possible crash on map
+- Fix: Better support for file / folder selection on Android 5 devices
+- New: Debug view for pending downloads
+- Change: Removed Pocket Query Creator from useful apps (app no longer maintained and does not work anymore)
+
+<!-- --------------------------------------------------------------------------------- --->
+
+## Older releases
+
+This type of changelog started with release 2021.05.20. For older changelogs see our [release history](https://github.com/cgeo/cgeo/releases)

--- a/main/res/raw/changelog_master.md
+++ b/main/res/raw/changelog_master.md
@@ -1,5 +1,3 @@
-## Nightly build
-
 ### Advanced filtering system (experimental)
 - Introducing a new filtering system to c:geo, supporting flexible, combinable and storable filters
 - Available in both cache lists and map view

--- a/main/res/raw/changelog_release.md
+++ b/main/res/raw/changelog_release.md
@@ -1,39 +1,10 @@
-## Beta Version 2021.05.11-RC
-
-### Geocaching Services
-- New: Added connector for Adventure Lab Caches - Shows starting coords of Adventure Labs with basic info on map and searches (PM-only). Use the link on the cache details page to start the Adventure Lab app to play the Adventure.
-
 ### Cache details
-- New: Long click on waypoint coordinates to copy coordinates
-- New: Export and import user defined caches with empty coordinates
-- New: Support changing found state for user-defined caches and Lab Adventures
-- New: Parse formula for waypoints in personal cache note
-- New: Added indicator for calculated coordinates in waypoint list
 
 
 ### Map
-- New: Automatic check for updates of downloaded map and theme files (optional)
-- New: BRouter: Show info message on missing routing data
-- New: Export individual route as track (in addition to "Export as route")
+
 
 ### Integrated routing engine
-- New: Integrated BRouter routing engine - you can now use either external BRouter app or the integrated routing engine
-- New: Integrated routing engine supports automatic download of missing routing tiles
-- New: Integrated routing engine supports automatic updates of downloaded routing tiles
-- New: Integrated routing engine supports selecting different routing profiles
 
 
 ### Other
-- Change: "Sort individual route" automatically closes on saving and checks for unsaved changes on using the back arrow
-- Fix: A couple of theming issues, esp. aligned theming of Google Maps and settings to "rest of app"
-- Fix: Optimize global search: If no trackable with matching tracking code is found, execute online cache name search afterwards
-- Fix: Avoid avatar images being displayed too wide and pushing the "Update / remove authorization" functionalty aside
-- Fix: Fix conversion error in some distance settings for imperial units
-- New: Debug view for pending downloads
-- Fix: Directory selected by user not taken over in wizard on older devices
-- Fix: Scan for map themes now run as background task on startup
-- Fix: Changing map source via settings being recognized after full restart only
-- Fix: Crash in "View settings" under certain conditions
-- Fix: Back arrow in map downloader returning to main screen
-- Fix: Avoid strange popup messages when attaching image to log
-- Fix: Possible crash on map

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -525,6 +525,8 @@
     <!-- about -->
     <string name="about_version">Version</string>
     <string name="about_changelog">Changelog</string>
+    <string name="about_changelog_nightly_build">Nightly build</string>
+    <string name="about_changelog_next_release">Next release</string>
     <string name="about_system">System</string>
     <string name="about_donate">Support us</string>
     <string name="about_donation_more">Visit website for info</string>

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -160,12 +160,13 @@ public class AboutActivity extends AbstractViewPagerActivity<AboutActivity.Page>
 
             final String changelogMaster = FileUtils.getChangelogMaster(AboutActivity.this);
             if (StringUtils.isNotBlank(changelogMaster)) {
-                markwon.setMarkdown(binding.changelogMaster, changelogMaster);
+                markwon.setMarkdown(binding.changelogMaster, "## " + getString(R.string.about_changelog_nightly_build) + "\n\n" + changelogMaster);
             } else {
                 binding.changelogMaster.setVisibility(View.GONE);
             }
 
-            markwon.setMarkdown(binding.changelogRelease, FileUtils.getChangelogRelease(AboutActivity.this));
+            final String versionRelease = FileUtils.getRawResourceAsString(AboutActivity.this, R.raw.version_release).trim();
+            markwon.setMarkdown(binding.changelogRelease, "## " + (StringUtils.isNotBlank(versionRelease) ? versionRelease : getString(R.string.about_changelog_next_release)) + "\n\n" + FileUtils.getChangelogRelease(AboutActivity.this));
             binding.changelogGithub.setOnClickListener(v -> ShareUtils.openUrl(AboutActivity.this, "https://github.com/cgeo/cgeo/releases"));
             return binding.getRoot();
         }


### PR DESCRIPTION
## Description
This PR introduces a differentiation between to-be-published changelog and "full" changelog by providing the infrastructure for it. (No changes to `changelog_master.md` yet, but cleaned `changelog_release.md` to show a possible differentiation between full and shortened changelog.)

The "full" changelog is divided into sections "next release" (`release`), "current development" (`master`) and published releases. As it starts with our latest release `2021.05.20`, it also contains a link to our release history for older releases.

This page (`raw/changelog_full.md`) can be linked to from our website as official release history.