### PR TITLE
fix #10940: make gc watchlist add/remove work again

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -53,7 +53,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -359,7 +358,7 @@ public final class GCParser {
                     final String coordinates = Network.getResponseData(Network.postRequest("https://www.geocaching.com/seek/" + queryUrl, params), false);
 
                     if (StringUtils.contains(coordinates, "You have not agreed to the license agreement. The license agreement is required before you can start downloading GPX or LOC files from Geocaching.com")) {
-                        Log.i("User has not agreed to the license agreement. Can\'t download .loc file.");
+                        Log.i("User has not agreed to the license agreement. Can't download .loc file.");
                         searchResult.setError(StatusCode.UNAPPROVED_LICENSE);
                         return searchResult;
                     }
@@ -1190,25 +1189,31 @@ public final class GCParser {
      * @return {@code false} if an error occurred, {@code true} otherwise
      */
     static boolean addToWatchlist(@NonNull final Geocache cache) {
-        final String uri = "https://www.geocaching.com/my/watchlist.aspx?w=" + cache.getCacheId();
-        final String page = GCLogin.getInstance().postRequestLogged(uri, null);
+        return addToOrRemoveFromWatchlist(cache, true);
+    }
 
-        if (StringUtils.isBlank(page)) {
-            Log.e("GCParser.addToWatchlist: No data from server");
-            return false; // error
+    /** internal method to handle add to / remove from watchlist */
+    private static boolean addToOrRemoveFromWatchlist(@NonNull final Geocache cache, final boolean doAdd) {
+
+        final String logContext = "GCParser.addToOrRemoveFromWatchlist(cache = " + cache.getGeocode() + ", add = " + doAdd + ")";
+
+        final String userToken = getUserToken(cache);
+        final ObjectNode jo = new ObjectNode(JsonUtils.factory).put("userToken", userToken).put("Add", doAdd);
+        final String uri = "https://www.geocaching.com/seek/cache_details.aspx/HandleWatchlistAction";
+
+        try {
+            Network.completeWithSuccess(Network.postJsonRequest(uri, jo));
+            Log.i(logContext + ": success");
+        } catch (final Exception ex) {
+            Log.e(logContext + ": error", ex);
+            return false;
         }
 
-        final boolean guidOnPage = isGuidContainedInPage(cache, page);
-        if (guidOnPage) {
-            Log.i("GCParser.addToWatchlist: cache is on watchlist");
-            cache.setOnWatchlist(true);
-        } else {
-            Log.e("GCParser.addToWatchlist: cache is not on watchlist");
-        }
-        // WatchListCount
+        // Set cache properties
+        cache.setOnWatchlist(doAdd);
         final String watchListPage = GCLogin.getInstance().postRequestLogged(cache.getLongUrl(), null);
         cache.setWatchlistCount(getWatchListCount(watchListPage));
-        return guidOnPage; // on watchlist (=added) / else: error
+        return true; 
     }
 
     /**
@@ -1237,49 +1242,7 @@ public final class GCParser {
      * @return {@code false} if an error occurred, {@code true} otherwise
      */
     static boolean removeFromWatchlist(@NonNull final Geocache cache) {
-        final String uri = "https://www.geocaching.com/my/watchlist.aspx?ds=1&action=rem&id=" + cache.getCacheId();
-        String page = GCLogin.getInstance().postRequestLogged(uri, null);
-
-        if (StringUtils.isBlank(page)) {
-            Log.e("GCParser.removeFromWatchlist: No data from server");
-            return false; // error
-        }
-
-        // removing cache from list needs approval by hitting "Yes" button
-        final Parameters params = new Parameters(
-                "__EVENTTARGET", "",
-                "__EVENTARGUMENT", "",
-                "ctl00$ContentBody$btnYes", "Yes");
-        GCLogin.transferViewstates(page, params);
-
-        page = Network.getResponseData(Network.postRequest(uri, params));
-        final boolean guidOnPage = isGuidContainedInPage(cache, page);
-        if (!guidOnPage) {
-            Log.i("GCParser.removeFromWatchlist: cache removed from watchlist");
-            cache.setOnWatchlist(false);
-        } else {
-            Log.e("GCParser.removeFromWatchlist: cache not removed from watchlist");
-        }
-
-        // WatchListCount
-        final String watchListPage = GCLogin.getInstance().postRequestLogged(cache.getLongUrl(), null);
-        cache.setWatchlistCount(getWatchListCount(watchListPage));
-        return !guidOnPage; // on watch list (=error) / not on watch list
-    }
-
-    /**
-     * Checks if a page contains the guid of a cache
-     *
-     * @param cache the geocache
-     * @param page
-     *            the page to search in, may be null
-     * @return true if the page contains the guid of the cache, false otherwise
-     */
-    private static boolean isGuidContainedInPage(@NonNull final Geocache cache, final String page) {
-        if (StringUtils.isBlank(page) || StringUtils.isBlank(cache.getGuid())) {
-            return false;
-        }
-        return Pattern.compile(cache.getGuid(), Pattern.CASE_INSENSITIVE).matcher(page).find();
+        return addToOrRemoveFromWatchlist(cache, false);
     }
 
     @Nullable


### PR DESCRIPTION
fix #10940: make gc watchlist add/remove work again:

adapt `GCParser` methods `addToWatchlist`/`removeFromWatchlist `to website changes on gc.com