### PR TITLE
adjust minHeight of all material checkboxes

### DIFF
--- a/main/res/layout/map_settings_item.xml
+++ b/main/res/layout/map_settings_item.xml
@@ -26,7 +26,6 @@
         android:clickable="false"
         android:layout_width="30dp"
         android:layout_height="wrap_content"
-        android:minHeight="32dp"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"/>
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -20,6 +20,12 @@
     <style name="text_note" parent="text">
     </style>
 
+    <!-- checkbox formatting -->
+
+    <style name="checkboxStyle" parent="@style/Widget.MaterialComponents.CompoundButton.CheckBox">
+        <item name="android:minHeight">32dp</item>
+    </style>
+
     <style name="checkbox_full">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>
@@ -31,6 +37,7 @@
     </style>
 
     <!-- actionbar -->
+
     <style name="actionBarStyle" parent="Widget.MaterialComponents.ActionBar.Solid">
         <item name="android:textColor">@color/colorTextActionBar</item>
         <item name="background">@color/colorBackgroundActionBar</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -5,6 +5,7 @@
 
     <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <item name="actionBarStyle">@style/actionBarStyle</item>
+        <item name="checkboxStyle">@style/checkboxStyle</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>


### PR DESCRIPTION
## Description
Found a way to apply the reduced line spacing to all material checkboxes, which will make it work not only in the map quick settings, but in other places, too, e. g. in the cache type filter:

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/120554915-a278d400-c3fa-11eb-864b-1fbb4439f710.png)|![image](https://user-images.githubusercontent.com/3754370/120554947-a99fe200-c3fa-11eb-8e33-7a3cd00cf3cc.png)|

The workaround (directly applying a new `minHeight` for the map quick settings item) can therefore be removed.