### PR TITLE
Do not display D/T for zero values (fix #11942)

### DIFF
--- a/main/src/cgeo/geocaching/ui/GeoItemSelectorUtils.java
+++ b/main/src/cgeo/geocaching/ui/GeoItemSelectorUtils.java
@@ -40,8 +40,12 @@ public class GeoItemSelectorUtils {
         tv.setCompoundDrawablesRelativeWithIntrinsicBounds(MapMarkerUtils.getCacheMarker(context.getResources(), cache, CacheListType.MAP).getDrawable(), null, null, null);
 
         final StringBuilder text = new StringBuilder(cache.getShortGeocode());
-        text.append(Formatter.SEPARATOR).append("D ").append(cache.getDifficulty());
-        text.append(Formatter.SEPARATOR).append("T ").append(cache.getTerrain());
+        if (cache.getDifficulty() > 0.1f) {
+            text.append(Formatter.SEPARATOR).append("D ").append(cache.getDifficulty());
+        }
+        if (cache.getTerrain() > 0.1f) {
+            text.append(Formatter.SEPARATOR).append("T ").append(cache.getTerrain());
+        }
 
         final TextView infoView = (TextView) view.findViewById(R.id.info);
         infoView.setText(text);


### PR DESCRIPTION
## Description
Do not display "Difficulty" value if difficulty is zero. Same for "Terrain".
Applies to several places in c:geo, two of them being selection list in OSM maps and search list for search on mainscreen.

![image](https://user-images.githubusercontent.com/3754370/138502289-2510dada-7c2d-4483-b66a-b5028785e774.png)
