### PR TITLE
Fix #11519 - Respect system font size on low Android versions

### DIFF
--- a/main/src/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/cgeo/geocaching/CgeoApplication.java
@@ -118,7 +118,7 @@ public class CgeoApplication extends Application {
      * Enforce a specific language if the user decided so.
      */
     private void initApplicationLocale() {
-        final Configuration config = new Configuration();
+        final Configuration config = getResources().getConfiguration();
         config.locale = Settings.getApplicationLocale();
         final Resources resources = getResources();
         resources.updateConfiguration(config, resources.getDisplayMetrics());


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
According to the links provided in #11519 the appcompat packages somehow changed the handling of system specific configurations taken over.

I found this hack which (proven in emulator) solves the problem:
https://stackoverflow.com/questions/43763993/application-text-size-not-scaling-with-system-font-size

I have no idea what this change implies, so please review it before merge whether it has any drawbacks or causes regressions elsewhere.
Please also provide feedback whether you consider it to experimental for merging on `release` and it should go to `master` instead.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11519

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->