### PR TITLE
partly revert logtemplate migration to TextInputLayout (fix #11024)

### DIFF
--- a/main/res/drawable/cursor.xml
+++ b/main/res/drawable/cursor.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <size android:width="2dp" />
-    <solid android:color="@color/colorAccent"  />
-</shape>

--- a/main/res/layout/template_preference_dialog.xml
+++ b/main/res/layout/template_preference_dialog.xml
@@ -7,16 +7,15 @@
     android:padding="8dp"
     tools:context=".settings.TemplateTextPreference" >
 
-    <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
-        <EditText
-            android:id="@+id/signature_dialog_text"
-            style="@style/textinput_embedded"
-            android:gravity="top|left"
-            android:inputType="textMultiLine|textCapSentences"
-            android:minLines="3"
-            android:hint="@string/init_signature"
-            android:autofillHints="@string/init_signature"/>
-    </com.google.android.material.textfield.TextInputLayout>
+    <EditText
+        android:id="@+id/signature_dialog_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="top|left"
+        android:inputType="textMultiLine|textCapSentences"
+        android:minLines="3"
+        android:hint="@string/init_signature"
+        android:autofillHints="@string/init_signature"/>
 
     <!-- @todo needs to get default button styling applied (button_full) as soon as preferences are migrated to PreferenceFragments etc. -->
     <Button

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -73,6 +73,7 @@
         <item name="android:colorBackground">@color/settings_colorBackgroundDark</item>
         <item name="android:dialogTheme">@style/settings.DialogTheme</item>
         <item name="android:alertDialogTheme">@style/settings.DialogTheme</item>
+
         <!-- icon resources - can be moved (without suffix "_white") to drawables-night when based on AppCompatActivity -->
         <item name="settings_cloud">@drawable/settings_cloud_white</item>
         <item name="settings_details">@drawable/settings_details_white</item>
@@ -112,8 +113,6 @@
         <item name="android:textColor">@color/settings_primary_selector_night</item>
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:background">@color/settings_colorDialogBackgroundDark</item>
-        <item name="android:windowBackground">@color/colorBackgroundTransparent</item>
         <item name="colorOnSurface">@color/colorAccent</item>
         <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
     </style>
@@ -122,8 +121,6 @@
         <item name="android:textColor">@color/settings_primary_selector_light</item>
         <item name="android:colorAccent">@color/colorAccent</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:background">@color/settings_colorDialogBackgroundLight</item>
-        <item name="android:windowBackground">@color/colorBackgroundTransparent</item>
         <item name="colorOnSurface">@color/colorAccent</item>
         <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
     </style>

--- a/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
+++ b/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
@@ -1,28 +1,21 @@
 package cgeo.geocaching.settings;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.log.LogTemplateProvider;
 import cgeo.geocaching.log.LogTemplateProvider.LogTemplate;
 import cgeo.geocaching.ui.dialog.Dialogs;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.PorterDuff;
-import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 
-import java.lang.reflect.Field;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -57,8 +50,6 @@ public class TemplateTextPreference extends DialogPreference {
 
         editText = view.findViewById(R.id.signature_dialog_text);
         editText.setText(getPersistedString(initialValue != null ? initialValue : StringUtils.EMPTY));
-        // @todo yet another workaround to be dismissed after migration of settings to PreferenceFragment
-        setCursorDrawableColor(editText, Settings.isLightSkin(getContext()) ? 0xff000000 : 0xffffffff);
         Dialogs.moveCursorToEnd(editText);
 
         final Button button = view.findViewById(R.id.signature_templates);
@@ -75,42 +66,10 @@ public class TemplateTextPreference extends DialogPreference {
                 final LogTemplate template = templates.get(position);
                 insertSignatureTemplate(template);
             });
-            final AlertDialog dialog = alert.create();
-            // @todo yet another workaround to be dismissed after migration of settings to PreferenceFragment
-            final int c = Build.VERSION.SDK_INT > 22 ? getContext().getColor(Settings.isLightSkin(getContext()) ? R.color.settings_colorDialogBackgroundLight : R.color.settings_colorDialogBackgroundDark) : CgeoApplication.getInstance().getResources().getColor(R.color.colorBackgroundSelected);
-            dialog.getListView().setBackgroundColor(c);
-            dialog.show();
+            alert.create().show();
         });
 
         super.onBindDialogView(view);
-    }
-
-    // @todo the whole method is yet another workaround to be dismissed after migration of settings to PreferenceFragment
-    @SuppressLint("UseCompatLoadingForDrawables")
-    public static void setCursorDrawableColor(final EditText editText, final int color) {
-        // adapted from https://stackoverflow.com/questions/11554078/set-textcursordrawable-programmatically
-        if (Build.VERSION.SDK_INT >= 29) {
-            editText.setTextCursorDrawable(R.drawable.cursor);
-        } else {
-            try {
-                final Field fCursorDrawableRes = TextView.class.getDeclaredField("mCursorDrawableRes");
-                fCursorDrawableRes.setAccessible(true);
-                final int mCursorDrawableRes = fCursorDrawableRes.getInt(editText);
-                final Field fEditor = TextView.class.getDeclaredField("mEditor");
-                fEditor.setAccessible(true);
-                final Object editor = fEditor.get(editText);
-                final Field fCursorDrawable = editor.getClass().getDeclaredField("mCursorDrawable");
-                fCursorDrawable.setAccessible(true);
-                final Drawable[] drawables = new Drawable[2];
-                drawables[0] = editText.getContext().getResources().getDrawable(mCursorDrawableRes);
-                drawables[1] = editText.getContext().getResources().getDrawable(mCursorDrawableRes);
-                drawables[0].setColorFilter(color, PorterDuff.Mode.SRC_IN);
-                drawables[1].setColorFilter(color, PorterDuff.Mode.SRC_IN);
-                fCursorDrawable.set(editor, drawables);
-            } catch (Throwable ignored) {
-            }
-        }
-        editText.setTextColor(color);
     }
 
     private void insertSignatureTemplate(final LogTemplate template) {


### PR DESCRIPTION
## Description
Partly reverts the logtemplate migration to `TextInputLayout` to avoid the side-effects involved.
IMHO it's not worth the effort to try to fix those side-effects by introducing so many workarounds (and so much time needed to find still missing ones), but better to wait for migration of settings to `PreferenceFragment` first.

After this PR, logtemplate preference will look like this:

![image](https://user-images.githubusercontent.com/3754370/124379007-dde61700-dcb4-11eb-9950-c0d5fb83d086.png).![image](https://user-images.githubusercontent.com/3754370/124378857-01f52880-dcb4-11eb-882a-5723ea89f4ea.png)
