### PR TITLE
Issue 11559 - Use 'sync' icon instead of 'cached'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ buildscript {
         // monitor our application method limit
         //noinspection GradleDependency - see https://github.com/cgeo/cgeo/issues/9208
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.3'
+
+        //google API
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
     }
 }
 
@@ -32,6 +35,9 @@ plugins {
     // 'tiJson' (export as a JSON file), see https://gitlab.com/barfuin/gradle-taskinfo
     // they need cmdline parameter, e.g. gradlew tiTree assenbleBasicDebug
     id 'org.barfuin.gradle.taskinfo' version '1.3.1'
+
+    //google API
+    //id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 /*

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,6 @@ buildscript {
         // monitor our application method limit
         //noinspection GradleDependency - see https://github.com/cgeo/cgeo/issues/9208
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.3'
-
-        //google API
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
     }
 }
 
@@ -35,9 +32,6 @@ plugins {
     // 'tiJson' (export as a JSON file), see https://gitlab.com/barfuin/gradle-taskinfo
     // they need cmdline parameter, e.g. gradlew tiTree assenbleBasicDebug
     id 'org.barfuin.gradle.taskinfo' version '1.3.1'
-
-    //google API
-    //id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 /*

--- a/main/res/drawable/ic_menu_sync_enabled.xml
+++ b/main/res/drawable/ic_menu_sync_enabled.xml
@@ -1,0 +1,11 @@
+<!-- taken from sync-disabled / material.io -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M 9.908 19.778 L 9.908 14.121 L 7.787 16.243 C 6.662 15.118 6.03 13.59 6.029 12 C 6.03 10.41 6.662 8.882 7.787 7.757 C 8.494 7.05 9.357 6.541 10.262 6.272 L 10.262 4.208 C 8.84 4.526 7.483 5.233 6.373 6.343 C 4.873 7.843 4.029 9.879 4.029 12 C 4.029 14.121 4.873 16.157 6.373 17.657 L 4.251 19.778 M 16.272 7.757 C 17.397 8.882 18.029 10.41 18.03 12 C 18.029 13.59 17.397 15.118 16.272 16.243 C 15.565 16.95 14.702 17.459 13.797 17.728 L 13.797 19.792 C 15.218 19.474 16.576 18.767 17.686 17.657 C 19.186 16.157 20.03 14.121 20.03 12 C 20.03 9.879 19.186 7.843 17.686 6.343 L 19.808 4.222 L 14.151 4.222 L 14.151 9.879"/>
+</vector>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -754,7 +754,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         try {
             final MenuItem itemMapLive = menu.findItem(R.id.menu_map_live);
             if (mapOptions.isLiveEnabled) {
-                itemMapLive.setIcon(R.drawable.ic_menu_refresh);
+                itemMapLive.setIcon(R.drawable.ic_menu_sync_enabled);
                 itemMapLive.setTitle(res.getString(R.string.map_live_disable));
             } else {
                 itemMapLive.setIcon(R.drawable.ic_menu_sync_disabled);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -379,7 +379,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
         try {
             final MenuItem itemMapLive = menu.findItem(R.id.menu_map_live);
             if (mapOptions.isLiveEnabled) {
-                itemMapLive.setIcon(R.drawable.ic_menu_refresh);
+                itemMapLive.setIcon(R.drawable.ic_menu_sync_enabled);
                 itemMapLive.setTitle(res.getString(R.string.map_live_disable));
             } else {
                 itemMapLive.setIcon(R.drawable.ic_menu_sync_disabled);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
new drawable ic_menu_sync_enabled.xml
replacing old "ic_menu_refresh.xml" by new "ic_menu_sync_enabled.xml" in CgeoMap.java and NewMap.java

i created a new icon starting from the original ic_menu_refresh by using https://shapeshifter.design/
- importing the xml > adding a group around the path : 
     <group android:translateX="29" android:translateY="12" android:rotation="135"><path="..." /></group>
- export as SVG
- import the SVG again
- export as XML drawable => see result in "ic_menu_sync_enabled.xml"

## Related issues
<!-- List the related issues fixed or improved by this PR -->
issue #11559

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->