### PR TITLE
replace viewpagerindicator by another one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,10 +122,6 @@ allprojects {
 subprojects {
     repositories {
         mavenCentral()
-        // viewpager fork
-        maven {
-            url 'https://dl.bintray.com/alexeydanilov/maven'
-        }
         // Android Support libraries are now in an online Maven repository
         google()
         // integrate as last one - for versions by commit ID

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -381,9 +381,8 @@ dependencies {
     implementation 'androidx.browser:browser:1.3.0'
 
     // ViewPagerIndicator, view pager titles for cache details and similar view pager based activities
-    //             url 'https://dl.bintray.com/alexeydanilov/maven'
     // this is a fork of the original viewpager library
-    implementation 'com.viewpagerindicator:viewpagerindicator:2.4.3'
+    implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1.1@aar'
 
     // Zxing barcode reader integration
     implementation 'com.google.zxing:android-integration:3.3.0'


### PR DESCRIPTION
## Description
Update viewpager lib on `release` (by cherry-picking @bekuno's PR) to be able to compile `release` again (even if the old viewpager is no longer cached locally)
