### PR TITLE
Revert "Bump core from 1.3.2 to 1.5.0"

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -376,7 +376,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
     // Support Library core (used for eg. HtmlCompat)
-    implementation 'androidx.core:core:1.5.0'
+    implementation 'androidx.core:core:1.3.2'
 
     // Support Library ExifInterface
     implementation 'androidx.exifinterface:exifinterface:1.3.2'


### PR DESCRIPTION
Reverts cgeo/cgeo#10680

see https://ci.cgeo.org/job/cgeo%20pull%20request/5833/console
and Issue #10730


