### PR TITLE
adapt filter name of 'stored since' to be more clear

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -512,7 +512,7 @@
     <string name="cache_filter_location">Location</string>
     <string name="cache_filter_stored_lists">Stored Lists</string>
     <string name="cache_filter_origin">Origin</string>
-    <string name="cache_filter_stored_since">Stored since</string>
+    <string name="cache_filter_stored_since">Last details update</string>
 
     <string name="cache_filtergroup_basic">Basic</string>
     <string name="cache_filtergroup_details">Details</string>


### PR DESCRIPTION
Previously, the name was misleading. At the first, I thought it's the time stamp when I saved the cache the first time... But it's the 'last update' time stamp.