### PR TITLE
set downloader destination to ExternalFilesDir (rel. to #11184)

### DIFF
--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -131,7 +131,7 @@ public class DownloaderUtils {
             .setTitle(filename)
             .setDescription(String.format(activity.getString(R.string.downloadmap_filename), filename))
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
+            .setDestinationInExternalFilesDir(activity, Environment.DIRECTORY_DOWNLOADS, filename)
             .setAllowedOverMetered(allowMeteredNetwork)
             .setAllowedOverRoaming(allowMeteredNetwork);
         Log.i("Download enqueued: " + Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/" + filename);


### PR DESCRIPTION
## Description
- related to #11184
- implements solution suggested in https://stackoverflow.com/questions/66050509/downloadmanager-throw-android-os-networkonmainthreadexception (changing download folder)

(works at least in API 30 emulator)