### PR TITLE
add delay option for updates check (fix #11548)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2349,6 +2349,7 @@
     <string name="done">Done</string>
     <string name="finish">Finish</string>
     <string name="back">Back</string>
+    <string name="later">Later</string>
 
     <!-- ChipChoiceGroup -->
     <string name="chipchoicegroup_selectall">Select All</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -451,9 +451,7 @@ public class MainActivity extends AbstractActionBarActivity {
     }
 
     private void returnFromTileUpdateCheck(final boolean updateCheckAllowed) {
-        if (updateCheckAllowed) {
-            Settings.setBrouterAutoTileDownloadsLastCheck();
-        }
+        Settings.setBrouterAutoTileDownloadsLastCheck(!updateCheckAllowed);
     }
 
     private void checkForMapUpdates() {
@@ -463,9 +461,7 @@ public class MainActivity extends AbstractActionBarActivity {
     }
 
     private void returnFromMapUpdateCheck(final boolean updateCheckAllowed) {
-        if (updateCheckAllowed) {
-            Settings.setMapAutoDownloadsLastCheck();
-        }
+        Settings.setMapAutoDownloadsLastCheck(!updateCheckAllowed);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -177,10 +177,10 @@ public class DownloaderUtils {
      * if yes: checks whether updates are available for the type specified
      *      if yes: ask user to download them all
      *              if yes: trigger download(s)
-     * calls callback with user reaction (true=checked for updates / false=user denied check)
+     * calls callback with user reaction (true=checked for updates / false=user delayed check)
      */
     public static void checkForUpdatesAndDownloadAll(final Activity activity, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, final Action1<Boolean> callback) {
-        SimpleDialog.of(activity).setTitle(title).setMessage(info).confirm((dialog, which) -> {
+        SimpleDialog.of(activity).setTitle(title).setMessage(info).setNegativeButton(TextParam.id(R.string.later)).confirm((dialog, which) -> {
             new CheckForDownloadsTask(activity, title, type).execute();
             callback.call(true);
         }, (dialog, w) -> callback.call(false));


### PR DESCRIPTION
## Description
- offer "later/ok" instead of "cancel/ok" for update check
- when selected "later", c:geo will prompt in three days instead of on next restart of c:geo
