### PR TITLE
unify accent color across themes (fix #11170)

### DIFF
--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -3,8 +3,6 @@
 
     <!-- dark theme-specific colors only -->
 
-    <color name="colorAccent">#F5981D</color>
-
     <color name="colorText">@color/just_white</color>
     <color name="colorTextDark">#AAFFFFFF</color>
     <color name="colorTextHint">#A0CCCCCC</color>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -8,6 +8,8 @@
         for dark theme-specific colors see values-night/colors.xml
     -->
 
+    <color name="colorAccent">#F5981D</color>
+
     <color name="just_white">#FFFFFFFF</color>
     <color name="just_black">#FF000000</color>
     <color name="archived_cache_color">#FFAC0B0B</color>

--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -3,8 +3,6 @@
 
     <!-- light theme-specific colors only -->
 
-    <color name="colorAccent">#F4AC4E</color>
-
     <color name="colorText">@color/just_black</color>
     <color name="colorTextDark">#AA000000</color>
     <color name="colorTextHint">#FF666666</color>


### PR DESCRIPTION
## Description
unify accent color using the current dark theme accent color for both themes, which results in a higher contrast for light theme compared to current light theme accent color

see https://github.com/cgeo/cgeo/issues/11170#issuecomment-877857919
