### PR TITLE
fix #10951: merge map quick settings with global filter, create filter context, migrate global settings

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -66,11 +66,6 @@
     <string translatable="false" name="pref_ratingwanted">ratingwanted</string>
     <string translatable="false" name="pref_friendlogswanted">friendlogswanted</string>
     <string translatable="false" name="pref_opendetailslastpage">opendetailslastpage</string>
-    <string translatable="false" name="pref_excludemine">excludemine</string>
-    <string translatable="false" name="pref_excludefound">excludefound</string>
-    <string translatable="false" name="pref_excludedisabled">excludedisabled</string>
-    <string translatable="false" name="pref_excludearchived">excludearchived</string>
-    <string translatable="false" name="pref_excludeofflinelog">excludeofflinelog</string>
     <string translatable="false" name="pref_global_wp_extraction_disable">globalWpExtractionDisable</string>
     <string translatable="false" name="pref_excludeWpOriginal">excludeWpOriginal</string>
     <string translatable="false" name="pref_excludeWpParking">excludeWpParking</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -506,6 +506,10 @@
     <string name="cache_filtergroup_details">Details</string>
     <string name="cache_filtergroup_userspecific">User specific</string>
 
+    <string name="cache_filter_contexttype_live_title">Live Filter</string>
+    <string name="cache_filter_contexttype_offline_title">Offline Filter</string>
+    <string name="cache_filter_contexttype_transient_title">Filter</string>
+
 
     <string name="cache_filter_include">Include</string>
     <string name="cache_filter_exclude">Exclude</string>
@@ -773,11 +777,6 @@
     <string name="init_select_language">Select language</string>
     <string name="init_summary_select_language">Select in-app language (requires restart)\n</string>
     <string name="init_use_default_language">Use default language</string>
-    <string name="init_category_exclude">Exclude caches</string>
-    <string name="init_exclude_own">Exclude Own</string>
-    <string name="init_summary_exclude_own">Exclude caches you own </string>
-    <string name="init_exclude_found">Exclude Found</string>
-    <string name="init_summary_exclude_found">Exclude caches you have found</string>
     <string name="init_showwaypoints">Show Waypoints</string>
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_zoomincludingwaypoints">Zoom includes waypoints</string>
@@ -798,12 +797,6 @@
     <string name="init_summary_useInternalRouting">Use c:geo internal routing to be able to use automatic routing data downloading and other functions</string>
     <string name="init_bigSmileysOnMap">Big icons for logged caches</string>
     <string name="init_summary_bigSmileysOnMap">If enabled big emoticons will be shown for logged caches on the map instead of the cache type icon (requires restart).</string>
-    <string name="init_disabled">Exclude Disabled</string>
-    <string name="init_summary_disabled">Exclude disabled caches</string>
-    <string name="init_archived">Exclude Archived</string>
-    <string name="init_summary_archived">Exclude archived caches</string>
-    <string name="init_offlinelog">Exclude Offline Log</string>
-    <string name="init_summary_offlinelog">Exclude caches with Offline Log</string>
     <string name="init_global_wp_extraction_disable">Disable waypoint extraction</string>
     <string name="init_summary_global_wp_extraction_disable">Globally disable waypoint extraction from personal cache notes. It can still be enabled for individual caches by deactivating the checkbox below the personal cache note</string>
     <string name="init_customtabs_as_browser">Use Chrome WebView</string>
@@ -1562,6 +1555,8 @@
     <string name="map_show_caches_title">Show Caches:</string>
     <string name="map_show_waypoints_title">Show waypoints:</string>
     <string name="map_show_other_title">Show other:</string>
+    <string name="map_settings_cache_filter_too_complex_title">Cache filter too complex</string>
+    <string name="map_settings_cache_filter_too_complex_message">The current cache filter is too complex to apply additional options here. Usually this means that the cache filter contains NOT or OR expressions instead of simple AND logic.</string>
 
     <!-- search -->
     <string name="search_bar_hint">Search caches/trackables</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -553,34 +553,6 @@
             android:title="@string/init_customtabs_as_browser"
             android:summary="@string/init_summary_customtabs_as_browser" />
 
