### PR TITLE
remove duplicated 'activate' strings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -715,9 +715,7 @@
 
     <string name="settings_goto_url_button">more …</string>
 
-    <string name="settings_activate_gc">Activate</string>
-    <string name="settings_activate_ec">Activate</string>
-    <string name="settings_activate_lc">Activate</string>
+    <string name="settings_service_activate">Activate</string>
     <string name="settings_gc_legal_note">With using the service of geocaching.com, you accept the Groundspeak Terms of Use.</string>
     <string name="settings_info_facebook_login_title">Login using Facebook or Google</string>
     <string name="settings_info_facebook_login">You can\'t make c:geo login to geocaching.com with your Facebook or Google account. But there is a simple workaround…</string>
@@ -728,30 +726,22 @@
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
     <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)\n\nChanging this setting requires a restart.</string>
     <string name="lc_default_description">This is a geocaching.com Adventure Lab Cache. Adventures can only be played with the Groundspeak Adventure Lab App. Tap on the Adventure Lab icon on the \"Details\" page to open/install the Adventure Lab App for this adventure from there.\nIf you don\'t want to see Adenture Lab caches on your map and search, you can deactivate using the \"settings\" menu - Services - Geocaching.com Adventure Lab</string>
-    <string name="settings_activate_oc">Activate</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>
     <string name="init_oc_de_description">Authorize c:geo with opencaching.de to search for caches and access/filter your found caches.</string>
-    <string name="settings_activate_oc_pl">Activate</string>
     <string name="init_summary_oc_pl">Load caches from opencaching.pl</string>
     <string name="init_oc_pl_description">Authorize c:geo with opencaching.pl to search for caches and access/filter your found caches.</string>
-    <string name="settings_activate_oc_nl">Activate</string>
     <string name="init_summary_oc_nl">Load caches from opencaching.nl</string>
     <string name="init_oc_nl_description">Authorize c:geo with opencaching.nl to search for caches and access/filter your found caches.</string>
-    <string name="settings_activate_oc_us">Activate</string>
     <string name="init_summary_oc_us">Load caches from opencaching.us</string>
     <string name="init_oc_us_description">Authorize c:geo with opencaching.us to search for caches and access/filter your found caches.</string>
-    <string name="settings_activate_oc_ro">Activate</string>
     <string name="init_summary_oc_ro">Load caches from opencaching.ro</string>
     <string name="init_oc_ro_description">Authorize c:geo with opencaching.ro to search for caches and access/filter your found caches.</string>
-    <string name="settings_activate_oc_uk">Activate</string>
     <string name="init_summary_oc_uk">Load caches from opencache.uk</string>
     <string name="init_oc_uk_description">Authorize c:geo with opencache.uk to search for caches and access/filter your found caches.</string>
     <string name="init_summary_su">Load caches from Geocaching.su</string>
-    <string name="settings_activate_su">Activate</string>
     <string name="init_gcvote_password_description">To be able to rate a cache, you need to follow the instructions at GCVote.com and enter your GCVote password here.</string>
     <string name="err_vote_send_rating">Error while sending rating.</string>
     <string name="vote_sent">Voting successfully sent</string>
-    <string name="settings_activate_twitter">Activate</string>
     <string name="init_login_popup">Login</string>
     <string name="init_login_popup_working">Logging in…</string>
     <string name="init_login_popup_ok">Login OK</string>
@@ -2081,7 +2071,6 @@
     <string name="confirm_report_problem_message">You want to report \'%s\'. Are you sure?</string>
 
     <!-- Geokrety -->
-    <string name="settings_activate_geokrety">Activate</string>
     <string name="init_summary_geokrety">Enable trackables from GeoKrety.org</string>
     <string name="init_geokrety_description">Authorize c:geo with GeoKrety.org to log GeoKrety trackables.</string>
     <string name="init_geokrety_userid">User Id: %s</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -20,7 +20,7 @@
                     <cgeo.geocaching.settings.CheckBoxWithPopupPreference
                         android:defaultValue="false"
                         android:key="@string/pref_connectorGCActive"
-                        android:title="@string/settings_activate_gc"
+                        android:title="@string/settings_service_activate"
                         app:text="@string/settings_gc_legal_note"
                         app:title="@string/settings_title_gc"
                         app:url="@string/settings_gc_legal_note_url"
@@ -72,7 +72,7 @@
                     <CheckBoxPreference
                         android:defaultValue="true"
                         android:key="@string/pref_connectorLCActive"
-                        android:title="@string/settings_activate_lc" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:layout="@layout/text_preference"
                         android:text="@string/settings_lc_description" />
@@ -98,7 +98,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorOCActive"
                         android:summary="@string/init_summary_oc_de"
-                        android:title="@string/settings_activate_oc" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorOCActive"
                         android:layout="@layout/text_preference"
@@ -129,7 +129,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorOCPLActive"
                         android:summary="@string/init_summary_oc_pl"
-                        android:title="@string/settings_activate_oc_pl" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorOCPLActive"
                         android:layout="@layout/text_preference"
@@ -160,7 +160,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorOCNLActive"
                         android:summary="@string/init_summary_oc_nl"
-                        android:title="@string/settings_activate_oc_nl" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorOCNLActive"
                         android:layout="@layout/text_preference"
@@ -192,7 +192,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorOCUSActive"
                         android:summary="@string/init_summary_oc_us"
-                        android:title="@string/settings_activate_oc_us" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorOCUSActive"
                         android:layout="@layout/text_preference"
@@ -223,7 +223,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorOCROActive"
                         android:summary="@string/init_summary_oc_ro"
-                        android:title="@string/settings_activate_oc_ro" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorOCROActive"
                         android:layout="@layout/text_preference"
@@ -254,7 +254,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorOCUKActive"
                         android:summary="@string/init_summary_oc_uk"
-                        android:title="@string/settings_activate_oc_uk" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorOCUKActive"
                         android:layout="@layout/text_preference"
@@ -284,7 +284,7 @@
                     <CheckBoxPreference
                         android:defaultValue="false"
                         android:key="@string/pref_connectorECActive"
-                        android:title="@string/settings_activate_ec" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorECActive"
                         android:layout="@layout/text_preference"
@@ -328,7 +328,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorSUActive"
                         android:summary="@string/init_summary_su"
-                        android:title="@string/settings_activate_su" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorSUActive"
                         android:layout="@layout/text_preference"
@@ -393,7 +393,7 @@
                         android:defaultValue="false"
                         android:key="@string/pref_connectorGeokretyActive"
                         android:summary="@string/init_summary_geokrety"
-                        android:title="@string/settings_activate_geokrety" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_connectorGeokretyActive"
                         android:layout="@layout/text_preference"
@@ -455,7 +455,7 @@
                     <CheckBoxPreference
                         android:defaultValue="false"
                         android:key="@string/pref_twitter"
-                        android:title="@string/settings_activate_twitter" />
+                        android:title="@string/settings_service_activate" />
                     <cgeo.geocaching.settings.TextPreference
                         android:dependency="@string/pref_twitter"
                         android:layout="@layout/text_preference"


### PR DESCRIPTION
## Description
Nearly every connector has its own string "Activate" as label for settings. It's sufficient to have this string only once in our resources, therefore let's remove the duplicates.
