### PR TITLE
fixes for downloader layout (fix #10805)

### DIFF
--- a/main/res/layout/downloader_item.xml
+++ b/main/res/layout/downloader_item.xml
@@ -13,7 +13,7 @@
 
     <ImageButton
         android:id="@+id/action"
-	style="@style/button_icon"
+        style="@style/button_icon"
         android:gravity="left|center_vertical"
         android:text="@null"
         android:layout_alignParentLeft="true" />
@@ -28,6 +28,7 @@
         android:textIsSelectable="false"
         android:paddingLeft="10dip"
         android:layout_toRightOf="@id/action"
+        android:textSize="@dimen/textSize_listsPrimary"
         tools:text="name"/>
 
     <TextView
@@ -42,6 +43,7 @@
         android:paddingLeft="10dip"
         android:layout_below="@id/label"
         android:layout_toRightOf="@id/action"
+        android:textSize="@dimen/textSize_listsSecondary"
         tools:text="info"
         android:maxLines="2" />
 

--- a/main/src/cgeo/geocaching/downloader/DownloadSelectorActivity.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadSelectorActivity.java
@@ -88,7 +88,7 @@ public class DownloadSelectorActivity extends AbstractActionBarActivity {
             holder.binding.label.setText(offlineMap.getName());
             if (offlineMap.getIsDir()) {
                 holder.binding.info.setText(R.string.downloadmap_directory);
-                holder.binding.action.setBackgroundResource(R.drawable.ic_menu_folder);
+                holder.binding.action.setImageResource(R.drawable.ic_menu_folder);
                 holder.binding.getRoot().setOnClickListener(v -> {
                     new MapListTask(activity, offlineMap.getUri(), offlineMap.getName()).execute();
                 });
@@ -101,7 +101,7 @@ public class DownloadSelectorActivity extends AbstractActionBarActivity {
                     + (StringUtils.isNotBlank(addInfo) ? " (" + addInfo + ")" : "")
                     + (StringUtils.isNotBlank(sizeInfo) ? Formatter.SEPARATOR + offlineMap.getSizeInfo() : "")
                     + Formatter.SEPARATOR + offlineMap.getTypeAsString());
-                holder.binding.action.setBackgroundResource(offlineMap.getIconRes());
+                holder.binding.action.setImageResource(offlineMap.getIconRes());
                 holder.binding.getRoot().setOnClickListener(v -> {
                     // return to caller with URL chosen
                     final Intent intent = new Intent();


### PR DESCRIPTION
## Description
- restores icon display for map downloader (fix #10805)
- sets correct font sizes for list entries

![image](https://user-images.githubusercontent.com/3754370/120098151-922fd300-c134-11eb-9a92-aeb995845cb4.png)
