### PR TITLE
fix minor downloader issues

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2265,6 +2265,7 @@
     <string name="download_confirmation">%1$sDownload file \"%2$s\"?%3$s</string>
     <string name="download_confirmation_updates">Updates found for:\n%1$s\n\nDo you want to update?%2$s</string>
     <string name="download_warning">This may take quite some time and can lead to significant costs, depending on your network connection.</string>
+    <string name="download_error">Download failed with error #%d</string>
     <string name="downloadmap_handling">The download itself will be handled by your system\'s download manager in the background. You should see a notification as soon as the download started (which may take a while).</string>
     <string name="button_continue">Continue</string>
     <string name="downloadmap_onedirup">(one level up)</string>

--- a/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.downloader;
 
 import cgeo.geocaching.Intents;
+import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.storage.extension.PendingDownload;
 import cgeo.geocaching.utils.Log;
@@ -47,7 +48,7 @@ class DownloadNotificationReceiver extends BroadcastReceiver {
                             case DownloadManager.STATUS_FAILED:
                                 PendingDownload.remove(pendingDownload);
                                 final int error = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
-                                ActivityMixin.showToast(context, "map download failed with error #" + error);
+                                ActivityMixin.showToast(context, String.format(context.getString(R.string.download_error), error));
                                 Log.d("download #" + pendingDownload + " failed with error #" + error);
                                 // remove file from system's download manager, which will also delete the broken file from storage
                                 downloadManager.remove(pendingDownload);

--- a/main/src/cgeo/geocaching/downloader/DownloadSelectorActivity.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadSelectorActivity.java
@@ -127,7 +127,7 @@ public class DownloadSelectorActivity extends AbstractActionBarActivity {
                                             cursor.moveToFirst();
                                             final int bytesDownloaded = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
                                             final int bytesTotal = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
-                                            final int progress = (int) ((bytesDownloaded * 100L) / bytesTotal);
+                                            final int progress = bytesTotal == 0 ? 0 : (int) ((bytesDownloaded * 100L) / bytesTotal);
 
                                             runOnUiThread(() -> holder.binding.progressHorizontal.setProgressCompat(progress, true));
                                             cursor.close();


### PR DESCRIPTION
## Description
While debugging for #11793 I've stumbled upon two minor issues and fixed them:
- make static error info string translatable
- avoid division by zero exception
