### PR TITLE
rel to #10711: store only one global filter setting, no contexts any more

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -510,9 +510,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         if (extras != null) {
             type = Intents.getListType(getIntent());
             coords = extras.getParcelable(Intents.EXTRA_COORDS);
-            if (extras.getString(Intents.EXTRA_FILTER) != null) {
-                GeocacheFilter.createFromConfig(extras.getString(Intents.EXTRA_FILTER)).storeForListType(type);
-            }
         } else {
             extras = new Bundle();
         }
@@ -528,7 +525,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         setTitle(title);
 
-        currentCacheFilter = GeocacheFilter.getStoredForListType(type);
+        currentCacheFilter = GeocacheFilter.loadFromSettings();
 
 
         // Check whether we're recreating a previously destroyed instance
@@ -1348,7 +1345,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setFilter(FilterActivity.getFilterFromPosition(filterIndex[0], filterIndex[1]), currentCacheFilter);
         } else if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             currentCacheFilter = GeocacheFilter.createFromConfig(data.getStringExtra(GeocacheFilterActivity.EXTRA_FILTER_RESULT));
-            currentCacheFilter.storeForListType(type);
             setFilter(currentFilter, currentCacheFilter);
 
             if (type == CacheListType.SEARCH_FILTER) {

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableTrackingCode;
 import cgeo.geocaching.databinding.SearchActivityBinding;
-import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.location.Geopoint;
@@ -287,7 +286,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     }
 
     private void findByFilterFn() {
-        GeocacheFilterActivity.selectFilter(this, GeocacheFilter.getStoredForListType(CacheListType.SEARCH_FILTER), null, false);
+        GeocacheFilterActivity.selectFilter(this, GeocacheFilter.loadFromSettings(), null, false);
 
     }
 

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
@@ -138,12 +137,12 @@ public class GeocacheFilter {
     }
 
     @NonNull
