### PR TITLE
migrate 'log trackable' to TextInputLayout

### DIFF
--- a/main/res/layout/logtrackable_activity.xml
+++ b/main/res/layout/logtrackable_activity.xml
@@ -49,19 +49,20 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/locationFrame"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal" >
 
-            <AutoCompleteTextView
-                android:id="@+id/geocode"
-                style="@style/edittext"
-                android:hint="@string/cache_geocode"
-                android:layout_marginLeft="10dip"
-                android:layout_weight="1"
-                android:layout_width="0dip"
-                android:layout_height="wrap_content"
-                android:inputType="textCapCharacters" />
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+                <AutoCompleteTextView
+                    android:id="@+id/geocode"
+                    style="@style/textinput_embedded"
+                    android:hint="@string/cache_geocode"
+                    android:layout_marginLeft="10dip"
+                    android:layout_weight="1"
+                    android:inputType="textCapCharacters" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <Button
                 android:id="@+id/coordinates"
@@ -71,21 +72,27 @@
                 android:layout_weight="1" />
         </LinearLayout>
 
-        <EditText
-            android:id="@+id/tracking"
-            style="@style/edittext_full"
-            android:hint="@string/trackable_code"
-            android:importantForAutofill="no"
-            android:inputType="textCapCharacters" />
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/trackingFrame"
+            style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/tracking"
+                style="@style/textinput_embedded"
+                android:hint="@string/trackable_code"
+                android:importantForAutofill="no"
+                android:inputType="textCapCharacters" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/log"
-            style="@style/edittext_full"
-            android:hint="@string/log_new_log_text"
-            android:autofillHints="@string/log_new_log_text"
-            android:inputType="textMultiLine|textCapSentences"
-            android:lines="5"
-            android:maxLength="4000" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+            <EditText
+                android:id="@+id/log"
+                style="@style/textinput_embedded"
+                android:hint="@string/log_new_log_text"
+                android:autofillHints="@string/log_new_log_text"
+                android:inputType="textMultiLine|textCapSentences"
+                android:lines="5"
+                android:maxLength="4000" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
             android:id="@+id/tweet_box"

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -330,26 +330,24 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
 
         // show/hide Tracking Code Field for note type
         if (typeSelected != LogTypeTrackable.NOTE || loggingManager.isTrackingCodeNeededToPostNote()) {
-            binding.tracking.setVisibility(View.VISIBLE);
+            binding.trackingFrame.setVisibility(View.VISIBLE);
             // Request focus if field is empty
             if (StringUtils.isBlank(binding.tracking.getText())) {
                 binding.tracking.requestFocus();
             }
         } else {
-            binding.tracking.setVisibility(View.GONE);
+            binding.trackingFrame.setVisibility(View.GONE);
         }
 
         // show/hide Coordinate fields as Trackable needs
         if (LogTypeTrackable.isCoordinatesNeeded(typeSelected) && loggingManager.canLogCoordinates()) {
-            binding.geocode.setVisibility(View.VISIBLE);
-            binding.coordinates.setVisibility(View.VISIBLE);
+            binding.locationFrame.setVisibility(View.VISIBLE);
             // Request focus if field is empty
             if (StringUtils.isBlank(binding.geocode.getText())) {
                 binding.geocode.requestFocus();
             }
         } else {
-            binding.geocode.setVisibility(View.GONE);
-            binding.coordinates.setVisibility(View.GONE);
+            binding.locationFrame.setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
## Description
Migrates the "log trackable" dialog to `TextInputLayout`

![image](https://user-images.githubusercontent.com/3754370/122637992-c7a35d00-d0f1-11eb-8a2e-53c5d20260c6.png).![image](https://user-images.githubusercontent.com/3754370/122637997-cbcf7a80-d0f1-11eb-8c62-cf11a9e29724.png)
