### PR TITLE
detect special case that listing background image is the only spoiler

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1748,6 +1748,13 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                     }
                     ImagesActivity.startActivity(activity, cache.getGeocode(), cache.getSpoilers());
                 });
+
+                // if there is only a listing background image without other additional pictures, change the text to better explain the content.
+                if (cache.getSpoilers().size() == 1 && getString(R.string.cache_image_background).equals(cache.getSpoilers().get(0).title)) {
+                    binding.hintSpoilerlink.setText(R.string.cache_image_background);
+                } else {
+                    binding.hintSpoilerlink.setText(R.string.cache_menu_spoilers);
+                }
             } else {
                 binding.hintSpoilerlink.setVisibility(View.GONE);
                 binding.hintSpoilerlink.setClickable(true);


### PR DESCRIPTION
Is there is only the background but no further spoilers, the previous text "spoiler" was misleading... Now, this case is handled specially:

![grafik](https://user-images.githubusercontent.com/64581222/128555127-7791e548-ac57-4582-9098-b7bd13e8ce2f.png)
