### PR TITLE
auto unhide track on loading new track (fix #12111)

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.files;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Route;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.utils.AndroidRxUtils;
@@ -26,7 +27,7 @@ public class GPXTrackOrRouteImporter {
     private GPXTrackOrRouteImporter() {
     }
 
-    public static void doImport(final Context context, final Uri uri, final Route.UpdateRoute callback) {
+    public static void doImport(final Context context, final Uri uri, final Route.UpdateRoute callback, final boolean resetVisibilitySetting) {
         final AtomicBoolean success = new AtomicBoolean(false);
         Toast.makeText(context, R.string.map_load_track_wait, Toast.LENGTH_SHORT).show();
         AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
@@ -36,6 +37,9 @@ public class GPXTrackOrRouteImporter {
                 if (success.get()) {
                     AndroidSchedulers.mainThread().createWorker().schedule(() -> {
                         try {
+                            if (resetVisibilitySetting) {
+                                Settings.setHideTrack(false);
+                            }
                             callback.updateRoute(value);
                         } catch (final Throwable t) {
                             //

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -649,7 +649,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     private void resumeTrack(final boolean preventReloading) {
         if (null == tracks && !preventReloading) {
-            getTrackUtils().loadTracks(this::setTracks);
+            getTrackUtils().loadTracks(this::setTracks, false);
         } else if (null != overlayPositionAndScale && overlayPositionAndScale instanceof GooglePositionAndHistory) {
             ((GooglePositionAndHistory) overlayPositionAndScale).updateRoute(tracks);
         }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -729,9 +729,10 @@ public class NewMap extends AbstractActionBarActivity implements Observer, Filte
 
     private void resumeTrack(final boolean preventReloading) {
         if (null == tracks && !preventReloading) {
-            this.trackUtils.loadTracks(this::setTracks);
+            this.trackUtils.loadTracks(this::setTracks, false);
         } else if (null != trackLayer) {
             trackLayer.updateRoute(tracks);
+            trackLayer.setHidden(Settings.isHideTrack());
         }
     }
 

--- a/main/src/cgeo/geocaching/utils/TrackUtils.java
+++ b/main/src/cgeo/geocaching/utils/TrackUtils.java
@@ -33,7 +33,7 @@ public class TrackUtils {
         this.fileSelector = new ContentStorageActivityHelper(activity, savedState == null ? null : savedState.getBundle(STATE_CSAH))
         .addSelectActionCallback(ContentStorageActivityHelper.SelectAction.SELECT_FILE_PERSISTED, PersistableUri.class, uri -> {
             if (uri != null && this.updateTracks != null) {
-                loadTracks(this.updateTracks);
+                loadTracks(this.updateTracks, true);
             }
         });
     }
@@ -56,7 +56,6 @@ public class TrackUtils {
 
     /**
      * Check if selected menu entry is for "load track" or hide/unhide track
-     * @param activity calling activity
      * @param id menu entry id
      * @return true, if selected menu entry is track related and consumed / false else
      */
@@ -97,10 +96,10 @@ public class TrackUtils {
         return fileSelector.onActivityResult(requestCode, resultCode, data);
     }
 
-    public void loadTracks(final Route.UpdateRoute updateRoute) {
+    public void loadTracks(final Route.UpdateRoute updateRoute, final boolean resetVisibilitySetting) {
         final Uri uri = PersistableUri.TRACK.getUri();
         if (null != uri) {
-            GPXTrackOrRouteImporter.doImport(activity, PersistableUri.TRACK.getUri(), updateRoute);
+            GPXTrackOrRouteImporter.doImport(activity, PersistableUri.TRACK.getUri(), updateRoute, resetVisibilitySetting);
         }
         ActivityMixin.invalidateOptionsMenu(activity);
     }


### PR DESCRIPTION
## Description
Automatically resets "hide track" setting to `false` on loading a new track.

## Additional context
PR is targeted to `master` currently, but based on `release`, so it can still be re-targeted and merged to `release` if requested.