### PR TITLE
add offline found counter to bottom navigation (fix #11936)

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -16,8 +16,10 @@ import cgeo.geocaching.maps.DefaultMap;
 import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.Log;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -42,6 +44,7 @@ import androidx.core.util.Consumer;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.navigation.NavigationBarView;
 import org.apache.commons.lang3.StringUtils;
 
@@ -106,6 +109,18 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
         } else {
             ((NavigationBarView) wrapper.activityBottomNavigation).removeBadge(MENU_MORE);
         }
+    }
+
+    public void updateCacheCounter() {
+        AndroidRxUtils.bindActivity(this, DataStore.getAllCachesCountObservable()).subscribe(countOfflineCaches -> {
+            if (countOfflineCaches > 0) {
+                final BadgeDrawable badge = ((NavigationBarView) wrapper.activityBottomNavigation).getOrCreateBadge(MENU_LIST);
+                badge.setNumber(countOfflineCaches);
+                badge.setBackgroundColor(getResources().getColor(R.color.colorAccent));
+            } else {
+                ((NavigationBarView) wrapper.activityBottomNavigation).removeBadge(MENU_LIST);
+            }
+        }, throwable -> Log.e("Unable to add bubble count", throwable));
     }
 
     protected void initHomeAsUpIndicator() {
@@ -193,6 +208,7 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
         super.onResume();
         registerLoginIssueHandler(loginHandler, getUpdateUserInfoHandler(), this::onLoginIssue);
         registerReceiver(connectivityChangeReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+        updateCacheCounter();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.InstallWizardActivity;
+import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.ILogin;
@@ -531,6 +532,9 @@ public class BackupUtils {
             dialog.dismiss();
             consumer.accept(stringBuilder.toString());
         });
+        if (activityContext instanceof MainActivity) {
+            ((MainActivity) activityContext).updateCacheCounter();
+        }
     }
 
     private void backupInternal(final Runnable runAfterwards) {


### PR DESCRIPTION
## Description
Show number of caches stored offline as badge on bottom navigation's "list" entry:

![image](https://user-images.githubusercontent.com/3754370/138522009-9a2229c3-86e5-4459-b3ce-d1c3b29c9302.png)

Currently our accent color is used for the badge. 
If we want to make it less visually intrusive, we could use the bottom navigation's text colors instead.