### PR TITLE
[cachelist] make strings more consistent

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1146,7 +1146,7 @@
     <string name="last_day_available">last day available</string>
 
     <string name="cache_offline_refresh">Refresh</string>
-    <string name="cache_offline_drop">Remove</string>
+    <string name="cache_offline_drop">Remove from list</string>
     <string name="cache_delete_userdefined_waypoints">Remove user-defined waypoints</string>
     <string name="cache_delete_userdefined_waypoints_confirm">Remove all user-defined waypoints of this cache?\n\nWaypoints will be deleted immediately, there is no undo.</string>
     <string name="cache_delete_userdefined_waypoints_note">Note: You have \"waypoints from note\" enabled. If you have coordinates in your personal note recognized by c:geo, waypoints will be recreated for them automatically. You can disable this in the personal note edit dialog.</string>


### PR DESCRIPTION
In the overflow menu we had changed the strings some time ago, but we forgot to do the same change for the popup as well...

## overflow menu
![grafik](https://user-images.githubusercontent.com/64581222/122946657-d7cd6d80-d379-11eb-86b1-1407cb6711cd.png)
![grafik](https://user-images.githubusercontent.com/64581222/122946832-fcc1e080-d379-11eb-9b0a-d9c03f97043c.png)

## popup
![grafik](https://user-images.githubusercontent.com/64581222/122946993-195e1880-d37a-11eb-8841-a1eba9d26ee9.png)
