### PR TITLE
Capitalize tab tile (follow-up to #11175)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1260,7 +1260,7 @@
     <string name="cache_images">Images</string>
     <string name="cache_advanced">Advanced</string>
     <string name="cache_waypoints">Waypoints</string>
-    <string name="waypoints_tabtitle" tools:ignore="PluralsCandidate">waypoints (%d)</string>
+    <string name="waypoints_tabtitle" tools:ignore="PluralsCandidate">Waypoints (%d)</string>
     <string name="cache_waypoints_add">Add Waypoint</string>
     <string name="cache_waypoints_add_currentLocation">Add current location</string>
     <string name="cache_waypoints_add_fromclipboard">Add from clipboard</string>


### PR DESCRIPTION
## Description
Follow-up to #11175: capitalize changed tab tile, see https://github.com/cgeo/cgeo/commit/48e48f7c783e7ccd15688853f61b4951d43be012#r53405011
