### PR TITLE
fix added waypoint not show immediately (fix #11201)

### DIFF
--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
@@ -57,6 +57,8 @@ public abstract class TabbedViewPagerFragment<ViewBindingClass extends ViewBindi
     public void notifyDataSetChanged() {
         synchronized (mutextContentIsUpToDate) {
             contentIsUpToDate = false;
+            // do an update anyway to catch situations where currently active view gets updated (and thus no onResume gets called)
+            setContent();
         }
     }
 


### PR DESCRIPTION
## Description
Makes viewpager fragment update on `notifyDatasetChanged` even if it's the currently active fragment
