### PR TITLE
revert #11157 (switching navigation apps' Context to Activity)

### DIFF
--- a/main/src/cgeo/geocaching/apps/cache/AbstractGeneralApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/AbstractGeneralApp.java
@@ -4,7 +4,7 @@ import cgeo.geocaching.apps.AbstractApp;
 import cgeo.geocaching.apps.navi.CacheNavigationApp;
 import cgeo.geocaching.models.Geocache;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
@@ -19,11 +19,11 @@ abstract class AbstractGeneralApp extends AbstractApp implements CacheNavigation
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final Intent intent = getLaunchIntent();
         if (intent != null) {
             intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-            activity.startActivity(intent);
+            context.startActivity(intent);
         }
     }
 }

--- a/main/src/cgeo/geocaching/apps/cache/WhereYouGoApp.java
+++ b/main/src/cgeo/geocaching/apps/cache/WhereYouGoApp.java
@@ -5,7 +5,7 @@ import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.ProcessUtils;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
@@ -32,8 +32,8 @@ public class WhereYouGoApp extends AbstractGeneralApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
-        activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getWhereIGoUrl(cache))));
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+        context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getWhereIGoUrl(cache))));
     }
 
     /**

--- a/main/src/cgeo/geocaching/apps/navi/AbstractPointNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/AbstractPointNavigationApp.java
@@ -5,7 +5,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
@@ -25,17 +25,17 @@ abstract class AbstractPointNavigationApp extends AbstractApp implements CacheNa
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // asserted by caller
-        navigate(activity, coords);
+        navigate(context, coords);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
         final Geopoint coords = waypoint.getCoords();
         assert coords != null; // asserted by caller
-        navigate(activity, coords);
+        navigate(context, coords);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/apps/navi/AbstractRadarApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/AbstractRadarApp.java
@@ -4,7 +4,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
@@ -28,22 +28,22 @@ abstract class AbstractRadarApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint point) {
-        activity.startActivity(createIntent(point));
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint point) {
+        context.startActivity(createIntent(point));
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final Intent intent = createIntent(cache.getCoords());
         addIntentExtras(intent, cache);
-        activity.startActivity(intent);
+        context.startActivity(intent);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
         final Intent intent = createIntent(waypoint.getCoords());
         addIntentExtras(intent, waypoint);
-        activity.startActivity(intent);
+        context.startActivity(intent);
     }
 
     protected abstract void addCoordinates(Intent intent, Geopoint point);

--- a/main/src/cgeo/geocaching/apps/navi/CacheNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/CacheNavigationApp.java
@@ -3,7 +3,7 @@ package cgeo.geocaching.apps.navi;
 import cgeo.geocaching.apps.App;
 import cgeo.geocaching.models.Geocache;
 
-import android.app.Activity;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 
@@ -15,5 +15,5 @@ public interface CacheNavigationApp extends App {
     /**
      * Navigate to the given cache. The caller will assert that cache.getCoords() is not null.
      */
-    void navigate(@NonNull Activity activity, @NonNull Geocache cache);
+    void navigate(@NonNull Context context, @NonNull Geocache cache);
 }

--- a/main/src/cgeo/geocaching/apps/navi/CompassApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/CompassApp.java
@@ -6,7 +6,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
-import android.app.Activity;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 
@@ -22,18 +22,18 @@ class CompassApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
-        CompassActivity.startActivityPoint(activity, coords, getString(R.string.navigation_direct_navigation));
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
+        CompassActivity.startActivityPoint(context, coords, getString(R.string.navigation_direct_navigation));
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
-        CompassActivity.startActivityWaypoint(activity, waypoint);
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
+        CompassActivity.startActivityWaypoint(context, waypoint);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
-        CompassActivity.startActivityCache(activity, cache);
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+        CompassActivity.startActivityCache(context, cache);
     }
 
 }

--- a/main/src/cgeo/geocaching/apps/navi/GeopointNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/GeopointNavigationApp.java
@@ -2,7 +2,7 @@ package cgeo.geocaching.apps.navi;
 
 import cgeo.geocaching.location.Geopoint;
 
