### PR TITLE
apply some formatting to downloads' debug info

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -605,6 +605,7 @@
     <string name="debug_user_error_report_title">Report a problem</string>
     <string name="debug_user_error_errortext">An unexpected problem has occured which we would request you to report to us:</string>
     <string name="debug_user_error_explain_options">Help us fixing c:geo problems by reporting them via email with system information and c:geo logfile included.\nPlease do always also include a detailed error description with your mail!\n\nBefore sending a mail please also check our FAQ and/or social media presence for known problems.\nOther contact options can be found at \'About c:geo\'</string>
+    <string name="debug_current_downloads">Current downloads</string>
 
     <!-- settings -->
     <string name="settings_title_open_settings">Open settings?</string>

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -514,7 +514,7 @@ public final class Dialogs {
     }
 
     /**
-     * Show a message dialog with a single "OK" button and an eventual icon.
+     * Show a message dialog with a single "OK" button
      * "message" can be formatted using markdown
      *
      * @param context
@@ -536,7 +536,6 @@ public final class Dialogs {
             builder.setTitle(title);
         }
         builder
-            .setIcon(ImageUtils.getTransparent1x1Drawable(context.getResources()))
             .setView(v)
             .create()
             .show();

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -111,7 +111,7 @@ public class DebugUtils {
             };
             while (c.moveToNext()) {
                 for (int column : columns) {
-                    sb.append(c.getColumnName(column)).append(" = ");
+                    sb.append("- ").append(c.getColumnName(column)).append(" = ");
                     if (column == columnStatus) {
                         sb.append(c.getString(column));
                         final int status = c.getInt(column);
@@ -162,10 +162,11 @@ public class DebugUtils {
                     }
                     sb.append("\n");
                 }
-                sb.append("\n------------------------\n\n");
+                sb.append("\n---\n\n");
             }
         }
-        Dialogs.message(activity, "current downloads", sb.toString());
+
+        Dialogs.messageMarkdown(activity, activity.getString(R.string.debug_current_downloads), sb.toString());
     }
 
 


### PR DESCRIPTION
## Description
Format the debug info for downloads which got initiated using the integrated downloader:
- replace dialog title by a translatable string
- remove the "invisible" icon in the dialog's header
- use markdown formatting for entries (basically the list mode)
