### PR TITLE
extend clickable area of filters view (fix #12052)

### DIFF
--- a/main/res/layout/filter_sort_bar.xml
+++ b/main/res/layout/filter_sort_bar.xml
@@ -7,7 +7,7 @@
 
     <LinearLayout
         android:id="@+id/filter_bar"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_toLeftOf="@id/sort_bar"


### PR DESCRIPTION
before|now
-|-
![Screenshot_20211105_080017_copy_539x199](https://user-images.githubusercontent.com/64581222/140471502-e7a069a9-1cc8-49f3-9cd6-8413ffd84c38.png)|![grafik](https://user-images.githubusercontent.com/64581222/140617793-7b365543-366f-43c4-b537-b1605e68752f.png)