### PR TITLE
use correct color for toolbar overflow menu (fix #11046)

### DIFF
--- a/main/res/layout/actionbar_popup.xml
+++ b/main/res/layout/actionbar_popup.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.Toolbar
+<com.google.android.material.appbar.MaterialToolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     android:theme="@style/tool_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@color/colorBackgroundActionBar"
     app:contentInsetStart="8dp" />

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -87,11 +87,8 @@
     <style name="tool_bar" parent="actionBarStyle">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">@dimen/actionbar_height</item>
-        <item name="android:orientation">horizontal</item>
-        <item name="android:gravity">center</item>
-        <item name="android:scaleType">center</item>
         <item name="colorControlNormal">@color/colorTextActionBar</item>
-        <item name="android:background">@color/colorBackgroundActionBar</item>
+        <item name="android:textColor">@color/colorText</item>
     </style>
 
     <style name="action_bar_action" parent="actionBarStyle">


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/64581222/125830763-f423de57-87a6-40cb-8a85-ac5fd005d16c.png)

Although my branch name points out, that I want to fix the elevation as well, I did not found a solution for it yet. But for now, let's start only with the coloring...