### PR TITLE
add spacing to cachelist spinner item (fix #10854)

### DIFF
--- a/main/res/layout/cachelist_spinneritem.xml
+++ b/main/res/layout/cachelist_spinneritem.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="?attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
-    android:layout_height="?attr/dropdownListPreferredItemHeight"
+    android:layout_height="?attr/listPreferredItemHeight"
     android:layout_gravity="left|center_vertical"
     android:minHeight="?attr/dropdownListPreferredItemHeight"
     android:orientation="vertical"


### PR DESCRIPTION
## Description
Adjust layout height of cachelist spinner to add some spacing between entries:

![image](https://user-images.githubusercontent.com/3754370/120889795-1be11400-c5ff-11eb-94a4-aaa5837f4038.png)
