### PR TITLE
Fix #11448 - Enlarge compass info and add space for direction

### DIFF
--- a/main/res/layout-land/compass_activity.xml
+++ b/main/res/layout-land/compass_activity.xml
@@ -79,7 +79,7 @@
                  <TextView
                      android:id="@+id/device_heading"
                      style="@style/single_degree_style"
-                     android:width="36dip"
+                     android:width="42dip"
                      android:layout_toRightOf="@+id/device_heading_label"/>
 
                  <TextView
@@ -118,7 +118,8 @@
             android:layout_gravity="left"
             android:layout_marginLeft="3dip"
             android:layout_below="@+id/device_information"
-            android:text="@null" />
+            android:text="@null"
+            android:textSize="@dimen/textSize_compassTargeting" />
 
         <TextView
             android:id="@+id/distance"
@@ -129,7 +130,8 @@
             android:layout_gravity="right"
             android:layout_marginRight="3dip"
             android:layout_below="@+id/device_information"
-            android:text="@null" />
+            android:text="@null"
+            android:textSize="@dimen/textSize_compassTargeting" />
 
         <TextView
             android:id="@+id/nav_location"

--- a/main/res/layout/compass_activity.xml
+++ b/main/res/layout/compass_activity.xml
@@ -61,7 +61,7 @@
              <TextView
                  android:id="@+id/device_heading"
                  style="@style/single_degree_style"
-                 android:width="36dip"
+                 android:width="42dip"
                  android:layout_toRightOf="@+id/device_heading_label"/>
 
              <TextView
@@ -102,7 +102,7 @@
                 android:layout_gravity="left"
                 android:layout_marginLeft="3dip"
                 android:text="@null"
-                android:textSize="@dimen/textSize_headingPrimary"
+                android:textSize="@dimen/textSize_compassTargeting"
                 tools:text="123°" />
 
             <TextView
@@ -113,7 +113,7 @@
                 android:layout_gravity="right"
                 android:layout_marginRight="3dip"
                 android:text="@null"
-                android:textSize="@dimen/textSize_headingPrimary"
+                android:textSize="@dimen/textSize_compassTargeting"
                 tools:text="123 km" />
         </RelativeLayout>
     </LinearLayout>

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -43,6 +43,9 @@
     <!-- buttons -->
     <dimen name="textSize_buttonsPrimary">@dimen/textSize_detailsSecondary</dimen>
 
+    <!-- compass -->
+    <dimen name="textSize_compassTargeting">26sp</dimen>
+
     <!-- all other text -->
     <dimen name="textSize_detailsPrimary">16sp</dimen>
     <dimen name="textSize_detailsSecondary">14sp</dimen>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
The `heading primary` text size leads to the compass direction/distance info be smaller compared to the old release. Therefore use explicit size for these text fields.
![before_after](https://user-images.githubusercontent.com/949669/128770422-d5219436-c22a-4761-b094-30c9f3f459d6.png)




## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11448

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Additionally fixes the cut off direction info if it has three digits:
![cut off orientation](https://user-images.githubusercontent.com/949669/128770495-29ad05b3-089c-48ad-98d5-54d3c73315bf.png)