### PR TITLE
add geocode to 'send message' link (fix #11677)

### DIFF
--- a/main/src/cgeo/geocaching/connector/UserAction.java
+++ b/main/src/cgeo/geocaching/connector/UserAction.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import java.lang.ref.WeakReference;
@@ -24,12 +25,14 @@ public class UserAction {
         public final String displayName;
         public final String userName;
         public final String userGUID;
+        public final String geocode;
         public WeakReference<Context> contextRef;
 
-        public UAContext(@NonNull final String displayName, @NonNull final String userName, @NonNull final String userGUID) {
+        public UAContext(@NonNull final String displayName, @NonNull final String userName, @NonNull final String userGUID, @Nullable final String geocode) {
             this.displayName = displayName;
             this.userName = userName;
             this.userGUID = userGUID;
+            this.geocode = geocode;
         }
 
         public void startActivity(final Intent intent) {

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -525,7 +525,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
         final List<UserAction> actions = super.getUserActions(user);
         actions.add(new UserAction(R.string.user_menu_open_browser, R.drawable.ic_menu_face, context -> ShareUtils.openUrl(context.getContext(), "https://www.geocaching.com/p/default.aspx?u=" + Network.encode(context.userName))));
         if (StringUtils.isNotBlank(user.userGUID)) {
-            actions.add(new UserAction(R.string.user_menu_send_message, R.drawable.ic_menu_email, context -> ShareUtils.openUrl(context.getContext(), "https://www.geocaching.com/account/messagecenter?recipientId=" + context.userGUID)));
+            actions.add(new UserAction(R.string.user_menu_send_message, R.drawable.ic_menu_email, context -> ShareUtils.openUrl(context.getContext(), "https://www.geocaching.com/account/messagecenter?recipientId=" + context.userGUID + (StringUtils.isNotBlank(context.geocode) ? "&gcCode=" + context.geocode : ""))));
         }
         actions.add(new UserAction(R.string.user_menu_send_email, R.drawable.ic_menu_email, context -> ShareUtils.openUrl(context.getContext(), "https://www.geocaching.com/email/?u=" + Network.encode(context.userName))));
         return actions;

--- a/main/src/cgeo/geocaching/ui/UserClickListener.java
+++ b/main/src/cgeo/geocaching/ui/UserClickListener.java
@@ -71,7 +71,7 @@ public abstract class UserClickListener implements View.OnClickListener {
     }
 
     public static OnClickListener forUser(final Trackable trackable, final String userName, final String userGuid) {
-        return new UserClickListener(new UAContext(userName, userName, userGuid)) {
+        return new UserClickListener(new UAContext(userName, userName, userGuid, null)) {
 
             @Override
             @NonNull
@@ -82,7 +82,7 @@ public abstract class UserClickListener implements View.OnClickListener {
     }
 
     public static UserClickListener forUser(final Geocache cache, final String userName, final String userId, final String userGuid) {
-        return new UserClickListener(new UAContext(userName, userId, userGuid)) {
+        return new UserClickListener(new UAContext(userName, userId, userGuid, cache.getGeocode())) {
 
             @Override
             @NonNull

--- a/tests/src/cgeo/geocaching/connector/trackable/UnknownTrackableConnectorTest.java
+++ b/tests/src/cgeo/geocaching/connector/trackable/UnknownTrackableConnectorTest.java
@@ -40,7 +40,7 @@ public class UnknownTrackableConnectorTest {
 
     @Test
     public void testGetUserActions() throws Exception {
-        assertThat(getConnector().getUserActions(new UserAction.UAContext(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY))).isEmpty();
+        assertThat(getConnector().getUserActions(new UserAction.UAContext(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, null))).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Description
Adds geocode to "send message" links (long tap on cache owner or user name), if available.
Leads to opened message in message center having an initial text line referencing the cache from which this links has been opened:

![image](https://user-images.githubusercontent.com/3754370/133926209-a33ec0ed-9bcd-4daf-8719-6663b419048e.png)