-        <PreferenceCategory android:title="@string/init_category_exclude"
-            android:layout="@layout/preference_category" >
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_excludemine"
-                android:summary="@string/init_summary_exclude_own"
-                android:title="@string/init_exclude_own" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_excludefound"
-                android:summary="@string/init_summary_exclude_found"
-                android:title="@string/init_exclude_found" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_excludedisabled"
-                android:summary="@string/init_summary_disabled"
-                android:title="@string/init_disabled" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_excludearchived"
-                android:summary="@string/init_summary_archived"
-                android:title="@string/init_archived" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_excludeofflinelog"
-                android:summary="@string/init_summary_offlinelog"
-                android:title="@string/init_offlinelog" />
-        </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -35,6 +35,7 @@ public class Intents {
     public static final String EXTRA_PQ_LIST_IMPORT = PREFIX + "pq_list_import";
     public static final String EXTRA_COORD_DESCRIPTION = PREFIX + "coord_description";
     public static final String EXTRA_WPT_PAGE_UPDATE = PREFIX + "wpt_page_update";
+    public static final String EXTRA_FILTER_CONTEXT = "filter_context";
 
     public static final String EXTRA_WPTTYPE = PREFIX + "wpttype";
     public static final String EXTRA_MAPSTATE = PREFIX + "mapstate";

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -8,7 +8,7 @@ import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableTrackingCode;
 import cgeo.geocaching.databinding.SearchActivityBinding;
-import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointFormatter;
@@ -287,7 +287,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     }
 
     private void findByFilterFn() {
-        GeocacheFilterActivity.selectFilter(this, GeocacheFilter.loadFromSettings(), null, false);
+        GeocacheFilterActivity.selectFilter(this, new GeocacheFilterContext(GeocacheFilterContext.FilterType.LIVE), null, false);
 
     }
 
@@ -295,8 +295,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     protected void onActivityResult(final int requestCode, final int resultCode, @Nullable final Intent data) {
 
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
-            final GeocacheFilter selectedFilter = GeocacheFilter.createFromConfig(data.getStringExtra(GeocacheFilterActivity.EXTRA_FILTER_RESULT));
-            CacheListActivity.startActivityFilter(this, selectedFilter);
+            CacheListActivity.startActivityFilter(this);
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -394,6 +394,7 @@ final class OkapiClient {
         final Geopoint usedCenter = center != null ? center : Sensors.getInstance().currentGeo().getCoords();
         final String centerString = GeopointFormatter.format(GeopointFormatter.Format.LAT_DECDEGREE_RAW, usedCenter) + SEPARATOR + GeopointFormatter.format(GeopointFormatter.Format.LON_DECDEGREE_RAW, usedCenter);
         valueMap.put("center", centerString);
+        valueMap.put("radius", "200");
         params.removeKey("search_method");
         params.put("search_method", METHOD_SEARCH_NEAREST);
     }
@@ -1062,7 +1063,7 @@ final class OkapiClient {
             }
         }
 
-        return SERVICE_CACHE_CORE_FIELDS;
+        return res.toString();
     }
 
     @NonNull

