### PR TITLE
add default margin for icon_button_style

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -175,6 +175,7 @@
     <style name="button_icon_accent" parent="button">
         <item name="android:layout_width">48dp</item>
         <item name="android:layout_height">48dp</item>
+        <item name="android:layout_margin">3dp</item>
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:paddingLeft">12dp</item>


### PR DESCRIPTION
The previous style looked quite squashed and like an unintentional bug, now the UI looks much more well-engineered ;-)

|before|now|
|-|-|
|![grafik](https://user-images.githubusercontent.com/64581222/122945614-faab5200-d378-11eb-8477-94e4a7da99b0.png)|![grafik](https://user-images.githubusercontent.com/64581222/122945811-20d0f200-d379-11eb-9031-eb133b267fc1.png)
