### PR TITLE
Dialog header color

### DIFF
--- a/main/res/layout/dialog_title_button_button.xml
+++ b/main/res/layout/dialog_title_button_button.xml
@@ -6,8 +6,9 @@
 
     <TextView
         android:id="@+id/dialog_title_title"
-        style="@style/action_bar_title"
+        style="@style/alertDialogTitleTextStyle"
         android:ellipsize="marquee"
+        android:paddingLeft="12dp"
         android:layout_width="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -60,7 +60,6 @@
 
     <style name="alertDialogTitleTextStyle" parent="MaterialAlertDialog.MaterialComponents.Title.Text">
         <item name="android:textSize">@dimen/textSize_headingPrimary</item>
-        <item name="android:textColor">@color/colorTextHeadline</item>
         <item name="android:textStyle">bold</item>
     </style>
 

--- a/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -37,6 +37,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.util.Consumer;
 
+import java.util.List;
 import java.util.Objects;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;


### PR DESCRIPTION
### Use black/white text color instead of gray for dialog headers (fix #11313):
![grafik](https://user-images.githubusercontent.com/64581222/131133913-795064c3-0715-49fb-9f71-656d6a326c17.png)

### Fix broken 'create UDC' dialog header style:
Before|Now
-|-
![grafik](https://user-images.githubusercontent.com/64581222/131133509-68616c11-1123-4bb8-9cb5-d23d98004934.png)|![grafik](https://user-images.githubusercontent.com/64581222/131135147-bcfd32f5-d43f-4fec-9cb6-895295c3ad92.png)

