### PR TITLE
set correct tint for action bar overflow button

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -74,6 +74,10 @@
         <item name="titleTextStyle">@style/action_bar_title</item>
     </style>
 
+    <style name="actionBarActionOverflow" parent="Widget.AppCompat.ActionButton.Overflow">
+        <item name="android:src">@drawable/three_dot_vertical</item>
+    </style>
+
     <style name="action_bar" parent="actionBarStyle">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">@dimen/actionbar_height</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- theme for (nearly) all activities) -->
+    <!-- theme for (nearly) all activities -->
 
     <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Action bar theming -->
         <item name="actionBarStyle">@style/actionBarStyle</item>
+        <item name="android:actionOverflowButtonStyle">@style/actionBarActionOverflow</item>
+
+        <!-- UX component styles -->
         <item name="checkboxStyle">@style/checkboxStyle</item>
         <item name="radioButtonStyle">@style/radioButtonStyle</item>
         <item name="materialAlertDialogTheme">@style/materialAlertDialogTheme</item>


### PR DESCRIPTION
A bit difficult to see, but before the overflow icon was gray while all other icons are white...

Before:
![grafik](https://user-images.githubusercontent.com/64581222/122647330-0baf5580-d124-11eb-80c6-75c8910ad0bf.png)


Now:
![grafik](https://user-images.githubusercontent.com/64581222/122647274-b70bda80-d123-11eb-9edb-e41ac74c7b41.png)