### PR TITLE
remove checkstyle check "UnnecessaryParentheses"

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -119,9 +119,6 @@
             <property name="severity" value="warning" />
         </module>
         <module name="SuppressWarningsHolder" />
-        <module name="UnnecessaryParentheses">
-            <property name="severity" value="info" />
-        </module>
         <module name="UnusedImports">
             <property name="severity" value="warning" />
             <property name="processJavadoc" value="true" />


### PR DESCRIPTION
## Description

In result of discussion in #11261 and different tests this check is to remove.

## Related issues

fix #11261
replaces #11425
