### PR TITLE
fix failing DownloadTest: new andromaps on server

### DIFF
--- a/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
@@ -69,7 +69,7 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         final List<Download> list = getList(MapDownloaderOpenAndroMaps.getInstance(), CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_downloadurl) + "europe/");
 
         // europe starting page currently has ... entries (including the "up" entry)
-        assertThat(list.size()).isEqualTo(59);
+        assertThat(list.size()).isEqualTo(60);
 
         // first entry has to be the "up" entry
         assertThat(list.get(0).getIsDir()).isTrue();
@@ -78,7 +78,7 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         assertThat(count(list, true)).isEqualTo(1);
 
         // number of non-dirs found
-        assertThat(count(list, false)).isEqualTo(58);
+        assertThat(count(list, false)).isEqualTo(59);
 
         // check one named entry
         final Download d = findByName(list, "Scandinavia_SouthWest");


### PR DESCRIPTION
fix failing DownloadTest: new andromaps on server

There's a new andromap on server. from date, I assume it is `Scandinavia_NorthEast.zip`  
![image](https://user-images.githubusercontent.com/6909759/121772220-5f460000-cb74-11eb-8fa2-0e9ea201ebbc.png)
