### PR TITLE
Do not reuse connector view that gets filled asynchronously (fix #11971)

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -126,12 +126,8 @@ public class MainActivity extends AbstractBottomNavigationActivity {
                     activity.binding.connectorstatusArea.setAdapter(new ArrayAdapter<ILogin>(activity, R.layout.main_activity_connectorstatus, loginConns) {
                         @Override
                         public View getView(final int position, final View convertView, @NonNull final android.view.ViewGroup parent) {
-                            View view = convertView;
-
-                            if (view == null) {
-                                view = activity.getLayoutInflater().inflate(R.layout.main_activity_connectorstatus, parent, false);
-                            }
-
+                            // do NOT use convertView, as it gets filled asynchronously, which may lead to the wrong view being filled
+                            final View view = activity.getLayoutInflater().inflate(R.layout.main_activity_connectorstatus, parent, false);
                             final ILogin connector = getItem(position);
                             fillView(view, connector);
                             return view;


### PR DESCRIPTION
## Description
Our connectors list uses a `ListView` with recycled views. This seems to clash with the view being filled asynchronously, so that some data ends up in the wrong place.
This PR changes this to recreate the view for each connector to avoid timing issues.

## Related issues
Attempts to fix #11971. A review would be highly appreciated.
