### PR TITLE
add MapsWithMe package name to AndroidManifest.xml (fix #11134)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -939,6 +939,8 @@
         <package android:name="com.google.android.street" />
         <package android:name="com.google.zxing.client.android" />
         <package android:name="com.groundspeak.react.adventures" />
+        <package android:name="com.mapwithme.maps.app" />
+        <package android:name="com.mapswithme.maps.pro" />
         <package android:name="com.silentlexx.gpslock" />
         <package android:name="com.sygic.aura" />
         <package android:name="com.sygic.aura_voucher" />

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -941,6 +941,7 @@
         <package android:name="com.groundspeak.react.adventures" />
         <package android:name="com.mapswithme.maps.app" />
         <package android:name="com.mapswithme.maps.pro" />
+        <package android:name="com.orux.oruxmapsDonate" />
         <package android:name="com.silentlexx.gpslock" />
         <package android:name="com.sygic.aura" />
         <package android:name="com.sygic.aura_voucher" />

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -939,7 +939,7 @@
         <package android:name="com.google.android.street" />
         <package android:name="com.google.zxing.client.android" />
         <package android:name="com.groundspeak.react.adventures" />
-        <package android:name="com.mapwithme.maps.app" />
+        <package android:name="com.mapswithme.maps.app" />
         <package android:name="com.mapswithme.maps.pro" />
         <package android:name="com.silentlexx.gpslock" />
         <package android:name="com.sygic.aura" />
@@ -949,6 +949,8 @@
         <package android:name="googoo.android.btgps" />
         <package android:name="menion.android.locus" />
         <package android:name="menion.android.whereyougo" />
+        <package android:name="net.osmand" />
+        <package android:name="net.osmand.plus" />
     </queries>
 
 </manifest>


### PR DESCRIPTION
## Description
Adds MapsWithMe package names to `AndroidManifest.xml` to be able to query those packages even when running on Android 11
