### PR TITLE
make getDrawableDimensions() compatible to non-bitmaps (rel. to #11139)

### DIFF
--- a/main/src/cgeo/geocaching/utils/DisplayUtils.java
+++ b/main/src/cgeo/geocaching/utils/DisplayUtils.java
@@ -4,8 +4,6 @@ import cgeo.geocaching.CgeoApplication;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Point;
 import android.graphics.drawable.Drawable;
 import android.text.Layout;
@@ -58,8 +56,9 @@ public class DisplayUtils {
      * @return actual width and height
      */
     public static Pair<Integer, Integer> getDrawableDimensions(final Resources res, @DrawableRes final int resToFitIn) {
-        final Bitmap calc = BitmapFactory.decodeResource(res, resToFitIn);
-        return new Pair<>(calc.getWidth(), calc.getHeight());
+        final Drawable calc = ResourcesCompat.getDrawable(res, resToFitIn, null);
+        assert calc != null;
+        return new Pair<>(calc.getIntrinsicWidth(), calc.getIntrinsicHeight());
     }
 
     /**


### PR DESCRIPTION
## Description
While playing a bit with https://github.com/ztNFny/cgeo/tree/vectorIcons I got crashes when setting an individual cache icon. Yet another method needed to be updated to be compatible with non-bitmaps.

## Related issues
#11139
