### PR TITLE
change cache log details color (fix #11162)

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -499,7 +499,7 @@
         <item name="android:scrollHorizontally">true</item>
         <item name="android:singleLine">true</item>
         <item name="android:textSize">@dimen/textSize_detailsSecondary</item>
-        <item name="android:textColor">@color/colorText</item>
+        <item name="android:textColor">@color/colorTextHint</item>
     </style>
 
     <!-- separator between log author and log content -->


### PR DESCRIPTION
## Description
Dims the color for log item details for better separation of log entries.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/125136964-0edaa780-e10c-11eb-86c5-40a04ef6bcde.png)|![image](https://user-images.githubusercontent.com/3754370/125137410-eb642c80-e10c-11eb-854c-5d569f87abec.png)|
