### PR TITLE
fix lc/al connector prefix (fix #10911)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -53,7 +53,7 @@
     <string translatable="false" name="pref_gc_avatar">gc_avatar</string>
     <string translatable="false" name="pref_gcvote_avatar">gcvote_avatar</string>
     <string translatable="false" name="pref_connectorECActive">connectorECActive</string>
-    <string translatable="false" name="pref_connectorLCActive">connectorLCActive</string>
+    <string translatable="false" name="pref_connectorALActive">connectorLCActive</string><!-- variable stays with "LC" for compatibility reasons -->
     <string translatable="false" name="pref_connectorGeokretyActive">connectorGeokretyActive</string>
     <string translatable="false" name="pref_user_vote">user-vote</string>
     <string translatable="false" name="pref_pass_vote">pass-vote</string>
@@ -243,7 +243,7 @@
     <string translatable="false" name="pref_fakekey_ocuk_register">fakekey_ocuk_register</string>
     <string translatable="false" name="pref_fakekey_ocuk_website">fakekey_ocuk_website</string>
     <string translatable="false" name="pref_fakekey_ec_website">fakekey_ec_website</string>
-    <string translatable="false" name="pref_fakekey_lc_website">fakekey_lc_website</string>
+    <string translatable="false" name="pref_fakekey_al_website">fakekey_al_website</string>
     <string translatable="false" name="pref_fakekey_su_website">fakekey_su_website</string>
     <string translatable="false" name="pref_su_tokensecret">su_tokensecret</string>
     <string translatable="false" name="pref_su_tokenpublic">su_tokenpublic</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -71,7 +71,7 @@
                     android:layout="@layout/preference_category" >
                     <CheckBoxPreference
                         android:defaultValue="true"
-                        android:key="@string/pref_connectorLCActive"
+                        android:key="@string/pref_connectorALActive"
                         android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:layout="@layout/text_preference"
@@ -81,7 +81,7 @@
                 <PreferenceCategory android:title="@string/settings_information"
                     android:layout="@layout/preference_category" >
                     <Preference
-                        android:key="@string/pref_fakekey_lc_website"
+                        android:key="@string/pref_fakekey_al_website"
                         android:title="@string/settings_open_website" />
                     <cgeo.geocaching.settings.CapabilitiesPreference
                         android:title="@string/settings_features"

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.command.AbstractCommand;
 import cgeo.geocaching.command.MoveToListAndRemoveFromOthersCommand;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.al.ALConnector;
 import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.IIgnoreCapability;
 import cgeo.geocaching.connector.capability.IVotingCapability;
@@ -20,7 +21,6 @@ import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.connector.capability.PgcChallengeCheckerCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
 import cgeo.geocaching.connector.internal.InternalConnector;
-import cgeo.geocaching.connector.lc.LCConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.databinding.CachedetailDescriptionPageBinding;
@@ -1658,7 +1658,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
             // extra description
             final String geocode = cache.getGeocode();
-            boolean hasExtraDescription = LCConnector.getInstance().canHandle(geocode); // could be generalized, but currently it's only LC
+            boolean hasExtraDescription = ALConnector.getInstance().canHandle(geocode); // could be generalized, but currently it's only AL
             if (hasExtraDescription) {
                 final IConnector conn = ConnectorFactory.getConnector(geocode);
                 if (conn != null) {

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.al.ALConnector;
 import cgeo.geocaching.connector.capability.ICredentials;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.ISearchByCenter;
@@ -16,7 +17,6 @@ import cgeo.geocaching.connector.ga.GeocachingAustraliaConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.ge.GeopeitusConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
-import cgeo.geocaching.connector.lc.LCConnector;
 import cgeo.geocaching.connector.oc.OCApiConnector.ApiSupport;
 import cgeo.geocaching.connector.oc.OCApiLiveConnector;
 import cgeo.geocaching.connector.oc.OCCZConnector;
@@ -65,12 +65,13 @@ public final class ConnectorFactory {
     @NonNull private static final Collection<IConnector> CONNECTORS = Collections.unmodifiableCollection(Arrays.<IConnector> asList(
             GCConnector.getInstance(),
             ECConnector.getInstance(),
-            LCConnector.getInstance(),
+            ALConnector.getInstance(),
             new OCDEConnector(),
             new OCCZConnector(),
             new OCApiLiveConnector("opencache.uk", "opencache.uk", false, "OK", "CC BY-NC-SA 2.5",
                     R.string.oc_uk2_okapi_consumer_key, R.string.oc_uk2_okapi_consumer_secret,
-                    R.string.pref_connectorOCUKActive, R.string.pref_ocuk2_tokenpublic, R.string.pref_ocuk2_tokensecret, ApiSupport.current, "OC.UK"), new OCConnector("OpenCaching.NO/SE", "www.opencaching.se", false, "OS", "OC.NO"),
+                    R.string.pref_connectorOCUKActive, R.string.pref_ocuk2_tokenpublic, R.string.pref_ocuk2_tokensecret, ApiSupport.current, "OC.UK"),
+            new OCConnector("OpenCaching.NO/SE", "www.opencaching.se", false, "OS", "OC.NO"),
             new OCApiLiveConnector("opencaching.nl", "www.opencaching.nl", false, "OB", "CC BY-SA 3.0",
                     R.string.oc_nl_okapi_consumer_key, R.string.oc_nl_okapi_consumer_secret,
                     R.string.pref_connectorOCNLActive, R.string.pref_ocnl_tokenpublic, R.string.pref_ocnl_tokensecret, ApiSupport.current, "OC.NL"),

--- a/main/src/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/cgeo/geocaching/connector/al/ALApi.java
@@ -1,4 +1,4 @@
-package cgeo.geocaching.connector.lc;
+package cgeo.geocaching.connector.al;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.IConnector;
@@ -43,7 +43,7 @@ import io.reactivex.rxjava3.functions.Function;
 import okhttp3.Response;
 import org.apache.commons.lang3.StringUtils;
 
-final class LCApi {
+final class ALApi {
 
     @NonNull
     private static final String API_HOST        = "https://labs-api.geocaching.com/Api/Adventures/";
@@ -55,7 +55,7 @@ final class LCApi {
     private static final String LATITUDE  = "Latitude";
     private static final String TITLE     = "Title";
 
-    private LCApi() {
+    private ALApi() {
         // utility class with static methods
     }
 
@@ -89,7 +89,7 @@ final class LCApi {
         final Geopoint gp1 = new Geopoint(lat1, lon1);
         final Geopoint gp2 = new Geopoint(lat2, lon2);
         final double radius = gp1.distanceTo(gp2) * 500; // we get diameter in km, need radius in m
-        Log.d("_LC Radius: " + (int) radius);
+        Log.d("_AL Radius: " + (int) radius);
         final Parameters params = new Parameters("skip", "0");
         final Parameters headers = new Parameters(CONSUMER_HEADER, CONSUMER_KEY);
         params.add("take", "500");
@@ -130,7 +130,7 @@ final class LCApi {
 
     @NonNull
     public static Collection<Geocache> searchByFilter(final GeocacheFilter filter, final IConnector connector) {
-        //for now we have to assume that LCConnector supports only SINGLE criteria search
+        //for now we have to assume that ALConnector supports only SINGLE criteria search
 
         final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
         final OriginGeocacheFilter of = GeocacheFilter.findInChain(filters, OriginGeocacheFilter.class);
@@ -175,14 +175,14 @@ final class LCApi {
         try {
             final String jsonString = Network.getResponseData(response);
             if (jsonString == null) {
-                Log.d("_LC importCacheFromJson: null response from network");
+                Log.d("_AL importCacheFromJson: null response from network");
                 return null;
             }
             final JsonNode json = JsonUtils.reader.readTree(jsonString);
-            Log.d("_LC importCacheFromJson: " + json.toPrettyString());
+            Log.d("_AL importCacheFromJson: " + json.toPrettyString());
             return parseCacheDetail(json);
         } catch (final Exception e) {
-            Log.w("_LC importCacheFromJSON", e);
+            Log.w("_AL importCacheFromJSON", e);
             return null;
         }
     }
@@ -192,11 +192,11 @@ final class LCApi {
         try {
             final String jsonString = Network.getResponseData(response);
             if (jsonString == null) {
-                Log.d("_LC importCachesFromJson: null response from network");
+                Log.d("_AL importCachesFromJson: null response from network");
                 return Collections.emptyList();
             }
             final JsonNode json = JsonUtils.reader.readTree(jsonString);
-            Log.d("_LC importCachesFromJson: " + json.toPrettyString());
+            Log.d("_AL importCachesFromJson: " + json.toPrettyString());
             final JsonNode items = json.at("/Items");
             if (!items.isArray()) {
                 return Collections.emptyList();
@@ -210,7 +210,7 @@ final class LCApi {
             }
             return caches;
         } catch (final Exception e) {
-            Log.w("_LC importCachesFromJSON", e);
+            Log.w("_AL importCachesFromJSON", e);
             return Collections.emptyList();
         }
     }
@@ -222,7 +222,7 @@ final class LCApi {
             final JsonNode location = response.at(LOCATION);
             final String firebaseDynamicLink = response.get("FirebaseDynamicLink").asText();
             final String[] segments = firebaseDynamicLink.split("/");
-            final String geocode = LCConnector.GEOCODE_PREFIX + response.get("Id").asText();
+            final String geocode = ALConnector.GEOCODE_PREFIX + response.get("Id").asText();
             cache.setGeocode(geocode);
             cache.setCacheId(segments[segments.length - 1]);
             cache.setName(response.get(TITLE).asText());
@@ -234,7 +234,7 @@ final class LCApi {
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.CACHE));
             return cache;
         } catch (final NullPointerException e) {
-            Log.e("_LC LCApi.parseCache", e);
+            Log.e("_AL ALApi.parseCache", e);
             return null;
         }
     }
@@ -249,7 +249,7 @@ final class LCApi {
             final JsonNode location = response.at(LOCATION);
             final String firebaseDynamicLink = response.get("FirebaseDynamicLink").asText();
             final String[] segments = firebaseDynamicLink.split("/");
-            final String geocode = LCConnector.GEOCODE_PREFIX + response.get("Id").asText();
+            final String geocode = ALConnector.GEOCODE_PREFIX + response.get("Id").asText();
             final String ilink = response.get("KeyImageUrl").asText();
             final String desc = response.get("Description").asText();
             cache.setGeocode(geocode);
@@ -269,7 +269,7 @@ final class LCApi {
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
             return cache;
         } catch (final NullPointerException e) {
-            Log.e("_LC LCApi.parseCache", e);
+            Log.e("_AL ALApi.parseCache", e);
             return null;
         }
     }
@@ -313,7 +313,7 @@ final class LCApi {
 
                 result.add(wpt);
             } catch (final NullPointerException e) {
-                Log.e("_LC LCApi.parseWaypoints", e);
+                Log.e("_AL ALApi.parseWaypoints", e);
             }
         }
         return result;

--- a/main/src/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/cgeo/geocaching/connector/al/ALConnector.java
@@ -1,4 +1,4 @@
-package cgeo.geocaching.connector.lc;
+package cgeo.geocaching.connector.al;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
@@ -27,23 +27,23 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-public class LCConnector extends AbstractConnector implements ISearchByGeocode, ISearchByFilter, ISearchByCenter, ISearchByViewPort {
+public class ALConnector extends AbstractConnector implements ISearchByGeocode, ISearchByFilter, ISearchByCenter, ISearchByViewPort {
 
     @NonNull
     private static final String CACHE_URL = "https://adventurelab.page.link/";
 
     @NonNull
-    protected static final String GEOCODE_PREFIX = "LC";
+    protected static final String GEOCODE_PREFIX = "AL";
 
     /**
-     * Pattern for LC codes
+     * Pattern for AL codes
      */
     @NonNull
-    private static final Pattern PATTERN_LC_CODE = Pattern.compile("LC[-\\w]+", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_AL_CODE = Pattern.compile("AL[-\\w]+", Pattern.CASE_INSENSITIVE);
 
     private final String name;
 
-    private LCConnector() {
+    private ALConnector() {
         // singleton
         name = CgeoApplication.getInstance().getString(R.string.settings_title_lc);
     }
@@ -52,23 +52,23 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
      * initialization on demand holder pattern
      */
     private static class Holder {
-        @NonNull private static final LCConnector INSTANCE = new LCConnector();
+        @NonNull private static final ALConnector INSTANCE = new ALConnector();
     }
 
     @NonNull
-    public static LCConnector getInstance() {
+    public static ALConnector getInstance() {
         return Holder.INSTANCE;
     }
 
     @Override
     public boolean canHandle(@NonNull final String geocode) {
-        return PATTERN_LC_CODE.matcher(geocode).matches();
+        return PATTERN_AL_CODE.matcher(geocode).matches();
     }
 
     @NotNull
     @Override
     public String[] getGeocodeSqlLikeExpressions() {
-        return new String[]{"LC%"};
+        return new String[]{"AL%"};
     }
 
 
@@ -116,16 +116,16 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
         if (geocode == null) {
             return null;
         }
-        Log.d("_LC searchByGeocode: geocode = " + geocode);
+        Log.d("_AL searchByGeocode: geocode = " + geocode);
         DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_loadpage);
-        final Geocache cache = LCApi.searchByGeocode(geocode);
+        final Geocache cache = ALApi.searchByGeocode(geocode);
         return cache != null ? new SearchResult(cache) : null;
     }
 
     @Override
     @NonNull
     public SearchResult searchByViewport(@NonNull final Viewport viewport) {
-        final Collection<Geocache> caches = LCApi.searchByBBox(viewport);
+        final Collection<Geocache> caches = ALApi.searchByBBox(viewport);
         final SearchResult searchResult = new SearchResult(caches);
         searchResult.setTotalCountGC(caches.size());
         return searchResult.filterSearchResults(false, false, Settings.getCacheType());
@@ -134,7 +134,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     @NonNull
     public SearchResult searchByCenter(@NonNull final Geopoint center) {
-        final Collection<Geocache> caches = LCApi.searchByCenter(center);
+        final Collection<Geocache> caches = ALApi.searchByCenter(center);
         final SearchResult searchResult = new SearchResult(caches);
         searchResult.setTotalCountGC(caches.size());
         return searchResult.filterSearchResults(false, false, Settings.getCacheType());
@@ -150,7 +150,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     @NonNull
     @Override
     public SearchResult searchByFilter(@NonNull final GeocacheFilter filter) {
-        return new SearchResult(LCApi.searchByFilter(filter, this));
+        return new SearchResult(ALApi.searchByFilter(filter, this));
     }
 
 
@@ -167,7 +167,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
 
     @Override
     public boolean isActive() {
-        return Settings.isLCConnectorActive() && Settings.isGCPremiumMember() && Settings.isGCConnectorActive();
+        return Settings.isALConnectorActive() && Settings.isGCPremiumMember() && Settings.isGCConnectorActive();
     }
 
     @Override
@@ -178,7 +178,7 @@ public class LCConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     @Nullable
     public String getGeocodeFromUrl(@NonNull final String url) {
-        final String geocode = "LC" + StringUtils.substringAfter(url, "https://adventurelab.page.link/");
+        final String geocode = "AL" + StringUtils.substringAfter(url, "https://adventurelab.page.link/");
         if (canHandle(geocode)) {
             return geocode;
         }

--- a/main/src/cgeo/geocaching/connector/al/package-info.java
+++ b/main/src/cgeo/geocaching/connector/al/package-info.java
@@ -1,5 +1,5 @@
 /**
  * <a https://labs.geocaching.com/">Geocaching Adventure Lab</a> implementation.
  */
-package cgeo.geocaching.connector.lc;
+package cgeo.geocaching.connector.al;
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -581,8 +581,8 @@ public class Settings {
         return getBoolean(R.string.pref_connectorECActive, false);
     }
 
-    public static boolean isLCConnectorActive() {
-        return getBoolean(R.string.pref_connectorLCActive, true);
+    public static boolean isALConnectorActive() {
+        return getBoolean(R.string.pref_connectorALActive, true);
     }
 
     public static boolean isSUConnectorActive() {

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -8,10 +8,10 @@ import cgeo.geocaching.apps.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.brouter.BRouterConstants;
 import cgeo.geocaching.brouter.util.DefaultFilesUtils;
 import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.al.ALConnector;
 import cgeo.geocaching.connector.capability.ICredentials;
 import cgeo.geocaching.connector.ec.ECConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
-import cgeo.geocaching.connector.lc.LCConnector;
 import cgeo.geocaching.connector.su.SuConnector;
 import cgeo.geocaching.downloader.DownloaderUtils;
 import cgeo.geocaching.gcvote.GCVote;
@@ -286,8 +286,8 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
         setWebsite(R.string.pref_fakekey_ec_website, ECConnector.getInstance().getHost());
         getPreference(R.string.preference_screen_ec).setSummary(getServiceSummary(Settings.isECConnectorActive()));
 
-        getPreference(R.string.pref_connectorLCActive).setOnPreferenceChangeListener(this);
-        setWebsite(R.string.pref_fakekey_lc_website, LCConnector.getInstance().getHost());
+        getPreference(R.string.pref_connectorALActive).setOnPreferenceChangeListener(this);
+        setWebsite(R.string.pref_fakekey_al_website, ALConnector.getInstance().getHost());
         initLCServicePreference(Settings.isGCConnectorActive());
 
         getPreference(R.string.pref_connectorSUActive).setOnPreferenceChangeListener(this);
@@ -309,9 +309,9 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
 
     private void initLCServicePreference(final boolean gcConnectorActive) {
         final boolean isActiveGCPM = gcConnectorActive && Settings.isGCPremiumMember();
-        getPreference(R.string.preference_screen_lc).setSummary(getLcServiceSummary(Settings.isLCConnectorActive(), gcConnectorActive));
+        getPreference(R.string.preference_screen_lc).setSummary(getLcServiceSummary(Settings.isALConnectorActive(), gcConnectorActive));
         if (isActiveGCPM) {
-            getPreference(R.string.pref_connectorLCActive).setEnabled(true);
+            getPreference(R.string.pref_connectorALActive).setEnabled(true);
         }
     }
 
@@ -969,7 +969,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                 || isPreference(preference, R.string.pref_connectorOCUKActive)
                 || isPreference(preference, R.string.pref_connectorGCActive)
                 || isPreference(preference, R.string.pref_connectorECActive)
-                || isPreference(preference, R.string.pref_connectorLCActive)
+                || isPreference(preference, R.string.pref_connectorALActive)
                 || isPreference(preference, R.string.pref_connectorSUActive)) {
             // update summary
             final boolean boolVal = (Boolean) value;
@@ -982,7 +982,7 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
                 initLCServicePreference(boolVal);
             } else if (isPreference(preference, R.string.pref_connectorECActive)) {
                 preference.getPreferenceManager().findPreference(getKey(R.string.preference_screen_ec)).setSummary(summary);
-            } else if (isPreference(preference, R.string.pref_connectorLCActive)) {
+            } else if (isPreference(preference, R.string.pref_connectorALActive)) {
                 preference.getPreferenceManager().findPreference(getKey(R.string.preference_screen_lc)).setSummary(getLcServiceSummary(boolVal, Settings.isGCConnectorActive()));
                 setResult(RESTART_NEEDED);
             } else if (isPreference(preference, R.string.pref_connectorSUActive)) {

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -223,7 +223,7 @@ public class DataStore {
      */
     private static final CacheCache cacheCache = new CacheCache();
     private static volatile SQLiteDatabase database = null;
-    private static final int dbVersion = 96;
+    private static final int dbVersion = 97;
     public static final int customListIdOffset = 10;
 
     /**
@@ -252,10 +252,11 @@ public class DataStore {
         90, // add user guid to cg_caches and cg_logs
         91, // add fields to cg_extension
         92, // add emoji id to cg_caches
-        93,  // add emoji id to cg_lists
-        94,  // add scale to offline log images
-        95,  // add table to store custom filters
-        96   // add preventAskForDeletion to cg_lists
+        93, // add emoji id to cg_lists
+        94, // add scale to offline log images
+        95, // add table to store custom filters
+        96, // add preventAskForDeletion to cg_lists
+        97  // rename ALC caches' geocodes from "LC" prefix to "AL" prefix
     ));
 
     @NonNull private static final String dbTableCaches = "cg_caches";
@@ -1608,6 +1609,23 @@ public class DataStore {
                         }
                     }
 
+                    //rename lab adventure caches geocodes prefix from LC to AL
+                    if (oldVersion < 97) {
+                        try {
+                            final String sql = " SET geocode = \"AL\" || SUBSTR(geocode, 3) WHERE SUBSTR(geocode, 1, 2) = \"LC\" AND LENGTH(geocode) > 10";
+                            db.execSQL("UPDATE " + dbTableCaches + sql);
+                            db.execSQL("UPDATE " + dbTableAttributes + sql);
+                            db.execSQL("UPDATE " + dbTableCachesLists + sql);
+                            db.execSQL("UPDATE " + dbTableLogCount + sql);
+                            db.execSQL("UPDATE " + dbTableLogs + sql);
+                            db.execSQL("UPDATE " + dbTableLogsOffline + sql);
+                            db.execSQL("UPDATE " + dbTableSpoilers + sql);
+                            db.execSQL("UPDATE " + dbTableTrackables + sql);
+                            db.execSQL("UPDATE " + dbTableWaypoints + sql);
+                        } catch (final SQLException e) {
+                            onUpgradeError(e, 97);
+                        }
+                    }
                 }
 
                 //at the very end of onUpgrade: rewrite downgradeable versions in database


### PR DESCRIPTION
## Description
- renames LC prefix to AL prefix for all stored ALC caches (including all references)
- renames LC connector to AL (including package name / folder)

## Related issues
- fixes #10911

## Additional info
I've added a wiki page which documents the connectors c:geo supports and the geocode prefixes they use: https://github.com/cgeo/cgeo/wiki/Supported-geocaching-platforms