### PR TITLE
make waypoint 'more details' button full-width

### DIFF
--- a/main/res/layout/waypoint_popup.xml
+++ b/main/res/layout/waypoint_popup.xml
@@ -70,7 +70,7 @@
 
                 <Button
                     android:id="@+id/more_details"
-                    style="@style/button_small"
+                    style="@style/button_full"
                     android:text="@string/popup_more" />
             </LinearLayout>
         </LinearLayout>


### PR DESCRIPTION
## Description
Currently the "more details" button label in waypoint popup gets truncated, therefore change this button to "full width":

![image](https://user-images.githubusercontent.com/3754370/120097694-53008280-c132-11eb-8723-44b32951771f.png).![image](https://user-images.githubusercontent.com/3754370/120097698-57c53680-c132-11eb-8003-71ca33e98e95.png)
