### PR TITLE
rel to #10128: use mapsforge version modified by eddiemuc which might solve arrayindexoutofbounds problem

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -323,22 +323,23 @@ dependencies {
     // Locus Maps integration
     implementation "com.asamm:locus-api-android:0.9.32"
 
-    // Mapsforge new version
-    def mapsforgeVersion = '0.16.0'
-    implementation "org.mapsforge:mapsforge-core:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-map:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-map-android:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-map-reader:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-themes:$mapsforgeVersion"
+    // Mapsforge official version
+    //def mapsforgeSource = 'org.mapsforge'
+    //def mapsforgeVersion = '0.16.0'
 
-    /* use following declaration type if a specific build is needed
-    def mapsforgeVersion = '905e9d48bb' // master as of 31.3.21, see https://jitpack.io/#mapsforge/mapsforge
-    implementation "com.github.mapsforge.mapsforge:mapsforge-core:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-map:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-map-android:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-map-reader:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-themes:$mapsforgeVersion"
-    */
+    // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
+    //def mapsforgeSource = 'com.github.mapsforge.mapsforge'
+    //def mapsforgeVersion = '905e9d48bb' // master as of 31.3.21
+
+    // Mapsforge Snapshot from eddiemuc's GitHub' repository (via https://jitpack.io/#eddiemuc/mapsforge)
+    def mapsforgeSource = 'com.github.eddiemuc.mapsforge'
+    def mapsforgeVersion = 'ebb99c8338' // fix for #10128
+
+    implementation "$mapsforgeSource:mapsforge-core:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-map:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-map-android:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-map-reader:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-themes:$mapsforgeVersion"
 
     configurations {
         all*.exclude group: 'net.sf.kxml', module: 'kxml2' // duplicate XmlPullParser class


### PR DESCRIPTION
rel to #10128: use mapsforge version modified by eddiemuc which might solve arrayindexoutofbounds problem

This PR will let cgeo use a hand-crafted version of mapsforge, hosted in github repo of eddiemuc. This version contains a fix which for the ArrayIndexOutOfBounds problem described in #10128. mapsforge requests the testing of this version prior of allowing the PR in their master. This is the reason for this PR.

I am open to any other solutions, but I couldn't think of any for now...