### PR TITLE
Related #11709 - Give 10sp more room to avoid ellipsize

### DIFF
--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -7,7 +7,7 @@
 
     <TextView
         android:id="@+id/name"
-        android:layout_width="90sp"
+        android:layout_width="100sp"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="false"


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Finetuning as mentioned in #11724 a bit of finetuning: Giving 10px more room will make it fit in german and some other languages (given the current translations).
There are still languages (e.g. greek) where we can never make it fit....but that's probably up to translators then to find a shorter term.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11709

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->