### PR TITLE
align full button margin to TextInputLayout margin

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -136,8 +136,8 @@
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>
 
-        <item name="android:layout_marginLeft">10dip</item>
-        <item name="android:layout_marginRight">10dip</item>
+        <item name="android:layout_marginLeft">6dip</item>
+        <item name="android:layout_marginRight">6dip</item>
         <item name="android:layout_marginBottom">5dip</item>
     </style>
 


### PR DESCRIPTION
## Description
As requested in one of the issues related to `TextInputLayout`:
Our full-width buttons should use the same margins as our input fields, which is what this PR adjusts styles to.

![image](https://user-images.githubusercontent.com/3754370/122672819-c8a9bc80-d1cd-11eb-9800-0e8c8106d42e.png)
