### PR TITLE
use smaller icon-size in map-settings (rel #10868)

### DIFF
--- a/main/res/layout/checkbox_item.xml
+++ b/main/res/layout/checkbox_item.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/item_icon"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:scaleType="fitCenter"
         android:layout_centerVertical="true" />
 
@@ -37,8 +37,8 @@
             android:textColor="@color/colorText"/>
         <ImageView
             android:id="@+id/item_info"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
             android:scaleType="fitCenter"
             android:visibility="gone"
             app:srcCompat="@drawable/settings_info"


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
use smaller icon size in map-settings
![grafik](https://user-images.githubusercontent.com/70113341/120922904-14d40780-c6cc-11eb-9850-579e0c26ddb2.png)


has also affects in filter-activity and even there for the cache-type-icons. I am not sure, if that is ok as well. Otherwise I have to find a different solution
![grafik](https://user-images.githubusercontent.com/70113341/120922915-24535080-c6cc-11eb-8184-9c124e6c8fd6.png)



## Related issues
<!-- List the related issues fixed or improved by this PR -->
#10868
