### PR TITLE
use same icons in filter and quick settings

### DIFF
--- a/main/res/drawable/map_circle.xml
+++ b/main/res/drawable/map_circle.xml
@@ -4,7 +4,7 @@
     android:height="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24"
-    android:tint="?android:textColorPrimary">
+    android:tint="@color/colorAccent">
   <path
       android:fillColor="#FF000000"
       android:pathData="M12,20C7.59,20 4,16.41 4,12 4,7.59 7.59,4 12,4c4.41,0 8,3.59 8,8 0,4.41 -3.59,8 -8,8M12,2C6.47,2 2,6.47 2,12 2,17.53 6.47,22 12,22 17.53,22 22,17.53 22,12 22,6.47 17.53,2 12,2"/>

--- a/main/res/drawable/map_hidetrack.xml
+++ b/main/res/drawable/map_hidetrack.xml
@@ -4,7 +4,7 @@
     android:height="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24"
-    android:tint="?android:textColorPrimary">
+    android:tint="@color/colorAccent">
   <path
       android:fillColor="#00000000"
       android:strokeColor="#FF000000"

--- a/main/res/drawable/map_status_archived.xml
+++ b/main/res/drawable/map_status_archived.xml
@@ -1,10 +1,10 @@
 <!-- taken (modified) from close-circle-outline / materialdesignicons-google -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
     android:height="24dp"
+    android:width="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24"
-    android:tint="?android:textColorPrimary">
+    android:tint="@color/archived_cache_color">
   <path
       android:fillColor="#FF000000"
       android:pathData="M12,20C7.59,20 4,16.41 4,12 4,7.59 7.59,4 12,4c4.41,0 8,3.59 8,8 0,4.41 -3.59,8 -8,8M12,2C6.47,2 2,6.47 2,12 2,17.53 6.47,22 12,22 17.53,22 22,17.53 22,12 22,6.47 17.53,2 12,2M17.09,5.5 L12,10.59 7.01,5.5 5.5,7.01 10.59,12 5.5,17.09 7.01,18.5 12,13.41 17.09,18.5 18.5,17.09 13.41,12 18.5,7.01Z"/>

--- a/main/res/drawable/map_status_disabled.xml
+++ b/main/res/drawable/map_status_disabled.xml
@@ -4,7 +4,7 @@
     android:width="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24"
-    android:tint="?android:textColorPrimary">
+    android:tint="@color/archived_cache_color">
      <path
       android:fillColor="#FF000000"
       android:pathData="M12,20C7.59,20 4,16.41 4,12 4,7.59 7.59,4 12,4c4.41,0 8,3.59 8,8 0,4.41 -3.59,8 -8,8M12,2C6.47,2 2,6.47 2,12 2,17.53 6.47,22 12,22 17.53,22 22,17.53 22,12 22,6.47 17.53,2 12,2M7.01,5.5 L5.5,7.01c3.8889,3.7696 8.056,7.956 11.59,11.49L18.5,17.09C14.5191,13.1432 10.6432,9.206 7.01,5.5Z"/>

--- a/main/res/layout/cache_filter_list_item.xml
+++ b/main/res/layout/cache_filter_list_item.xml
@@ -46,8 +46,8 @@
 
         <ImageView
             android:id="@+id/filter_drag"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"
+            android:layout_width="@dimen/buttonSize_iconButton"
+            android:layout_height="@dimen/buttonSize_iconButton"
             android:layout_centerVertical="true"
             android:layout_marginLeft="6dp"
             android:layout_marginRight="6dp"

--- a/main/res/layout/imagelist_item.xml
+++ b/main/res/layout/imagelist_item.xml
@@ -82,8 +82,8 @@
 
         <ImageView
             android:id="@+id/image_delete"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"
+            android:layout_width="@dimen/buttonSize_iconButton"
+            android:layout_height="@dimen/buttonSize_iconButton"
             android:layout_centerVertical="true"
             android:layout_marginLeft="6dp"
             android:scaleType="centerInside"
@@ -94,8 +94,8 @@
 
         <ImageView
             android:id="@+id/image_drag"
-            android:layout_width="@dimen/icon_size"
-            android:layout_height="@dimen/icon_size"
+            android:layout_width="@dimen/buttonSize_iconButton"
+            android:layout_height="@dimen/buttonSize_iconButton"
             android:layout_centerVertical="true"
             android:layout_marginLeft="6dp"
             android:layout_marginRight="6dp"

--- a/main/res/layout/twotexts_button_image_item.xml
+++ b/main/res/layout/twotexts_button_image_item.xml
@@ -49,8 +49,8 @@
 
     <ImageView
         android:id="@+id/img_right"
