### PR TITLE
rel to #10952: add things to status filter, add stored since filter

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="cache_filter_location">Location</string>
     <string name="cache_filter_stored_lists">Stored Lists</string>
     <string name="cache_filter_origin">Origin</string>
+    <string name="cache_filter_stored_since">Stored since</string>
 
     <string name="cache_filtergroup_basic">Basic</string>
     <string name="cache_filtergroup_details">Details</string>
@@ -560,9 +561,12 @@
     <string name="cache_filter_status_select_label_found">Found</string>
     <string name="cache_filter_status_select_label_owned">Owned</string>
     <string name="cache_filter_status_select_label_stored">Stored</string>
-    <string name="cache_filter_status_select_label_favorite">Favored</string>
+    <string name="cache_filter_status_select_label_favorite">Own Favorite</string>
     <string name="cache_filter_status_select_label_watchlist">On Watchlist</string>
     <string name="cache_filter_status_select_label_premium">Premium</string>
+    <string name="cache_filter_status_select_label_has_trackable">Has Trackable</string>
+    <string name="cache_filter_status_select_label_has_own_vote">Has Own Vote</string>
+    <string name="cache_filter_status_select_label_has_offline_log">Has Offline Log</string>
     <string name="cache_filter_status_select_label_solved_mystery">Solved Mystery</string>
     <string name="cache_filter_status_select_infotext_solved_mystery">This filter setting will only affect mystery caches.\n\n A mystery is considered \'solved\' if it has either changed coordinates or a valid final waypoint filled with coordinates.</string>
 
@@ -576,6 +580,31 @@
     <string name="cache_filter_log_entry_foundby">Found by:</string>
     <string name="cache_filter_log_entry_logtext">Log text:</string>
 
+    <string name="cache_filter_stored_since_notstored">Not stored</string>
+    <string name="cache_filter_stored_since_notstored_short">-</string>
+
+    <string name="cache_filter_stored_since_stored_zero">0 hours</string>
+    <string name="cache_filter_stored_since_stored_zero_short">0h</string>
+    <integer-array name="cache_filter_stored_since_stored_values_h" translatable="false">
+        <item>8</item>
+        <item>24</item>
+        <item>168</item> <!-- 7 days in hours -->
+        <item>720</item> <!-- 30 days in hours -->
+    </integer-array>
+    <string-array name="cache_filter_stored_since_stored_values_label">
+        <item>8 hours</item>
+        <item>24 hours</item>
+        <item>7 days</item>
+        <item>30 days</item>
+    </string-array>
+    <string-array name="cache_filter_stored_since_stored_values_label_short">
+        <item>8h</item>
+        <item>24h</item>
+        <item>7d</item>
+        <item>30d</item>
+    </string-array>
+    <string name="cache_filter_stored_since_stored_max">the dawn of time</string>
+    <string name="cache_filter_stored_since_stored_max_short">max</string>
 
 
     <!-- about -->

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilterType.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilterType.java
@@ -29,7 +29,8 @@ public enum GeocacheFilterType {
     LOG_ENTRY("log_entry", R.string.cache_filter_log_entry, R.string.cache_filtergroup_details, LogEntryGeocacheFilter::new),
     LOCATION("location", R.string.cache_filter_location, R.string.cache_filtergroup_details, LocationGeocacheFilter::new),
     STORED_LISTS("stored_list", R.string.cache_filter_stored_lists, R.string.cache_filtergroup_userspecific, StoredListGeocacheFilter::new),
-    ORIGIN("origin", R.string.cache_filter_origin, R.string.cache_filtergroup_details, OriginGeocacheFilter::new);
+    ORIGIN("origin", R.string.cache_filter_origin, R.string.cache_filtergroup_details, OriginGeocacheFilter::new),
+    STORED_SINCE("stored_since", R.string.cache_filter_stored_since, R.string.cache_filtergroup_userspecific, StoredSinceGeocacheFilter::new);
 
 
     private final String typeId;

--- a/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
@@ -22,6 +22,10 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
         return null;
     }
 
