### PR TITLE
migrate 'edit note' dialog to TextInputLayout

### DIFF
--- a/main/res/layout/fragment_edit_note.xml
+++ b/main/res/layout/fragment_edit_note.xml
@@ -1,43 +1,50 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/edit_note"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:orientation="vertical"
     tools:context=".ui.EditNoteDialog" >
-
-    <include layout="@layout/dialog_title_ok_cancel" />
-
-    <EditText
-        android:id="@+id/note"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:gravity="start"
-        android:inputType="textMultiLine"
-        android:minLines="8"
-        android:hint="@string/waypoint_note"
-        android:importantForAutofill="no"
-        android:layout_weight="1"/>
-
-    <View style="@style/action_bar_separator"
-        android:visibility="gone"
-        android:layout_weight="0"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_weight="0">
-        <CheckBox
-            android:id="@+id/preventWaypointsFromNote"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <TextView
-            android:id="@+id/textPreventWaypointsFromNote"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/cache_personal_note_preventWaypointsExtraction"/>
-    </LinearLayout>
+        android:orientation="vertical">
 
-</LinearLayout>
+        <include layout="@layout/dialog_title_ok_cancel" />
+
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+            <EditText
+                android:id="@+id/note"
+                style="@style/textinput_edittext"
+                android:gravity="start"
+                android:inputType="textMultiLine"
+                android:minLines="8"
+                android:hint="@string/waypoint_note"
+                android:textSize="@dimen/textSize_detailsPrimary"
+                android:importantForAutofill="no"
+                android:layout_weight="1"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <View style="@style/action_bar_separator"
+            android:visibility="gone"
+            android:layout_weight="0"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_weight="0">
+            <CheckBox
+                android:id="@+id/preventWaypointsFromNote"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+            <TextView
+                android:id="@+id/textPreventWaypointsFromNote"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/cache_personal_note_preventWaypointsExtraction"/>
+        </LinearLayout>
+
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Description
Migrates "edit note" dialog to `TextInputLayout`

Same problem arises here as described in #10953: dialog gets truncated as the keyboard opens up immediately, hiding contents of the dialog. Depending on screen and keyboard size there may not even be a visual indicator, that something is outside the visible area and can be scrolled to (e. g.: the checkbox below the dialog).

![image](https://user-images.githubusercontent.com/3754370/122639600-0984d100-d0fb-11eb-9568-abea6ae2dbd3.png).![image](https://user-images.githubusercontent.com/3754370/122639607-0ee21b80-d0fb-11eb-9589-0e416bffb7f7.png)
