### PR TITLE
rel to #11347: add active services to origin filter automatically

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -562,6 +562,7 @@
 
     <string name="cache_filter_checkboxlist_selectallnone">Select all</string>
     <string name="cache_filter_checkboxlist_add_items">Add more items</string>
+    <string name="cache_filter_checkboxlist_add_all_items">Add all items</string>
     <string name="cache_filter_checkboxlist_add_items_dialog_title">Add items</string>
 
     <string name="cache_filter_favorites_absolute">Absolute</string>

--- a/main/src/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class FilterViewHolderCreator {
                         .setSelectableValues(Arrays.asList(CacheType.TRADITIONAL, CacheType.MULTI, CacheType.MYSTERY, CacheType.LETTERBOX, CacheType.EVENT,
                             CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.ADVLAB, CacheType.USER_DEFINED))
                         .setValueDisplayTextGetter(CacheType::getShortL10n)
-                        .setValueDrawableGetter(ct -> ImageParam.id(ct.markerId)) , 2, false);
+                        .setValueDrawableGetter(ct -> ImageParam.id(ct.markerId)) , 2, null);
                 break;
             case SIZE:
                 result = new ChipChoiceFilterViewHolder<>(
@@ -116,7 +117,8 @@ public class FilterViewHolderCreator {
                     ValueGroupFilterAccessor.<IConnector, OriginGeocacheFilter>createForValueGroupFilter()
                         .setSelectableValues(ConnectorFactory.getConnectors())
                         .setValueDisplayTextGetter(IConnector::getName)
-                        .setValueDrawableGetter(ct -> ImageParam.id(R.drawable.ic_menu_upload)) , 1, true);
+                        .setValueDrawableGetter(ct -> ImageParam.id(R.drawable.ic_menu_upload)) , 1,
+                    new HashSet<>(ConnectorFactory.getActiveConnectors()));
                 break;
             case STORED_SINCE:
                 result = createStoredSinceFilterViewHolder();
@@ -197,7 +199,7 @@ public class FilterViewHolderCreator {
             .setValueDisplayTextGetter(f -> f.title)
             .setGeocacheValueGetter((f, c) -> CollectionStream.of(c.getLists()).map(allListsById::get).toSet());
 
-        return new CheckboxFilterViewHolder<>(vgfa, 1, true);
+        return new CheckboxFilterViewHolder<>(vgfa, 1, Collections.emptySet());
     }
 
     private static IFilterViewHolder<?> createStoredSinceFilterViewHolder() {


### PR DESCRIPTION
rel to #11347: add active services to origin filter automatically

This PR will:
* add origins from active services to the list of selectable "origins" in origin filter automatically
* adds an "add all items" button to checkbox filters with "add more items" button (currently "origin" and "stored lists").

This PR will **not** completely solve #11347: a possibility to select all/none items in "add more items" dialog is not included. This feature deserves its own PR since it is not filter-specific.