### PR TITLE
hide sensitive preference data in settings view (fix #11612)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -4,6 +4,9 @@
     <!--
     Preferences used in settings are defined as strings here, so we can use them in the preferences.xml
     and in the Java code as constants and avoid code duplication.
+
+    If you add a preference key which stores sensitive data not to be included in settings backup
+    by default, make sure to add the key to Settings.getSensitivePreferenceKeys()
     -->
 
     <string translatable="false" name="preference_screen_main">fakekey_main_screen</string>

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -56,6 +56,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1887,6 +1888,26 @@ public class Settings {
 
     public static int getListInitialLoadLimit() {
         return getInt(R.string.pref_list_initial_load_limit, getKeyInt(R.integer.list_load_limit_default));
+    }
+
+    /** return a list of preference keys containing sensitive data */
+    public static HashSet<String> getSensitivePreferenceKeys(final Context context) {
+        final HashSet<String> sensitiveKeys = new HashSet<>();
+        Collections.addAll(sensitiveKeys,
+            context.getString(R.string.pref_username), context.getString(R.string.pref_password),
+            context.getString(R.string.pref_ecusername), context.getString(R.string.pref_ecpassword),
+            context.getString(R.string.pref_user_vote), context.getString(R.string.pref_pass_vote),
+            context.getString(R.string.pref_twitter), context.getString(R.string.pref_temp_twitter_token_secret), context.getString(R.string.pref_temp_twitter_token_public), context.getString(R.string.pref_twitter_token_secret), context.getString(R.string.pref_twitter_token_public),
+            context.getString(R.string.pref_ocde_tokensecret), context.getString(R.string.pref_ocde_tokenpublic), context.getString(R.string.pref_temp_ocde_token_secret), context.getString(R.string.pref_temp_ocde_token_public),
+            context.getString(R.string.pref_ocpl_tokensecret), context.getString(R.string.pref_ocpl_tokenpublic), context.getString(R.string.pref_temp_ocpl_token_secret), context.getString(R.string.pref_temp_ocpl_token_public),
+            context.getString(R.string.pref_ocnl_tokensecret), context.getString(R.string.pref_ocnl_tokenpublic), context.getString(R.string.pref_temp_ocnl_token_secret), context.getString(R.string.pref_temp_ocnl_token_public),
+            context.getString(R.string.pref_ocus_tokensecret), context.getString(R.string.pref_ocus_tokenpublic), context.getString(R.string.pref_temp_ocus_token_secret), context.getString(R.string.pref_temp_ocus_token_public),
+            context.getString(R.string.pref_ocro_tokensecret), context.getString(R.string.pref_ocro_tokenpublic), context.getString(R.string.pref_temp_ocro_token_secret), context.getString(R.string.pref_temp_ocro_token_public),
+            context.getString(R.string.pref_ocuk2_tokensecret), context.getString(R.string.pref_ocuk2_tokenpublic), context.getString(R.string.pref_temp_ocuk2_token_secret), context.getString(R.string.pref_temp_ocuk2_token_public),
+            context.getString(R.string.pref_su_tokensecret), context.getString(R.string.pref_su_tokenpublic), context.getString(R.string.pref_temp_su_token_secret), context.getString(R.string.pref_temp_su_token_public),
+            context.getString(R.string.pref_fakekey_geokrety_authorization)
+        );
+        return sensitiveKeys;
     }
 
 }

--- a/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -31,6 +31,7 @@ import androidx.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -92,6 +93,7 @@ public class ViewSettingsActivity extends AbstractActivity {
         private HashMap<String, Integer> mapFirstPosition;
         private HashMap<String, Integer> mapSection;
         private String[] sections;
+        private final HashSet<String> sensitiveKeys = Settings.getSensitivePreferenceKeys(getContext());
 
         SettingsAdapter(final Activity activity) {
             super(activity, 0, items);
@@ -116,6 +118,7 @@ public class ViewSettingsActivity extends AbstractActivity {
             }
         }
 
+        @NonNull
         public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
             View v = convertView;
             if (null == convertView) {
@@ -124,7 +127,7 @@ public class ViewSettingsActivity extends AbstractActivity {
 
             final KeyValue keyValue = items.get(position);
             ((TextView) v.findViewById(R.id.title)).setText(keyValue.key);
-            ((TextView) v.findViewById(R.id.detail)).setText(keyValue.value);
+            ((TextView) v.findViewById(R.id.detail)).setText(sensitiveKeys.contains(keyValue.key) ? "******" : keyValue.value);
 
             final MaterialButton buttonDelete = v.findViewById(R.id.button_right);
             buttonDelete.setIconResource(R.drawable.ic_menu_delete);

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -49,7 +49,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -563,20 +562,7 @@ public class BackupUtils {
 
         // if a backup without account data is requested add all account related preference keys to the ignore set
         if (!fullBackup) {
-            Collections.addAll(ignoreKeys,
-                    activityContext.getString(R.string.pref_username), activityContext.getString(R.string.pref_password), activityContext.getString(R.string.pref_memberstatus), activityContext.getString(R.string.pref_gccustomdate),
-                    activityContext.getString(R.string.pref_ecusername), activityContext.getString(R.string.pref_ecpassword),
-                    activityContext.getString(R.string.pref_user_vote), activityContext.getString(R.string.pref_pass_vote),
-                    activityContext.getString(R.string.pref_twitter), activityContext.getString(R.string.pref_temp_twitter_token_secret), activityContext.getString(R.string.pref_temp_twitter_token_public), activityContext.getString(R.string.pref_twitter_token_secret), activityContext.getString(R.string.pref_twitter_token_public),
-                    activityContext.getString(R.string.pref_ocde_tokensecret), activityContext.getString(R.string.pref_ocde_tokenpublic), activityContext.getString(R.string.pref_temp_ocde_token_secret), activityContext.getString(R.string.pref_temp_ocde_token_public),
-                    activityContext.getString(R.string.pref_ocpl_tokensecret), activityContext.getString(R.string.pref_ocpl_tokenpublic), activityContext.getString(R.string.pref_temp_ocpl_token_secret), activityContext.getString(R.string.pref_temp_ocpl_token_public),
-                    activityContext.getString(R.string.pref_ocnl_tokensecret), activityContext.getString(R.string.pref_ocnl_tokenpublic), activityContext.getString(R.string.pref_temp_ocnl_token_secret), activityContext.getString(R.string.pref_temp_ocnl_token_public),
-                    activityContext.getString(R.string.pref_ocus_tokensecret), activityContext.getString(R.string.pref_ocus_tokenpublic), activityContext.getString(R.string.pref_temp_ocus_token_secret), activityContext.getString(R.string.pref_temp_ocus_token_public),
-                    activityContext.getString(R.string.pref_ocro_tokensecret), activityContext.getString(R.string.pref_ocro_tokenpublic), activityContext.getString(R.string.pref_temp_ocro_token_secret), activityContext.getString(R.string.pref_temp_ocro_token_public),
-                    activityContext.getString(R.string.pref_ocuk2_tokensecret), activityContext.getString(R.string.pref_ocuk2_tokenpublic), activityContext.getString(R.string.pref_temp_ocuk2_token_secret), activityContext.getString(R.string.pref_temp_ocuk2_token_public),
-                    activityContext.getString(R.string.pref_su_tokensecret), activityContext.getString(R.string.pref_su_tokenpublic), activityContext.getString(R.string.pref_temp_su_token_secret), activityContext.getString(R.string.pref_temp_su_token_public),
-                    activityContext.getString(R.string.pref_fakekey_geokrety_authorization)
-            );
+            ignoreKeys.addAll(Settings.getSensitivePreferenceKeys(activityContext));
         }
 
         final Uri backupFile = ContentStorage.get().create(backupDir, SETTINGS_FILENAME);


### PR DESCRIPTION
## Description
- Contents of sensitive preference keys is no longer displayer in "settings => system => view settings" to avoid displaying sensitive data accidentally. "******" are being displayed instead.
- On editing such an entry, content is still being displayed to allow editing and lookup.
- Which fields are considered "sensitive" is shared between settings view and backup utils.

![image](https://user-images.githubusercontent.com/3754370/132066511-d294e733-2f53-4498-b9da-992c11b813f7.png)
