### PR TITLE
remove breaking requestWindowFeature for edit PN

### DIFF
--- a/main/src/cgeo/geocaching/ui/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/EditNoteDialog.java
@@ -7,7 +7,6 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import android.app.Dialog;
 import android.os.Bundle;
 import android.view.View;
-import android.view.Window;
 import android.view.WindowManager;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -71,11 +70,7 @@ public class EditNoteDialog extends DialogFragment {
         final boolean preventWaypointsFromNote = getArguments().getBoolean(ARGUMENT_INITIAL_PREVENT);
         mPreventCheckbox.setChecked(preventWaypointsFromNote);
 
-        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
-        builder.setView(view);
-        final AlertDialog dialog = builder.create();
-
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        final AlertDialog dialog = Dialogs.newBuilder(activity).setView(view).create();
         final TextView title = view.findViewById(R.id.dialog_title_title);
         title.setText(R.string.cache_personal_note);
         title.setVisibility(View.VISIBLE);


### PR DESCRIPTION
## Description
- See https://github.com/cgeo/cgeo/commit/6c3a37b2a5cbf4685b85c0a808d0de3ae79532e8#commitcomment-51695604
- removes the offending call to "requestWindowFeature", which makes the dialog break at least on API 21 and seems not to be necessary anyway
- tested successfully against API 21 and API 30