### PR TITLE
avoid CursorIndexOutOfBoundsException in map downloader

### DIFF
--- a/main/src/cgeo/geocaching/downloader/DownloadSelectorActivity.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadSelectorActivity.java
@@ -125,9 +125,16 @@ public class DownloadSelectorActivity extends AbstractActionBarActivity {
                                             q.setFilterById(id);
                                             final Cursor cursor = manager.query(q);
                                             cursor.moveToFirst();
-                                            final int bytesDownloaded = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
-                                            final int bytesTotal = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
-                                            final int progress = bytesTotal == 0 ? 0 : (int) ((bytesDownloaded * 100L) / bytesTotal);
+                                            final int bytesDownloadedPos = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR);
+                                            final int bytesTotalPos = cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES);
+                                            final int progress;
+                                            if (bytesDownloadedPos >= 0 && bytesTotalPos >= 0) {
+                                                final int bytesDownloaded = cursor.getInt(bytesDownloadedPos);
+                                                final int bytesTotal = cursor.getInt(bytesTotalPos);
+                                                progress = bytesTotal == 0 ? 0 : (int) ((bytesDownloaded * 100L) / bytesTotal);
+                                            } else {
+                                                progress = 0;
+                                            }
 
                                             runOnUiThread(() -> holder.binding.progressHorizontal.setProgressCompat(progress, true));
                                             cursor.close();


### PR DESCRIPTION
## Description
Avoids a `CursorIndexOutOfBoundsException` in map downloader, which has app. 180 occurrences for versions `2021.10.08`, `2021.09.27` and current RC over the last 30 days.

(Reason for this exception is that the requested columns sometimes were not available in the query, thus `cursor.getInt()` triggered that exception.)
