### PR TITLE
fix #10831: move gui stuff out of async log send task into GUI thread

### DIFF
--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -782,8 +782,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
                             for (Image img : imageListFragment.getImages()) {
                                 ImageUtils.deleteImage(img.getUri());
                             }
-                            imageListFragment.clearImages();
-                            imageListFragment.adjustImagePersistentState();
                         }
                     }
 
@@ -870,6 +868,9 @@ public class LogCacheActivity extends AbstractLoggingActivity {
                 resetValues();
                 refreshGui();
                 lastSavedState = getEntryFromView();
+
+                imageListFragment.clearImages();
+                imageListFragment.adjustImagePersistentState();
 
                 showToast(res.getString(R.string.info_log_posted));
                 // Prevent from saving log after it was sent successfully.


### PR DESCRIPTION
fix #10831: move gui stuff out of async log send task into GUI thread