### PR TITLE
avoid IllegalAccessException in DownloadNotificationReceiver

### DIFF
--- a/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
@@ -15,7 +15,7 @@ import android.net.Uri;
 
 import androidx.core.content.ContextCompat;
 
-class DownloadNotificationReceiver extends BroadcastReceiver {
+public class DownloadNotificationReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {


### PR DESCRIPTION
## Description
Avoids `IllegalAccessException` on starting a download

```
10-23 23:44:16.867  5766  5766 E AndroidRuntime: java.lang.RuntimeException: Unable to instantiate receiver cgeo.geocaching.downloader.DownloadNotificationReceiver: java.lang.IllegalAccessException: java.lang.Class<cgeo.geocaching.downloader.DownloadNotificationReceiver> is not accessible from java.lang.Class<android.app.AppComponentFactory>
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at android.app.ActivityThread.handleReceiver(ActivityThread.java:4453)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at android.app.ActivityThread.access$1600(ActivityThread.java:301)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2177)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:246)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8633)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
10-23 23:44:16.867  5766  5766 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```
