### PR TITLE
use solid button in wizard for default action only (fix #10835)

### DIFF
--- a/main/res/layout/install_wizard.xml
+++ b/main/res/layout/install_wizard.xml
@@ -98,8 +98,13 @@
             android:layout_weight="1" />
         <Button
             android:id="@+id/wizard_next"
-            style="@style/InstallationWizardButtonFooter"
+            style="@style/InstallationWizardButtonFooterSolid"
             android:text="@string/next" />
+        <Button
+            android:id="@+id/wizard_next_outlined"
+            style="@style/InstallationWizardButtonFooter"
+            android:text="@string/next"
+            android:visibility="gone"/>
 
     </LinearLayout>
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -484,18 +484,31 @@
         <item name="android:layout_marginLeft">16dp</item>
         <item name="android:layout_marginRight">16dp</item>
     </style>
-    <style name="InstallationWizardButtonFull" parent="InstallationWizardMarginsLR">
-        <item name="android:layout_width">match_parent</item>
+    <style name="InstallationWizardButtonOutlined" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginLeft">16dp</item>
+        <item name="android:layout_marginRight">16dp</item>
+    </style>
+    <style name="InstallationWizardButtonFull" parent="InstallationWizardButtonOutlined">
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_centerHorizontal">true</item>
         <item name="android:layout_marginTop">12dp</item>
     </style>
-    <style name="InstallationWizardButtonFooter" parent="InstallationWizardMarginsLR">
+    <style name="InstallationWizardButtonFooter" parent="InstallationWizardButtonOutlined">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_alignParentBottom">true</item>
+        <item name="android:gravity">center</item>
+        <item name="android:padding">12dp</item>
+        <item name="android:layout_marginBottom">12dp</item>
+    </style>
+    <style name="InstallationWizardButtonFooterSolid" parent="@style/Widget.MaterialComponents.Button">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_alignParentBottom">true</item>
         <item name="android:gravity">center</item>
         <item name="android:padding">12dp</item>
+        <item name="android:layout_marginLeft">16dp</item>
+        <item name="android:layout_marginRight">16dp</item>
         <item name="android:layout_marginBottom">12dp</item>
     </style>
     <style name="InstallationWizardTextViewBase" parent="InstallationWizardMarginsLR">

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -300,7 +300,7 @@ public class InstallWizardActivity extends AppCompatActivity {
             skip.setOnClickListener(v -> listenerSkip.run());
         }
 
-        final boolean useNextOutlinedButton = (nextLabelRes == R.string.skip);
+        final boolean useNextOutlinedButton = nextLabelRes == R.string.skip;
         if (listenerNext == null) {
             next.setVisibility(View.GONE);
             nextOutlined.setVisibility(View.GONE);

--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -92,6 +92,7 @@ public class InstallWizardActivity extends AppCompatActivity {
     private Button prev = null;
     private Button skip = null;
     private Button next = null;
+    private Button nextOutlined = null;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -121,6 +122,7 @@ public class InstallWizardActivity extends AppCompatActivity {
         prev = binding.wizardPrev;
         skip = binding.wizardSkip;
         next = binding.wizardNext;
+        nextOutlined = binding.wizardNextOutlined;
 
         this.contentStorageActivityHelper = new ContentStorageActivityHelper(this, savedInstanceState == null ? null : savedInstanceState.getBundle(BUNDLE_CSAH))
             .addSelectActionCallback(ContentStorageActivityHelper.SelectAction.SELECT_FOLDER_PERSISTED, PersistableFolder.class, pf -> {
@@ -297,12 +299,21 @@ public class InstallWizardActivity extends AppCompatActivity {
             skip.setText(skipLabelRes == 0 ? R.string.skip : skipLabelRes);
             skip.setOnClickListener(v -> listenerSkip.run());
         }
+
+        final boolean useNextOutlinedButton = (nextLabelRes == R.string.skip);
         if (listenerNext == null) {
             next.setVisibility(View.GONE);
+            nextOutlined.setVisibility(View.GONE);
         } else {
-            next.setVisibility(View.VISIBLE);
-            next.setText(nextLabelRes == 0 ? R.string.next : nextLabelRes);
-            next.setOnClickListener(v -> listenerNext.run());
+            next.setVisibility(useNextOutlinedButton ? View.GONE : View.VISIBLE);
+            nextOutlined.setVisibility(useNextOutlinedButton ? View.VISIBLE : View.GONE);
+            if (useNextOutlinedButton) {
+                nextOutlined.setText(nextLabelRes);
+                nextOutlined.setOnClickListener(v -> listenerNext.run());
+            } else {
+                next.setText(nextLabelRes == 0 ? R.string.next : nextLabelRes);
+                next.setOnClickListener(v -> listenerNext.run());
+            }
         }
     }
 


### PR DESCRIPTION
## Description
- uses solid button for default action only
- pages without a default action (because of having several actions of equal importance) will no longer have any solid button at all (e. g.: services page, advanced settings page)

![image](https://user-images.githubusercontent.com/3754370/120863089-4c3a9b00-c58a-11eb-9e7d-ed731de58215.png).![image](https://user-images.githubusercontent.com/3754370/120862953-172e4880-c58a-11eb-9e94-b336a39a9691.png).![image](https://user-images.githubusercontent.com/3754370/120862963-1b5a6600-c58a-11eb-9897-0217e5b664da.png).![image](https://user-images.githubusercontent.com/3754370/120863133-58bef380-c58a-11eb-891e-fc92411e34e5.png)

