### PR TITLE
migrate individual route export dialog to material

### DIFF
--- a/main/res/layout/gpx_export_individual_route_dialog.xml
+++ b/main/res/layout/gpx_export_individual_route_dialog.xml
@@ -5,44 +5,18 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="3dip"
     tools:context=".export.IndividualRouteExport" >
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <TextView
-            android:id="@+id/filename_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="20dp"
-            android:paddingLeft="8dp"
-            android:text="@string/filename_without_extension"
-            android:labelFor="@id/filename"/>
-
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/textinput_edittext_singleline"
+        app:endIconMode="clear_text">
         <EditText
             android:id="@+id/filename"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            style="@style/textinput_embedded"
             android:inputType="textUri"
-            android:layout_below="@id/filename_title"
-            android:layout_alignParentLeft="true"
-            android:layout_gravity="left"
-            android:layout_marginLeft="6dip"
-            android:layout_marginRight="51dip"
-            android:paddingRight="3dip"
-            />
+            android:hint="@string/filename_without_extension" />
+    </com.google.android.material.textfield.TextInputLayout>
 
-        <ImageButton
-            android:id="@+id/button_reset"
-            style="@style/button_icon"
-            app:srcCompat="@drawable/ic_menu_delete"
-            android:layout_alignBottom="@id/filename"
-            android:layout_alignParentRight="true" />
-
-    </RelativeLayout>
-
-    <include layout="@layout/gpx_export_fragment" />
+    <include layout="@layout/gpx_export_fragment" android:id="@+id/info" />
 
 </LinearLayout>

--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.export;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.databinding.GpxExportIndividualRouteDialogBinding;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteSegment;
@@ -21,9 +22,7 @@ import cgeo.org.kxml2.io.KXmlSerializer;
 import android.app.Activity;
 import android.net.Uri;
 import android.text.InputFilter;
-import android.view.View;
 import android.widget.EditText;
-import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -65,17 +64,14 @@ public class IndividualRouteExport {
         final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(R.string.export_individualroute_title);
 
-        final View layout = View.inflate(activity, R.layout.gpx_export_individual_route_dialog, null);
-        builder.setView(layout);
+        final GpxExportIndividualRouteDialogBinding binding = GpxExportIndividualRouteDialogBinding.inflate(activity.getLayoutInflater());
+        builder.setView(binding.getRoot());
 
-        final EditText editFilename = layout.findViewById(R.id.filename);
+        final EditText editFilename = binding.filename;
         editFilename.setFilters(new InputFilter[] { filter });
         editFilename.setText(filename);
 
-        final ImageButton resetFilename = layout.findViewById(R.id.button_reset);
-        resetFilename.setOnClickListener(v -> editFilename.setText(""));
-
-        final TextView text = layout.findViewById(R.id.info);
+        final TextView text = binding.info.info;
         text.setText(activity.getString(R.string.export_confirm_message, PersistableFolder.GPX.toUserDisplayableValue(), filename + FileUtils.GPX_FILE_EXTENSION));
 
         builder


### PR DESCRIPTION
## Description
Migrates the "Export individual route as GPX" filename dialog to material `TextInputLayout`

## Question
Does work generally, but the dialog actually shrinks on entering the text input field, leading to info text below the input field being cut off. - Any ideas?

![image](https://user-images.githubusercontent.com/3754370/122109414-a4d92600-ce1d-11eb-8ac4-b394c41f045b.png).![image](https://user-images.githubusercontent.com/3754370/122109437-aa367080-ce1d-11eb-96a9-2d9c63e50ccb.png)
