### PR TITLE
WIP - Material theming: icon buttons

### DIFF
--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -3,10 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/colorBackgroundTransparent"
     android:windowBackground="@color/colorBackgroundTransparent"
     android:orientation="vertical"
-    tools:context=".CachePopupFragment" >
+    tools:context=".CachePopupFragment">
 
     <include layout="@layout/actionbar_popup" />
     <ScrollView
@@ -41,10 +42,10 @@
                     android:layout_gravity="center_horizontal"
                     android:text="@string/popup_more" />
 
-                <ImageButton
+                <Button
                     android:id="@+id/offline_hint"
                     style="@style/button_icon"
-                    android:src="@drawable/ic_menu_hint"
+                    app:icon="@drawable/ic_menu_hint"
                     android:layout_alignParentRight="true"
                     android:layout_marginLeft="0dp"
                     android:visibility="gone"

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2507,7 +2507,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
 
         // check if hint is available and set onClickListener and hint button visibility accordingly
         final boolean hintButtonEnabled = setOfflineHintText(showHintClickListener, view.findViewById(R.id.offline_hint_text), cache.getHint(), cache.getPersonalNote());
-        final ImageButton offlineHint = view.findViewById(R.id.offline_hint);
+        final Button offlineHint = view.findViewById(R.id.offline_hint);
         if (null != offlineHint) {
             if (hintButtonEnabled) {
                 offlineHint.setVisibility(View.VISIBLE);


### PR DESCRIPTION
fix #10769

---
![grafik](https://user-images.githubusercontent.com/64581222/119869318-60deb980-bf20-11eb-99b9-8c7911cadb88.png)

If we want to theme our icon buttons like buttons (as before), we need to switch from `IconButton` to `Button` as the `IconButton` class is not really supported by material design...

What do you think? Should we go this way, or is this getting too colorful?