### PR TITLE
[waypoint marker] use correct connector shape in singlePointMode

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -225,11 +225,11 @@ public class CompassActivity extends AbstractActionBarActivity {
         final int id = item.getItemId();
         if (id == R.id.menu_map) {
             if (waypoint != null) {
-                DefaultMap.startActivityCoords(this, waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName());
+                DefaultMap.startActivityCoords(this, waypoint);
             } else if (cache != null) {
                 DefaultMap.startActivityGeoCode(this, cache.getGeocode());
             } else {
-                DefaultMap.startActivityCoords(this, dstCoords, null, null);
+                DefaultMap.startActivityCoords(this, dstCoords);
             }
         } else if (id == R.id.menu_tts_toggle) {
             SpeechService.toggleService(this, dstCoords);

--- a/main/src/cgeo/geocaching/address/AddressListActivity.java
+++ b/main/src/cgeo/geocaching/address/AddressListActivity.java
@@ -63,7 +63,7 @@ public class AddressListActivity extends AbstractActionBarActivity implements Ad
 
     @Override
     public void onClickMapIcon(@NonNull final Address address) {
-        DefaultMap.startActivityGeoCode(this, new Geopoint(address.getLatitude(), address.getLongitude()));
+        DefaultMap.startActivityInitialCoords(this, new Geopoint(address.getLatitude(), address.getLongitude()));
         finish();
     }
 }

--- a/main/src/cgeo/geocaching/apps/navi/InternalMap.java
+++ b/main/src/cgeo/geocaching/apps/navi/InternalMap.java
@@ -33,12 +33,12 @@ class InternalMap extends AbstractPointNavigationApp {
 
     @Override
     public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
-        DefaultMap.startActivityCoords(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), coords, WaypointType.WAYPOINT, null);
+        DefaultMap.startActivityCoords(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), coords, WaypointType.WAYPOINT);
     }
 
     @Override
     public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
-        DefaultMap.startActivityCoords(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName());
+        DefaultMap.startActivityCoords(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), waypoint);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1446,6 +1446,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
         final Waypoint waypoint = new Waypoint("some place", mapOptions.waypointType != null ? mapOptions.waypointType : WaypointType.WAYPOINT, false);
         waypoint.setCoords(coords);
+        waypoint.setGeocode(mapOptions.geocode);
 
         final CachesOverlayItemImpl item = getWaypointItem(waypoint, Settings.getCompactIconMode() == Settings.COMPACTICON_ON);
         mapView.updateItems(Collections.singletonList(item));

--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -33,19 +33,23 @@ public final class DefaultMap {
         return new MapOptions(coords).newIntent(fromActivity, getDefaultMapClass());
     }
 
-    public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Geopoint coords, final WaypointType type, final String title) {
-        new MapOptions(coords, type, title).startIntent(fromActivity, cls);
-    }
-
     public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Waypoint waypoint) {
         new MapOptions(waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName(), waypoint.getGeocode()).startIntent(fromActivity, cls);
     }
 
-    public static void startActivityCoords(final Activity fromActivity, final Geopoint coords, final WaypointType type, final String title) {
-        startActivityCoords(fromActivity, getDefaultMapClass(), coords, type, title);
+    public static void startActivityCoords(final Context fromActivity, final Waypoint waypoint) {
+        startActivityCoords(fromActivity, getDefaultMapClass(), waypoint);
     }
 
-    public static void startActivityGeoCode(final Context fromActivity, final Geopoint coords) {
+    public static void startActivityCoords(final Activity fromActivity, final Geopoint coords) {
+        startActivityCoords(fromActivity, getDefaultMapClass(), coords, null);
+    }
+
+    public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Geopoint coords, final WaypointType type) {
+        new MapOptions(coords, type).startIntent(fromActivity, cls);
+    }
+
+    public static void startActivityInitialCoords(final Context fromActivity, final Geopoint coords) {
         new MapOptions(coords).startIntent(fromActivity, getDefaultMapClass());
     }
 

--- a/main/src/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/cgeo/geocaching/maps/MapOptions.java
@@ -80,10 +80,9 @@ public class MapOptions {
         isLiveEnabled = Settings.isLiveMap();
     }
 
-    public MapOptions(final Geopoint coords, final WaypointType type, final String title) {
+    public MapOptions(final Geopoint coords, final WaypointType type) {
         this.coords = coords;
         this.waypointType = type;
-        this.title = title;
         mapMode = MapMode.COORDS;
         isLiveEnabled = false;
     }


### PR DESCRIPTION
fix #11424

on the way, I've touched some methods where the name was misleading, or some parameters were always `null`

![grafik](https://user-images.githubusercontent.com/64581222/135761911-a3ef2f11-40b3-498c-b156-cf7803f6b6ec.png)

Tested on OSM and GMap