### PR TITLE
use 'latest' subfolder for FZK downloads (rel. to #11817)

### DIFF
--- a/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
@@ -52,7 +52,7 @@ public class MapDownloaderFreizeitkarte extends AbstractMapDownloader {
                 description = "";
                 dateInfo = "";
             });
-            map.getChild("", "Url").setEndTextElementListener(body -> url = body);
+            map.getChild("", "Url").setEndTextElementListener(body -> url = body.replaceAll("\\/[0-9]{4,4}\\/", "/latest/"));
             map.getChild("", "Size").setEndTextElementListener(body -> size = Long.parseLong(body));
             map.getChild("", "DescriptionEnglish").setEndTextElementListener(body -> description = body);
             map.getChild("", "MapsforgeDateOfCreation").setEndTextElementListener(body -> dateInfo = body);


### PR DESCRIPTION
## Description
Related to #11817: Use "latest" subfolder instead of "yymm" subfolder - helps avoiding folder naming errors on server side like that one that happened recently / always downloads the most recent version
