### PR TITLE
tweak settings' dialog theming (fix #10792)

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -104,16 +104,24 @@
         <item name="android:textColor">@color/settings_primary_selector_night</item>
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:windowBackground">@color/settings_colorDialogBackgroundDark</item>
+        <item name="android:background">@color/settings_colorDialogBackgroundDark</item>
+        <item name="android:windowBackground">@color/colorBackgroundTransparent</item>
         <item name="colorOnSurface">@color/colorAccent</item>
+        <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
     </style>
 
     <style name="settings.DialogTheme.light" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:textColor">@color/settings_primary_selector_light</item>
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:windowBackground">@color/settings_colorDialogBackgroundLight</item>
+        <item name="android:background">@color/settings_colorDialogBackgroundLight</item>
+        <item name="android:windowBackground">@color/colorBackgroundTransparent</item>
         <item name="colorOnSurface">@color/colorAccent</item>
+        <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
+    </style>
+
+    <style name="settings.buttons" parent="@style/button">
+        <item name="android:textColor">@color/colorAccent</item>
     </style>
 
     <!-- theme for splash screen -->


### PR DESCRIPTION
## Description
- make dialog windowBackground transparent and only set the dialog's own background to specified color
- force colorAccent on button labels' text

![image](https://user-images.githubusercontent.com/3754370/122685599-ab481300-d20c-11eb-8739-46488acfb2dc.png).![image](https://user-images.githubusercontent.com/3754370/122685601-b00cc700-d20c-11eb-914b-d5b4ae3df300.png)
