### PR TITLE
fix and migrate 'add setting' dialog (fix #10953)

### DIFF
--- a/main/res/layout/view_settings_add.xml
+++ b/main/res/layout/view_settings_add.xml
@@ -1,42 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="3dip"
     tools:context=".settings.ViewSettingsActivity" >
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="20dp"
-        android:paddingLeft="8dp"
-        android:text="@string/add_setting_preference_name"
-        android:labelFor="@id/preference_name"
-	android:textSize="@dimen/textSize_detailsPrimary" />
-
-    <EditText
-        android:id="@+id/preference_name"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="left"
-        android:inputType="text"
-	android:textSize="@dimen/textSize_detailsPrimary" />
+        android:padding="3dip"
+        android:orientation="vertical">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingTop="20dp"
-        android:paddingLeft="8dp"
-        android:text="@string/add_setting_preference_type"
-	android:textSize="@dimen/textSize_detailsPrimary" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/preference_name"
+                style="@style/textinput_embedded"
+                android:hint="@string/add_setting_preference_name"
+                android:textSize="@dimen/textSize_detailsPrimary" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <RadioGroup
-        android:id="@+id/preference_type"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="center_vertical"
-        android:orientation="vertical"
-	    android:textSize="@dimen/textSize_detailsPrimary" />
-</LinearLayout>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="20dp"
+            android:paddingLeft="8dp"
+            android:text="@string/add_setting_preference_type"
+            android:labelFor="@id/preference_type"
+            android:textSize="@dimen/textSize_detailsPrimary" />
+
+        <RadioGroup
+            android:id="@+id/preference_type"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
+            android:orientation="vertical"
+            android:textSize="@dimen/textSize_detailsPrimary" />
+    </LinearLayout>
+</ScrollView>

--- a/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -19,7 +19,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
@@ -199,30 +198,19 @@ public class ViewSettingsActivity extends AbstractActivity {
                 inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL;
                 break;
         }
-        final EditText editText = new EditText(this);
-        editText.setInputType(inputType);
-        editText.setText(keyValue.value);
-
-        Dialogs.newBuilder(this)
-            .setTitle(String.format(getString(R.string.edit_setting), key))
-            .setView(editText)
-            .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> {
-                final String newValue = editText.getText().toString();
-                final SharedPreferences.Editor editor = prefs.edit();
-                try {
-                    SettingsUtils.putValue(editor, type, key, newValue);
-                    editor.apply();
-                    debugAdapter.remove(keyValue);
-                    debugAdapter.insert(new KeyValue(key, newValue, type), position);
-                } catch (XmlPullParserException e) {
-                    showToast(R.string.edit_setting_error_unknown_type);
-                } catch (NumberFormatException e) {
-                    showToast(String.format(getString(R.string.edit_setting_error_invalid_data), newValue));
-                }
-            })
-            .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })
-            .show()
-        ;
+        Dialogs.input(this, String.format(getString(R.string.edit_setting), key), keyValue.value, null, inputType, 1, 1, newValue -> {
+            final SharedPreferences.Editor editor = prefs.edit();
+            try {
+                SettingsUtils.putValue(editor, type, key, newValue);
+                editor.apply();
+                debugAdapter.remove(keyValue);
+                debugAdapter.insert(new KeyValue(key, newValue, type), position);
+            } catch (XmlPullParserException e) {
+                showToast(R.string.edit_setting_error_unknown_type);
+            } catch (NumberFormatException e) {
+                showToast(String.format(getString(R.string.edit_setting_error_invalid_data), newValue));
+            }
+        });
     }
 
     private void addItem() {

--- a/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.databinding.ViewSettingsAddBinding;
 import cgeo.geocaching.ui.FastScrollListener;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
@@ -39,6 +40,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.radiobutton.MaterialRadioButton;
 import org.apache.commons.lang3.StringUtils;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -224,24 +226,21 @@ public class ViewSettingsActivity extends AbstractActivity {
     }
 
     private void addItem() {
-        final View layout = View.inflate(this, R.layout.view_settings_add, null);
-
-        final EditText preferenceNameEdit = layout.findViewById(R.id.preference_name);
-
+        final ViewSettingsAddBinding binding = ViewSettingsAddBinding.inflate(getLayoutInflater());
         final List<String> stringList = SettingsUtils.SettingsType.getStringList();
-        final RadioGroup rg = layout.findViewById(R.id.preference_type);
+        final RadioGroup rg = binding.preferenceType;
         for (int i = 0; i < stringList.size(); i++) {
-            final RadioButton rb = new RadioButton(this);
+            final MaterialRadioButton rb = new MaterialRadioButton(this);
             rb.setText(stringList.get(i));
             rg.addView(rb);
         }
 
         Dialogs.newBuilder(this)
             .setTitle(R.string.add_setting)
-            .setView(layout)
+            .setView(binding.getRoot())
             .setNegativeButton(android.R.string.cancel, (d, which) -> d.dismiss())
             .setPositiveButton(android.R.string.ok, (d, which) -> {
-                final String preferenceName = preferenceNameEdit.getText().toString().trim();
+                final String preferenceName = binding.preferenceName.getText().toString().trim();
                 final int rbId = rg.getCheckedRadioButtonId();
                 if (rbId == -1) {
                     Toast.makeText(this, R.string.add_setting_missing_type, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
## Description
Fixes and migrates "add setting" dialog:
- make dialog scrollable (to keep radio buttons accessible on opening keyboard)
- migrate layout to viewbindings
- migrate text field to TextInputLayout
- fix some formatting errors in the layout file

Also migrates the "edit setting" dialog