### PR TITLE
reduce size of waypoint markers (fix #11861)

### DIFF
--- a/main/res/drawable/waypoint_marker.xml
+++ b/main/res/drawable/waypoint_marker.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <path
+      android:pathData="M3.758,18.001a14.011,14.011 0,1 0,28.022 0a14.011,14.011 0,1 0,-28.022 0z"
+      android:strokeWidth=".75"
+      android:fillColor="#fff"
+      android:strokeColor="#383838"/>
+</vector>

--- a/main/res/drawable/waypoint_marker_oc.xml
+++ b/main/res/drawable/waypoint_marker_oc.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <path
+      android:pathData="M8.3431,3.99L27.1937,3.99A4.5852,4.5852 0,0 1,31.7789 8.5752L31.7789,27.4278A4.5852,4.5852 0,0 1,27.1937 32.013L8.3431,32.013A4.5852,4.5852 0,0 1,3.7579 27.4278L3.7579,8.5752A4.5852,4.5852 0,0 1,8.3431 3.99z"
+      android:strokeWidth=".75"
+      android:fillColor="#fff"
+      android:strokeColor="#383838"
+      android:strokeLineCap="square"/>
+</vector>

--- a/main/res/drawable/waypoint_marker_other.xml
+++ b/main/res/drawable/waypoint_marker_other.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <path
+      android:pathData="m33.9468,18.0012 l-8.0891,14.0113l-16.1781,0l-8.0891,-14.0113 8.0891,-14.0113l16.1781,0z"
+      android:strokeWidth="0.74999845"
+      android:fillColor="#fff"
+      android:strokeColor="#383838"/>
+</vector>

--- a/main/res/drawable/waypoint_marker_pin.xml
+++ b/main/res/drawable/waypoint_marker_pin.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <path
+      android:pathData="m17.7691,28.0396c-0.9727,0.3763 -1.9405,1.1999 -2.4986,2.3145 -1.218,2.4324 2.4986,5.1681 2.4986,5.1681s3.7165,-2.7357 2.4986,-5.1681c-0.5581,-1.1147 -1.5259,-1.9382 -2.4986,-2.3145z"
+      android:strokeWidth="0.7743973"
+      android:fillColor="#fff"
+      android:fillType="evenOdd"
+      android:strokeColor="#383838"/>
+</vector>

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -220,6 +220,11 @@ public abstract class AbstractConnector implements IConnector {
     }
 
     @Override
+    public int getWaypointMapMarkerId() {
+        return R.drawable.waypoint_marker_other;
+    };
+
+    @Override
     @NonNull
     public List<LogType> getPossibleLogTypes(@NonNull final Geocache geocache) {
         final List<LogType> logTypes = new ArrayList<>();

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -233,6 +233,12 @@ public interface IConnector {
     int getCacheMapDotMarkerBackgroundId();
 
     /**
+     * Return the marker id of the waypoints for this connector. Similar to getMapMarkerId, but smaller in size.
+     * on the map.
+     */
+    int getWaypointMapMarkerId();
+
+    /**
      * Get the list of <b>potentially</b> possible log types for a cache. Those may still be filtered further during the
      * actual logging activity.
      *

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -458,6 +458,11 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    public int getWaypointMapMarkerId() {
+        return R.drawable.waypoint_marker;
+    };
+
+    @Override
     public boolean login(final Handler handler, @Nullable final Activity fromActivity) {
         // login
         final StatusCode status = GCLogin.getInstance().login();

--- a/main/src/cgeo/geocaching/connector/oc/OCConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCConnector.java
@@ -144,6 +144,11 @@ public class OCConnector extends AbstractConnector implements SmileyCapability {
     }
 
     @Override
+    public int getWaypointMapMarkerId() {
+        return R.drawable.waypoint_marker_oc;
+    };
+
+    @Override
     @NonNull
     public final List<LogType> getPossibleLogTypes(@NonNull final Geocache cache) {
         if (cache.isEventCache()) {

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -492,7 +492,7 @@ public class Waypoint implements IWaypoint {
     }
 
     public int getMapMarkerId() {
-        return ConnectorFactory.getConnector(geocode).getCacheMapMarkerId();
+        return ConnectorFactory.getConnector(geocode).getWaypointMapMarkerId();
     }
 
     public int getMapDotMarkerId() {

--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -245,7 +245,7 @@ public final class MapMarkerUtils {
 
         final Drawable marker = ResourcesCompat.getDrawable(res, waypoint.getMapMarkerId(), null);
         final InsetsBuilder insetsBuilder = new InsetsBuilder(res, marker.getIntrinsicWidth(), marker.getIntrinsicHeight());
-        insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_pin));
+        insetsBuilder.withInset(new InsetBuilder(R.drawable.waypoint_marker_pin));
         insetsBuilder.withInset(new InsetBuilder(marker));
 
         final Drawable mainMarker = DrawableCompat.wrap(ResourcesCompat.getDrawable(res, null == waypointType ? WaypointType.WAYPOINT.markerId : waypoint.getWaypointType().markerId, null));


### PR DESCRIPTION
## Description
Reduces the size of waypoint markers to a) reduce white space in markers and b) make them better distinguishable from cache markers.

![grafik](https://user-images.githubusercontent.com/3754370/137026020-35427d64-6d38-446b-b843-925896f6a0cd.png)
