### PR TITLE
remove tint from copyright sign (fix #10855)

### DIFF
--- a/main/res/drawable/copyright.xml
+++ b/main/res/drawable/copyright.xml
@@ -3,7 +3,6 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?android:textColorPrimary"
     android:alpha="@dimen/icon_alpha">
   <path
       android:pathData="M12,12m-11.5,0a11.5,11.5 0,1 1,23 0a11.5,11.5 0,1 1,-23 0"


### PR DESCRIPTION
## Description
The copyright sign itself already uses black color on white background, so no tint needed (which was white in this case and covered the c sign).
