### PR TITLE
set dialog background for settings in dark theme (fix #11096)

### DIFF
--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -115,6 +115,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorOnSurface">@color/colorAccent</item>
         <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
+        <item name="android:background">@color/settings_colorBackgroundDark</item>
     </style>
 
     <style name="settings.DialogTheme.light" parent="@style/Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
## Description
Fixes broken dialog's background for settings in dark theme
