### PR TITLE
fix lint: remove non-constant resource id in Settings

### DIFF
--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1848,17 +1848,16 @@ public class Settings {
     }
 
     private static String[] getLegacyPreferenceKeysFor(final int keyId) {
-        switch (keyId) {
-            case R.string.pref_persistablefolder_offlinemaps:
-                return new String[]{"mapDirectory"};
-            case R.string.pref_persistablefolder_gpx:
-                return new String[]{"gpxExportDir", "gpxImportDir"};
-            case R.string.pref_persistableuri_track:
-                return new String[]{"pref_trackfile"};
-            case R.string.pref_persistablefolder_offlinemapthemes:
-                return new String[]{"renderthemepath"};
-            default:
-                return new String[0];
+        if (keyId == R.string.pref_persistablefolder_offlinemaps) {
+            return new String[]{"mapDirectory"};
+        } else if (keyId == R.string.pref_persistablefolder_gpx) {
+            return new String[]{"gpxExportDir", "gpxImportDir"};
+        } else if (keyId == R.string.pref_persistableuri_track) {
+            return new String[]{"pref_trackfile"};
+        } else if (keyId == R.string.pref_persistablefolder_offlinemapthemes) {
+            return new String[]{"renderthemepath"};
+        } else {
+            return new String[0];
         }
     }
 


### PR DESCRIPTION
## Description
Replaces the case statement using resource ids by if/else statements in `Settings` in preparation for Gradle 8, which claims to make resource ids non-constant.

Left the usage of case statement in combination with resource ids in `SettingsActivity` intentionally to not interfere with #11298.
