### PR TITLE
fix #10567: make LCConnector consider totalcountGc, make SearchResult-takeover use larger number

### DIFF
--- a/main/src/cgeo/geocaching/SearchResult.java
+++ b/main/src/cgeo/geocaching/SearchResult.java
@@ -302,7 +302,9 @@ public class SearchResult implements Parcelable {
             url = other.url;
         }
         // copy the GC total search results number to be able to use "More caches" button
-        if (getTotalCountGC() == 0 && other.getTotalCountGC() != 0) {
+        // take over the larger number in order to make "more caches" work in case of cache filters (see #10567)
+        //   (otherwise a low find count of e.g. LabCaches under 20 will lead to "no more caches" shown if it is added "first")
+        if (getTotalCountGC() < other.getTotalCountGC()) {
             setViewstates(other.getViewstates());
             setTotalCountGC(other.getTotalCountGC());
         }

--- a/main/src/cgeo/geocaching/connector/lc/LCConnector.java
+++ b/main/src/cgeo/geocaching/connector/lc/LCConnector.java
@@ -115,6 +115,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     public SearchResult searchByViewport(@NonNull final Viewport viewport) {
         final Collection<Geocache> caches = LCApi.searchByBBox(viewport);
         final SearchResult searchResult = new SearchResult(caches);
+        searchResult.setTotalCountGC(caches.size());
         return searchResult.filterSearchResults(false, false, Settings.getCacheType());
     }
 
@@ -123,6 +124,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     public SearchResult searchByCenter(@NonNull final Geopoint center) {
         final Collection<Geocache> caches = LCApi.searchByCenter(center);
         final SearchResult searchResult = new SearchResult(caches);
+        searchResult.setTotalCountGC(caches.size());
         return searchResult.filterSearchResults(false, false, Settings.getCacheType());
     }
 

--- a/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
@@ -69,7 +69,7 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         final List<Download> list = getList(MapDownloaderOpenAndroMaps.getInstance(), CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_downloadurl) + "europe/");
 
         // europe starting page currently has ... entries (including the "up" entry)
-        assertThat(list.size()).isEqualTo(59);
+        assertThat(list.size()).isEqualTo(60);
 
         // first entry has to be the "up" entry
         assertThat(list.get(0).getIsDir()).isTrue();
@@ -78,7 +78,7 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         assertThat(count(list, true)).isEqualTo(1);
 
         // number of non-dirs found
-        assertThat(count(list, false)).isEqualTo(58);
+        assertThat(count(list, false)).isEqualTo(59);
 
         // check one named entry
         final Download d = findByName(list, "Scandinavia_SouthWest");


### PR DESCRIPTION
fix #10567: make LCConnector consider totalcountGc, make SearchResult-takeover use larger number

Note that this whole "totalCountGC" logic in SearchResult is a bit mysterious to me, I would appreciate a review from someone knowing this a little better.

My assumption is that this is all no longer necessary once we remove "INextPage" capability