### PR TITLE
Log templates

### DIFF
--- a/main/res/layout/template_preference_dialog.xml
+++ b/main/res/layout/template_preference_dialog.xml
@@ -9,12 +9,21 @@
 
     <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
         <EditText
+            android:id="@+id/title"
+            style="@style/textinput_embedded"
+            android:inputType="textEmailSubject"
+            android:autofillHints="@string/init_template_title"
+            android:hint="@string/init_template_title" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+        <EditText
             android:id="@+id/edit"
             style="@style/textinput_embedded"
             android:inputType="textMultiLine|textCapSentences"
             android:minLines="3"
-            android:hint="@string/init_signature"
-            android:autofillHints="@string/init_signature"/>
+            android:hint="@string/init_template_text"
+            android:autofillHints="@string/init_template_text"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <TextView

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -82,6 +82,11 @@
     <string translatable="false" name="pref_supersizeDistance">supersizeDistanceToggle</string>
     <string translatable="false" name="pref_plainLogs">plainLogs</string>
     <string translatable="false" name="pref_signature">signature</string>
+    <string translatable="false" name="pref_logTemplate1">pref_logTemplate1</string>
+    <string translatable="false" name="pref_logTemplate2">pref_logTemplate2</string>
+    <string translatable="false" name="pref_logTemplate3">pref_logTemplate3</string>
+    <string translatable="false" name="pref_logTemplate4">pref_logTemplate4</string>
+    <string translatable="false" name="pref_logTemplate5">pref_logTemplate5</string>
     <string translatable="false" name="pref_sigautoinsert">sigautoinsert</string>
     <string translatable="false" name="pref_offlinelogs_homescreen">offlinelogs_homescreen</string>
     <string translatable="false" name="pref_trackautovisit">trackautovisit</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -766,8 +766,14 @@
     <string name="settings_service_active_unavailable">Active/Unavailable</string>
     <string name="settings_navigation_disabled">This app seems not to be installed</string>
     <string name="init_signature">Signature</string>
+    <string name="init_template_title">Template Title</string>
+    <string name="init_template_text">Template Text</string>
+    <string name="init_log_template">Log Template</string>
+    <string name="init_log_templates">Log Templates</string>
+    <string name="init_log_template_prefix">Template:\u0020</string>
+    <string name="init_log_template_missing_error">Both template title and text need to be provided.</string>
     <string name="init_template_help">Placeholder strings - like [NAME] - are filled with the designated text when the template is used.</string>
-    <string name="init_signature_template_button">Insert Template</string>
+    <string name="init_signature_template_button">Insert Placeholder</string>
     <string name="init_signature_template_date">Date</string>
     <string name="init_signature_template_time">Time</string>
     <string name="init_signature_template_datetime">Date &amp; Time</string>

--- a/main/res/xml/preferences_logging.xml
+++ b/main/res/xml/preferences_logging.xml
@@ -20,6 +20,31 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/init_log_templates"
+        app:iconSpaceReserved="false">
+        <cgeo.geocaching.settings.TemplateTextPreference
+            android:key="@string/pref_logTemplate1"
+            android:title="@string/init_log_template"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.TemplateTextPreference
+            android:key="@string/pref_logTemplate2"
+            android:title="@string/init_log_template"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.TemplateTextPreference
+            android:key="@string/pref_logTemplate3"
+            android:title="@string/init_log_template"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.TemplateTextPreference
+            android:key="@string/pref_logTemplate4"
+            android:title="@string/init_log_template"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.TemplateTextPreference
+            android:key="@string/pref_logTemplate5"
+            android:title="@string/init_log_template"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/settings_category_logging_other"
         app:iconSpaceReserved="false">
         <CheckBoxPreference

--- a/main/src/cgeo/geocaching/log/AbstractLoggingActivity.java
+++ b/main/src/cgeo/geocaching/log/AbstractLoggingActivity.java
@@ -34,7 +34,11 @@ public abstract class AbstractLoggingActivity extends AbstractActionBarActivity 
 
         final SubMenu menuLog = menu.findItem(R.id.menu_templates).getSubMenu();
         for (final LogTemplate template : LogTemplateProvider.getTemplatesWithSignature()) {
-            menuLog.add(0, template.getItemId(), 0, template.getResourceId());
+            if (template.getResourceId() == 0) {
+                menuLog.add(0, template.getItemId(), 0, getString(R.string.init_log_template_prefix) + template.getName());
+            } else {
+                menuLog.add(0, template.getItemId(), 0, template.getResourceId());
+            }
         }
 
         final SubMenu menuSmilies = menu.findItem(R.id.menu_smilies).getSubMenu();

