### PR TITLE
use material TextInputLayout for edit waypoint page (rel. to #10763)

### DIFF
--- a/main/res/layout/cache_filter_generic_string.xml
+++ b/main/res/layout/cache_filter_generic_string.xml
@@ -53,25 +53,13 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/searchtext"
-        android:hint="@string/cache_filter_stringfilter_searchtext_hint"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
         style="@style/textinput_dropdown"
-        app:endIconMode="clear_text"
         android:layout_below="@+id/filter_options"
         android:layout_alignParentLeft="true"
         android:layout_alignParentRight="true">
-
-    <AutoCompleteTextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inputType="text"
-
-        />
-
+        <AutoCompleteTextView
+            style="@style/textinput_embedded"
+            android:hint="@string/cache_filter_stringfilter_searchtext_hint" />
     </com.google.android.material.textfield.TextInputLayout>
-
-
-
 
 </RelativeLayout>

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -34,7 +34,7 @@
             android:importantForAutofill="noExcludeDescendants">
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/textinput_edittext_singleline_full"
+                style="@style/textinput_edittext_singleline"
                 app:endIconMode="clear_text">
                 <EditText
                     android:id="@+id/bearing"
@@ -49,7 +49,7 @@
                 android:layout_height="wrap_content">
 
                 <com.google.android.material.textfield.TextInputLayout
-                    style="@style/textinput_edittext_singleline_full"
+                    style="@style/textinput_edittext_singleline"
                     android:layout_toLeftOf="@id/distanceUnit"
                     app:endIconMode="clear_text">
                     <EditText
@@ -87,9 +87,7 @@
             android:visibility="gone"
             tools:listitem="@android:layout/simple_spinner_item" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/name"
                 style="@style/textinput_embedded"
@@ -98,8 +96,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/note_layout"
-            style="@style/textinput_edittext_full"
-            app:endIconMode="clear_text">
+            style="@style/textinput_edittext">
             <EditText
                 android:id="@+id/note"
                 style="@style/textinput_embedded"
@@ -108,9 +105,7 @@
                 android:minLines="5"/>
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_edittext_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
             <EditText
                 android:id="@+id/user_note"
                 style="@style/textinput_embedded"

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:padding="4dip"
-    tools:context=".EditWaypointActivity" >
+    tools:context=".EditWaypointActivity">
 
     <LinearLayout
         android:layout_width="fill_parent"
@@ -30,34 +32,50 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:importantForAutofill="noExcludeDescendants">
-            <EditText
-                android:id="@+id/bearing"
-                style="@style/edittext_full"
-                android:hint="@string/waypoint_bearing"
-                android:inputType="numberDecimal|numberSigned"
-                android:enabled="false"/>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/textinput_edittext_singleline_full"
+                app:endIconMode="clear_text">
+                <EditText
+                    android:id="@+id/bearing"
+                    style="@style/textinput_embedded"
+                    android:hint="@string/waypoint_bearing"
+                    android:inputType="numberDecimal|numberSigned"
+                    android:enabled="false"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/textinput_edittext_singleline_full"
+                    android:layout_toLeftOf="@id/distanceUnit"
+                    app:endIconMode="clear_text">
+                    <EditText
+                        android:id="@+id/distance"
+                        style="@style/textinput_embedded"
+                        android:hint="@string/waypoint_distance"
+                        android:inputType="numberDecimal"
+                        android:enabled="false"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/distanceUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_centerInParent="true"
+                    android:entries="@array/distance_units"
+                    tools:listitem="@android:layout/simple_spinner_item"
+                    android:enabled="false"/>
+            </RelativeLayout>
 
             <LinearLayout
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal" >
 
-                <EditText
-                    android:id="@+id/distance"
-                    style="@style/edittext_full"
-                    android:layout_width="0dip"
-                    android:layout_weight="1"
-                    android:hint="@string/waypoint_distance"
-                    android:inputType="numberDecimal"
-                    android:enabled="false"/>
-
-                <Spinner
-                    android:id="@+id/distanceUnit"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:entries="@array/distance_units"
-                    tools:listitem="@android:layout/simple_spinner_item"
-                    android:enabled="false"/>
 
             </LinearLayout>
         </LinearLayout>
@@ -69,26 +87,37 @@
             android:visibility="gone"
             tools:listitem="@android:layout/simple_spinner_item" />
 
-        <AutoCompleteTextView
-            android:id="@+id/name"
-            style="@style/edittext_full"
-            android:hint="@string/waypoint_name" />
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/textinput_dropdown_full"
+            app:endIconMode="clear_text">
+            <AutoCompleteTextView
+                android:id="@+id/name"
+                style="@style/textinput_embedded"
+                android:hint="@string/waypoint_name" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/note"
-            style="@style/edittext_full"
-            android:layout_height="wrap_content"
-            android:hint="@string/waypoint_note"
-            android:inputType="textMultiLine|textCapSentences"
-            android:minLines="5"/>
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/note_layout"
+            style="@style/textinput_edittext_full"
+            app:endIconMode="clear_text">
+            <EditText
+                android:id="@+id/note"
+                style="@style/textinput_embedded"
+                android:hint="@string/waypoint_note"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="5"/>
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/user_note"
-            style="@style/edittext_full"
-            android:layout_height="wrap_content"
-            android:hint="@string/waypoint_user_note"
-            android:inputType="textMultiLine|textCapSentences"
-            android:minLines="5" />
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/textinput_edittext_full"
+            app:endIconMode="clear_text">
+            <EditText
+                android:id="@+id/user_note"
+                style="@style/textinput_embedded"
+                android:hint="@string/waypoint_user_note"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="5" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <CheckBox
             android:id="@+id/wpt_visited_checkbox"

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -48,7 +48,7 @@
             app:endIconMode="clear_text">
             <AutoCompleteTextView
                 android:id="@+id/address"
-                style="@style/textinput_embedded_autocomplete"
+                style="@style/textinput_embedded"
                 android:hint="@string/search_address"
                 android:imeOptions="actionGo" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -71,7 +71,7 @@
             app:endIconMode="clear_text">
             <AutoCompleteTextView
                 android:id="@+id/geocode"
-                style="@style/textinput_embedded_autocomplete"
+                style="@style/textinput_embedded"
                 android:hint="@string/search_geo"
                 android:imeOptions="actionGo"
                 android:inputType="textVisiblePassword"
@@ -97,7 +97,7 @@
             app:endIconMode="clear_text">
             <AutoCompleteTextView
                 android:id="@+id/keyword"
-                style="@style/textinput_embedded_autocomplete"
+                style="@style/textinput_embedded"
                 android:hint="@string/search_kw_prefill"
                 android:imeOptions="actionGo" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -120,7 +120,7 @@
             app:endIconMode="clear_text">
             <AutoCompleteTextView
                 android:id="@+id/finder"
-                style="@style/textinput_embedded_autocomplete"
+                style="@style/textinput_embedded"
                 android:hint="@string/search_fbu_prefill"
                 android:imeOptions="actionGo" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -143,7 +143,7 @@
             app:endIconMode="clear_text">
             <AutoCompleteTextView
                 android:id="@+id/owner"
-                style="@style/textinput_embedded_autocomplete"
+                style="@style/textinput_embedded"
                 android:hint="@string/search_hbu_prefill"
                 android:imeOptions="actionGo" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -198,7 +198,7 @@
             app:endIconMode="clear_text">
             <AutoCompleteTextView
                 android:id="@+id/trackable"
-                style="@style/textinput_embedded_autocomplete"
+                style="@style/textinput_embedded"
                 android:hint="@string/search_tb_hint"
                 android:imeOptions="actionGo"
                 android:inputType="textVisiblePassword" />

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -43,9 +43,7 @@
                 android:text="@string/search_address" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/address"
                 style="@style/textinput_embedded"
@@ -66,9 +64,7 @@
                 android:text="@string/search_geo" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/geocode"
                 style="@style/textinput_embedded"
@@ -92,9 +88,7 @@
                 android:text="@string/search_kw" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/keyword"
                 style="@style/textinput_embedded"
@@ -115,9 +109,7 @@
                 android:text="@string/search_fbu" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/finder"
                 style="@style/textinput_embedded"
@@ -138,9 +130,7 @@
                 android:text="@string/search_hbu" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/owner"
                 style="@style/textinput_embedded"
@@ -193,9 +183,7 @@
                 android:text="@string/search_tb" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            style="@style/textinput_dropdown_full"
-            app:endIconMode="clear_text">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
             <AutoCompleteTextView
                 android:id="@+id/trackable"
                 style="@style/textinput_embedded"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -198,23 +198,22 @@
         <item name="android:autoText">true</item>
         <item name="android:gravity">top|left</item>
         <item name="android:capitalize">none</item>
-    </style>
-
-    <style name="textinput_dropdown_full" parent="textinput_dropdown">
-        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+        <item name="endIconMode">clear_text</item>
     </style>
 
-    <style name="textinput_edittext_full" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+    <style name="textinput_edittext" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:padding">6dip</item>
         <item name="android:autoText">true</item>
         <item name="android:gravity">top|left</item>
         <item name="android:capitalize">none</item>
-        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+        <item name="endIconMode">clear_text</item>
     </style>
 
-    <style name="textinput_edittext_singleline_full" parent="textinput_edittext_full">
+    <style name="textinput_edittext_singleline" parent="textinput_edittext">
         <item name="android:singleLine">true</item>
     </style>
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -205,7 +205,22 @@
         <item name="android:layout_height">wrap_content</item>
     </style>
 
-    <style name="textinput_embedded_autocomplete">
+    <style name="textinput_edittext_full" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+        <item name="android:padding">6dip</item>
+        <item name="android:autoText">true</item>
+        <item name="android:gravity">top|left</item>
+        <item name="android:capitalize">none</item>
+        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="textinput_edittext_singleline_full" parent="textinput_edittext_full">
+        <item name="android:singleLine">true</item>
+    </style>
+
+    <!-- for AutoCompleteTextView or EditText embedded in material TextInputLayout -->
+
+    <style name="textinput_embedded">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:inputType">text</item>

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -167,7 +167,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                 }
 
                 if (StringUtils.isBlank(activity.binding.note.getText())) {
-                    activity.binding.note.setVisibility(View.GONE);
+                    activity.binding.noteLayout.setVisibility(View.GONE);
                 }
 
             } catch (final RuntimeException e) {
@@ -232,7 +232,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
             (new LoadWaypointThread()).start();
         } else { // new waypoint
             initializeWaypointTypeSelector();
-            binding.note.setVisibility(View.GONE);
+            binding.noteLayout.setVisibility(View.GONE);
             updateCoordinates(initialCoords);
         }
 

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -45,13 +45,7 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
-import android.widget.Button;
-import android.widget.CheckBox;
 import android.widget.EditText;
