### PR TITLE
Avoid cut off favcount and tbcount in lists

### DIFF
--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -108,7 +108,7 @@
         <view
             android:id="@+id/direction"
             android:layout_width="78dip"
-            android:layout_height="28px"
+            android:layout_height="28dip"
             android:layout_centerHorizontal="true"
             android:layout_gravity="center"
             android:layout_marginTop="21dip"

--- a/main/res/layout/cacheslist_item.xml
+++ b/main/res/layout/cacheslist_item.xml
@@ -146,9 +146,10 @@
         <TextView
             android:id="@+id/inventory"
             android:layout_width="match_parent"
-            android:layout_height="22dip"
+            android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_gravity="center_vertical|center_horizontal"
+            android:layout_marginBottom="1dip"
             app:drawableLeftCompat="@drawable/trackable_all"
             android:drawablePadding="-10sp"
             android:gravity="center"
@@ -164,7 +165,7 @@
         <TextView
             android:id="@+id/favorite"
             android:layout_width="match_parent"
-            android:layout_height="22dp"
+            android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:ellipsize="none"
             android:gravity="center"


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
I started looking through the layout while explicitly using the largest possible system font on my Google Pixel 3a.
This was one finding I tried to tackle here: The favorite count and also the inventory icon and count were cut off as they had a absolute height. I changed this to `wrap_content`. 
Furthermore added a 1dip margin below tbcount as otherwise it floats into the border of the favorite count.

Please review as these are my first steps into layout changes. :)

|Current release|This PR|
|---|---|
|![Screenshot_20210712-153827](https://user-images.githubusercontent.com/949669/125297392-79b3fa80-e327-11eb-8783-8753eecbda0a.png)|![Screenshot_20210712-153229](https://user-images.githubusercontent.com/949669/125297412-7f114500-e327-11eb-9d09-66d5d6d4e1f8.png)




## Related issues
<!-- List the related issues fixed or improved by this PR -->
None
