### PR TITLE
adjust minHeight of all material radioButtons

### DIFF
--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -5,6 +5,8 @@
     <dimen name="actionbar_separator_height">37dip</dimen>
     <dimen name="actionbar_separator_width">2dip</dimen>
 
+    <dimen name="checkboxRadiobuttonMinHeight">32dp</dimen>
+
     <!-- Dimensions for Samsung Multi-Window support -->
     <dimen name="app_defaultsize_w">632.0dip</dimen>
     <dimen name="app_defaultsize_h">598.0dip</dimen>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -23,12 +23,18 @@
     <!-- checkbox formatting -->
 
     <style name="checkboxStyle" parent="@style/Widget.MaterialComponents.CompoundButton.CheckBox">
-        <item name="android:minHeight">32dp</item>
+        <item name="android:minHeight">@dimen/checkboxRadiobuttonMinHeight</item>
     </style>
 
     <style name="checkbox_full">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <!-- radiobutton formatting -->
+
+    <style name="radiobuttonStyle" parent="@style/Widget.MaterialComponents.CompoundButton.RadioButton">
+        <item name="android:minHeight">@dimen/checkboxRadiobuttonMinHeight</item>
     </style>
 
     <style name="radiobutton_wrap">

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -6,6 +6,7 @@
     <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <item name="actionBarStyle">@style/actionBarStyle</item>
         <item name="checkboxStyle">@style/checkboxStyle</item>
+        <item name="radioButtonStyle">@style/radiobuttonStyle</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>


### PR DESCRIPTION
## Description
- see https://github.com/cgeo/cgeo/pull/10826#issuecomment-853557166
- adjusts (decreases) the minimum height of material radiobuttons (same as #10826, but for radiobuttons)
- extracts this minimum height as a dimension, used for both checkboxes and radiobuttons
