### PR TITLE
set initial page without transition (fix #11527)

### DIFF
--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerActivity.java
@@ -54,7 +54,7 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
         viewPager = findViewById(R.id.viewpager);
         viewPager.setAdapter(new ViewPagerAdapter(this));
         viewPager.registerOnPageChangeCallback(pageChangeCallback);
-        viewPager.setCurrentItem(pageIdToPosition(currentPageId));
+        viewPager.setCurrentItem(pageIdToPosition(currentPageId), false);
         viewPager.setOffscreenPageLimit(10);
 
         swipeRefreshLayout = findViewById(R.id.swipe_refresh);


### PR DESCRIPTION
## Description
Another shot at #11527: Set initial page for viewpager without transition (but in contrast to the first try, let transitions for the `TabLayoutMediator` be activated).

Observed behavior with this PR is:
- Initial page gets set directly, without transition.
- Sliding from tab to tab has transitions
- as well as activating a page by tapping on a tab.
- The tab indicator is centered to the tab label.

I've targeted this PR to `master` to have some time for cross-checking for unwanted side-effects... 
