### PR TITLE
make slider color context-aware (fix #10852)

### DIFF
--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -130,7 +130,9 @@ public class ViewUtils {
                 final TextView tv = new TextView(ctx);
                 tv.setText(itemText);
                 tv.setMaxLines(1);
-                if (APP_RESSOURCES != null) {
+                if (Build.VERSION.SDK_INT >= 23) {
+                    tv.setTextColor(ctx.getColor(R.color.colorText));
+                } else if (APP_RESSOURCES != null) {
                     tv.setTextColor(APP_RESSOURCES.getColor(R.color.colorText));
                 }
                 if (DEBUG_LAYOUT) {


### PR DESCRIPTION
## Description
Currently slider label uses a color retrieved from (static) application context, which returns black always.
Make this context-aware to retrieve a theme-specific color.

![image](https://user-images.githubusercontent.com/3754370/120890517-754b4200-c603-11eb-8688-661a82de8f9b.png).![image](https://user-images.githubusercontent.com/3754370/120890522-7bd9b980-c603-11eb-9e8f-6e72b701ddb2.png)
