### PR TITLE
Fix #7630 - Use normal check mark to avoid wrong coloring

### DIFF
--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -46,7 +46,7 @@ public final class LoggingUI extends AbstractUIFactory {
             String text = logType.getL10n();
 
             if (isActive) {
-                text += " ✔";
+                text += " ✓";
             }
 
             return text;


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Usage of another unicode character for the quick offline log menu, which solves the device specific issue #7630


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#7630 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Confirmed to be working on an affected device (Samsung S20, black theme, Android 11)