### PR TITLE
rel to #11369: fix material.io date picker bug by adding explicit string ok resource

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- fixes -->
+
+    <!-- This entry shall solve a bug with material.io Date picker, see https://github.com/material-components/material-components-android/issues/1346 -->
+    <string name="mtrl_picker_confirm" tools:override="true">OK</string>
+
     <!-- basics -->
     <string name="cache">Cache</string>
     <string name="detail">Details</string>


### PR DESCRIPTION
rel to #11369: fix material.io date picker bug by adding explicit string ok resource

See also https://github.com/material-components/material-components-android/issues/1346