### PR TITLE
cache detail list: increase textSize and spacing (fix #10759)

### DIFF
--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -7,19 +7,20 @@
 
     <TextView
         android:id="@+id/name"
-        android:layout_width="80dip"
+        android:layout_width="90dip"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="false"
         android:layout_centerVertical="true"
         android:layout_gravity="left|top"
-        android:layout_marginRight="4dip"
+        android:layout_marginRight="8dip"
         android:ellipsize="end"
         android:gravity="right"
         android:lines="1"
         android:scrollHorizontally="false"
         android:text="@null"
         android:textIsSelectable="false"
+        android:textSize="@dimen/textSize_detailsPrimary"
         android:textColor="@color/colorText"
         tools:text="property"/>
 
@@ -31,6 +32,7 @@
         android:layout_marginRight="5dip"
         android:layout_toRightOf="@+id/name"
         android:gravity="center_vertical"
+        android:textSize="@dimen/textSize_detailsPrimary"
         android:textIsSelectable="false"
         android:textColor="@color/colorText"
         tools:text="value"/>


### PR DESCRIPTION
## Description
Increases text size in cache details list to `detailsPrimary` and increase the space between label and item:

![image](https://user-images.githubusercontent.com/3754370/120029093-ea13f000-bff5-11eb-9f6a-0eb95a51ab05.png)
