### PR TITLE
use OutlinedButtonStyle for button theming

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -68,14 +68,13 @@
 
     <!-- buttons -->
 
-    <style name="button">
+    <style name="button" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:padding">6dip</item>
         <item name="android:lines">1</item>
         <item name="android:singleLine">true</item>
         <item name="android:scrollHorizontally">true</item>
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
-        <item name="android:background">?button</item>
     </style>
 
     <style name="button_borderless" parent="button">

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -4,8 +4,6 @@
     <!-- theme for (nearly) all activities) -->
 
     <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <item name="button">@drawable/action_button</item>
-        <item name="android:buttonStyle">@style/button</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>


### PR DESCRIPTION
fix #10739

As pointed out, changing the general button theme seems to be not that easy. As "quick fix" let's just apply the OutlinedButtonStyle  as base of our existing button style. This works like a charm as all existing buttons already use that style, but we need to add the `button`-style to every newly created button...

There might be better solutions, but this is the easiest for now.