### PR TITLE
migrate coordinates input dialogs to TextInputLayout

### DIFF
--- a/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
+++ b/main/res/layout-w1200dp/coordinatescalculate_dialog.xml
@@ -69,17 +69,17 @@
                 android:layout_weight="1"
                 android:orientation="vertical" >
 
-                <EditText
-                    android:id="@+id/notes_text"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    style="@style/edittext_full"
-                    android:singleLine="false"
-                    android:overScrollMode="always"
-                    android:scrollbarStyle="insideInset"
-                    android:scrollbars="vertical"
-                    android:inputType="textMultiLine|textCapSentences"
-                    android:hint="@string/waypointcalc_notes_prompt" />
+                <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+                    <EditText
+                        android:id="@+id/notes_text"
+                        style="@style/textinput_embedded"
+                        android:singleLine="false"
+                        android:overScrollMode="always"
+                        android:scrollbarStyle="insideInset"
+                        android:scrollbars="vertical"
+                        android:inputType="textMultiLine|textCapSentences"
+                        android:hint="@string/waypointcalc_notes_prompt" />
+                </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
         </LinearLayout>
     </ScrollView>

--- a/main/res/layout/coordinates_calculate.xml
+++ b/main/res/layout/coordinates_calculate.xml
@@ -20,21 +20,21 @@
         android:layout_height="wrap_content"
         android:importantForAutofill="noExcludeDescendants"
         android:orientation="vertical">
-        <EditText
-            android:id="@+id/PlainLat"
-            style="@style/edittext_full"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:inputType="text|textCapCharacters"
-            android:hint="@string/latitude" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/PlainLat"
+                style="@style/textinput_embedded"
+                android:inputType="text|textCapCharacters"
+                android:hint="@string/latitude" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/PlainLon"
-            style="@style/edittext_full"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:inputType="text|textCapCharacters"
-            android:hint="@string/longitude" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/PlainLon"
+                style="@style/textinput_embedded"
+                android:inputType="text|textCapCharacters"
+                android:hint="@string/longitude" />
+        </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 
     <!-- H DDD°MM'SS.PPPPP" -->

--- a/main/res/layout/coordinates_input.xml
+++ b/main/res/layout/coordinates_input.xml
@@ -162,20 +162,20 @@
         </TableRow>
     </TableLayout>
 
-    <EditText
-        android:id="@+id/latitude"
-        style="@style/edittext_full"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:inputType="textNoSuggestions"
-        android:hint="@string/latitude" />
+    <com.google.android.material.textfield.TextInputLayout android:id="@+id/latitudeFrame" style="@style/textinput_edittext_singleline">
+        <EditText
+            android:id="@+id/latitude"
+            style="@style/textinput_embedded"
+            android:inputType="textNoSuggestions"
+            android:hint="@string/latitude" />
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <EditText
-        android:id="@+id/longitude"
-        style="@style/edittext_full"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:inputType="textNoSuggestions"
-        android:hint="@string/longitude" />
+    <com.google.android.material.textfield.TextInputLayout android:id="@+id/longitudeFrame" style="@style/textinput_edittext_singleline">
+        <EditText
+            android:id="@+id/longitude"
+            style="@style/textinput_embedded"
+            android:inputType="textNoSuggestions"
+            android:hint="@string/longitude" />
+    </com.google.android.material.textfield.TextInputLayout>
 
 </merge>

--- a/main/res/layout/coordinatescalculate_dialog.xml
+++ b/main/res/layout/coordinatescalculate_dialog.xml
@@ -49,18 +49,18 @@
                 android:gravity="end"
                 android:textAlignment="gravity"/>
 
-            <EditText
-                android:id="@+id/notes_text"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                style="@style/edittext_full"
-                android:textSize="@dimen/textSize_detailsPrimary"
-                android:singleLine="false"
-                android:overScrollMode="always"
-                android:scrollbarStyle="insideInset"
-                android:scrollbars="vertical"
-                android:inputType="textMultiLine|textCapSentences"
-                android:hint="@string/waypointcalc_notes_prompt" />
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+                <EditText
+                    android:id="@+id/notes_text"
+                    style="@style/textinput_embedded"
+                    android:textSize="@dimen/textSize_detailsPrimary"
+                    android:singleLine="false"
+                    android:overScrollMode="always"
+                    android:scrollbarStyle="insideInset"
+                    android:scrollbars="vertical"
+                    android:inputType="textMultiLine|textCapSentences"
+                    android:hint="@string/waypointcalc_notes_prompt" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <Button
                 android:id="@+id/done"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -222,7 +222,7 @@
         <item name="android:capitalize">none</item>
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="endIconMode">clear_text</item>
+        <item name="endIconMode">none</item>
         <item name="endIconTint">@color/colorTextDark</item>
         <item name="prefixTextColor">@color/colorTextDark</item>
         <item name="suffixTextColor">@color/colorTextDark</item>
@@ -230,6 +230,7 @@
 
     <style name="textinput_edittext_singleline" parent="textinput_edittext">
         <item name="android:singleLine">true</item>
+        <item name="endIconMode">clear_text</item>
     </style>
 
     <!-- for AutoCompleteTextView or EditText embedded in material TextInputLayout -->

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -45,6 +45,7 @@ import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.List;
 
