### PR TITLE
fix #10906: mapquicksettings layout on low res devices with SDK 21

### DIFF
--- a/main/res/layout/map_settings_dialog.xml
+++ b/main/res/layout/map_settings_dialog.xml
@@ -8,8 +8,8 @@
 
     <LinearLayout
         android:id="@+id/map_settings_columns"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
         android:orientation="horizontal" />


### PR DESCRIPTION
fix #10906: mapquicksettings layout on low res devices with SDK 21:

![image](https://user-images.githubusercontent.com/6909759/121771674-03c64300-cb71-11eb-8388-cf28a29b726d.png)
