### PR TITLE
fix #11825: make lint MissingDefaultResource informational

### DIFF
--- a/main/lint.xml
+++ b/main/lint.xml
@@ -51,4 +51,6 @@
         <ignore path="res/values/vpi__colors.xml" />
         <ignore path="res/values-*/strings.xml" />
     </issue>
+
+    <issue id="MissingDefaultResource" severity="informational"/>
 </lint>


### PR DESCRIPTION
fix #11825: make lint MissingDefaultResource informational