### PR TITLE
switch settings/about to buttons in MoreActivity (rel. to #11904)

### DIFF
--- a/main/res/menu/more_activity_overflow.xml
+++ b/main/res/menu/more_activity_overflow.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_about"
+        android:icon="@drawable/ic_menu_info_details"
+        android:title="@string/menu_about"
+        app:showAsAction="always|withText">
+    </item>
+    <item
+        android:id="@+id/menu_settings"
+        android:icon="@drawable/ic_menu_preferences"
+        android:title="@string/menu_settings"
+        app:showAsAction="ifRoom|withText">
+    </item>
+</menu>

--- a/main/res/menu/more_activity_popup.xml
+++ b/main/res/menu/more_activity_popup.xml
@@ -27,19 +27,9 @@
         android:visible="false">
     </item>
     <item
-        android:id="@+id/menu_about"
-        android:icon="@drawable/ic_menu_info_details"
-        android:title="@string/menu_about">
-    </item>
-    <item
         android:id="@+id/menu_wizard"
         android:icon="@drawable/ic_menu_preferences"
         android:title="@string/wizard">
-    </item>
-    <item
-        android:id="@+id/menu_settings"
-        android:icon="@drawable/ic_menu_preferences"
-        android:title="@string/menu_settings">
     </item>
     <item
         android:id="@+id/menu_backup"

--- a/main/src/cgeo/geocaching/MoreActivity.java
+++ b/main/src/cgeo/geocaching/MoreActivity.java
@@ -58,7 +58,7 @@ public class MoreActivity extends AbstractBottomNavigationActivity {
 
         final PopupMenu p = new PopupMenu(this, null);
         final Menu menu = p.getMenu();
-        getMenuInflater().inflate(R.menu.bottom_navigation_more, menu);
+        getMenuInflater().inflate(R.menu.more_activity_popup, menu);
 
         // initialize menu items
         menu.findItem(R.id.menu_wizard).setVisible(!InstallWizardActivity.isConfigurationOk(this));
@@ -118,6 +118,12 @@ public class MoreActivity extends AbstractBottomNavigationActivity {
                 }
             }
         }, 250); // menuItems might not be available if executed too early
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        getMenuInflater().inflate(R.menu.more_activity_overflow, menu);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Description
As discussed in #11904: Switch list entries "about c:geo" and "settings" to toolbar buttons, shown as icons (with text, if room):

![grafik](https://user-images.githubusercontent.com/3754370/137554878-09bbedf7-2950-4332-a2ce-3334c356fbe1.png)
![grafik](https://user-images.githubusercontent.com/3754370/137554905-e12d21b6-7107-4e47-935b-44ca48717a00.png)
