### PR TITLE
rel to #10128: use mapsforge version 0.16 with fix from eddiemuc for arrayindexoutofboundsexception

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -320,22 +320,23 @@ dependencies {
     // Locus Maps integration
     implementation "com.asamm:locus-api-android:0.9.32"
 
-    // Mapsforge new version
-    def mapsforgeVersion = '0.16.0'
-    implementation "org.mapsforge:mapsforge-core:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-map:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-map-android:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-map-reader:$mapsforgeVersion"
-    implementation "org.mapsforge:mapsforge-themes:$mapsforgeVersion"
+    // Mapsforge official version
+    //def mapsforgeSource = 'org.mapsforge'
+    //def mapsforgeVersion = '0.16.0'
 
-    /* use following declaration type if a specific build is needed
-    def mapsforgeVersion = '905e9d48bb' // master as of 31.3.21, see https://jitpack.io/#mapsforge/mapsforge
-    implementation "com.github.mapsforge.mapsforge:mapsforge-core:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-map:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-map-android:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-map-reader:$mapsforgeVersion"
-    implementation "com.github.mapsforge.mapsforge:mapsforge-themes:$mapsforgeVersion"
-    */
+    // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
+    //def mapsforgeSource = 'com.github.mapsforge.mapsforge'
+    //def mapsforgeVersion = '905e9d48bb' // master as of 31.3.21
+
+    // Mapsforge Snapshot from eddiemuc's GitHub' repository (via https://jitpack.io/#eddiemuc/mapsforge)
+    def mapsforgeSource = 'com.github.eddiemuc.mapsforge'
+    def mapsforgeVersion = 'ebb99c8338' // fix for #10128
+
+    implementation "$mapsforgeSource:mapsforge-core:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-map:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-map-android:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-map-reader:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-themes:$mapsforgeVersion"
 
     configurations {
         all*.exclude group: 'net.sf.kxml', module: 'kxml2' // duplicate XmlPullParser class


### PR DESCRIPTION
rel to #10128: use mapsforge version 0.16 with fix from eddiemuc for arrayindexoutofboundsexception

This PR is to tryx the fix on beta test (must be present on release branch)