### PR TITLE
fix small system info formatting error

### DIFF
--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -138,7 +138,7 @@ public final class SystemInformation {
     }
 
     private static void appendSettings(@NonNull final StringBuilder body) {
-        body.append("\n -Settings: ").append(versionInfoToString(Settings.getActualVersion(), Settings.getExpectedVersion()))
+        body.append("\n- Settings: ").append(versionInfoToString(Settings.getActualVersion(), Settings.getExpectedVersion()))
             .append(", Count:").append(Settings.getPreferencesCount());
     }
 


### PR DESCRIPTION
## Description
Due to a misplaced space the "settings" info was tangled with the "routing mode info":

![image](https://user-images.githubusercontent.com/3754370/120545539-11e8c680-c3ef-11eb-99a5-4d0ac20c551c.png)