-        android:layout_width="@dimen/icon_size"
-        android:layout_height="@dimen/icon_size"
+        android:layout_width="@dimen/buttonSize_iconButton"
+        android:layout_height="@dimen/buttonSize_iconButton"
         android:layout_marginLeft="6dip"
         android:layout_marginRight="6dip"
         android:layout_marginTop="3dip"

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -43,11 +43,11 @@
     <!-- buttons -->
     <dimen name="textSize_buttonsPrimary">@dimen/textSize_detailsSecondary</dimen>
 
-    <!-- icons -->
-    <dimen name="icon_size">42dp</dimen>
-
     <!-- all other text -->
     <dimen name="textSize_detailsPrimary">16sp</dimen>
     <dimen name="textSize_detailsSecondary">14sp</dimen>
+
+    <!-- button size dimensions ====================================== -->
+    <dimen name="buttonSize_iconButton">42dp</dimen>
 
 </resources>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -181,8 +181,8 @@
     </style>
 
     <style name="button_icon_accent" parent="button">
-        <item name="android:layout_width">@dimen/icon_size</item>
-        <item name="android:layout_height">@dimen/icon_size</item>
+        <item name="android:layout_width">@dimen/buttonSize_iconButton</item>
+        <item name="android:layout_height">@dimen/buttonSize_iconButton</item>
         <item name="android:layout_margin">3dp</item>
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>

