### PR TITLE
gradle 6.9.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update gradle from 6.8.3 to 7.9.1.
Using it on the release branch to have bugs fixed there.

This is a backport release from gradle 7.x to 6.x.
No problems so far found in tests and from the ReleaseNotes.

For ReleaseNotes see
 - https://docs.gradle.org/6.9/release-notes.html
 - https://docs.gradle.org/6.9.1/release-notes.html

