### PR TITLE
adapt styling of OSM zoom controls (fix #11696)

### DIFF
--- a/main/res/drawable/white_bcg.xml
+++ b/main/res/drawable/white_bcg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@android:color/black">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#C0FFFFFF" />
+            <corners android:radius="2dp" />
+        </shape>
+    </item>
+</ripple>

--- a/main/res/drawable/zoomin.xml
+++ b/main/res/drawable/zoomin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/white_bcg"/>
+    <item
+        android:drawable="@drawable/zoomin_fg"
+        android:top="3dp"
+        android:bottom="3dp"
+        android:left="3dp"
+        android:right="3dp"
+        android:gravity="center"/>
+</layer-list>

--- a/main/res/drawable/zoomin_fg.xml
+++ b/main/res/drawable/zoomin_fg.xml
@@ -1,0 +1,11 @@
+<!-- based on material.io icon "add", rounded, 24dp -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/osm_zoomcontrol">
+  <path
+      android:fillColor="@color/osm_zoomcontrol"
+      android:pathData="M18,13h-5v5c0,0.55 -0.45,1 -1,1s-1,-0.45 -1,-1v-5H6c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1h5V6c0,-0.55 0.45,-1 1,-1s1,0.45 1,1v5h5c0.55,0 1,0.45 1,1s-0.45,1 -1,1z"/>
+</vector>

--- a/main/res/drawable/zoomout.xml
+++ b/main/res/drawable/zoomout.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/white_bcg"/>
+    <item
+        android:drawable="@drawable/zoomout_fg"
+        android:top="3dp"
+        android:bottom="3dp"
+        android:left="3dp"
+        android:right="3dp"
+        android:gravity="center"/>
+</layer-list>

--- a/main/res/drawable/zoomout_fg.xml
+++ b/main/res/drawable/zoomout_fg.xml
@@ -1,0 +1,11 @@
+<!-- based on material.io icon "remove", rounded, 24dp -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/osm_zoomcontrol">
+  <path
+      android:fillColor="@color/osm_zoomcontrol"
+      android:pathData="M18,13H6c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1h12c0.55,0 1,0.45 1,1s-0.45,1 -1,1z"/>
+</vector>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -19,6 +19,8 @@
     <color name="colorText_listsSecondary">@color/colorTextHint</color>
     <color name="colorTextActionBar">#FFE4E4E4</color>
 
+    <color name="osm_zoomcontrol">#666666</color>
+
     <!-- values needed only until settings activity is based on AppCompatActivity -->
     <color name="settings_colorTextDark">@color/just_white</color>
     <color name="settings_colorTextLight">@color/just_black</color>
@@ -28,8 +30,6 @@
     <color name="settings_colorBackgroundLight">@color/just_white</color>
     <color name="settings_colorDialogBackgroundDark">#FF191919</color>
     <color name="settings_colorDialogBackgroundLight">@color/just_white</color>
-
-
 
     <!-- default colors for map lines -->
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -137,6 +137,7 @@ import org.mapsforge.core.model.MapPosition;
 import org.mapsforge.core.util.Parameters;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.graphics.AndroidResourceBitmap;
+import org.mapsforge.map.android.input.MapZoomControls;
 import org.mapsforge.map.android.util.AndroidUtil;
 import org.mapsforge.map.layer.Layers;
 import org.mapsforge.map.layer.cache.TileCache;
@@ -278,6 +279,15 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
         mapView.setClickable(true);
         mapView.getMapScaleBar().setVisible(true);
         mapView.setBuiltInZoomControls(true);
+
+        // style zoom controls
+        final MapZoomControls zoomControls = mapView.getMapZoomControls();
+        zoomControls.setZoomControlsOrientation(MapZoomControls.Orientation.VERTICAL_IN_OUT);
+        zoomControls.setZoomInResource(R.drawable.zoomin);
+        zoomControls.setZoomOutResource(R.drawable.zoomout);
+        final int padding = ViewUtils.dpToPixel(10.0f);
+        zoomControls.setPadding(padding, padding, padding, padding);
+        zoomControls.setAutoHide(false);
 
         //make room for map attribution icon button
         final int mapAttPx = Math.round(this.getResources().getDisplayMetrics().density * 30);


### PR DESCRIPTION
## Description
Adapt styling of OSM zoom controls to look more similar to GM zoom controls:
- use vertical arrangement (zoom in on top, zoom out below)
- use +/- symbols as zoom controls
- use semi-transparent white box as background
- disable auto-hide of zoom controls

![image](https://user-images.githubusercontent.com/3754370/135755207-49522503-13d9-447a-902a-421327bccc13.png)
