### PR TITLE
fix some minor search view bugs

### DIFF
--- a/main/res/layout-h390dp-land/activity_bottom_navigation.xml
+++ b/main/res/layout-h390dp-land/activity_bottom_navigation.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/activity_viewroot"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,6 +12,7 @@
         android:layout_alignParentEnd="true"
         android:layout_toEndOf="@id/activity_bottom_navigation" />
 
+    <!-- Show a navigation rail on landscape devices instead. -->
     <com.google.android.material.navigationrail.NavigationRailView
         android:id="@+id/activity_bottom_navigation"
         android:layout_width="wrap_content"
@@ -18,4 +20,4 @@
         android:layout_alignParentStart="true"
         app:labelVisibilityMode="labeled"
         app:menu="@menu/bottom_navigation_menu" />
-</RelativeLayout>
+</cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>

--- a/main/res/layout-land/activity_bottom_navigation.xml
+++ b/main/res/layout-land/activity_bottom_navigation.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/activity_viewroot"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,7 +12,7 @@
         android:layout_alignParentEnd="true"
         android:layout_toEndOf="@id/activity_bottom_navigation" />
 
-    <!-- on rather small screens, don't show labels in landscape as otherwise some items would not fit -->
+    <!-- Show a navigation rail on landscape devices instead. On rather small screens, don't show labels to save some space -->
     <com.google.android.material.navigationrail.NavigationRailView
         android:id="@+id/activity_bottom_navigation"
         style="@style/Widget.MaterialComponents.NavigationRailView.Compact"
@@ -20,4 +21,4 @@
         android:layout_alignParentStart="true"
         app:labelVisibilityMode="unlabeled"
         app:menu="@menu/bottom_navigation_menu" />
-</RelativeLayout>
+</cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>

--- a/main/res/layout/activity_bottom_navigation.xml
+++ b/main/res/layout/activity_bottom_navigation.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/activity_viewroot"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:id="@+id/activity_content"
@@ -18,4 +19,4 @@
         android:layout_alignParentBottom="true"
         app:labelVisibilityMode="labeled"
         app:menu="@menu/bottom_navigation_menu" />
-</RelativeLayout>
+</cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -2,7 +2,6 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
 import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.address.AndroidGeocoder;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.IAvatar;
@@ -32,6 +31,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.ui.AvatarUtils;
+import cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -99,7 +99,6 @@ public class MainActivity extends AbstractBottomNavigationActivity {
     private Geopoint addCoords = null;
     private boolean initialized = false;
     private boolean restoreMessageShown = false;
-    private boolean keyboardWasActive = false;
 
     private final UpdateLocation locationUpdater = new UpdateLocation();
     private final Handler updateUserInfoHandler = new UpdateUserInfoHandler(this);
@@ -545,8 +544,6 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
             @Override
             public boolean onMenuItemActionExpand(final MenuItem item) {
-                keyboardWasActive = true;
-
                 for (int i = 0; i < menu.size(); i++) {
                     if (menu.getItem(i).getItemId() != R.id.menu_gosearch) {
                         menu.getItem(i).setVisible(false);
@@ -605,14 +602,18 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         final AutoCompleteTextView searchAutoComplete = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
         searchAutoComplete.setOnDismissListener(() -> {
             if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
-                if (keyboardWasActive) {
-                    keyboardWasActive = Keyboard.isVisible(this);
-                    searchAutoComplete.showDropDown();
-                } else {
-                    searchItem.collapseActionView();
-                    searchView.setIconified(true);
-                }
+                searchAutoComplete.showDropDown();
             }
+        });
+        final RelativeLayoutWithInterceptTouchEventPossibility activityViewroot = findViewById(R.id.activity_viewroot);
+        activityViewroot.setOnInterceptTouchEventListener(ev -> {
+            if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
+                searchItem.collapseActionView();
+                searchView.setIconified(true);
+                return true; // intercept touch event to do not trigger an unwanted action
+            }
+            // In general, we don't want to intercept touch events...
+            return false;
         });
     }
 

--- a/main/src/cgeo/geocaching/ui/RelativeLayoutWithInterceptTouchEventPossibility.java
+++ b/main/src/cgeo/geocaching/ui/RelativeLayoutWithInterceptTouchEventPossibility.java
@@ -1,0 +1,49 @@
+package cgeo.geocaching.ui;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.widget.RelativeLayout;
+
+public class RelativeLayoutWithInterceptTouchEventPossibility extends RelativeLayout {
+    private OnInterceptTouchEventListener onInterceptTouchEventListener = null;
+
+    public RelativeLayoutWithInterceptTouchEventPossibility(final Context context) {
+        super(context);
+    }
+
+    public RelativeLayoutWithInterceptTouchEventPossibility(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public RelativeLayoutWithInterceptTouchEventPossibility(final Context context, final AttributeSet attrs, final int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public RelativeLayoutWithInterceptTouchEventPossibility(final Context context, final AttributeSet attrs, final int defStyleAttr, final int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(final MotionEvent ev) {
+        if (onInterceptTouchEventListener != null && onInterceptTouchEventListener.onTouchEvent(ev)) {
+            return true;
+        }
+        return super.onInterceptTouchEvent(ev);
+    }
+
+    public void setOnInterceptTouchEventListener(final OnInterceptTouchEventListener listener) {
+        onInterceptTouchEventListener = listener;
+    }
+
+    public interface OnInterceptTouchEventListener {
+        /**
+         * Called when the view group is touched.
+         *
+         * @param ev The motion event
+         *
+         * @return true if the touch event should be intercepted, otherwise false.
+         */
+        boolean onTouchEvent(MotionEvent ev);
+    }
+}


### PR DESCRIPTION
When the search dropdown is in expand mode without keyboard being active, the search view gets closed when clicking in the textarea. Instead, the keyboard should get opened again...

To get this working, I had to create a small extension of `RealtiveLayout`, which supports setting a `onInterceptTouchEventListener` on demand.
