### PR TITLE
style quick settings buttons like zoom buttons

### DIFF
--- a/main/res/drawable/white_bcg.xml
+++ b/main/res/drawable/white_bcg.xml
@@ -5,7 +5,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/osm_zoomcontrolbackground" />
-            <corners android:radius="2dp" />/>
+            <corners android:radius="2dp" />
         </shape>
     </item>
 </ripple>

--- a/main/res/drawable/white_bcg.xml
+++ b/main/res/drawable/white_bcg.xml
@@ -4,8 +4,8 @@
     android:color="@android:color/black">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#C0FFFFFF" />
-            <corners android:radius="2dp" />
+            <solid android:color="@color/osm_zoomcontrolbackground" />
+            <corners android:radius="2dp" />/>
         </shape>
     </item>
 </ripple>

--- a/main/res/layout/map_settings_button.xml
+++ b/main/res/layout/map_settings_button.xml
@@ -4,14 +4,29 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingBottom="5dp"
     android:layout_alignParentBottom="true">
 
-    <LinearLayout android:id="@+id/container_settings" style="@style/map_quickbuttons" android:layout_centerHorizontal="true">
-        <Button android:id="@+id/map_settings_popup" style="@style/button_icon_map" app:icon="@drawable/map_quick_settings" />
+    <LinearLayout
+        android:id="@+id/container_settings"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true">
+        <ImageButton
+            android:id="@+id/map_settings_popup"
+            android:src="@drawable/map_quick_settings"
+            style="@style/map_quicksettingsbutton" />
     </LinearLayout>
-
-    <LinearLayout android:id="@+id/container_individualroute" style="@style/map_quickbuttons" android:layout_toRightOf="@id/container_settings" android:visibility="gone">
-        <Button android:id="@+id/map_individualroute_popup" style="@style/button_icon_map" app:icon="@drawable/map_quick_route" />
+    <LinearLayout
+        android:id="@+id/container_individualroute"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/container_settings"
+        android:layout_marginLeft="6dp"
+        android:visibility="gone">
+        <ImageButton
+            android:id="@+id/map_individualroute_popup"
+            style="@style/map_quicksettingsbutton"
+            android:src="@drawable/map_quick_route" />
     </LinearLayout>
-
 </RelativeLayout>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -196,14 +196,6 @@
         <item name="materialThemeOverlay">@style/IconButtonThemeOverlay</item>
     </style>
 
-    <style name="button_icon_map" parent="button_icon">
-        <item name="android:layout_width">36dp</item>
-        <item name="android:layout_height">36dp</item>
-        <item name="android:layout_margin">3dp</item>
-        <item name="android:padding">3dp</item>
-        <item name="iconTint">@color/osm_zoomcontrol</item>
-    </style>
-
     <style name="button_icon_colored" parent="button_icon_accent">
         <!-- display icon as colored image, without reverting all colors to tint color -->
         <item name="iconTint">#FFFFFFFF</item>
@@ -500,12 +492,15 @@
     </style>
 
     <!-- map quick buttons styles -->
-    <style name="map_quickbuttons">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
+    <style name="map_quicksettingsbutton">
+        <item name="android:layout_width">38dp</item>
+        <item name="android:layout_height">38dp</item>
+        <item name="android:gravity">bottom</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:padding">8dp</item>
         <item name="android:background">@drawable/white_bcg</item>
-        <item name="android:layout_marginLeft">3dp</item>
-        <item name="android:layout_marginRight">3dp</item>
+        <item name="android:tint">@color/osm_zoomcontrol</item>
     </style>
 
     <!-- authorization styles -->


### PR DESCRIPTION
Use ImageButton instead of Button to remove outlines on map settings buttons

![image](https://user-images.githubusercontent.com/1258173/142673464-82908efe-7a13-42c7-af55-8fac1cb4a929.png)

## Related issues
fixes #12041 
fixes #11907