### PR TITLE
re-add 'clear manual targets' to map menu

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -162,6 +162,11 @@
         android:title="@string/map_load_individual_route">
     </item>
     <item
+        android:id="@+id/menu_clear_targets"
+        android:title="@string/map_clear_manual_targets"
+        android:visible="false">
+    </item>
+    <item
         android:id="@+id/menu_as_list"
         android:icon="@drawable/ic_menu_agenda"
         android:title="@string/map_as_list">

--- a/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
+++ b/main/src/cgeo/geocaching/utils/IndividualRouteUtils.java
@@ -79,8 +79,9 @@ public class IndividualRouteUtils {
      *
      * @param menu menu to be configured
      */
-    public void onPrepareOptionsMenu(final Menu menu, final View anchor, final IndividualRoute route, final boolean targetIsSet) {
+    public void onPrepareOptionsMenu(final Menu menu, final View anchor, final IndividualRoute route, final boolean isTargetSet) {
         anchor.setVisibility(isVisible(route) ? View.VISIBLE : View.GONE);
+        menu.findItem(R.id.menu_clear_targets).setVisible(isTargetSet);
     }
 
     /**


### PR DESCRIPTION
## Description
With #11771 nearly all navigation related menu entries were move to the new bottom popup menu, which is ok in general, but "Clear manual targets" needs to be available in the regular map menu as well, as it is not only related to individual routes, but also to a cache set as target. This PR therefore re-adds this menu entry to the map menu.
