### PR TITLE
fix lint: remove unused strings, fix static string usage

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -312,7 +312,6 @@
     <string name="confirm_unsaved_changes_title">Unsaved changes</string>
     <string name="confirm_discard_changes">Discard unsaved changes?</string>
     <string name="confirm_discard_wp_changes">Discard unsaved waypoint changes?</string>
-    <string name="err_request_popup_info">c:geo failed to get cache popup info.</string>
     <string name="warn_log_load_additional_data">c:geo failed to load additional data (trackables/favorite points) for logging.</string>
     <string name="more_information">More information</string>
     <string name="undo">Undo</string>
@@ -523,7 +522,6 @@
         <item quantity="other">%1$d items</item>
     </plurals>
 
-    <string name="cache_filter_storage_load_button">Load</string>
     <string name="cache_filter_storage_delete_button">Delete</string>
     <string name="cache_filter_storage_clear_button">Clear</string>
     <string name="cache_filter_storage_load_delete_title">Load or delete an existing filter</string>
@@ -2027,14 +2025,6 @@
         <item quantity="few">%d days ago</item>
         <item quantity="many">%d days ago</item>
         <item quantity="other">%d days ago</item>
-    </plurals>
-    <plurals name="favorite_points">
-        <item quantity="zero">%s favorites</item>
-        <item quantity="one">%s favorite</item>
-        <item quantity="two">%s favorites</item>
-        <item quantity="few">%s favorites</item>
-        <item quantity="many">%s favorites</item>
-        <item quantity="other">%s favorites</item>
     </plurals>
 
     <!-- shortcuts -->

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -224,7 +224,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             final String changelogBugfix = FileUtils.getChangelogRelease(activity);
             if (BranchDetectionHelper.FROM_BRANCH_RELEASE == 1) {
                 // we are on release branch
-                markwon.setMarkdown(binding.changelogMaster, (changelogBugfix.startsWith("##") ? "" : "## Next bugfix release\n\n") +  changelogBugfix);
+                markwon.setMarkdown(binding.changelogMaster, (changelogBugfix.startsWith("##") ? "" : "## " + getString(R.string.about_changelog_next_release) + "\n\n") +  changelogBugfix);
                 markwon.setMarkdown(binding.changelogRelease, "## " + BranchDetectionHelper.FEATURE_VERSION_NAME + "\n\n" + changelogBase);
             } else {
                 // we are on a non-release branch


### PR DESCRIPTION
## Description
(recreated PR, as the first one got closed automatically)
- Removes three strings no longer used
- Fixes a static string usage in `AboutActivity`
