### PR TITLE
fix #11196: make storedsince range work for non-offline caches

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2535,7 +2535,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         offlineRefresh.setOnClickListener(refreshCacheClickListener);
 
         if (cache.isOffline()) {
-            offlineText.setText(Formatter.formatStoredAgo(cache.getUpdated()));
+            offlineText.setText(Formatter.formatStoredAgo(cache.getDetailedUpdate()));
 
             offlineStore.setVisibility(View.GONE);
             offlineDrop.setVisibility(View.VISIBLE);

--- a/main/src/cgeo/geocaching/filters/core/StoredSinceGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/StoredSinceGeocacheFilter.java
@@ -38,14 +38,14 @@ public class StoredSinceGeocacheFilter extends NumberRangeGeocacheFilter<Long> {
     @Override
     public Long getValue(final Geocache cache) {
         if (!cache.isOffline()) {
-            return -1L;
+            return -10L;
         }
-        return (System.currentTimeMillis() - cache.getUpdated()) / 1000;
+        return (System.currentTimeMillis() - cache.getDetailedUpdate()) / 1000;
     }
 
     @Override
     protected String getSqlColumnExpression(final SqlBuilder sqlBuilder) {
-        return "((" + System.currentTimeMillis() + " - " + sqlBuilder.getMainTableId() + ".updated) / 1000)";
+        return "((" + System.currentTimeMillis() + " - " + sqlBuilder.getMainTableId() + ".detailedupdate) / 1000)";
     }
 
     @Override


### PR DESCRIPTION
fix #11196: make storedsince range work for non-offline caches

also fixes the strange  "a few minutes ago" message on cache detail popup for caches stored much longer time before.