### PR TITLE
add getMapMarkerId() for waypoints (rel. to #11139)

### DIFF
--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.models;
 
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -477,4 +478,9 @@ public class Waypoint implements IWaypoint {
     public boolean belongsToUserDefinedCache() {
         return InternalConnector.getInstance().canHandle(geocode);
     }
+
+    public int getMapMarkerId() {
+        return ConnectorFactory.getConnector(geocode).getCacheMapMarkerId(false);
+    }
+
 }


### PR DESCRIPTION
## Description
returns the id of the map marker (background) for the connector the current waypoint belongs to
(similar to `Geocache.getMapMarkerId()`, but for `Waypoint`)

## Related issues
needed to set correct marker (shape) for waypoints, as discussed in #11424 and yesterday's meetup
