### PR TITLE
Compact latitude/longitude button

### DIFF
--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -2,7 +2,6 @@
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
@@ -15,16 +14,10 @@
         android:orientation="vertical" >
 
         <Button
-            android:id="@+id/buttonLatitude"
-            style="@style/button_full"
+            android:id="@+id/buttonLatLongitude"
+            style="@style/button_full_double"
             android:freezesText="true"
-            android:hint="@string/latitude" />
-
-        <Button
-            android:id="@+id/buttonLongitude"
-            style="@style/button_full"
-            android:freezesText="true"
-            android:hint="@string/longitude" />
+            android:hint="@string/latlongitude" />
 
         <LinearLayout
             android:id="@+id/projection"

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -78,14 +78,9 @@
         </RelativeLayout>
 
         <Button
-            android:id="@+id/buttonLatitude"
-            style="@style/button_full"
-            android:hint="@string/latitude" />
-
-        <Button
-            android:id="@+id/buttonLongitude"
-            style="@style/button_full"
-            android:hint="@string/longitude" />
+            android:id="@+id/buttonLatLongitude"
+            style="@style/button_full_double"
+            android:hint="@string/latlongitude" />
 
         <Button
             android:id="@+id/search_coordinates"

--- a/main/res/values/dimens.xml
+++ b/main/res/values/dimens.xml
@@ -42,6 +42,7 @@
 
     <!-- buttons -->
     <dimen name="textSize_buttonsPrimary">@dimen/textSize_detailsSecondary</dimen>
+    <dimen name="textSize_buttonsDouble">@dimen/textSize_detailsPrimary</dimen>
 
     <!-- compass -->
     <dimen name="textSize_compassTargeting">26sp</dimen>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="about">About c:geo</string>
     <string name="latitude">Latitude</string>
     <string name="longitude">Longitude</string>
+    <string name="latlongitude">Latitude\nLongitude</string>
 
     <!-- actionbar -->
     <string name="settings_titlebar">c:geo Settings</string>
@@ -393,7 +394,7 @@
     <string name="caches_sort_favorites">Favorites</string>
     <string name="caches_sort_favorites_ratio">Favorites [%]</string>
     <string name="caches_sort_name">Name</string>
-    <string name="caches_sort_geocode">Geo Code</string>
+    <string name="caches_sort_geocode">Geocode</string>
     <string name="caches_sort_rating">Rating</string>
     <string name="caches_sort_vote">Vote (Own Rating)</string>
     <string name="caches_sort_inventory">Count of Inventory</string>
@@ -1247,7 +1248,7 @@
     <string name="cache_advanced">Advanced</string>
     <string name="cache_waypoints">Waypoints</string>
     <string name="waypoints_tabtitle" tools:ignore="PluralsCandidate">Waypoints (%d)</string>
-    <string name="cache_waypoints_add">Add Waypoint</string>
+    <string name="cache_waypoints_add">Add waypoint</string>
     <string name="cache_waypoints_add_currentLocation">Add current location</string>
     <string name="cache_waypoints_add_fromclipboard">Add from clipboard</string>
     <string name="cache_waypoints_remove_original_waypoint">Waypoint copied from clipboard to this cache.\n\nRemove original waypoint?</string>
@@ -1335,10 +1336,10 @@
     <string name="cache_status_disabled">Disabled</string>
     <string name="cache_status_active">Active</string>
     <string name="cache_status_premium">Premium Members only</string>
-    <string name="cache_geocode">Geo code</string>
+    <string name="cache_geocode">Geocode</string>
     <string name="cache_name">Name</string>
-    <string name="cache_name_set">Set cachename</string>
-    <string name="cache_name_updated">Cachename updated</string>
+    <string name="cache_name_set">Set cache name</string>
+    <string name="cache_name_updated">Cache name updated</string>
     <string name="cache_description_set">Set cache description</string>
     <string name="cache_description_updated">Cache description updated</string>
     <string name="cache_type">Type</string>
@@ -1540,22 +1541,22 @@
 
     <!-- search -->
     <string name="search_bar_hint">Search caches/trackables</string>
-    <string name="search_bar_desc">Caches (geo code, keyword), Trackables (TB code)</string>
+    <string name="search_bar_desc">Caches (geocode, keyword), Trackables (TB code)</string>
     <string name="search_coordinates">Coordinates</string>
     <string name="search_coordinates_button">Search by coordinates</string>
     <string name="search_address">Address</string>
     <string name="search_address_button">Search by address</string>
