### PR TITLE
Work on #11484 - Restore font size in coord input

### DIFF
--- a/main/res/layout/coordinates_input.xml
+++ b/main/res/layout/coordinates_input.xml
@@ -35,6 +35,7 @@
                 android:layout_marginRight="2dp"
                 android:gravity="right"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_degrees"
                 android:selectAllOnFocus="true" />
 
@@ -52,6 +53,7 @@
                 android:layout_marginRight="2dp"
                 android:gravity="right"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_minutes"
                 android:selectAllOnFocus="true" />
 
@@ -69,6 +71,7 @@
                 android:layout_marginRight="2dp"
                 android:gravity="right"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_seconds"
                 android:selectAllOnFocus="true" />
 
@@ -85,6 +88,7 @@
                 android:layout_marginLeft="2dp"
                 android:layout_marginRight="2dp"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_fraction"
                 android:selectAllOnFocus="true" />
             <TextView
@@ -109,6 +113,7 @@
                 android:layout_marginRight="2dp"
                 android:gravity="right"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_degrees"
                 android:selectAllOnFocus="true" />
 
@@ -126,6 +131,7 @@
                 android:layout_marginRight="2dp"
                 android:gravity="right"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_minutes"
                 android:selectAllOnFocus="true" />
 
@@ -143,6 +149,7 @@
                 android:layout_marginRight="2dp"
                 android:gravity="right"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_seconds"
                 android:selectAllOnFocus="true" />
 
@@ -159,6 +166,7 @@
                 android:layout_marginLeft="2dp"
                 android:layout_marginRight="2dp"
                 android:inputType="number"
+                android:textSize="@dimen/textSize_calculator"
                 android:hint="@string/cc_hint_fraction"
                 android:selectAllOnFocus="true" />
         </TableRow>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Restore equal font size by explicitly applying text size to all coord text input elements.

| Before | After  |  
|---|---|
| ![font_coords_before_white](https://user-images.githubusercontent.com/949669/130335283-0aa073d9-a998-4ed9-8c96-f5028d348024.png)| ![font_coords_after_white](https://user-images.githubusercontent.com/949669/130335290-74407053-8bf9-4b21-a70a-0750371ff75f.png)|



## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11484

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->