### PR TITLE
disable check if short description is part of long description

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1835,7 +1835,8 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                     descriptionView.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
                     descriptionView.setVisibility(View.VISIBLE);
                     activity.addContextMenu(descriptionView);
-                    activity.potentiallyHideShortDescription();
+                    // TODO fix the non working method, see https://github.com/cgeo/cgeo/issues/11455
+                    //activity.potentiallyHideShortDescription();
                 }
                 if (loadingIndicatorView != null) {
                     loadingIndicatorView.setVisibility(View.GONE);

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1897,6 +1897,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     /**
      * Hide the short description, if it is contained somewhere at the start of the long description.
      */
+    /** TODO fix the non working method, see https://github.com/cgeo/cgeo/issues/11455
     public void potentiallyHideShortDescription() {
         final View shortView = findViewById(R.id.description);
         if (shortView == null) {
@@ -1914,6 +1915,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             }
         }
     }
+    */
 
     private void ensureSaved() {
         if (!cache.isOffline()) {


### PR DESCRIPTION
## Description

Disable the check if short description is part of long description and therefore no removing of short description, if it is contained.
In the previous release the check did not work. Therefore remove for now the check and so both description are shown as before.

The real problem should be solved separately.
Also tests are missing.

## Related issues

fixes #11455

