### PR TITLE
switch map quick settings close icon to arrow-down (fix #11222)

### DIFF
--- a/main/res/drawable/ic_expand_more_white.xml
+++ b/main/res/drawable/ic_expand_more_white.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
+</vector>

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -258,7 +258,7 @@ public final class Dialogs {
 
     private static void updateActionbarAfterStateChange(final BottomSheetDialog dialog, final BottomsheetDialogWithActionbarBinding dialogView) {
         if (dialog.getBehavior().getState() == BottomSheetBehavior.STATE_EXPANDED) {
-            dialogView.toolbar.setNavigationIcon(R.drawable.ic_close_white);
+            dialogView.toolbar.setNavigationIcon(R.drawable.ic_expand_more_white);
         } else {
             dialogView.toolbar.setNavigationIcon(R.drawable.ic_expand_less_white);
         }


### PR DESCRIPTION
## Description
replaces the "x" icon on fully expanded dialog by a "v" icon, as discussed in #11222

![grafik](https://user-images.githubusercontent.com/3754370/127185706-47a4f82f-96f4-4167-9d48-8dc57f3c04b2.png)
