### PR TITLE
restrict AL connector to 100 results (fix #11538)

### DIFF
--- a/main/src/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/cgeo/geocaching/connector/al/ALApi.java
@@ -92,7 +92,7 @@ final class ALApi {
         Log.d("_AL Radius: " + (int) radius);
         final Parameters params = new Parameters("skip", "0");
         final Parameters headers = new Parameters(CONSUMER_HEADER, CONSUMER_KEY);
-        params.add("take", "500");
+        params.add("take", "100");
         params.add("radiusMeters", String.valueOf((int) radius));
         params.add("origin.latitude", String.valueOf(latcenter));
         params.add("origin.longitude", String.valueOf(loncenter));
@@ -115,7 +115,7 @@ final class ALApi {
             return Collections.emptyList();
         }
         final Parameters params = new Parameters("skip", "0");
-        params.add("take", "200");
+        params.add("take", "100");
         params.add("radiusMeters", "" + (distanceInKm * 1000));
         params.add("origin.latitude", String.valueOf(center.getLatitude()));
         params.add("origin.longitude", String.valueOf(center.getLongitude()));


### PR DESCRIPTION
## Description
As described in the related issue, AL connector currently returns 500 hits on each request, which covers a much wider area than GC connector. To reduce server impact and make it more compatible with GC connector, restrict limit to 100 lab adventures.
