### PR TITLE
apply top margin to 'not connected' message (fix #11939)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -21,6 +21,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dip"
+        android:layout_marginTop="16dip"
         android:layout_below="@id/status"
         android:background="@drawable/helper_bcg"
         android:visibility="gone">


### PR DESCRIPTION
## Description
Fixes the missing margin if both status message and "not logged in" message are being shown:

![image](https://user-images.githubusercontent.com/3754370/138505992-b5d904e6-73dc-4e5c-9c7e-21bab6ead8e4.png)
