### PR TITLE
add missing super calls to onRequestPermissionsResult (fix #10732)

### DIFF
--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -415,6 +415,7 @@ public class InstallWizardActivity extends AppCompatActivity {
 
     @Override
     public void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         gotoNext();
     }
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -368,6 +368,7 @@ public class MainActivity extends AbstractActionBarActivity {
 
     @Override
     public void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
             PermissionHandler.executeCallbacksFor(permissions);
         } else {


### PR DESCRIPTION
## Description
Fix the lint error of missing calls to `super.onRequestPermissionsResult`
