### PR TITLE
fix: wrap resource-id to integer for list-limit-default (rel #11191)

### DIFF
--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1916,7 +1916,7 @@ public class Settings {
     }
 
     public static int getListInitialLoadLimit() {
-        return getInt(R.string.pref_list_initial_load_limit, R.integer.list_load_limit_default);
+        return getInt(R.string.pref_list_initial_load_limit, getKeyInt(R.integer.list_load_limit_default));
     }
 
 }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
wrap resource-id to integer for list-limit-default. 
Was 

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #11191
