### PR TITLE
add "+" icon to "add filter criteria"

### DIFF
--- a/main/res/layout/cache_filter_activity.xml
+++ b/main/res/layout/cache_filter_activity.xml
@@ -37,7 +37,8 @@
             android:layout_centerVertical="true"
             android:gravity="center"
             android:layout_margin="6dp"
-            android:text="@string/cache_filter_add_button"/>
+            android:text="@string/cache_filter_add_button"
+            app:icon="@drawable/ic_menu_add" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
The button text is quite long, so the text might not be understandable, especially when using large font sizes:

![grafik](https://user-images.githubusercontent.com/64581222/125501565-5d820373-6c39-4316-b63d-5258356f313c.png)
![grafik](https://user-images.githubusercontent.com/64581222/125523120-66d4d304-6a69-4e17-afb5-cf28b8e0ae97.png)


When adding an icon in front, the meaning is much easier to understand in such cases:

![grafik](https://user-images.githubusercontent.com/64581222/125502078-6fe578d5-a0b1-423e-bc0b-984c96ce5591.png)
