### PR TITLE
use correct tint for "swap" icon

### DIFF
--- a/main/res/drawable/ic_menu_swap_vert.xml
+++ b/main/res/drawable/ic_menu_swap_vert.xml
@@ -3,7 +3,7 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:tint="?android:textColorPrimary">
   <path
       android:fillColor="@android:color/white"
       android:pathData="M16,17.01V10h-2v7.01h-3L15,21l4,-3.99h-3zM9,3L5,6.99h3V14h2V6.99h3L9,3z"/>


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/64581222/130517467-c4f13299-d8a7-4744-ab2e-a225e9ac0e35.png)

As can be seen in the screenshot, the swap icon had used a slightly different tint...