--- a/main/src/cgeo/geocaching/enumerations/CacheListType.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheListType.java
@@ -1,38 +1,41 @@
 package cgeo.geocaching.enumerations;
 
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.loaders.AbstractSearchLoader.CacheListLoaderType;
 
 import androidx.annotation.NonNull;
 
 public enum CacheListType {
-    OFFLINE(true, CacheListLoaderType.OFFLINE, true),
-    POCKET(false, CacheListLoaderType.POCKET),
-    HISTORY(true, CacheListLoaderType.HISTORY, true),
-    NEAREST(false, CacheListLoaderType.NEAREST),
-    COORDINATE(false, CacheListLoaderType.COORDINATE),
-    KEYWORD(false, CacheListLoaderType.KEYWORD),
-    ADDRESS(false, CacheListLoaderType.ADDRESS),
-    FINDER(false, CacheListLoaderType.FINDER),
-    OWNER(false, CacheListLoaderType.OWNER),
-    MAP(false, CacheListLoaderType.MAP),
-    SEARCH_FILTER(false, CacheListLoaderType.SEARCH_FILTER);
+    OFFLINE(true, CacheListLoaderType.OFFLINE, GeocacheFilterContext.FilterType.OFFLINE, true),
+    POCKET(false, CacheListLoaderType.POCKET, GeocacheFilterContext.FilterType.LIVE),
+    HISTORY(true, CacheListLoaderType.HISTORY, GeocacheFilterContext.FilterType.TRANSIENT, true),
+    NEAREST(false, CacheListLoaderType.NEAREST, GeocacheFilterContext.FilterType.LIVE),
+    COORDINATE(false, CacheListLoaderType.COORDINATE, GeocacheFilterContext.FilterType.LIVE),
+    KEYWORD(false, CacheListLoaderType.KEYWORD, GeocacheFilterContext.FilterType.LIVE),
+    ADDRESS(false, CacheListLoaderType.ADDRESS, GeocacheFilterContext.FilterType.LIVE),
+    FINDER(false, CacheListLoaderType.FINDER, GeocacheFilterContext.FilterType.LIVE),
+    OWNER(false, CacheListLoaderType.OWNER, GeocacheFilterContext.FilterType.LIVE),
+    MAP(false, CacheListLoaderType.MAP, GeocacheFilterContext.FilterType.TRANSIENT),
+    SEARCH_FILTER(false, CacheListLoaderType.SEARCH_FILTER, GeocacheFilterContext.FilterType.LIVE);
 
     /**
      * whether or not this list allows switching to another list
      */
     public final boolean canSwitch;
+    public final GeocacheFilterContext.FilterType filterContextType;
     public final boolean isStoredInDatabase;
 
     @NonNull public final CacheListLoaderType loaderType;
 
-    CacheListType(final boolean canSwitch, @NonNull final CacheListLoaderType loaderType) {
-        this(canSwitch, loaderType, false);
+    CacheListType(final boolean canSwitch, @NonNull final CacheListLoaderType loaderType, @NonNull final GeocacheFilterContext.FilterType filterContextType) {
+        this(canSwitch, loaderType, filterContextType, false);
     }
 
-    CacheListType(final boolean canSwitch, @NonNull final CacheListLoaderType loaderType, final boolean isStoredInDatabase) {
+    CacheListType(final boolean canSwitch, @NonNull final CacheListLoaderType loaderType, @NonNull final GeocacheFilterContext.FilterType filterContextType, final boolean isStoredInDatabase) {
         this.canSwitch = canSwitch;
         this.loaderType = loaderType;
         this.isStoredInDatabase = isStoredInDatabase;
+        this.filterContextType = filterContextType;
     }
 
     public int getLoaderId() {

--- a/main/src/cgeo/geocaching/filters/core/DistanceGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/DistanceGeocacheFilter.java
@@ -84,4 +84,15 @@ public class DistanceGeocacheFilter extends NumberRangeGeocacheFilter<Float> {
         addRangeToSqlBuilder(sqlBuilder, sql, v -> v * v);
     }
 
+    @Override
+    public boolean isFiltering() {
+        return super.isFiltering() || !useCurrentPosition;
+    }
+
+    @Override
+    protected String getUserDisplayableConfig() {
+        return GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT, getEffectiveCoordinate()) + "(" + super.getUserDisplayableConfig() + ")";
+    }
+
+
 }

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilterContext.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilterContext.java
@@ -1,0 +1,100 @@
+package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
+public class GeocacheFilterContext implements Parcelable {
+
+    public enum FilterType {
+        LIVE(R.string.cache_filter_contexttype_live_title),
+        OFFLINE(R.string.cache_filter_contexttype_offline_title),
+        TRANSIENT(R.string.cache_filter_contexttype_transient_title);
+
+        @StringRes
+        public final int titleId;
+
+        FilterType(@StringRes final int titleId) {
+            this.titleId = titleId;
+        }
+    }
+
+    private FilterType type;
+    private GeocacheFilter filter;
+
+    public GeocacheFilterContext(final FilterType type) {
+        setType(type);
+    }
+
+    @NonNull
+    public FilterType getType() {
+        return type;
+    }
+
+    public void setType(final FilterType type) {
+        this.type = type == null ? FilterType.TRANSIENT : type;
+        if (type == FilterType.TRANSIENT && filter == null) {
+            filter = GeocacheFilter.createEmpty();
+        }
+        if (type != FilterType.TRANSIENT) {
+            filter = null;
+        }
+    }
+
+    public GeocacheFilter get() {
+        if (type == FilterType.TRANSIENT) {
+            return filter;
+        }
+        return getForType(type);
+    }
+
+    public void set(final GeocacheFilter filter) {
+        if (type == FilterType.TRANSIENT) {
+            this.filter = filter == null ? GeocacheFilter.createEmpty() : filter;
+        } else {
+            Settings.setCacheFilterConfig(type.name(), filter.toConfig());
+        }
+    }
+
+    public static GeocacheFilter getForType(final FilterType type) {
+        if (type == FilterType.TRANSIENT) {
+            return GeocacheFilter.createEmpty();
+        }
+        return GeocacheFilter.createFromConfig(Settings.getCacheFilterConfig(type.name()));
+    }
+
+    public static final Creator<GeocacheFilterContext> CREATOR = new Creator<GeocacheFilterContext>() {
+        @Override
+        public GeocacheFilterContext createFromParcel(final Parcel in) {
+            final FilterType type = (FilterType) in.readSerializable();
+            final String filterConfig = in.readString();
+
+            final GeocacheFilterContext ctx = new GeocacheFilterContext(type);
+            if (filterConfig != null) {
+                ctx.set(GeocacheFilter.createFromConfig(filterConfig));
+            }
+            return ctx;
+        }
+
+        @Override
+        public GeocacheFilterContext[] newArray(final int size) {
+            return new GeocacheFilterContext[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeSerializable(type);
+        dest.writeString(filter == null ? null : filter.toConfig());
+    }
+}

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilterType.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilterType.java
@@ -51,8 +51,9 @@ public enum GeocacheFilterType {
         return this.typeId;
     }
 
-    public BaseGeocacheFilter create() {
-        final BaseGeocacheFilter gcf = supplier.get();
+    @SuppressWarnings("unchecked")
+    public <T extends BaseGeocacheFilter> T create() {
+        final T gcf = (T) supplier.get();
         gcf.setType(this);
         return gcf;
     }

--- a/main/src/cgeo/geocaching/loaders/CoordsGeocacheListLoader.java
+++ b/main/src/cgeo/geocaching/loaders/CoordsGeocacheListLoader.java
@@ -4,9 +4,11 @@ import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.filters.core.DistanceGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
+import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.LIVE;
 
 import android.app.Activity;
 
@@ -30,10 +32,10 @@ public class CoordsGeocacheListLoader extends AbstractSearchLoader {
     @Override
     public SearchResult runSearch() {
         //use filter search instead of dedicated distance search
-        final GeocacheFilter baseFilter = GeocacheFilter.loadFromSettings();
+        final GeocacheFilter coordFilter = GeocacheFilterContext.getForType(LIVE).and(getAdditionalFilterParameter());
 
         return nonEmptyCombineActive(ConnectorFactory.getSearchByFilterConnectors(GeocacheFilterType.DISTANCE),
-            connector -> connector.searchByFilter(baseFilter.and(getAdditionalFilterParameter())));
+            connector -> connector.searchByFilter(coordFilter));
     }
 
 }

--- a/main/src/cgeo/geocaching/loaders/KeywordGeocacheListLoader.java
+++ b/main/src/cgeo/geocaching/loaders/KeywordGeocacheListLoader.java
@@ -3,9 +3,11 @@ package cgeo.geocaching.loaders;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
 import cgeo.geocaching.filters.core.NameGeocacheFilter;
+import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.LIVE;
 
 import android.app.Activity;
 
@@ -30,10 +32,10 @@ public class KeywordGeocacheListLoader extends AbstractSearchLoader {
     @Override
     public SearchResult runSearch() {
         //use filter search instead of dedicated keyword search
-        final GeocacheFilter baseFilter = GeocacheFilter.loadFromSettings();
+        final GeocacheFilter useFilter = GeocacheFilterContext.getForType(LIVE).and(getAdditionalFilterParameter());
 
         return nonEmptyCombineActive(ConnectorFactory.getSearchByFilterConnectors(GeocacheFilterType.NAME),
-            connector -> connector.searchByFilter(baseFilter.and(getAdditionalFilterParameter())));
+            connector -> connector.searchByFilter(useFilter));
     }
 
 }

--- a/main/src/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -3,9 +3,11 @@ package cgeo.geocaching.loaders;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
+import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.LIVE;
 
 import android.app.Activity;
 
@@ -30,12 +32,10 @@ public class OwnerGeocacheListLoader extends AbstractSearchLoader {
     @Override
     public SearchResult runSearch() {
         //use filter search instead of dedicated owner search
-        final GeocacheFilter baseFilter = GeocacheFilter.loadFromSettings();
-
-
+        final GeocacheFilter useFilter = GeocacheFilterContext.getForType(LIVE).and(getAdditionalFilterParameter());
 
         return nonEmptyCombineActive(ConnectorFactory.getSearchByFilterConnectors(GeocacheFilterType.OWNER),
-            connector -> connector.searchByFilter(baseFilter.and(getAdditionalFilterParameter())));
+            connector -> connector.searchByFilter(useFilter));
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.interfaces.CachesOverlayItemImpl;
@@ -155,5 +156,9 @@ public abstract class AbstractMap {
     }
 
     public abstract Collection<Geocache> getCaches();
+
+     public abstract GeocacheFilterContext getFilterContext();
+
+     public abstract MapOptions getMapOptions();
 
 }

--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps;
 
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.settings.Settings;
 
@@ -56,7 +57,9 @@ public final class DefaultMap {
     }
 
     public static void startActivitySearch(final Activity fromActivity, final SearchResult search, final String title, final int fromList) {
-        startActivitySearch(fromActivity, getDefaultMapClass(), search, title, fromList);
+        final MapOptions mo = new MapOptions(search, title, fromList);
+        mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
+        mo.startIntent(fromActivity, getDefaultMapClass());
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/cgeo/geocaching/maps/MapOptions.java
@@ -4,9 +4,11 @@ import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.settings.Settings;
+import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.LIVE;
 
 import android.content.Context;
 import android.content.Intent;
@@ -28,6 +30,7 @@ public class MapOptions {
     public MapState mapState;
     public String title;
     public int fromList;
+    public GeocacheFilterContext filterContext = new GeocacheFilterContext(LIVE);
 
     public MapOptions(final Context context, @Nullable final Bundle extras) {
         if (extras != null) {
@@ -44,6 +47,7 @@ public class MapOptions {
                 waypointType = WaypointType.WAYPOINT;
             }
             fromList = extras.getInt(Intents.EXTRA_LIST_ID, StoredList.TEMPORARY_LIST.id);
+            filterContext = extras.getParcelable(Intents.EXTRA_FILTER_CONTEXT);
         } else {
             mapMode = MapMode.LIVE;
             isStoredEnabled = true;
@@ -102,6 +106,7 @@ public class MapOptions {
         intent.putExtra(Intents.EXTRA_MAPSTATE, mapState);
         intent.putExtra(Intents.EXTRA_TITLE, title);
         intent.putExtra(Intents.EXTRA_LIST_ID, fromList);
+        intent.putExtra(Intents.EXTRA_FILTER_CONTEXT, filterContext);
         return intent;
     }
 

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
@@ -36,7 +37,7 @@ public class MapUtils {
     }
 
     // filter waypoints from owned caches or certain wp types if requested.
-    public static void filter(final Set<Waypoint> waypoints, final boolean checkCacheFilters) {
+    public static void filter(final Set<Waypoint> waypoints, final GeocacheFilterContext filterContext, final boolean checkCacheFilters) {
         final boolean excludeMine = checkCacheFilters && Settings.isExcludeMyCaches();
         final boolean excludeFound = checkCacheFilters && Settings.isExcludeFound();
         final boolean excludeDisabled = checkCacheFilters && Settings.isExcludeDisabledCaches();
@@ -44,7 +45,7 @@ public class MapUtils {
         final boolean excludeOfflineLog = checkCacheFilters && Settings.isExcludeOfflineLog();
         final CacheType filterCacheType = checkCacheFilters ? null : (Settings.getCacheType() == null ? CacheType.ALL : Settings.getCacheType());
 
-        final GeocacheFilter filter = GeocacheFilter.loadFromSettings();
+        final GeocacheFilter filter = filterContext.get();
 
         final boolean excludeWpOriginal = Settings.isExcludeWpOriginal();
         final boolean excludeWpParking = Settings.isExcludeWpParking();
@@ -66,9 +67,9 @@ public class MapUtils {
     }
 
     /** Applies given filter to cache list. Additionally, creates a second list additionally filtered by own/found/disabled caches if required */
-    public static void filter(final Collection<Geocache> caches) {
+    public static void filter(final Collection<Geocache> caches, final GeocacheFilterContext filterContext) {
 
-        final GeocacheFilter filter = GeocacheFilter.loadFromSettings();
+        final GeocacheFilter filter = filterContext.get();
         filter.filterList(caches);
 
 
@@ -100,16 +101,16 @@ public class MapUtils {
 
     }
 
-    public static void openFilterActivity(final Activity activity, final Collection<Geocache> filteredList) {
+    public static void openFilterActivity(final Activity activity, final GeocacheFilterContext filterContext, final Collection<Geocache> filteredList) {
 
         GeocacheFilterActivity.selectFilter(
             activity,
-            GeocacheFilter.loadFromSettings(),
+            filterContext,
             filteredList, true);
     }
 
-    public static void setFilterBar(final Activity activity) {
-        final List<String> filterNames = getMapFilters();
+    public static void setFilterBar(final Activity activity, final GeocacheFilterContext filterContext) {
+        final List<String> filterNames = getMapFilters(filterContext);
         if (filterNames.isEmpty()) {
             activity.findViewById(R.id.filter_bar).setVisibility(GONE);
         } else {
@@ -120,14 +121,14 @@ public class MapUtils {
     }
 
     @NonNull
-    private static List<String> getMapFilters() {
+    private static List<String> getMapFilters(final GeocacheFilterContext filterContext) {
         final List<String> filters = new ArrayList<>();
         if (Settings.getCacheType() != CacheType.ALL) {
             filters.add(Settings.getCacheType().getL10n());
         }
 
-        final GeocacheFilter filter = GeocacheFilter.loadFromSettings();
-        if (filter.hasFilter()) {
+        final GeocacheFilter filter = filterContext.get();
+        if (filter.isFiltering()) {
             filters.add(filter.toUserDisplayableString());
         }
 

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -16,6 +16,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.IndividualRouteUtils;
 import cgeo.geocaching.utils.TrackUtils;
+import static cgeo.geocaching.filters.gui.GeocacheFilterActivity.EXTRA_FILTER_CONTEXT;
 import static cgeo.geocaching.maps.google.v2.GoogleMapUtils.isGoogleMapsAvailable;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
@@ -240,7 +241,8 @@ public class GoogleMapActivity extends AppCompatActivity implements MapActivityI
             */
         }
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
-            MapUtils.setFilterBar(this);
+            mapBase.getMapOptions().filterContext = data.getParcelableExtra(EXTRA_FILTER_CONTEXT);
+            mapBase.onMapSettingsPopupFinished(false);
         }
 
         this.trackUtils.onActivityResult(requestCode, resultCode, data);
@@ -250,7 +252,7 @@ public class GoogleMapActivity extends AppCompatActivity implements MapActivityI
 
     @Override
     public void showFilterMenu(final View view) {
-        MapUtils.openFilterActivity(this, mapBase.getCaches());
+        MapUtils.openFilterActivity(this, mapBase.getFilterContext(), mapBase.getCaches());
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.location.WaypointDistanceInfo;
@@ -40,6 +41,7 @@ public abstract class AbstractCachesOverlay {
     private final MapHandlers mapHandlers;
     private boolean invalidated = true;
     private boolean showCircles;
+    private GeocacheFilterContext filterContext;
     private final WeakReference<NewMap> mapRef;
 
     public AbstractCachesOverlay(final NewMap map, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers) {
@@ -135,6 +137,14 @@ public abstract class AbstractCachesOverlay {
                 }
             }
         }
+    }
+
+    protected void setFilterContext(final GeocacheFilterContext filterContext) {
+        this.filterContext = filterContext;
+    }
+
+    protected GeocacheFilterContext getFilterContext() {
+        return filterContext;
     }
 
     protected void update(final Set<Geocache> cachesToDisplay) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.location.WaypointDistanceInfo;
@@ -283,6 +284,21 @@ public class CachesBundle {
         }
         if (liveOverlay != null) {
             liveOverlay.switchCircles();
+        }
+    }
+
+    public void setFilterContext(final GeocacheFilterContext filterContext) {
+        if (wpOverlay != null) {
+            wpOverlay.setFilterContext(filterContext);
+        }
+        if (baseOverlay != null) {
+            baseOverlay.setFilterContext(filterContext);
+        }
+        if (storedOverlay != null) {
+            storedOverlay.setFilterContext(filterContext);
+        }
+        if (liveOverlay != null) {
+            liveOverlay.setFilterContext(filterContext);
         }
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/CachesOverlay.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Viewport;
+import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.mapsforge.v6.MapHandlers;
 import cgeo.geocaching.maps.mapsforge.v6.NewMap;
 import cgeo.geocaching.models.Geocache;
@@ -44,7 +45,7 @@ public class CachesOverlay extends AbstractCachesOverlay {
         return Schedulers.newThread().schedulePeriodicallyDirect(new CachesOverlay.LoadTimerAction(this), 0, 250, TimeUnit.MILLISECONDS);
     }
 
-    private static final class LoadTimerAction implements Runnable {
+    private final class LoadTimerAction implements Runnable {
 
         @NonNull
         private final WeakReference<CachesOverlay> overlayRef;
@@ -65,6 +66,7 @@ public class CachesOverlay extends AbstractCachesOverlay {
                 // Initially bring the main list in
                 if (overlay.firstRun || overlay.isInvalidated()) {
                     final Set<Geocache> cachesToDisplay = overlay.search.getCachesFromSearchResult(LoadFlags.LOAD_WAYPOINTS);
+                    MapUtils.filter(cachesToDisplay, getFilterContext());
                     overlay.display(cachesToDisplay);
                     overlay.firstRun = false;
                     overlay.refreshed();

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/LiveCachesOverlay.java
@@ -107,7 +107,7 @@ public class LiveCachesOverlay extends AbstractCachesOverlay {
             final SearchResult searchResult = useLastSearchResult ? lastSearchResult : ConnectorFactory.searchByViewport(newViewport);
 
             final Set<Geocache> result = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_CACHE_OR_DB);
-            MapUtils.filter(result);
+            MapUtils.filter(result, getFilterContext());
             // update the caches
             // first remove filtered out
             final Set<String> filteredCodes = searchResult.getFilteredGeocodes();

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/StoredCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/StoredCachesOverlay.java
@@ -87,7 +87,7 @@ public class StoredCachesOverlay extends AbstractCachesOverlay {
 
             final Set<Geocache> cachesFromSearchResult = searchResult.getCachesFromSearchResult(LoadFlags.LOAD_WAYPOINTS);
 
-            MapUtils.filter(cachesFromSearchResult);
+            MapUtils.filter(cachesFromSearchResult, getFilterContext());
 
             // render
             update(cachesFromSearchResult);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -37,7 +37,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
 
         for (final Geocache cache : baseCaches) {
             final Set<Waypoint> filteredWaypoints = new HashSet<>(cache.getWaypoints());
-            MapUtils.filter(filteredWaypoints, checkOwnership);
+            MapUtils.filter(filteredWaypoints, getFilterContext(), checkOwnership);
             waypoints.addAll(filteredWaypoints);
         }
 
@@ -50,7 +50,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
             final CacheType type = Settings.getCacheType();
 
             final Set<Waypoint> waypointsInViewport = DataStore.loadWaypoints(getViewport(), excludeMine, excludeFound, excludeDisabled, excludeArchived, excludeOfflineLog, type);
-            MapUtils.filter(waypointsInViewport, checkOwnership);
+            MapUtils.filter(waypointsInViewport, getFilterContext(), checkOwnership);
             waypoints.addAll(waypointsInViewport);
         }
 
@@ -80,7 +80,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
 
     /**
      * get waypoint IDs for geocodes and invalidate them
-     * @param geocodes
+     * @param geocodes the codes
      */
     public void invalidateWaypoints(final Collection<String> geocodes) {
         final Set<Geocache> baseCaches = DataStore.loadCaches(geocodes, LoadFlags.LOAD_WAYPOINTS);

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -205,7 +205,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
      * Called when a new page of caches was loaded.
      */
     public void reFilter() {
-        if (currentFilter != null || (currentGeocacheFilter != null && currentGeocacheFilter.hasFilter())) {
+        if (hasActiveFilter()) {
             // Back up the list again
             originalList = new ArrayList<>(list);
 
@@ -230,7 +230,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
         // If there is already a filter in place, this is a request to change or clear the filter, so we have to
         // replace the original cache list
-        if (currentFilter != null || (currentGeocacheFilter != null && currentGeocacheFilter.hasFilter())) {
+        if (hasActiveFilter()) {
             list.clear();
             list.addAll(originalList);
         }
@@ -248,18 +248,19 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
         if (currentFilter != null) {
             currentFilter.filter(list);
         }
-        if (currentGeocacheFilter != null && currentGeocacheFilter.hasFilter()) {
+        if (currentGeocacheFilter != null && currentGeocacheFilter.isFiltering()) {
             currentGeocacheFilter.filterList(list);
         }
     }
 
-    public boolean isFiltered() {
-        return currentFilter != null || (currentGeocacheFilter != null && currentGeocacheFilter.hasFilter());
+    public boolean hasActiveFilter() {
+        final boolean newFilterFilters = currentGeocacheFilter != null && currentGeocacheFilter.isFiltering();
+        return currentFilter != null || newFilterFilters;
     }
 
     public String getFilterName() {
         return (currentFilter == null ? "-" : currentFilter.getName()) + "|" +
-            (currentGeocacheFilter == null || !currentGeocacheFilter.hasFilter() ? "-" : currentGeocacheFilter.toUserDisplayableString());
+            (currentGeocacheFilter == null || !currentGeocacheFilter.isFiltering() ? "-" : currentGeocacheFilter.toUserDisplayableString());
     }
 
     public int getCheckedCount() {

--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -74,6 +74,19 @@ public class ViewUtils {
         }
     }
 
+    /** Sets enabled/disabled flag for given view and all nested child views recursively */
+    public static void setEnabledDeep(final View view, final boolean enabled) {
+        if (view == null) {
+            return;
+        }
+        view.setEnabled(enabled);
+        if (view instanceof ViewGroup) {
+            for (int i = 0; i < ((ViewGroup) view).getChildCount(); i++) {
+                setEnabledDeep(((ViewGroup) view).getChildAt(i), enabled);
+            }
+        }
+    }
+
     /**
      * creates a standard column layout and adds it to a given parent view. A standard layout consists of a vertically orientated LinearLayout per column.
      * @param ctx context to use for creating views

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -223,24 +223,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
      *
      */
     private static void withMockedFilters(final Runnable runnable) {
-        // backup user settings
-        final boolean excludeMine = Settings.isExcludeMyCaches();
-        final boolean excludeDisabled = Settings.isExcludeDisabledCaches();
-        final boolean excludeFound = Settings.isExcludeFound();
-        try {
-            // set up settings required for test
-            TestSettings.setExcludeMine(false);
-            TestSettings.setExcludeFound(false);
-            TestSettings.setExcludeDisabledCaches(false);
-
-            runnable.run();
-
-        } finally {
-            // restore user settings
-            TestSettings.setExcludeMine(excludeMine);
-            TestSettings.setExcludeFound(excludeFound);
-            TestSettings.setExcludeDisabledCaches(excludeDisabled);
-        }
+        runnable.run();
     }
 
     /**
@@ -293,7 +276,6 @@ public class CgeoApplicationTest extends CGeoTestCase {
 
             try {
                 // set up settings required for test
-                TestSettings.setExcludeMine(false);
                 Settings.setCacheType(CacheType.ALL);
 
                 final GC3FJ5F mockedCache = new GC3FJ5F();

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.settings.TestSettings;
 import cgeo.geocaching.test.AbstractResourceInstrumentationTestCase;
 
 import java.util.Set;
@@ -22,13 +21,9 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
 
     public static void testGetViewport() {
         // backup user settings
-        final boolean excludeMine = Settings.isExcludeMyCaches();
-        final boolean excludeFound = Settings.isExcludeFound();
         final CacheType cacheType = Settings.getCacheType();
         try {
             // set up settings required for test
-            TestSettings.setExcludeMine(false);
-            TestSettings.setExcludeFound(false);
             Settings.setCacheType(CacheType.ALL);
             GCLogin.getInstance().login();
 
@@ -59,8 +54,6 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
             }
         } finally {
             // restore user settings
-            TestSettings.setExcludeMine(excludeMine);
-            TestSettings.setExcludeFound(excludeFound);
             Settings.setCacheType(cacheType);
         }
     }

--- a/tests/src-android/cgeo/geocaching/settings/TestSettings.java
+++ b/tests/src-android/cgeo/geocaching/settings/TestSettings.java
@@ -16,14 +16,6 @@ public final class TestSettings extends Settings {
         throw new InstantiationError();
     }
 
-    public static void setExcludeDisabledCaches(final boolean exclude) {
-        putBoolean(R.string.pref_excludedisabled, exclude);
-    }
-
-    public static void setExcludeMine(final boolean exclude) {
-        putBoolean(R.string.pref_excludemine, exclude);
-    }
-
     public static void setLogin(final Credentials credentials) {
         Settings.setLogin(credentials.getUsernameRaw(), credentials.getPasswordRaw());
     }


### PR DESCRIPTION
fix #10951: merge map quick settings with global filter, create filter context, migrate global settings

This PR, if merged, will sync the map quick settings related to cache filtering (OWN, FOUND, DISABLED, ARCHIVED, HAS_OFFLINE_LOG) no longer with the global exclude settings but with the currently active filter:
* states shown are extracted from current filter. (ALL or YES will lead to checked box, NO will lead to unchecked box)
* changes done in quick settings will be merged to current filter (Status filter, if not yet available, will be created; checked box will lead to ALL, unchecked box to "NO". 
* Important: it is not possible to set a status filter to "YES" in map quick settings (two states have to be mapped to three states)! In order to preserve YES status set in normal filter dialog, merge will only be done for really changed checkboxes (marked -> unmarked or unmarked->marked). This also means that an existing YES can only be converted to an ALL by first deselecting, then closing, then reopening, then selecting again a setting in map quick settings (I am pretty sure that an issue will fly in for that later...)
* If filter is "too complex" to merge status lossless (means: it is an AND or a NOT filter), then map quick settings cache filter is disabled with all checkboxes selected:

![image](https://user-images.githubusercontent.com/6909759/126043268-39e92e7d-a5ef-443f-87dc-9c574e978cb7.png)
