### PR TITLE
reduce font sizes for lists to 18sp/16sp (rel. to #11124)

### DIFF
--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -30,7 +30,7 @@
     <dimen name="textSize_headingSecondary">18sp</dimen>
 
     <!-- lists -->
-    <dimen name="textSize_listsPrimary">20sp</dimen>
+    <dimen name="textSize_listsPrimary">18sp</dimen>
     <dimen name="textSize_listsSecondary">16sp</dimen>
 
     <!-- calculator labels between input buttons -->


### PR DESCRIPTION
## Description
- reduce font size for lists to 18sp (primary) / 16sp (secondary) instead of 20sp/16sp
- see https://github.com/cgeo/cgeo/issues/11124#issuecomment-875076492
