### PR TITLE
fix #11386: prevent image duplication on cache refresh

### DIFF
--- a/main/src/cgeo/geocaching/ui/ImagesList.java
+++ b/main/src/cgeo/geocaching/ui/ImagesList.java
@@ -109,6 +109,7 @@ public class ImagesList {
         final CompositeDisposable disposables = new CompositeDisposable(new CancellableDisposable(this::removeAllViews));
 
         imagesView = parentView.findViewById(R.id.spoiler_list);
+        imagesView.removeAllViews();
 
         final HtmlImage imgGetter = new HtmlImage(geocode, true, false, false);
 


### PR DESCRIPTION
fix #11386: prevent image duplication on cache refresh

I tried to test this for unwanted side effects, and it seems to work fine.
@moving-bits I would be thankful for a code review on this