### PR TITLE
don't merge PCN (resolves #10193)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -74,6 +74,7 @@
     <string translatable="false" name="pref_friendlogswanted">friendlogswanted</string>
     <string translatable="false" name="pref_opendetailslastpage">opendetailslastpage</string>
     <string translatable="false" name="pref_global_wp_extraction_disable">globalWpExtractionDisable</string>
+    <string translatable="false" name="pref_personal_cache_note_merge_disable">personalCacheNoteMergeDisable</string>
     <string translatable="false" name="pref_excludeWpOriginal">excludeWpOriginal</string>
     <string translatable="false" name="pref_excludeWpParking">excludeWpParking</string>
     <string translatable="false" name="pref_excludeWpVisited">excludeWpVisited</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -827,7 +827,9 @@
     <string name="init_bigSmileysOnMap">Big icons</string>
     <string name="init_summary_bigSmileysOnMap">If enabled, symbols like the \'found smiley\' or the \'corrected coordinates\' marker will be shown enlarged on the map instead of the cache type icon (requires restart).</string>
     <string name="init_global_wp_extraction_disable">Disable waypoint extraction</string>
-    <string name="init_summary_global_wp_extraction_disable">Globally disable waypoint extraction from personal cache notes. It can still be enabled for individual caches by deactivating the checkbox below the personal cache note</string>
+    <string name="init_summary_global_wp_extraction_disable">Globally disable waypoint extraction from personal cache notes. It can still be enabled for individual caches by deactivating the checkbox below the personal cache note.</string>
+    <string name="init_prevent_cache_note_merge">Overwrite Personal Cache Note</string>
+    <string name="init_summary_prevent_cache_note_merge">If this setting is enabled c:geo will delete the locally stored note permanently and replace it by the personal note on the server. No merging will be done.</string>
     <string name="init_customtabs_as_browser">Use Chrome WebView</string>
     <string name="init_summary_customtabs_as_browser">External websites will be displayed without leaving c:geo (only possible if Chrome is installed)</string>
     <string name="init_save_log_img">Save Images</string>

--- a/main/res/xml/preferences_cachedetails.xml
+++ b/main/res/xml/preferences_cachedetails.xml
@@ -31,6 +31,12 @@
         app:iconSpaceReserved="false" />
     <CheckBoxPreference
         android:defaultValue="false"
+        android:key="@string/pref_personal_cache_note_merge_disable"
+        android:title="@string/init_prevent_cache_note_merge"
+        android:summary="@string/init_summary_prevent_cache_note_merge"
+        app:iconSpaceReserved="false" />
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:key="@string/pref_customtabs_as_browser"
         android:title="@string/init_customtabs_as_browser"
         android:summary="@string/init_summary_customtabs_as_browser"

--- a/main/src/cgeo/geocaching/models/PersonalNote.java
+++ b/main/src/cgeo/geocaching/models/PersonalNote.java
@@ -1,8 +1,12 @@
 package cgeo.geocaching.models;
 
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.Log;
+
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
+
 
 
 public class PersonalNote {
@@ -29,6 +33,10 @@ public class PersonalNote {
 
     public final void gatherMissingDataFrom(final PersonalNote other) {
         // don't use StringUtils.isBlank here. Otherwise we cannot recognize a note which was deleted on GC
+        if (Settings.isPersonalCacheNoteMergeDisabled()) {
+            Log.d("running with personal note merging disabled");
+            return;
+        }
         if (note == null) {
             note = other.note;
         } else if (other.note != null && fromProvider && !other.fromProvider) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1402,6 +1402,10 @@ public class Settings {
         return getBoolean(R.string.pref_global_wp_extraction_disable, false);
     }
 
+    public static boolean isPersonalCacheNoteMergeDisabled() {
+        return getBoolean(R.string.pref_personal_cache_note_merge_disable, false);
+    }
+
     public static int getLastDetailsPage() {
         return getInt(R.string.pref_lastdetailspage, 1);
     }


### PR DESCRIPTION
see referenced issue #10193.

In a nutshell: Provide a preference setting to tell cgeo not to merge personal cache notes data coming down from the provider with what cgeo already might have stored locally. The datamodel behind this is that there is only one authoritative source for that data and that is in the provider's database. On refresh, take what comes down verbatim. If local changes are made, make sure to push them to the provider manually. The functionality to push, is already there, even for lists.