### PR TITLE
fix some low contrast texts in light mode

### DIFF
--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -20,6 +20,7 @@
         android:scrollHorizontally="false"
         android:text="@null"
         android:textIsSelectable="false"
+        android:textColor="@color/colorText"
         tools:text="property"/>
 
     <TextView
@@ -31,6 +32,7 @@
         android:layout_toRightOf="@+id/name"
         android:gravity="center_vertical"
         android:textIsSelectable="false"
+        android:textColor="@color/colorText"
         tools:text="value"/>
 
     <RatingBar
@@ -58,6 +60,7 @@
         android:gravity="center_vertical"
         android:textIsSelectable="false"
         android:visibility="gone"
+        android:textColor="@color/colorText"
         tools:text="additional text"
         tools:visibility="visible"/>
 

--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -22,6 +22,7 @@
             android:linksClickable="true"
             android:textIsSelectable="true"
             android:textSize="@dimen/textSize_detailsPrimary"
+            android:textColor="@color/colorText"
             android:visibility="gone"
             tools:text="This is the cache description. It might be very long..."
             tools:visibility="visible" />
@@ -64,7 +65,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dip"
-                android:textSize="@dimen/textSize_detailsPrimary" />
+                android:textSize="@dimen/textSize_detailsPrimary"
+                android:textColor="@color/colorText" />
         </LinearLayout>
 
         <!-- Hint and spoiler-images box -->
@@ -95,6 +97,7 @@
                 android:linksClickable="true"
                 android:textIsSelectable="true"
                 android:textSize="@dimen/textSize_detailsPrimary"
+                android:textColor="@color/colorText"
                 tools:text="A hint for finding the cache..." />
 
             <TextView
@@ -106,6 +109,7 @@
                 android:drawablePadding="3dip"
                 android:text="@string/cache_menu_spoilers"
                 android:textSize="@dimen/textSize_detailsPrimary"
+                android:textColor="@color/colorText"
                 app:drawableLeftCompat="@drawable/log_img" />
         </LinearLayout>
 
@@ -133,6 +137,7 @@
                 android:layout_height="wrap_content"
                 android:linksClickable="true"
                 android:textSize="@dimen/textSize_detailsPrimary"
+                android:textColor="@color/colorText"
                 tools:text="Personal note text\nline 2\nline 3" />
 
             <View style="@style/separator_horizontal"

--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -57,6 +57,7 @@
                 android:paddingRight="6dp"
                 android:textIsSelectable="false"
                 android:textSize="@dimen/textSize_detailsSecondary"
+                android:textColor="@color/colorText"
                 tools:text="attribute 1\nattribute 2\nattribute 3"/>
         </LinearLayout>
 
@@ -88,6 +89,7 @@
                     android:layout_marginRight="6dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="This cache has not been stored. Or has it? Maybe an hour ago?"
                     android:textIsSelectable="false" />
 
@@ -123,6 +125,7 @@
                     android:layout_marginRight="6dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="list 1, list 2, list 3, and many, many, many, many, many more lists"
                     android:textIsSelectable="false" />
 
@@ -172,6 +175,7 @@
                     android:layout_marginRight="60dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="The cache may or may not be on your watch list."
                     android:textIsSelectable="false" />
 
@@ -222,6 +226,7 @@
                     android:layout_marginRight="60dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="Send to WhereYouGo"
                     android:textIsSelectable="false" />
 
@@ -265,6 +270,7 @@
                     android:layout_marginRight="60dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="Start Chirp Wolf"
                     android:textIsSelectable="false" />
 
@@ -308,6 +314,7 @@
                     android:layout_marginRight="60dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="Start Adventure Lab"
                     android:textIsSelectable="false" />
 
@@ -349,6 +356,7 @@
                     android:layout_marginRight="60dip"
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
                     tools:text="Probably not on your favorite list. You may have some fav points remaining."
                     android:textIsSelectable="false" />
 
@@ -396,6 +404,7 @@
                 android:linksClickable="true"
                 android:padding="3dip"
                 android:textSize="@dimen/textSize_detailsSecondary"
+                android:textColor="@color/colorText"
                 tools:text="some license text"/>
         </LinearLayout>
 

--- a/main/res/layout/logs_item.xml
+++ b/main/res/layout/logs_item.xml
@@ -70,7 +70,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:gravity="left"
-                android:textSize="@dimen/textSize_detailsPrimary" />
+                android:textSize="@dimen/textSize_detailsPrimary"
+                android:textColor="@color/colorText"/>
 
             <TextView
                 android:id="@+id/log_images"

--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -72,7 +72,8 @@
                     android:layout_marginRight="51dip"
                     android:paddingRight="3dip"
                     android:textIsSelectable="false"
-                    android:textSize="@dimen/textSize_detailsSecondary" />
+                    android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"/>
 
                 <ImageButton
                     android:id="@+id/offline_refresh"
@@ -95,7 +96,8 @@
                     android:paddingRight="3dip"
                     android:textIsSelectable="false"
                     android:textSize="@dimen/textSize_detailsSecondary"
-                    tools:text="list 1, list 2"/>
+                    tools:text="list 1, list 2"
+                    android:textColor="@color/colorText"/>
 
                 <ImageButton
                     android:id="@+id/offline_edit"
@@ -130,7 +132,8 @@
                 android:textIsSelectable="false"
                 android:textSize="@dimen/textSize_detailsSecondary"
                 android:visibility="gone"
-                tools:text="hint"/>
+                tools:text="hint"
+                android:textColor="@color/colorText"/>
 
         </LinearLayout>
     </ScrollView>

--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -44,6 +44,7 @@
                 android:layout_height="wrap_content"
                 android:focusable="false"
                 android:textSize="@dimen/textSize_listsPrimary"
+                android:textColor="@color/colorText"
                 tools:text="Description of the waypoint with a lot of small words so that an incorrect layout should easily be noticed"/>
 
             <TextView
@@ -57,6 +58,7 @@
                 android:lines="1"
                 android:scrollHorizontally="true"
                 android:textSize="@dimen/textSize_listsSecondary"
+                android:textColor="@color/colorText"
                 android:visibility="gone"
                 tools:visiblity="visible"
                 tools:text="Info"
@@ -75,6 +77,7 @@
         android:lines="1"
         android:scrollHorizontally="true"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="1.2.3.4.5N 6.7.8.9.10S"
@@ -92,6 +95,7 @@
         android:maxLines="1"
         android:scrollHorizontally="true"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText"
         android:visibility="gone"
         android:text="@string/waypoint_calculated_coordinates"
         tools:visiblity="visible" />
@@ -104,6 +108,7 @@
         android:layout_marginLeft="12dp"
         android:focusable="false"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="Note"/>
@@ -116,6 +121,7 @@
         android:layout_marginLeft="12dp"
         android:focusable="false"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="User Note"/>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -361,6 +361,7 @@
         <item name="android:scrollHorizontally">true</item>
         <item name="android:singleLine">true</item>
         <item name="android:textSize">@dimen/textSize_headingSecondary</item>
+        <item name="android:textColor">@color/colorText</item>
     </style>
 
     <!-- date, found state on the left of a log entry -->
@@ -374,6 +375,7 @@
         <item name="android:scrollHorizontally">true</item>
         <item name="android:singleLine">true</item>
         <item name="android:textSize">@dimen/textSize_detailsSecondary</item>
+        <item name="android:textColor">@color/colorText</item>
     </style>
 
     <!-- separator between log author and log content -->


### PR DESCRIPTION
## Description
Not setting `textColor` for certain elements lead to low-contrast texts in light mode, therefore added `textColor` to several elements in cache detail pages and cache popup.
