### PR TITLE
add 'invert order' to route sort

### DIFF
--- a/main/res/drawable/ic_menu_swap_vert.xml
+++ b/main/res/drawable/ic_menu_swap_vert.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16,17.01V10h-2v7.01h-3L15,21l4,-3.99h-3zM9,3L5,6.99h3V14h2V6.99h3L9,3z"/>
+</vector>

--- a/main/res/menu/menu_ok_cancel.xml
+++ b/main/res/menu/menu_ok_cancel.xml
@@ -4,6 +4,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <item
+        android:id="@+id/menu_invert_order"
+        android:icon="@drawable/ic_menu_swap_vert"
+        android:title="@string/menu_invert_order"
+        android:visible="false"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction">
+    </item>
+    <item
         android:id="@+id/menu_item_delete"
         android:icon="@drawable/ic_menu_delete"
         android:title="@string/cache_filter_storage_delete_button"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -346,6 +346,7 @@
     <string name="menu_scan_geo">Scan geocode</string>
     <string name="menu_lists_pocket_queries">Lists / pocket queries</string>
     <string name="menu_scan_description">c:geo can scan geocodes which are printed as QR code. The necessary app is not installed. Do you want to open Google Play to install it?</string>
+    <string name="menu_invert_order">Invert order</string>
 
     <!-- main screen -->
     <string name="live_map_button">Live map</string>

--- a/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -32,6 +32,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 import com.google.android.material.button.MaterialButton;
 import com.mobeta.android.dslv.DragSortController;
@@ -106,7 +107,7 @@ public class RouteSortActivity extends AbstractActionBarActivity {
                             title.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, 0, 0);
                             break;
                         default:
-                            throw new IllegalStateException("unknow RouteItemType in RouteSortActivity");
+                            throw new IllegalStateException("unknown RouteItemType in RouteSortActivity");
                     }
                     title.setOnClickListener(v1 -> CacheDetailActivity.startActivity(listView.getContext(), data.getGeocode(), data.getName()));
                     detail.setOnClickListener(v1 -> CacheDetailActivity.startActivity(listView.getContext(), data.getGeocode(), data.getName()));
@@ -141,25 +142,31 @@ public class RouteSortActivity extends AbstractActionBarActivity {
         final SimpleFloatViewManager simpleFloatViewManager = new SimpleFloatViewManager(listView);
         simpleFloatViewManager.setBackgroundColor(getResources().getColor(R.color.colorBackgroundSelected));
         listView.setFloatViewManager(simpleFloatViewManager);
-
     }
 
-    private boolean delete(final int position) {
+    private void delete(final int position) {
         routeItems.remove(position);
         routeItemAdapter.notifyDataSetChanged();
         changed = true;
-        return true;
+    }
+
+    private void invertOrder() {
+        Collections.reverse(routeItems);
+        routeItemAdapter.notifyDataSetChanged();
+        changed = true;
     }
 
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         getMenuInflater().inflate(R.menu.menu_ok_cancel, menu);
+        menu.findItem(R.id.menu_invert_order).setVisible(true);
         return true;
     }
 
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
-        if (item.getItemId() == R.id.menu_item_save) {
+        final int itemId = item.getItemId();
+        if (itemId == R.id.menu_item_save) {
             AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.saveIndividualRoute(routeItems), () -> {
                 changed = false;
                 invalidateOptionsMenu();
@@ -167,10 +174,13 @@ public class RouteSortActivity extends AbstractActionBarActivity {
                 finish();
             });
             return true;
-        } else if (item.getItemId() == R.id.menu_item_cancel) {
+        } else if (itemId == R.id.menu_item_cancel) {
             finish();
             return true;
-        } else if (item.getItemId() == android.R.id.home) {
+        } else if (itemId == R.id.menu_invert_order) {
+            invertOrder();
+            return true;
+        } else if (itemId == android.R.id.home) {
             onBackPressed();
             return true;
         }


### PR DESCRIPTION
## Description
I frequently find myself in a situation where I have planned a route at some time in the past in a certain order, but when I actually start that tour, I would like to take it in exactly the opposite order. Swapping all positions can be done using the "route sort" activity, but is quite cumbersome, especially for tours of more than 10 caches...

This PR adds a "invert oder" button to `RouteSortActivity` which reverses all items of the route.
