### PR TITLE
User white color for data on waypoint tab

### DIFF
--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -77,7 +77,7 @@
         android:lines="1"
         android:scrollHorizontally="true"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorText_listsSecondary"
+        android:textColor="@color/colorText_listsPrimary"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="1.2.3.4.5N 6.7.8.9.10S"
@@ -95,7 +95,7 @@
         android:maxLines="1"
         android:scrollHorizontally="true"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorText_listsSecondary"
+        android:textColor="@color/colorText_listsPrimary"
         android:visibility="gone"
         android:text="@string/waypoint_calculated_coordinates"
         tools:visiblity="visible" />
@@ -108,7 +108,7 @@
         android:layout_marginLeft="12dp"
         android:focusable="false"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorText_listsSecondary"
+        android:textColor="@color/colorText_listsPrimary"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="Note"/>
@@ -121,7 +121,7 @@
         android:layout_marginLeft="12dp"
         android:focusable="false"
         android:textSize="@dimen/textSize_listsSecondary"
-        android:textColor="@color/colorText_listsSecondary"
+        android:textColor="@color/colorText_listsPrimary"
         android:visibility="gone"
         tools:visiblity="visible"
         tools:text="User Note"/>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
While talking to other cachers about the new release, there was a IMHO relevant point: On the waypoint tab of caches, we have all text of the waypoint in a less contrast grey. The user said, that he has problems to read notes and coords and wonders why its different to the cache details page.

Looking at the details page, we use the `secondary` color for the captions, but stick to `primary` for the real individual information. I adapted the waypoint tab to use the same principal.

Screenshots before/after attached:

| Before | After  |  
|---|---|
|  ![color improve before](https://user-images.githubusercontent.com/949669/130334913-6a83cac9-64fd-4ea7-a766-cab0c85b5261.png) |![color improve after](https://user-images.githubusercontent.com/949669/130334917-e5046027-6365-48a2-8e45-4ba6eb72a777.png)  |  
|  ![color improve before_white](https://user-images.githubusercontent.com/949669/130334932-809357c0-59b5-455c-a9b5-b1d29e9bb203.png)| ![color improve after_white](https://user-images.githubusercontent.com/949669/130334938-78065c10-dbfb-4444-9c8d-4a632fb7932d.png)|

## Related issues
<!-- List the related issues fixed or improved by this PR -->
None created

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->