### PR TITLE
Revert "fix lint: remove outdated onclick in mainscreen layout file"

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -35,6 +35,7 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
+                android:onClick="cgeoFindOnMap"
                 tools:ignore="UseCompoundDrawables">
 
                 <ImageView
@@ -65,7 +66,8 @@
                 android:layout_width="0dip"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:onClick="cgeoFindByOffline">
 
                 <TextView
                     android:id="@+id/offline_count"
@@ -93,6 +95,7 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
+                android:onClick="cgeoSearch"
                 tools:ignore="UseCompoundDrawables">
 
                 <ImageView
@@ -107,6 +110,7 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
+                android:onClick="cgeoPoint"
                 tools:ignore="UseCompoundDrawables">
 
                 <ImageView
@@ -121,6 +125,7 @@
 
             <LinearLayout
                 style="@style/icon_mainscreen_cell"
+                android:onClick="cgeoFilter"
                 tools:ignore="UseCompoundDrawables">
 
                 <ImageView

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -777,37 +777,65 @@ public class MainActivity extends AbstractActionBarActivity {
         }
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoFindOnMap(final View v) {
         binding.map.setPressed(true);
         startActivity(DefaultMap.getLiveMapIntent(this));
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoFindNearest(final View v) {
         binding.nearest.setPressed(true);
         startActivity(CacheListActivity.getNearestIntent(this));
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoFindByOffline(final View v) {
         binding.searchOffline.setPressed(true);
         CacheListActivity.startActivityOffline(this);
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoSearch(final View v) {
         binding.advancedButton.setPressed(true);
         startActivity(new Intent(this, SearchActivity.class));
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoPoint(final View v) {
         binding.anyButton.setPressed(true);
         InternalConnector.assertHistoryCacheExists(this);
         CacheDetailActivity.startActivity(this, InternalConnector.GEOCODE_HISTORY_CACHE, true);
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoFilter(final View v) {
         binding.filterButton.setPressed(true);
         binding.filterButton.performClick();
     }
 
+    /**
+     * @param v
+     *            unused here but needed since this method is referenced from XML layout
+     */
     public void cgeoNavSettings(final View v) {
         startActivity(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS));
     }


### PR DESCRIPTION
This reverts commit a454de15ebca028ce0c967da4e194cc23b9fea8c.

## Description
Reverts #11823 due to unwanted side-effects on bottom navigation PR and as the lint issues fixed by #11823 will be obsolete after merging the bottom navigation PR anyway.
