### PR TITLE
reduce linespacing in map quick settings (fix #10809)

### DIFF
--- a/main/res/layout/map_settings_item.xml
+++ b/main/res/layout/map_settings_item.xml
@@ -26,6 +26,7 @@
         android:clickable="false"
         android:layout_width="30dp"
         android:layout_height="wrap_content"
+        android:minHeight="32dp"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"/>
 


### PR DESCRIPTION
## Description
Reduces the linespacing in map quick settings menu for caches/waypoints settings by reducing the min-width for the checkbox

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/120544205-7440c780-c3ed-11eb-9d38-7c1721a17e47.png)|![image](https://user-images.githubusercontent.com/3754370/120544232-7a36a880-c3ed-11eb-8040-c4ca4067e78b.png)|

Before it was set to `minTouchTargetSize` by material theme (being 48dp), now it's set to 32dp.
Have not found a way yet to set this for all checkboxes, though.