### PR TITLE
make icons in MaterialButton centered

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -155,6 +155,8 @@
         <item name="android:insetBottom">0dp</item>
         <item name="android:paddingLeft">12dp</item>
         <item name="android:paddingRight">12dp</item>
+        <item name="iconGravity">textStart</item>
+        <item name="iconPadding">0dp</item>
     </style>
 
     <!-- edittext -->


### PR DESCRIPTION
## Description
Center icon in buttons styled with `button_icon`, see https://github.com/cgeo/cgeo/pull/10818#issuecomment-854489671
