### PR TITLE
override some colors in caches list (fix #11145)

### DIFF
--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -102,8 +102,8 @@
             android:lines="1"
             android:scrollHorizontally="true"
             android:textSize="@dimen/textSize_listsSecondary"
-            android:textColor="@color/colorText_listsSecondary"
-            android:maxLines="1" />
+            android:textColor="@color/colorText_listsPrimary"
+            android:maxLines="1" /><!-- explicitly use default text color here -->
 
         <view
             android:id="@+id/direction"
@@ -156,10 +156,10 @@
             android:text=""
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsSecondary"
-            android:textColor="@color/colorText_listsSecondary"
+            android:textColor="@color/colorText_listsPrimary"
             android:textStyle="bold"
             tools:text="12"
-            android:maxLines="1" />
+            android:maxLines="1" /><!-- explicitly use default text color here -->
 
         <TextView
             android:id="@+id/favorite"
@@ -176,9 +176,9 @@
             android:scrollHorizontally="true"
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_listsSecondary"
-            android:textColor="@color/colorText_listsSecondary"
+            android:textColor="@color/colorText_listsPrimary"
             android:textStyle="bold"
-            tools:text="345" />
+            tools:text="345" /><!-- explicitly use default text color here -->
     </RelativeLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Description
Override some colors (\*) in caches list for better contrast
(\*) distance, tb count, favo count

![image](https://user-images.githubusercontent.com/3754370/125113703-47b55500-e0e9-11eb-8278-b50e7f66674f.png).![image](https://user-images.githubusercontent.com/3754370/125113719-4c7a0900-e0e9-11eb-81ab-3218357e9b23.png)

