### PR TITLE
force singleline in map settings popup

### DIFF
--- a/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -70,18 +70,18 @@ public class MapSettingsUtils {
         final LinearLayout leftColumn = columns.get(0);
         final LinearLayout rightColumn = columns.get(1);
 
-        leftColumn.addView(ViewUtils.createTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_caches_title)));
+        leftColumn.addView(ViewUtils.createSubtitleTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_caches_title)));
         foundCb.addToViewGroup(activity, leftColumn);
         ownCb.addToViewGroup(activity, leftColumn);
         disabledCb.addToViewGroup(activity, leftColumn);
         archivedCb.addToViewGroup(activity, leftColumn);
         offlineLogCb.addToViewGroup(activity, leftColumn);
 
-        rightColumn.addView(ViewUtils.createTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_waypoints_title)));
+        rightColumn.addView(ViewUtils.createSubtitleTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_waypoints_title)));
         wpOriginalCb.addToViewGroup(activity, rightColumn);
         wpParkingCb.addToViewGroup(activity, rightColumn);
         wbVisitedCb.addToViewGroup(activity, rightColumn);
-        rightColumn.addView(ViewUtils.createTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_other_title)));
+        rightColumn.addView(ViewUtils.createSubtitleTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_other_title)));
         if (trackCb != null) {
             trackCb.addToViewGroup(activity, rightColumn);
         }

--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -12,6 +12,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
+import android.text.TextUtils;
 import android.util.Pair;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
@@ -181,8 +182,11 @@ public class ViewUtils {
         return ip.right;
     }
 
-    public static TextView createTextItem(final Context ctx, @StyleRes final int styleId, final TextParam text) {
+    public static TextView createSubtitleTextItem(final Context ctx, @StyleRes final int styleId, final TextParam text) {
         final TextView tv = new TextView(wrap(ctx), null, 0, styleId);
+        tv.setEllipsize(TextUtils.TruncateAt.END);
+        tv.setHorizontallyScrolling(false);
+        tv.setSingleLine();
         text.applyTo(tv);
         return tv;
     }


### PR DESCRIPTION
...to provide a way more cleaned up design experience (and because all other (sub-)titles in c:geo are single-line as well)

before|now
-|-
![grafik](https://user-images.githubusercontent.com/64581222/123691294-baa30e00-d855-11eb-859c-84c02460e43e.png)|![grafik](https://user-images.githubusercontent.com/64581222/123692023-9c89dd80-d856-11eb-8441-3b2762e8f151.png)