+import com.google.android.material.textfield.TextInputLayout;
 import org.apache.commons.lang3.StringUtils;
 
 public class CoordinatesInputDialog extends DialogFragment {
@@ -52,6 +53,7 @@ public class CoordinatesInputDialog extends DialogFragment {
     private Geopoint gp;
     private Geopoint cacheCoords;
 
+    private TextInputLayout eLatFrame, eLonFrame;
     private EditText eLat, eLon;
     private Button bLat, bLon;
     private Button bCalculate;
@@ -159,6 +161,7 @@ public class CoordinatesInputDialog extends DialogFragment {
         spinner.setSelection(Settings.getCoordInputFormat().ordinal());
         spinner.setOnItemSelectedListener(new CoordinateFormatListener());
 
+        eLatFrame = v.findViewById(R.id.latitudeFrame);
         bLat = v.findViewById(R.id.ButtonLat);
         eLat = v.findViewById(R.id.latitude);
         eLatDeg = v.findViewById(R.id.EditTextLatDeg);
@@ -169,6 +172,7 @@ public class CoordinatesInputDialog extends DialogFragment {
         tLatSep2 = v.findViewById(R.id.LatSeparator2);
         tLatSep3 = v.findViewById(R.id.LatSeparator3);
 
+        eLonFrame = v.findViewById(R.id.longitudeFrame);
         bLon = v.findViewById(R.id.ButtonLon);
         eLon = v.findViewById(R.id.longitude);
         eLonDeg = v.findViewById(R.id.EditTextLonDeg);
@@ -256,8 +260,8 @@ public class CoordinatesInputDialog extends DialogFragment {
         switch (currentFormat) {
             case Plain:
                 setVisible(R.id.coordTable, View.GONE);
-                eLat.setVisibility(View.VISIBLE);
-                eLon.setVisibility(View.VISIBLE);
+                eLatFrame.setVisibility(View.VISIBLE);
+                eLonFrame.setVisibility(View.VISIBLE);
                 if (gp != null) {
                     eLat.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
                     eLon.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
@@ -265,8 +269,8 @@ public class CoordinatesInputDialog extends DialogFragment {
                 break;
             case Deg: // DDD.DDDDD°
                 setVisible(R.id.coordTable, View.VISIBLE);
-                eLat.setVisibility(View.GONE);
-                eLon.setVisibility(View.GONE);
+                eLatFrame.setVisibility(View.GONE);
+                eLonFrame.setVisibility(View.GONE);
                 eLatSec.setVisibility(View.GONE);
                 eLonSec.setVisibility(View.GONE);
                 tLatSep3.setVisibility(View.GONE);
@@ -294,8 +298,8 @@ public class CoordinatesInputDialog extends DialogFragment {
                 break;
             case Min: // DDD° MM.MMM
                 setVisible(R.id.coordTable, View.VISIBLE);
-                eLat.setVisibility(View.GONE);
-                eLon.setVisibility(View.GONE);
+                eLatFrame.setVisibility(View.GONE);
+                eLonFrame.setVisibility(View.GONE);
                 eLatSec.setVisibility(View.VISIBLE);
                 eLonSec.setVisibility(View.VISIBLE);
                 tLatSep3.setVisibility(View.VISIBLE);
@@ -329,8 +333,8 @@ public class CoordinatesInputDialog extends DialogFragment {
                 break;
             case Sec: // DDD° MM SS.SSS
                 setVisible(R.id.coordTable, View.VISIBLE);
-                eLat.setVisibility(View.GONE);
-                eLon.setVisibility(View.GONE);
+                eLatFrame.setVisibility(View.GONE);
+                eLonFrame.setVisibility(View.GONE);
                 eLatSec.setVisibility(View.VISIBLE);
                 eLonSec.setVisibility(View.VISIBLE);
                 tLatSep3.setVisibility(View.VISIBLE);

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -53,14 +53,27 @@ public class CoordinatesInputDialog extends DialogFragment {
     private Geopoint gp;
     private Geopoint cacheCoords;
 
-    private TextInputLayout eLatFrame, eLonFrame;
-    private EditText eLat, eLon;
-    private Button bLat, bLon;
+    private TextInputLayout eLatFrame;
+    private TextInputLayout eLonFrame;
+    private EditText eLat;
+    private EditText eLon;
+    private Button bLat;
+    private Button bLon;
     private Button bCalculate;
-    private EditText eLatDeg, eLatMin, eLatSec, eLatSub;
-    private EditText eLonDeg, eLonMin, eLonSec, eLonSub;
-    private TextView tLatSep1, tLatSep2, tLatSep3;
-    private TextView tLonSep1, tLonSep2, tLonSep3;
+    private EditText eLatDeg;
+    private EditText eLatMin;
+    private EditText eLatSec;
+    private EditText eLatSub;
+    private EditText eLonDeg;
+    private EditText eLonMin;
+    private EditText eLonSec;
+    private EditText eLonSub;
+    private TextView tLatSep1;
+    private TextView tLatSep2;
+    private TextView tLatSep3;
+    private TextView tLonSep1;
+    private TextView tLonSep2;
+    private TextView tLonSep3;
 
     private CoordInputFormatEnum currentFormat = null;
     private List<EditText> orderedInputs;


### PR DESCRIPTION
## Description
- migrates coordinates input dialogs to `TextInputLayout` (except the detailed variants, as discussed in our last meeting)
- removes `clear_text` ability from multi-line input dialogs, as discussed in https://github.com/cgeo/cgeo/pull/10955#issuecomment-864383257

