### PR TITLE
add offline stored counter to dashboard (fix #11936)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -71,6 +71,21 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/offline_counter"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:layout_gravity="center"
+            android:gravity="center_horizontal"
+            android:lines="1"
+            android:maxLines="1"
+            android:textIsSelectable="false"
+            android:textSize="@dimen/textSize_listsPrimary"
+            android:visibility="gone"
+            tools:text="1234 caches stored offline"/>
+        <View style="@style/separator_horizontal" />
+
+        <TextView
             android:id="@+id/nav_location"
             style="@style/location_current"
             android:textIsSelectable="false"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -457,6 +457,14 @@
         <item quantity="many">%d logged offline</item>
         <item quantity="other">%d logged offline</item>
     </plurals>
+    <plurals name="caches_stored_offline">
+        <item quantity="zero">%d caches stored offline</item>
+        <item quantity="one">%d cache stored offline</item>
+        <item quantity="two">%d caches stored offline</item>
+        <item quantity="few">%d caches stored offline</item>
+        <item quantity="many">%d caches stored offline</item>
+        <item quantity="other">%d caches stored offline</item>
+    </plurals>
 
     <!-- caches lists -->
     <string name="menu_lists">Manage lists</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -346,6 +346,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
         checkRestore();
         DataStore.cleanIfNeeded(this);
+        updateCacheCounter();
     }
 
     @Override
@@ -537,6 +538,16 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         integrator.setTitleByID(R.string.menu_scan_geo);
         integrator.setMessageByID(R.string.menu_scan_description);
         integrator.initiateScan(IntentIntegrator.QR_CODE_TYPES);
+    }
+
+    public void updateCacheCounter() {
+        AndroidRxUtils.bindActivity(this, DataStore.getAllCachesCountObservable()).subscribe(countOfflineCaches -> {
+            final TextView counter = findViewById(R.id.offline_counter);
+            counter.setVisibility(countOfflineCaches > 0 ? View.VISIBLE : View.GONE);
+            if (countOfflineCaches > 0) {
+                counter.setText(getResources().getQuantityString(R.plurals.caches_stored_offline, countOfflineCaches, countOfflineCaches));
+            }
+        }, throwable -> Log.e("Unable to add bubble count", throwable));
     }
 
     private void hideActionIconsWhenSearchIsActive(final Menu menu) {

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.InstallWizardActivity;
+import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.ILogin;
@@ -531,6 +532,9 @@ public class BackupUtils {
             dialog.dismiss();
             consumer.accept(stringBuilder.toString());
         });
+        if (activityContext instanceof MainActivity) {
+            ((MainActivity) activityContext).updateCacheCounter();
+        }
     }
 
     private void backupInternal(final Runnable runAfterwards) {


### PR DESCRIPTION
(Less intrusive alternative to #11957)

## Description
Add a "offline stored counter" to the dashboard, added below all connector infos:

![image](https://user-images.githubusercontent.com/3754370/138568705-cdaef7d1-d534-40ff-9c96-5c21485a8166.png)
