### PR TITLE
show wp count after tab title (fix #11175)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1260,15 +1260,7 @@
     <string name="cache_images">Images</string>
     <string name="cache_advanced">Advanced</string>
     <string name="cache_waypoints">Waypoints</string>
-    <plurals name="waypoints">
-        <item quantity="zero">%d waypoints</item>
-        <item quantity="one">%d waypoint</item>
-        <item quantity="two">%d waypoints</item>
-        <item quantity="few">%d waypoints</item>
-        <item quantity="many">%d waypoints</item>
-        <item quantity="other">%d waypoints</item>
-    </plurals>
-
+    <string name="waypoints_tabtitle" tools:ignore="PluralsCandidate">waypoints (%d)</string>
     <string name="cache_waypoints_add">Add Waypoint</string>
     <string name="cache_waypoints_add_currentLocation">Add current location</string>
     <string name="cache_waypoints_add_fromclipboard">Add from clipboard</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2422,7 +2422,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         // show number of waypoints directly in waypoint title
         if (pageId == Page.WAYPOINTS.id) {
             final int waypointCount = cache == null ? 0 : cache.getWaypoints().size();
-            return res.getQuantityString(R.plurals.waypoints, waypointCount, waypointCount);
+            return String.format(getString(R.string.waypoints_tabtitle), waypointCount);
         }
         return this.getString(Page.find(pageId).titleStringId);
     }


### PR DESCRIPTION
## Description
Show wp count after the tab title instead of in front of

![image](https://user-images.githubusercontent.com/3754370/125346622-4474d000-e35a-11eb-962b-bd8f7aeb0118.png)
