### PR TITLE
implement about pages with ViewPager2 and material tabs

### DIFF
--- a/main/res/layout/avpactivity.xml
+++ b/main/res/layout/avpactivity.xml
@@ -1,0 +1,29 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewpager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <View style="@style/separator_horizontal" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
+        app:tabTextColor="@color/colorTextActionBar"
+        app:tabSelectedTextColor="@color/colorAccent"
+        app:tabIndicatorColor="@color/colorAccent"
+        app:tabPaddingStart="36sp"
+        app:tabPaddingEnd="36sp"
+        app:tabMode="scrollable"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/textSize_detailsPrimary"
+        android:background="@color/colorBackgroundActionBar" />
+
+</LinearLayout>

--- a/main/src/cgeo/geocaching/activity/AVPActivity.java
+++ b/main/src/cgeo/geocaching/activity/AVPActivity.java
@@ -1,0 +1,134 @@
+package cgeo.geocaching.activity;
+
+import cgeo.geocaching.R;
+
+import android.view.Menu;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+import androidx.viewpager2.widget.ViewPager2;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+
+import com.google.android.material.tabs.TabLayoutMediator;
+import org.apache.commons.lang3.StringUtils;
+
+public abstract class AVPActivity extends AppCompatActivity {
+    protected static final ArrayList<AVPFragment> pages = new ArrayList<>();
+    protected static final ArrayList<Page> pagesSource = new ArrayList<>();
+
+    private ActionBar actionBar;
+    private String prefix;
+    private int currentPage = 0;
+
+    protected void configure(final int currentPageNum, final String prefix) {
+        this.currentPage = currentPageNum;
+        this.prefix = prefix;
+
+        setContentView(R.layout.avpactivity);
+        actionBar = getSupportActionBar();
+
+        final ViewPager2 viewPager = (ViewPager2) findViewById(R.id.viewpager);
+        viewPager.setAdapter(new ViewPagerAdapter(this));
+        viewPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
+            /*
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+                super.onPageScrolled(position, positionOffset, positionOffsetPixels);
+            }
+            */
+
+            @Override
+            public void onPageSelected(final int position) {
+                super.onPageSelected(position);
+                currentPage = position;
+                setActionBarTitle();
+            }
+
+            /*
+            @Override
+            public void onPageScrollStateChanged(int state) {
+                super.onPageScrollStateChanged(state);
+            }
+            */
+        });
+        viewPager.setCurrentItem(currentPage);
+
+        new TabLayoutMediator(findViewById(R.id.tab_layout), viewPager,
+            (tab, position) -> tab.setText(getTitle(position))
+        ).attach();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        setActionBarTitle(); // set title here to avoid a race condition in onCreate/configure
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    protected String getTitle(final int page) {
+        return getResources().getString(pagesSource.get(page).resourceId);
+    }
+
+    private void setActionBarTitle() {
+        if (actionBar != null) {
+            actionBar.setTitle((StringUtils.isNotBlank(prefix) ? prefix + " - " : "") + getTitle(currentPage));
+        }
+    }
+
+    protected static class Page {
+        @StringRes
+        private final int resourceId;
+        private final Class clazz;
+
+        public Page(@StringRes final int resourceId, final Class clazz) {
+            this.resourceId = resourceId;
+            this.clazz = clazz;
+        }
+    }
+
+    private static class ViewPagerAdapter extends FragmentStateAdapter {
+        private final WeakReference<FragmentActivity> fragmentActivityWeakReference;
+
+        ViewPagerAdapter(final FragmentActivity fa) {
+            super(fa);
+            fragmentActivityWeakReference = new WeakReference<>(fa);
+        }
+
+        @Override
+        @NonNull
+        public Fragment createFragment(final int page) {
+            if (pages.size() > page) {
+                return pages.get(page);
+            }
+            if (pagesSource.size() > page) {
+                try {
+                    final AVPFragment fragment = (AVPFragment) pagesSource.get(page).clazz.newInstance();
+                    fragment.setActivity(fragmentActivityWeakReference.get());
+                    pages.add(page, fragment);
+                    return fragment;
+                } catch (IllegalAccessException | InstantiationException e) {
+                    return null;
+                }
+            }
+            throw new IllegalStateException(); // cannot happen, when switch case is enum complete
+        }
+
+        @Override
+        public int getItemCount() {
+            return pagesSource.size();
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        pages.clear();
+    }
+
+}

--- a/main/src/cgeo/geocaching/activity/AVPFragment.java
+++ b/main/src/cgeo/geocaching/activity/AVPFragment.java
@@ -1,0 +1,26 @@
+package cgeo.geocaching.activity;
+
+import cgeo.geocaching.utils.ShareUtils;
+
+import android.app.Activity;
+import android.view.View;
+
+import androidx.fragment.app.Fragment;
+
+import java.lang.ref.WeakReference;
+
+public class AVPFragment extends Fragment {
+    protected WeakReference<Activity> activityWeakReference = null;
+
+    public void setActivity(final Activity activity) {
+        this.activityWeakReference = new WeakReference<>(activity);
+    }
+
+    public void setClickListener(final View view, final String url) {
+        final Activity activity = activityWeakReference.get();
+        if (activity != null) {
+            view.setOnClickListener(v -> ShareUtils.openUrl(activity, url));
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
Reimplements c:geo's about pages using ViewPager2 and Material Tabs instead of the old viewpager.
Can be a base to remove the old viewpager completely (after having migrated `CacheDetailsActivity` to ViewpPager2 / Material Tabs as well.

This is a first shot at migration. Looks fully functional to me, but could use more safeguards, and I'm not sure yet, whether this approach will work for `CacheDetailActivity` as well. Just wanted to start with the easier part as a MVP...

![image](https://user-images.githubusercontent.com/3754370/120078711-2193a280-c0b1-11eb-9a71-9222a810cb88.png).![image](https://user-images.githubusercontent.com/3754370/120078719-26585680-c0b1-11eb-908a-bad5c7b36a1e.png).![image](https://user-images.githubusercontent.com/3754370/120078725-2b1d0a80-c0b1-11eb-8716-eae169e79325.png)
![image](https://user-images.githubusercontent.com/3754370/120078728-2eb09180-c0b1-11eb-93a0-a623e446e520.png).![image](https://user-images.githubusercontent.com/3754370/120078732-32dcaf00-c0b1-11eb-9b04-1e573a8d4d8e.png)