-import android.app.Activity;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 
@@ -11,5 +11,5 @@ import androidx.annotation.NonNull;
  *
  */
 interface GeopointNavigationApp {
-    void navigate(@NonNull Activity activity, @NonNull Geopoint coords);
+    void navigate(@NonNull Context context, @NonNull Geopoint coords);
 }

--- a/main/src/cgeo/geocaching/apps/navi/GoogleMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/GoogleMapsApp.java
@@ -9,7 +9,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.utils.Log;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
@@ -27,34 +27,34 @@ class GoogleMapsApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint point) {
-        navigate(activity, point, activity.getString(R.string.waypoint));
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint point) {
+        navigate(context, point, context.getString(R.string.waypoint));
     }
 
-    private static void navigate(final Activity activity, final Geopoint point, final String label) {
+    private static void navigate(final Context context, final Geopoint point, final String label) {
         try {
             final String latitude = GeopointFormatter.format(GeopointFormatter.Format.LAT_DECDEGREE_RAW, point);
             final String longitude = GeopointFormatter.format(Format.LON_DECDEGREE_RAW, point);
             final String geoLocation = "geo:" + latitude + "," + longitude;
             final String query = latitude + "," + longitude + "(" + label + ")";
             final String uriString = geoLocation + "?q=" + Uri.encode(query);
-            activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(uriString)));
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(uriString)));
             return;
         } catch (final RuntimeException ignored) {
             // nothing
         }
         Log.i("GoogleMapsApp.navigate: No maps application available.");
 
-        ActivityMixin.showToast(activity, getString(R.string.err_application_no));
+        ActivityMixin.showToast(context, getString(R.string.err_application_no));
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
-        navigate(activity, cache.getCoords(), cache.getName());
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+        navigate(context, cache.getCoords(), cache.getName());
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
-        navigate(activity, waypoint.getCoords(), waypoint.getName());
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
+        navigate(context, waypoint.getCoords(), waypoint.getName());
     }
 }

--- a/main/src/cgeo/geocaching/apps/navi/GoogleMapsDirectionApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/GoogleMapsDirectionApp.java
@@ -7,7 +7,7 @@ import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.utils.Log;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
@@ -25,10 +25,10 @@ class GoogleMapsDirectionApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
         try {
             final GeoData geo = Sensors.getInstance().currentGeo();
-            activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri
                     .parse("http://maps.google.com/maps?f=d&saddr="
                             + geo.getCoords().getLatitude() + "," + geo.getCoords().getLongitude() + "&daddr="
                             + coords.getLatitude() + "," + coords.getLongitude())));

--- a/main/src/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
@@ -9,9 +9,10 @@ import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.Log;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -38,9 +39,9 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
         try {
-            activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri
                     .parse("google.navigation:ll=" + coords.getLatitude() + ","
                             + coords.getLongitude() + "&mode=" + mode)));
 
@@ -67,7 +68,7 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
         }
 
         @Override
-        public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+        public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
             final ArrayList<IWaypoint> targets = new ArrayList<>();
             targets.add(cache);
             for (final Waypoint waypoint : cache.getWaypoints()) {
@@ -76,22 +77,24 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
                 }
             }
             if (targets.size() > 1) {
-                selectDriveTarget(activity, targets);
+                selectDriveTarget(context, targets);
             } else {
-                super.navigate(activity, cache);
+                super.navigate(context, cache);
             }
         }
 
         /**
          * show a selection of all parking places and the cache itself, when using the navigation for driving
          */
