### PR TITLE
remove failed download from download manager (rel. to #10815)

### DIFF
--- a/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
@@ -47,6 +47,8 @@ class DownloadNotificationReceiver extends BroadcastReceiver {
                                 final int error = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
                                 ActivityMixin.showToast(context, "map download failed with error #" + error);
                                 Log.d("download #" + pendingDownload + " failed with error #" + error);
+                                // remove file from system's download manager, which will also delete the broken file from storage
+                                downloadManager.remove(pendingDownload);
                                 break;
                             default:
                                 // ignore unknown state by logging silently


### PR DESCRIPTION
## Description
Related to #10815: Deletes broken downloads from system's download manager, which automatically deletes the partial file from storage as well.

Does not delete a partially copied file after a successful download (which is the other part of #10815), therefore not closing that issue yet.
