### PR TITLE
define background color for cache/wpt popup (fix #10777)

### DIFF
--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:background="@color/colorBackgroundTransparent"
+    android:background="@color/colorBackgroundDialog"
     android:windowBackground="@color/colorBackgroundTransparent"
     android:orientation="vertical"
     tools:context=".CachePopupFragment" >

--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -14,6 +14,7 @@
     <color name="colorBackground">#FF141414</color>
     <color name="colorBackgroundNotice">#FF191919</color>
     <color name="colorBackgroundTransparent">#44000000</color>
+    <color name="colorBackgroundDialog">#FF424242</color>
 
     <color name="colorSeparator">#44FFFFFF</color>
 

--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -14,6 +14,7 @@
     <color name="colorBackground">#FFFFFFFF</color>
     <color name="colorBackgroundNotice">#FFDFDFDF</color>
     <color name="colorBackgroundTransparent">#44FFFFFF</color>
+    <color name="colorBackgroundDialog">#FFFFFFFF</color>
 
     <color name="colorSeparator">#44000000</color>
 


### PR DESCRIPTION
## Description
Defines background color for cache / waypoint popup, using the same color as other dialogs (white in light theme, #424242 in dark theme)
