### PR TITLE
fix tb log geocode box formatting (fix #11257)

### DIFF
--- a/main/res/layout/cache_filter_generic_string.xml
+++ b/main/res/layout/cache_filter_generic_string.xml
@@ -53,7 +53,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/searchtext"
-        style="@style/textinput_dropdown"
+        style="@style/textinput_autocompletetextview"
         android:layout_below="@+id/filter_options"
         android:layout_alignParentLeft="true"
         android:layout_alignParentRight="true">

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -79,7 +79,7 @@
             android:layout_marginBottom="16dp"
             tools:listitem="@android:layout/simple_spinner_item" />
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
             <AutoCompleteTextView
                 android:id="@+id/name"
                 style="@style/textinput_embedded"

--- a/main/res/layout/logtrackable_activity.xml
+++ b/main/res/layout/logtrackable_activity.xml
@@ -54,21 +54,18 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal" >
 
-            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
                 <AutoCompleteTextView
                     android:id="@+id/geocode"
                     style="@style/textinput_embedded"
                     android:hint="@string/cache_geocode"
-                    android:layout_weight="1"
                     android:inputType="textCapCharacters" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <Button
                 android:id="@+id/coordinates"
                 style="@style/button_full"
-                android:hint="@string/cache_coordinates"
-                android:layout_width="0dip"
-                android:layout_weight="1" />
+                android:hint="@string/cache_coordinates" />
         </LinearLayout>
 
         <com.google.android.material.textfield.TextInputLayout

--- a/main/res/layout/logtrackable_activity.xml
+++ b/main/res/layout/logtrackable_activity.xml
@@ -54,7 +54,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal" >
 
-            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
                 <AutoCompleteTextView
                     android:id="@+id/geocode"
                     style="@style/textinput_embedded"

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -43,7 +43,7 @@
                 android:text="@string/search_address" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
             <AutoCompleteTextView
                 android:id="@+id/address"
                 style="@style/textinput_embedded"
@@ -64,7 +64,7 @@
                 android:text="@string/search_geo" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
             <AutoCompleteTextView
                 android:id="@+id/geocode"
                 style="@style/textinput_embedded"
@@ -88,7 +88,7 @@
                 android:text="@string/search_kw" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
             <AutoCompleteTextView
                 android:id="@+id/keyword"
                 style="@style/textinput_embedded"
@@ -109,7 +109,7 @@
                 android:text="@string/search_hbu" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
             <AutoCompleteTextView
                 android:id="@+id/owner"
                 style="@style/textinput_embedded"
@@ -162,7 +162,7 @@
                 android:text="@string/search_tb" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_dropdown">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
             <AutoCompleteTextView
                 android:id="@+id/trackable"
                 style="@style/textinput_embedded"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -225,9 +225,9 @@
         <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
     </style>
 
-    <!-- textinput -->
+    <!-- TextInputLayout for AutoCompleteTextView or EditText -->
 
-    <style name="textinput_dropdown" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+    <style name="textinput_autocompletetextview" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
         <item name="android:padding">6dip</item>
         <item name="android:singleLine">true</item>
         <item name="android:autoText">true</item>


### PR DESCRIPTION
## Description
Fixes styling for geocode input box in trackable logging activity

![image](https://user-images.githubusercontent.com/3754370/126388300-ee76e39c-370d-4a31-95a3-198feaf01549.png)

(For embedded `AutoCompleteTextView` you need to use a different styling for the surrounding `TextInputLayout`)