### PR TITLE
set circular spinner color (fix #10793)

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -18,6 +18,9 @@
         <item name="colorSecondary">@color/colorAccent</item>
         <item name="colorSecondaryVariant">@color/colorAccent</item>
 
+        <!-- circular spinner color -->
+        <item name="android:indeterminateTint">@color/colorAccent</item>
+
     </style>
 
     <!-- theme for cache/waypoint popups -->


### PR DESCRIPTION
## Description
Sets the color of our circular indeterminate spinner to `accentColor` (e. g.: open cache details when coming from map)
