### PR TITLE
Fix #11323 - Use funnel icon for filter bar

### DIFF
--- a/main/res/layout/filter_bar.xml
+++ b/main/res/layout/filter_bar.xml
@@ -10,7 +10,7 @@
 
     <ImageView
         style="@style/filter_bar_image"
-        android:src="@drawable/main_filter_default" >
+        android:src="@drawable/ic_menu_filter" >
     </ImageView>
 
     <TextView


### PR DESCRIPTION
## Description
Use funnel icon instead of the old school switch.
Thanks to XML that was an easy one.


## Related issues
#11323


## Additional context
![image](https://user-images.githubusercontent.com/949669/127197037-1dffd435-fdd9-44a3-a78f-65cc1f1ea9cd.png)

![image](https://user-images.githubusercontent.com/949669/127197092-b687f912-edea-473b-ba5f-27cd82eee4b2.png)
