### PR TITLE
only launch dashboard if activity is task root (fix #11863)

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -137,12 +137,13 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         final int id = item.getItemId();
-        if (id == android.R.id.home) {
+        if (id == android.R.id.home && isTaskRoot()) {
             startActivity(new Intent(this, MainActivity.class));
             ActivityMixin.overrideTransitionToFade(this);
             finish();
+            return true;
         }
-        return true;
+        return super.onOptionsItemSelected(item);
     }
 
     @Override


### PR DESCRIPTION
When using the map to navigate to a cache and clicking the back icon in upper left, correctly return to the listing instead of dashboard...