### PR TITLE
Fix #11014 - Action bar coloring

### DIFF
--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -14,6 +14,7 @@
     <color name="colorBackgroundTransparent">#44000000</color>
     <color name="colorBackgroundDialog">#FF424242</color>
     <color name="colorBackgroundSelected">#FF444444</color>
+    <color name="colorBackgroundActionBar">#FF202020</color>
 
     <color name="colorSeparator">#44FFFFFF</color>
 

--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -8,6 +8,7 @@
     <color name="colorTextHint">#A0CCCCCC</color>
 
     <color name="colorTextHeadline">#88FFFFFF</color>
+    <color name="colorTextHintActionBar">@color/colorTextHint</color>
 
     <color name="colorBackground">#FF141414</color>
     <color name="colorBackgroundNotice">#FF191919</color>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -19,7 +19,6 @@
     <color name="colorText_listsSecondary">@color/colorTextHint</color>
     <color name="colorTextActionBar">#FFE4E4E4</color>
     <color name="colorTextHintActionBar">@color/colorTextHint</color>
-    <color name="colorBackgroundActionBar">#FF303030</color>
 
     <!-- values needed only until settings activity is based on AppCompatActivity -->
     <color name="settings_colorTextDark">@color/just_white</color>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -18,7 +18,6 @@
     <color name="colorText_listsPrimary">@color/colorText</color>
     <color name="colorText_listsSecondary">@color/colorTextHint</color>
     <color name="colorTextActionBar">#FFE4E4E4</color>
-    <color name="colorTextHintActionBar">@color/colorTextHint</color>
 
     <!-- values needed only until settings activity is based on AppCompatActivity -->
     <color name="settings_colorTextDark">@color/just_white</color>

--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -8,6 +8,7 @@
     <color name="colorTextHint">#FF666666</color>
 
     <color name="colorTextHeadline">#88000000</color>
+    <color name="colorTextHintActionBar">#FFAAAAAA</color>
 
     <color name="colorBackground">#FFFFFFFF</color>
     <color name="colorBackgroundNotice">#FFDFDFDF</color>

--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -14,6 +14,7 @@
     <color name="colorBackgroundTransparent">#44FFFFFF</color>
     <color name="colorBackgroundDialog">#FFFFFFFF</color>
     <color name="colorBackgroundSelected">#FFCCCCCC</color>
+    <color name="colorBackgroundActionBar">#FF505050</color>
 
     <color name="colorSeparator">#44000000</color>
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Proposal for action bar coloring, screenshots see https://github.com/cgeo/cgeo/issues/11014#issuecomment-878147799

I took:
- FF202020 for dark theme
- FF505050 for white theme

@moving-bits Please check if I understood the mechanic of `values-night` correctly to split up the color. At least it looks working on my emulator.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fix #11014
