### PR TITLE
prevent doubling cache description on reload (fix #10901)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1644,6 +1644,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 return;
             }
 
+            // reset description
+            binding.description.setText("");
+
             // cache short description
             if (StringUtils.isNotBlank(cache.getShortDescription())) {
                 loadDescription(activity, cache.getShortDescription(), binding.description, null);


### PR DESCRIPTION
## Description
Reset cache description on reloading a cache to prevent doubling the contents.
