### PR TITLE
gradle plugin 4.2.2 Upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         // un-mocking of portable Android classes
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
@@ -110,9 +110,9 @@ allprojects {
                 // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
                 force 'com.google.guava:guava:26.0-jre'
 
-                // force this version because of conflict to our resolutionStrategy from lint-gradle 27.2.1 (referencing 4.1.0-alpha01-6193524)
-                // TODO check after gradle update (gradlew :main:lintBasicDebug)
-                force 'com.android.tools.build:aapt2-proto:4.2.1-7147631'
+                // force this version because of conflict to our resolutionStrategy from lint-gradle
+                // TODO check necessity after every gradle update (gradlew :main:lintBasicDebug)
+                force 'com.android.tools.build:aapt2-proto:4.2.2-7147631'
             }
         }
     }


### PR DESCRIPTION
As we are currently not able to switch to gradle 7 lets install this small gradle plugin fix
(including aapt2-proto prerequisite).
