### PR TITLE
migrate SimpleDialog.input to material TextInputLayout

### DIFF
--- a/main/res/layout/dialog_edittext.xml
+++ b/main/res/layout/dialog_edittext.xml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.textfield.TextInputLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".export.IndividualRouteExport" >
-
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/input_frame"
-        style="@style/textinput_edittext_singleline"
-        app:endIconMode="clear_text">
-        <EditText
-            android:id="@+id/input"
-            style="@style/textinput_embedded"
-            android:inputType="text"
-            android:hint="" tools:ignore="LabelFor" /> <!-- hint needs to be set by caller -->
-    </com.google.android.material.textfield.TextInputLayout>
-
-</LinearLayout>
+    android:id="@+id/input_frame"
+    style="@style/textinput_edittext_singleline">
+    <EditText
+        android:id="@+id/input"
+        style="@style/textinput_embedded"
+        android:inputType="text"
+        android:hint="" tools:ignore="LabelFor" /> <!-- hint needs to be set by caller -->
+</com.google.android.material.textfield.TextInputLayout>

--- a/main/res/layout/gpx_export_individual_route_dialog.xml
+++ b/main/res/layout/gpx_export_individual_route_dialog.xml
@@ -17,6 +17,6 @@
             android:hint="@string/filename_without_extension" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <include layout="@layout/gpx_export_fragment" android:id="@+id/info" />
+    <include layout="@layout/gpx_export_fragment" android:id="@+id/infoinclude" />
 
 </LinearLayout>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -210,6 +210,9 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="endIconMode">clear_text</item>
+        <item name="endIconTint">@color/colorTextDark</item>
+        <item name="prefixTextColor">@color/colorTextDark</item>
+        <item name="suffixTextColor">@color/colorTextDark</item>
     </style>
 
     <style name="textinput_edittext" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
@@ -220,6 +223,9 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="endIconMode">clear_text</item>
+        <item name="endIconTint">@color/colorTextDark</item>
+        <item name="prefixTextColor">@color/colorTextDark</item>
+        <item name="suffixTextColor">@color/colorTextDark</item>
     </style>
 
     <style name="textinput_edittext_singleline" parent="textinput_edittext">
@@ -232,6 +238,8 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:inputType">text</item>
+        <item name="android:textColor">@color/colorText</item>
+        <item name="colorOnSurface">@color/colorText</item>
     </style>
 
     <!-- edittext (TODO: should at some point be completely replaced by textinput) -->

--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -71,7 +71,7 @@ public class IndividualRouteExport {
         editFilename.setFilters(new InputFilter[] { filter });
         editFilename.setText(filename);
 
-        final TextView text = binding.info.info;
+        final TextView text = binding.infoinclude.info;
         text.setText(activity.getString(R.string.export_confirm_message, PersistableFolder.GPX.toUserDisplayableValue(), filename + FileUtils.GPX_FILE_EXTENSION));
 
         builder

--- a/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -125,7 +125,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
                 filterName = filterName.substring(0, filterName.length() - 1);
             }
             SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_save_title)
