### PR TITLE
add extra padding for easier fastscroll in wpt list (rel. to #9992)

### DIFF
--- a/main/res/layout/cachedetail_waypoints_page.xml
+++ b/main/res/layout/cachedetail_waypoints_page.xml
@@ -11,6 +11,7 @@
     android:headerDividersEnabled="false"
     android:nestedScrollingEnabled="true"
     android:scrollbarStyle="outsideOverlay"
+    android:paddingRight="@dimen/paddingRight_fastscroll"
     tools:context=".CacheDetailActivity$WaypointsViewCreator">
 
 </ListView>

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -15,6 +15,8 @@
 
     <dimen name="dialog_padding_horizontal">24dip</dimen>
 
+    <!-- fastscroll extra padding -->
+    <dimen name="paddingRight_fastscroll">5dp</dimen>
 
     <!-- font size dimensions ====================================== -->
 


### PR DESCRIPTION
## Description
This is a proposal for how to handle the conflict between fastscroll handler and content accessibility - for waypoint list in this case. I've added a small extra padding of `5dp`, see screens below.

If this works out fine, we can apply the same for the other fastscroll-enabled views.

|without extra padding|with added fastscroll padding|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/123526141-29595d80-d6d6-11eb-96d7-8804491046af.png)|![image](https://user-images.githubusercontent.com/3754370/123526145-324a2f00-d6d6-11eb-8914-87d8a79470a5.png)|