### PR TITLE
revert global listheight, format alertdialog lists (fix #10861)

### DIFF
--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -6,7 +6,6 @@
     <dimen name="actionbar_separator_width">2dip</dimen>
 
     <dimen name="radioButtonCheckboxPreferredItemHeight">32dp</dimen>
-    <dimen name="listPreferredItemHeightSmall">40dp</dimen>
 
     <!-- Dimensions for Samsung Multi-Window support -->
     <dimen name="app_defaultsize_w">632.0dip</dimen>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -24,6 +24,8 @@
 
     <style name="checkboxStyle" parent="@style/Widget.MaterialComponents.CompoundButton.CheckBox">
         <item name="android:minHeight">@dimen/radioButtonCheckboxPreferredItemHeight</item>
+        <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
+        <item name="android:textColor">@color/colorText</item>
     </style>
 
     <style name="checkbox_full">

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -8,7 +8,6 @@
         <item name="checkboxStyle">@style/checkboxStyle</item>
         <item name="radioButtonStyle">@style/radioButtonStyle</item>
         <item name="materialAlertDialogTheme">@style/materialAlertDialogTheme</item>
-        <item name="android:listPreferredItemHeightSmall">@dimen/listPreferredItemHeightSmall</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>
@@ -27,9 +26,19 @@
     </style>
 
     <!-- theme for alert dialogs -->
+
     <style name="materialAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="materialAlertDialogTitleTextStyle">@style/alertDialogTitleTextStyle</item>
         <item name="materialAlertDialogBodyTextStyle">@style/alertDialogBodyTextStyle</item>
+    </style>
+
+    <!-- theme for dialogs with compact lists (e. g.: "pick a list" dialogs -->
+
+    <style name="cgeo.compactDialogs" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="android:listPreferredItemHeightSmall">40dp</item>
+        <item name="materialAlertDialogTitleTextStyle">@style/alertDialogTitleTextStyle</item>
+        <item name="materialAlertDialogBodyTextStyle">@style/alertDialogBodyTextStyle</item>
+        <item name="android:checkedTextViewStyle">@style/checkboxStyle</item>
     </style>
 
     <!-- theme for cache/waypoint popups -->

--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -108,7 +108,7 @@ public final class StoredList extends AbstractList {
             }
 
             final Activity activity = activityRef.get();
-            final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
+            final AlertDialog.Builder builder = Dialogs.newBuilder(activity, R.style.cgeo_compactDialogs);
             builder.setTitle(res.getString(titleId));
             builder.setMultiChoiceItems(listTitles, selectedItems, new MultiChoiceClickListener(lists, selectedListIds));
             builder.setPositiveButton(android.R.string.ok, new OnOkClickListener(selectedListIds, runAfterwards, listNameMemento));
@@ -134,7 +134,7 @@ public final class StoredList extends AbstractList {
             final CharSequence[] items = new CharSequence[listsTitle.size()];
 
             final Activity activity = activityRef.get();
-            final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
+            final AlertDialog.Builder builder = Dialogs.newBuilder(activity, R.style.cgeo_compactDialogs);
             builder.setTitle(res.getString(titleId));
             builder.setItems(listsTitle.toArray(items), (dialogInterface, itemId) -> {
                 final AbstractList list = lists.get(itemId);

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -43,6 +43,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.annotation.StyleRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
 
@@ -1075,6 +1076,10 @@ public final class Dialogs {
 
     public static AlertDialog.Builder newBuilder(final Context context) {
         return new MaterialAlertDialogBuilder(newContextThemeWrapper(context));
+    }
+
+    public static AlertDialog.Builder newBuilder(final Context context, final @StyleRes int resId) {
+        return new MaterialAlertDialogBuilder(newContextThemeWrapper(context), resId);
     }
 
     public static ContextThemeWrapper newContextThemeWrapper(final Context context) {


### PR DESCRIPTION
## Description
- revert setting a global list line height
- add optional `styleRes` parameter to `Dialogs.newBuilder()`
- create a style `compactDialogs` based on `cgeo` and material alert dialogs with a reduced list line height and correct font colors and sizes
- and apply this style to the three "pick a list" dialogs

![image](https://user-images.githubusercontent.com/3754370/120900261-3ed9eb00-c634-11eb-989d-c80729b46cb1.png).![image](https://user-images.githubusercontent.com/3754370/120900279-50bb8e00-c634-11eb-999a-f96b92517507.png).![image](https://user-images.githubusercontent.com/3754370/120900282-55804200-c634-11eb-9a0e-cf01636d98ad.png)
