### PR TITLE
unify list colors based on primary/secondary info level

### DIFF
--- a/main/res/layout/addresslist_item.xml
+++ b/main/res/layout/addresslist_item.xml
@@ -27,6 +27,7 @@
             android:scrollHorizontally="true"
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsPrimary"
+            android:textColor="@color/colorText_listsPrimary"
             tools:text="Address of place\nwith multiple lines"/>
 
         <TextView
@@ -39,6 +40,7 @@
             android:scrollHorizontally="true"
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsSecondary"
+            android:textColor="@color/colorText_listsSecondary"
             tools:text="distance"
             android:maxLines="1" />
 

--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -62,6 +62,7 @@
             android:scrollHorizontally="true"
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsPrimary"
+            android:textColor="@color/colorText_listsPrimary"
             tools:text="name" />
 
         <!-- cache attributes and other info -->
@@ -76,6 +77,7 @@
             android:scrollHorizontally="true"
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsSecondary"
+            android:textColor="@color/colorText_listsSecondary"
             tools:text="terrain, difficulty and others" />
     </LinearLayout>
 
@@ -100,6 +102,7 @@
             android:lines="1"
             android:scrollHorizontally="true"
             android:textSize="@dimen/textSize_listsSecondary"
+            android:textColor="@color/colorText_listsSecondary"
             android:maxLines="1" />
 
         <view
@@ -153,6 +156,7 @@
             android:text=""
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsSecondary"
+            android:textColor="@color/colorText_listsSecondary"
             android:textStyle="bold"
             tools:text="12"
             android:maxLines="1" />
@@ -172,6 +176,7 @@
             android:scrollHorizontally="true"
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsSecondary"
+            android:textColor="@color/colorText_listsSecondary"
             android:textStyle="bold"
             tools:text="345" />
     </RelativeLayout>

--- a/main/res/layout/cacheslist_item_select.xml
+++ b/main/res/layout/cacheslist_item_select.xml
@@ -22,6 +22,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary"
         tools:text="name"
         android:maxLines="1" />
 
@@ -43,6 +44,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText_listsSecondary"
         tools:text="geocode"
         android:maxLines="1" />
 

--- a/main/res/layout/downloader_item.xml
+++ b/main/res/layout/downloader_item.xml
@@ -30,6 +30,7 @@
         android:paddingLeft="10dip"
         android:layout_toRightOf="@id/action"
         android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary"
         tools:text="name"/>
 
     <TextView
@@ -45,6 +46,7 @@
         android:layout_below="@id/label"
         android:layout_toRightOf="@id/action"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText_listsSecondary"
         tools:text="info"
         android:maxLines="2" />
 

--- a/main/res/layout/imagelist_item.xml
+++ b/main/res/layout/imagelist_item.xml
@@ -47,6 +47,7 @@
                 android:ellipsize="end"
                 android:focusable="false"
                 android:textSize="@dimen/textSize_listsPrimary"
+                android:textColor="@color/colorText_listsPrimary"
                 android:lines="1"
                 tools:visibility="visible"
                 tools:text="Title of the image, might be a bit longer"/>
@@ -61,6 +62,7 @@
                 android:maxLines="3"
                 android:scrollHorizontally="true"
                 android:textSize="@dimen/textSize_listsSecondary"
+                android:textColor="@color/colorText_listsSecondary"
                 android:visibility="visible"
                 tools:visiblity="visible"
                 tools:text="Details: resolution, size, name"/>
@@ -74,6 +76,7 @@
                 android:focusable="false"
                 android:scrollHorizontally="true"
                 android:textSize="@dimen/textSize_listsSecondary"
+                android:textColor="@color/colorText_listsSecondary"
                 android:visibility="visible"
                 tools:visiblity="visible"
                 tools:text="Description for the image"

--- a/main/res/layout/pocketquery_item.xml
+++ b/main/res/layout/pocketquery_item.xml
@@ -41,6 +41,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary"
         android:paddingRight="5dip"
         android:layout_toLeftOf="@id/buttons"
         tools:text="name"/>
@@ -55,6 +56,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText_listsSecondary"
         android:layout_below="@id/label"
         android:layout_alignParentLeft="true"
         tools:text="info"

