### PR TITLE
enlarge favo column just another bit (rel. to #11044)

### DIFF
--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -134,7 +134,7 @@
 
     <!-- inventory and favorites -->
     <RelativeLayout
-        android:layout_width="40dip"
+        android:layout_width="45dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="1dip"
         android:layout_marginTop="1dip"


### PR DESCRIPTION
## Description
Give favo column another 5dp to avoid truncating a four-digit favo count, see https://github.com/cgeo/cgeo/issues/11044#issuecomment-873489753
