### PR TITLE
temporarily disable GC watchcount test 

### DIFF
--- a/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -260,9 +260,13 @@ public class GCParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(CgeoApplicationTest.testSearchByGeocode("GC68TJE").getHiddenDate()).isEqualTo("2016-01-23");
     }
 
+/*
+    temporarily disable this test until website is fixed
+        
     public static void testOnlineWatchCount() {
         assertThat(CgeoApplicationTest.testSearchByGeocode("GCK25B").getWatchlistCount()).as("Geocaching HQ watch count").isGreaterThan(50);
     }
+ */
 
     public void testSpoilerDescriptionForOwner() {
         final Geocache cache = parseCache(R.raw.gc352y3_owner_view);


### PR DESCRIPTION
## Description
temporarily disable GC watchcount test which fails due to website changes (see #10939)

(I'll add a reminder over there to re-enable this test after fixing the issue)
