### PR TITLE
add waypoint name to popup (fix #11110)

### DIFF
--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -82,8 +82,10 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
 
             details = new CacheDetailsCreator(getActivity(), binding.waypointDetailsList);
 
-            //Waypoint geocode
-            details.add(R.string.cache_geocode, wpCode);
+            //Waypoint name
+            if (StringUtils.isNotBlank(waypoint.getName())) {
+                details.add(R.string.cache_name, waypoint.getName());
+            }
             waypointDistance = details.addDistance(waypoint, waypointDistance);
             final String note = waypoint.getNote();
             if (StringUtils.isNotBlank(note)) {


### PR DESCRIPTION
## Description
- Displays the waypoint name in map's waypoint popup
- waypoint code remove from popup's content (as it is shown in the titlebar already)

![image](https://user-images.githubusercontent.com/3754370/124814456-4f98bc00-df66-11eb-8303-8708ba1367e4.png)
