### PR TITLE
set darker background for dark mode (fix #10752)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -156,7 +156,7 @@
             android:name=".CachePopup"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
-            android:theme="@style/cgeo.popup"
+            android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
             android:windowSoftInputMode="stateHidden" >
         </activity>
         <activity
@@ -727,7 +727,7 @@
             android:name="WaypointPopup"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/waypoint"
-            android:theme="@style/cgeo.popup"
+            android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
             android:windowSoftInputMode="stateHidden" >
         </activity>
         <activity

--- a/main/res/layout/cachelist_spinneritem.xml
+++ b/main/res/layout/cachelist_spinneritem.xml
@@ -16,6 +16,7 @@
         android:layout_width="match_parent"
         style="?attr/titleTextStyle"
         android:textSize="@dimen/textSize_toolbarPrimary"
+        android:textColor="@color/colorTextActionBar"
         android:layout_height="wrap_content"
         android:maxLines="1" />
 
@@ -26,6 +27,7 @@
         android:ellipsize="end"
         style="?attr/subtitleTextStyle"
         android:textSize="@dimen/textSize_toolbarSecondary"
+        android:textColor="@color/colorTextActionBar"
         tools:text="This is the subtitle"
         android:id="@android:id/text2"
         android:maxLines="1" />

--- a/main/res/layout/settings_toolbar.xml
+++ b/main/res/layout/settings_toolbar.xml
@@ -9,4 +9,5 @@
     app:navigationContentDescription="@string/abc_action_bar_up_description"
     app:navigationIcon="?attr/homeAsUpIndicator"
     android:textSize="@dimen/textSize_toolbarSingle"
+    android:theme="@style/settings_actionbar_theme"
     />

--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -11,10 +11,9 @@
 
     <color name="colorTextHeadline">#88FFFFFF</color>
 
-    <color name="colorBackground">#FF202020</color>
+    <color name="colorBackground">#FF141414</color>
     <color name="colorBackgroundNotice">#FF191919</color>
     <color name="colorBackgroundTransparent">#44000000</color>
-    <color name="colorBackgroundActionBar">#FF000000</color>
 
     <color name="colorSeparator">#44FFFFFF</color>
 

--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -11,7 +11,7 @@
 
     <color name="colorTextHeadline">#88FFFFFF</color>
 
-    <color name="colorBackground">#FF404040</color>
+    <color name="colorBackground">#FF202020</color>
     <color name="colorBackgroundNotice">#FF191919</color>
     <color name="colorBackgroundTransparent">#44000000</color>
     <color name="colorBackgroundActionBar">#FF000000</color>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -22,7 +22,8 @@
     -->
     <color name="text_icon">#FFFFFFFF</color>
 
-
+    <color name="colorTextActionBar">#FFE4E4E4</color>
+    <color name="colorBackgroundActionBar">#FF303030</color>
 
     <!-- values needed only until settings activity is based on AppCompatActivity -->
     <color name="settings_colorTextDark">@color/just_white</color>

--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -14,7 +14,6 @@
     <color name="colorBackground">#FFFFFFFF</color>
     <color name="colorBackgroundNotice">#FFDFDFDF</color>
     <color name="colorBackgroundTransparent">#44FFFFFF</color>
-    <color name="colorBackgroundActionBar">@color/colorAccent</color>
 
     <color name="colorSeparator">#44000000</color>
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -31,14 +31,20 @@
     </style>
 
     <!-- actionbar -->
-    <style name="action_bar">
+    <style name="actionBarStyle" parent="Widget.MaterialComponents.ActionBar.Solid">
+        <item name="android:textColor">@color/colorTextActionBar</item>
+        <item name="background">@color/colorBackgroundActionBar</item>
+        <item name="titleTextStyle">@style/action_bar_title</item>
+    </style>
+
+    <style name="action_bar" parent="actionBarStyle">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">@dimen/actionbar_height</item>
         <item name="android:orientation">horizontal</item>
         <item name="android:gravity">center</item>
     </style>
 
-    <style name="action_bar_action">
+    <style name="action_bar_action" parent="actionBarStyle">
         <item name="android:layout_width">@dimen/actionbar_height</item>
         <item name="android:layout_height">@dimen/actionbar_height</item>
         <item name="android:padding">2dip</item>
@@ -53,7 +59,7 @@
         <item name="android:background">@color/colorSeparator</item>
     </style>
 
-    <style name="action_bar_title">
+    <style name="action_bar_title" parent="@style/TextAppearance.AppCompat.Widget.ActionBar.Title">
         <item name="android:layout_width">0dip</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_weight">1</item>
@@ -64,6 +70,12 @@
         <item name="android:lines">1</item>
         <item name="android:text">c:geo</item>
         <item name="android:textSize">@dimen/textSize_toolbarSingle</item>
+        <item name="android:textColor">@color/colorTextActionBar</item>
+    </style>
+
+    <style name="settings_actionbar_theme" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
+        <!-- Customize color of back arrow -->
+        <item name="android:textColorPrimary">@color/colorTextActionBar</item>
     </style>
 
     <!-- buttons -->

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -4,6 +4,7 @@
     <!-- theme for (nearly) all activities) -->
 
     <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="actionBarStyle">@style/actionBarStyle</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -22,11 +22,14 @@
 
     <!-- theme for cache/waypoint popups -->
 
