### PR TITLE
replace brouter info with dialog (fix #10776)

### DIFF
--- a/main/res/layout/map_settings_dialog.xml
+++ b/main/res/layout/map_settings_dialog.xml
@@ -113,16 +113,13 @@
                 app:icon="@drawable/routing_car" />
         </com.google.android.material.button.MaterialButtonToggleGroup>
 
-        <TextView
-            android:id="@+id/brouter_install"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/routing_tooglegroup"
-            android:layout_marginLeft="6dp"
-            android:layout_marginRight="6dp"
-            android:layout_marginBottom="8dp"
-            android:text="@string/map_routing_brouter"
-            android:visibility="gone" />
+        <ImageButton
+            android:id="@+id/routing_info"
+            style="@style/button_icon"
+            android:src="@drawable/ic_info_blue"
+            android:layout_alignParentRight="true"
+            android:layout_alignBottom="@id/routing_tooglegroup"
+            android:visibility="gone"/>
     </RelativeLayout>
 
     <RelativeLayout

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1500,7 +1500,8 @@
     <string name="map_as_list">Show as list</string>
     <string name="map_select_multiple_items">Select item</string>
     <string name="map_routing">Routing</string>
-    <string name="map_routing_brouter">Routing is only available if <a href="">BRouter</a> is installed</string>
+    <string name="map_routing_activate_title">Enable routing</string>
+    <string name="map_routing_activate">Some routing modes are currently not available, as no routing engine is active.\n\nDo you want to activate c:geo\'s internal routing engine and downloading of routing data?</string>
     <string name="map_gm_autorotation">Map auto rotation</string>
     <string name="map_gm_autorotation_disable">Disable map auto rotation?\n\nYou can enable it again using the Map rotation menu</string>
     <string name="quick_settings">Quick settings</string>

--- a/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.IndividualRouteUtils;
-import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
@@ -114,15 +113,25 @@ public class MapSettingsUtils {
         routingChoiceWrapper.init();
 
         if (!Routing.isAvailable()) {
-            for (final ButtonChoiceModel<RoutingMode> button : routingChoiceWrapper.list) {
-                if (!(button.assignedValue == RoutingMode.OFF || button.assignedValue == RoutingMode.STRAIGHT)) {
-                    button.button.setEnabled(false);
-                    button.button.setAlpha(.3f);
-                }
-            }
+            configureRoutingButtons(false, routingChoiceWrapper);
+            dialogView.routingInfo.setVisibility(View.VISIBLE);
+            dialogView.routingInfo.setOnClickListener(v -> {
+                Dialogs.confirm(activity, R.string.map_routing_activate_title, R.string.map_routing_activate, (dialog1, which) -> {
+                    Settings.setUseInternalRouting(true);
+                    Settings.setBrouterAutoTileDownloads(true);
+                    configureRoutingButtons(true, routingChoiceWrapper);
+                    dialogView.routingInfo.setVisibility(View.GONE);
+                });
+            });
+        }
+    }
 
-            dialogView.brouterInstall.setVisibility(View.VISIBLE);
-            dialogView.brouterInstall.setOnClickListener(v -> ProcessUtils.openMarket(activity, activity.getString(R.string.package_brouter)));
+    private static void configureRoutingButtons(final boolean enabled, final ToggleButtonWrapper<RoutingMode> routingChoiceWrapper) {
+        for (final ButtonChoiceModel<RoutingMode> button : routingChoiceWrapper.list) {
+            if (!(button.assignedValue == RoutingMode.OFF || button.assignedValue == RoutingMode.STRAIGHT)) {
+                button.button.setEnabled(enabled);
+                button.button.setAlpha(enabled ? 1f : .3f);
+            }
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1110,6 +1110,10 @@ public class Settings {
         return getBoolean(R.string.pref_brouterAutoTileDownloads, false);
     }
 
+    public static void setBrouterAutoTileDownloads(final boolean value) {
+        putBoolean(R.string.pref_brouterAutoTileDownloads, value);
+    }
+
     public static boolean brouterAutoTileDownloadsNeedUpdate() {
         final long lastCheck = getLong(R.string.pref_brouterAutoTileDownloadsLastCheck, 0);
         if (lastCheck == 0) {


### PR DESCRIPTION
## Description
- remove the text "Routing is only available if BRouter is installed" in map quick settings
- adds a blue "?" button right of routing mode buttons, if no routing is available
- pushing that button asks the user to activate internal routing and auto-download of routing data, and updates settings and the dialog's contents if activation is confirmed

![image](https://user-images.githubusercontent.com/3754370/120033553-0155dc00-bffc-11eb-8bc2-f0d47fbc6365.png).![image](https://user-images.githubusercontent.com/3754370/120033606-0f0b6180-bffc-11eb-8960-57b0dbb162d8.png).![image](https://user-images.githubusercontent.com/3754370/120033582-09158080-bffc-11eb-9a51-0a9329fb6675.png)
