### PR TITLE
migrate log template dialog (rel. to #10763)

### DIFF
--- a/main/res/layout/template_preference_dialog.xml
+++ b/main/res/layout/template_preference_dialog.xml
@@ -7,16 +7,18 @@
     android:padding="8dp"
     tools:context=".settings.TemplateTextPreference" >
 
-    <EditText
-        android:id="@+id/signature_dialog_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="top|left"
-        android:inputType="textMultiLine|textCapSentences"
-        android:minLines="3"
-        android:hint="@string/init_signature"
-        android:autofillHints="@string/init_signature"/>
+    <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+        <EditText
+            android:id="@+id/signature_dialog_text"
+            style="@style/textinput_embedded"
+            android:gravity="top|left"
+            android:inputType="textMultiLine|textCapSentences"
+            android:minLines="3"
+            android:hint="@string/init_signature"
+            android:autofillHints="@string/init_signature"/>
+    </com.google.android.material.textfield.TextInputLayout>
 
+    <!-- @todo needs to get default button styling applied (button_full) as soon as preferences are migrated to PreferenceFragments etc. -->
     <Button
         android:id="@+id/signature_templates"
         android:layout_width="wrap_content"
@@ -30,6 +32,6 @@
         android:layout_height="wrap_content"
         android:paddingBottom="8dp"
         android:text="@string/init_template_help"
-        android:textAppearance="?android:attr/textAppearanceSmall" />
+        android:textSize="@dimen/textSize_detailsSecondary" />
 
 </LinearLayout>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -32,6 +32,8 @@
     <color name="settings_colorTextSecondaryLight">#AA000000</color>
     <color name="settings_colorBackgroundDark">@color/just_black</color>
     <color name="settings_colorBackgroundLight">@color/just_white</color>
+    <color name="settings_colorDialogBackgroundDark">#FF191919</color>
+    <color name="settings_colorDialogBackgroundLight">@color/just_white</color>
 
 
 

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -63,7 +63,8 @@
         <item name="android:textColor">@color/settings_primary_selector_night</item>
         <item name="android:textColorSecondary">@color/settings_secondary_selector_night</item>
         <item name="android:colorBackground">@color/settings_colorBackgroundDark</item>
-
+        <item name="android:dialogTheme">@style/settings.DialogTheme</item>
+        <item name="android:alertDialogTheme">@style/settings.DialogTheme</item>
         <!-- icon resources - can be moved (without suffix "_white") to drawables-night when based on AppCompatActivity -->
         <item name="settings_cloud">@drawable/settings_cloud_white</item>
         <item name="settings_details">@drawable/settings_details_white</item>
@@ -82,6 +83,8 @@
         <item name="android:textColor">@color/settings_primary_selector_light</item>
         <item name="android:textColorSecondary">@color/settings_secondary_selector_light</item>
         <item name="android:colorBackground">@color/settings_colorBackgroundLight</item>
+        <item name="android:dialogTheme">@style/settings.DialogTheme.light</item>
+        <item name="android:alertDialogTheme">@style/settings.DialogTheme.light</item>
 
         <!-- icon resources - can be moved (without suffix "_black") to drawables when based on AppCompatActivity -->
         <item name="settings_cloud">@drawable/settings_cloud_black</item>
@@ -95,6 +98,22 @@
         <item name="settings_backup">@drawable/settings_backup_black</item>
         <item name="settings_info_icon">@drawable/settings_info_icon_black</item>
         <item name="settings_map_icon">@drawable/settings_map_black</item>
+    </style>
+
+    <style name="settings.DialogTheme" parent="@style/Theme.AppCompat.Dialog.Alert">
+        <item name="android:textColor">@color/settings_primary_selector_night</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:windowBackground">@color/settings_colorDialogBackgroundDark</item>
+        <item name="colorOnSurface">@color/colorAccent</item>
+    </style>
+
+    <style name="settings.DialogTheme.light" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:textColor">@color/settings_primary_selector_light</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:windowBackground">@color/settings_colorDialogBackgroundLight</item>
+        <item name="colorOnSurface">@color/colorAccent</item>
     </style>
 
     <!-- theme for splash screen -->

--- a/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
+++ b/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.settings;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.log.LogTemplateProvider;
@@ -8,6 +9,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.View;
@@ -50,6 +52,8 @@ public class TemplateTextPreference extends DialogPreference {
 
         editText = view.findViewById(R.id.signature_dialog_text);
         editText.setText(getPersistedString(initialValue != null ? initialValue : StringUtils.EMPTY));
+        // @todo yet another workaround to be dismissed after migration of settings to PreferenceFragment
+        editText.setTextColor(Settings.isLightSkin(getContext()) ? 0xff000000 : 0xffffffff);
         Dialogs.moveCursorToEnd(editText);
 
         final Button button = view.findViewById(R.id.signature_templates);
@@ -66,7 +70,11 @@ public class TemplateTextPreference extends DialogPreference {
                 final LogTemplate template = templates.get(position);
                 insertSignatureTemplate(template);
             });
-            alert.create().show();
+            final AlertDialog dialog = alert.create();
+            // @todo yet another workaround to be dismissed after migration of settings to PreferenceFragment
+            final int c = Build.VERSION.SDK_INT > 22 ? getContext().getColor(Settings.isLightSkin(getContext()) ? R.color.settings_colorDialogBackgroundLight : R.color.settings_colorDialogBackgroundDark) : CgeoApplication.getInstance().getResources().getColor(R.color.colorBackgroundSelected);
+            dialog.getListView().setBackgroundColor(c);
+            dialog.show();
         });
 
         super.onBindDialogView(view);


### PR DESCRIPTION
## Description
And now down into the more ugly parts of our preferences...
- Migrates the "log template" dialog to `TextInputLayout`. Needs some manual adjustments of colors.
- Adds some basic dialog styling for our old preferences.
