### PR TITLE
fix linked apps' icon being black/white (fix #11078)

### DIFF
--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -241,7 +241,7 @@
 
                 <Button
                     android:id="@+id/send_to_whereyougo"
-                    style="@style/button_icon"
+                    style="@style/button_icon_colored"
                     android:layout_alignParentRight="true"
                     app:icon="@drawable/icon_gc_wherigo"
                     android:visibility="visible"
@@ -285,7 +285,7 @@
 
                 <Button
                     android:id="@+id/send_to_chirp"
-                    style="@style/button_icon"
+                    style="@style/button_icon_colored"
                     android:layout_alignParentRight="true"
                     app:icon="@drawable/icon_gc_chirpwolf"
                     android:visibility="visible"
@@ -329,7 +329,7 @@
 
                 <Button
                     android:id="@+id/send_to_alc"
-                    style="@style/button_icon"
+                    style="@style/button_icon_colored"
                     android:layout_alignParentRight="true"
                     app:icon="@drawable/icon_gc_alc"
                     android:visibility="visible"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -197,6 +197,12 @@
         <item name="materialThemeOverlay">@style/IconButtonThemeOverlay</item>
     </style>
 
+    <style name="button_icon_colored" parent="button_icon_accent">
+        <!-- display icon as colored image, without reverting all colors to tint color -->
+        <item name="iconTint">#FFFFFFFF</item>
+        <item name="iconTintMode">multiply</item>
+    </style>
+
      <style name="IconButtonThemeOverlay">
         <!-- For filled buttons, your theme's colorPrimary provides the default background color of the component -->
         <item name="colorPrimary">@color/colorText</item>


### PR DESCRIPTION
## Description
Keep the icons' colors for linked apps' icons on cache details page

![image](https://user-images.githubusercontent.com/3754370/124380974-57373700-dcc0-11eb-8658-380ad99ffa5a.png)
