### PR TITLE
fix image label color in about:version page

### DIFF
--- a/main/res/layout/about_version_page.xml
+++ b/main/res/layout/about_version_page.xml
@@ -46,6 +46,7 @@
                     android:layout_marginRight="10dip"
                     android:layout_marginTop="5dip"
                     android:text="@string/quote"
+                    android:textColor="@color/just_white"
                     android:textSize="@dimen/textSize_detailsPrimary" />
 
                 <TextView


### PR DESCRIPTION
## Description
The label on top of the image in the about:version page is currently unreadable in both dark and light theme, text should always be white for this label.
