### PR TITLE
Export formula to PN instead of coordinates for completed formula

### DIFF
--- a/main/src/cgeo/geocaching/models/WaypointParser.java
+++ b/main/src/cgeo/geocaching/models/WaypointParser.java
@@ -399,16 +399,18 @@ public class WaypointParser {
         //type
         sb.append(PARSING_TYPE_OPEN).append(wp.getWaypointType().getShortId().toUpperCase(Locale.US))
             .append(PARSING_TYPE_CLOSE).append(" ");
-        //coordinate
-        if (wp.getCoords() == null) {
-            final String calcStateJson = wp.getCalcStateJson();
-            if (null != calcStateJson) {
-                sb.append(getParseableFormula(wp));
-            } else {
-                sb.append(PARSING_COORD_EMPTY);
-            }
+
+        // formula
+        final String calcStateJson = wp.getCalcStateJson();
+        if (null != calcStateJson) {
+            sb.append(getParseableFormula(wp));
         } else {
-            sb.append(wp.getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT_RAW));
+        //coordinate
+            if (wp.getCoords() == null) {
+                sb.append(PARSING_COORD_EMPTY);
+            } else {
+                sb.append(wp.getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT_RAW));
+            }
         }
 
         //user note

--- a/tests/src/cgeo/geocaching/models/WaypointParserTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointParserTest.java
@@ -249,6 +249,24 @@ public class WaypointParserTest {
     }
 
     /**
+     * Parse Waypoint with formula and variables and get parseable text.
+     * Formula and description should be correct.
+     */
+    @Test
+    public void testParseWaypointWithCompleteFormulaAndCreateParseableWaypointText() {
+        final String note = "@name (F) " + WaypointParser.PARSING_COORD_FORMULA_PLAIN + " N 45° A.B(C+D)  E 9° (A-B).(2*D)EF | A = a + b |B=1|a=2|b=47|C=10|D=4|E=2|F=3| this is the description\n\"this shall NOT be part of the note\"";
+        final WaypointParser waypointParser = new WaypointParser("Prefix");
+        final Collection<Waypoint> waypoints = waypointParser.parseWaypoints(note);
+        assertThat(waypoints).hasSize(1);
+        final Iterator<Waypoint> iterator = waypoints.iterator();
+        final Waypoint wp = iterator.next();
+
+        final String parseableText = WaypointParser.getParseableText(wp, -1);
+        assertThat(parseableText).isEqualTo(
+            "@name (F) " + WaypointParser.PARSING_COORD_FORMULA_PLAIN + " N 45° A.B(C+D)' E 9° (A-B).(2*D)EF' |A=a + b|B=1|C=10|D=4|E=2|F=3|a=2|b=47| \"this is the description\"");
+    }
+
+    /**
      * Waypoint with formula and variables should be created
      */
     @Test


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
Exports the formula of a waypoint to the PN, even if all variables are defined and the coordinates could be calculated.
This would be to have the variables "archived" in the PN.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#9211 
#9633 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
see comment of @Lineflyer  https://github.com/cgeo/cgeo/issues/9211#issuecomment-854134154