### PR TITLE
workaround for cursor not showing in settings' edittext (fix #10984)

### DIFF
--- a/main/res/drawable/cursor.xml
+++ b/main/res/drawable/cursor.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <size android:width="2dp" />
+    <solid android:color="@color/colorAccent"  />
+</shape>


### PR DESCRIPTION
## Description
Workaround for cursor not showing in our `TemplateTextPreference` in settings.
Slightly different solutions needed for API < 29 / API 29+ due to API changes.