### PR TITLE
Use rounded distance for premium cache BM heuristic

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.gcvote.GCVote;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.Units;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.log.LogTypeTrackable;
@@ -854,7 +855,7 @@ class GCWebAPI {
             if (c.getCoords() != null) {
                 final float newDistance = search.getOrigin().distanceTo(c.getCoords());
                 for (Geocache emptyC : emptyCoordCaches) {
-                    emptyC.setDistance((newDistance + lastDistance) / 2);
+                    emptyC.setDistance(Units.generateSmartRoundedAverageDistance(newDistance, lastDistance));
                 }
                 emptyCoordCaches.clear();
                 lastDistance = newDistance;

--- a/main/src/cgeo/geocaching/location/Units.java
+++ b/main/src/cgeo/geocaching/location/Units.java
@@ -26,6 +26,26 @@ public class Units {
         }
     }
 
+    public static float generateSmartRoundedAverageDistance(final float newDistance, final float lastDistance) {
+        final float scaleFactor;
+        if (Settings.useImperialUnits()) { // the rounded values should be user displayable. Therefore, use a different scaling factor for imperial units.
+            scaleFactor = 10 / IConversion.MILES_TO_KILOMETER; // use 0.1 mi scale
+        } else {
+            scaleFactor = 1000; // use 1m scale
+        }
+        final float originalDelta = scaleFactor * (newDistance - lastDistance);
+        float delta = originalDelta;
+        while (delta >= 10) {
+            delta /= 10;
+        }
+        final float roundingFactor = originalDelta / delta; // depending on the delta, generate the best suitable rounding factor
+
+        final float average = scaleFactor * (newDistance + lastDistance) / 2;
+        final float roundedValue = (Math.round(average / roundingFactor)) * roundingFactor;
+
+        return roundedValue / scaleFactor;
+    }
+
     public static String getDistanceFromKilometers(final Float distanceKilometers) {
         if (distanceKilometers == null) {
             return "?";


### PR DESCRIPTION
fix #11631 - Use rounded distance for premium cache BM heuristic

These values have always been just a blind guess. Therefore, it makes no sense to display extremely accurate distances...

before|now
-|-
![grafik](https://user-images.githubusercontent.com/64581222/140810446-f1df7901-b672-4612-bc9a-52802a1bf5aa.png)|![grafik](https://user-images.githubusercontent.com/64581222/140809216-abd22e49-71d7-47f4-8898-4c74d8647e96.png)

(does also work for imperial units)
![grafik](https://user-images.githubusercontent.com/64581222/140811484-5d2a8319-11e9-4b5c-b6ab-026ff77f25f9.png)


Some more examples how values will be rounded:
```
E/cgeo: [network--10] before 0.0	next 0.114486255	|  result: 0.1
E/cgeo: [network--10] before 2.2910788	next 2.98085		|  result: 2.6
E/cgeo: [network--10] before 5.601692	next 6.563045		|  result: 6.1
E/cgeo: [network--10] before 7.8604755	next 8.457116		|  result: 8.2
E/cgeo: [network--10] before 9.295073	next 9.41279		|  result: 9.4
E/cgeo: [network--10] before 9.41279	next 9.525498		|  result: 9.5
E/cgeo: [network--10] before 11.103125	next 11.355427		|  result: 11.2
E/cgeo: [network--10] before 12.273866	next 12.880837		|  result: 12.6
E/cgeo: [network--10] before 12.273866	next 12.880837		|  result: 12.6
E/cgeo: [network--10] before 13.469846	next 13.599312		|  result: 13.5
E/cgeo: [network--10] before 13.848788	next 13.8623295		|  result: 13.86
E/cgeo: [network--10] before 13.8988	next 13.960519		|  result: 13.93
E/cgeo: [network--10] before 14.006933	next 14.051192		|  result: 14.03
E/cgeo: [network--10] before 14.066135	next 14.120402		|  result: 14.09
E/cgeo: [network--10] before 14.255808	next 14.376359		|  result: 14.3
E/cgeo: [network--10] before 14.742109	next 14.890624		|  result: 14.8
E/cgeo: [network--10] before 14.742109	next 14.890624		|  result: 14.8
E/cgeo: [network--10] before 15.0128355	next 15.190348		|  result: 15.1
```

Was quite a funny and challenging math exercise for me BTW ;-)
