### PR TITLE
add more package names for Locus app (fix #11200)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -946,6 +946,12 @@
         <package android:name="de.wolffire.chirpwolf" />
         <package android:name="googoo.android.btgps" />
         <package android:name="menion.android.locus" />
+        <package android:name="menion.android.locus.free.amazon" />
+        <package android:name="menion.android.locus.free.samsung" />
+        <package android:name="menion.android.locus.pro" />
+        <package android:name="menion.android.locus.pro.amazon" />
+        <package android:name="menion.android.locus.pro.asamm" />
+        <package android:name="menion.android.locus.pro.computerBild" />
         <package android:name="menion.android.whereyougo" />
     </queries>
 


### PR DESCRIPTION
## Description
Locus app uses several package names, depending on free/pro state and on distribution channel, see `LocusUtil` that comes with the integration files.
This PR adds the package names yet missing to `AndroidManifest.xml` to be able to query that package on Android 11 systems.
