### PR TITLE
remove "Log Text" from log insert menu

### DIFF
--- a/main/src/cgeo/geocaching/log/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/log/LogTemplateProvider.java
@@ -277,16 +277,6 @@ public final class LogTemplateProvider {
                 return StringUtils.EMPTY;
             }
         });
-        templates.add(new LogTemplate("LOG", R.string.init_signature_template_log) {
-            @Override
-            public String getValue(final LogContext context) {
-                final LogEntry logEntry = context.getLogEntry();
-                if (logEntry != null) {
-                    return logEntry.getDisplayText();
-                }
-                return StringUtils.EMPTY;
-            }
-        });
         templates.add(new LogTemplate("TYPE",  R.string.init_signature_template_type) {
             @Override
             public String getValue(final LogContext context) {
@@ -345,6 +335,25 @@ public final class LogTemplateProvider {
                     return "invalid signature template";
                 }
                 return applyTemplates(nestedTemplate, context);
+            }
+        });
+        return templates;
+    }
+
+    /**
+     * @return all user-facing templates, including the log text template
+     */
+    @NonNull
+    public static List<LogTemplate> getTemplatesWithLogText() {
+        final List<LogTemplate> templates = getTemplatesWithoutSignature();
+        templates.add(new LogTemplate("LOG", R.string.init_signature_template_log) {
+            @Override
+            public String getValue(final LogContext context) {
+                final LogEntry logEntry = context.getLogEntry();
+                if (logEntry != null) {
+                    return logEntry.getDisplayText();
+                }
+                return StringUtils.EMPTY;
             }
         });
         return templates;

--- a/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
+++ b/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
@@ -56,7 +56,7 @@ public class TemplateTextPreference extends DialogPreference {
         button.setOnClickListener(button1 -> {
             final AlertDialog.Builder alert = Dialogs.newBuilder(TemplateTextPreference.this.getContext());
             alert.setTitle(R.string.init_signature_template_button);
-            final List<LogTemplate> templates = LogTemplateProvider.getTemplatesWithoutSignature();
+            final List<LogTemplate> templates = LogTemplateProvider.getTemplatesWithLogText();
             final String[] items = new String[templates.size()];
             for (int i = 0; i < templates.size(); i++) {
                 items[i] = settingsActivity.getString(templates.get(i).getResourceId());


### PR DESCRIPTION
Log "insert" menu contains an item "Log text". That placeholder was added in #3368 and should be available for Twitter only. Inserting the log text into the log text doesn't make any sense.

fixes #12066