### PR TITLE
use MarkDown for about:contributors and about:system info

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -581,7 +581,7 @@
     <string name="about_contributors_carnerodetails">as the father of c:geo</string>
     <string name="about_contributors_recent">Recent contributors</string>
     <string name="about_contributors_specialthanks">Special thanks to</string>
-    <string name="about_contributors_specialthanksdetails">· all our translation contributors on <a href="https://crowdin.net/project/cgeo">Crowdin.net</a>!\n· all issue creators\n· and all other supporters.\n</string>
+    <string name="about_contributors_specialthanksdetails">- all our translation contributors on [Crowdin.net](https://crowdin.net/project/cgeo)!\n- all issue creators\n- and all other supporters.\n</string>
     <string name="about_contributors_other">Other contributors</string>
     <string name="about_components">Components</string>
     <string name="contribution_code">code</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -136,32 +136,37 @@
     zenobios||c|
     </string>
 
+    <!-- this one is a MarkDown-formatted string; %1 will be replaced with a MarkDown-prepared version of "components2" -->
     <string translatable="false" name="components">
-    · <a href="https://code.google.com/p/mapsforge/">Mapsforge</a> (OSM-rendering)\n
-    · <a href="https://thenounproject.com/">The Noun Project</a> (basis for attribute icons):\n
-    &#160;&#160;&#160;· add by Susannanova from the Noun Project\n
-    &#160;&#160;&#160;· Arrow by Jamison Wieser from The Noun Project\n
-    &#160;&#160;&#160;· challenge by Adrien Coquet from the Noun Project\n
-    &#160;&#160;&#160;· color palette by Vlad Likh from the Noun Project\n
-    &#160;&#160;&#160;· Folder by Landan Lloyd from the Noun Project\n
-    &#160;&#160;&#160;· new-idea by Artem Korotkikh from The Noun Project\n
-    &#160;&#160;&#160;· solution by Adrien Coquet from the Noun Project\n
-    &#160;&#160;&#160;· Trail by Martina Krasnayová from the Noun Project\n
-    &#160;&#160;&#160;· USB by Kenneth Von Alt from The Noun Project\n
-    · <a href="https://commons.apache.org/">The Apache Commons Project</a>\n
-    · <a href="https://androidicons.com/">Android Icons</a> (<a href="http://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA 4.0</a>)\n
-    · <a href="https://github.com/RRZE-PP/rrze-icon-set">RRZE Icon set</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA 3.0</a>)\n
-    · <a href="https://iconfindr.com/1mNr3rl">Layers icon by Cole Bemis</a> (<a href="https://creativecommons.org/licenses/by/3.0/">CC-BY 3.0</a>)\n
-    · <a href="https://material.io/tools/icons/">Google Material Design Icons</a> (<a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache license version 2.0</a>)\n
-    · <a href="https://github.com/bauerca/drag-sort-listview/">DragSortListView library by Carl Bauer</a> (<a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache license version 2.0</a>)\n
-    · <a href="https://www.mapquest.com/">Geocoding courtesy of MapQuest</a>\n
-    · <a href="https://www.openstreetmap.org/">Geocoding data from OpenStreetMap</a>\n
-    · The <a href="http://tango.freedesktop.org/Tango_Desktop_Project">Tango! Desktop Project</a> (Public Domain)\n
-    · OpenStreetMap cartography (OSM:Mapnik) © OpenStreetMap contributors. Map tile data <a href="http://www.openstreetmap.org/copyright/en">licensed</a> under Creative Commons 2.0 BY-SA.\n
-    · More maps based on OpenStreetMap cartography: © <a href="https://www.openstreetmap.de/">openstreetmap.de</a> and © <a href="https://www.cyclosm.org/">cyclosm.org</a>.\n
-    · Map Downloader supports maps from <a href="https://github.com/mapsforge">Mapsforge</a>, <a href="https://www.openandromaps.org">OpenAndroMaps</a>, <a href="https://www.freizeitkarte-osm.de/">Freizeitkarte</a> and <a href="https://kartat.hylly.org/">Hylly</a>.\n
-    · Routing © 2019 BRouter contributors (<a href="https://github.com/abrensch/brouter/blob/master/LICENSE">MIT license</a>)\n
+    - [Mapsforge](https://code.google.com/p/mapsforge/) (OSM-rendering)\n
+    - [The Noun Project](https://thenounproject.com/) (basis for attribute icons):\n%1
+    - [The Apache Commons Project](https://commons.apache.org/)\n
+    - [Android Icons](https://androidicons.com/) ([CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/))\n
+    - [RRZE Icon set](https://github.com/RRZE-PP/rrze-icon-set) ([CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))\n
+    - [Layers icon by Cole Bemis](https://iconfindr.com/1mNr3rl) ([CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/))\n
+    - [Google Material Design Icons](https://material.io/tools/icons/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
+    - [DragSortListView library by Carl Bauer](https://github.com/bauerca/drag-sort-listview/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
+    - [Geocoding courtesy of MapQuest](https://www.mapquest.com/)\n
+    - [Geocoding data from OpenStreetMap](https://www.openstreetmap.org/)\n
+    - The [Tango! Desktop Project](http://tango.freedesktop.org/Tango_Desktop_Project) (Public Domain)\n
+    - OpenStreetMap cartography (OSM:Mapnik) © OpenStreetMap contributors. Map tile data [licensed](http://www.openstreetmap.org/copyright/en) under Creative Commons 2.0 BY-SA.\n
+    - More maps based on OpenStreetMap cartography: © [openstreetmap.de](https://www.openstreetmap.de/) and © [cyclosm.org](https://www.cyclosm.org/).\n
+    - Map Downloader supports maps from [Mapsforge](https://github.com/mapsforge), [OpenAndroMaps](https://www.openandromaps.org), [Freizeitkarte](https://www.freizeitkarte-osm.de/) and [Hylly](https://kartat.hylly.org/).\n
+    - Routing © 2019 BRouter contributors ([MIT license](https://github.com/abrensch/brouter/blob/master/LICENSE))\n
 	</string>
+
+    <!-- see comment for "components" -->
+    <string translatable="false" name="components2">
+    - add by Susannanova from the Noun Project\n
+    - Arrow by Jamison Wieser from The Noun Project\n
+    - challenge by Adrien Coquet from the Noun Project\n
+    - color palette by Vlad Likh from the Noun Project\n
+    - Folder by Landan Lloyd from the Noun Project\n
+    - new-idea by Artem Korotkikh from The Noun Project\n
+    - solution by Adrien Coquet from the Noun Project\n
+    - Trail by Martina Krasnayová from the Noun Project\n
+    - USB by Kenneth Von Alt from The Noun Project\n
+    </string>
 
     <!-- cache details -->
     <string translatable="false" name="favorite_count">%1$d</string>

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -61,7 +61,7 @@ public final class SystemInformation {
         }
         final String hideCaches = (Settings.isExcludeMyCaches() ? "own/found " : "") + (Settings.isExcludeDisabledCaches() ? "disabled " : "") + (Settings.isExcludeArchivedCaches() ? "archived" : "");
         final String hideWaypoints = (Settings.isExcludeWpOriginal() ? "original " : "") + (Settings.isExcludeWpParking() ? "parking " : "") + (Settings.isExcludeWpVisited() ? "visited" : "");
-        final StringBuilder body = new StringBuilder("--- System information ---")
+        final StringBuilder body = new StringBuilder("## System information").append("\n")
             .append("\nc:geo version: ").append(Version.getVersionName(context)).append("\n")
 
             .append("\nDevice:")
@@ -125,7 +125,7 @@ public final class SystemInformation {
         appendPersistedUriPermission(body, context);
         appendDatabase(body);
 
-        body.append("\n--- End of system information ---\n");
+        body.append("\n\n--- End of system information ---\n");
         return body.toString();
     }
 


### PR DESCRIPTION
## Description
Now that we are using MarkDown to format our version history, let's expand this to about:contributors and about:system info

![image](https://user-images.githubusercontent.com/3754370/119252715-f7704b00-bbad-11eb-8ac8-1eab6aba9f6b.png).![image](https://user-images.githubusercontent.com/3754370/119252718-fccd9580-bbad-11eb-83b1-3f43fbcfc0e6.png).![image](https://user-images.githubusercontent.com/3754370/119252721-01924980-bbae-11eb-96bd-a0cfe8d9431b.png)
