### PR TITLE
remove 'remove list' dialog (fix #11081)

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -975,17 +975,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         return true;
     }
 
-    private void checkIfEmptyAndRemoveAfterConfirm() {
-        final boolean isNonDefaultList = isConcreteList() && listId != StoredList.STANDARD_LIST_ID;
-        // Check local cacheList first, and Datastore only if needed (because of filtered lists)
-        // Checking is done in this order for performance reasons
-        if (isNonDefaultList && CollectionUtils.isEmpty(cacheList)
-                && DataStore.getAllStoredCachesCount(CacheType.ALL, listId) == 0) {
-            // ask user, if he wants to delete the now empty list
-            SimpleDialog.of(this).setTitle(R.string.list_dialog_remove_title).setMessage(R.string.list_dialog_remove_nowempty).setButtons(SimpleDialog.ButtonTextSet.YES_NO).confirm((dialog, whichButton) -> removeListInternal());
-        }
-    }
-
     private boolean cacheToShow() {
         if (search == null || CollectionUtils.isEmpty(cacheList)) {
             showToast(res.getString(R.string.warn_no_cache_coord));
@@ -2074,15 +2063,16 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         showProgress(false);
         hideLoading();
         invalidateOptionsMenuCompatible();
+        /* expand following block if necessary
         if (arg0 instanceof AbstractSearchLoader) {
             switch (((AbstractSearchLoader) arg0).getAfterLoadAction()) {
                 case CHECK_IF_EMPTY:
-                    checkIfEmptyAndRemoveAfterConfirm();
                     break;
                 case NO_ACTION:
                     break;
             }
         }
+        */
     }
 
     @Override


### PR DESCRIPTION
## Description
Removes the "remove list" dialog which is not only shown after removing all caches from a list, but also when entering an empty list
