### PR TITLE
Generalize dialog background color (fix #11839)

### DIFF
--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -13,7 +13,7 @@
     <color name="colorBackground">#FF141414</color>
     <color name="colorBackgroundNotice">#FF191919</color>
     <color name="colorBackgroundTransparent">#44000000</color>
-    <color name="colorBackgroundDialog">#FF424242</color>
+    <color name="colorBackgroundDialog">#FF353535</color>
     <color name="colorBackgroundSelected">#FF444444</color>
     <color name="colorBackgroundActionBar">#FF2A2A2A</color>
 

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -36,14 +36,13 @@
     <style name="materialAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="materialAlertDialogTitleTextStyle">@style/alertDialogTitleTextStyle</item>
         <item name="materialAlertDialogBodyTextStyle">@style/alertDialogBodyTextStyle</item>
+        <item name="android:colorBackground">@color/colorBackgroundDialog</item>
     </style>
 
     <!-- theme for dialogs with compact lists (e. g.: "pick a list" dialogs -->
 
-    <style name="cgeo.compactDialogs" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+    <style name="cgeo.compactDialogs" parent="materialAlertDialogTheme">
         <item name="android:listPreferredItemHeightSmall">40dp</item>
-        <item name="materialAlertDialogTitleTextStyle">@style/alertDialogTitleTextStyle</item>
-        <item name="materialAlertDialogBodyTextStyle">@style/alertDialogBodyTextStyle</item>
         <item name="android:checkedTextViewStyle">@style/checkboxStyleNoParent</item>
     </style>
 


### PR DESCRIPTION
adapt `colorBackgroundDialog `to our current dialog background color and actually use use it in our `dialogTheme`. (fix #11839)

might be good to have it in the beta.