-        private void selectDriveTarget(final Activity activity, final ArrayList<IWaypoint> targets) {
-            final ListAdapter adapter = new ArrayAdapter<IWaypoint>(activity, R.layout.cacheslist_item_select, targets) {
+        private void selectDriveTarget(final Context context, final ArrayList<IWaypoint> targets) {
+            final Context themeContext = Dialogs.newContextThemeWrapper(context);
+            final LayoutInflater inflater = LayoutInflater.from(themeContext);
+            final ListAdapter adapter = new ArrayAdapter<IWaypoint>(themeContext, R.layout.cacheslist_item_select, targets) {
                 @Override
                 public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
 
-                    final View view = convertView == null ? activity.getLayoutInflater().inflate(R.layout.cacheslist_item_select, parent, false) : convertView;
-                    final TextView tv = view.findViewById(R.id.text);
+                    final View view = convertView == null ? inflater.inflate(R.layout.cacheslist_item_select, parent, false) : convertView;
+                    final TextView tv = (TextView) view.findViewById(R.id.text);
 
                     final IWaypoint item = getItem(position);
                     tv.setText(item.getName());
@@ -99,7 +102,7 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
                     final int icon = item instanceof Waypoint ? item.getWaypointType().markerId : ((Geocache) item).getType().markerId;
                     tv.setCompoundDrawablesWithIntrinsicBounds(icon, 0, 0, 0);
 
-                    final TextView infoView = view.findViewById(R.id.info);
+                    final TextView infoView = (TextView) view.findViewById(R.id.info);
                     if (item instanceof Waypoint) {
                         infoView.setText(((Waypoint) item).getNote());
                     } else {
@@ -110,15 +113,15 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
                 }
             };
 
-            Dialogs.newBuilder(activity)
+            Dialogs.newBuilder(context)
                 .setTitle(R.string.cache_menu_navigation_drive_select_target)
                 .setAdapter(adapter, (dialog, which) -> {
                     final IWaypoint target = targets.get(which);
                     if (target instanceof Geocache) {
-                        GoogleNavigationDrivingApp.super.navigate(activity, (Geocache) target);
+                        GoogleNavigationDrivingApp.super.navigate(context, (Geocache) target);
                     }
                     if (target instanceof Waypoint) {
-                        navigate(activity, (Waypoint) target);
+                        navigate(context, (Waypoint) target);
                     }
                 }).show();
         }

--- a/main/src/cgeo/geocaching/apps/navi/InternalMap.java
+++ b/main/src/cgeo/geocaching/apps/navi/InternalMap.java
@@ -8,7 +8,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
 
-import android.app.Activity;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 
@@ -32,18 +32,18 @@ class InternalMap extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
-        DefaultMap.startActivityCoords(activity, cls != null ? cls : Settings.getMapProvider().getMapClass(), coords, WaypointType.WAYPOINT, null);
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
+        DefaultMap.startActivityCoords(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), coords, WaypointType.WAYPOINT, null);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
-        DefaultMap.startActivityCoords(activity, cls != null ? cls : Settings.getMapProvider().getMapClass(), waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName());
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
+        DefaultMap.startActivityCoords(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName());
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
-        DefaultMap.startActivityGeoCode(activity, cls != null ? cls : Settings.getMapProvider().getMapClass(), cache.getGeocode());
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+        DefaultMap.startActivityGeoCode(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), cache.getGeocode());
     }
 
 }

--- a/main/src/cgeo/geocaching/apps/navi/LocusApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/LocusApp.java
@@ -5,7 +5,7 @@ import cgeo.geocaching.apps.AbstractLocusApp;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
@@ -36,12 +36,12 @@ class LocusApp extends AbstractLocusApp implements CacheNavigationApp, WaypointN
      *
      */
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
-        showInLocus(Collections.singletonList(waypoint), true, false, activity);
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
+        showInLocus(Collections.singletonList(waypoint), true, false, context);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
-        showInLocus(Collections.singletonList(cache), true, false, activity);
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+        showInLocus(Collections.singletonList(cache), true, false, context);
     }
 }

--- a/main/src/cgeo/geocaching/apps/navi/MapsMeApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/MapsMeApp.java
@@ -6,6 +6,8 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
 
 import androidx.annotation.NonNull;
 
