### PR TITLE
point wizard to internal routing engine (fix #10745)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2304,8 +2304,8 @@
     <string name="wizard_welcome_advanced">Advanced configuration</string>
     <string name="wizard_advanced_offlinemaps_label">Offline maps</string>
     <string name="wizard_advanced_offlinemaps_info">This page provides some advanced functions, which are optional to use.\n\nc:geo can download map files for offline usage.</string>
-    <string name="wizard_advanced_brouter_label">Routing app</string>
-    <string name="wizard_advanced_brouter_info">By installing and configuring a companion app named \"BRouter Offline Navigation\" c:geo can navigate to targets and show routing infos on your map.</string>
+    <string name="wizard_advanced_routing_label">Activate offline routing</string>
+    <string name="wizard_advanced_routing_info">c:geo has an internal routing engine for offline routing and can automatically download missing routing data for you.</string>
     <string name="wizard_advanced_restore_label">Restore</string>
     <string name="wizard_advanced_restore_info">If you have a backup of a previous installation you can restore settings and/or geocache data.</string>
     <string name="status_not_ok">ERROR</string>

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -21,7 +21,6 @@ import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.BackupUtils;
-import cgeo.geocaching.utils.ProcessUtils;
 
 import android.Manifest;
 import android.content.Context;
@@ -222,10 +221,14 @@ public class InstallWizardActivity extends AppCompatActivity {
                     setButtonToDone();
                     startActivityForResult(new Intent(this, DownloadSelectorActivity.class), DownloaderUtils.REQUEST_CODE);
                 }, button1Info, R.string.wizard_advanced_offlinemaps_info);
-                setButton(button2, R.string.wizard_advanced_brouter_label, v -> {
-                    setButtonToDone();
-                    ProcessUtils.openMarket(this, getString(R.string.package_brouter));
-                }, button2Info, R.string.wizard_advanced_brouter_info);
+                if (!Routing.isAvailable()) {
+                    setButton(button2, R.string.wizard_advanced_routing_label, v -> {
+                        setButtonToDone();
+                        Settings.setUseInternalRouting(true);
+                        Settings.setBrouterAutoTileDownloads(true);
+                        setButton(button2, 0, null, button2Info, 0);
+                    }, button2Info, R.string.wizard_advanced_routing_info);
+                }
                 setButton(button3, R.string.wizard_advanced_restore_label, v -> {
                     setButtonToDone();
                     DataStore.resetNewlyCreatedDatabase();


### PR DESCRIPTION
## Description
Changes the "advanced" page of the configuration wizard: Instead of pointing to the external BRouter app in Play Store shows a button to activate internal routing engine and auto-downloading of missing routing data (if no routing available currently).

|No routing engine available currently|Routing engine available currently|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/120038790-19315e00-c004-11eb-861b-517ef6b363ec.png)|![image](https://user-images.githubusercontent.com/3754370/120038313-58ab7a80-c003-11eb-9b99-5ee737b03c50.png)|
