### PR TITLE
show cache name in poup details (fix #10774)

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.CacheDetailsCreator;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.TextUtils;
 
 import android.app.Activity;
 import android.content.DialogInterface;
@@ -157,6 +158,9 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
 
     protected final void addCacheDetails() {
         assert cache != null;
+
+        details.add(R.string.cache_name, TextUtils.coloredCacheText(cache, cache.getName()));
+
         // cache type
         final String cacheType = cache.getType().getL10n();
         final String cacheSize = cache.showSize() ? " (" + cache.getSize().getL10n() + ")" : "";

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -114,8 +114,6 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             });
 
             details = new CacheDetailsCreator(getActivity(), binding.detailsList);
-            details.add(R.string.cache_name, cache.getName());
-
             addCacheDetails();
 
             final View view = getView();


### PR DESCRIPTION
## Description
Displays the cache name in the cache popup to help with display of long cache names which get truncated in the popup's actionbar title.

|cache popup|waypoint popup|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/120035804-724ac300-bfff-11eb-8d38-3acbc364e35a.png)|![image](https://user-images.githubusercontent.com/3754370/120035823-7d055800-bfff-11eb-928e-ef81f8a213a7.png)|

