### PR TITLE
convert leftover old edittext fields to material text layouts in distance and log entry filter

### DIFF
--- a/main/res/layout/cache_filter_activity.xml
+++ b/main/res/layout/cache_filter_activity.xml
@@ -66,9 +66,11 @@
 
         <TextView
             android:id="@+id/filter_storage_name"
+            android:textSize="@dimen/textSize_detailsPrimary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
+            android:layout_marginLeft="5dp"
             android:layout_toRightOf="@+id/filter_storage_save"
             android:layout_alignParentRight="true"
             android:ellipsize="end"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -551,6 +551,7 @@
     <string name="cache_filter_favorites_absolute">Absolute</string>
     <string name="cache_filter_favorites_percentage">Percentage</string>
 
+    <string name="cache_filter_distance_coordinates">Coordinates</string>
     <string name="cache_filter_distance_use_current_position">Use current position</string>
 
     <string name="cache_filter_status_select_all">All</string>
@@ -576,8 +577,8 @@
     <string name="cache_filter_status_exclude_disabled">Exclude Disabled</string>
     <string name="cache_filter_status_exclude_archived">Exclude Archived</string>
 
-    <string name="cache_filter_log_entry_foundby">Found by:</string>
-    <string name="cache_filter_log_entry_logtext">Log text:</string>
+    <string name="cache_filter_log_entry_foundby">Found by</string>
+    <string name="cache_filter_log_entry_logtext">Log text</string>
 
     <string name="cache_filter_stored_since_notstored">Not stored</string>
     <string name="cache_filter_stored_since_notstored_short">-</string>

--- a/main/src/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
 import static cgeo.geocaching.ui.ViewUtils.dpToPixel;
 
+import android.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
@@ -38,8 +39,9 @@ public class DistanceFilterViewHolder extends BaseFilterViewHolder<DistanceGeoca
         useCurrentPosition = ViewUtils.addCheckboxItem(getActivity(), ll, TextParam.id(R.string.cache_filter_distance_use_current_position), R.drawable.ic_menu_mylocation, null);
         useCurrentPosition.setChecked(true);
 
