### PR TITLE
adjust cacheslist spinner formatting (fix #10982)

### DIFF
--- a/main/res/layout/cachelist_spinneritem.xml
+++ b/main/res/layout/cachelist_spinneritem.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="?attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
-    android:layout_height="?attr/listPreferredItemHeight"
+    android:layout_height="?attr/dropdownListPreferredItemHeight"
     android:layout_gravity="left|center_vertical"
     android:minHeight="?attr/dropdownListPreferredItemHeight"
     android:orientation="vertical"
@@ -28,7 +28,7 @@
         android:ellipsize="end"
         style="?attr/subtitleTextStyle"
         android:textSize="@dimen/textSize_toolbarSecondary"
-        android:textColor="@color/colorTextActionBar"
+        android:textColor="@color/colorTextHintActionBar"
         tools:text="This is the subtitle"
         android:id="@android:id/text2"
         android:maxLines="1" />

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -23,6 +23,7 @@
     <color name="text_icon">#FFFFFFFF</color>
 
     <color name="colorTextActionBar">#FFE4E4E4</color>
+    <color name="colorTextHintActionBar">@color/colorTextHint</color>
     <color name="colorBackgroundActionBar">#FF303030</color>
 
     <!-- values needed only until settings activity is based on AppCompatActivity -->


### PR DESCRIPTION
## Description
- reverts additional spacing between entries to original value
- uses hint color for "number of caches" line
- see https://github.com/cgeo/cgeo/issues/10982#issuecomment-873549971 for screenshots
