### PR TITLE
make new filter system the default

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -10,12 +10,12 @@
     <item
         android:id="@+id/menu_filter"
         android:icon="@drawable/ic_menu_filter"
-        android:title="@string/caches_filter"
+        android:title="@string/caches_filter_menuitem"
         app:showAsAction="ifRoom|withText"/>
     <item
-        android:id="@+id/menu_cache_filter"
+        android:id="@+id/menu_filter_legacy"
         android:icon="@drawable/ic_menu_filter"
-        android:title="@string/caches_filter_menuitem"
+        android:title="@string/caches_filter"
         app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_sort"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -415,8 +415,8 @@
     <string name="caches_copy_selected">Copy selected</string>
     <string name="caches_copy_all">Copy all</string>
     <string name="caches_map_locus_export">Export to Locus</string>
-    <string name="caches_filter">Filter</string>
-    <string name="caches_filter_menuitem">New Cache Filter (Experimental)</string>
+    <string name="caches_filter">Filter (legacy)</string>
+    <string name="caches_filter_menuitem">Filter</string>
     <string name="caches_filter_title">Filter by</string>
     <string name="caches_filter_size">Size</string>
     <string name="caches_filter_type">Type</string>
@@ -1558,7 +1558,7 @@
     <string name="search_hbu">Hidden by</string>
     <string name="search_hbu_prefill">Owner</string>
     <string name="search_hbu_button">Search by owner name</string>
-    <string name="search_filter">Filter (experimental)</string>
+    <string name="search_filter">Filter</string>
     <string name="search_filter_button">Search by Filter</string>
     <string name="search_filter_info_message">**Search by filter** searches caches on all active online services (e.g. geocaching.com) using a provided filter. However, search capabilities of these services are usually more limited than filter capabilities of c:geo.\n\n- All services only support AND filters (no OR filters and no filter inversion).\n- The more basic filters like **cache type** or **cache size** are supported by all services. More complicated filters are often not supported or have some restrictions e.g. **favorites** or **hidden date**.\n- A detailed list on supported filters per service can be found [here](https://github.com/cgeo/cgeo/wiki/%22Search-by-Filter%22-support-by-c:geo-Connectors).\n\nFilters not supported by the online service will be applied by c:geo on the received results.</string>
     <string name="search_tb">Trackable</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -751,7 +751,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         try {
             // toplevel menu items
             setEnabled(menu, R.id.menu_show_on_map, !isEmpty);
-            setEnabled(menu, R.id.menu_filter, search != null && search.getCount() > 0);
+            setEnabled(menu, R.id.menu_filter_legacy, search != null && search.getCount() > 0);
             setVisibleEnabled(menu, R.id.menu_sort, !isHistory, !isEmpty);
             if (adapter.isSelectMode()) {
                 menu.findItem(R.id.menu_switch_select_mode).setTitle(res.getString(R.string.caches_select_mode_exit))
@@ -907,9 +907,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         } else if (menuItem == R.id.menu_invert_selection) {
             adapter.invertSelection();
             invalidateOptionsMenuCompatible();
-        } else if (menuItem == R.id.menu_filter) {
+        } else if (menuItem == R.id.menu_filter_legacy) {
             showLegacyFilterMenu(null);
-        } else if (menuItem == R.id.menu_cache_filter) {
+        } else if (menuItem == R.id.menu_filter) {
             showFilterMenu(null);
         } else if (menuItem == R.id.menu_import_web) {
             importWeb();


### PR DESCRIPTION
This PR will make the new filter system the default one and moves the old filter system to a "prio 2" position.

It will also rename corresponding new filter items to "Filter" (remove "experimental") and rename the old filter to "Filter (legacy)"

![image](https://user-images.githubusercontent.com/6909759/123537442-c694b000-d72f-11eb-9dc6-7242ba081ce3.png)