-import android.widget.LinearLayout;
-import android.widget.RadioButton;
-import android.widget.RadioGroup;
-import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -67,7 +61,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.Extra;
 import org.androidannotations.annotations.InstanceState;
-import org.androidannotations.annotations.ViewById;
 import org.apache.commons.lang3.StringUtils;
 
 @EActivity

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -36,6 +36,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.viewbinding.ViewBinding;
 
 import java.util.Locale;
 
@@ -130,6 +131,11 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
 
     protected void setThemeAndContentView(@LayoutRes final int resourceLayoutID) {
         setThemeAndContentView(resourceLayoutID, false);
+    }
+
+    protected void setThemeAndContentView(final ViewBinding binding) {
+        ActivityMixin.setTheme(this, false);
+        setContentView(binding.getRoot());
     }
 
     protected void setThemeAndContentView(@LayoutRes final int resourceLayoutID, final boolean isDialog) {


### PR DESCRIPTION
## Description
- use material TextInputLayout for edit waypoint page 
- replace old viewbindings (colliding with Gradle plugin 5) with ViewBinding class

|default|multi-line edit|with bearing + distance|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3754370/121253536-83ba8780-c8a9-11eb-8dd5-80e17421896e.png)|![image](https://user-images.githubusercontent.com/3754370/121253585-946afd80-c8a9-11eb-992b-7fdd5c8edfeb.png)|![image](https://user-images.githubusercontent.com/3754370/121253632-a482dd00-c8a9-11eb-8c77-3d2d6f800e32.png)|

(First two screenshots are from editing a given waypoint, third screenshot is from creating a user-defined waypoint)

## Additional context
- use style `textinput_dropdown` if you are embedding a single line `AutoCompleteTextView`
- use style `textinput_edittext` if you are embedding a single or multi line `EditText`
- use style `textinput_embedded` for the embedded `AutoCompleteTextView` or `EditText`

## Note
If you want to set visibility to an embedded `AutoCompleteTextView` or `EditText`, you will have to set the visibility of the surrounding `TextInputLayout`, otherwise it will not work.