### PR TITLE
fix #11959: avoid npe when opening cachelist to import gpx (extras will then be null)

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -589,7 +589,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         }
 
         if (isInvokedFromAttachment()) {
-            listNameMemento.rememberTerm(extras.getString(Intents.EXTRA_NAME));
+            if (extras != null && !StringUtils.isBlank(extras.getString(Intents.EXTRA_NAME))) {
+                listNameMemento.rememberTerm(extras.getString(Intents.EXTRA_NAME));
+            }
             importGpxAttachement();
         }
     }


### PR DESCRIPTION
fix #11959: avoid npe when opening cachelist to import gpx (extras will then be null)