-        coordinate = new EditText(getActivity());
-        ll.addView(coordinate);
+        final Pair<View, EditText> coordField = ViewUtils.createTextField(getActivity(), null, TextParam.id(R.string.cache_filter_distance_coordinates), null, -1, 1, 1);
+        coordinate = coordField.second;
+        ll.addView(coordField.first);
 
         slider = new ContinuousRangeSlider(getActivity());
         slider.setScale(-0.2f, maxDistance + 0.2f, f -> {

--- a/main/src/cgeo/geocaching/filters/gui/LogEntryFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/LogEntryFilterViewHolder.java
@@ -3,13 +3,15 @@ package cgeo.geocaching.filters.gui;
 import cgeo.geocaching.R;
 import cgeo.geocaching.filters.core.LogEntryGeocacheFilter;
 import cgeo.geocaching.ui.ButtonToggleGroup;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
 import static cgeo.geocaching.ui.ViewUtils.dpToPixel;
 
+import android.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 public class LogEntryFilterViewHolder extends BaseFilterViewHolder<LogEntryGeocacheFilter> {
 
@@ -31,29 +33,17 @@ public class LogEntryFilterViewHolder extends BaseFilterViewHolder<LogEntryGeoca
         llp.setMargins(0, dpToPixel(20), 0, dpToPixel(5));
         ll.addView(inverseFoundBy, llp);
 
-        final TextView label1 = new TextView(getActivity(), null, 0, R.style.text_label);
-        label1.setText(R.string.cache_filter_log_entry_foundby);
-
-        llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        llp.setMargins(0, dpToPixel(5), 0, dpToPixel(0));
-        ll.addView(label1, llp);
-
-        foundByText = new EditText(getActivity(), null, 0, R.style.edittext_full);
-        llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        final Pair<View, EditText> foundByField = ViewUtils.createTextField(getActivity(), null, TextParam.id(R.string.cache_filter_log_entry_foundby), null, -1, 1, 1);
+        foundByText = foundByField.second;
+        llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         llp.setMargins(0, dpToPixel(0), 0, dpToPixel(5));
-        ll.addView(foundByText, llp);
+        ll.addView(foundByField.first, llp);
 
-        final TextView label2 = new TextView(getActivity(), null, 0, R.style.text_label);
-        label2.setText(R.string.cache_filter_log_entry_logtext);
-
-        llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-        llp.setMargins(0, dpToPixel(5), 0, 0);
-        ll.addView(label2, llp);
-
-        logText = new EditText(getActivity(), null, 0, R.style.edittext_full);
-        llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        final Pair<View, EditText> logTextField = ViewUtils.createTextField(getActivity(), null, TextParam.id(R.string.cache_filter_log_entry_logtext), null, -1, 1, 1);
+        logText = logTextField.second;
+        llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         llp.setMargins(0, dpToPixel(0), 0, dpToPixel(20));
-        ll.addView(logText, llp);
+        ll.addView(logTextField.first, llp);
 
         return ll;
     }

--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.ui;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.databinding.CheckboxItemBinding;
+import cgeo.geocaching.databinding.DialogEdittextBinding;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.functions.Func1;
 import cgeo.geocaching.utils.functions.Func2;
@@ -12,6 +14,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
+import android.text.method.ScrollingMovementMethod;
 import android.util.Pair;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
@@ -20,8 +23,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 import android.widget.ListView;
@@ -36,6 +41,7 @@ import androidx.annotation.StyleRes;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class ViewUtils {
@@ -198,6 +204,36 @@ public class ViewUtils {
         final Button button = (Button) LayoutInflater.from(wrap(root == null ? context : root.getContext())).inflate(R.layout.button_view, root, false);
         text.applyTo(button);
         return button;
+    }
+
+    public static Pair<View, EditText> createTextField(final Context context, final String currentValue, final TextParam label, @Nullable final TextParam suffix, final int inputType, final int minLines, final int maxLines) {
+        final DialogEdittextBinding binding = DialogEdittextBinding.inflate(LayoutInflater.from(context));
+        if (StringUtils.isNotBlank(currentValue)) {
+            binding.input.setText(currentValue);
+        }
+        if (label != null) {
+            binding.inputFrame.setHint(label.getText(context));
+        }
+        if (suffix != null) {
+            binding.inputFrame.setSuffixText(suffix.getText(context));
+        }
+        if (maxLines > 1) {
+            binding.input.setSingleLine(false);
+            binding.input.setLines(minLines);
+            binding.input.setMaxLines(maxLines);
+            binding.input.setImeOptions(EditorInfo.IME_FLAG_NO_ENTER_ACTION);
+            binding.input.setVerticalScrollBarEnabled(true);
+            binding.input.setMovementMethod(ScrollingMovementMethod.getInstance());
+            binding.input.setScrollBarStyle(View.SCROLLBARS_INSIDE_INSET);
+            binding.input.invalidate();
+            Dialogs.moveCursorToEnd(binding.input);
+        } else {
+            binding.input.setSingleLine();
+        }
+        if (inputType >= 0) {
+            binding.input.setInputType(inputType);
+        }
+        return new Pair<>(binding.getRoot(), binding.input);
     }
 
     public static ImmutablePair<View, CheckBox> createCheckboxItem(final Activity activity, @Nullable final ViewGroup context, final TextParam text, final ImageParam icon, final TextParam infoText) {

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -2,12 +2,12 @@ package cgeo.geocaching.ui.dialog;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.databinding.BottomsheetDialogWithActionbarBinding;
-import cgeo.geocaching.databinding.DialogEdittextBinding;
 import cgeo.geocaching.databinding.DialogTextCheckboxBinding;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.ShareUtils;
@@ -19,11 +19,10 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.InputType;
-import android.text.method.ScrollingMovementMethod;
+import android.util.Pair;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
 
@@ -299,33 +298,11 @@ public final class Dialogs {
      * @param callback      method to call on positive confirmation, gets current text as parameter
      */
     public static void input(final Activity activity, final String title, final String currentValue, final String label, final int inputType, final int minLines, final int maxLines, final Consumer<String> callback) {
-        final DialogEdittextBinding binding = DialogEdittextBinding.inflate(activity.getLayoutInflater());
-        if (StringUtils.isNotBlank(currentValue)) {
-            binding.input.setText(currentValue);
-        }
-        if (StringUtils.isNotBlank(label)) {
-            binding.inputFrame.setHint(label);
-        }
-        if (maxLines > 1) {
-            binding.input.setSingleLine(false);
-            binding.input.setLines(minLines);
-            binding.input.setMaxLines(maxLines);
-            binding.input.setImeOptions(EditorInfo.IME_FLAG_NO_ENTER_ACTION);
-            binding.input.setVerticalScrollBarEnabled(true);
-            binding.input.setMovementMethod(ScrollingMovementMethod.getInstance());
-            binding.input.setScrollBarStyle(View.SCROLLBARS_INSIDE_INSET);
-            binding.input.invalidate();
-            moveCursorToEnd(binding.input);
-        } else {
-            binding.input.setSingleLine();
-        }
-        if (inputType >= 0) {
-            binding.input.setInputType(inputType);
-        }
+        final Pair<View, EditText> textField = ViewUtils.createTextField(activity, currentValue, TextParam.text(label), null, inputType, minLines, maxLines);
         newBuilder(activity)
-            .setView(binding.getRoot())
+            .setView(textField.first)
             .setTitle(title)
-            .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> callback.accept(binding.input.getText().toString().trim()))
+            .setPositiveButton(android.R.string.ok, (dialog, whichButton) -> callback.accept(textField.second.getText().toString().trim()))
             .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> { })
             .show();
     }

--- a/main/src/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.ui.dialog;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.functions.Action2;
 import cgeo.geocaching.utils.functions.Func2;
 
@@ -12,7 +13,7 @@ import android.content.DialogInterface;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
-import android.view.LayoutInflater;
+import android.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Set;
 import static java.lang.Boolean.TRUE;
 
-import com.google.android.material.textfield.TextInputLayout;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -373,26 +373,18 @@ public class SimpleDialog {
      */
 
     public void input(final int inputType, @Nullable final String defaultValue, @Nullable final String label, @Nullable final String suffix, final Consumer<String> okayListener) {
-        final TextInputLayout editTextFrame = (TextInputLayout) LayoutInflater.from(context).inflate(R.layout.dialog_edittext, null);
-        final EditText editText = editTextFrame.findViewById(R.id.input);
-        editText.setInputType(inputType < 0 ? InputType.TYPE_TEXT_FLAG_CAP_SENTENCES | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_CLASS_TEXT : inputType);
-        editText.setText(defaultValue == null ? "" : defaultValue.trim());
-        if (StringUtils.isNotBlank(label)) {
-            editTextFrame.setHint("");
-        }
-        if (StringUtils.isNotBlank(suffix)) {
-            editTextFrame.setSuffixText(suffix);
-        }
+
+        final Pair<View, EditText> textField = ViewUtils.createTextField(getContext(), defaultValue, TextParam.text(label), TextParam.text(suffix), inputType, 1, 1);
 
         final AlertDialog.Builder builder = Dialogs.newBuilder(getContext());
         applyCommons(builder);
-        builder.setView(editTextFrame);
+        builder.setView(textField.first);
         // remove whitespaces added by autocompletion of Android keyboard before calling okayListener
-        builder.setPositiveButton(getPositiveButton(), (dialog, which) -> okayListener.accept(editText.getText().toString().trim()));
+        builder.setPositiveButton(getPositiveButton(), (dialog, which) -> okayListener.accept(textField.second.getText().toString().trim()));
         builder.setNegativeButton(getNegativeButton(), (dialog, whichButton) -> dialog.dismiss());
         final AlertDialog dialog = builder.create();
 
-        editText.addTextChangedListener(new TextWatcher() {
+        textField.second.addTextChangedListener(new TextWatcher() {
 
             @Override
             public void onTextChanged(final CharSequence s, final int start, final int before, final int count) {
@@ -410,12 +402,12 @@ public class SimpleDialog {
             }
         });
         // force keyboard
-        Keyboard.show(getContext(), editText);
+        Keyboard.show(getContext(), textField.second);
 
         // disable button
         dialog.show();
         enableDialogButtonIfNotEmpty(dialog, String.valueOf(defaultValue));
-        Dialogs.moveCursorToEnd(editText);
+        Dialogs.moveCursorToEnd(textField.second);
         adjustCommons(dialog);
     }
 


### PR DESCRIPTION
Convert leftover old edittext fields to material text layouts in distance and log entry filter:

![image](https://user-images.githubusercontent.com/6909759/125167315-3418f580-e1a0-11eb-97da-eaff8b11d336.png)
