### PR TITLE
align multi-line edittexts to top left (fix #11008)

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -248,6 +248,7 @@
         <item name="android:inputType">text</item>
         <item name="android:textColor">@color/colorText</item>
         <item name="colorOnSurface">@color/colorText</item>
+        <item name="android:gravity">top|left</item>
     </style>
 
     <!-- edittext (TODO: should at some point be completely replaced by textinput) -->


### PR DESCRIPTION
## Description
Aligns text fields styled with `textinput_embedded` to top-left.

![image](https://user-images.githubusercontent.com/3754370/123505986-2de42e80-d662-11eb-9fed-cda504ad266d.png)
