### PR TITLE
Save waypoints to DB for ALC caches if alc_advanced is set

### DIFF
--- a/main/src/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/cgeo/geocaching/connector/al/ALApi.java
@@ -262,7 +262,7 @@ final class ALApi {
             cache.setDisabled(false);
             cache.setHidden(parseDate(response.get("PublishedUtc").asText()));
             cache.setOwnerDisplayName(response.get("OwnerUsername").asText());
-            cache.setWaypoints(parseWaypoints((ArrayNode) response.path("GeocacheSummaries")), false);
+            cache.setWaypoints(parseWaypoints((ArrayNode) response.path("GeocacheSummaries")), true);
             cache.setDetailedUpdatedNow();
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
             return cache;


### PR DESCRIPTION
For ALC, if the hidden property alc_advanced is set, the waypoints are also loaded. But they are not saved to DB, and this means that they are not displayed correctly / concurrently on the map, only the waypoints of the last opened ALC cache are visible at one time.