### PR TITLE
correct initialisation of DifficultyAndTerrain-Filter

### DIFF
--- a/main/src/cgeo/geocaching/filters/core/DifficultyAndTerrainGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/DifficultyAndTerrainGeocacheFilter.java
@@ -8,11 +8,17 @@ import androidx.annotation.NonNull;
 
 public class DifficultyAndTerrainGeocacheFilter extends BaseGeocacheFilter {
 
-    public DifficultyGeocacheFilter difficultyGeocacheFilter = new DifficultyGeocacheFilter();
-    public TerrainGeocacheFilter terrainGeocacheFilter = new TerrainGeocacheFilter();
+    public DifficultyGeocacheFilter difficultyGeocacheFilter;
+    public TerrainGeocacheFilter terrainGeocacheFilter;
 
     private static final String CONFIG_DIFFICULTY = "difficulty";
     private static final String CONFIG_TERRAIN = "terrain";
+
+
+    public DifficultyAndTerrainGeocacheFilter() {
+        difficultyGeocacheFilter = GeocacheFilterType.DIFFICULTY.create();
+        terrainGeocacheFilter = GeocacheFilterType.TERRAIN.create();
+    }
 
     @Override
     public Boolean filter(final Geocache cache) {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Fixes empty searches in some cases.
use GeoCacheFilterType.create to create the child-filters for the combined.
Otherwise the type is not set correct.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11360 
fix #11331

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
To reproduce (thanks to @bekuno, see https://github.com/cgeo/cgeo/issues/11331#issuecomment-887697022):

- Open live map
- open filter
- switch to extended
- delete all filter criteria
- save
- open the search
- search for eg. Berlin
- result is empty (except for e.g. LabCaches)