### PR TITLE
use correct tint for progress dialogs (fix #10793)

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -26,8 +26,9 @@
         <item name="colorSecondary">@color/colorAccent</item>
         <item name="colorSecondaryVariant">@color/colorAccent</item>
 
-        <!-- circular spinner color -->
+        <!-- some components aren't fully compatible with AppCompat, therefore we need these legacy style definitions -->
         <item name="android:indeterminateTint">@color/colorAccent</item>
+        <item name="android:progressTint">@color/colorAccent</item>
     </style>
 
     <!-- theme for alert dialogs -->


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/64581222/124167703-8e310100-daa4-11eb-9413-c850e9f527ed.png)

The solution seems to be even too easy, but it works... 😁