### PR TITLE
fix fragment instantiation exception in TabbedViewPager

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -152,8 +152,13 @@ public class AboutActivity extends TabbedViewPagerActivity {
         }
 
         @Override
+        public long getPageId() {
+            return Page.VERSION.id;
+        }
+
+        @Override
         public void setContent() {
-            final AboutActivity activity = (AboutActivity) activityWeakReference.get();
+            final AboutActivity activity = (AboutActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -201,8 +206,13 @@ public class AboutActivity extends TabbedViewPagerActivity {
         }
 
         @Override
+        public long getPageId() {
+            return Page.CHANGELOG.id;
+        }
+
+        @Override
         public void setContent() {
-            final Activity activity = activityWeakReference.get();
+            final Activity activity = getActivity();
             if (activity == null) {
                 return;
             }
@@ -230,8 +240,13 @@ public class AboutActivity extends TabbedViewPagerActivity {
         }
 
         @Override
+        public long getPageId() {
+            return Page.SYSTEM.id;
+        }
+
+        @Override
         public void setContent() {
-            final AboutActivity activity = (AboutActivity) activityWeakReference.get();
+            final AboutActivity activity = (AboutActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -268,6 +283,11 @@ public class AboutActivity extends TabbedViewPagerActivity {
         }
 
         @Override
+        public long getPageId() {
+            return Page.LICENSE.id;
+        }
+
+        @Override
         public void setContent() {
             binding.getRoot().setVisibility(View.VISIBLE);
             setClickListener(binding.license, "https://www.apache.org/licenses/LICENSE-2.0.html");
@@ -299,8 +319,13 @@ public class AboutActivity extends TabbedViewPagerActivity {
         }
 
         @Override
+        public long getPageId() {
+            return Page.CONTRIBUTORS.id;
+        }
+
+        @Override
         public void setContent() {
-            final Activity activity = activityWeakReference.get();
+            final Activity activity = getActivity();
             if (activity == null) {
                 return;
             }

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -980,7 +980,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         IMAGES(R.string.cache_images);
 
         private final int titleStringId;
-        private final long id;
+        public final long id;
 
         Page(final int titleStringId) {
             this.titleStringId = titleStringId;
@@ -1129,10 +1129,15 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         @Override
+        public long getPageId() {
+            return Page.DETAILS.id;
+        }
+
+        @Override
         @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"}) // splitting up that method would not help improve readability
         public void setContent() {
             // retrieve activity and cache - if either of them is null, something's really wrong!
-            final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+            final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -1299,7 +1304,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private class StoreCacheClickListener implements View.OnClickListener, View.OnLongClickListener {
             @Override
             public void onClick(final View arg0) {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     activity.storeCache(false);
                 }
@@ -1307,7 +1312,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
             @Override
             public boolean onLongClick(final View v) {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     activity.storeCache(true);
                 }
@@ -1318,7 +1323,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private class MoveCacheClickListener implements OnLongClickListener {
             @Override
             public boolean onLongClick(final View v) {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     activity.moveCache();
                 }
@@ -1329,7 +1334,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private class DropCacheClickListener implements View.OnClickListener {
             @Override
             public void onClick(final View arg0) {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     activity.dropCache();
                 }
@@ -1339,7 +1344,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private class RefreshCacheClickListener implements View.OnClickListener {
             @Override
             public void onClick(final View arg0) {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     activity.refreshCache();
                 }
@@ -1353,12 +1358,12 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             private final SimpleDisposableHandler handler;
 
             AbstractPropertyListener() {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 handler = new CheckboxHandler(DetailsViewCreator.this, activity, activity.progress);
             }
 
             public void doExecute(final int titleId, final int messageId, final Action1<SimpleDisposableHandler> action) {
-                final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+                final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     if (activity.progress.isShowing()) {
                         activity.showToast(activity.res.getString(R.string.err_watchlist_still_managing));
@@ -1620,10 +1625,15 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         @Override
+        public long getPageId() {
+            return Page.DESCRIPTION.id;
+        }
+
+        @Override
         @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"}) // splitting up that method would not help improve readability
         public void setContent() {
             // retrieve activity and cache - if either of them is null, something's really wrong!
-            final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+            final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -1938,9 +1948,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         @Override
+        public long getPageId() {
+            return Page.WAYPOINTS.id;
+        }
+
+        @Override
         public void setContent() {
             // retrieve activity and cache - if either if this is null, something is really wrong...
-            final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+            final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -2140,9 +2155,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         @Override
+        public long getPageId() {
+            return Page.INVENTORY.id;
+        }
+
+        @Override
         public void setContent() {
             // retrieve activity and cache - if either if this is null, something is really wrong...
-            final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+            final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -2170,9 +2190,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         @Override
+        public long getPageId() {
+            return Page.IMAGES.id;
+        }
+
+        @Override
         public void setContent() {
             // retrieve activity and cache - if either if this is null, something is really wrong...
-            final CacheDetailActivity activity = (CacheDetailActivity) activityWeakReference.get();
+            final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -2462,9 +2487,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         } else if (pageId == Page.DESCRIPTION.id) {
             return new DescriptionViewCreator();
         } else if (pageId == Page.LOGS.id) {
-            return new CacheLogsViewCreator(this, true);
+            return CacheLogsViewCreator.newInstance(true);
         } else if (pageId == Page.LOGSFRIENDS.id) {
-            return new CacheLogsViewCreator(this, false);
+            return CacheLogsViewCreator.newInstance(false);
         } else if (pageId == Page.WAYPOINTS.id) {
             return new WaypointsViewCreator();
         } else if (pageId == Page.INVENTORY.id) {

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -368,7 +368,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
         if (pageId == Page.DETAILS.id) {
             return new DetailsViewCreator();
         } else if (pageId == Page.LOGS.id) {
-            return new TrackableLogsViewCreator(this);
+            return new TrackableLogsViewCreator();
         } else if (pageId == Page.IMAGES.id) {
             return new ImagesViewCreator();
         }
@@ -383,8 +383,13 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
         }
 
         @Override
+        public long getPageId() {
+            return Page.IMAGES.id;
+        }
+
+        @Override
         public void setContent() {
-            final TrackableActivity activity = (TrackableActivity) activityWeakReference.get();
+            final TrackableActivity activity = (TrackableActivity) getActivity();
             if (activity == null) {
                 return;
             }
@@ -433,9 +438,14 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
         }
 
         @Override
+        public long getPageId() {
+            return Page.DETAILS.id;
+        }
+
+        @Override
         @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"}) // splitting up that method would not help improve readability
         public void setContent() {
-            final TrackableActivity activity = (TrackableActivity) activityWeakReference.get();
+            final TrackableActivity activity = (TrackableActivity) getActivity();
             if (activity == null) {
                 return;
             }

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -125,7 +125,12 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
     public void onCreate(final Bundle savedInstanceState) {
         Log.v(logToken + ".onCreate(Bundle)");
         ApplicationSettings.setLocale(this);
-        super.onCreate(savedInstanceState);
+        try {
+            super.onCreate(savedInstanceState);
+        } catch (Exception e) {
+            Log.e(e.toString());
+            throw e;
+        }
         onCreateCommon();
     }
 

--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
@@ -1,8 +1,10 @@
 package cgeo.geocaching.activity;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.functions.Action1;
 
+import android.os.Bundle;
 import android.util.DisplayMetrics;
 
 import androidx.annotation.NonNull;
@@ -13,7 +15,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
-import java.lang.ref.WeakReference;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -146,11 +147,9 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
     protected abstract TabbedViewPagerFragment createNewFragment(long pageId);
 
     private class ViewPagerAdapter extends FragmentStateAdapter {
-        private final WeakReference<FragmentActivity> fragmentActivityWeakReference;
 
         ViewPagerAdapter(final FragmentActivity fa) {
             super(fa);
-            fragmentActivityWeakReference = new WeakReference<>(fa);
         }
 
         @Override
@@ -163,7 +162,6 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
                 return fragment;
             }
             fragment = createNewFragment(pageId);
-            fragment.setActivity(fragmentActivityWeakReference.get());
             fragmentMap.put(pageId, fragment);
             return fragment;
         }
@@ -208,6 +206,11 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
     }
 
     @SuppressWarnings("rawtypes")
+    public void registerFragment(final long pageId, final TabbedViewPagerFragment fragment) {
+        fragmentMap.put(pageId, fragment);
+    }
+
+    @SuppressWarnings("rawtypes")
     protected void reinitializePage(final long pageId) {
         final TabbedViewPagerFragment fragment = fragmentMap.get(pageId);
         if (fragment != null) {
@@ -249,11 +252,69 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
     }
 
     @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.d("TabbedViewPagerActivity.onCreate");
+        if (savedInstanceState != null) {
+            initialPageId = savedInstanceState.getLong("initialPageId", 0);
+            initialPageShown = savedInstanceState.getBoolean("initialPageShown", false);
+            currentPageId = savedInstanceState.getLong("currentPageId", 0);
+            orderedPages = savedInstanceState.getLongArray("orderedPages");
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(@NonNull final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putLong("initialPageId", initialPageId);
+        outState.putBoolean("initialPageShown", initialPageShown);
+        outState.putLong("currentPageId", currentPageId);
+        outState.putLongArray("orderedPages", orderedPages);
+    }
+
+    @Override
     protected void onDestroy() {
+        Log.d("TabbedViewPagerActivity.onDestroy");
         if (viewPager != null) {
             viewPager.unregisterOnPageChangeCallback(pageChangeCallback);
         }
         super.onDestroy();
     }
+
+    // ---------------------------------------------------------------------------------
+    // ab hier lifecycle logging only
+    // ---------------------------------------------------------------------------------
+
+    /*
+    @Override
+    public void onStart() {
+        super.onStart();
+        Log.e("TabbedViewPagerActivity.onStart");
+    }
+
+    @Override
+    public void onRestart() {
+        super.onRestart();
+        Log.e("TabbedViewPagerActivity.onRestart");
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        Log.e("TabbedViewPagerActivity.onResume");
+    }
+
+    @Override
+    public void onPause() {
+        Log.e("TabbedViewPagerActivity.onPause");
+        super.onPause();
+    }
+
+    @Override
+    public void onStop() {
+        Log.e("TabbedViewPagerActivity.onStop");
+        super.onStop();
+    }
+    */
 
 }

--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
@@ -13,28 +13,33 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.viewbinding.ViewBinding;
 
-import java.lang.ref.WeakReference;
-
 public abstract class TabbedViewPagerFragment<ViewBindingClass extends ViewBinding> extends Fragment {
-    protected WeakReference<Activity> activityWeakReference = null;
     protected ViewBindingClass binding;
     protected ViewGroup container;
     private boolean contentIsUpToDate = false;
     private final Integer mutextContentIsUpToDate = 0;
 
-    public void setActivity(final Activity activity) {
-        this.activityWeakReference = new WeakReference<>(activity);
+    public TabbedViewPagerFragment() {
+        Log.d("new fragment for " + getClass().toString());
     }
 
     public void setClickListener(final View view, final String url) {
-        final Activity activity = activityWeakReference.get();
+        final Activity activity = getActivity();
         if (activity != null) {
             view.setOnClickListener(v -> ShareUtils.openUrl(activity, url));
         }
     }
 
+    @Override
+    public void onAttach(@NonNull final Activity activity) {
+        super.onAttach(activity);
+        // notify TabbedViewPagerActivity to help it rebuild the fragment cache
+        ((TabbedViewPagerActivity) activity).registerFragment(getPageId(), this);
+    }
+
     public abstract ViewBindingClass createView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState);
     public abstract void setContent();
+    public abstract long getPageId();
 
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {

--- a/main/src/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/LogsViewCreator.java
@@ -37,12 +37,6 @@ import org.apache.commons.text.StringEscapeUtils;
 
 public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBinding> {
 
-    protected final AbstractActionBarActivity activity;
-
-    public LogsViewCreator(final AbstractActionBarActivity activity) {
-        this.activity = activity;
-    }
-
     @Override
     public LogsPageBinding createView(@NonNull final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
         return LogsPageBinding.inflate(inflater, container, false);
@@ -58,14 +52,14 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
         final List<LogEntry> logs = getLogs();
 
         addHeaderView();
-        binding.getRoot().setAdapter(new ArrayAdapter<LogEntry>(activity, R.layout.logs_item, logs) {
+        binding.getRoot().setAdapter(new ArrayAdapter<LogEntry>(getActivity(), R.layout.logs_item, logs) {
 
             @Override
             @NonNull
             public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
                 View rowView = convertView;
                 if (rowView == null) {
-                    rowView = activity.getLayoutInflater().inflate(R.layout.logs_item, parent, false);
+                    rowView = getActivity().getLayoutInflater().inflate(R.layout.logs_item, parent, false);
                 }
                 LogViewHolder holder = (LogViewHolder) rowView.getTag();
                 if (holder == null) {
@@ -109,7 +103,7 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
         if (log.hasLogImages()) {
             holder.binding.logImages.setText(log.getImageTitles());
             holder.binding.logImages.setVisibility(View.VISIBLE);
-            holder.binding.logImages.setOnClickListener(v -> ImagesActivity.startActivity(activity, getGeocode(), new ArrayList<>(log.logImages)));
+            holder.binding.logImages.setOnClickListener(v -> ImagesActivity.startActivity(getActivity(), getGeocode(), new ArrayList<>(log.logImages)));
         } else {
             holder.binding.logImages.setVisibility(View.GONE);
         }
@@ -134,6 +128,7 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
 
     protected View.OnClickListener createOnLogClickListener(final LogViewHolder holder, final LogEntry log) {
         return v -> {
+            final AbstractActionBarActivity activity = (AbstractActionBarActivity) getActivity();
             final String author = StringEscapeUtils.unescapeHtml4(log.author);
             final String title = activity.getString(R.string.cache_log_menu_popup_title, author);
 

--- a/main/src/cgeo/geocaching/log/TrackableLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/TrackableLogsViewCreator.java
@@ -26,10 +26,14 @@ public class TrackableLogsViewCreator extends LogsViewCreator {
 
     /**
      */
-    public TrackableLogsViewCreator(final TrackableActivity trackableActivity) {
-        super(trackableActivity);
-        this.trackableActivity = trackableActivity;
+    public TrackableLogsViewCreator() {
+        this.trackableActivity = (TrackableActivity) getActivity();
         trackable = trackableActivity.getTrackable();
+    }
+
+    @Override
+    public long getPageId() {
+        return CacheDetailActivity.Page.LOGS.id;
     }
 
     @Override
@@ -57,12 +61,12 @@ public class TrackableLogsViewCreator extends LogsViewCreator {
             final String cacheName = log.cacheName;
             holder.binding.gcinfo.setOnClickListener(arg0 -> {
                 if (StringUtils.isNotBlank(cacheGuid)) {
-                    CacheDetailActivity.startActivityGuid(activity, cacheGuid, TextUtils.stripHtml(cacheName));
+                    CacheDetailActivity.startActivityGuid(getActivity(), cacheGuid, TextUtils.stripHtml(cacheName));
                 } else {
                     // for GeoKrety we only know the cache geocode
                     final String cacheGeocode = log.cacheGeocode;
                     if (ConnectorFactory.canHandle(cacheGeocode)) {
-                        CacheDetailActivity.startActivity(activity, cacheGeocode);
+                        CacheDetailActivity.startActivity(getActivity(), cacheGeocode);
                     }
                 }
             });


### PR DESCRIPTION
## Description
PR attempts to fix the fragment instantiation error described in #11204 by
- adding common fragment constructor,
- removing weakReferences to calling activity in fragments,
- supporting indirect fragment instantiation and `getArguments()` for fragments that need parameters,
- rebuilding `fragmentMap` dynamically on configuration changes
- ...

## How to test
For me the following steps worked reliably to force the error:
- open cache detail page
- switch to Android system's language selection screen and select a different language
- return to c:geo => configation change triggers the error described in the referenced issue