### PR TITLE
make actionbar font size independent of device settings

### DIFF
--- a/main/res/layout/cachelist_spinner_actionbar.xml
+++ b/main/res/layout/cachelist_spinner_actionbar.xml
@@ -3,12 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="?attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:layout_gravity="left|center_vertical"
-    android:minHeight="?attr/dropdownListPreferredItemHeight"
     android:orientation="vertical"
-    android:background="@color/colorBackgroundActionBar"
-    tools:context=".CacheListSpinnerAdapter" >
+    tools:context=".CacheListSpinnerAdapter">
 
     <TextView
         android:id="@android:id/text1"
@@ -19,7 +17,8 @@
         android:textSize="@dimen/textSize_toolbarPrimary"
         android:textColor="@color/colorTextActionBar"
         android:layout_height="wrap_content"
-        android:maxLines="1" />
+        android:maxLines="1"
+        tools:ignore="SpUsage" />
 
 
     <TextView
@@ -31,6 +30,7 @@
         android:textColor="@color/colorTextHintActionBar"
         tools:text="This is the subtitle"
         android:id="@android:id/text2"
-        android:maxLines="1" />
+        android:maxLines="1"
+        tools:ignore="SpUsage" />
 
 </LinearLayout>

--- a/main/res/layout/cachelist_spinner_dropdownitem.xml
+++ b/main/res/layout/cachelist_spinner_dropdownitem.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="?attr/spinnerDropDownItemStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="left|center_vertical"
+    android:minHeight="?attr/dropdownListPreferredItemHeight"
+    android:orientation="vertical"
+    android:foreground="?android:attr/selectableItemBackground"
+    android:background="@color/colorBackgroundActionBar"
+    tools:context=".CacheListSpinnerAdapter">
+
+    <TextView
+        android:id="@android:id/text1"
+        tools:text="This is the title"
+        android:ellipsize="end"
+        android:layout_width="match_parent"
+        style="?attr/titleTextStyle"
+        android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorTextActionBar"
+        android:layout_height="wrap_content"
+        android:maxLines="1" />
+
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        style="?attr/subtitleTextStyle"
+        android:textSize="@dimen/textSize_listsSecondary"
+        android:textColor="@color/colorTextHintActionBar"
+        tools:text="This is the subtitle"
+        android:id="@android:id/text2"
+        android:maxLines="1" />
+
+</LinearLayout>

--- a/main/res/layout/pq_actionbar.xml
+++ b/main/res/layout/pq_actionbar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="horizontal" >
@@ -15,7 +16,7 @@
         android:layout_toLeftOf="@id/switchAB"
         android:maxLines="1"
         android:ellipsize="end"
-        android:textSize="@dimen/textSize_toolbarSingle"
+        android:textSize="@dimen/textSize_toolbarPrimary"
         android:textColor="@color/colorTextActionBar"
         android:text="@string/menu_lists_pocket_queries" />
 
@@ -28,5 +29,6 @@
         android:gravity="right|center_vertical"
         android:textSize="@dimen/textSize_toolbarSecondary"
         android:textColor="@color/colorTextActionBar"
-        android:text="@string/show_all" />
+        android:text="@string/show_all"
+        tools:ignore="SpUsage" />
 </RelativeLayout>

--- a/main/res/layout/settings_toolbar.xml
+++ b/main/res/layout/settings_toolbar.xml
@@ -8,6 +8,6 @@
     android:minHeight="?attr/actionBarSize"
     app:navigationContentDescription="@string/abc_action_bar_up_description"
     app:navigationIcon="?attr/homeAsUpIndicator"
-    android:textSize="@dimen/textSize_toolbarSingle"
+    android:textSize="@dimen/textSize_toolbarPrimary"
     android:theme="@style/settings_actionbar_theme"
     />

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -21,9 +21,9 @@
     <!-- font size dimensions ====================================== -->
 
     <!-- all toolbars except main screen -->
