### PR TITLE
remove old mainscreen icon styles no longer needed

### DIFF
--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -301,45 +301,6 @@
         <item name="android:layout_marginBottom">5dip</item>
     </style>
 
-    <!-- mainscreen icon -->
-
-    <style name="icon_mainscreen">
-        <item name="android:layout_width">48dip</item>
-        <item name="android:layout_height">48dip</item>
-        <item name="android:layout_gravity">center_horizontal</item>
-        <item name="android:gravity">center</item>
-        <item name="android:layout_margin">4dip</item>
-        <item name="android:focusable">true</item>
-    </style>
-
-    <style name="icon_mainscreen_text">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_gravity">center_horizontal</item>
-        <item name="android:gravity">center</item>
-        <item name="android:paddingTop">1dip</item>
-        <item name="android:paddingBottom">1dip</item>
-        <item name="android:paddingLeft">5dip</item>
-        <item name="android:paddingRight">5dip</item>
-        <item name="android:maxLines">2</item>
-        <item name="android:ellipsize">marquee</item>
-        <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
-    </style>
-
-    <style name="icon_mainscreen_cell">
-        <item name="android:layout_width">0dip</item>
-        <item name="android:layout_weight">1</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:orientation">vertical</item>
-    </style>
-    <style name="icon_mainscreen_row">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_margin">4dip</item>
-        <item name="android:gravity">center_horizontal</item>
-        <item name="android:orientation">horizontal</item>
-    </style>
-
     <!-- current location -->
 
     <style name="location_current">


### PR DESCRIPTION
## Description
Remove the styles used for icon positioning and formatting on the old mainscreen, as those are no longer used with bottom navigation.
