### PR TITLE
change color for disabled settings to grey (fix #10845)

### DIFF
--- a/main/res/color/settings_primary_selector_light.xml
+++ b/main/res/color/settings_primary_selector_light.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:state_enabled="false" android:color="#80000000"/>
+    <item android:color="@color/settings_colorTextLight"/>
+</selector>

--- a/main/res/color/settings_primary_selector_night.xml
+++ b/main/res/color/settings_primary_selector_night.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:state_enabled="false" android:color="#80FFFFFF"/>
+    <item android:color="@color/settings_colorTextDark"/>
+</selector>

--- a/main/res/color/settings_secondary_selector_light.xml
+++ b/main/res/color/settings_secondary_selector_light.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:state_enabled="false" android:color="#80000000"/>
+    <item android:color="@color/settings_colorTextSecondaryLight"/>
+</selector>

--- a/main/res/color/settings_secondary_selector_night.xml
+++ b/main/res/color/settings_secondary_selector_night.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:state_enabled="false" android:color="#80FFFFFF"/>
+    <item android:color="@color/settings_colorTextSecondaryDark"/>
+</selector>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -163,7 +163,6 @@
     <style name="button_icon" parent="button">
         <item name="android:layout_width">48dp</item>
         <item name="android:layout_height">48dp</item>
-        <item name="iconPadding">0dp</item>
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:paddingLeft">12dp</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -47,11 +47,11 @@
     <!-- theme for settings (temporary workaround, needed only as long as SettingsActivity is not derived from AppCompatActivity) -->
 
     <style name="settings" parent="cgeo">
-        <item name="android:textColor">@color/settings_colorTextDark</item>
-        <item name="android:textColorSecondary">@color/settings_colorTextSecondaryDark</item>
+        <item name="android:textColor">@color/settings_primary_selector_night</item>
+        <item name="android:textColorSecondary">@color/settings_secondary_selector_night</item>
         <item name="android:colorBackground">@color/settings_colorBackgroundDark</item>
 
-        <!-- icon resources - can be moved to drawables-night when based on AppCompatActivity -->
+        <!-- icon resources - can be moved (without suffix "_white") to drawables-night when based on AppCompatActivity -->
         <item name="settings_cloud">@drawable/settings_cloud_white</item>
         <item name="settings_details">@drawable/settings_details_white</item>
         <item name="settings_eye">@drawable/settings_eye_white</item>
@@ -66,11 +66,11 @@
     </style>
 
     <style name="settings.light" parent="cgeo">
-        <item name="android:textColor">@color/settings_colorTextLight</item>
-        <item name="android:textColorSecondary">@color/settings_colorTextSecondaryLight</item>
+        <item name="android:textColor">@color/settings_primary_selector_light</item>
+        <item name="android:textColorSecondary">@color/settings_secondary_selector_light</item>
         <item name="android:colorBackground">@color/settings_colorBackgroundLight</item>
 
-        <!-- icon resources -->
+        <!-- icon resources - can be moved (without suffix "_black") to drawables when based on AppCompatActivity -->
         <item name="settings_cloud">@drawable/settings_cloud_black</item>
         <item name="settings_details">@drawable/settings_details_black</item>
         <item name="settings_eye">@drawable/settings_eye_black</item>


### PR DESCRIPTION
## Description
adds color selectors for settings activity to be able to distinguish between enabled and disabled settings

![image](https://user-images.githubusercontent.com/3754370/120842406-ee4b8a80-c56c-11eb-9a4b-e2ac37210b58.png).![image](https://user-images.githubusercontent.com/3754370/120842419-f277a800-c56c-11eb-836d-cff6bbca6761.png)
