### PR TITLE
use shorter key for D/T-config (fix #11362)

### DIFF
--- a/main/src/cgeo/geocaching/filters/core/DifficultyAndTerrainGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/DifficultyAndTerrainGeocacheFilter.java
@@ -11,8 +11,8 @@ public class DifficultyAndTerrainGeocacheFilter extends BaseGeocacheFilter {
     public DifficultyGeocacheFilter difficultyGeocacheFilter;
     public TerrainGeocacheFilter terrainGeocacheFilter;
 
-    private static final String CONFIG_DIFFICULTY = "difficulty";
-    private static final String CONFIG_TERRAIN = "terrain";
+    private static final String CONFIG_KEY_DIFFICULTY = "d";
+    private static final String CONFIG_KEY_TERRAIN = "t";
 
 
     public DifficultyAndTerrainGeocacheFilter() {
@@ -51,15 +51,15 @@ public class DifficultyAndTerrainGeocacheFilter extends BaseGeocacheFilter {
 
     @Override
     public void setConfig(final ExpressionConfig config) {
-        setToFilterConfig(difficultyGeocacheFilter, CONFIG_DIFFICULTY, config);
-        setToFilterConfig(terrainGeocacheFilter, CONFIG_TERRAIN, config);
+        setToFilterConfig(difficultyGeocacheFilter, CONFIG_KEY_DIFFICULTY, config);
+        setToFilterConfig(terrainGeocacheFilter, CONFIG_KEY_TERRAIN, config);
     }
 
     @Override
     public ExpressionConfig getConfig() {
         final ExpressionConfig config = new ExpressionConfig();
-        addFromFilterConfig(difficultyGeocacheFilter, CONFIG_DIFFICULTY, config);
-        addFromFilterConfig(terrainGeocacheFilter, CONFIG_TERRAIN, config);
+        addFromFilterConfig(difficultyGeocacheFilter, CONFIG_KEY_DIFFICULTY, config);
+        addFromFilterConfig(terrainGeocacheFilter, CONFIG_KEY_TERRAIN, config);
         return config;
     }
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
use "d" and "t" as key instead of "difficulty" and "terrain" to shorten the config-output.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11362 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
if we want to use a shorter version, we should introduce it before releasing to avoid migrating effort.

Or we refactor the combined filter anyway and this here is not necessary