### PR TITLE
add attribution to material design icons (fix #10858)

### DIFF
--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -145,6 +145,7 @@
     - [RRZE Icon set](https://github.com/RRZE-PP/rrze-icon-set) ([CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))\n
     - [Layers icon by Cole Bemis](https://iconfindr.com/1mNr3rl) ([CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/))\n
     - [Google Material Design Icons](https://material.io/tools/icons/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
+    - [Material Design Icons](https://materialdesignicons.com/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
     - [DragSortListView library by Carl Bauer](https://github.com/bauerca/drag-sort-listview/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
     - [Geocoding courtesy of MapQuest](https://www.mapquest.com/)\n
     - [Geocoding data from OpenStreetMap](https://www.openstreetmap.org/)\n


### PR DESCRIPTION
## Description
Add attribution to material design icons in about:contributors' page
