### PR TITLE
position snackbar above bottom navigation (fix #12014)

### DIFF
--- a/main/src/cgeo/geocaching/command/AbstractCommand.java
+++ b/main/src/cgeo/geocaching/command/AbstractCommand.java
@@ -126,6 +126,7 @@ public abstract class AbstractCommand implements Command {
             if (StringUtils.isNotEmpty(resultMessage)) {
                 Snackbar.make(context.findViewById(android.R.id.content), resultMessage, UNDO_DURATION_MILLISEC)
                         .setAction(context.getString(R.string.undo), this)
+                        .setAnchorView(context.findViewById(R.id.activity_bottom_navigation))
                         .show();
             }
         }


### PR DESCRIPTION
## Description
Use bottom navigation layout element as anchor view to position the snackbar above it.
If bottom navigation layout element is not found (null) placement will be as today.

![image](https://user-images.githubusercontent.com/3754370/140614564-fdf0f4c8-efeb-4d52-b4c9-364a519d31b5.png)
