### PR TITLE
rel to #11227: log stacktraces for long running GUI loops

### DIFF
--- a/main/src/cgeo/geocaching/LooperLogger.java
+++ b/main/src/cgeo/geocaching/LooperLogger.java
@@ -1,20 +1,45 @@
 package cgeo.geocaching;
 
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.os.Looper;
 
+import java.text.Format;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang3.time.FastDateFormat;
+
 /** Helper class, gaining and logging statistics about a looper */
 public class LooperLogger {
+
+    private static final Format DATE_FORMATTER = FastDateFormat.getInstance("hh:mm:ss.SSS");
 
     private long totalTime = 0;
     private long currStartTime = 0;
     private String currMsg = null;
     private long totalMsgCount = 0;
 
+    private final AtomicBoolean collectTraces = new AtomicBoolean(false);
+    private final List<String> collectedInfos = new ArrayList<>();
+
     public static void startLogging(final Looper looper) {
         final LooperLogger ll = new LooperLogger();
         looper.setMessageLogging(ll::process);
+        looper.getThread().getStackTrace();
+        AndroidRxUtils.runPeriodically(AndroidRxUtils.networkScheduler, () -> {
+            if (!ll.collectTraces.get()) {
+                return;
+            }
+            synchronized (ll.collectedInfos) {
+                ll.collectedInfos.add(
+                    DATE_FORMATTER.format(new Date(System.currentTimeMillis())) + "/" + looper.getThread().getState() + ": " +
+                    Log.stackTraceToShortString(looper.getThread().getStackTrace(), 0, null));
+            }
+        }, 0, 200);
     }
 
     private LooperLogger() {
@@ -27,12 +52,22 @@ public class LooperLogger {
             currStartTime = System.currentTimeMillis();
             currMsg = msg;
             totalMsgCount++;
+            synchronized (collectedInfos) {
+                collectedInfos.clear();
+            }
+            collectTraces.set(Log.isEnabled(Log.LogLevel.DEBUG));
         } else {
+            collectTraces.set(false);
             final long duration = System.currentTimeMillis() - currStartTime;
             totalTime += duration;
 
             if (duration > 500) {
-                Log.w("LooperLogger: long process time for " + currMsg + " (" + duration + "ms, " + getStats() + ")");
+                final StringBuilder sb = new StringBuilder("LooperLogger: long process time for " + currMsg + " (" + duration + "ms, " + getStats() + "), " + collectedInfos.size() + "traces:");
+                for (String info : collectedInfos) {
+                    sb.append("\n   ").append(info);
+                }
+
+                Log.w(sb.toString());
             } else if (Log.isDebug() && totalMsgCount % 1000 == 0) {
                 Log.d("LooperLogger: " + getStats());
             }

--- a/main/src/cgeo/geocaching/utils/AndroidRxUtils.java
+++ b/main/src/cgeo/geocaching/utils/AndroidRxUtils.java
@@ -72,6 +72,10 @@ public class AndroidRxUtils {
         });
     }
 
+    public static Disposable runPeriodically(final Scheduler scheduler, final Runnable runnable, final long initialDelayInMs, final long periodInMs) {
+        return scheduler.createWorker().schedulePeriodically(runnable, initialDelayInMs, periodInMs, TimeUnit.MILLISECONDS);
+    }
+
     public static <T> Observable<T> bindActivity(final Activity activity, final Observable<T> source) {
         final WeakReference<Activity> activityRef = new WeakReference<>(activity);
         return source.observeOn(AndroidSchedulers.mainThread()).takeWhile(t -> {

--- a/main/src/cgeo/geocaching/utils/Log.java
+++ b/main/src/cgeo/geocaching/utils/Log.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.utils.functions.Func1;
 
 import android.net.Uri;
 
@@ -16,6 +17,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
+import static java.lang.Boolean.TRUE;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -336,15 +338,21 @@ public final class Log {
     private static String getCallerInfo(final int maxDepth) {
         final String logClassName = Log.class.getName();
         final String contextLoggerClassname = ContextLogger.class.getName();
+
+        return stackTraceToShortString(new RuntimeException().getStackTrace(), maxDepth, st ->
+            !st.getClassName().equals(logClassName) && !st.getClassName().equals(contextLoggerClassname));
+    }
+
+    public static String stackTraceToShortString(final StackTraceElement[] stackTraceElements, final int maxDepth, final Func1<StackTraceElement, Boolean> filter) {
         final StringBuilder sb = new StringBuilder();
         int cnt = 0;
-        for (final StackTraceElement st : new RuntimeException().getStackTrace()) {
-            if (!st.getClassName().equals(logClassName) && !st.getClassName().equals(contextLoggerClassname)) {
+        for (final StackTraceElement st : stackTraceElements) {
+            if (filter == null || TRUE.equals(filter.call(st))) {
                 if (sb.length() > 0) {
                     sb.append("/");
                 }
                 sb.append(stackTraceElementToString(st));
-                if (++cnt >= maxDepth) {
+                if (maxDepth > 0 && ++cnt >= maxDepth) {
                     break;
                 }
             }


### PR DESCRIPTION
rel to #11227: log stacktraces for long running GUI loops

This PR will collect and log main thread stack traces every 200ms for long-running GUI thread processes (over 500ms), but only if in DEBUG mode. My hope is this helps analyzing the huge waiting times of #11227