### PR TITLE
fix touch target "hole" in checkbox item

### DIFF
--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -205,8 +205,7 @@ public class ViewUtils {
             itemBinding.itemInfo.setVisibility(View.VISIBLE);
             itemBinding.itemInfo.setOnClickListener(v -> SimpleDialog.of(activity).setMessage(infoText).show());
         }
-        itemBinding.itemIcon.setOnClickListener(v -> itemBinding.itemCheckbox.toggle());
-        itemBinding.itemText.setOnClickListener(v -> itemBinding.itemCheckbox.toggle());
+        itemView.setOnClickListener(v -> itemBinding.itemCheckbox.toggle());
 
         return new ImmutablePair<>(itemView, itemBinding.itemCheckbox);
     }


### PR DESCRIPTION
There was a "hole" in the touch target of checkbox items, if you click the view between the text and the checkbox...

![Screenshot_20210622_175509_com google android apps accessibility auditor](https://user-images.githubusercontent.com/64581222/122961348-9abaa880-d384-11eb-9547-65173d91814b.png)
