### PR TITLE
migrate authentification activities to TextInputLayout (fix #10893)

### DIFF
--- a/main/res/layout/authorization_credentials_activity.xml
+++ b/main/res/layout/authorization_credentials_activity.xml
@@ -24,21 +24,25 @@
             android:layout_marginBottom="5dip"
             tools:text="Auth text 2"/>
 
-        <EditText
-            android:id="@+id/username"
-            android:inputType="textPersonName"
-            style="@style/edittext_full"
-            android:hint="@string/init_authorization_credential_username"
-            android:autofillHints=".AUTOFILL_HINT_USERNAME"
-            android:layout_margin="7dip" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/username"
+                android:inputType="textPersonName"
+                style="@style/textinput_embedded"
+                android:hint="@string/init_authorization_credential_username"
+                android:autofillHints=".AUTOFILL_HINT_USERNAME"
+                android:layout_margin="7dip" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/password"
-            android:inputType="textPassword"
-            android:hint="@string/init_authorization_credential_password"
-            style="@style/edittext_full"
-            android:autofillHints=".AUTOFILL_HINT_PASSWORD"
-            android:layout_margin="7dip" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/password"
+                android:inputType="textPassword"
+                android:hint="@string/init_authorization_credential_password"
+                style="@style/textinput_embedded"
+                android:autofillHints=".AUTOFILL_HINT_PASSWORD"
+                android:layout_margin="7dip" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/check"

--- a/main/res/layout/authorization_token_activity.xml
+++ b/main/res/layout/authorization_token_activity.xml
@@ -24,21 +24,25 @@
             android:layout_marginBottom="5dip"
             tools:text="Auth text 2"/>
 
-        <EditText
-            android:id="@+id/username"
-            android:inputType="textPersonName"
-            style="@style/edittext_full"
-            android:hint="@string/init_authorization_credential_username"
-            android:autofillHints=".AUTOFILL_HINT_USERNAME"
-            android:layout_margin="7dip" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/username"
+                android:inputType="textPersonName"
+                style="@style/textinput_embedded"
+                android:hint="@string/init_authorization_credential_username"
+                android:autofillHints=".AUTOFILL_HINT_USERNAME"
+                android:layout_margin="7dip" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/password"
-            android:inputType="textPassword"
-            android:hint="@string/init_authorization_credential_password"
-            style="@style/edittext_full"
-            android:autofillHints=".AUTOFILL_HINT_PASSWORD"
-            android:layout_margin="7dip" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/password"
+                android:inputType="textPassword"
+                android:hint="@string/init_authorization_credential_password"
+                style="@style/textinput_embedded"
+                android:autofillHints=".AUTOFILL_HINT_PASSWORD"
+                android:layout_margin="7dip" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/start"

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -33,9 +33,7 @@
             android:orientation="vertical"
             android:importantForAutofill="noExcludeDescendants">
 
-            <com.google.android.material.textfield.TextInputLayout
-                style="@style/textinput_edittext_singleline"
-                app:endIconMode="clear_text">
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
                 <EditText
                     android:id="@+id/bearing"
                     style="@style/textinput_embedded"
@@ -50,8 +48,7 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                     style="@style/textinput_edittext_singleline"
-                    android:layout_toLeftOf="@id/distanceUnit"
-                    app:endIconMode="clear_text">
+                    android:layout_toLeftOf="@id/distanceUnit">
                     <EditText
                         android:id="@+id/distance"
                         style="@style/textinput_embedded"


### PR DESCRIPTION
## Description
- Adds `TextInputLayout` styling to credentials activity and authorization token activity, which migrates stlying for gc.com, gcvote and geokrety services. OAuth-based services are untouched as they do not use input fields within c:geo
- also simplifies some styling for EditWaypointActivity (separate commit)

![image](https://user-images.githubusercontent.com/3754370/122634075-73da4900-d0dc-11eb-92b7-23be39bb3aa4.png)
