### PR TITLE
issue_11001 improved

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -278,6 +278,7 @@
     <string translatable="false" name="pref_localstorage_version">localstorage_version</string>
     <string translatable="false" name="pref_alc_advanced">alc_advanced</string>
     <string translatable="false" name="pref_alc_launcher">alc_launcher</string>
+    <string translatable="false" name="pref_alc_consumerkey">alc_consumerkey</string>
 
     <!-- ids for persistable folder prefs -->
     <string translatable="false" name="pref_group_localfilesystem">group_localfilesystem</string>

--- a/main/src/cgeo/geocaching/connector/lc/LCApi.java
+++ b/main/src/cgeo/geocaching/connector/lc/LCApi.java
@@ -41,7 +41,7 @@ final class LCApi {
     @NonNull
     private static final String API_HOST        = "https://labs-api.geocaching.com/Api/Adventures/";
     private static final String CONSUMER_HEADER = "X-Consumer-Key";
-    private static final String CONSUMER_KEY    = "11111111-2222-3333-4444-5555555555555";
+    private static final String CONSUMER_KEY    = Settings.getALCConsumerKey();
 
     private LCApi() {
         // utility class with static methods

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -506,9 +506,13 @@ public class Settings {
     public static boolean isALCAdvanced() {
         return getBoolean(R.string.pref_alc_advanced, false);
     }
- 
-     public static String getALCLauncher() {
+
+    public static String getALCLauncher() {
         return getString(R.string.pref_alc_launcher, "");
+    }
+
+    public static String getALCConsumerKey() {
+        return getString(R.string.pref_alc_consumerkey, "");
     }
 
     public static GCMemberState getGCMemberStatus() {


### PR DESCRIPTION
attached pls find an update that treats the consumer-key in a more intelligent way. The string constant in the earlier PR had no real meaning after all. This PR provides a way to actually make use of the key.