### PR TITLE
Fix #11584 - Allow more space for log date by disabling ellipsis

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -503,7 +503,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">right</item>
-        <item name="android:ellipsize">marquee</item>
+        <item name="android:ellipsize">none</item>
         <item name="android:gravity">left</item>
         <item name="android:lines">1</item>
         <item name="android:scrollHorizontally">true</item>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
For some reason setting `marquee` does not work and I personally also think that marquee text is not so nice anyway.
To avoid ellipsis characters and get most possible room for the fields I suggest to simply disable ellipsizing at this place.

It should be a sufficient workaround for the problem described in #11584 without needing to increase the field size or similar.



## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11584

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
If this later turns out not to be enough, there are AFAICS also possibilities to define a maximum font size scaling per text view.
