### PR TITLE
hide friends-log page if the setting is deactivated

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2437,7 +2437,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (cache.supportsLogging() || !cache.getLogs().isEmpty()) {
                 pages.add(Page.LOGS.id);
             }
-            if (CollectionUtils.isNotEmpty(cache.getFriendsLogs())) {
+            if (CollectionUtils.isNotEmpty(cache.getFriendsLogs()) && Settings.isFriendLogsWanted()) {
                 pages.add(Page.LOGSFRIENDS.id);
             }
             if (CollectionUtils.isNotEmpty(cache.getInventory()) || CollectionUtils.isNotEmpty(genericTrackables)) {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
hides the page to view own and friends-log if the setting is not deactivated.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11167 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
keeping old behaviour: friends-logs are not fetched from server, so refreshing an offline stored cache is still necessary to show friends log on activating the setting