--- a/main/src/cgeo/geocaching/log/LogTemplateProvider.java
+++ b/main/src/cgeo/geocaching/log/LogTemplateProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * Provides all the available templates for logging.
@@ -80,11 +81,17 @@ public final class LogTemplateProvider {
     public abstract static class LogTemplate {
         private final String template;
         @StringRes
-        private final int resourceId;
+        private int resourceId = 0;
+        private String name = "";
 
         protected LogTemplate(final String template, @StringRes final int resourceId) {
             this.template = template;
             this.resourceId = resourceId;
+        }
+
+        protected LogTemplate(final String template, final String name) {
+            this.template = template;
+            this.name = name;
         }
 
         public abstract String getValue(LogContext context);
@@ -96,6 +103,10 @@ public final class LogTemplateProvider {
 
         public final int getItemId() {
             return template.hashCode();
+        }
+
+        public final String getName() {
+            return name;
         }
 
         public final String getTemplateString() {
@@ -337,6 +348,20 @@ public final class LogTemplateProvider {
                 return applyTemplates(nestedTemplate, context);
             }
         });
+        for (int i = 1; i <= 5; i++) {
+            final ImmutablePair<String, String> template = Settings.getLogTemplate("pref_logTemplate" + i);
+            if (!template.getKey().isEmpty()) {
+                templates.add(new LogTemplate("TEMPLATE", template.getKey()) {
+                    @Override
+                    public String getValue(final LogContext context) {
+                        if (StringUtils.contains(template.getValue(), "TEMPLATE")) {
+                            return "invalid template";
+                        }
+                        return applyTemplates(template.getValue(), context);
+                    }
+                });
+            }
+        }
         return templates;
     }
 

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1958,4 +1958,18 @@ public class Settings {
         return sensitiveKeys;
     }
 
+    public static void putLogTemplate(final String preferenceBaseName, final String title, final String text) {
+        putStringDirect(preferenceBaseName + ".Title", title);
+        putStringDirect(preferenceBaseName, text);
+    }
+
+    public static ImmutablePair<String, String> getLogTemplate(final String preferenceBaseName) {
+        return new ImmutablePair<>(getStringDirect(preferenceBaseName + ".Title", ""), getStringDirect(preferenceBaseName, ""));
+    }
+
+    public static String getLogTemplatePreview(final String preferenceBaseName) {
+        final ImmutablePair<String, String> template = getLogTemplate(preferenceBaseName);
+        return template.getKey() + ": " + template.getValue();
+    }
+
 }

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
@@ -18,10 +18,21 @@ public class PreferenceLoggingFragment extends PreferenceFragmentCompat {
     public void onResume() {
         super.onResume();
         getActivity().setTitle(R.string.settings_title_logging);
+        // Update "Signature" preview
         SettingsUtils.setPrefSummary(this, R.string.pref_signature, Settings.getSignature());
         findPreference(getString(R.string.pref_signature)).setOnPreferenceChangeListener((preference, newValue) -> {
             SettingsUtils.setPrefSummary(this, R.string.pref_signature, Settings.getSignature());
             return true;
         });
+        // Update "Log Templates" previews
+        for (int i = 1; i <= 5; i++) {
+            final int preferenceId = getResources().getIdentifier("pref_logTemplate" + i, "string", getActivity().getPackageName());
+            SettingsUtils.setPrefSummary(this, preferenceId, Settings.getLogTemplatePreview("pref_logTemplate" + i));
+            findPreference(getString(preferenceId)).setOnPreferenceChangeListener((preference, newValue) -> {
+                SettingsUtils.setPrefSummary(this, preferenceId, Settings.getLogTemplatePreview(preference.getKey()));
+                return true;
+            });
+        }
+
     }
 }


### PR DESCRIPTION
I have added 5 additional templates that work in the same way "Signature" does in defining them in preferences.
They do show up in the "insert" menu right below signature - but only if they are non-empty - from where you can insert them manually.

Showing the title is currently done in an ugly way, using one preference to store template name and text with a divider - I couldn't find any good way to have two associated preference keys (for title and text). If someone has an idea on that please feel free to pick up the code in PR (#12071). Due to this I've marked the PR as Draft for now.
(Also the number of templates is fixed now as it's using preferences, implementing title and text as some form of objects would probably allow making that dynamic)

![image](https://user-images.githubusercontent.com/1258173/140794752-79ffd2e6-cbf3-4aba-9c18-dbbcad77a683.png)
![image](https://user-images.githubusercontent.com/1258173/140794808-331ed1ed-45b2-40b0-bf00-e452598fc800.png)
