### PR TITLE
shorten scaling info (fix #11350)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -191,7 +191,9 @@
     <string name="log_problem_archive_text">This geocacher reported that this geocache should be archived. A community volunteer reviewer has been notified.</string>
 
     <string name="log_image_scale_option_noscaling">No scaling</string>
-    <string name="log_image_info">%1$d x %2$d px, %3$s\nScaled/Compressed:\n%4$d x %5$d px, ~%6$s</string>
+    <string name="log_image_info2">%1$s\n%2$d x %3$d px\n~%4$s</string>
+    <string name="log_image_info_scaled">scaled</string>
+    <string name="log_image_info_notscaled">not scaled</string>
     <string name="log_image_titleprefix">Image</string>
 
     <string name="datetime_clear_button">Clear</string>

--- a/main/src/cgeo/geocaching/ui/ImageListFragment.java
+++ b/main/src/cgeo/geocaching/ui/ImageListFragment.java
@@ -218,6 +218,7 @@ public class ImageListFragment extends Fragment {
                 scaledWidth = scaledImageSizes.left;
                 scaledHeight = scaledImageSizes.middle;
             }
+            final String isScaled = getString(width != scaledWidth || height != scaledHeight ? R.string.log_image_info_scaled : R.string.log_image_info_notscaled);
 
             final long fileSize = imageFileInfo == null ? 0 : imageFileInfo.size;
             //A rough estimation for the size of the compressed image:
@@ -227,7 +228,7 @@ public class ImageListFragment extends Fragment {
             final long roughCompressedSize = width * height == 0 ? 0 :
                 ((fileSize * (scaledHeight * scaledWidth) / 10 / (width * height)) / 1024) * 1024;
 
-            return getString(R.string.log_image_info, width, height, Formatter.formatBytes(fileSize), scaledWidth, scaledHeight, Formatter.formatBytes(roughCompressedSize));
+            return getString(R.string.log_image_info2, isScaled, scaledWidth, scaledHeight, Formatter.formatBytes(roughCompressedSize));
         }
 
         @NonNull


### PR DESCRIPTION
## Description
Shorten scaling info for log images as described in referenced issue

|unscaled|scaled|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/129481740-5de65380-16df-4e45-b738-17bbf17f435e.png)|![image](https://user-images.githubusercontent.com/3754370/129481727-8acb8937-23b2-460d-ae80-ecff65c47129.png)|