+    protected String getSqlColumnExpression(final SqlBuilder sqlBuilder) {
+        return getSqlColumnName() == null ? null : sqlBuilder.getMainTableId() + "." + getSqlColumnName();
+    }
+
     @Override
     public Boolean filter(final Geocache cache) {
         if (cache == null) {
@@ -79,7 +83,7 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
 
     @Override
     public void addToSql(final SqlBuilder sqlBuilder) {
-        addRangeToSqlBuilder(sqlBuilder, getSqlColumnName() == null ? null : sqlBuilder.getMainTableId() + "." + getSqlColumnName());
+        addRangeToSqlBuilder(sqlBuilder, getSqlColumnExpression(sqlBuilder));
     }
 
     protected void addRangeToSqlBuilder(final SqlBuilder sqlBuilder, final String valueExpression) {

--- a/main/src/cgeo/geocaching/filters/core/StoredSinceGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/StoredSinceGeocacheFilter.java
@@ -1,0 +1,73 @@
+package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.SqlBuilder;
+import cgeo.geocaching.utils.LocalizationUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StoredSinceGeocacheFilter extends NumberRangeGeocacheFilter<Long> {
+
+    private static Long[] range;
+    private static final Map<Long, String> labelMap = new HashMap<>();
+    private static final Map<Long, String> shortLabelMap = new HashMap<>();
+
+    static {
+        final int[] values = LocalizationUtils.getIntArray(R.array.cache_filter_stored_since_stored_values_h);
+        final String[] labels = LocalizationUtils.getStringArray(R.array.cache_filter_stored_since_stored_values_label);
+        final String[] shortLabels = LocalizationUtils.getStringArray(R.array.cache_filter_stored_since_stored_values_label_short);
+        range = new Long[values.length + 3];
+        range[0] = -10L;
+        range[1] = 0L;
+        range[range.length - 1] = Long.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            final Long value = (long) values[i] * 60 * 60;
+            range[i + 2] = value;
+            labelMap.put(value, i < labels.length ? labels[i] : values[i] + " hour(s)");
+            shortLabelMap.put(value, i < shortLabels.length ? shortLabels[i] : values[i] + "h");
+        }
+    }
+
+    public StoredSinceGeocacheFilter() {
+        super(Long::valueOf);
+    }
+
+    /** returns stored time in SECONDS, or -1 if cache is not stored at all */
+    @Override
+    public Long getValue(final Geocache cache) {
+        if (!cache.isOffline()) {
+            return -1L;
+        }
+        return (System.currentTimeMillis() - cache.getUpdated()) / 1000;
+    }
+
+    @Override
+    protected String getSqlColumnExpression(final SqlBuilder sqlBuilder) {
+        return "((" + System.currentTimeMillis() + " - " + sqlBuilder.getMainTableId() + ".updated) / 1000)";
+    }
+
+    @Override
+    protected String getUserDisplayableConfig() {
+        return toUserDisplayValue(getMinRangeValue(), true) + "-" + toUserDisplayValue(getMaxRangeValue(), true);
+    }
+
+    public static Long[] getValueRange() {
+        return range;
+    }
+
+    public static String toUserDisplayValue(final Long value, final boolean useShort) {
+        if (value < 0) {
+            return useShort ? LocalizationUtils.getString(R.string.cache_filter_stored_since_notstored_short) : LocalizationUtils.getString(R.string.cache_filter_stored_since_notstored);
+        }
+        if (value == 0) {
+            return useShort ? LocalizationUtils.getString(R.string.cache_filter_stored_since_stored_zero_short) : LocalizationUtils.getString(R.string.cache_filter_stored_since_stored_zero);
+        }
+        if (labelMap.containsKey(value)) {
+            return useShort ? shortLabelMap.get(value) : labelMap.get(value);
+        }
+        return useShort ? LocalizationUtils.getString(R.string.cache_filter_stored_since_stored_max_short) : LocalizationUtils.getString(R.string.cache_filter_stored_since_stored_max);
+    }
+
+}

--- a/main/src/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.filters.core.NumberRangeGeocacheFilter;
 import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.SizeGeocacheFilter;
 import cgeo.geocaching.filters.core.StoredListGeocacheFilter;
+import cgeo.geocaching.filters.core.StoredSinceGeocacheFilter;
 import cgeo.geocaching.filters.core.TypeGeocacheFilter;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.models.Geocache;
@@ -113,6 +114,9 @@ public class FilterViewHolderCreator {
                         .setValueDisplayTextGetter(IConnector::getName)
                         .setValueDrawableGetter(ct -> ImageParam.id(R.drawable.ic_menu_upload)) , 1, true);
                 break;
+            case STORED_SINCE:
+                result = createStoredSinceFilterViewHolder();
+                break;
             default:
                 result = null;
                 break;
@@ -190,6 +194,16 @@ public class FilterViewHolderCreator {
             .setGeocacheValueGetter((f, c) -> CollectionStream.of(c.getLists()).map(allListsById::get).toSet());
 
         return new CheckboxFilterViewHolder<>(vgfa, 1, true);
+    }
+
+    private static IFilterViewHolder<?> createStoredSinceFilterViewHolder() {
+        return new ItemRangeSelectorViewHolder<>(
+            new ValueGroupFilterAccessor<Long, StoredSinceGeocacheFilter>()
+                .setSelectableValues(StoredSinceGeocacheFilter.getValueRange())
+                .setFilterValueGetter(f -> f.getValuesInRange(StoredSinceGeocacheFilter.getValueRange()))
+                .setFilterValueSetter(NumberRangeGeocacheFilter::setRangeFromValues)
+                .setValueDisplayTextGetter(s -> StoredSinceGeocacheFilter.toUserDisplayValue(s, false)),
+            (i, s) -> StoredSinceGeocacheFilter.toUserDisplayValue(s, true));
     }
 
 }

--- a/main/src/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
@@ -26,6 +26,9 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
     private ButtonToggleGroup statusFavorite = null;
     private ButtonToggleGroup statusWatchlist = null;
     private ButtonToggleGroup statusPremium = null;
+    private ButtonToggleGroup statusHasTrackable = null;
+    private ButtonToggleGroup statusHasOwnVote = null;
+    private ButtonToggleGroup statusHasOfflineLog = null;
     private ButtonToggleGroup statusSolvedMystery = null;
 
     @Override
@@ -48,8 +51,12 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         statusFavorite = createGroup(ll, StatusGeocacheFilter.StatusType.FAVORITE);
         statusWatchlist = createGroup(ll, StatusGeocacheFilter.StatusType.WATCHLIST);
         statusPremium = createGroup(ll, StatusGeocacheFilter.StatusType.PREMIUM);
+        statusHasTrackable = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_TRACKABLE);
+        statusHasOwnVote = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OWN_VOTE);
+        statusHasOfflineLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_LOG);
         statusSolvedMystery = createGroup(ll, StatusGeocacheFilter.StatusType.SOLVED_MYSTERY);
