### PR TITLE
migrate 'select image' dialog to TextInputLayout + add counters

### DIFF
--- a/main/res/layout/imageselect_activity.xml
+++ b/main/res/layout/imageselect_activity.xml
@@ -56,25 +56,29 @@
             android:visibility="gone"
             tools:visibility="visible"/>
 
-        <EditText
-            android:id="@+id/caption"
-            style="@style/edittext_full"
-            android:layout_height="wrap_content"
-            android:hint="@string/log_image_caption"
-            android:autofillHints="@string/log_image_caption"
-            android:inputType="textCapSentences"
-            android:maxLength="50"
-            android:minLines="1" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <EditText
+                android:id="@+id/caption"
+                style="@style/textinput_embedded"
+                android:layout_height="wrap_content"
+                android:hint="@string/log_image_caption"
+                android:autofillHints="@string/log_image_caption"
+                android:inputType="textCapSentences"
+                android:maxLength="50"
+                android:minLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/description"
-            style="@style/edittext_full"
-            android:layout_height="wrap_content"
-            android:hint="@string/log_image_description"
-            android:autofillHints="@string/log_image_description"
-            android:inputType="textMultiLine|textCapSentences"
-            android:maxLength="250"
-            android:minLines="5" />
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+            <EditText
+                android:id="@+id/description"
+                style="@style/textinput_embedded"
+                android:layout_height="wrap_content"
+                android:hint="@string/log_image_description"
+                android:autofillHints="@string/log_image_description"
+                android:inputType="textMultiLine|textCapSentences"
+                android:maxLength="250"
+                android:minLines="5" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <Spinner
             android:id="@+id/logImageScale"

--- a/main/res/layout/imageselect_activity.xml
+++ b/main/res/layout/imageselect_activity.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/imageselect_activity_viewroot"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:padding="4dip"
-    tools:context=".ImageSelectActivity" >
+    tools:context=".ImageSelectActivity">
 
     <LinearLayout
         android:layout_width="fill_parent"
@@ -56,7 +58,10 @@
             android:visibility="gone"
             tools:visibility="visible"/>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/textinput_edittext_singleline"
+            app:counterEnabled="true"
+            app:counterMaxLength="50">
             <EditText
                 android:id="@+id/caption"
                 style="@style/textinput_embedded"
@@ -68,7 +73,10 @@
                 android:minLines="1" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/textinput_edittext"
+            app:counterEnabled="true"
+            app:counterMaxLength="250">
             <EditText
                 android:id="@+id/description"
                 style="@style/textinput_embedded"


### PR DESCRIPTION
## Description
- Migrates "select image" dialog to `TextInputLayout`
- Adds character counters for both text fields (as they are limited on gc.com)

![image](https://user-images.githubusercontent.com/3754370/122640029-697c7700-d0fd-11eb-87a6-2cf7165dbdbf.png)