-    <string name="search_geo">Geo code</string>
-    <string name="search_geo_button">Search by geo code</string>
+    <string name="search_geo">Geocode</string>
+    <string name="search_geo_button">Search by geocode</string>
     <string name="search_geocode_from_clipboard">Geocode was pasted from clipboard.</string>
-    <string name="search_kw">Keywords</string>
+    <string name="search_kw">Keyword</string>
     <string name="search_kw_prefill">Keyword</string>
     <string name="search_kw_button">Search by keyword</string>
     <string name="search_hbu">Hidden by</string>
     <string name="search_hbu_prefill">Owner</string>
     <string name="search_hbu_button">Search by owner name</string>
     <string name="search_filter">Filter</string>
-    <string name="search_filter_button">Search by Filter</string>
+    <string name="search_filter_button">Search by filter</string>
     <string name="search_filter_info_message" formatted="false">**Search by filter** searches caches on all active online services (e.g. geocaching.com) using a provided filter. However, search capabilities of these services are usually more limited than filter capabilities of c:geo.\n\n- All services only support AND filters (no OR filters and no filter inversion).\n- The more basic filters like **cache type** or **cache size** are supported by all services. More complicated filters are often not supported or have some restrictions e.g. **favorites** or **hidden date**.\n- A detailed list on supported filters per service can be found [here](https://github.com/cgeo/cgeo/wiki/%22Search-by-Filter%22-support-by-c:geo-Connectors).\n\nFilters not supported by the online service will be applied by c:geo on the received results.</string>
     <string name="search_filter_temporary_user_information_title">New filter framework</string>
     <string name="search_filter_temporary_user_information">c:geo has introduced a new filtering system, supporting flexible, combinable and storable filters. \n\nThe global filter can from now on be changed directly in cache lists and the live map.</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -45,7 +45,7 @@
     <string translatable="false" name="map_source_osm_cyclosm">CyclOSM</string>
     <string translatable="false" name="map_source_mapy_cz">Mapy.cz</string>
 
-    <!-- calendar adder -->
+    <!-- edit waypoint -->
     <string translatable="false" name="waypoint_latitude_null">N/S --° --.---</string>
     <string translatable="false" name="waypoint_longitude_null">E/W --° --.---</string>
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -151,6 +151,12 @@
         <item name="android:layout_marginBottom">5dip</item>
     </style>
 
+    <style name="button_full_double" parent="button_full">
+        <item name="android:lines">2</item>
+        <item name="android:singleLine">false</item>
+        <item name="android:textSize">@dimen/textSize_buttonsDouble</item>
+    </style>
+
     <style name="button_full_spinner" parent="button_full">
         <item name="icon">@drawable/outline_arrow_drop_down_24</item>
         <item name="iconGravity">textEnd</item>

--- a/main/src/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/cgeo/geocaching/EditWaypointActivity.java
@@ -50,6 +50,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.text.HtmlCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -197,8 +198,7 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
             setTitle(res.getString(R.string.waypoint_edit_title));
         }
 
-        binding.buttonLatitude.setOnClickListener(new CoordDialogListener());
-        binding.buttonLongitude.setOnClickListener(new CoordDialogListener());
+        binding.buttonLatLongitude.setOnClickListener(new CoordDialogListener());
 
         final List<String> wayPointTypes = new ArrayList<>();
         for (final WaypointType wpt : WaypointType.ALL_TYPES_EXCEPT_OWN_AND_ORIGINAL) {
@@ -393,7 +393,8 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
         public void onClick(final View view) {
             Geopoint gp = null;
             try {
-                gp = new Geopoint(binding.buttonLatitude.getText().toString(), binding.buttonLongitude.getText().toString());
+                final String[] latlonText = binding.buttonLatLongitude.getText().toString().split("\n");
+                gp = new Geopoint(StringUtils.trim(latlonText[0]), StringUtils.trim(latlonText[1]));
             } catch (final Geopoint.ParseException ignored) {
                 // button text is blank when creating new waypoint
             }
@@ -405,7 +406,6 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                     showCoordinateOptionsDialog(view, geopoint, cache);
                 }
             });
-
         }
 
         private void showCoordinateOptionsDialog(final View view, final Geopoint geopoint, final Geocache cache) {
@@ -433,18 +433,15 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
             coordsDialog.setCancelable(true);
             coordsDialog.show(getSupportFragmentManager(), "wpeditdialog");
         }
-
     }
 
     @Override
