### PR TITLE
rel to #11153: make results without finds count inconclusive

### DIFF
--- a/main/src/cgeo/geocaching/filters/core/FavoritesGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/FavoritesGeocacheFilter.java
@@ -30,12 +30,12 @@ public  class FavoritesGeocacheFilter extends NumberRangeGeocacheFilter<Float> {
 
     @Override
     public Float getValue(final Geocache cache) {
-        if (!percentage) {
+        if (!percentage || cache.getFavoritePoints() == 0) {
             return (float) cache.getFavoritePoints();
         }
         final int rawFindsCount = cache.getFindsCount();
 
-        return rawFindsCount == 0 ? (float) cache.getFavoritePoints() : ((float) cache.getFavoritePoints()) / rawFindsCount;
+        return rawFindsCount == 0 ? null : ((float) cache.getFavoritePoints()) / rawFindsCount;
     }
 
     @Override


### PR DESCRIPTION
rel to #11153: make results without finds count inconclusive

filter by percentage fav with inconclusive-inclusion turned OFF (gc.com and oc.de) 
-> gc.com caches are excluded, only correctly filtered oc.de caches show (just one in tis case):

![image](https://user-images.githubusercontent.com/6909759/125152134-e8882c80-e14a-11eb-9349-70c4e34d579c.png)

filter by percentage fav with inconclusive-inclusion turned ON (gc.com and oc.de) 
-> all gc.com caches are included together with the correctly filtered oc.de caches:

![image](https://user-images.githubusercontent.com/6909759/125152095-c2fb2300-e14a-11eb-8f89-d564847bfa84.png)

