### PR TITLE
Let status notification background use ActionBarColor

### DIFF
--- a/main/res/drawable/helper_bcg.xml
+++ b/main/res/drawable/helper_bcg.xml
@@ -6,7 +6,7 @@
         android:width="2px"
         android:color="#99FFFFFF" />
 
-    <solid android:color="#FF191919" />
+    <solid android:color="@color/colorBackgroundActionBar" />
 
     <corners
         android:bottomLeftRadius="3dp"


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
To me it would look more consistent if the status notifcation (new version, etc) would use the action bar color, because then
- on black theme it is no longer in same color as the backgroun
- on white theme its no longer a dark black

|Current master|New look in combination with PR#11192|
|---|---|
|![Screenshot_1626089174](https://user-images.githubusercontent.com/949669/125281444-82e89b80-e316-11eb-8fd3-742c1fd147d3.png)|![Screenshot_1626089650](https://user-images.githubusercontent.com/949669/125281462-89771300-e316-11eb-8dfc-9c381a069471.png)

|Current master|New look in combination with PR#11192|
|---|---|
|![Screenshot_1626089187](https://user-images.githubusercontent.com/949669/125281513-998ef280-e316-11eb-99f4-bebf0442c50f.png)|![Screenshot_1626089483](https://user-images.githubusercontent.com/949669/125281543-a0b60080-e316-11eb-8cc2-1007e651bc7a.png)


## Related issues
<!-- List the related issues fixed or improved by this PR -->
None

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Please kindly doublecheck whether this `@drawable/helper_bcg.xml` is used elsewhere. I could not find any other spots yet.