### PR TITLE
UnMockPlugin update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.2.1'
 
         // un-mocking of portable Android classes
-        classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
+        classpath 'com.github.bjoernq:unmockplugin:0.7.9'
 
         // monitor our application method limit
         //noinspection GradleDependency - see https://github.com/cgeo/cgeo/issues/9208


### PR DESCRIPTION
see https://github.com/bjoernQ/unmock-plugin#versions

 - renaming plugin (classpath), switch to mavenCentral
 - Gradle 7 compatibility fixes

