### PR TITLE
Display of multiple separate tracks in single GPX file (fix #10432)

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXIndividualRouteParser.java
+++ b/main/src/cgeo/geocaching/files/GPXIndividualRouteParser.java
@@ -28,7 +28,7 @@ public class GPXIndividualRouteParser extends AbstractTrackOrRouteParser impleme
         point.getChild(namespace, "name").setEndTextElementListener(body -> tempName = body);
         point.setEndElementListener(() -> {
             if (temp.size() > 0) {
-                result.add(new RouteSegment(new RouteItem(tempName, temp.get(temp.size() - 1)), temp));
+                result.add(new RouteSegment(new RouteItem(tempName, temp.get(temp.size() - 1)), temp, true));
                 temp = new ArrayList<>();
             }
         });

--- a/main/src/cgeo/geocaching/files/GPXRouteParser.java
+++ b/main/src/cgeo/geocaching/files/GPXRouteParser.java
@@ -26,7 +26,7 @@ public class GPXRouteParser extends AbstractTrackOrRouteParser implements Abstra
 
         point.setEndElementListener(() -> {
             if (temp.size() > 0) {
-                result.add(new RouteSegment(new RouteItem(temp.get(temp.size() - 1)), temp));
+                result.add(new RouteSegment(new RouteItem(temp.get(temp.size() - 1)), temp, false));
                 temp = new ArrayList<>();
             }
         });

--- a/main/src/cgeo/geocaching/files/GPXTrackParser.java
+++ b/main/src/cgeo/geocaching/files/GPXTrackParser.java
@@ -27,7 +27,7 @@ public class GPXTrackParser extends AbstractTrackOrRouteParser implements Abstra
 
         points.setEndElementListener(() -> {
             if (temp.size() > 0) {
-                result.add(new RouteSegment(new RouteItem(temp.get(temp.size() - 1)), temp));
+                result.add(new RouteSegment(new RouteItem(temp.get(temp.size() - 1)), temp, false));
                 temp = null;
             }
         });

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -69,9 +69,9 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
     private static Bitmap locationIcon;
 
-    private ArrayList<LatLng> route = null;
+    private ArrayList<ArrayList<LatLng>> route = null;
     private Viewport lastViewport = null;
-    private ArrayList<LatLng> track = null;
+    private ArrayList<ArrayList<LatLng>> track = null;
 
     public GooglePositionAndHistory(final GoogleMap googleMap, final GoogleMapView mapView, final GoogleMapView.PostRealDistance postRealDistance, final GoogleMapView.PostRealDistance postRouteDistance) {
         this.mapRef = new WeakReference<>(googleMap);
@@ -306,12 +306,14 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
     private synchronized void drawRoute() {
         routeObjs.removeAll();
         if (route != null && route.size() > 1) {
-            routeObjs.addPolyline(new PolylineOptions()
-                    .addAll(route)
+            for (ArrayList<LatLng> segment : route) {
+                routeObjs.addPolyline(new PolylineOptions()
+                    .addAll(segment)
                     .color(MapLineUtils.getRouteColor())
                     .width(MapLineUtils.getRouteLineWidth())
                     .zIndex(ZINDEX_ROUTE)
-            );
+                );
+            }
         }
     }
 
@@ -336,12 +338,14 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
     private synchronized void drawTrack() {
         trackObjs.removeAll();
         if (track != null && track.size() > 1 && !Settings.isHideTrack()) {
-            trackObjs.addPolyline(new PolylineOptions()
-                .addAll(track)
-                .color(MapLineUtils.getTrackColor())
-                .width(MapLineUtils.getTrackLineWidth())
-                .zIndex(ZINDEX_TRACK)
-            );
+            for (ArrayList<LatLng> segment : track) {
+                trackObjs.addPolyline(new PolylineOptions()
+                    .addAll(segment)
+                    .color(MapLineUtils.getTrackColor())
+                    .width(MapLineUtils.getTrackLineWidth())
+                    .zIndex(ZINDEX_TRACK)
+                );
+            }
         }
     }
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/AbstractRouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/AbstractRouteLayer.java
@@ -25,7 +25,7 @@ abstract class AbstractRouteLayer extends Layer {
     private final Boolean pathLock = true;
 
     // used for caching
-    private ArrayList<Geopoint> track = null;
+    private ArrayList<ArrayList<Geopoint>> track = null;
     private Path path = null;
     private long mapSize = -1;
     private Point topLeftPoint = null;
@@ -64,7 +64,7 @@ abstract class AbstractRouteLayer extends Layer {
         }
 
         // no route or route too short?
-        if (this.track == null || this.track.size() < 2) {
+        if (this.track == null || this.track.size() < 1) {
             return;
         }
 
@@ -84,19 +84,26 @@ abstract class AbstractRouteLayer extends Layer {
         this.topLeftPoint = topLeftPoint;
         this.path = null;
 
-        final Iterator<Geopoint> iterator = track.iterator();
-        if (!iterator.hasNext()) {
+        final Iterator<ArrayList<Geopoint>> segmentIterator = track.iterator();
+        if (!segmentIterator.hasNext()) {
             return;
         }
 
-        Geopoint point = iterator.next();
         path = AndroidGraphicFactory.INSTANCE.createPath();
-        path.moveTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
+        ArrayList<Geopoint> segment = segmentIterator.next();
+        while (segment != null) {
+            final Iterator<Geopoint> geopointIterator = segment.iterator();
+            Geopoint geopoint = geopointIterator.next();
+            path.moveTo((float) (MercatorProjection.longitudeToPixelX(geopoint.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(geopoint.getLatitude(), mapSize) - topLeftPoint.y));
 
-        while (iterator.hasNext()) {
-            point = iterator.next();
-            path.lineTo((float) (MercatorProjection.longitudeToPixelX(point.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(point.getLatitude(), mapSize) - topLeftPoint.y));
+            while (geopointIterator.hasNext()) {
+                geopoint = geopointIterator.next();
+                path.lineTo((float) (MercatorProjection.longitudeToPixelX(geopoint.getLongitude(), mapSize) - topLeftPoint.x), (float) (MercatorProjection.latitudeToPixelY(geopoint.getLatitude(), mapSize) - topLeftPoint.y));
+            }
+
+            segment = segmentIterator.hasNext() ? segmentIterator.next() : null;
         }
+
     }
 
 }

--- a/main/src/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/cgeo/geocaching/models/IndividualRoute.java
@@ -127,7 +127,7 @@ public class IndividualRoute extends Route implements Parcelable {
         }
         final int pos = pos(item);
         if (pos == -1) {
-            final RouteSegment segment = new RouteSegment(item, null);
+            final RouteSegment segment = new RouteSegment(item, null, true);
             if (segment.hasPoint()) {
                 segments.add(segment);
                 calculateNavigationRoute(segments.size() - 1);

--- a/main/src/cgeo/geocaching/models/Route.java
+++ b/main/src/cgeo/geocaching/models/Route.java
@@ -54,26 +54,39 @@ public class Route implements Parcelable {
         return numPoints;
     }
 
-    public ArrayList<Geopoint> getAllPoints() {
-        final ArrayList<Geopoint> points = new ArrayList<>();
-        if (null != segments) {
+    public ArrayList<ArrayList<Geopoint>> getAllPoints() {
+        final ArrayList<ArrayList<Geopoint>> allPoints = new ArrayList<>();
+        if (segments != null) {
             for (RouteSegment segment : segments) {
-                points.addAll(segment.getPoints());
-            }
-        }
-        return points;
-    }
-
-    public ArrayList<LatLng> getAllPointsLatLng() {
-        final ArrayList<LatLng> points = new ArrayList<>();
-        if (null != segments) {
-            for (RouteSegment segment : segments) {
-                for (Geopoint point : segment.getPoints()) {
-                    points.add(new LatLng(point.getLatitude(), point.getLongitude()));
+                // extend existing list of points, if linking of segments is requested - otherwise add new segment
+                if (allPoints.size() > 0 && segment.getLinkToPreviousSegment()) {
+                    allPoints.get(allPoints.size() - 1).addAll(segment.getPoints());
+                } else {
+                    allPoints.add(new ArrayList<>(segment.getPoints()));
                 }
             }
         }
-        return points;
+        return allPoints;
+    }
+
+    public ArrayList<ArrayList<LatLng>> getAllPointsLatLng() {
+        final ArrayList<ArrayList<LatLng>> allPoints = new ArrayList<>();
+        if (segments != null) {
+            for (RouteSegment segment : segments) {
+                // convert to list of LatLng
+                final ArrayList<LatLng> points = new ArrayList<>();
+                for (Geopoint point : segment.getPoints()) {
+                    points.add(new LatLng(point.getLatitude(), point.getLongitude()));
+                }
+                // extend existing list of points, if linking of segments is requested - otherwise add new segment
+                if (allPoints.size() > 0 && segment.getLinkToPreviousSegment()) {
+                    allPoints.get(allPoints.size() - 1).addAll(points);
+                } else {
+                    allPoints.add(points);
+                }
+            }
+        }
+        return allPoints;
     }
 
     public RouteSegment[] getSegments() {

--- a/main/src/cgeo/geocaching/models/RouteSegment.java
+++ b/main/src/cgeo/geocaching/models/RouteSegment.java
@@ -11,11 +11,13 @@ public class RouteSegment implements Parcelable {
     private final RouteItem item;
     private float distance;
     private ArrayList<Geopoint> points;
+    private boolean linkToPreviousSegment = true;
 
-    public RouteSegment(final RouteItem item, final ArrayList<Geopoint> points) {
+    public RouteSegment(final RouteItem item, final ArrayList<Geopoint> points, final boolean linkToPreviousSegment) {
         this.item = item;
         distance = 0.0f;
         this.points = points;
+        this.linkToPreviousSegment = linkToPreviousSegment;
     }
 
     public float calculateDistance() {
@@ -68,6 +70,10 @@ public class RouteSegment implements Parcelable {
     public void resetPoints() {
         points = new ArrayList<>();
         distance = 0.0f;
+    }
+
+    public boolean getLinkToPreviousSegment() {
+        return linkToPreviousSegment;
     }
 
     // Parcelable methods


### PR DESCRIPTION
## Description
If a GPX file contains multiple tracks, display them separately instead of connecting them into one track:

|before|now|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/141651016-8a8f0187-9b11-446d-a66d-19825b4df5b1.png)|![image](https://user-images.githubusercontent.com/3754370/141650989-44e182d3-e014-4f06-8ea2-ec58950dbbaf.png)|

(for testing see the GPX file provided in https://github.com/cgeo/cgeo/issues/10432#issuecomment-841788817)