### PR TITLE
Fix wrong text color in about activity (text "carnero" was invisible)

### DIFF
--- a/main/res/layout/about_version_page.xml
+++ b/main/res/layout/about_version_page.xml
@@ -4,7 +4,6 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
-    android:padding="4dip"
     tools:context=".AboutActivity$VersionViewCreator" >
 
     <LinearLayout
@@ -57,6 +56,7 @@
                     android:layout_marginLeft="10dip"
                     android:layout_marginRight="10dip"
                     android:text="@string/powered_by"
+                    android:textColor="@color/just_white"
                     android:textSize="@dimen/textSize_detailsPrimary" />
             </LinearLayout>
         </FrameLayout>


### PR DESCRIPTION
Before (string "canero" is black on black when using light theme):

![grafik](https://user-images.githubusercontent.com/64581222/122072463-e22abd00-cdf7-11eb-88a5-749c05668052.png)