--- a/main/res/layout/trackable_item.xml
+++ b/main/res/layout/trackable_item.xml
@@ -24,6 +24,7 @@
         android:minHeight="?android:attr/listPreferredItemHeight"
         android:textAppearance="?android:attr/textAppearanceLarge"
         android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary"
         android:textIsSelectable="false"
         tools:text="trackable name"/>
 </LinearLayout>

--- a/main/res/layout/twotexts_button_image_item.xml
+++ b/main/res/layout/twotexts_button_image_item.xml
@@ -23,6 +23,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary"
         tools:text="title" />
     <TextView
         android:id="@+id/detail"
@@ -38,6 +39,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText_listsSecondary"
         tools:text="detail info" />
 
     <Button

--- a/main/res/layout/twotexts_twobuttons_item.xml
+++ b/main/res/layout/twotexts_twobuttons_item.xml
@@ -23,6 +23,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary"
         tools:text="title" />
     <TextView
         android:id="@+id/detail"
@@ -38,6 +39,7 @@
         android:scrollHorizontally="true"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorText_listsSecondary"
         tools:text="detail info" />
     <Button
         android:id="@+id/button_left"

--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -44,7 +44,7 @@
                 android:layout_height="wrap_content"
                 android:focusable="false"
                 android:textSize="@dimen/textSize_listsPrimary"
-                android:textColor="@color/colorText"
+                android:textColor="@color/colorText_listsPrimary"
                 tools:text="Description of the waypoint with a lot of small words so that an incorrect layout should easily be noticed"/>
 
             <TextView
@@ -58,7 +58,7 @@
                 android:lines="1"
                 android:scrollHorizontally="true"
                 android:textSize="@dimen/textSize_listsSecondary"
-                android:textColor="@color/colorTextHint"
+                android:textColor="@color/colorText_listsSecondary"
                 android:visibility="gone"
                 tools:visiblity="visible"
                 tools:text="Info"
@@ -77,7 +77,7 @@
         android:lines="1"
         android:scrollHorizontally="true"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorTextHint"
+        android:textColor="@color/colorText_listsSecondary"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="1.2.3.4.5N 6.7.8.9.10S"
@@ -95,7 +95,7 @@
         android:maxLines="1"
         android:scrollHorizontally="true"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorTextHint"
+        android:textColor="@color/colorText_listsSecondary"
         android:visibility="gone"
         android:text="@string/waypoint_calculated_coordinates"
         tools:visiblity="visible" />
@@ -108,7 +108,7 @@
         android:layout_marginLeft="12dp"
         android:focusable="false"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorText"
+        android:textColor="@color/colorText_listsSecondary"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="Note"/>
@@ -121,7 +121,7 @@
         android:layout_marginLeft="12dp"
         android:focusable="false"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorText"
+        android:textColor="@color/colorText_listsSecondary"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="User Note"/>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -10,18 +10,11 @@
 
     <color name="just_white">#FFFFFFFF</color>
     <color name="just_black">#FF000000</color>
-    <!--
-    <color name="link">#FF00C0FF</color>
-    <color name="button_enabled">#FF000000</color>
-    <color name="button_disabled">#66000000</color>
-    -->
     <color name="archived_cache_color">#FFAC0B0B</color>
-    <!--
-    <color name="button_default">#282828</color>
-    <color name="steel">#675C68</color>
-    -->
     <color name="text_icon">#FFFFFFFF</color>
 
+    <color name="colorText_listsPrimary">@color/colorText</color>
+    <color name="colorText_listsSecondary">@color/colorTextHint</color>
     <color name="colorTextActionBar">#FFE4E4E4</color>
     <color name="colorTextHintActionBar">@color/colorTextHint</color>
     <color name="colorBackgroundActionBar">#FF303030</color>


### PR DESCRIPTION
## Description
- see https://github.com/cgeo/cgeo/issues/11124#issuecomment-875827189
- unify text colors across all lists using `textSize_listsPrimary` / `textSize_listsSecondary` - we have new color variables `textColor_listsPrimary` and `textColor_listsSecondary` (which point to our default text color for primary text and to the dimmed "hint color" for secondary text)
