### PR TITLE
enlarge cache size for TabbedViewPagerActivity

### DIFF
--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
@@ -50,6 +50,7 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
         viewPager.setAdapter(new ViewPagerAdapter(this));
         viewPager.registerOnPageChangeCallback(pageChangeCallback);
         viewPager.setCurrentItem(pageIdToPosition(currentPageId));
+        viewPager.setOffscreenPageLimit(10);
 
         swipeRefreshLayout = findViewById(R.id.swipe_refresh);
         if (swipeRefreshLayout != null) {


### PR DESCRIPTION
## Description
ViewPager2 has a built-in caching mechanism. Enlarge this to cover `CacheDetailActivity` pages completely.

## Related issues
- fixes #10975
- fixes #10978
- fixes #10964