-                .input(-1, filterName, null, newName -> {
+                .input(-1, filterName, null, null, newName -> {
                     final GeocacheFilter filter = getFilterFromView();
                     if (GeocacheFilter.Storage.existsAndDiffers(newName, filter)) {
                         SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_save_confirm_title).setMessage(R.string.cache_filter_storage_save_confirm_message, newName).confirm(

--- a/main/src/cgeo/geocaching/list/StoredList.java
+++ b/main/src/cgeo/geocaching/list/StoredList.java
@@ -251,7 +251,7 @@ public final class StoredList extends AbstractList {
                 return;
             }
             SimpleDialog.of(activity).setTitle(dialogTitle).setPositiveButton(TextParam.id(buttonTitle))
-                .input(-1, defaultValue, null, input -> {
+                .input(-1, defaultValue, null, null, input -> {
                 if (StringUtils.isNotBlank(input)) {
                     runnable.call(input);
                 }

--- a/main/src/cgeo/geocaching/settings/SeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/SeekbarPreference.java
@@ -209,7 +209,7 @@ public class SeekbarPreference extends Preference {
                     Toast.makeText(context, R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
                 }
             };
-            SimpleDialog.of((Activity) context).setTitle(TextParam.text(title)).input(inputType, defaultValue, getUnitString(), listener);
+            SimpleDialog.of((Activity) context).setTitle(TextParam.text(title)).input(inputType, defaultValue, null, getUnitString(), listener);
         });
 
         return v;

--- a/main/src/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.ui.dialog;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.ui.TextParam;
-import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.functions.Action2;
 import cgeo.geocaching.utils.functions.Func2;
 
@@ -13,12 +12,11 @@ import android.content.DialogInterface;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
-import android.view.Gravity;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
-import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.TextView;
 
@@ -34,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import static java.lang.Boolean.TRUE;
 
+import com.google.android.material.textfield.TextInputLayout;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -368,39 +367,26 @@ public class SimpleDialog {
      *
      * @param inputType    input type flag mask, use constants defined in class {@link InputType}. If a value below 0 is given then standard input type settings (text) are assumed
      * @param defaultValue if non-null, this will be the prefilled value of the input field
-     * @param label        if non-null, this will be displayed as a label on the right side of text input field (e.g. to display units like km/ft)
+     * @param label        if non-null & non-empty, this will be displayed as a hint within the input field (e.g. to display a hint)
+     * @param suffix       if non-null & non-empty, this will be displayed as a suffix at the end of the input field (e.g. to display units like km/ft)
      * @param okayListener provide the select listener called when user entered something and finishes it (called when user clicks on positive button)
      */
 
-    public void input(final int inputType, @Nullable final String defaultValue, @Nullable final String label, final Consumer<String> okayListener) {
-        final LinearLayout layout = new LinearLayout(getContext());
-        layout.setOrientation(LinearLayout.HORIZONTAL);
-        layout.setGravity(Gravity.CENTER_HORIZONTAL);
-
-        final boolean hasUnit = StringUtils.isNotEmpty(label);
-        final int dialogPadding = getContext().getResources().getDimensionPixelSize(R.dimen.dialog_padding_horizontal);
-        final LinearLayout.LayoutParams textParam = new LinearLayout.LayoutParams(0, android.view.ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
-        textParam.setMargins(dialogPadding, 0, hasUnit ? 0 : dialogPadding, 0);
-
-        final EditText editText = new EditText(getContext(), null, 0, R.style.edittext);
+    public void input(final int inputType, @Nullable final String defaultValue, @Nullable final String label, @Nullable final String suffix, final Consumer<String> okayListener) {
+        final TextInputLayout editTextFrame = (TextInputLayout) LayoutInflater.from(context).inflate(R.layout.dialog_edittext, null);
+        final EditText editText = editTextFrame.findViewById(R.id.input);
         editText.setInputType(inputType < 0 ? InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_CLASS_TEXT : inputType);
         editText.setText(defaultValue == null ? "" : defaultValue.trim());
-        editText.setGravity(Gravity.LEFT);
-        editText.setLayoutParams(textParam);
-        layout.addView(editText);
-
-        if (hasUnit) {
-            final TextView unitText = ViewUtils.createTextItem(getContext(), R.style.text, TextParam.text(label));
-            final LinearLayout.LayoutParams unitParam = new LinearLayout.LayoutParams(android.view.ViewGroup.LayoutParams.WRAP_CONTENT, android.view.ViewGroup.LayoutParams.WRAP_CONTENT);
-            unitParam.setMargins(0, 0, dialogPadding, 0);
-            unitText.setLayoutParams(unitParam);
-            layout.addView(unitText);
-            editText.setGravity(Gravity.RIGHT);
+        if (StringUtils.isNotBlank(label)) {
+            editTextFrame.setHint("");
+        }
+        if (StringUtils.isNotBlank(suffix)) {
+            editTextFrame.setSuffixText(suffix);
         }
 
         final AlertDialog.Builder builder = Dialogs.newBuilder(getContext());
         applyCommons(builder);
-        builder.setView(layout);
+        builder.setView(editTextFrame);
         // remove whitespaces added by autocompletion of Android keyboard before calling okayListener
         builder.setPositiveButton(getPositiveButton(), (dialog, which) -> okayListener.accept(editText.getText().toString().trim()));
         builder.setNegativeButton(getNegativeButton(), (dialog, whichButton) -> dialog.dismiss());


### PR DESCRIPTION
## Description
migrate SimpleDialog.input to material TextInputLayout

![image](https://user-images.githubusercontent.com/3754370/122285704-585e1b00-ceef-11eb-96aa-73caad29d0f8.png).![image](https://user-images.githubusercontent.com/3754370/122285725-5d22cf00-ceef-11eb-8ccc-8102ef269568.png).![image](https://user-images.githubusercontent.com/3754370/122285753-62801980-ceef-11eb-964d-61908663691e.png)

The last one is not yet perfect, although it's using identical source code, but as settings are not based on `AppCompatActivity` I guess there's not much we can do about it.

@eddiemuc 
Can you cross-check if I haven't broken anything in `SimpleDialog.input`? Thanks.