### PR TITLE
enable tabbed view on successful load only (fix #10900)

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -157,6 +157,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             if (activity == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
             binding.aboutVersionString.setText(Version.getVersionName(activity));
             setClickListener(binding.donate, "https://www.cgeo.org");
             if (StringUtils.isNotEmpty(BuildConfig.SPECIAL_BUILD)) {
@@ -205,6 +206,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             if (activity == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
             final Markwon markwon = Markwon.create(activity);
 
             final String changelogMaster = FileUtils.getChangelogMaster(activity);
@@ -233,6 +235,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             if (activity == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             binding.system.setText(R.string.about_system_collecting);
             binding.copy.setEnabled(false);
@@ -266,6 +269,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
 
         @Override
         public void setContent() {
+            binding.getRoot().setVisibility(View.VISIBLE);
             setClickListener(binding.license, "https://www.apache.org/licenses/LICENSE-2.0.html");
             binding.licenseText.setText(getRawResourceString(R.raw.license));
         }
@@ -300,6 +304,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             if (activity == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             final Markwon markwon = Markwon.create(activity);
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1142,6 +1142,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (cache == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             // Reference to the details list and favorite line, so that the helper-method can access them without an additional argument
             final CacheDetailsCreator details = new CacheDetailsCreator(activity, binding.detailsList);
@@ -1643,6 +1644,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (cache == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             // reset description
             binding.description.setText("");
@@ -1981,6 +1983,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             }
 
             final ListView v = binding.getRoot();
+            v.setVisibility(View.VISIBLE);
             v.setClickable(true);
 
             // sort waypoints: PP, Sx, FI, OWN
@@ -2180,6 +2183,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (cache == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             // TODO: fix layout, then switch back to Android-resource and delete copied one
             // this copy is modified to respect the text color
@@ -2209,6 +2213,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (cache == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             if (activity.imagesList == null) {
                 activity.imagesList = new ImagesList(activity, cache.getGeocode(), cache);

--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
@@ -39,6 +39,7 @@ public abstract class TabbedViewPagerFragment<ViewBindingClass extends ViewBindi
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
         binding = createView(inflater, container, savedInstanceState);
+        binding.getRoot().setVisibility(View.GONE);
         this.container = container;
         synchronized (mutextContentIsUpToDate) {
             contentIsUpToDate = false;

--- a/main/src/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/LogsViewCreator.java
@@ -53,6 +53,7 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
         if (!isValid()) {
             return;
         }
+        binding.getRoot().setVisibility(View.VISIBLE);
 
         final List<LogEntry> logs = getLogs();
 


### PR DESCRIPTION
## Description
- Disable tabbed content view on view creation
- and enable it only after successful load of content

=> avoids "view skeletons" described in #10900