### PR TITLE
Display caches with corrected coords with enlarged "blue flag" marker

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -788,8 +788,8 @@
     <string name="init_summary_brouterShowBothDistances">If routing is active: Show the straight distance in addition to the calculated route length.</string>
     <string name="init_useInternalRouting">Use internal routing</string>
     <string name="init_summary_useInternalRouting">Use c:geo internal routing to be able to use automatic routing data downloading and other functions</string>
-    <string name="init_bigSmileysOnMap">Big icons for logged caches</string>
-    <string name="init_summary_bigSmileysOnMap">If enabled big emoticons will be shown for logged caches on the map instead of the cache type icon (requires restart).</string>
+    <string name="init_bigSmileysOnMap">Big icons</string>
+    <string name="init_summary_bigSmileysOnMap">If enabled, symbols like the \'found smiley\' or the \'corrected coordinates\' marker will be shown enlarged on the map instead of the cache type icon (requires restart).</string>
     <string name="init_global_wp_extraction_disable">Disable waypoint extraction</string>
     <string name="init_summary_global_wp_extraction_disable">Globally disable waypoint extraction from personal cache notes. It can still be enabled for individual caches by deactivating the checkbox below the personal cache note</string>
     <string name="init_customtabs_as_browser">Use Chrome WebView</string>

--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -171,9 +171,9 @@ public final class MapMarkerUtils {
             }
         }
         // bottom-right: user modified coords / final waypoint defined
-        if (cache.hasUserModifiedCoords()) {
+        if (cache.hasUserModifiedCoords() && !doubleSize) {
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_usermodifiedcoords, Gravity.BOTTOM | Gravity.RIGHT));
-        } else if (cache.hasFinalDefined()) {
+        } else if (cache.hasFinalDefined() && !cache.hasUserModifiedCoords()) {
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_hasfinal, Gravity.BOTTOM | Gravity.RIGHT));
         }
         // bottom-left: personal note
@@ -537,6 +537,9 @@ public final class MapMarkerUtils {
             final Integer offlineLogType = getMarkerIdIfLogged(cache);
             if (offlineLogType != null) {
                 return offlineLogType;
+            }
+            if (cache.hasUserModifiedCoords()) {
+                return R.drawable.marker_usermodifiedcoords;
             }
         }
         return cache.getType().markerId;


### PR DESCRIPTION
rel. to #10924

This will look like this:

![grafik](https://user-images.githubusercontent.com/64581222/141535069-2ccf9399-11f7-4bf5-aef8-5696b9fe0582.png)

@ztNFny are you ok with this implementation?