-        ButtonToggleGroup.alignWidths(statusOwn, statusFound, statusStored, statusFavorite, statusWatchlist, statusPremium, statusSolvedMystery);
+        ButtonToggleGroup.alignWidths(statusOwn, statusFound, statusStored, statusFavorite, statusWatchlist,
+            statusPremium, statusHasTrackable, statusHasOwnVote, statusHasOfflineLog, statusSolvedMystery);
 
         return ll;
     }
@@ -86,6 +93,9 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         setFromBoolean(statusFavorite, filter.getStatusFavorite());
         setFromBoolean(statusWatchlist, filter.getStatusWatchlist());
         setFromBoolean(statusPremium, filter.getStatusPremium());
+        setFromBoolean(statusHasTrackable, filter.getStatusHasTrackable());
+        setFromBoolean(statusHasOwnVote, filter.getStatusHasOwnVote());
+        setFromBoolean(statusHasOfflineLog, filter.getStatusHasOfflineLog());
         setFromBoolean(statusSolvedMystery, filter.getStatusSolvedMystery());
     }
 
@@ -105,6 +115,9 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         filter.setStatusFavorite(getFromGroup(statusFavorite));
         filter.setStatusWatchlist(getFromGroup(statusWatchlist));
         filter.setStatusPremium(getFromGroup(statusPremium));
+        filter.setStatusHasTrackable(getFromGroup(statusHasTrackable));
+        filter.setStatusHasOwnVote(getFromGroup(statusHasOwnVote));
+        filter.setStatusHasOfflineLog(getFromGroup(statusHasOfflineLog));
         filter.setStatusSolvedMystery(getFromGroup(statusSolvedMystery));
         return filter;
     }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -153,8 +153,8 @@ public class Geocache implements IWaypoint {
     // FIXME: this makes no sense to favor this over the other. 0 should not be a special case here as it is
     // in the range of acceptable values. This is probably the case at other places (rating etc.) too.
     private int votes = 0;
-    private float myVote = 0; // valid ratings are larger than zero
-    private int inventoryItems = 0;
+    private float myVote = 0.0f; // valid ratings are larger than zero
+    private int inventoryItems = -1;
     private final LazyInitializedList<String> attributes = new LazyInitializedList<String>() {
         @Override
         public List<String> call() {
@@ -1132,7 +1132,11 @@ public class Geocache implements IWaypoint {
      * @return the inventory size
      */
     public int getInventoryItems() {
-        return inventoryItems;
+        return Math.max(inventoryItems, 0);
+    }
+
+    public boolean hasInventoryItemsSet() {
+        return inventoryItems >= 0;
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/LocalizationUtils.java
+++ b/main/src/cgeo/geocaching/utils/LocalizationUtils.java
@@ -10,6 +10,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
 
+import androidx.annotation.ArrayRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.PluralsRes;
 import androidx.annotation.StringRes;
@@ -69,7 +70,21 @@ public final class LocalizationUtils {
         if (APPLICATION_CONTEXT == null) {
             return quantity + " " + fallback;
         }
-        return CgeoApplication.getInstance().getApplicationContext().getResources().getQuantityString(pluralId, quantity, quantity);
+        return APPLICATION_CONTEXT.getResources().getQuantityString(pluralId, quantity, quantity);
+    }
+
+    public static String[] getStringArray(@ArrayRes final int arrayId, final String ... fallback) {
+        if (APPLICATION_CONTEXT == null) {
+            return fallback == null ? new String[0] : fallback;
+        }
+        return APPLICATION_CONTEXT.getResources().getStringArray(arrayId);
+    }
+
+    public static int[] getIntArray(@ArrayRes final int arrayId, final int ... fallback) {
+        if (APPLICATION_CONTEXT == null) {
+            return fallback == null ? new int[0] : fallback;
+        }
+        return APPLICATION_CONTEXT.getResources().getIntArray(arrayId);
     }
 
     /**


### PR DESCRIPTION
rel to #10952: add things to status filter, add stored since filter

Status filter can now filter for "has trackables", "has own vote" and "has offline log":

![image](https://user-images.githubusercontent.com/6909759/124005087-f7e3d900-d9d8-11eb-94ca-7f8b531fee87.png)

New filter "stored since" allows for filtering of storage date/timestamp:

![image](https://user-images.githubusercontent.com/6909759/124005243-1f3aa600-d9d9-11eb-9dd1-9052ea1ace32.png)
