### PR TITLE
add colored border to coordinates input (for consistency)

### DIFF
--- a/main/res/drawable/textinputlayout_bcg_active.xml
+++ b/main/res/drawable/textinputlayout_bcg_active.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:left="6dp" android:right="6dp" android:bottom="6dp" android:top="6dp">
+        <shape>
+            <solid android:color="@color/colorBackgroundTransparent"/>
+            <stroke android:width="2dp" android:color="@color/colorAccent" />
+            <corners android:radius="4dp"/>
+            <padding android:left="3dp" android:top="3dp" android:right="3dp" android:bottom="3dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/main/res/drawable/textinputlayout_bcg_default.xml
+++ b/main/res/drawable/textinputlayout_bcg_default.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- same as textinputlayout_bcg_active, but different stroke color -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:left="6dp" android:right="6dp" android:bottom="6dp" android:top="6dp">
+        <shape>
+            <solid android:color="@color/colorBackgroundTransparent"/>
+            <stroke android:width="2dp" android:color="#FFE0E0E0" />
+            <corners android:radius="4dp"/>
+            <padding android:left="3dp" android:top="3dp" android:right="3dp" android:bottom="3dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/main/res/layout/coordinates_calculate.xml
+++ b/main/res/layout/coordinates_calculate.xml
@@ -42,7 +42,9 @@
         android:id="@+id/coordTable"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:columnCount="17">
+        app:columnCount="17"
+        android:background="@drawable/textinputlayout_bcg_active"
+        android:padding="8dp">
 
         <Button
             android:id="@+id/ButtonLatHem"

--- a/main/res/layout/coordinates_input.xml
+++ b/main/res/layout/coordinates_input.xml
@@ -19,9 +19,10 @@
         android:layout_height="0dp"
         android:layout_weight="1"
         android:shrinkColumns="1,3,5,7"
-        android:stretchColumns="0,1,3,5,7" >
+        android:stretchColumns="0,1,3,5,7">
 
-        <TableRow android:id="@+id/latRow" >
+        <TableRow android:id="@+id/latRow"
+            android:layout_margin="6dp">
 
             <Button
                 android:id="@+id/ButtonLat"
@@ -94,7 +95,8 @@
 
             </TableRow>
 
-        <TableRow android:id="@+id/lonRow" >
+        <TableRow android:id="@+id/lonRow"
+            android:layout_margin="6dp">
 
             <Button
                 android:id="@+id/ButtonLon"

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -33,6 +33,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
+import android.widget.TableLayout;
 import android.widget.TextView;
 
 import androidx.annotation.IdRes;
@@ -53,6 +54,7 @@ public class CoordinatesInputDialog extends DialogFragment {
     private Geopoint gp;
     private Geopoint cacheCoords;
 
+    private TableLayout coordTable;
     private TextInputLayout eLatFrame;
     private TextInputLayout eLonFrame;
     private EditText eLat;
@@ -144,6 +146,11 @@ public class CoordinatesInputDialog extends DialogFragment {
 
         final View v = inflater.inflate(R.layout.coordinatesinput_dialog, container, false);
         final InputDoneListener inputdone = new InputDoneListener();
+
+        // change table border color depending on "any child has focus" state
+        coordTable = v.findViewById(R.id.coordTable);
+        coordTable.getViewTreeObserver().addOnGlobalFocusChangeListener((oldFocus, newFocus) -> coordTable.setBackgroundResource(coordTable.findFocus() != null ? R.drawable.textinputlayout_bcg_active : R.drawable.textinputlayout_bcg_default));
+
         if (!noTitle) {
             dialog.setTitle(R.string.cache_coordinates);
         } else {


### PR DESCRIPTION
## Description
- related to #10763
- add a colored border around the coordinate input fields in coordinate calculator for consistency (both coordinates input and calculator input)
- there's no added functionality like `TextInputLayout` has, so no hint, no start/end icon etc.
- it has the same outer margins as `TextInputLayout`, but inner padding is made smaller deliberately, as so many input boxes are included which need space

![image](https://user-images.githubusercontent.com/3754370/122672438-cc3c4400-d1cb-11eb-8394-a2eb28f9fa69.png).![image](https://user-images.githubusercontent.com/3754370/122672444-d100f800-d1cb-11eb-8642-4180e9986782.png).![image](https://user-images.githubusercontent.com/3754370/122672430-c5adcc80-d1cb-11eb-8007-0fd63e093985.png)

