### PR TITLE
fix #11351: make lc connector detect premium after reconnect

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -762,6 +762,7 @@
     <string name="init_authorization_credential_username">Username</string>
     <string name="init_authorization_credential_password">Password</string>
     <string name="settings_service_active">Active</string>
+    <string name="settings_service_active_unavailable">Active/Unavailable</string>
     <string name="settings_navigation_disabled">This app seems not to be installed</string>
     <string name="init_signature">Signature</string>
     <string name="init_template_help">Placeholder strings - like [NAME] - are filled with the designated text when the template is used.</string>

--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -230,6 +230,7 @@ public class GCLogin extends AbstractLogin {
     public StatusCode logout() {
         try {
             getResponseBodyOrStatus(Network.postRequest("https://www.geocaching.com/account/logout", null).blockingGet());
+            serverParameters = null;
         } catch (final StatusException status) {
             return status.statusCode;
         } catch (final Exception ignored) {

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -309,8 +309,22 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
     private void initLCServicePreference(final boolean gcConnectorActive) {
         final boolean isActiveGCPM = gcConnectorActive && Settings.isGCPremiumMember();
-        getPreference(R.string.preference_screen_lc).setSummary(getServiceSummary(Settings.isLCConnectorActive() && isActiveGCPM));
-        getPreference(R.string.pref_connectorLCActive).setEnabled(isActiveGCPM);
+        getPreference(R.string.preference_screen_lc).setSummary(getLcServiceSummary(Settings.isLCConnectorActive(), gcConnectorActive));
+        if (isActiveGCPM) {
+            getPreference(R.string.pref_connectorLCActive).setEnabled(true);
+        }
+    }
+
+    private String getLcServiceSummary(final boolean lcConnectorActive, final boolean gcConnectorActive) {
+        if (!lcConnectorActive) {
+            return StringUtils.EMPTY;
+        }
+
+        //lc service is set to active by user. Check whether it can actually be actived due to GC conditions
+        final int lcStatusTextId = gcConnectorActive && Settings.isGCPremiumMember() ?
+            R.string.settings_service_active : R.string.settings_service_active_unavailable;
+
+        return CgeoApplication.getInstance().getString(lcStatusTextId);
     }
 
     private void setWebsite(final int preferenceKey, final String urlOrHost) {
@@ -969,7 +983,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             } else if (isPreference(preference, R.string.pref_connectorECActive)) {
                 preference.getPreferenceManager().findPreference(getKey(R.string.preference_screen_ec)).setSummary(summary);
             } else if (isPreference(preference, R.string.pref_connectorLCActive)) {
-                preference.getPreferenceManager().findPreference(getKey(R.string.preference_screen_lc)).setSummary(summary);
+                preference.getPreferenceManager().findPreference(getKey(R.string.preference_screen_lc)).setSummary(getLcServiceSummary(boolVal, Settings.isGCConnectorActive()));
                 setResult(RESTART_NEEDED);
             } else if (isPreference(preference, R.string.pref_connectorSUActive)) {
                 preference.getPreferenceManager().findPreference(getKey(R.string.preference_screen_su)).setSummary(summary);


### PR DESCRIPTION
fix #11351: make lc connector detect premium after reconnect

basic problem was that serverparameters were not reset in GCConnector after logout - so they stayed the same even after re-login. This incluided the premium state.

But this was not enough, some fiddling inside Settings for LC connector was also necessary to get this running...

@baiti : I would appreciate a review for this PR