### PR TITLE
fix #11292: repair broken status filter wrt active, disabled, archived

### DIFF
--- a/main/src/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
@@ -90,9 +90,9 @@ public class StatusGeocacheFilter extends BaseGeocacheFilter {
         }
 
         return
-            ((!excludeActive && !cache.isDisabled() && !cache.isArchived()) ||
-                (!excludeDisabled && cache.isDisabled()) ||
-                (!excludeArchived && cache.isArchived())) &&
+            (!excludeActive || cache.isDisabled() || cache.isArchived()) &&
+            (!excludeDisabled || !cache.isDisabled()) &&
+            (!excludeArchived || !cache.isArchived()) &&
             (statusOwned == null || (cache.isOwner() == statusOwned)) &&
             (statusFound == null || cache.isFound() == statusFound) &&
             (statusStored == null || cache.isOffline() == statusStored) &&
@@ -363,8 +363,8 @@ public class StatusGeocacheFilter extends BaseGeocacheFilter {
             }
             if (excludeActive) {
                 sqlBuilder.openWhere(SqlBuilder.WhereType.OR);
-                sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".disabled = 1");
-                sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".archived = 1");
+                sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".disabled <> 0");
+                sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".archived <> 0");
                 sqlBuilder.closeWhere();
             }
             if (excludeDisabled) {

--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -45,7 +45,9 @@ public final class DefaultMap {
     }
 
     public static void startActivityGeoCode(final Context fromActivity, final Class<?> cls, final String geocode) {
-        new MapOptions(geocode).startIntent(fromActivity, cls);
+        final MapOptions mo = new MapOptions(geocode);
+        mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
+        mo.startIntent(fromActivity, cls);
     }
 
     public static void startActivityGeoCode(final Activity fromActivity, final String geocode) {
@@ -61,5 +63,6 @@ public final class DefaultMap {
         mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
         mo.startIntent(fromActivity, getDefaultMapClass());
     }
+
 
 }


### PR DESCRIPTION
fix #11292: repair broken status filter wrt active, disabled, archived

This PR also fixes that previously opening map for single caches did open map viewer with LIVE filter, but should be opened with TRANSIENT (empty) filter