--- a/main/src/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
@@ -23,15 +23,15 @@ public class StatusGeocacheFilter extends BaseGeocacheFilter {
     private static final String FLAG_EXCLUDE_ARCHIVED = "exclude_archived";
 
     public enum StatusType {
-        OWNED(R.string.cache_filter_status_select_label_owned, "owned", ImageParam.id(R.drawable.ic_menu_myplaces)),
-        FOUND(R.string.cache_filter_status_select_label_found, "found", ImageParam.id(R.drawable.ic_menu_found)),
-        STORED(R.string.cache_filter_status_select_label_stored, "stored", ImageParam.id(R.drawable.ic_menu_save)),
+        OWNED(R.string.cache_filter_status_select_label_owned, "owned", ImageParam.id(R.drawable.marker_own)),
+        FOUND(R.string.cache_filter_status_select_label_found, "found", ImageParam.id(R.drawable.marker_found)),
+        STORED(R.string.cache_filter_status_select_label_stored, "stored", ImageParam.id(R.drawable.marker_stored)),
         FAVORITE(R.string.cache_filter_status_select_label_favorite, "favorite", ImageParam.emoji(EmojiUtils.SMILEY_LOVE)),
         WATCHLIST(R.string.cache_filter_status_select_label_watchlist, "watchlist", ImageParam.emoji(EmojiUtils.SMILEY_MONOCLE)),
         PREMIUM(R.string.cache_filter_status_select_label_premium, "premium", ImageParam.emoji(EmojiUtils.SPARKLES)),
         HAS_TRACKABLE(R.string.cache_filter_status_select_label_has_trackable, "has_trackable", ImageParam.id(R.drawable.trackable_all)),
         HAS_OWN_VOTE(R.string.cache_filter_status_select_label_has_own_vote, "has_own_vote", ImageParam.id(R.drawable.star_on)),
-        HAS_OFFLINE_LOG(R.string.cache_filter_status_select_label_has_offline_log, "has_offline_log", ImageParam.id(R.drawable.marker_note)),
+        HAS_OFFLINE_LOG(R.string.cache_filter_status_select_label_has_offline_log, "has_offline_log", ImageParam.id(R.drawable.marker_found_offline)),
         SOLVED_MYSTERY(R.string.cache_filter_status_select_label_solved_mystery, "solved_mystery", ImageParam.id(R.drawable.waypoint_puzzle), R.string.cache_filter_status_select_infotext_solved_mystery);
 
         @StringRes public final int labelId;

--- a/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -12,7 +12,6 @@ import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
-import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.functions.Action1;
 

--- a/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -7,10 +7,12 @@ import cgeo.geocaching.maps.routing.RoutingMode;
 import cgeo.geocaching.models.IndividualRoute;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.PersistableUri;
+import cgeo.geocaching.ui.ImageParam;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
@@ -53,16 +55,17 @@ public class MapSettingsUtils {
         showAutotargetIndividualRoute = isAutotargetIndividualRoute || (route != null && route.getNumSegments() > 0);
 
         final ArrayList<SettingsCheckboxModel> allCbs = new ArrayList<>();
-        final SettingsCheckboxModel foundCb = createCb(allCbs, R.string.map_showc_found, R.drawable.ic_menu_found, Settings.isExcludeFound(), Settings::setExcludeFound, true);
-        final SettingsCheckboxModel ownCb = createCb(allCbs, R.string.map_showc_own, R.drawable.ic_menu_myplaces, Settings.isExcludeMyCaches(), Settings::setExcludeMine, true);
-        final SettingsCheckboxModel disabledCb = createCb(allCbs, R.string.map_showc_disabled, R.drawable.ic_menu_disabled, Settings.isExcludeDisabledCaches(), Settings::setExcludeDisabled, true);
-        final SettingsCheckboxModel archivedCb = createCb(allCbs, R.string.map_showc_archived, R.drawable.ic_menu_archived, Settings.isExcludeArchivedCaches(), Settings::setExcludeArchived, true);
-        final SettingsCheckboxModel offlineLogCb = createCb(allCbs, R.string.map_showc_offlinelog, R.drawable.ic_menu_edit, Settings.isExcludeOfflineLog(), Settings::setExcludeOfflineLog, true);
-        final SettingsCheckboxModel wpOriginalCb = createCb(allCbs, R.string.map_showwp_original, R.drawable.ic_menu_waypoint, Settings.isExcludeWpOriginal(), Settings::setExcludeWpOriginal, true);
-        final SettingsCheckboxModel wpParkingCb = createCb(allCbs, R.string.map_showwp_parking, R.drawable.ic_menu_parking, Settings.isExcludeWpParking(), Settings::setExcludeWpParking, true);
-        final SettingsCheckboxModel wbVisitedCb = createCb(allCbs, R.string.map_showwp_visited, R.drawable.ic_menu_visited, Settings.isExcludeWpVisited(), Settings::setExcludeWpVisited, true);
-        final SettingsCheckboxModel trackCb = !PersistableUri.TRACK.hasValue() ? null : createCb(allCbs, R.string.map_show_track, R.drawable.ic_menu_hidetrack, Settings.isHideTrack(), Settings::setHideTrack, true);
-        final SettingsCheckboxModel circlesCb = createCb(allCbs, R.string.map_show_circles, R.drawable.ic_menu_circle, isShowCircles, Settings::setShowCircles, false);
+
+        final SettingsCheckboxModel foundCb = createCb(allCbs, R.string.map_showc_found, ImageParam.id(R.drawable.marker_found), Settings.isExcludeFound(), Settings::setExcludeFound, true);
+        final SettingsCheckboxModel ownCb = createCb(allCbs, R.string.map_showc_own, ImageParam.id(R.drawable.marker_own), Settings.isExcludeMyCaches(), Settings::setExcludeMine, true);
+        final SettingsCheckboxModel disabledCb = createCb(allCbs, R.string.map_showc_disabled,  R.drawable.map_status_disabled, Settings.isExcludeDisabledCaches(), Settings::setExcludeDisabled, true);
+        final SettingsCheckboxModel archivedCb = createCb(allCbs, R.string.map_showc_archived, R.drawable.map_status_archived, Settings.isExcludeArchivedCaches(), Settings::setExcludeArchived, true);
+        final SettingsCheckboxModel offlineLogCb = createCb(allCbs, R.string.map_showc_offlinelog, R.drawable.marker_found_offline, Settings.isExcludeOfflineLog(), Settings::setExcludeOfflineLog, true);
+        final SettingsCheckboxModel wpOriginalCb = createCb(allCbs, R.string.map_showwp_original, R.drawable.waypoint_waypoint, Settings.isExcludeWpOriginal(), Settings::setExcludeWpOriginal, true);
+        final SettingsCheckboxModel wpParkingCb = createCb(allCbs, R.string.map_showwp_parking, R.drawable.waypoint_pkg, Settings.isExcludeWpParking(), Settings::setExcludeWpParking, true);
+        final SettingsCheckboxModel wbVisitedCb = createCb(allCbs, R.string.map_showwp_visited, R.drawable.tick, Settings.isExcludeWpVisited(), Settings::setExcludeWpVisited, true);
+        final SettingsCheckboxModel trackCb = !PersistableUri.TRACK.hasValue() ? null : createCb(allCbs, R.string.map_show_track, R.drawable.map_hidetrack, Settings.isHideTrack(), Settings::setHideTrack, true);
+        final SettingsCheckboxModel circlesCb = createCb(allCbs, R.string.map_show_circles, R.drawable.map_circle, isShowCircles, Settings::setShowCircles, false);
 
         final MapSettingsDialogBinding dialogView = MapSettingsDialogBinding.inflate(LayoutInflater.from(Dialogs.newContextThemeWrapper(activity)));
 
@@ -151,16 +154,30 @@ public class MapSettingsUtils {
         return result;
     }
 
+    private static SettingsCheckboxModel createCb(final Collection<SettingsCheckboxModel> coll, @StringRes final int resTitle,  final ImageParam imageParam, final boolean currentValue, final Action1<Boolean> setValue, final boolean isNegated) {
+        final SettingsCheckboxModel result = new SettingsCheckboxModel(resTitle, imageParam, currentValue, setValue, isNegated);
+        coll.add(result);
+        return result;
+    }
+
     private static class SettingsCheckboxModel {
         @StringRes private final int resTitle;
-        @DrawableRes private final int resIcon;
+        private final ImageParam imageParam;
         private boolean currentValue;
         private final Action1<Boolean> setValue;
         private final boolean isNegated;
 
         SettingsCheckboxModel(@StringRes final int resTitle, @DrawableRes final int resIcon, final boolean currentValue, final Action1<Boolean> setValue, final boolean isNegated) {
             this.resTitle = resTitle;
-            this.resIcon = resIcon;
+            this.imageParam = ImageParam.id(resIcon);
+            this.currentValue = isNegated != currentValue;
+            this.setValue = setValue;
+            this.isNegated = isNegated;
+        }
+
+        SettingsCheckboxModel(@StringRes final int resTitle, final ImageParam imageParam, final boolean currentValue, final Action1<Boolean> setValue, final boolean isNegated) {
+            this.resTitle = resTitle;
+            this.imageParam = imageParam;
             this.currentValue = isNegated != currentValue;
             this.setValue = setValue;
             this.isNegated = isNegated;
@@ -171,7 +188,7 @@ public class MapSettingsUtils {
         }
 
         public void addToViewGroup(final Activity ctx, final ViewGroup viewGroup) {
-            final CheckBox cb = ViewUtils.addCheckboxItem(ctx, viewGroup, TextParam.id(resTitle), resIcon);
+            final CheckBox cb = ViewUtils.addCheckboxItem(ctx, viewGroup, TextParam.id(resTitle), imageParam);
             cb.setChecked(currentValue);
             cb.setOnCheckedChangeListener((v, c) -> this.currentValue = !this.currentValue);
         }

--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -181,6 +181,13 @@ public class ViewUtils {
         return ip.right;
     }
 
+    public static CheckBox addCheckboxItem(final Activity activity, @NonNull final ViewGroup viewGroup, final TextParam text, final ImageParam imageParam) {
+
+        final ImmutablePair<View, CheckBox> ip = createCheckboxItem(activity, viewGroup, text, imageParam, null);
+        viewGroup.addView(ip.left);
+        return ip.right;
+    }
+
     public static TextView createTextItem(final Context ctx, @StyleRes final int styleId, final TextParam text) {
         final TextView tv = new TextView(wrap(ctx), null, 0, styleId);
         text.applyTo(tv);

--- a/main/src/cgeo/geocaching/utils/EmojiUtils.java
+++ b/main/src/cgeo/geocaching/utils/EmojiUtils.java
@@ -72,10 +72,10 @@ public class EmojiUtils {
     // The newest emoji standard can be found here: https://unicode.org/emoji/charts/full-emoji-list.html
 
     public static final int SMILEY_LIKE = 0x1f600;
-    public static final int SMILEY_LOVE = 0x1f60d;
-    public static final int SMILEY_MONOCLE = 0x1f9d0;
+    public static final int SMILEY_LOVE = 0x1f499;
+    public static final int SMILEY_MONOCLE = 0x1f453;
     public static final int SPARKLES = 0x2728;
-
+    
 
     private static final EmojiSet[] symbols = {
         // category symbols


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
* use icons from map for "Found", "Owned" and "Has Offline Log" in FilterView and QuickSettings
* Use different icons for "On watchlist" and "Own favorite"

![image](https://user-images.githubusercontent.com/70113341/124364922-0c2c0e00-dc45-11eb-92fa-e821639f7982.png)  ![image](https://user-images.githubusercontent.com/70113341/124368366-c715d500-dc60-11eb-86a2-d792c7ded93c.png)

API 21
![image](https://user-images.githubusercontent.com/70113341/124368317-6d150f80-dc60-11eb-9a76-8bed685a29a5.png)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11060

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Similar to GC
![image](https://user-images.githubusercontent.com/70113341/124364940-2bc33680-dc45-11eb-968e-307cb5a8db9e.png)
