### PR TITLE
disable minify for debug builds (rel. to #11886)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -126,11 +126,11 @@ android {
     }
 
     buildTypes.all { buildType ->
-        // enable proguard and remove unused code
-        minifyEnabled true
-
-        // as it affects the build speed, do not shrink resources for debug builds
+        // as it affects the build speed, do skip some steps for debug builds
         if (buildType.name != 'debug') {
+            // enable proguard and remove unused code
+            minifyEnabled true
+
             // remove unused resources in addition to unused code
             shrinkResources true
         }

--- a/main/src/cgeo/geocaching/SplashActivity.java
+++ b/main/src/cgeo/geocaching/SplashActivity.java
@@ -14,7 +14,7 @@ import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-class SplashActivity extends AppCompatActivity {
+public class SplashActivity extends AppCompatActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {


### PR DESCRIPTION
## Description
disables minify for debug builds

## Additional context
After making `SplashActivity` `public` c:geo starts without crashes, as well as switching between different activities from `BottomNavigation`. Don't have verified figures about the impact on build performance yet. need a few more builds for that.