### PR TITLE
fix #11261: checkstyle: exclude check for parenthesis around logical and

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -121,6 +121,8 @@
         <module name="SuppressWarningsHolder" />
         <module name="UnnecessaryParentheses">
             <property name="severity" value="info" />
+            <!-- put this check on all tokens except: LAND (Logical AND) -->
+            <property name="tokens" value="EXPR,IDENT,NUM_DOUBLE,NUM_FLOAT,NUM_INT,NUM_LONG,STRING_LITERAL,LITERAL_NULL,LITERAL_FALSE,LITERAL_TRUE,ASSIGN,BAND_ASSIGN,BOR_ASSIGN,BSR_ASSIGN,BXOR_ASSIGN,DIV_ASSIGN,MINUS_ASSIGN,MOD_ASSIGN,PLUS_ASSIGN,SL_ASSIGN,SR_ASSIGN,STAR_ASSIGN,LAMBDA,TEXT_BLOCK_LITERAL_BEGIN,LITERAL_INSTANCEOF,GT,LT,GE,LE,EQUAL,NOT_EQUAL,UNARY_MINUS,UNARY_PLUS,INC,DEC,LNOT,BNOT,POST_INC,POST_DEC"/>
         </module>
         <module name="UnusedImports">
             <property name="severity" value="warning" />


### PR DESCRIPTION
fix #11261: checkstyle: exclude check for parenthesis around logical and