### PR TITLE
logout from active connectors, when restoring a settings backup

### DIFF
--- a/main/src/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.databinding.AuthorizationCredentialsActivityBinding;
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
@@ -100,6 +101,7 @@ public abstract class AbstractCredentialsAuthorizationActivity extends AbstractA
             loginDialog.dismiss();
             if (statusCode == StatusCode.NO_ERROR) {
                 setCredentials(credentials);
+                ConnectorFactory.forceRelog();
                 showToast(getAuthDialogCompleted());
                 setResult(RESULT_OK);
                 finish();


### PR DESCRIPTION
Today I had the issue, that although I had restored a settings backup with a different user account, the old/wrong account was still logged in...

I thought, I had seen some similar issues in our issue tracker, but I cannot find them... 🤷‍♂️ 

Anyway, something that is worth to fix ;-)