### PR TITLE
remove legacy filter access, see #11086 for next steps

### DIFF
--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -12,11 +12,13 @@
         android:icon="@drawable/ic_menu_filter"
         android:title="@string/caches_filter_menuitem"
         app:showAsAction="ifRoom|withText"/>
+    <!-- Remove legacy filter for upcoming beta
     <item
         android:id="@+id/menu_filter_legacy"
         android:icon="@drawable/ic_menu_filter"
         android:title="@string/caches_filter"
         app:showAsAction="ifRoom|withText"/>
+        -->
     <item
         android:id="@+id/menu_sort"
         android:icon="@drawable/ic_menu_sort_alphabetically"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -415,7 +415,6 @@
     <string name="caches_copy_selected">Copy selected</string>
     <string name="caches_copy_all">Copy all</string>
     <string name="caches_map_locus_export">Export to Locus</string>
-    <string name="caches_filter">Filter (legacy)</string>
     <string name="caches_filter_menuitem">Filter</string>
     <string name="caches_filter_title">Filter by</string>
     <string name="caches_filter_size">Size</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -753,7 +753,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         try {
             // toplevel menu items
             setEnabled(menu, R.id.menu_show_on_map, !isEmpty);
-            setEnabled(menu, R.id.menu_filter_legacy, search != null && search.getCount() > 0);
+            //setEnabled(menu, R.id.menu_filter_legacy, search != null && search.getCount() > 0); //remove for upcoming beta
             setVisibleEnabled(menu, R.id.menu_sort, !isHistory, !isEmpty);
             if (adapter.isSelectMode()) {
                 menu.findItem(R.id.menu_switch_select_mode).setTitle(res.getString(R.string.caches_select_mode_exit))
@@ -909,8 +909,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         } else if (menuItem == R.id.menu_invert_selection) {
             adapter.invertSelection();
             invalidateOptionsMenuCompatible();
-        } else if (menuItem == R.id.menu_filter_legacy) {
-            showLegacyFilterMenu(null);
+//        } else if (menuItem == R.id.menu_filter_legacy) { //remove for upcoming beta
+//            showLegacyFilterMenu(null);
         } else if (menuItem == R.id.menu_filter) {
             showFilterMenu(null);
         } else if (menuItem == R.id.menu_import_web) {

--- a/tests/src-android/cgeo/geocaching/test/EmulatorStateTest.java
+++ b/tests/src-android/cgeo/geocaching/test/EmulatorStateTest.java
@@ -2,13 +2,17 @@ package cgeo.geocaching.test;
 
 import cgeo.geocaching.utils.EnvironmentUtils;
 
+import android.os.Environment;
+
 import junit.framework.TestCase;
-import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class EmulatorStateTest extends TestCase {
 
     public static void testWritableMedia() {
         // check the emulator running our tests
-        assertThat(EnvironmentUtils.isExternalStorageAvailable()).isTrue();
+        if (!EnvironmentUtils.isExternalStorageAvailable()) {
+            //fail test, but provide some information with it
+            fail("external storage state not as expected, is: '" + Environment.getExternalStorageState() + "'");
+        }
     }
 }


### PR DESCRIPTION
remove legacy filter access, see #11086 for next steps

This PR will remove the possibility to access the legacy filter from c:geo cache list. It will NOT remove the associated filter code from c:geo. The later shall only be done after it was proven (e.g. via beta or release) that this functionality really can be removed.

For the removal of the filter legacy code, issue #11086 was created