### PR TITLE
make about pages non-refreshable (fix #10903)

### DIFF
--- a/main/res/layout/cache_image_item.xml
+++ b/main/res/layout/cache_image_item.xml
@@ -29,10 +29,10 @@
         tools:visibility="visible"
         />
 
-    <ProgressBar
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progress_bar"
-        style="@android:style/Widget.ProgressBar.Small"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:indeterminate="true"/>
 
 </LinearLayout>

--- a/main/res/layout/tabbed_viewpager_activity_refreshable.xml
+++ b/main/res/layout/tabbed_viewpager_activity_refreshable.xml
@@ -7,11 +7,19 @@
     android:orientation="vertical"
     tools:context=".activity.TabbedViewPagerActivity">
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/viewpager"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1">
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewpager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <View style="@style/separator_horizontal" />
 

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -98,7 +98,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             orderedPages[i] = pages[i].id;
         }
 
-        createViewPager(startPage, orderedPages, this::onPageChangeListener);
+        createViewPager(startPage, orderedPages, this::onPageChangeListener, false);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -243,7 +243,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setThemeAndContentView(R.layout.tabbed_viewpager_activity);
+        setThemeAndContentView(R.layout.tabbed_viewpager_activity_refreshable);
 
         // get parameters
         final Bundle extras = getIntent().getExtras();
@@ -344,7 +344,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (currentActionMode != null) {
                 currentActionMode.finish();
             }
-        });
+        }, true);
         requireGeodata = pageToOpen == Page.DETAILS.id;
 
         final String realGeocode = geocode;

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -121,7 +121,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setThemeAndContentView(R.layout.tabbed_viewpager_activity);
+        setThemeAndContentView(R.layout.tabbed_viewpager_activity_refreshable);
 
         // set title in code, as the activity needs a hard coded title due to the intent filters
         setTitle(res.getString(R.string.trackable));
@@ -205,7 +205,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
         // If we have a newer Android device setup Android Beam for easy cache sharing
         AndroidBeam.enable(this, this);
 
-        createViewPager(Page.DETAILS.id, getOrderedPages(), null);
+        createViewPager(Page.DETAILS.id, getOrderedPages(), null, true);
 
         refreshTrackable(message);
     }
@@ -392,6 +392,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
             if (trackable == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             if (activity.imagesList == null) {
                 activity.imagesList = new ImagesList(activity, trackable.getGeocode(), null);
@@ -442,6 +443,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
             if (trackable == null) {
                 return;
             }
+            binding.getRoot().setVisibility(View.VISIBLE);
 
             final CacheDetailsCreator details = new CacheDetailsCreator(activity, binding.detailsList);
 

--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
@@ -38,12 +38,13 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
      */
     private boolean isRefreshable = true;
 
-    protected void createViewPager(final long initialPageId, final long[] orderedPages, final Action1<Long> onPageChangeListener) {
+    protected void createViewPager(final long initialPageId, final long[] orderedPages, final Action1<Long> onPageChangeListener, final boolean isRefreshable) {
+        this.isRefreshable = isRefreshable;
         this.currentPageId = initialPageId;
         setOrderedPages(orderedPages);
         this.onPageChangeListener = onPageChangeListener;
 
-        setContentView(R.layout.tabbed_viewpager_activity);
+        setContentView(isRefreshable ? R.layout.tabbed_viewpager_activity_refreshable : R.layout.tabbed_viewpager_activity);
 
         viewPager = findViewById(R.id.viewpager);
         viewPager.setAdapter(new ViewPagerAdapter(this));


### PR DESCRIPTION
## Description
- support non-refreshable pages in `TabbedViewpager` & set about pages to non-refreshable
- fix setting content view for trackable pages
- fix cache details image page progress spinners