### PR TITLE
Exclude translations for new changelogs from merging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,8 +8,8 @@
 /cgeo-contacts/res/values-*/strings.xml merge=ours
 
 # Ignore translated changelogs
-/main/res/raw-*/changelog_master.md merge=ours
-/main/res/raw-*/changelog_release.md merge=ours
+/main/res/raw-*/changelog_base.md merge=ours
+/main/res/raw-*/changelog_bugfix.md merge=ours
 
 # Ignore translated playstore description 
 /main/project/playstore/description/translated/*/*.txt merge=ours


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
As Crowdin will deliver translations to each branch individually we IMHO need to:
- Exclude `changelog_base.md` as it is for sure present on both branches and might diverge. Even if not, merging on one branch might result in merge conflicts for the PR to the other branch after branches are merged.
- Exclude `changlog_bugfix.md` as while it might not be present at first on `master` it will be present after once `release` has been merged to `master`. Thereafter Crowdin will deliver translations to both branches with effects as described above


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#11101

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Please merge before merging any crowdin updates...unless my description above is wrong.