### PR TITLE
do not shrink resources for debug builds to increase build performance

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -129,8 +129,11 @@ android {
         // enable proguard and remove unused code
         minifyEnabled true
 
-        // remove unused resources in addition to unused code
-        shrinkResources true
+        // as it affects the build speed, do not shrink resources for debug builds
+        if (buildType.name != 'debug') {
+            // remove unused resources in addition to unused code
+            shrinkResources true
+        }
 
         // proguard rules
         proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'


### PR DESCRIPTION
Cause of quite slow build performance (around 2 minutes per build), I started debugging what the root cause for it could be.

Result: 
Over 50% of build time are used to shrink the resources. While this makes sense for production releases, it has no benefit for development... even the other way around: shrinking resources decreases our development productivity ;-)