### PR TITLE
format waypoint type spinner (fix #10974)

### DIFF
--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -77,7 +77,6 @@
             android:visibility="gone"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"
-            android:popupBackground="@color/colorBackgroundDialog"
             tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -82,6 +82,9 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:visibility="gone"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:popupBackground="@color/colorBackgroundDialog"
             tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -68,13 +68,6 @@
                     android:enabled="false"/>
             </RelativeLayout>
 
-            <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal" >
-
-
-            </LinearLayout>
         </LinearLayout>
 
         <Spinner

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -52,6 +52,12 @@
         <item name="android:layout_height">wrap_content</item>
     </style>
 
+    <!-- spinner popup formatting -->
+
+    <style name="spinnerStyle" parent="Base.Widget.AppCompat.Spinner">
+        <item name="android:popupBackground">@color/colorBackgroundDialog</item>
+    </style>
+
     <!-- alert dialog formatting -->
 
     <style name="alertDialogTitleTextStyle" parent="MaterialAlertDialog.MaterialComponents.Title.Text">

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -12,6 +12,7 @@
         <item name="checkboxStyle">@style/checkboxStyle</item>
         <item name="radioButtonStyle">@style/radioButtonStyle</item>
         <item name="materialAlertDialogTheme">@style/materialAlertDialogTheme</item>
+        <item name="android:spinnerStyle">@style/spinnerStyle</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>


### PR DESCRIPTION
## Description
- applies more room around waypoint type spinner
- apply dialog background to spinner popup to be distinguishable from background in dark mode

![image](https://user-images.githubusercontent.com/3754370/123505049-2d956480-d65d-11eb-90fb-6e2085a437a5.png).![image](https://user-images.githubusercontent.com/3754370/123505055-32f2af00-d65d-11eb-8d09-b30344787dfb.png).![image](https://user-images.githubusercontent.com/3754370/123505060-384ff980-d65d-11eb-8216-7cc249c5555f.png)