-    <style name="cgeo.popup" parent="cgeo">
+    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="cgeo">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowAnimationStyle">@android:style/Animation</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
     </style>
 
     <!-- theme for settings (temporary workaround, needed only as long as SettingsActivity is not derived from AppCompatActivity) -->

--- a/main/src/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/cgeo/geocaching/activity/ActivityMixin.java
@@ -67,7 +67,7 @@ public final class ActivityMixin {
     }
 
     public static int getDialogTheme() {
-        return R.style.cgeo_popup;
+        return R.style.Theme_AppCompat_Transparent_NoActionBar;
     }
 
     /**

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -254,7 +254,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private final Handler displayHandler = new DisplayHandler(this);
 
     private void setTitle() {
-        getActionBar().setTitle(calculateTitle());
+        getActionBar().setTitle(MapUtils.getColoredValue(calculateTitle()));
     }
 
     private String calculateTitle() {
@@ -286,8 +286,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         if (StringUtils.isEmpty(subtitle)) {
             return;
         }
-
-        getActionBar().setSubtitle(subtitle);
+        getActionBar().setSubtitle(MapUtils.getColoredValue(subtitle));
     }
 
     private String calculateSubtitle() {

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.maps;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
@@ -15,6 +16,8 @@ import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.Activity;
+import android.text.Html;
+import android.text.Spanned;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
@@ -143,5 +146,11 @@ public class MapUtils {
 
     public static CacheListType getMapViewerListType() {
         return CacheListType.MAP;
+    }
+
+    // workaround for colored ActionBar titles/subtitles
+    // @todo remove after switching map ActionBar to Toolbar
+    public static Spanned getColoredValue(final String value) {
+        return Html.fromHtml("<font color=\"" + String.format("#%06X", 0xFFFFFF & CgeoApplication.getInstance().getResources().getColor(R.color.colorTextActionBar)) + "\">" + value + "</font>");
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1047,7 +1047,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
 
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setTitle(title);
+            actionBar.setTitle(MapUtils.getColoredValue(title));
         }
     }
 
@@ -1073,7 +1073,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
 
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setSubtitle(subtitle);
+            actionBar.setSubtitle(MapUtils.getColoredValue(subtitle));
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -161,8 +161,8 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         bar.setTitle(title);
         bar.setNavigationOnClickListener(onClickListener);
         // @todo Remove next two lines after switching to AppCompatActitivy
-        bar.setTitleTextColor(getResources().getColor(Settings.isLightSkin() ? R.color.settings_colorTextSecondaryLight : R.color.settings_colorTextSecondaryDark));
-        bar.setBackgroundColor(getResources().getColor(Settings.isLightSkin() ? R.color.colorAccent : R.color.just_black));
+        bar.setTitleTextColor(getResources().getColor(R.color.colorTextActionBar));
+        bar.setBackgroundColor(getResources().getColor(R.color.colorBackgroundActionBar));
     }
 
     @Override


### PR DESCRIPTION
## Description
Set the background color #FF202020 as suggested in https://github.com/cgeo/cgeo/issues/10752#issuecomment-848974727

Result would be like this:
![image](https://user-images.githubusercontent.com/3754370/119710225-696ebb80-be5e-11eb-9049-0e41d8055130.png).![image](https://user-images.githubusercontent.com/3754370/119710240-6e336f80-be5e-11eb-8ab8-19f6f92ca058.png).![image](https://user-images.githubusercontent.com/3754370/119710263-725f8d00-be5e-11eb-9245-7878249af6b6.png)

And in conjunction with #10764 it would look like this:
![image](https://user-images.githubusercontent.com/3754370/119710667-e8fc8a80-be5e-11eb-89bf-c16a345e0a48.png).![image](https://user-images.githubusercontent.com/3754370/119710686-ef8b0200-be5e-11eb-8b7d-99b9b708dc5e.png)
