### PR TITLE
set status bar color for splash screen to black (fix #10761)

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -73,6 +73,7 @@
     <!-- theme for splash screen -->
 
     <style name="SplashScreenTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@color/just_black</item>
         <item name="android:windowBackground">@drawable/splashscreen_background</item>
         <item name="android:windowActivityTransitions">false</item>
     </style>


### PR DESCRIPTION
## Description
Sets the status bar color for splash screen to pure black