### PR TITLE
show cache geocode in wp popup only (fix #11155)

### DIFF
--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -119,7 +119,7 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         super.onPause();
     }
 
-    protected final void addCacheDetails() {
+    protected final void addCacheDetails(final boolean showGeocode) {
         assert cache != null;
 
         details.add(R.string.cache_name, TextUtils.coloredCacheText(cache, cache.getName()));
@@ -129,7 +129,9 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
         final String cacheSize = cache.showSize() ? " (" + cache.getSize().getL10n() + ")" : "";
         details.add(R.string.cache_type, cacheType + cacheSize);
 
-        details.add(R.string.cache_geocode, cache.getShortGeocode());
+        if (showGeocode) {
+            details.add(R.string.cache_geocode, cache.getShortGeocode());
+        }
         details.addCacheState(cache);
 
         cacheDistance = details.addDistance(cache, cacheDistance);

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -139,7 +139,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
             final LinearLayout layout = view.findViewById(R.id.details_list);
             details = new CacheDetailsCreator(getActivity(), layout);
 
-            addCacheDetails();
+            addCacheDetails(false);
 
             // offline use
             CacheDetailActivity.updateOfflineBox(view, cache, res, new RefreshCacheClickListener(), new DropCacheClickListener(), new StoreCacheClickListener(), new ShowHintClickListener(view), null, new StoreCacheClickListener());

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -109,7 +109,7 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             });
 
             details = new CacheDetailsCreator(getActivity(), binding.detailsList);
-            addCacheDetails();
+            addCacheDetails(true);
 
             final View view = getView();
             assert view != null;


### PR DESCRIPTION
## Description
Remove geocode from cache popup (but keep it in waypoint popup)

![image](https://user-images.githubusercontent.com/3754370/125125679-3c1e5a00-e0fa-11eb-913f-6ae752a24709.png).![image](https://user-images.githubusercontent.com/3754370/125125684-3fb1e100-e0fa-11eb-89ce-7e7ac911e148.png)
