### PR TITLE
make some calculation vectordrawable compatible (fix #11248)

### DIFF
--- a/main/src/cgeo/geocaching/ui/CompassMiniView.java
+++ b/main/src/cgeo/geocaching/ui/CompassMiniView.java
@@ -7,14 +7,15 @@ import cgeo.geocaching.utils.AngleUtils;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PaintFlagsDrawFilter;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.res.ResourcesCompat;
 
 public final class CompassMiniView extends View {
     private Geopoint targetCoords = null;
@@ -63,7 +64,15 @@ public final class CompassMiniView extends View {
         super.onAttachedToWindow();
         if (instances++ == 0) {
             final int drawable = isInEditMode() || !Settings.isLightSkin(getContext()) ? R.drawable.compass_arrow_mini_white : R.drawable.compass_arrow_mini_black;
-            compassArrow = BitmapFactory.decodeResource(getResources(), drawable);
+            final Drawable temp = ResourcesCompat.getDrawable(getResources(), drawable, null);
+            try {
+                compassArrow = Bitmap.createBitmap(temp.getIntrinsicWidth(), temp.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+                final Canvas canvas = new Canvas(compassArrow);
+                temp.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+                temp.draw(canvas);
+            } catch (OutOfMemoryError e) {
+                throw new IllegalStateException();
+            }
             compassArrowWidth = compassArrow.getWidth();
             compassArrowHeight = compassArrow.getWidth();
         }

--- a/main/src/cgeo/geocaching/utils/CompactIconModeUtils.java
+++ b/main/src/cgeo/geocaching/utils/CompactIconModeUtils.java
@@ -4,11 +4,12 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
 
 import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 
 import androidx.core.content.res.ResourcesCompat;
+
+import java.util.Objects;
 
 public class CompactIconModeUtils {
 
@@ -18,12 +19,11 @@ public class CompactIconModeUtils {
         // utility class
     }
 
-
     public static void setCompactIconModeThreshold(final Resources resources) {
         // cache density metrics
-        final Bitmap marker = ((BitmapDrawable) ResourcesCompat.getDrawable(resources, R.drawable.marker, null)).getBitmap();
+        final Drawable marker = Objects.requireNonNull(ResourcesCompat.getDrawable(resources, R.drawable.marker, null));
         final DisplayMetrics displayMetrics = resources.getDisplayMetrics();
-        compactIconModeThreshold = (int) ((displayMetrics.heightPixels / marker.getHeight()) * (displayMetrics.widthPixels / marker.getWidth()) / 4f);
+        compactIconModeThreshold = (int) ((displayMetrics.heightPixels / marker.getIntrinsicHeight()) * (displayMetrics.widthPixels / marker.getIntrinsicWidth()) / 4f);
     }
 
     public static boolean forceCompactIconMode(final int size) {


### PR DESCRIPTION
## Description
- Remove the need for certain images to be bitmaps.
- Applies to "compact icon mode threshold calculation" and "mini compass view"

## Related issues
- related to #11139

@ztNFny 
Can you cross check whether this unblocks opening cache list and map even after full migration to svg (meaning: if this PR fixes issue #11248)?