### PR TITLE
counting LC as active requires active GC connection as PM (fix #10707)

### DIFF
--- a/main/src/cgeo/geocaching/connector/lc/LCConnector.java
+++ b/main/src/cgeo/geocaching/connector/lc/LCConnector.java
@@ -139,8 +139,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
 
     @Override
     public boolean isActive() {
-        Log.d("_LC isActive: " + Settings.isLCConnectorActive());
-        return Settings.isLCConnectorActive();
+        return Settings.isLCConnectorActive() && Settings.isGCPremiumMember() && Settings.isGCConnectorActive();
     }
 
     @Override


### PR DESCRIPTION
## Description
Our status updates queries all connectors for their `isActive()` state. LC connector reported this only according to the setting for LC, but as LC connector also depends on having an active GC connection as a PM, those connections needed to be checked additionally for the counter to be correct.
