### PR TITLE
fix #11731: status filter solved mystery: handle only mysteries as inconclusive

### DIFF
--- a/main/src/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
@@ -91,7 +91,7 @@ public class StatusGeocacheFilter extends BaseGeocacheFilter {
             (statusWatchlist != null && cache.isOnWatchlistRaw() == null) ||
             (statusPremium != null && cache.isPremiumMembersOnlyRaw() == null) ||
             (statusHasTrackable != null && !cache.hasInventoryItemsSet()) ||
-            (statusSolvedMystery != null && cache.getUserModifiedCoordsRaw() == null)) {
+            (statusSolvedMystery != null && cache.getType() == CacheType.MYSTERY && cache.getUserModifiedCoordsRaw() == null)) {
             return null;
         }
 


### PR DESCRIPTION
fix #11731: status filter solved mystery: handle only mysteries as inconclusive