### PR TITLE
add proguard rules related to OkHttp

### DIFF
--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -96,6 +96,11 @@
 -dontwarn okhttp3.OkHttpClient$Builder
 # OkHttp platform used only on JVM and when Conscrypt dependency is available.
 -dontnote okhttp3.internal.platform.**
+# R8 missing, probaly fixed in next OkHttp release,
+# see https://github.com/square/okhttp/pull/6792
+-dontwarn org.bouncycastle.jsse.**
+-dontwarn org.conscrypt.*
+-dontwarn org.openjsse.**
 
 # Play Services -----------------------------------------------------------------------------------
 

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -98,9 +98,7 @@
 -dontnote okhttp3.internal.platform.**
 # R8 missing, probaly fixed in next OkHttp release,
 # see https://github.com/square/okhttp/pull/6792
--dontwarn org.bouncycastle.jsse.**
--dontwarn org.conscrypt.*
--dontwarn org.openjsse.**
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
 
 # Play Services -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix R8 missing class warnings, probaly fixed in next OkHttp release,
see https://github.com/square/okhttp/pull/6792
