### PR TITLE
Extract waypoint with same name but different coordinates from personal note (fix #10677)

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1674,23 +1674,27 @@ public class Geocache implements IWaypoint {
         }
 
         //try to match coordinate
-        final Geopoint point = searchWp.getCoords();
-        if (null != point) {
+        final Geopoint searchWpPoint = searchWp.getCoords();
+        if (null != searchWpPoint) {
             for (final Waypoint waypoint : waypoints) {
                 // waypoint can have no coords such as a Final set by cache owner
                 final Geopoint coords = waypoint.getCoords();
-                if (coords != null && coords.equalsDecMinute(point)) {
+                if (coords != null && coords.equalsDecMinute(searchWpPoint)) {
                     return waypoint;
                 }
             }
         }
 
-        //try to match name if prefix is empty and coords are not equal
+        //try to match name if prefix is empty and coords are not equal.
+        //But only, if coordinates of waypoint can be updated, otherwise create a new waypoint
+        //(it's not a bug, it's a feature - otherwise the coordinates gets lost)
         final String searchWpName = searchWp.getName();
         final String searchWpType = searchWp.getWaypointType().getL10n();
         if (StringUtils.isNotBlank(searchWpName)) {
             for (final Waypoint waypoint : waypoints) {
-                if (searchWpName.equals(waypoint.getName()) && searchWpType.equals(waypoint.getWaypointType().getL10n())) {
+                final Geopoint point = waypoint.getCoords();
+                final boolean canChangeCoordinates = null == searchWpPoint || null == point;
+                if (canChangeCoordinates && searchWpName.equals(waypoint.getName()) && searchWpType.equals(waypoint.getWaypointType().getL10n())) {
                     return waypoint;
                 }
             }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
Waypoint was not extracted, if already a waypoint with same name but different coordinates exist.

Don't compare name for waypoints with coordinates.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#10677

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
bug was introduced by me in PR #9337, there the waypoint-name-matching was introduced for waypoints with empty coordinates