### PR TITLE
set connector defaults to UNKNOWN_FINDS instead of 0 (rel. to #11971)

### DIFF
--- a/main/src/cgeo/geocaching/connector/AbstractLogin.java
+++ b/main/src/cgeo/geocaching/connector/AbstractLogin.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.settings.Credentials;
 import cgeo.geocaching.settings.DiskCookieStore;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.LocalizationUtils;
+import static cgeo.geocaching.connector.capability.ILogin.UNKNOWN_FINDS;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -27,7 +28,7 @@ public abstract class AbstractLogin {
      * Number of caches found. An unknown number is signaled by the value -1, while 0 really indicates zero caches found
      * by the user.
      */
-    private int actualCachesFound = -1;
+    private int actualCachesFound = UNKNOWN_FINDS;
     /**
      * use "not logged in" as default. Connectors should update there status as soon as they start establishing a connection.
      */

--- a/main/src/cgeo/geocaching/connector/capability/ILogin.java
+++ b/main/src/cgeo/geocaching/connector/capability/ILogin.java
@@ -7,6 +7,8 @@ import android.os.Handler;
 
 public interface ILogin extends IConnector {
 
+    int UNKNOWN_FINDS = -1;
+
     /**
      * Contacts the server the connector belongs to and verifies/establishes authentication and retrieves information
      * about the current user (Name, found caches) if applicable.

--- a/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
@@ -36,7 +36,7 @@ public class OCApiLiveConnector extends OCApiConnector implements ISearchByViewP
     private final int isActivePrefKeyId;
     private final int tokenPublicPrefKeyId;
     private final int tokenSecretPrefKeyId;
-    private UserInfo userInfo = new UserInfo(StringUtils.EMPTY, 0, UserInfoStatus.NOT_RETRIEVED);
+    private UserInfo userInfo = new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfoStatus.NOT_RETRIEVED);
 
     public OCApiLiveConnector(final String name, final String host, final boolean https, final String prefix, final String licenseString, @StringRes final int cKResId, @StringRes final int cSResId, final int isActivePrefKeyId, final int tokenPublicPrefKeyId, final int tokenSecretPrefKeyId, final ApiSupport apiSupport, @NonNull final String abbreviation) {
         super(name, host, https, prefix, CryptUtils.rot13(CgeoApplication.getInstance().getString(cKResId)), licenseString, apiSupport, abbreviation);
@@ -138,7 +138,7 @@ public class OCApiLiveConnector extends OCApiConnector implements ISearchByViewP
         if (supportsPersonalization()) {
             userInfo = OkapiClient.getUserInfo(this);
         } else {
-            userInfo = new UserInfo(StringUtils.EMPTY, 0, UserInfoStatus.NOT_SUPPORTED);
+            userInfo = new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfoStatus.NOT_SUPPORTED);
         }
         // update cache counter
         FoundNumCounter.getAndUpdateFoundNum(this);

--- a/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -54,6 +54,7 @@ import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.SynchronizedDateFormat;
+import static cgeo.geocaching.connector.capability.ILogin.UNKNOWN_FINDS;
 
 import android.annotation.SuppressLint;
 import android.net.Uri;
@@ -1219,7 +1220,7 @@ final class OkapiClient {
         if (!result.isSuccess) {
             final OkapiError error = new OkapiError(result.data);
             Log.w("OkapiClient.getUserInfo: error getting user info: '" + error.getMessage() + "'");
-            return new UserInfo(StringUtils.EMPTY, 0, UserInfoStatus.getFromOkapiError(error.getResult()));
+            return new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfoStatus.getFromOkapiError(error.getResult()));
         }
 
         final ObjectNode data = result.data;

--- a/main/src/cgeo/geocaching/connector/su/SuApi.java
+++ b/main/src/cgeo/geocaching/connector/su/SuApi.java
@@ -27,6 +27,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.SynchronizedDateFormat;
+import static cgeo.geocaching.connector.capability.ILogin.UNKNOWN_FINDS;
 
 import android.util.Base64;
 import static android.util.Base64.DEFAULT;
@@ -63,7 +64,7 @@ public class SuApi {
         final JSONResult result = getRequest(connector, SuApiEndpoint.USER, params);
 
         if (!result.isSuccess) {
-            return new UserInfo(StringUtils.EMPTY, 0, UserInfoStatus.FAILED);
+            return new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfoStatus.FAILED);
         }
 
         return SuParser.parseUser(result.data);

--- a/main/src/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/cgeo/geocaching/connector/su/SuConnector.java
@@ -56,7 +56,7 @@ public class SuConnector extends AbstractConnector implements ISearchByGeocode, 
     // all IDs are unique at SU
     private static final CharSequence PREFIX_GENERAL = "SU";
 
-    private UserInfo userInfo = new UserInfo(StringUtils.EMPTY, 0, UserInfoStatus.NOT_RETRIEVED);
+    private UserInfo userInfo = new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfoStatus.NOT_RETRIEVED);
 
     private SuConnector() {
         // singleton
@@ -99,10 +99,10 @@ public class SuConnector extends AbstractConnector implements ISearchByGeocode, 
             try {
                 userInfo = SuApi.getUserInfo(this);
             } catch (final SuApi.SuApiException e) {
-                userInfo = new UserInfo(StringUtils.EMPTY, 0, UserInfoStatus.FAILED);
+                userInfo = new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfoStatus.FAILED);
             }
         } else {
-            userInfo = new UserInfo(StringUtils.EMPTY, 0, UserInfo.UserInfoStatus.NOT_SUPPORTED);
+            userInfo = new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfo.UserInfoStatus.NOT_SUPPORTED);
         }
         // update cache counter
         FoundNumCounter.getAndUpdateFoundNum(this);

--- a/main/src/cgeo/geocaching/connector/su/SuParser.java
+++ b/main/src/cgeo/geocaching/connector/su/SuParser.java
@@ -16,6 +16,7 @@ import cgeo.geocaching.models.Image;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.SynchronizedDateFormat;
+import static cgeo.geocaching.connector.capability.ILogin.UNKNOWN_FINDS;
 
 import android.content.res.Resources;
 
@@ -111,7 +112,7 @@ public class SuParser {
 
         if (!(data.has(USER_FOUNDS) && data.has(USER_NAME))) {
             // Either server issue or wrong response - looks suspicious, we need to retry logging in later
-            return new UserInfo(StringUtils.EMPTY, 0, UserInfo.UserInfoStatus.FAILED);
+            return new UserInfo(StringUtils.EMPTY, UNKNOWN_FINDS, UserInfo.UserInfoStatus.FAILED);
         }
         final int finds = data.get(USER_FOUNDS).asInt();
         final String name = data.get(USER_NAME).asText();

--- a/main/src/cgeo/geocaching/storage/extension/FoundNumCounter.java
+++ b/main/src/cgeo/geocaching/storage/extension/FoundNumCounter.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.LocalizationUtils;
+import static cgeo.geocaching.connector.capability.ILogin.UNKNOWN_FINDS;
 
 import androidx.annotation.Nullable;
 
@@ -58,7 +59,7 @@ public class FoundNumCounter extends DataStore.DBExtension {
     public static int getAndUpdateFoundNum(final ILogin conn) {
         int current = conn.getCachesFound();
 
-        if (current < 0) { // try getting cached information, if the counter is zero
+        if (current == UNKNOWN_FINDS) { // try getting cached information, if counter is unknown
             final FoundNumCounter f = FoundNumCounter.load(conn.getName());
             if (f != null) {
                 current = (int) f.getLong1();


### PR DESCRIPTION
## Description
Currently most connectors return "0" as found count if they don't know the actual found count, which prevents c:geo from using the fallback value stored in database.
This PR changes this behavior to use `UNKNOWN_FINDS` (= -1) as default in this case to be able to differentiate.

## Related issues
Related to #11971