-    public static GeocacheFilter getStoredForListType(final CacheListType listType) {
-        return GeocacheFilter.createFromConfig(Settings.getCacheFilterConfig(listType));
+    public static GeocacheFilter loadFromSettings() {
+        return GeocacheFilter.createFromConfig(Settings.getCacheFilterConfig());
     }
 
-    public void storeForListType(final CacheListType listType) {
-        Settings.setCacheFilterConfig(listType, this.toConfig());
+    public void storeToSettings() {
+        Settings.setCacheFilterConfig(this.toConfig());
     }
 
     public static GeocacheFilter checkConfig(final String filterConfig) throws ParseException {
@@ -193,8 +192,7 @@ public class GeocacheFilter {
         config.addToDefaultList(getName());
         config.putList(CONFIG_KEY_ADV_MODE, BooleanUtils.toStringTrueFalse(isOpenInAdvancedMode()));
         config.putList(CONFIG_KEY_INCLUDE_INCLUSIVE, BooleanUtils.toStringTrueFalse(isIncludeInconclusive()));
-        final String configString = "[" + ExpressionParser.toConfig(config) + "]" + (tree == null ? "" : FILTER_PARSER.getConfig(tree));
-        return configString;
+        return "[" + ExpressionParser.toConfig(config) + "]" + (tree == null ? "" : FILTER_PARSER.getConfig(tree));
     }
 
 

--- a/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -296,7 +296,9 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     private void finishWithResult() {
         final Intent resultIntent = new Intent();
-        resultIntent.putExtra(EXTRA_FILTER_RESULT, getFilterFromView().toConfig());
+        final GeocacheFilter newFilter = getFilterFromView();
+        newFilter.storeToSettings();
+        resultIntent.putExtra(EXTRA_FILTER_RESULT, newFilter.toConfig());
         FilterViewHolderCreator.clearListInfo();
         setResult(Activity.RESULT_OK, resultIntent);
         finish();

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.maps;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
-import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.WaypointType;
@@ -45,7 +44,7 @@ public class MapUtils {
         final boolean excludeOfflineLog = checkCacheFilters && Settings.isExcludeOfflineLog();
         final CacheType filterCacheType = checkCacheFilters ? null : (Settings.getCacheType() == null ? CacheType.ALL : Settings.getCacheType());
 
-        final GeocacheFilter filter = GeocacheFilter.getStoredForListType(getMapViewerListType());
+        final GeocacheFilter filter = GeocacheFilter.loadFromSettings();
 
         final boolean excludeWpOriginal = Settings.isExcludeWpOriginal();
         final boolean excludeWpParking = Settings.isExcludeWpParking();
@@ -69,10 +68,9 @@ public class MapUtils {
     /** Applies given filter to cache list. Additionally, creates a second list additionally filtered by own/found/disabled caches if required */
     public static void filter(final Collection<Geocache> caches) {
 
-        final GeocacheFilter filter = GeocacheFilter.getStoredForListType(getMapViewerListType());
-        if (filter != null) {
-            filter.filterList(caches);
-        }
+        final GeocacheFilter filter = GeocacheFilter.loadFromSettings();
+        filter.filterList(caches);
+
 
         final boolean excludeMine = Settings.isExcludeMyCaches();
         final boolean excludeFound = Settings.isExcludeFound();
@@ -106,13 +104,8 @@ public class MapUtils {
 
         GeocacheFilterActivity.selectFilter(
             activity,
-            GeocacheFilter.getStoredForListType(MapUtils.getMapViewerListType()),
+            GeocacheFilter.loadFromSettings(),
             filteredList, true);
-    }
-
-    public static void changeMapFilter(final Activity activity, final GeocacheFilter mapFilter) {
-        mapFilter.storeForListType(MapUtils.getMapViewerListType());
-        setFilterBar(activity);
     }
 
     public static void setFilterBar(final Activity activity) {
@@ -133,7 +126,7 @@ public class MapUtils {
             filters.add(Settings.getCacheType().getL10n());
         }
 
-        final GeocacheFilter filter = GeocacheFilter.getStoredForListType(getMapViewerListType());
+        final GeocacheFilter filter = GeocacheFilter.loadFromSettings();
         if (filter.hasFilter()) {
             filters.add(filter.toUserDisplayableString());
         }
@@ -141,18 +134,11 @@ public class MapUtils {
         return filters;
     }
 
-
-
     // one-time messages to be shown for maps
     public static void showMapOneTimeMessages(final Activity activity) {
         Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
         Dialogs.basicOneTimeMessage(activity, Settings.isLongTapOnMapActivated() ? OneTimeDialogs.DialogType.MAP_LONG_TAP_ENABLED : OneTimeDialogs.DialogType.MAP_LONG_TAP_DISABLED);
     }
-
-    public static CacheListType getMapViewerListType() {
-        return CacheListType.MAP;
-    }
-
     // workaround for colored ActionBar titles/subtitles
     // @todo remove after switching map ActionBar to Toolbar
     public static Spanned getColoredValue(final String value) {

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -6,7 +6,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.downloader.DownloaderUtils;
-import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.maps.AbstractMap;
 import cgeo.geocaching.maps.CGeoMap;
@@ -17,7 +16,6 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.TrackUtils;
-import static cgeo.geocaching.filters.gui.GeocacheFilterActivity.EXTRA_FILTER_RESULT;
 import static cgeo.geocaching.maps.google.v2.GoogleMapUtils.isGoogleMapsAvailable;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
@@ -242,8 +240,7 @@ public class GoogleMapActivity extends AppCompatActivity implements MapActivityI
             */
         }
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
-            final String filterConfig = data.getExtras().getString(EXTRA_FILTER_RESULT);
-            MapUtils.changeMapFilter(this, GeocacheFilter.createFromConfig(filterConfig));
+            MapUtils.setFilterBar(this);
         }
 
         this.trackUtils.onActivityResult(requestCode, resultCode, data);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -21,7 +21,6 @@ import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
-import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
@@ -75,7 +74,6 @@ import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TrackUtils;
-import static cgeo.geocaching.filters.gui.GeocacheFilterActivity.EXTRA_FILTER_RESULT;
 import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT;
 import static cgeo.geocaching.maps.mapsforge.v6.caches.CachesBundle.NO_OVERLAY_ID;
 
@@ -1640,8 +1638,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
             }
         }
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
-            final String filterConfig = data.getExtras().getString(EXTRA_FILTER_RESULT);
-            MapUtils.changeMapFilter(this, GeocacheFilter.createFromConfig(filterConfig));
+            MapUtils.setFilterBar(this);
         }
 
         this.trackUtils.onActivityResult(requestCode, resultCode, data);

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -8,7 +8,6 @@ import cgeo.geocaching.connector.capability.ICredentials;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.connector.gc.GCMemberState;
-import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
@@ -1874,14 +1873,13 @@ public class Settings {
     }
 
     /** Should SOLELY be called by class {@link cgeo.geocaching.filters.core.GeocacheFilter}! */
-    public static String getCacheFilterConfig(final CacheListType listType) {
-        return getStringDirect(getKey(R.string.pref_cache_filter_config) + "_" + (listType == null ? "default" : listType.name()),
-            null);
+    public static String getCacheFilterConfig() {
+        return getString(R.string.pref_cache_filter_config, null);
     }
 
     /** Should SOLELY be called by class {@link cgeo.geocaching.filters.core.GeocacheFilter}! */
-    public static void setCacheFilterConfig(final CacheListType listType, final String config) {
-        putStringDirect(getKey(R.string.pref_cache_filter_config) + "_" + (listType == null ? "default" : listType.name()), config);
+    public static void setCacheFilterConfig(final String config) {
+        putString(R.string.pref_cache_filter_config, config);
     }
 
     public static int getListInitialLoadLimit() {


### PR DESCRIPTION
related to #10711: store only one global filter setting, no contexts any more

This PR will remove context-specific filter storage completely. There will only be one filter set stored (always the last one used) across all contexts: map, offline cache lists and online search results (nearby search, owner, user, search-by-filter).

This PR will not yet replace the current additional global cache type filter, this remains in parallel for now