@@ -22,21 +24,26 @@ class MapsMeApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
-        navigate(activity, coords, getString(R.string.unknown));
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
+        navigate(context, coords, getString(R.string.unknown));
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final List<Waypoint> waypoints = cache.getWaypoints();
         if (waypoints.isEmpty()) {
-            navigate(activity, cache.getCoords(), cache.getName());
+            navigate(context, cache.getCoords(), cache.getName());
         } else {
-            navigateWithWaypoints(activity, cache);
+            navigateWithWaypoints(context, cache);
         }
     }
 
-    private static void navigateWithWaypoints(final Activity activity, final Geocache cache) {
+    private static void navigateWithWaypoints(final Context context, final Geocache cache) {
+        final Activity activity = getActivity(context);
+        if (activity == null) {
+            return;
+        }
+
         final ArrayList<MWMPoint> points = new ArrayList<>();
         points.add(new MWMPoint(cache.getCoords().getLatitude(), cache.getCoords().getLongitude(), cache.getName()));
         for (final Waypoint waypoint : cache.getWaypoints()) {
@@ -49,19 +56,34 @@ class MapsMeApp extends AbstractPointNavigationApp {
         MapsWithMeApi.showPointsOnMap(activity, cache.getName(), pointsArray);
     }
 
-    private static void navigate(final Activity activity, final Geopoint coords, final String label) {
+    private static void navigate(final Context context, final Geopoint coords, final String label) {
+        final Activity activity = getActivity(context);
+        if (activity == null) {
+            return;
+        }
+
         MapsWithMeApi.showPointOnMap(activity, coords.getLatitude(), coords.getLongitude(), label);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
-        navigate(activity, waypoint.getCoords(), waypoint.getName());
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
+        navigate(context, waypoint.getCoords(), waypoint.getName());
     }
 
     @Override
     public boolean isInstalled() {
         // the library can handle the app not being installed
         return true;
+    }
+
+    private static Activity getActivity(final Context context) {
+        // TODO Mapsme API will do a hard cast. We could locally fix this by re-declaring all API methods
+        if (context instanceof Activity) {
+            return (Activity) context;
+        } else if (context instanceof ContextWrapper) {
+            return getActivity(((ContextWrapper) context).getBaseContext());
+        }
+        return null;
     }
 
 }

--- a/main/src/cgeo/geocaching/apps/navi/NavigationSelectionActionProvider.java
+++ b/main/src/cgeo/geocaching/apps/navi/NavigationSelectionActionProvider.java
@@ -21,7 +21,7 @@ import androidx.core.view.MenuItemCompat;
 public class NavigationSelectionActionProvider extends AbstractMenuActionProvider {
 
     private Geocache geocache;
-    private final Activity activity;
+    private Activity activity;
 
     /** Constructor MUST (!) be of type Context, NOT Activity! Otherwise it can't be instantiated by Android infrastructure. See #11251 */
     public NavigationSelectionActionProvider(final Context context) {

--- a/main/src/cgeo/geocaching/apps/navi/OruxMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/OruxMapsApp.java
@@ -5,7 +5,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
@@ -23,7 +23,7 @@ abstract class OruxMapsApp extends AbstractPointNavigationApp {
         super(getString(nameResourceId), intent);
     }
 
-    private void navigate(@NonNull final Activity activity, @NonNull final Geopoint point, @NonNull final String name) {
+    private void navigate(@NonNull final Context context, @NonNull final Geopoint point, @NonNull final String name) {
         final Intent intent = new Intent(this.intent);
         final double[] targetLat = { point.getLatitude() };
         final double[] targetLon = { point.getLongitude() };
@@ -34,26 +34,26 @@ abstract class OruxMapsApp extends AbstractPointNavigationApp {
             intent.putExtra(ORUXMAPS_EXTRA_NAME, targetName);
         }
 
-        activity.startActivity(intent);
+        context.startActivity(intent);
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint point) {
-        navigate(activity, point, "Waypoint");
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint point) {
+        navigate(context, point, "Waypoint");
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // guaranteed by caller
-        navigate(activity, coords, cache.getName());
+        navigate(context, coords, cache.getName());
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
         final Geopoint coords = waypoint.getCoords();
         assert coords != null; // guaranteed by caller
-        navigate(activity, coords, waypoint.getName());
+        navigate(context, coords, waypoint.getName());
     }
 
     static class OruxOnlineMapApp extends OruxMapsApp {

--- a/main/src/cgeo/geocaching/apps/navi/OsmAndApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/OsmAndApp.java
@@ -7,7 +7,7 @@ import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.network.Parameters;
 import cgeo.geocaching.utils.ProcessUtils;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
@@ -35,29 +35,29 @@ public class OsmAndApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geocache cache) {
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // guaranteed by super class
-        navigate(activity, coords, cache.getName());
+        navigate(context, coords, cache.getName());
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Waypoint waypoint) {
+    public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
         final Geopoint coords = waypoint.getCoords();
         assert coords != null; // guaranteed by super class
-        navigate(activity, coords, waypoint.getName());
+        navigate(context, coords, waypoint.getName());
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
-        navigate(activity, coords, activity.getString(R.string.osmand_marker_cgeo));
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
+        navigate(context, coords, context.getString(R.string.osmand_marker_cgeo));
     }
 
-    private static void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords, @NonNull final String markerName) {
+    private static void navigate(@NonNull final Context context, @NonNull final Geopoint coords, @NonNull final String markerName) {
         final Parameters params = new Parameters(PARAM_LAT, String.valueOf(coords.getLatitude()),
                 PARAM_LON, String.valueOf(coords.getLongitude()),
                 PARAM_NAME, markerName);
-        activity.startActivity(buildIntent(params));
+        context.startActivity(buildIntent(params));
     }
 
     private static Intent buildIntent(@Nullable final Parameters parameters) {

--- a/main/src/cgeo/geocaching/apps/navi/StreetviewApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/StreetviewApp.java
@@ -6,8 +6,8 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.utils.ProcessUtils;
 
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
@@ -28,12 +28,12 @@ class StreetviewApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint point) {
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint point) {
         try {
-            activity.startActivity(new Intent(Intent.ACTION_VIEW,
+            context.startActivity(new Intent(Intent.ACTION_VIEW,
                     Uri.parse("google.streetview:cbll=" + point.getLatitude() + "," + point.getLongitude())));
         } catch (final ActivityNotFoundException ignored) {
-            ActivityMixin.showToast(activity, CgeoApplication.getInstance().getString(R.string.err_application_no));
+            ActivityMixin.showToast(context, CgeoApplication.getInstance().getString(R.string.err_application_no));
         }
     }
 }

--- a/main/src/cgeo/geocaching/apps/navi/SygicNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/SygicNavigationApp.java
@@ -4,7 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.utils.ProcessUtils;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
@@ -36,9 +36,9 @@ abstract class SygicNavigationApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Activity activity, @NonNull final Geopoint coords) {
+    public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
         final String str = "com.sygic.aura://coordinate|" + coords.getLongitude() + "|" + coords.getLatitude() + "|" + mode;
-        activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(str)));
+        context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(str)));
     }
 
     static class SygicNavigationWalkingApp extends SygicNavigationApp {

--- a/main/src/cgeo/geocaching/apps/navi/WaypointNavigationApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/WaypointNavigationApp.java
@@ -2,7 +2,7 @@ package cgeo.geocaching.apps.navi;
 
 import cgeo.geocaching.models.Waypoint;
 
-import android.app.Activity;
+import android.content.Context;
 
 import androidx.annotation.NonNull;
 
@@ -14,7 +14,7 @@ interface WaypointNavigationApp {
     /**
      * Navigate to the given waypoint. The caller will assert that waypoint.getCoords() is not null.
      */
-    void navigate(@NonNull Activity context, @NonNull Waypoint waypoint);
+    void navigate(@NonNull Context context, @NonNull Waypoint waypoint);
 
     boolean isEnabled(@NonNull Waypoint waypoint);
 }


### PR DESCRIPTION
## Description
- reverts the change from `Context` to `Activity` for navigation apps (introduced by #11157)
- but keeps the changes introduced by #11397 (which fixes #11251, a side-effect of #11157)
