### PR TITLE
set cache list spinner item bg color to actionbar bg (rel. to #10982)

### DIFF
--- a/main/res/layout/cachelist_spinneritem.xml
+++ b/main/res/layout/cachelist_spinneritem.xml
@@ -7,6 +7,7 @@
     android:layout_gravity="left|center_vertical"
     android:minHeight="?attr/dropdownListPreferredItemHeight"
     android:orientation="vertical"
+    android:background="@color/colorBackgroundActionBar"
     tools:context=".CacheListSpinnerAdapter" >
 
     <TextView


### PR DESCRIPTION
## Description
For better readability set cache list spinner popup background color to actionbar background color, so it stays consistent with actionbar, but has better contrast to cache list background.

![image](https://user-images.githubusercontent.com/3754370/123509743-9e497a80-d677-11eb-8c1f-8eec4485fd89.png)
