### PR TITLE
use Resource to get text-color for all API-version (fix #11342)

### DIFF
--- a/main/src/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/cgeo/geocaching/ui/ViewUtils.java
@@ -147,11 +147,7 @@ public class ViewUtils {
                 final TextView tv = new TextView(ctx);
                 tv.setText(itemText);
                 tv.setMaxLines(1);
-                if (Build.VERSION.SDK_INT >= 23) {
-                    tv.setTextColor(ctx.getColor(R.color.colorText));
-                } else if (APP_RESOURCES != null) {
-                    tv.setTextColor(APP_RESOURCES.getColor(R.color.colorText));
-                }
+                tv.setTextColor(ctx.getResources().getColor(R.color.colorText));
                 if (DEBUG_LAYOUT) {
                     tv.setBackgroundResource(R.drawable.mark_orange);
                 }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
fixes dark slider-scale color in dark-mode for API < 23

use Resource to get text-color for all API-version

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11342 
