### PR TITLE
fix #11958 crash on opening calculator dialog

### DIFF
--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateDialog.java
@@ -329,11 +329,17 @@ public class CoordinatesCalculateDialog extends DialogFragment implements ClickC
         gp = getArguments().getParcelable(GEOPOINT_ARG);
         if (gp == null) {
             if (savedState != null) {
-                gp = new Geopoint(savedState.plainLat, savedState.plainLon);
+                try {
+                    gp = new Geopoint(savedState.plainLat, savedState.plainLon);
+                } catch (final Geopoint.ParseException ignored) {
+                    // gathering from one of the other formats?
+                    gp = Sensors.getInstance().currentGeo().getCoords();
+                }
             } else {
                 gp = Sensors.getInstance().currentGeo().getCoords();
             }
         }
+
         if (savedInstanceState != null) {
             if (savedInstanceState.getParcelable(GEOPOINT_ARG) != null) {
                 gp = savedInstanceState.getParcelable(GEOPOINT_ARG);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Fixes an uncatched exception while creating a Geopoint from string,
put try-catch-block around

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11958 
rel #11668 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
still open, which initial coordinates should be used in that case. Using current position for a first shot (old behaviour).
The initial coordinates for plain format should only impacts, when switching the formula format.