### PR TITLE
make button outline more visible

### DIFF
--- a/main/res/color/button_strokecolor_selector.xml
+++ b/main/res/color/button_strokecolor_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- derived from mtl_btn_stroke_color_selector, but higher alpha value -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorPrimary" android:state_checked="true"/>
+    <item android:alpha="0.38" android:color="?attr/colorOnSurface" android:state_checked="false"/>
+</selector>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -142,6 +142,7 @@
         <item name="android:scrollHorizontally">true</item>
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">@dimen/textSize_buttonsPrimary</item>
+        <item name="strokeColor">@color/button_strokecolor_selector</item>
     </style>
 
     <style name="button_full" parent="button">


### PR DESCRIPTION
## Description
Our outline button uses a border stroke color which is barely visible, at least in dark mode. This PR increases opacity for stroke color a bit to make the outline more visible.

![grafik](https://user-images.githubusercontent.com/3754370/127287790-b87e9fb4-e854-4905-8bb6-33e5b4f6dabe.png).![grafik](https://user-images.githubusercontent.com/3754370/127287751-04754cc2-a3d8-49ba-9a6c-92fa3486aaff.png)
