### PR TITLE
don't ignore already stored caches while downloading on OSM (fix #11847)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1559,10 +1559,7 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
                     if (handler.isDisposed()) {
                         break;
                     }
-
-                    if (!DataStore.isOffline(geocode, null)) {
-                        Geocache.storeCache(null, geocode, listIds, false, handler);
-                    }
+                    Geocache.storeCache(null, geocode, listIds, false, handler);
                 } catch (final Exception e) {
                     Log.e("CGeoMap.LoadDetails.run", e);
                 } finally {


### PR DESCRIPTION
Looks a bit like a "Wimmelbild". Try to find the differences ;-)

Who has copied all code parts back in the days instead of creating a good abstraction layer...? 



|Google Map (known as `CGeoMap`)|OSM Map (known as `NewMap`)|
-|-
![grafik](https://user-images.githubusercontent.com/64581222/137371901-0607afe4-0b71-4a05-a018-c08b05358545.png)|![grafik](https://user-images.githubusercontent.com/64581222/137371976-8bab78ff-aeed-4b5f-bd74-40e4be92c21a.png)
