### PR TITLE
fix getting next available id for UDC creation (fix #11480)

### DIFF
--- a/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -249,7 +249,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
      * @return geocode      geocode of the newly created cache
      */
     public static String createCache(final Context context, @Nullable final String name, @Nullable final String description, final int assignedEmoji, @Nullable final Geopoint geopoint, final int listId) {
-        final long newId = DataStore.incSequenceInternalCache();
+        final long newId = DataStore.getNextAvailableInternalCacheId();
         assertCacheExists(context, newId, name, description, assignedEmoji, geopoint, listId);
         return geocodeFromId(newId);
     }

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -511,8 +511,6 @@ public class DataStore {
     // reminder to myself: when adding a new CREATE TABLE statement:
     // make sure to add it to both onUpgrade() and onCreate()
 
-    private static final String SEQUENCE_INTERNAL_CACHE = "seq_internal_cache";
-
     public static int getExpectedDBVersion() {
         return dbVersion;
     }
@@ -1782,8 +1780,16 @@ public class DataStore {
         }
     }
 
-    public static synchronized long incSequenceInternalCache () {
-        return incSequence(SEQUENCE_INTERNAL_CACHE, 1000);
+    public static synchronized long getNextAvailableInternalCacheId() {
+        final int minimum = 1000;
+
+        init();
+        final Cursor c = database.rawQuery("SELECT MAX(CAST(SUBSTR(geocode," + (1 + InternalConnector.PREFIX.length()) + ") AS INTEGER)) FROM " + dbTableCaches + " WHERE substr(geocode,1," + InternalConnector.PREFIX.length() + ") = \"" + InternalConnector.PREFIX + "\"", new String []{});
+        final Set<Integer> nextId = cursorToColl(c, new HashSet<>(), GET_INTEGER_0);
+        for (Integer i : nextId) {
+            return Math.max(i + 1, minimum);
+        }
+        return minimum;
     }
 
     /**


### PR DESCRIPTION
## Description
Determines next available UDC ID dynamically instead of relying on a sequence (which may not get updated on importing a GPX with UDC)
