### PR TITLE
Fix #11709 - Make name column in cache details zoomable

### DIFF
--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -7,7 +7,7 @@
 
     <TextView
         android:id="@+id/name"
-        android:layout_width="90dip"
+        android:layout_width="90sp"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="false"


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Use `sp` for width of the name column to make it expand/shrink in same relation as the text. This avoids cut off single line names in that column.
I left the value same, it might need some fine tuning if e.g. some translations are much longer. However due to the original design I guess it will fit in most occasions now.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fixes #11709

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->