### PR TITLE
show info dialog in map when live mode is disabled (fix #7741)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1518,6 +1518,8 @@
     <string name="map_language">Map language</string>
     <string name="map_live_enable">Enable live</string>
     <string name="map_live_disable">Disable live</string>
+    <string name="map_live_disabled">Live mode disabled</string>
+    <string name="map_live_disabled_hint">Live mode is disabled. You will only see stored caches. Use the menu to enable live mode.</string>
     <string name="map_as_list">Show as list</string>
     <string name="map_select_multiple_items">Select item</string>
     <string name="map_routing">Routing</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -604,7 +604,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         AndroidBeam.disable(activity);
 
-        MapUtils.showMapOneTimeMessages(activity);
+        MapUtils.showMapOneTimeMessages(activity, mapOptions.mapMode);
 
         MapsforgeMapProvider.getInstance().updateOfflineMaps();
     }

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -75,9 +75,12 @@ public class MapUtils {
     }
 
     // one-time messages to be shown for maps
-    public static void showMapOneTimeMessages(final Activity activity) {
+    public static void showMapOneTimeMessages(final Activity activity, final MapMode mapMode) {
         Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_QUICK_SETTINGS);
         Dialogs.basicOneTimeMessage(activity, Settings.isLongTapOnMapActivated() ? OneTimeDialogs.DialogType.MAP_LONG_TAP_ENABLED : OneTimeDialogs.DialogType.MAP_LONG_TAP_DISABLED);
+        if (mapMode == MapMode.LIVE && !Settings.isLiveMap()) {
+            Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_LIVE_DISABLED);
+        }
     }
 
     // workaround for colored ActionBar titles/subtitles

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -330,7 +330,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
 
         MapsforgeMapProvider.getInstance().updateOfflineMaps();
 
-        MapUtils.showMapOneTimeMessages(this);
+        MapUtils.showMapOneTimeMessages(this, mapMode);
     }
 
     private void postZoomToViewport(final Viewport viewport) {

--- a/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -29,7 +29,8 @@ public class OneTimeDialogs extends DataStore.DBExtension {
         MAP_LONG_TAP_ENABLED(R.string.init_longtap_map, R.string.onetime_info_longtap_enabled, DefaultBehavior.SHOW_ALWAYS, R.string.manual_url_mapbehavior),
         MISSING_UNICODE_CHARACTERS(R.string.select_icon, R.string.onetime_missing_unicode_info, DefaultBehavior.SHOW_ALWAYS, 0),
         MAP_THEME_FIX_SLOWNESS(R.string.onetime_mapthemefixslow_title, R.string.onetime_mapthemefixslow_message, DefaultBehavior.SHOW_ALWAYS, R.string.faq_url_settings_themes),
-        MAP_AUTOROTATION_DISABLE(R.string.map_gm_autorotation, R.string.map_gm_autorotation_disable, DefaultBehavior.SHOW_ALWAYS, 0);
+        MAP_AUTOROTATION_DISABLE(R.string.map_gm_autorotation, R.string.map_gm_autorotation_disable, DefaultBehavior.SHOW_ALWAYS, 0),
+        MAP_LIVE_DISABLED(R.string.map_live_disabled, R.string.map_live_disabled_hint, DefaultBehavior.SHOW_ALWAYS, 0);
 
         public final Integer messageTitle;
         public final Integer messageText;


### PR DESCRIPTION
## Description
Display a one time message on opening map when live mode is disabled.

![image](https://user-images.githubusercontent.com/3754370/132989112-a9f47ea6-1077-4636-bd67-b0dad8becd2c.png)
