### PR TITLE
reduce activity nesting part 1 - SearchActivity

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -230,8 +230,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     @Override
     public void onNavigationItemReselected(@NonNull final MenuItem item) {
-        if (!isTaskRoot()) {
-            finish();
+        if (item.getItemId() == MENU_SEARCH) {
+            onNavigationItemSelectedIgnoreReselected(item);
         }
     }
 

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -176,6 +176,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
 
         if (keywordSearch) { // keyword fallback, if desired by caller
             CacheListActivity.startActivityKeyword(this, query.trim());
+            ActivityMixin.finishWithFadeTransition(this);
             return true;
         }
 
@@ -294,7 +295,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
 
         try {
             CacheListActivity.startActivityCoordinates(this, new Geopoint(StringUtils.trim(latlonText[0]), StringUtils.trim(latlonText[1])), null);
-            ActivityMixin.overrideTransitionToFade(this);
+            ActivityMixin.finishWithFadeTransition(this);
         } catch (final Geopoint.ParseException e) {
             showToast(res.getString(e.resource));
         }
@@ -314,7 +315,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
         }
 
         CacheListActivity.startActivityKeyword(this, keyText);
-        ActivityMixin.overrideTransitionToFade(this);
+        ActivityMixin.finishWithFadeTransition(this);
     }
 
     private void findByAddressFn() {
@@ -328,6 +329,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
         final Intent addressesIntent = new Intent(this, AddressListActivity.class);
         addressesIntent.putExtra(Intents.EXTRA_KEYWORD, addText);
         startActivity(addressesIntent);
+        ActivityMixin.finishWithFadeTransition(this);
     }
 
     private void findByOwnerFn() {
@@ -343,7 +345,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
         }
 
         CacheListActivity.startActivityOwner(this, usernameText);
-        ActivityMixin.overrideTransitionToFade(this);
+        ActivityMixin.finishWithFadeTransition(this);
     }
 
     private void findByFilterFn() {
@@ -355,7 +357,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
 
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             CacheListActivity.startActivityFilter(this);
-            ActivityMixin.overrideTransitionToFade(this);
+            ActivityMixin.finishWithFadeTransition(this);
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }

--- a/main/src/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -243,6 +243,11 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
             onNavigationItemReselected(item);
             return true;
         }
+        return onNavigationItemSelectedIgnoreReselected(item);
+    }
+
+    public boolean onNavigationItemSelectedIgnoreReselected(final @NonNull MenuItem item) {
+        final int id = item.getItemId();
 
         if (id == MENU_MAP) {
             startActivity(DefaultMap.getLiveMapIntent(this));

--- a/main/src/cgeo/geocaching/address/AddressListActivity.java
+++ b/main/src/cgeo/geocaching/address/AddressListActivity.java
@@ -3,7 +3,8 @@ package cgeo.geocaching.address;
 import cgeo.geocaching.CacheListActivity;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
-import cgeo.geocaching.activity.AbstractActionBarActivity;
+import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.DefaultMap;
 import cgeo.geocaching.ui.recyclerview.RecyclerViewProvider;
@@ -12,6 +13,7 @@ import cgeo.geocaching.utils.AndroidRxUtils;
 import android.app.ProgressDialog;
 import android.location.Address;
 import android.os.Bundle;
+import android.view.MenuItem;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -21,7 +23,7 @@ import java.util.ArrayList;
 import io.reactivex.rxjava3.core.Observable;
 import org.apache.commons.lang3.StringUtils;
 
-public class AddressListActivity extends AbstractActionBarActivity implements AddressClickListener {
+public class AddressListActivity extends AbstractBottomNavigationActivity implements AddressClickListener {
 
     @NonNull
     private final ArrayList<Address> addresses = new ArrayList<>();
@@ -58,12 +60,24 @@ public class AddressListActivity extends AbstractActionBarActivity implements Ad
     @Override
     public void onClickAddress(@NonNull final Address address) {
         CacheListActivity.startActivityAddress(this, new Geopoint(address.getLatitude(), address.getLongitude()), StringUtils.defaultString(address.getAddressLine(0)));
-        finish();
+        ActivityMixin.finishWithFadeTransition(this);
     }
 
     @Override
     public void onClickMapIcon(@NonNull final Address address) {
         DefaultMap.startActivityInitialCoords(this, new Geopoint(address.getLatitude(), address.getLongitude()));
-        finish();
+        ActivityMixin.finishWithFadeTransition(this);
+    }
+
+    @Override
+    public int getSelectedBottomItemId() {
+        return MENU_SEARCH;
+    }
+
+    @Override
+    public void onNavigationItemReselected(@NonNull final MenuItem item) {
+        if (item.getItemId() == MENU_SEARCH) {
+            onNavigationItemSelectedIgnoreReselected(item);
+        }
     }
 }


### PR DESCRIPTION
### Reduce activity nesting part 1 - light up `SearchActivity` hierarchies

before: (launched as sub-activity)
![grafik](https://user-images.githubusercontent.com/64581222/137602986-60dd0b5c-75f6-4d6e-b764-360652007990.png)

now: (top-level | search activity can be reached again via re-selecting the item)
![grafik](https://user-images.githubusercontent.com/64581222/137603064-55203755-bb2a-48a0-b962-509ee3e013e4.png)![grafik](https://user-images.githubusercontent.com/64581222/137603168-a6b15399-9cc9-4114-addb-97debc55638c.png)
