### PR TITLE
fix IllegalAccessException for PQ and bookmark lists

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/BookmarkListActivity.java
+++ b/main/src/cgeo/geocaching/connector/gc/BookmarkListActivity.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class BookmarkListActivity extends AbstractListActivity {
 
-    BookmarkListActivity() {
+    public BookmarkListActivity() {
         title = R.string.menu_lists_bookmarklists;
         progressInfo = R.string.search_bookmark_list;
         errorReadingList = R.string.err_read_bookmark_list;

--- a/main/src/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
+++ b/main/src/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class PocketQueryListActivity extends AbstractListActivity {
 
-    PocketQueryListActivity() {
+    public PocketQueryListActivity() {
         title = R.string.menu_lists_pocket_queries;
         progressInfo = R.string.search_pocket_loading;
         errorReadingList = R.string.err_read_pocket_query_list;


### PR DESCRIPTION
## Description
When trying to list either pocket queries or bookmark lists from the "more" activity, c:geo currently crashes with an `IllegalAccessException`:

```
java.lang.RuntimeException: Unable to instantiate activity ComponentInfo{cgeo.geocaching/cgeo.geocaching.connector.gc.BookmarkListActivity}: java.lang.IllegalAccessException: void cgeo.geocaching.connector.gc.BookmarkListActivity.<init>() is not accessible from java.lang.Class<android.app.AppComponentFactory>
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3365)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
...
```
and
```
java.lang.RuntimeException: Unable to instantiate activity ComponentInfo{cgeo.geocaching/cgeo.geocaching.connector.gc.PocketQueryListActivity}: java.lang.IllegalAccessException: void cgeo.geocaching.connector.gc.PocketQueryListActivity.<init>() is not accessible from java.lang.Class<android.app.AppComponentFactory>
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3365)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
...
```

This is due to the constructor of the two involved classes not being declared as `public` and therefore not being accessible from the new "more" activity. This PR fixes this issue.
