### PR TITLE
explicitly set textColor on Emojis as the default has some alpha

### DIFF
--- a/main/res/layout/emojiselector_item.xml
+++ b/main/res/layout/emojiselector_item.xml
@@ -13,6 +13,7 @@
         android:layout_height="match_parent"
         android:layout_centerVertical="true"
         android:layout_centerHorizontal="true"
+        android:textColor="#ffffffff"
         android:gravity="center"/>
     <ImageView
         android:id="@+id/info_drawable"


### PR DESCRIPTION
Display emojis in custom icon selector without transparency

## Related issues
Fixes #11673
