### PR TITLE
use different separator styles for headings (rel. to #11965)

### DIFF
--- a/main/res/layout/about_contributors_page.xml
+++ b/main/res/layout/about_contributors_page.xml
@@ -13,9 +13,9 @@
         android:orientation="vertical" >
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/contributors_carnero"
                 android:textSize="@dimen/textSize_headingPrimary" />
         </RelativeLayout>
@@ -28,9 +28,9 @@
             android:text="@string/about_contributors_carnerodetails" />
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/about_contributors_recent"
                 android:textSize="@dimen/textSize_headingPrimary" />
         </RelativeLayout>
@@ -43,9 +43,9 @@
             android:text="@string/contributors_recent" />
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/about_contributors_specialthanks"
                 android:textSize="@dimen/textSize_headingPrimary" />
         </RelativeLayout>
@@ -58,9 +58,9 @@
             android:text="@string/about_contributors_specialthanksdetails" />
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/about_contributors_other"
                 android:textSize="@dimen/textSize_headingPrimary" />
         </RelativeLayout>
@@ -73,9 +73,9 @@
             android:text="@string/contributors_other" />
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/about_components"
                 android:textSize="@dimen/textSize_headingPrimary" />
         </RelativeLayout>

--- a/main/res/layout/about_version_page.xml
+++ b/main/res/layout/about_version_page.xml
@@ -62,8 +62,8 @@
         </FrameLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
-            <TextView style="@style/separator_horizontal_headline" android:text="@string/about_version" />
+            <View style="@style/separator_horizontal_heading" />
+            <TextView style="@style/separator_horizontal_heading_text" android:text="@string/about_version" />
         </RelativeLayout>
 
         <TextView
@@ -93,8 +93,8 @@
             tools:visibility="visible"/>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
-            <TextView style="@style/separator_horizontal_headline" android:text="@string/about_donate" />
+            <View style="@style/separator_horizontal_heading" />
+            <TextView style="@style/separator_horizontal_heading_text" android:text="@string/about_donate" />
         </RelativeLayout>
 
         <LinearLayout
@@ -114,8 +114,8 @@
         </LinearLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
-            <TextView style="@style/separator_horizontal_headline" android:text="@string/about_help" />
+            <View style="@style/separator_horizontal_heading" />
+            <TextView style="@style/separator_horizontal_heading_text" android:text="@string/about_help" />
         </RelativeLayout>
 
         <TableLayout

--- a/main/res/layout/cache_image_item.xml
+++ b/main/res/layout/cache_image_item.xml
@@ -9,11 +9,10 @@
         android:id="@+id/titleLayout"
         style="@style/separator_horizontal_layout">
 
-        <View style="@style/separator_horizontal" />
-
+        <View style="@style/separator_horizontal_heading" />
         <TextView
             android:id="@+id/title"
-            style="@style/separator_horizontal_headline"
+            style="@style/separator_horizontal_heading_text"
             android:text="@string/log_image"
             tools:text="image title"/>
     </RelativeLayout>

--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -54,10 +54,10 @@
             tools:visibility="visible">
 
             <RelativeLayout style="@style/separator_horizontal_layout">
-                <View style="@style/separator_horizontal" />
+                <View style="@style/separator_horizontal_heading" />
                 <TextView
                     android:id="@+id/extra_description_title"
-                    style="@style/separator_horizontal_headline" />
+                    style="@style/separator_horizontal_heading_text" />
             </RelativeLayout>
 
             <TextView
@@ -82,10 +82,10 @@
 
             <RelativeLayout style="@style/separator_horizontal_layout">
 
-                <View style="@style/separator_horizontal" />
+                <View style="@style/separator_horizontal_heading" />
 
                 <TextView
-                    style="@style/separator_horizontal_headline"
+                    style="@style/separator_horizontal_heading_text"
                     android:text="@string/cache_hint" />
             </RelativeLayout>
 
@@ -124,10 +124,10 @@
 
             <RelativeLayout style="@style/separator_horizontal_layout">
 
-                <View style="@style/separator_horizontal" />
+                <View style="@style/separator_horizontal_heading" />
 
                 <TextView
-                    style="@style/separator_horizontal_headline"
+                    style="@style/separator_horizontal_heading_text"
                     android:text="@string/cache_personal_note" />
             </RelativeLayout>
 

--- a/main/res/layout/cachedetail_details_page.xml
+++ b/main/res/layout/cachedetail_details_page.xml
@@ -397,11 +397,9 @@
             tools:visibility="visible">
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-
-                <View style="@style/separator_horizontal" />
-
+                <View style="@style/separator_horizontal_heading" />
                 <TextView
-                    style="@style/separator_horizontal_headline"
+                    style="@style/separator_horizontal_heading_text"
                     android:text="@string/cache_license" />
             </RelativeLayout>
 

--- a/main/res/layout/imagelist_fragment.xml
+++ b/main/res/layout/imagelist_fragment.xml
@@ -12,11 +12,9 @@
     tools:visibility="visible">
 
     <RelativeLayout style="@style/separator_horizontal_layout">
-
-        <View style="@style/separator_horizontal" />
-
+        <View style="@style/separator_horizontal_heading" />
         <TextView
-            style="@style/separator_horizontal_headline"
+            style="@style/separator_horizontal_heading_text"
             android:text="@string/log_images" />
     </RelativeLayout>
 

--- a/main/res/layout/imageselect_activity.xml
+++ b/main/res/layout/imageselect_activity.xml
@@ -16,11 +16,9 @@
         android:orientation="vertical" >
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-
-            <View style="@style/separator_horizontal" />
-
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/log_image" />
         </RelativeLayout>
 

--- a/main/res/layout/logcache_activity.xml
+++ b/main/res/layout/logcache_activity.xml
@@ -162,9 +162,9 @@
             tools:visibility="visible">
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-                <View style="@style/separator_horizontal" />
+                <View style="@style/separator_horizontal_heading" />
                 <TextView
-                    style="@style/separator_horizontal_headline"
+                    style="@style/separator_horizontal_heading_text"
                     android:text="@string/cache_inventory" />
             </RelativeLayout>
 

--- a/main/res/layout/popup.xml
+++ b/main/res/layout/popup.xml
@@ -70,7 +70,6 @@
             </RelativeLayout>
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-
                 <View style="@style/separator_horizontal" />
             </RelativeLayout>
 

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -14,9 +14,9 @@
         android:orientation="vertical" >
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_filter" />
         </RelativeLayout>
 
@@ -45,9 +45,9 @@
         </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_geo" />
         </RelativeLayout>
 
@@ -71,9 +71,9 @@
         <!-- ** -->
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_coordinates" />
         </RelativeLayout>
 
@@ -89,9 +89,9 @@
         <!-- ** -->
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_address" />
         </RelativeLayout>
 
@@ -110,9 +110,9 @@
         <!-- ** -->
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_kw" />
         </RelativeLayout>
 
@@ -131,9 +131,9 @@
         <!-- ** -->
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_hbu" />
         </RelativeLayout>
 
@@ -152,9 +152,9 @@
         <!-- ** -->
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_finder" />
         </RelativeLayout>
 
@@ -174,9 +174,9 @@
 
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal" />
+            <View style="@style/separator_horizontal_heading" />
             <TextView
-                style="@style/separator_horizontal_headline"
+                style="@style/separator_horizontal_heading_text"
                 android:text="@string/search_tb" />
         </RelativeLayout>
 

--- a/main/res/layout/trackable_details_view.xml
+++ b/main/res/layout/trackable_details_view.xml
@@ -28,8 +28,8 @@
             tools:visibility="visible">
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-                <View style="@style/separator_horizontal" />
-                <TextView style="@style/separator_horizontal_headline" android:text="@string/trackable_goal" />
+                <View style="@style/separator_horizontal_heading" />
+                <TextView style="@style/separator_horizontal_heading_text" android:text="@string/trackable_goal" />
             </RelativeLayout>
 
             <TextView
@@ -54,8 +54,8 @@
             tools:visibility="visible">
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-                <View style="@style/separator_horizontal" />
-                <TextView style="@style/separator_horizontal_headline" android:text="@string/trackable_details" />
+                <View style="@style/separator_horizontal_heading" />
+                <TextView style="@style/separator_horizontal_heading_text" android:text="@string/trackable_details" />
             </RelativeLayout>
 
             <TextView
@@ -80,8 +80,8 @@
             tools:visibility="visible">
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-                <View style="@style/separator_horizontal" />
-                <TextView style="@style/separator_horizontal_headline" android:text="@string/trackable_image" />
+                <View style="@style/separator_horizontal_heading" />
+                <TextView style="@style/separator_horizontal_heading_text" android:text="@string/trackable_image" />
             </RelativeLayout>
 
             <LinearLayout

--- a/main/res/layout/usefulapps_item.xml
+++ b/main/res/layout/usefulapps_item.xml
@@ -10,12 +10,10 @@
     tools:context=".helper.UsefulAppsActivity" >
 
     <RelativeLayout style="@style/separator_horizontal_layout" >
-
-        <View style="@style/separator_horizontal" />
-
+        <View style="@style/separator_horizontal_heading" />
         <TextView
             android:id="@+id/title"
-            style="@style/separator_horizontal_headline"
+            style="@style/separator_horizontal_heading_text"
             android:textIsSelectable="true" />
     </RelativeLayout>
 

--- a/main/res/layout/waypoint_popup.xml
+++ b/main/res/layout/waypoint_popup.xml
@@ -61,7 +61,6 @@
             </RelativeLayout>
 
             <RelativeLayout style="@style/separator_horizontal_layout" >
-
                 <View style="@style/separator_horizontal" />
             </RelativeLayout>
 

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -396,7 +396,7 @@
     <!-- separators -->
     <style name="separator_horizontal">
         <item name="android:layout_width">fill_parent</item>
-        <item name="android:layout_height">3dip</item>
+        <item name="android:layout_height">1dip</item>
         <item name="android:layout_centerInParent">true</item>
         <item name="android:background">@color/colorSeparator</item>
     </style>
@@ -415,7 +415,14 @@
         <item name="android:layout_marginBottom">2dip</item>
     </style>
 
-    <style name="separator_horizontal_headline">
+    <style name="separator_horizontal_heading">
+        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_height">3dip</item>
+        <item name="android:layout_centerInParent">true</item>
+        <item name="android:background">@color/colorSeparator</item>
+    </style>
+
+    <style name="separator_horizontal_heading_text">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_alignParentLeft">true</item>

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -47,7 +47,6 @@ import java.util.Locale;
 import de.k3b.geo.api.GeoPointDto;
 import de.k3b.geo.api.IGeoPointInfo;
 import de.k3b.geo.io.GeoUri;
-
 import org.apache.commons.lang3.StringUtils;
 
 public class SearchActivity extends AbstractBottomNavigationActivity implements CoordinatesInputDialog.CoordinateUpdate {


### PR DESCRIPTION
## Description
Reduces separator height to 1 dip, except for headings with text, where it will stay at 3 dip. See discussion in #11965).

![image](https://user-images.githubusercontent.com/3754370/139137201-eaaea1fd-009a-4d02-934d-8edd756af9cc.png).![image](https://user-images.githubusercontent.com/3754370/139137228-887ec573-7f8a-4233-90a6-181a3dc06d2c.png)
