### PR TITLE
fine-tune cache hint color for light mode (rel. to #11069)

### DIFF
--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -7,7 +7,7 @@
 
     <color name="colorText">@color/just_black</color>
     <color name="colorTextDark">#AA000000</color>
-    <color name="colorTextHint">#FFAAAAAA</color>
+    <color name="colorTextHint">#FF666666</color>
 
     <color name="colorTextHeadline">#88000000</color>
 


### PR DESCRIPTION
## Description
Adjusts hint color used for cache info (popup / cache details) for light mode, see https://github.com/cgeo/cgeo/pull/11071#issuecomment-873540732
