### PR TITLE
enlage cache list favo entry (fix #11044)

### DIFF
--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -134,7 +134,7 @@
 
     <!-- inventory and favorites -->
     <RelativeLayout
-        android:layout_width="35dip"
+        android:layout_width="40dip"
         android:layout_height="wrap_content"
         android:layout_marginBottom="1dip"
         android:layout_marginTop="1dip"
@@ -142,7 +142,7 @@
 
         <TextView
             android:id="@+id/inventory"
-            android:layout_width="35dip"
+            android:layout_width="match_parent"
             android:layout_height="22dip"
             android:layout_alignParentTop="true"
             android:layout_gravity="center_vertical|center_horizontal"
@@ -159,14 +159,13 @@
 
         <TextView
             android:id="@+id/favorite"
-            android:layout_width="35dip"
+            android:layout_width="match_parent"
             android:layout_height="22dp"
             android:layout_gravity="center"
-            android:ellipsize="end"
+            android:ellipsize="none"
             android:gravity="center"
             android:layout_below="@id/inventory"
-            android:lines="1"
-            android:maxLines="1"
+            android:singleLine="true"
             android:paddingLeft="3dip"
             android:paddingRight="3dip"
             android:paddingBottom="1dip"


### PR DESCRIPTION
## Description
- enlarge info column in cache list to accommodate four digit favo counters
- adapt favo counter styling to disallow ellipsizing

![image](https://user-images.githubusercontent.com/3754370/124319618-c60a7800-db7a-11eb-87db-6d464c194715.png)
