### PR TITLE
improve icon button size and popup layout

### DIFF
--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -61,6 +61,7 @@
         android:layout_toRightOf="@+id/stars"
         android:gravity="center_vertical"
         android:textIsSelectable="false"
+        android:maxLines="1"
         android:visibility="gone"
         android:textColor="@color/colorText"
         tools:text="additional text"

--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -35,12 +35,13 @@
 
                 <Button
                     android:id="@+id/more_details"
-                    style="@style/button_small"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_toLeftOf="@id/offline_hint"
+                    style="@style/button_full"
+                    android:layout_height="@dimen/buttonSize_iconButton"
+                    android:layout_centerVertical="true"
+                    android:layout_margin="3dp"
                     android:insetTop="0dp"
+                    android:insetBottom="0dp"
+                    android:layout_toLeftOf="@id/offline_hint"
                     android:text="@string/popup_more" />
 
                 <Button
@@ -48,6 +49,7 @@
                     style="@style/button_icon"
                     app:icon="@drawable/ic_menu_hint"
                     android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true"
                     android:layout_alignBaseline="@id/more_details"
                     android:layout_marginLeft="0dp"
                     android:visibility="gone"

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -48,6 +48,6 @@
     <dimen name="textSize_detailsSecondary">14sp</dimen>
 
     <!-- button size dimensions ====================================== -->
-    <dimen name="buttonSize_iconButton">42dp</dimen>
+    <dimen name="buttonSize_iconButton">45dp</dimen>
 
 </resources>


### PR DESCRIPTION
See discussion in #11070

---

Fix some strange effects (before):


![Screenshot_20210705_220727_cgeo geocaching_copy_389x222](https://user-images.githubusercontent.com/64581222/124514528-8abbb380-dddd-11eb-8bde-2ef1d86b3f54.png)

A bit larger icon button size (as seen in the screenshots, this change is even nearly invisible):

![grafik](https://user-images.githubusercontent.com/64581222/124513769-d40b0380-dddb-11eb-82d4-861444f28082.png)

