### PR TITLE
remove disabling favo button (fix #11583)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1538,9 +1538,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
             // Add/remove to Favorites is only possible if the cache has been found
             if (!cache.isFound()) {
-                binding.addToFavpoint.setEnabled(false);
                 binding.addToFavpoint.setVisibility(View.GONE);
-                binding.removeFromFavpoint.setEnabled(false);
                 binding.removeFromFavpoint.setVisibility(View.GONE);
             }
         }


### PR DESCRIPTION
## Description
Remove disabling the add/remove favo button - there's no need to, as the button's view gets already set to either `VISIBLE` or `GONE`.
