### PR TITLE
fix checkbox unreachable error in pick list (fix #10867)

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -28,6 +28,12 @@
         <item name="android:textColor">@color/colorText</item>
     </style>
 
+    <style name="checkboxStyleNoParent">
+        <item name="android:minHeight">@dimen/radioButtonCheckboxPreferredItemHeight</item>
+        <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
+        <item name="android:textColor">@color/colorText</item>
+    </style>
+
     <style name="checkbox_full">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -38,7 +38,7 @@
         <item name="android:listPreferredItemHeightSmall">40dp</item>
         <item name="materialAlertDialogTitleTextStyle">@style/alertDialogTitleTextStyle</item>
         <item name="materialAlertDialogBodyTextStyle">@style/alertDialogBodyTextStyle</item>
-        <item name="android:checkedTextViewStyle">@style/checkboxStyle</item>
+        <item name="android:checkedTextViewStyle">@style/checkboxStyleNoParent</item>
     </style>
 
     <!-- theme for cache/waypoint popups -->


### PR DESCRIPTION
## Description
- fixes the "cannot use checkboxes in multi-select "pick a list" dialog
- reason: `checkedTextViewStyle` for `AlterDialog` with multi selection enabled must not inherit from `Widget.MaterialComponents.CompoundButton.CheckBox`
