### PR TITLE
implement generic 'select item dialog' with additional delete action

### DIFF
--- a/main/res/layout/select_or_delete_item.xml
+++ b/main/res/layout/select_or_delete_item.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:background="?android:attr/selectableItemBackground"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@android:id/text1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:textSize="@dimen/textSize_detailsPrimary"
+        tools:text="some text..." />
+
+    <ImageView
+        android:id="@+id/delete"
+        android:layout_width="@dimen/buttonSize_iconButton"
+        android:layout_height="@dimen/buttonSize_iconButton"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_gravity="left"
+        android:layout_marginLeft="6dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:scaleType="centerInside"
+        app:srcCompat="@drawable/ic_menu_delete" />
+</RelativeLayout>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -544,6 +544,8 @@
     <string name="cache_filter_storage_clear_button">Clear</string>
     <string name="cache_filter_storage_load_delete_title">Load or delete an existing filter</string>
     <string name="cache_filter_storage_select_title">Select filter</string>
+    <string name="cache_filter_storage_delete_title">Delete filter</string>
+    <string name="cache_filter_storage_delete_message">Do you really want to delete this filter config?</string>
     <string name="cache_filter_storage_select_clear_title">Select filter or clear current filter</string>
     <string name="cache_filter_storage_load_delete_nofilter_message">No filter are stored yet.</string>
     <string name="cache_filter_storage_save_title">Save filter with name</string>

--- a/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.TextSpinner;
 import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.ui.recyclerview.ManagedListAdapter;
 import cgeo.geocaching.utils.Log;
@@ -154,24 +155,28 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
         //handling of "load/delete" button
         binding.filterStorageManage.setOnClickListener(v -> {
-                final List<GeocacheFilter> filters = new ArrayList<>(GeocacheFilter.Storage.getStoredFilters());
+            final List<GeocacheFilter> filters = new ArrayList<>(GeocacheFilter.Storage.getStoredFilters());
 
-                if (filters.isEmpty()) {
-                    SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_load_delete_title).setMessage(R.string.cache_filter_storage_load_delete_nofilter_message).show();
-                } else {
-                    SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_load_delete_title)
-                        .setButtons(R.string.cache_filter_storage_load_button, R.string.cache_filter_storage_delete_button, 0)
-                        .selectSingle(filters, (f, i) -> TextParam.text(f.getName()), -1, true,
-                            (f, pos) -> fillViewFromFilter(f.toConfig(), isAdvancedView()),
-                            (f, pos) -> {
-                                GeocacheFilter.Storage.delete(f);
-                                //if currently shown view was just deleted -> then delete it in view as well
-                                if (f.getName().contentEquals(binding.filterStorageName.getText())) {
-                                    binding.filterStorageName.setText("");
-                                }
-                            });
-               }
-            });
+            if (filters.isEmpty()) {
+                SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_load_delete_title).setMessage(R.string.cache_filter_storage_load_delete_nofilter_message).show();
+            } else {
+                Dialogs.selectItemDialogWithAdditionalDeleteButton(this, R.string.cache_filter_storage_load_delete_title,
+                        filters, (f) -> TextParam.text(f.getName()),
+                        // select listener
+                        (f) -> fillViewFromFilter(f.toConfig(), isAdvancedView()),
+                        // delete listener
+                        (f) -> SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_delete_title)
+                                .setMessage(R.string.cache_filter_storage_delete_message)
+                                .confirm((dialog, which) -> {
+                                    GeocacheFilter.Storage.delete(f);
+                                    //if currently shown view was just deleted -> then delete it in view as well
+                                    if (f.getName().contentEquals(binding.filterStorageName.getText())) {
+                                        binding.filterStorageName.setText("");
+                                    }
+                                })
+                );
+            }
+        });
         ViewUtils.setTooltip(binding.filterStorageManage, TextParam.id(R.string.cache_filter_storage_load_delete_title));
 
     }

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.functions.Action1;
+import cgeo.geocaching.utils.functions.Func1;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
@@ -23,9 +24,12 @@ import android.util.Pair;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.ListAdapter;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -48,6 +52,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Helper class providing methods when constructing custom Dialogs.
@@ -205,6 +210,46 @@ public final class Dialogs {
         if (context instanceof Activity) {
             alertDialog.setOwnerActivity((Activity) context);
         }
+    }
+
+    /**
+     * Show a select dialog with additional delete item button
+     */
+    public static <T> void selectItemDialogWithAdditionalDeleteButton(final Context context, final @StringRes int title, @NonNull final List<T> items, @NotNull final Func1<T, TextParam> displayMapper, final Action1<T> onSelectListener, final Action1<T> onDeleteListener) {
+        final AlertDialog.Builder builder = Dialogs.newBuilder(context).setTitle(title);
+        final AlertDialog[] dialog = new AlertDialog[] { null };
+
+        final ListAdapter adapter = new ArrayAdapter<T>(context, R.layout.select_or_delete_item, android.R.id.text1, items) {
+            public View getView(final int position, final View convertView, final ViewGroup parent) {
+                //Use super class to create the View.
+                final View v = super.getView(position, convertView, parent);
+
+                // set text
+                final TextView tv = v.findViewById(android.R.id.text1);
+                displayMapper.call(getItem(position)).applyTo(tv);
+
+                // register delete listener
+                final View deleteButton = v.findViewById(R.id.delete);
+                deleteButton.setOnClickListener(v1 -> {
+                    onDeleteListener.call(items.get(position));
+
+                    // dismiss dialog
+                    if (dialog[0] != null) {
+                        dialog[0].dismiss();
+                    }
+                });
+                return v;
+            }
+        };
+
+        builder.setSingleChoiceItems(adapter, -1, (d, pos) -> {
+            d.dismiss();
+            onSelectListener.call(items.get(pos));
+        });
+
+        dialog[0] = builder.create();
+        dialog[0].show();
+
     }
 
 


### PR DESCRIPTION


Before, "delete" and "load" were equal from an accessibility point of view (both two clicks). Furthermore, the filter config was deleted without an additional warning. I added a warning, so "delete" will still require two clicks, while users now only need one single click instead of two to select a filter config, which improves the workflow by 50% ;-) 

![grafik](https://user-images.githubusercontent.com/64581222/130963440-7a5a2e2a-a243-4db9-81ff-306f8a67cb4e.png)
![grafik](https://user-images.githubusercontent.com/64581222/131046094-eabbff46-4f20-4ef5-aeb4-395ba36dced8.png)

I implemented the dialog in a generic way, as I need the same dialog for #118