### PR TITLE
add reference + source for route invert order icon (rel. to #11389)

### DIFF
--- a/main/res/drawable/ic_menu_swap_vert.xml
+++ b/main/res/drawable/ic_menu_swap_vert.xml
@@ -1,3 +1,4 @@
+<!-- taken from baseline_swap_vert_24 / material.io -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"


### PR DESCRIPTION
## Description
see https://github.com/cgeo/cgeo/pull/11389#issuecomment-906777137
- adds reference to source file in svg for route invert order icon
- adds unmodified source file for this