-    <dimen name="textSize_toolbarSingle">20sp</dimen>
-    <dimen name="textSize_toolbarPrimary">18sp</dimen>
-    <dimen name="textSize_toolbarSecondary">16sp</dimen>
+    <!-- (we explicitly use dp for toolbar to avoid cuts offs and follow material guidelines) -->
+    <dimen name="textSize_toolbarPrimary">20dp</dimen>
+    <dimen name="textSize_toolbarSecondary">18dp</dimen>
 
     <!-- headings (not toolbar) -->
     <dimen name="textSize_headingPrimary">20sp</dimen>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -78,6 +78,7 @@
         <item name="android:textColor">@color/colorTextActionBar</item>
         <item name="background">@color/colorBackgroundActionBar</item>
         <item name="titleTextStyle">@style/action_bar_title</item>
+        <item name="subtitleTextStyle">@style/action_bar_subtitle</item>
     </style>
 
     <style name="actionBarActionOverflow" parent="Widget.AppCompat.ActionButton.Overflow">
@@ -120,8 +121,14 @@
         <item name="android:ellipsize">marquee</item>
         <item name="android:lines">1</item>
         <item name="android:text">c:geo</item>
-        <item name="android:textSize">@dimen/textSize_toolbarSingle</item>
+        <item name="android:textSize">@dimen/textSize_toolbarPrimary</item>
         <item name="android:textColor">@color/colorTextActionBar</item>
+    </style>
+
+    <style name="action_bar_subtitle" parent="action_bar_title">
+        <item name="android:textSize">@dimen/textSize_toolbarSecondary</item>
+        <item name="android:textColor">@color/colorTextHintActionBar</item>
+        <item name="android:text" />
     </style>
 
     <style name="settings_actionbar_theme" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">

--- a/main/src/cgeo/geocaching/CacheListSpinnerAdapter.java
+++ b/main/src/cgeo/geocaching/CacheListSpinnerAdapter.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 
 class CacheListSpinnerAdapter extends ArrayAdapter<AbstractList> {
@@ -27,23 +28,23 @@ class CacheListSpinnerAdapter extends ArrayAdapter<AbstractList> {
 
     @Override
     public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
-        return getCustomView(position, convertView, parent);
+        return getCustomView(position, convertView, parent, R.layout.cachelist_spinner_actionbar);
     }
 
 
     @Override
     public View getDropDownView(final int position, final View convertView, @NonNull final ViewGroup parent) {
-        return getCustomView(position, convertView, parent);
+        return getCustomView(position, convertView, parent, R.layout.cachelist_spinner_dropdownitem);
     }
 
-    public View getCustomView(final int position, final View convertView, final ViewGroup parent) {
+    public View getCustomView(final int position, final View convertView, final ViewGroup parent, final @LayoutRes int layoutRes) {
 
         View resultView = convertView;
         final LayoutInflater inflater = LayoutInflater.from(cacheListActivity);
 
         final CacheListSpinnerAdapter.ViewHolder holder;
         if (resultView == null) {
-            resultView = inflater.inflate(R.layout.cachelist_spinneritem, parent, false);
+            resultView = inflater.inflate(layoutRes, parent, false);
             holder = new ViewHolder();
             holder.title = resultView.findViewById(android.R.id.text1);
             holder.subtitle = resultView.findViewById(android.R.id.text2);


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/64581222/125497818-47796a3d-d535-4f82-964d-5a14ebfe3101.png)![grafik](https://user-images.githubusercontent.com/64581222/125499269-3ec8a2ba-4f38-4330-a41d-bb68080decc2.png)

Furthermore, I added the "Android Touch" effect to the spinner (like we have at many other places like cache list). I'm unsure about the background color. Both would easily possible:

action bar color (currently done in this PR)|popup background color
-|-
![grafik](https://user-images.githubusercontent.com/64581222/125493075-af655b9c-8001-4fba-b317-5f3cc4f3a835.png)|![grafik](https://user-images.githubusercontent.com/64581222/125492669-5d760d93-ab93-4a16-afa1-a1c5b7126a84.png)