### PR TITLE
rel to #10951: convert keyword search to filter

### DIFF
--- a/main/src/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/cgeo/geocaching/connector/su/SuConnector.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.IOAuthCapability;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
+import cgeo.geocaching.connector.capability.ISearchByFilter;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.capability.ISearchByKeyword;
 import cgeo.geocaching.connector.capability.ISearchByOwner;
@@ -21,6 +22,7 @@ import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
 import cgeo.geocaching.connector.oc.OCApiConnector.OAuthLevel;
 import cgeo.geocaching.enumerations.StatusCode;
+import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.log.LogCacheActivity;
@@ -43,7 +45,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-public class SuConnector extends AbstractConnector implements ISearchByCenter, ISearchByGeocode, ISearchByViewPort, ILogin, IOAuthCapability, WatchListCapability, PersonalNoteCapability, ISearchByKeyword, ISearchByOwner, IFavoriteCapability, IVotingCapability, IgnoreCapability {
+public class SuConnector extends AbstractConnector implements ISearchByCenter, ISearchByGeocode, ISearchByViewPort, ILogin, IOAuthCapability, WatchListCapability, PersonalNoteCapability, ISearchByKeyword, ISearchByOwner, ISearchByFilter, IFavoriteCapability, IVotingCapability, IgnoreCapability {
 
     private static final CharSequence PREFIX_MULTISTEP_VIRTUAL = "MV";
     private static final CharSequence PREFIX_TRADITIONAL = "TR";
@@ -257,6 +259,21 @@ public class SuConnector extends AbstractConnector implements ISearchByCenter, I
             return new SearchResult(StatusCode.UNKNOWN_ERROR);
         }
 
+    }
+
+    @Override
+    @NonNull
+    public SearchResult searchByFilter(@NonNull final GeocacheFilter filter) {
+        try {
+            return new SearchResult(SuApi.searchByFilter(filter, this));
+        } catch (final SuApi.NotAuthorizedException e) {
+            return new SearchResult(StatusCode.NOT_LOGGED_IN);
+        } catch (final SuApi.ConnectionErrorException e) {
+            return new SearchResult(StatusCode.CONNECTION_FAILED_SU);
+        } catch (final Exception e) {
+            Log.e("SuConnector.searchByFilter failed: ", e);
+            return new SearchResult(StatusCode.UNKNOWN_ERROR);
+        }
     }
 
     @Override

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -222,6 +222,21 @@ public class GeocacheFilter {
         list.addAll(itemsToKeep);
     }
 
+    /** constructs a new GeocacheFilter which is identical to this filter but adds the given AND conditions to it */
+    public GeocacheFilter and(final IGeocacheFilter ... filters) {
+
+        if (filters == null || filters.length == 0) {
+            return this;
+        }
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(this.tree);
+        for (IGeocacheFilter f : filters) {
+            andFilter.addChild(f);
+        }
+        return new GeocacheFilter(null, openInAdvancedMode, includeInconclusive, andFilter);
+    }
+
     public boolean isSaved() {
         return Storage.exists(getName());
     }

--- a/main/src/cgeo/geocaching/filters/core/StringGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/StringGeocacheFilter.java
@@ -4,6 +4,8 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.SqlBuilder;
 import cgeo.geocaching.utils.expressions.ExpressionConfig;
 
+import androidx.annotation.NonNull;
+
 
 public abstract class StringGeocacheFilter extends BaseGeocacheFilter {
 
@@ -15,6 +17,7 @@ public abstract class StringGeocacheFilter extends BaseGeocacheFilter {
         return null;
     }
 
+    @NonNull
     public StringFilter getStringFilter() {
         return stringFilter;
     }

--- a/main/src/cgeo/geocaching/loaders/KeywordGeocacheListLoader.java
+++ b/main/src/cgeo/geocaching/loaders/KeywordGeocacheListLoader.java
@@ -2,6 +2,9 @@ package cgeo.geocaching.loaders;
 
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.NameGeocacheFilter;
 
 import android.app.Activity;
 
@@ -9,7 +12,7 @@ import androidx.annotation.NonNull;
 
 public class KeywordGeocacheListLoader extends AbstractSearchLoader {
 
-    @NonNull private final String keyword;
+    @NonNull public final String keyword;
 
     public KeywordGeocacheListLoader(final Activity activity, @NonNull final String keyword) {
         super(activity);
@@ -18,8 +21,14 @@ public class KeywordGeocacheListLoader extends AbstractSearchLoader {
 
     @Override
     public SearchResult runSearch() {
-        return nonEmptyCombineActive(ConnectorFactory.getSearchByKeywordConnectors(),
-                connector -> connector.searchByKeyword(keyword));
+        //use filter search instead of dedicated keyword search
+        final GeocacheFilter baseFilter = GeocacheFilter.loadFromSettings();
+
+        final NameGeocacheFilter nameFilter = (NameGeocacheFilter) GeocacheFilterType.NAME.create();
+        nameFilter.getStringFilter().setTextValue(keyword);
+
+        return nonEmptyCombineActive(ConnectorFactory.getSearchByFilterConnectors(),
+            connector -> connector.searchByFilter(baseFilter.and(nameFilter)));
     }
 
 }


### PR DESCRIPTION
rel to #10951: convert keyword search to filter

This PR converts the "keyword" online search to the new filter system. This means:
* the search does NO LONGER use the global settings "exclude found/own/disabled/archived"
* instead it filters using the current global filter IN ADDITION (AND-combined) to the given keyword
* Also, when changing the filter in list view afterwards, the online search is retriggered

As part of this PR the SUConnector was enabled for ISearchByFilter

And one discussion point: I realized while implementing this that ISearchByFilter makes most other search capabilities superfluous (e.g. `ISearchByKeyword`, `ISearchByOwner`, ...), so I guess they can be removed one-by-one once `ISearchByFilter` takes over. This also means that most of the Search-Loaders used by `CacheListActivity `can be removed (for now I kept the `KeywordGeocacheListLoader`). 