### PR TITLE
set tint for ratingbar (fix #11063)

### DIFF
--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -42,7 +42,7 @@
         style="@style/cacheRatingBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="false"
+        android:layout_centerVertical="true"
         android:layout_gravity="center_horizontal"
         android:layout_toRightOf="@+id/value"
         android:baselineAligned="false"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -513,6 +513,10 @@
         <item name="android:max">5</item>
         <item name="android:stepSize">0.5</item>
         <item name="android:isIndicator">true</item>
+        <!-- show accented stars, but hide "unused parts" of the stars completely (merge into background) -->
+        <item name="android:progressTint">@color/colorAccent</item>
+        <item name="android:secondaryProgressTint">@color/colorBackground</item>
+        <item name="android:progressBackgroundTint">@color/colorBackground</item>
     </style>
 
     <!-- map progressbar style -->


### PR DESCRIPTION
## Description
- explicitly set a tint for ratingbar to override our general accent color for it
- instead of the old red color, which may be hard to differentiate from grey background for color-blind people, I've chosen blue as tint

|dark mode|light mode|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/124366314-2834ad00-dc4f-11eb-839e-9b6d0366d015.png)|![image](https://user-images.githubusercontent.com/3754370/124366289-e99ef280-dc4e-11eb-90d1-51b973fd5811.png)|

