### PR TITLE
make actionbar bg color a bit lighter in dark theme

### DIFF
--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -15,7 +15,7 @@
     <color name="colorBackgroundTransparent">#44000000</color>
     <color name="colorBackgroundDialog">#FF424242</color>
     <color name="colorBackgroundSelected">#FF444444</color>
-    <color name="colorBackgroundActionBar">#FF202020</color>
+    <color name="colorBackgroundActionBar">#FF303030</color>
 
     <color name="colorSeparator">#44FFFFFF</color>
 


### PR DESCRIPTION
## Description
As discussed in https://github.com/cgeo/cgeo/pull/11220#issuecomment-879400901 we should make the actionbar color a bit lighter in dark theme to be able to differentiate between regular background and actionbar dropdown background color:

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/125682132-8026f944-8a9b-43c8-b78f-d31111906d5f.png)|![image](https://user-images.githubusercontent.com/3754370/125682149-5279d818-dd6f-4964-95ad-c873e0bed1df.png)|
