### PR TITLE
cleanup components section

### DIFF
--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -141,15 +141,11 @@
     - [Mapsforge](https://code.google.com/p/mapsforge/) (OSM-rendering)\n
     - [The Noun Project](https://thenounproject.com/) (basis for attribute icons):\n%1
     - [The Apache Commons Project](https://commons.apache.org/)\n
-    - [Android Icons](https://androidicons.com/) ([CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/))\n
-    - [RRZE Icon set](https://github.com/RRZE-PP/rrze-icon-set) ([CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))\n
-    - [Layers icon by Cole Bemis](https://iconfindr.com/1mNr3rl) ([CC-BY 3.0](https://creativecommons.org/licenses/by/3.0/))\n
     - [Google Material Design Icons](https://material.io/tools/icons/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
-    - [Material Design Icons](https://materialdesignicons.com/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
+    - [Community Material Design Icons](https://materialdesignicons.com/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
     - [DragSortListView library by Carl Bauer](https://github.com/bauerca/drag-sort-listview/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
     - [Geocoding courtesy of MapQuest](https://www.mapquest.com/)\n
     - [Geocoding data from OpenStreetMap](https://www.openstreetmap.org/)\n
-    - The [Tango! Desktop Project](http://tango.freedesktop.org/Tango_Desktop_Project) (Public Domain)\n
     - OpenStreetMap cartography (OSM:Mapnik) © OpenStreetMap contributors. Map tile data [licensed](http://www.openstreetmap.org/copyright/en) under Creative Commons 2.0 BY-SA.\n
     - More maps based on OpenStreetMap cartography: © [openstreetmap.de](https://www.openstreetmap.de/) and © [cyclosm.org](https://www.cyclosm.org/).\n
     - Map Downloader supports maps from [Mapsforge](https://github.com/mapsforge), [OpenAndroMaps](https://www.openandromaps.org), [Freizeitkarte](https://www.freizeitkarte-osm.de/) and [Hylly](https://kartat.hylly.org/).\n
@@ -158,15 +154,15 @@
 
     <!-- see comment for "components" -->
     <string translatable="false" name="components2">
-    - add by Susannanova from the Noun Project\n
-    - Arrow by Jamison Wieser from The Noun Project\n
-    - challenge by Adrien Coquet from the Noun Project\n
-    - color palette by Vlad Likh from the Noun Project\n
-    - Folder by Landan Lloyd from the Noun Project\n
-    - new-idea by Artem Korotkikh from The Noun Project\n
-    - solution by Adrien Coquet from the Noun Project\n
-    - Trail by Martina Krasnayová from the Noun Project\n
-    - USB by Kenneth Von Alt from The Noun Project\n
+    - add by Susannanova\n
+    - Arrow by Jamison Wieser\n
+    - challenge by Adrien Coquet\n
+    - color palette by Vlad Likh\n
+    - Folder by Landan Lloyd\n
+    - new-idea by Artem Korotkikh\n
+    - solution by Adrien Coquet\n
+    - Trail by Martina Krasnayová\n
+    - USB by Kenneth Von Alt\n
     </string>
 
     <!-- cache details -->


### PR DESCRIPTION
We had quite some leftovers in our components section. AFAIK we don't use them anymore, but can someone cross-check?

Especially, I'm not sure about these two ones:
     - [RRZE Icon set](https://github.com/RRZE-PP/rrze-icon-set) ([CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))
     - The [Tango! Desktop Project](http://tango.freedesktop.org/Tango_Desktop_Project) (Public Domain)

Furthermore, I removed the "from the Noun Project" which was behind every listed icon. This information was superfluous, since all elements are listed in "the Noun Project" subcategory anyway.

|before|now|
|-|-|
| ![grafik](https://user-images.githubusercontent.com/64581222/122939008-8621e480-d373-11eb-8167-f1c4b158bfac.png) |![grafik](https://user-images.githubusercontent.com/64581222/122942304-6a6c0d80-d376-11eb-81bc-1464d5e4fbdb.png)
