### PR TITLE
avoid trackable image duplication on refresh (fix #11072)

### DIFF
--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -602,6 +602,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
 
                 AndroidRxUtils.bindActivity(activity, new HtmlImage(activity.geocode, true, false, false).fetchDrawable(trackable.getImage())).subscribe(trackableImage::setImageDrawable);
 
+                binding.image.removeAllViews();
                 binding.image.addView(trackableImage);
             }
         }


### PR DESCRIPTION
## Description
Avoid adding a trackable image twice (or multiple times) on refresh of trackable details page
