### PR TITLE
add 'set as start' to route sort

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2215,6 +2215,8 @@
         <item quantity="other">Route loaded with %d route points</item>
     </plurals>
     <string name="center_on_route">Center on route</string>
+    <string name="individual_route_set_as_start_title">Set as route start</string>
+    <string name="individual_route_set_as_start_message">Set this item as route start and move all subsequent items to the top of the current route?</string>
 
     <!-- individual track -->
     <string name="individual_track">GPX track/route</string>

--- a/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.models.IWaypoint;
 import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Formatter;
@@ -110,6 +111,8 @@ public class RouteSortActivity extends AbstractActionBarActivity {
                     }
                     title.setOnClickListener(v1 -> CacheDetailActivity.startActivity(listView.getContext(), data.getGeocode(), data.getName()));
                     detail.setOnClickListener(v1 -> CacheDetailActivity.startActivity(listView.getContext(), data.getGeocode(), data.getName()));
+                    title.setOnLongClickListener(v1 -> setAsStart(position));
+                    detail.setOnLongClickListener(v1 -> setAsStart(position));
                 }
 
                 final MaterialButton buttonDelete = v.findViewById(R.id.button_left);
@@ -148,6 +151,25 @@ public class RouteSortActivity extends AbstractActionBarActivity {
         routeItems.remove(position);
         routeItemAdapter.notifyDataSetChanged();
         changed = true;
+        return true;
+    }
+
+    private boolean setAsStart(final int position) {
+        if (position < 1 || position >= routeItems.size()) {
+            return false;
+        }
+        SimpleDialog.ofContext(this).setTitle(TextParam.id(R.string.individual_route_set_as_start_title)).setMessage(TextParam.id(R.string.individual_route_set_as_start_message)).confirm((d, v) -> {
+            final ArrayList<RouteItem> newRouteItems = new ArrayList<>();
+            for (int i = position; i < routeItems.size(); i++) {
+                newRouteItems.add(routeItems.get(i));
+            }
+            for (int i = 0; i < position; i++) {
+                newRouteItems.add(routeItems.get(i));
+            }
+            routeItems = newRouteItems;
+            routeItemAdapter.notifyDataSetChanged();
+            changed = true;
+        });
         return true;
     }
 


### PR DESCRIPTION
## Description
I frequently find myself in a situation that I've planned a tour in a certain order some time ago, let's say in order "cache 1 - cache 10", but on starting the tour decide to start with "cache 3", continue to "cache 10", and do "cache 1" and "cache 2" only then. Reordering the tour is possible using the route sort activity, but can become quite cumbersome depending on route length and new entry point.

This PR adds a long tap action to the route sort activity, which will bring up a info message, and resorts the tour on confirmation.
