### PR TITLE
Improve GPX log import

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -5,6 +5,8 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCUtils;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.tc.TerraCachingLogType;
 import cgeo.geocaching.connector.tc.TerraCachingType;
@@ -619,8 +621,13 @@ abstract class GPXParser extends FileParser {
             try {
                 if (attrs.getIndex("id") > -1) {
                     logBuilder.setId(Integer.parseInt(attrs.getValue("id")));
+
+                    final IConnector connector = ConnectorFactory.getConnector(cache);
+                    if (connector instanceof GCConnector) {
+                        logBuilder.setServiceLogId(GCUtils.logIdToLogCode(logBuilder.getId()));
+                    }
                 }
-            } catch (final NumberFormatException ignored) {
+            } catch (final Exception ignored) {
                 // nothing
             }
         });

--- a/main/src/cgeo/geocaching/utils/CalendarUtils.java
+++ b/main/src/cgeo/geocaching/utils/CalendarUtils.java
@@ -18,6 +18,8 @@ import java.util.Locale;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
 public final class CalendarUtils {
 
     public static final String PATTERN_YYYYMM = "yyyy-MM";
@@ -28,16 +30,20 @@ public final class CalendarUtils {
         // utility class
     }
 
+    public static void resetTimeToMidnight(final Calendar date) {
+        date.set(Calendar.SECOND, 0);
+        date.set(Calendar.MINUTE, 0);
+        date.set(Calendar.HOUR_OF_DAY, 0);
+    }
+
     public static int daysSince(final long date) {
         final Calendar logDate = Calendar.getInstance();
         logDate.setTimeInMillis(date);
-        logDate.set(Calendar.SECOND, 0);
-        logDate.set(Calendar.MINUTE, 0);
-        logDate.set(Calendar.HOUR_OF_DAY, 0);
+        resetTimeToMidnight(logDate);
+
         final Calendar today = Calendar.getInstance();
-        today.set(Calendar.SECOND, 0);
-        today.set(Calendar.MINUTE, 0);
-        today.set(Calendar.HOUR_OF_DAY, 0);
+        resetTimeToMidnight(today);
+
         return (int) Math.round((today.getTimeInMillis() - logDate.getTimeInMillis()) / 86400000d);
     }
 
@@ -144,5 +150,16 @@ public final class CalendarUtils {
         } catch (ParseException e) {
             return 0;
         }
+    }
+
+    /**
+     * parses given date to a long
+     */
+    public static ImmutablePair<Long, Long> getStartAndEndOfDay(final long timestamp) {
+        final Calendar date = Calendar.getInstance();
+        date.setTimeInMillis(timestamp);
+        resetTimeToMidnight(date);
+
+        return new ImmutablePair<>(date.getTimeInMillis(), date.getTimeInMillis() + 86400000);
     }
 }


### PR DESCRIPTION
fix #9639 
fix #10028

- Store service-specific `log_id` on PQ / GPX import 
- avoid log entry duplicates while importing PQ / GPX

The second is done by don't search for a specific timestamp in the db anymore, but rather accept the whole time range of the log day while searching for duplicates.

It's currently targeted to master, as users seam not to be affected too much by this bug (~at least @Lineflyer hadn't reported any support requests~ there where really quite some requests at the start of this year which seem to  got lost). If we want to do another small bugfix release anyway, I can retarget the PR for sure...