### PR TITLE
remember last set map language (fix #11089)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -88,7 +88,7 @@
     <string translatable="false" name="pref_choose_list">choose_list</string>
     <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
     <string translatable="false" name="pref_mapsource">mapsource</string>
-    <string translatable="false" name="pref_maplanguage">maplanguage</string>
+    <string translatable="false" name="pref_mapLanguage">mapLanguage</string>
     <string translatable="false" name="pref_mapRotation">mapRotation</string>
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_zoomincludingwaypoints">zoomincludingwaypoints</string>

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class MapProviderFactory {
 
-    public static final int MAP_LANGUAGE_DEFAULT = 432198765;
+    public static final int MAP_LANGUAGE_DEFAULT_ID = 432198765;
 
     //use a linkedhashmap to keep track of insertion order (c:geo uses this to control menu order of map sources)
     private static final HashMap<String, MapSource> mapSources = new LinkedHashMap<>();
@@ -143,9 +143,9 @@ public class MapProviderFactory {
     public static void addMapViewLanguageMenuItems(final Menu menu) {
         final MenuItem parentMenu = menu.findItem(R.id.menu_select_language);
         if (languages != null) {
-            final int currentLanguage = Settings.getMapLanguage();
+            final int currentLanguage = Settings.getMapLanguageId();
             final SubMenu subMenu = parentMenu.getSubMenu();
-            subMenu.add(R.id.menu_group_map_languages, MAP_LANGUAGE_DEFAULT, 0, R.string.switch_default).setCheckable(true).setChecked(MAP_LANGUAGE_DEFAULT == currentLanguage);
+            subMenu.add(R.id.menu_group_map_languages, MAP_LANGUAGE_DEFAULT_ID, 0, R.string.switch_default).setCheckable(true).setChecked(MAP_LANGUAGE_DEFAULT_ID == currentLanguage);
             for (int i = 0; i < languages.length; i++) {
                 final int languageId = languages[i].hashCode();
                 subMenu.add(R.id.menu_group_map_languages, languageId, i, languages[i]).setCheckable(true).setChecked(languageId == currentLanguage);

--- a/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -332,7 +332,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
 
         if (fis != null) {
             try {
-                return new MapFile((FileInputStream) fis, 0, MapProviderFactory.getLanguage(Settings.getMapLanguage()));
+                return new MapFile((FileInputStream) fis, 0, Settings.getMapLanguage());
             } catch (MapFileException mfe) {
                 Log.e("Problem opening map file '" + mapFileCtx + "'", mfe);
             }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -74,7 +74,7 @@ import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TrackUtils;
-import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT;
+import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT_ID;
 import static cgeo.geocaching.maps.mapsforge.v6.caches.CachesBundle.NO_OVERLAY_ID;
 
 import android.annotation.SuppressLint;
@@ -443,9 +443,9 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
             && !this.individualRouteUtils.onOptionsItemSelected(id, individualRoute, this::centerOnPosition, this::setTarget)
             && !DownloaderUtils.onOptionsItemSelected(this, id)) {
             final String language = MapProviderFactory.getLanguage(id);
-            if (language != null || id == MAP_LANGUAGE_DEFAULT) {
+            if (language != null || id == MAP_LANGUAGE_DEFAULT_ID) {
                 item.setChecked(true);
-                changeLanguage(id);
+                changeLanguage(language);
                 return true;
             } else {
                 final MapSource mapSource = MapProviderFactory.getMapSource(id);
@@ -584,8 +584,8 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
         }
     }
 
-    private void changeLanguage(final int languageId) {
-        Settings.setMapLanguage(languageId);
+    private void changeLanguage(final String language) {
+        Settings.setMapLanguage(language);
         mapRestart();
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -37,7 +37,7 @@ import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.utils.CryptUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
-import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT;
+import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT_ID;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -1033,12 +1033,19 @@ public class Settings {
         }
     }
 
-    public static void setMapLanguage(final int languageId) {
-        putInt(R.string.pref_maplanguage, languageId);
+    public static void setMapLanguage(@Nullable final String language) {
+        putString(R.string.pref_mapLanguage, StringUtils.isBlank(language) ? "" : language);
     }
 
-    public static int getMapLanguage() {
-        return getInt(R.string.pref_maplanguage, MAP_LANGUAGE_DEFAULT);
+    @Nullable
+    public static String getMapLanguage() {
+        final String language = getString(R.string.pref_mapLanguage, null);
+        return StringUtils.isBlank(language) ? null : language;
+    }
+
+    public static int getMapLanguageId() {
+        final String language = getMapLanguage();
+        return StringUtils.isBlank(language) ? MAP_LANGUAGE_DEFAULT_ID : language.hashCode();
     }
 
     public static void setMapDownloaderSource(final int source) {


### PR DESCRIPTION
## Description
- remember last set map language
- store as string to be able to use it on opening the map file directly (no translation needed)
- changing the settings type (and name) will requires users which use a map language, to re-store it once after updating
