### PR TITLE
fix mssing touch-feedback for compass in cache-detail

### DIFF
--- a/main/res/layout/navigation_action.xml
+++ b/main/res/layout/navigation_action.xml
@@ -14,7 +14,8 @@
         android:id="@+id/default_navigation_action"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        style="@style/tool_bar"
+        style="?actionButtonStyle"
+        android:layout_gravity="center_vertical"
         android:scaleType="centerInside"
         app:srcCompat="@drawable/ic_menu_compass" />
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
fix mssing touch-feedback for compass in cache-detail
(revert to style ?actionButtonStyle and add android:layout_gravity="center_vertical" to navigation_action

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11039
#10943

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
still for API 21 squared effect in popup.
![image](https://user-images.githubusercontent.com/70113341/123965029-577bbd80-d9b4-11eb-9f11-f000fe30d38c.png)
in full cache-detail all is fine for API 21
![image](https://user-images.githubusercontent.com/70113341/123965342-a32e6700-d9b4-11eb-89af-420a06e5990d.png)

but for API 30 all is fine
![image](https://user-images.githubusercontent.com/70113341/123965167-78dca980-d9b4-11eb-93df-9362f41d692d.png)

