### PR TITLE
rel to #11227: dont initialize default folders at startup - it takes very long time

### DIFF
--- a/main/src/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/cgeo/geocaching/InstallWizardActivity.java
@@ -13,7 +13,6 @@ import cgeo.geocaching.settings.Credentials;
 import cgeo.geocaching.settings.GCAuthorizationActivity;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
-import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.ContentStorageActivityHelper;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
@@ -514,7 +513,7 @@ public class InstallWizardActivity extends AppCompatActivity {
 
     private void prepareFolderDefaultValues() {
         // re-evaluate default folder values, as the public folder may not have been accessible on startup
-        ContentStorage.get().reevaluateFolderDefaults();
+        PersistableFolder.reevaluateDefaultFolders();
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
rel to #11227: dont initialize default folders at startup - it takes very long time

Although this is a bug in production, I would prefer to put this fix to master. The reason is that it changes core parts of `ContentStorage`, and I want to use the beta phase to check unwanted side effects before pushing this out to all end users.