### PR TITLE
replace AlertDialog with androidx.appcompat version (rel. to #10793)

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -18,6 +18,8 @@
         <item name="colorSecondary">@color/colorAccent</item>
         <item name="colorSecondaryVariant">@color/colorAccent</item>
 
+        <!-- circular spinner color -->
+        <item name="android:indeterminateTint">@color/colorAccent</item>
     </style>
 
     <!-- theme for cache/waypoint popups -->

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2341,7 +2341,7 @@ public class CacheDetailActivity extends AbstractViewPagerActivity<CacheDetailAc
      */
     private AlertDialog createResetCacheCoordinatesDialog(final Waypoint wpt) {
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(this);
         builder.setTitle(R.string.waypoint_reset_cache_coords);
 
         final String[] items = { res.getString(R.string.waypoint_localy_reset_cache_coords), res.getString(R.string.waypoint_reset_local_and_remote_cache_coords) };

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -97,7 +97,6 @@ import static cgeo.geocaching.apps.cache.WhereYouGoApp.isWhereYouGoInstalled;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.BroadcastReceiver;
 import android.content.ClipboardManager;
@@ -149,6 +148,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.res.ResourcesCompat;

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -88,7 +88,6 @@ import cgeo.geocaching.utils.functions.Action1;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -115,6 +114,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.view.MenuItemCompat;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -31,7 +31,6 @@ import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.UnknownTagsHandler;
 import static cgeo.geocaching.models.Waypoint.getDefaultWaypointName;
 
-import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -55,6 +54,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.text.HtmlCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -426,7 +426,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         }
 
         private void showCoordinateOptionsDialog(final View view, final Geopoint geopoint, final Geocache cache) {
-            final AlertDialog.Builder builder = new AlertDialog.Builder(view.getContext());
+            final AlertDialog.Builder builder = Dialogs.newBuilder(view.getContext());
             builder.setTitle(res.getString(R.string.waypoint_coordinates));
             builder.setItems(R.array.waypoint_coordinates_options, (dialog, item) -> {
                 final String selectedOption = res.getStringArray(R.array.waypoint_coordinates_options)[item];

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -49,7 +49,6 @@ import cgeo.geocaching.utils.Version;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.SearchManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -70,6 +69,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.SearchView.OnQueryTextListener;
 import androidx.appcompat.widget.SearchView.OnSuggestionListener;

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -69,7 +69,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.SearchView.OnQueryTextListener;
 import androidx.appcompat.widget.SearchView.OnSuggestionListener;
@@ -711,7 +710,7 @@ public class MainActivity extends AbstractActionBarActivity {
             if (BackupUtils.hasBackup(BackupUtils.newestBackupFolder())) {
 
                 restoreMessageShown = true;
-                new AlertDialog.Builder(this)
+                Dialogs.newBuilder(this)
                         .setTitle(res.getString(R.string.init_backup_restore))
                         .setMessage(res.getString(R.string.init_restore_confirm))
                         .setCancelable(false)

--- a/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
+++ b/main/src/cgeo/geocaching/NavigateAnyPointActivity.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
 
@@ -111,7 +112,7 @@ public class NavigateAnyPointActivity extends AbstractActionBarActivity {
             }
         };
 
-        final AlertDialog dialog = new AlertDialog.Builder(context)
+        final AlertDialog dialog = Dialogs.newBuilder(context)
             .setTitle(R.string.add_target_to)
             .setAdapter(adapter, (dialog1, which) -> {
                 final String geocode;

--- a/main/src/cgeo/geocaching/apps/navi/NavigationAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/navi/NavigationAppFactory.java
@@ -20,12 +20,12 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.view.MenuItem;
 import android.widget.ArrayAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -18,7 +18,6 @@ import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.content.Intent;
 import android.net.Uri;
@@ -32,6 +31,7 @@ import static android.content.Context.DOWNLOAD_SERVICE;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;

--- a/main/src/cgeo/geocaching/export/FieldNoteExport.java
+++ b/main/src/cgeo/geocaching/export/FieldNoteExport.java
@@ -21,7 +21,6 @@ import cgeo.geocaching.utils.UriUtils;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.net.Uri;
@@ -31,6 +30,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import java.io.File;
 import java.text.SimpleDateFormat;

--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -15,7 +15,6 @@ import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.UriUtils;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.net.Uri;
 import android.view.View;
@@ -24,6 +23,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -19,7 +19,6 @@ import cgeo.geocaching.utils.XmlUtils;
 import cgeo.org.kxml2.io.KXmlSerializer;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.net.Uri;
 import android.text.InputFilter;
 import android.view.View;
@@ -29,6 +28,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/main/src/cgeo/geocaching/export/TrailHistoryExport.java
+++ b/main/src/cgeo/geocaching/export/TrailHistoryExport.java
@@ -18,11 +18,12 @@ import cgeo.geocaching.utils.XmlUtils;
 import cgeo.org.kxml2.io.KXmlSerializer;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.net.Uri;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/main/src/cgeo/geocaching/gcvote/VoteDialog.java
+++ b/main/src/cgeo/geocaching/gcvote/VoteDialog.java
@@ -13,7 +13,6 @@ import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.Application;
 import android.content.DialogInterface;
 import android.view.View;
@@ -22,6 +21,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 /**
  * Small dialog showing only a rating bar to vote for the cache. Confirming the dialog will send the vote over the

--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -134,7 +134,7 @@ public final class StoredList extends AbstractList {
             final CharSequence[] items = new CharSequence[listsTitle.size()];
 
             final Activity activity = activityRef.get();
-            final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+            final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
             builder.setTitle(res.getString(titleId));
             builder.setItems(listsTitle.toArray(items), (dialogInterface, itemId) -> {
                 final AbstractList list = lists.get(itemId);

--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -10,13 +10,13 @@ import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.view.View;
 import android.widget.ListView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
 import java.lang.ref.WeakReference;
 import java.text.Collator;

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -35,7 +35,6 @@ import cgeo.geocaching.utils.Log;
 import android.R.layout;
 import android.R.string;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -49,6 +48,7 @@ import android.view.View.OnFocusChangeListener;
 import android.widget.CheckBox;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.AbstractUIFactory;
+import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.Activity;
 import android.content.DialogInterface;
@@ -93,7 +94,7 @@ public final class LoggingUI extends AbstractUIFactory {
         }
         list.add(new LogTypeEntry(null, SpecialLogType.LOG_CACHE, false));
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(R.string.cache_menu_visit_offline);
 
         final ArrayAdapter<LogTypeEntry> adapter = new ArrayAdapter<>(activity, android.R.layout.select_dialog_item, list);

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -7,13 +7,13 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.AbstractUIFactory;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ArrayAdapter;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -81,7 +81,6 @@ import static cgeo.geocaching.maps.mapsforge.v6.caches.CachesBundle.NO_OVERLAY_I
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -112,6 +111,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.text.HtmlCompat;
 import androidx.core.util.Supplier;
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1412,7 +1412,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
                 }
             };
 
-            final AlertDialog dialog = new AlertDialog.Builder(this)
+            final AlertDialog dialog = Dialogs.newBuilder(this)
                     .setTitle(res.getString(R.string.map_select_multiple_items))
                     .setAdapter(adapter, new SelectionClickListener(sorted, longPressMode))
                     .create();

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeHelper.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeHelper.java
@@ -21,7 +21,6 @@ import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.UriUtils;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -29,6 +28,7 @@ import android.os.AsyncTask;
 import android.preference.PreferenceManager;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Consumer;
 
 import java.io.File;

--- a/main/src/cgeo/geocaching/settings/AbstractClickablePreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractClickablePreference.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.settings;
 import cgeo.geocaching.R;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.preference.Preference;
 import android.util.AttributeSet;
@@ -11,6 +10,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListAdapter;
 import android.widget.ListView;
+
+import androidx.appcompat.app.AlertDialog;
 
 abstract class AbstractClickablePreference extends Preference implements View.OnLongClickListener {
 

--- a/main/src/cgeo/geocaching/settings/ColorpickerPreference.java
+++ b/main/src/cgeo/geocaching/settings/ColorpickerPreference.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.DisplayUtils;
 
+// need to use non-androidX AlertDialog until we migrate to preferenceFragment
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -41,7 +41,6 @@ import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ShareUtils;
 
 import android.R.string;
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.app.backup.BackupManager;
@@ -69,6 +68,7 @@ import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 
 import java.io.File;

--- a/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
+++ b/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
@@ -6,7 +6,6 @@ import cgeo.geocaching.log.LogTemplateProvider;
 import cgeo.geocaching.log.LogTemplateProvider.LogTemplate;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.preference.DialogPreference;
@@ -14,6 +13,8 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+
+import androidx.appcompat.app.AlertDialog;
 
 import java.util.List;
 

--- a/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.UriUtils;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
@@ -24,6 +23,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Consumer;
 
 import java.util.ArrayList;

--- a/main/src/cgeo/geocaching/ui/DateTimeEditor.java
+++ b/main/src/cgeo/geocaching/ui/DateTimeEditor.java
@@ -5,7 +5,6 @@ import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
-import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
@@ -18,6 +17,7 @@ import android.widget.TimePicker;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 

--- a/main/src/cgeo/geocaching/ui/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/EditNoteDialog.java
@@ -71,7 +71,7 @@ public class EditNoteDialog extends DialogFragment {
         final boolean preventWaypointsFromNote = getArguments().getBoolean(ARGUMENT_INITIAL_PREVENT);
         mPreventCheckbox.setChecked(preventWaypointsFromNote);
 
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setView(view);
         final AlertDialog dialog = builder.create();
 

--- a/main/src/cgeo/geocaching/ui/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/EditNoteDialog.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
 import android.view.View;
@@ -15,6 +14,7 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 

--- a/main/src/cgeo/geocaching/ui/TextSpinner.java
+++ b/main/src/cgeo/geocaching/ui/TextSpinner.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Action2;
 import cgeo.geocaching.utils.functions.Func1;
 
-import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.graphics.Typeface;
 import android.text.SpannableStringBuilder;
@@ -23,6 +22,7 @@ import static android.text.Spanned.SPAN_INCLUSIVE_EXCLUSIVE;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/main/src/cgeo/geocaching/ui/UrlPopup.java
+++ b/main/src/cgeo/geocaching/ui/UrlPopup.java
@@ -3,10 +3,11 @@ package cgeo.geocaching.ui;
 import cgeo.geocaching.R;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+
+import androidx.appcompat.app.AlertDialog;
 
 public class UrlPopup {
 

--- a/main/src/cgeo/geocaching/ui/dialog/ContextMenuDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/ContextMenuDialog.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.ui.dialog;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.functions.Action1;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Rect;
@@ -16,6 +15,7 @@ import android.widget.TextView;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
 
 import java.util.ArrayList;

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -18,7 +18,6 @@ import cgeo.geocaching.utils.functions.Action2;
 import cgeo.geocaching.utils.functions.Func1;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -44,6 +43,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
 
 import java.util.ArrayList;
@@ -54,6 +54,7 @@ import java.util.Objects;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import io.noties.markwon.Markwon;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
@@ -1074,7 +1075,7 @@ public final class Dialogs {
     }
 
     public static AlertDialog.Builder newBuilder(final Context context) {
-        return new AlertDialog.Builder(newContextThemeWrapper(context));
+        return new MaterialAlertDialogBuilder (newContextThemeWrapper(context));
     }
 
     public static ContextThemeWrapper newContextThemeWrapper(final Context context) {

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -19,7 +19,6 @@ import static cgeo.geocaching.utils.SettingsUtils.SettingsType.TYPE_UNKNOWN;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -37,6 +36,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Consumer;
 
 import java.io.IOException;

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -26,7 +26,6 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Xml;
-import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -319,7 +318,7 @@ public class BackupUtils {
             textView.setText(R.string.init_backup_history_delete_warning);
             checkbox.setText(R.string.init_user_confirmation);
 
-            final AlertDialog alertDialog = new AlertDialog.Builder(new ContextThemeWrapper(activityContext, R.style.cgeo))
+            final AlertDialog alertDialog = Dialogs.newBuilder(activityContext)
                 .setView(content)
                 .setTitle(R.string.init_backup_backup_history)
                 .setCancelable(true)

--- a/main/src/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/cgeo/geocaching/utils/EmojiUtils.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.functions.Action1;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -32,6 +31,7 @@ import android.widget.TextView;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 


### PR DESCRIPTION
## Description
- replaces `android.app.AlertDialog` with `androidx.appcompat.app.AlertDialog`
- uses `MaterialAlertDialogBuilder` in `Dialogs` instead of `AlertDialog.Builder`
- uses `Dialogs.newBuilder(...)` instead of `new AlertDialog.Builder(...)`

=> resolves some of the problems mentioned in #10793
