### PR TITLE
use filled home icon and add documentation

### DIFF
--- a/main/res/drawable/ic_expand_less_white.xml
+++ b/main/res/drawable/ic_expand_less_white.xml
@@ -1,3 +1,4 @@
+<!-- taken from expand-less / material.com -->
 <vector android:height="24dp" android:tint="#FFFFFF"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">

--- a/main/res/drawable/ic_expand_more_white.xml
+++ b/main/res/drawable/ic_expand_more_white.xml
@@ -1,3 +1,4 @@
+<!-- taken from expand-more / material.com -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/main/res/drawable/ic_menu_home.xml
+++ b/main/res/drawable/ic_menu_home.xml
@@ -1,10 +1,11 @@
+<!-- taken from home / material.com -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:tint="?android:textColorPrimary">
   <path
       android:fillColor="@android:color/white"
-      android:pathData="M12,5.69l5,4.5V18h-2v-6H9v6H7v-7.81l5,-4.5M12,3L2,12h3v8h6v-6h2v6h6v-8h3L12,3z"/>
+      android:pathData="M10,20V14H14V20H19V12H22L12,3L2,12H5V20H10Z"/>
 </vector>


### PR DESCRIPTION
Material provides two icon sets - filled and outlined. 

At most places in c:geo we have filled icons. The outlined ones are only used if the filled icon is considered being too "massive" or is harder to recognize.

For the bottom navigation, all icons except home use the "filled" variant. (Search and Nearby are the same in both styles). Therefore, "home" should IMHO be filled as well (the "map" icon has always been filled in cgeo, long before "home" was introduced ;-)).

![grafik](https://user-images.githubusercontent.com/64581222/138611473-b4f1a0d1-515c-49c1-8bbd-377b30629634.png)|![grafik](https://user-images.githubusercontent.com/64581222/138611493-1d08b375-6f53-4041-a515-7f59e24dd8da.png)
-|-
![grafik](https://user-images.githubusercontent.com/64581222/138611517-7711b0fb-3dda-4161-a284-b825c8c07768.png)|![grafik](https://user-images.githubusercontent.com/64581222/138611526-b9dc6084-425a-45cc-8aac-c4c450f888dc.png)

I also added missing documentation to some icons while being on the way...

![grafik](https://user-images.githubusercontent.com/64581222/138612252-0c209571-1be1-4907-8dad-8425ab276b25.png)
