### PR TITLE
Fix #11477 - Use more common english abbreviation for Traditional

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="unknown">Unknown Type</string>
 
     <string name="all_types_short">All</string>
-    <string name="traditional_short">Tradi</string>
+    <string name="traditional_short">Trad</string>
     <string name="multi_short">Multi</string>
     <string name="mystery_short">Mystery</string>
     <string name="letterbox_short">Letterbox</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
According to native speakers the abbreviation "Tradi"/"Tradis" is not used in English, but they commonly use "Trad"/"Trads".


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11477

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->