### PR TITLE
switch to AndroidStudio 4.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.1'
 
         // un-mocking of portable Android classes
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
@@ -105,9 +105,9 @@ allprojects {
                 // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
                 force 'com.google.guava:guava:26.0-jre'
 
-                // force this version because of conflict to our resolutionStrategy from lint-gradle 4.1.3 (referencing 4.1.0-alpha01-6193524)
+                // force this version because of conflict to our resolutionStrategy from lint-gradle 27.2.1 (referencing 4.1.0-alpha01-6193524)
                 // TODO check after gradle update (gradlew :main:lintBasicDebug)
-                force 'com.android.tools.build:aapt2-proto:4.1.3-6503028'
+                force 'com.android.tools.build:aapt2-proto:4.2.1-7147631'
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,8 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 
 # Use more memory to benefit from in-process dexing
-org.gradle.jvmargs = -Xmx2048m
+# Use the parallel garbage collector
+org.gradle.jvmargs = -Xmx2048m -XX:+UseParallelGC
 
 # Only configure other modules when they are actually needed for the task being executed
 org.gradle.configureondemand=true
@@ -23,3 +24,7 @@ systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 # AndroidX configuration
 android.useAndroidX=true
 android.enableJetifier=true
+
+# see the entirety of the native output
+# default value of this property is quiet
+android.native.buildOutput=verbose

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,3 @@ systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 # AndroidX configuration
 android.useAndroidX=true
 android.enableJetifier=true
-
-# see the entirety of the native output
-# default value of this property is quiet
-android.native.buildOutput=verbose


### PR DESCRIPTION
- switch to gradle plugin 4.2.1 (supersedes #10620 and #10537)
- use aapt2-proto:4.2.1 (supersedes #10619)
- use the parallel garbage collector (new in AS 4.2)

For the releaseNotes see
- AS: https://developer.android.com/studio/releases/#4-2-0
- AGP: https://developer.android.com/studio/releases/gradle-plugin#4-2-0

fix #10548
supersedes #10620 #10619 #10537

Remarks:
1. garbage collector:
  I made a test as suggested in https://developer.android.com/studio/build/profile-your-build#gradle-profile-option .
  You have to call the following commands with and without the `-XX:+UseParallelGC` part.
~~~
gradlew clean
gradlew --profile --offline --rerun-tasks assembleBasicDebug
~~~
  On my dev machine (dual core) it shows sometime a time reducing. But I think this machine is not representative.

2. v3 and v4 signing
   see https://developer.android.com/studio/releases/gradle-plugin#v3-v4-signing
   Android Gradle Plugin 4.2 now supports APK v3 and APK v4 signing formats. 
   This is not included in this PR .

3. new property `android.native.buildOutput`
   see https://developer.android.com/studio/releases/gradle-plugin#native-build-output
   This is not related to our java build. I saw no extra output during the tests. Therefore it is not used.