-    public void updateCoordinates(final Geopoint gp) {
+    public void updateCoordinates(@Nullable final Geopoint gp) {
         if (gp != null) {
-            binding.buttonLatitude.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
-            binding.buttonLongitude.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
+            binding.buttonLatLongitude.setText(String.format("%s%n%s", gp.format(GeopointFormatter.Format.LAT_DECMINUTE), gp.format(GeopointFormatter.Format.LON_DECMINUTE)));
             setProjectionEnabled(true);
         } else {
-            binding.buttonLatitude.setText(R.string.waypoint_latitude_null);
-            binding.buttonLongitude.setText(R.string.waypoint_longitude_null);
+            binding.buttonLatLongitude.setText(String.format("%s%n%s", getResources().getString(R.string.waypoint_latitude_null), getResources().getString(R.string.waypoint_longitude_null)));
             setProjectionEnabled(false);
         }
     }
@@ -510,9 +507,11 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                 && !lonText.equals(getResources().getString(R.string.waypoint_longitude_null));
     }
 
+    @Nullable
     private ActivityData getActivityData() {
-        final String latText = binding.buttonLatitude.getText().toString();
-        final String lonText = binding.buttonLongitude.getText().toString();
+        final String[] latlonText = binding.buttonLatLongitude.getText().toString().split("\n");
+        final String latText = StringUtils.trim(latlonText[0]);
+        final String lonText = StringUtils.trim(latlonText[1]);
         Geopoint coords = null;
         if (coordsTextsValid(latText, lonText)) {
             try {

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -174,8 +174,7 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     }
 
     private void init() {
-        binding.buttonLatitude.setOnClickListener(v -> updateCoordinates());
-        binding.buttonLongitude.setOnClickListener(v -> updateCoordinates());
+        binding.buttonLatLongitude.setOnClickListener(v -> updateCoordinates());
 
         binding.searchCoordinates.setOnClickListener(arg0 -> findByCoordsFn());
 
@@ -246,9 +245,8 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     }
 
     @Override
-    public void updateCoordinates(final Geopoint gp) {
-        binding.buttonLatitude.setText(gp.format(GeopointFormatter.Format.LAT_DECMINUTE));
-        binding.buttonLongitude.setText(gp.format(GeopointFormatter.Format.LON_DECMINUTE));
+    public void updateCoordinates(@NonNull final Geopoint gp) {
+        binding.buttonLatLongitude.setText(String.format("%s%n%s", gp.format(GeopointFormatter.Format.LAT_DECMINUTE), gp.format(GeopointFormatter.Format.LON_DECMINUTE)));
     }
 
     @Override
@@ -259,25 +257,25 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
     private void findByCoordsFn() {
         String[] latlonText = getCoordText();
 
-        if (StringUtils.isEmpty(latlonText[0]) || StringUtils.isEmpty(latlonText[1])) {
+        if (latlonText.length < 2) {
             final Geopoint gp = Sensors.getInstance().currentGeo().getCoords();
-            updateCoordinates(gp);
-            latlonText = getCoordText();
+            if (gp.isValid()) {
+                updateCoordinates(gp);
+                latlonText = getCoordText();
+            } else {
+                return;
+            }
         }
 
         try {
-            CacheListActivity.startActivityCoordinates(this, new Geopoint(latlonText[0], latlonText[1]), null);
+            CacheListActivity.startActivityCoordinates(this, new Geopoint(StringUtils.trim(latlonText[0]), StringUtils.trim(latlonText[1])), null);
         } catch (final Geopoint.ParseException e) {
             showToast(res.getString(e.resource));
         }
     }
 
     private String[] getCoordText() {
-
-        return new String[] {
-            StringUtils.trim(binding.buttonLatitude.getText().toString()),
-            StringUtils.trim(binding.buttonLongitude.getText().toString())
-         };
+        return binding.buttonLatLongitude.getText().toString().split("\n");
     }
 
     private void findByKeywordFn() {
@@ -322,7 +320,6 @@ public class SearchActivity extends AbstractActionBarActivity implements Coordin
 
     private void findByFilterFn() {
         GeocacheFilterActivity.selectFilter(this, new GeocacheFilterContext(GeocacheFilterContext.FilterType.LIVE), null, false);
-
     }
 
     @Override


### PR DESCRIPTION
## Description

Follow up to the design optimization for the coordinate selection presented in https://github.com/cgeo/cgeo/issues/11354#issuecomment-890254665 .

- replace the 2 coordinate buttons by a single double line button for the search activity and the editwaypoint activity
- Defining a slightly larger font for the coordinates for better readability
- fix some string problems
  - "geo code" to "geocode"
  - "cachename" to "cache name"
  - "Keywords" to "Keyword" in search headline
  - some upper case/lower case optimizations

There is no change to the problem coordinates vs. coordinate.
The opinions were different in #11390.

## Related issues

Releated to #11354
Releated to #11390

Fixes #11391
