### PR TITLE
Move full screen progress spinner to CircularProgressIndicator

### DIFF
--- a/main/res/layout/cacheslist_activity.xml
+++ b/main/res/layout/cacheslist_activity.xml
@@ -14,14 +14,12 @@
         android:layout_height="fill_parent"
         tools:visibility="gone">
 
-        <ProgressBar
-            style="@android:style/Widget.ProgressBar.Large"
+        <com.google.android.material.progressindicator.CircularProgressIndicator
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
             android:gravity="center"
-            android:indeterminate="true"
-            android:indeterminateOnly="true" />
+            android:indeterminate="true" />
     </RelativeLayout>
 
     <ListView

--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -5,6 +5,7 @@
     android:id="@+id/one_cache"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
     tools:context=".ui.CacheListAdapter">
 
     <!-- "found" marker, vertical green/red line -->

--- a/main/res/layout/downloader_item.xml
+++ b/main/res/layout/downloader_item.xml
@@ -9,6 +9,7 @@
     android:paddingLeft="5dip"
     android:paddingRight="5dip"
     android:paddingTop="7dip"
+    android:background="?android:attr/selectableItemBackground"
     tools:context=".downloader.DownloadSelectorActivity">
 
     <ImageButton


### PR DESCRIPTION
Fix progress spinner not spinning (#10891) and give UI touch feedback in cache list and map downloader...

![grafik](https://user-images.githubusercontent.com/64581222/121944882-73942380-cd53-11eb-9039-66f68a315faa.png)![grafik](https://user-images.githubusercontent.com/64581222/121945070-a6d6b280-cd53-11eb-8797-7aeedf9b9d21.png)
