### PR TITLE
(hopefully) fix wrong activity stack (fix #12010)

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -280,7 +280,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             }
             cLog.add("ds");
 
-            if ((getIntent().getFlags() & Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
+            if (!isTaskRoot()) {
                 // If we had been open already, start from the last used activity.
                 finish();
                 return;


### PR DESCRIPTION
The start page should never be opened as sub-activity. If c:geo had been open already, start from the last used activity instead. 

The same check was introduced long ago, but seem to no longer work on some modern launchers.