### PR TITLE
Fix #11267 - Wrong text field hint alignment

### DIFF
--- a/main/res/layout/authorization_credentials_activity.xml
+++ b/main/res/layout/authorization_credentials_activity.xml
@@ -30,8 +30,7 @@
                 android:inputType="textPersonName"
                 style="@style/textinput_embedded"
                 android:hint="@string/init_authorization_credential_username"
-                android:autofillHints=".AUTOFILL_HINT_USERNAME"
-                android:layout_margin="7dip" />
+                android:autofillHints=".AUTOFILL_HINT_USERNAME" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
@@ -40,8 +39,7 @@
                 android:inputType="textPassword"
                 android:hint="@string/init_authorization_credential_password"
                 style="@style/textinput_embedded"
-                android:autofillHints=".AUTOFILL_HINT_PASSWORD"
-                android:layout_margin="7dip" />
+                android:autofillHints=".AUTOFILL_HINT_PASSWORD" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button

--- a/main/res/layout/authorization_token_activity.xml
+++ b/main/res/layout/authorization_token_activity.xml
@@ -30,8 +30,7 @@
                 android:inputType="textPersonName"
                 style="@style/textinput_embedded"
                 android:hint="@string/init_authorization_credential_username"
-                android:autofillHints=".AUTOFILL_HINT_USERNAME"
-                android:layout_margin="7dip" />
+                android:autofillHints=".AUTOFILL_HINT_USERNAME" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
@@ -40,8 +39,7 @@
                 android:inputType="textPassword"
                 android:hint="@string/init_authorization_credential_password"
                 style="@style/textinput_embedded"
-                android:autofillHints=".AUTOFILL_HINT_PASSWORD"
-                android:layout_margin="7dip" />
+                android:autofillHints=".AUTOFILL_HINT_PASSWORD" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button

--- a/main/res/layout/logtrackable_activity.xml
+++ b/main/res/layout/logtrackable_activity.xml
@@ -59,7 +59,6 @@
                     android:id="@+id/geocode"
                     style="@style/textinput_embedded"
                     android:hint="@string/cache_geocode"
-                    android:layout_marginLeft="10dip"
                     android:layout_weight="1"
                     android:inputType="textCapCharacters" />
             </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
This also touches the broken geocode field in `logtrackable_activity.xml` as there is kind of the same problem. It does however not solve #11257