### PR TITLE
smart-detect build type in BranchDetectionHelper

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -222,7 +222,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
 
             final String changelogBase = FileUtils.getChangelogMaster(activity);
             final String changelogBugfix = FileUtils.getChangelogRelease(activity);
-            if (BranchDetectionHelper.FROM_BRANCH_RELEASE == 1) {
+            if (BranchDetectionHelper.isProductionBuild()) {
                 // we are on release branch
                 markwon.setMarkdown(binding.changelogMaster, (changelogBugfix.startsWith("##") ? "" : "## " + getString(R.string.about_changelog_next_release) + "\n\n") +  changelogBugfix);
                 markwon.setMarkdown(binding.changelogRelease, "## " + BranchDetectionHelper.FEATURE_VERSION_NAME + "\n\n" + changelogBase);
@@ -455,4 +455,3 @@ public class AboutActivity extends TabbedViewPagerActivity {
     }
 
 }
-

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -81,6 +81,7 @@ import cgeo.geocaching.ui.dialog.EditNoteDialog.EditNoteDialogListener;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.ui.recyclerview.RecyclerViewProvider;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.CheckerUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
@@ -2488,7 +2489,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
     protected long[] getOrderedPages() {
         final ArrayList<Long> pages = new ArrayList<>();
-        if (BuildConfig.BUILD_TYPE.equals("debug") || BuildConfig.BUILD_TYPE.equals("nightly")) {
+        if (!BranchDetectionHelper.isProductionBuild()) {
             pages.add(Page.VARIABLES.id);
         }
         pages.add(Page.WAYPOINTS.id);

--- a/main/src/cgeo/geocaching/utils/BranchDetectionHelper.java
+++ b/main/src/cgeo/geocaching/utils/BranchDetectionHelper.java
@@ -1,13 +1,21 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.BuildConfig;
+
 public class BranchDetectionHelper {
-    // should be "1" if on branch "release", and "0" else
-    public static final int FROM_BRANCH_RELEASE = 1;
 
     // should contain the version name of the last feature release
     public static final String FEATURE_VERSION_NAME = "2021.10-11-RC";
 
     private BranchDetectionHelper() {
         // utility class
+    }
+
+    /**
+     * @return true, if BUILD_TYPE is not a nightly or debug build
+     */
+    @SuppressWarnings("ConstantConditions") // BUILD_TYPE is detected as constant but can change depending on the build configuration
+    public static boolean isProductionBuild() {
+        return !(BuildConfig.BUILD_TYPE.equals("debug") || BuildConfig.BUILD_TYPE.equals("nightly"));
     }
 }


### PR DESCRIPTION
### pro:
- no manual editing necessary
### con:
- for testing the "release optic" in the emulator, you will need to temporarily modify the `isProductionBuild` method, to see how the result will look like