### PR TITLE
pass current cache coordinates to geochecker

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointFormatter.java
+++ b/main/src/cgeo/geocaching/location/GeopointFormatter.java
@@ -70,7 +70,13 @@ public class GeopointFormatter {
         LON_DECMINSEC,
 
         /** Example: "32U E 549996 N 5600860" */
-        UTM
+        UTM,
+
+        /** Example: N48+12.345+E11+12.345 **/
+        GEOCHECKERCOM,
+
+        /** Example: N5536498E01305095 **/
+        GEOCHECKORG
     }
 
     /**
@@ -156,6 +162,16 @@ public class GeopointFormatter {
             case UTM: {
                 return UTMPoint.latLong2UTM(gp).toString();
             }
+
+            case GEOCHECKERCOM:
+                return String.format((Locale) null, "%c%d+%02d.%03d+%c%d+%02d.%03d",
+                    gp.getLatDir(), gp.getDecMinuteLatDeg(), gp.getDecMinuteLatMin(), gp.getDecMinuteLatMinFrac(),
+                    gp.getLonDir(), gp.getDecMinuteLonDeg(), gp.getDecMinuteLonMin(), gp.getDecMinuteLonMinFrac());
+
+            case GEOCHECKORG:
+                return String.format((Locale) null, "%c%02d%02d%03d%c%03d%02d%03d",
+                    gp.getLatDir(), gp.getDecMinuteLatDeg(), gp.getDecMinuteLatMin(), gp.getDecMinuteLatMinFrac(),
+                    gp.getLonDir(), gp.getDecMinuteLonDeg(), gp.getDecMinuteLonMin(), gp.getDecMinuteLonMinFrac());
 
         }
         throw new IllegalStateException(); // cannot happen, if switch case is enum complete

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -402,7 +402,7 @@ public class Geocache implements IWaypoint {
     /**
      * Returns the first found Waypoint matching the given condition
      */
-    private Waypoint getFirstMatchingWaypoint(final Func1<Waypoint, Boolean> condition) {
+    public Waypoint getFirstMatchingWaypoint(final Func1<Waypoint, Boolean> condition) {
         for (final Waypoint wpt : waypoints) {
             if (wpt != null && condition.call(wpt)) {
                 return wpt;

--- a/main/src/cgeo/geocaching/utils/CheckerUtils.java
+++ b/main/src/cgeo/geocaching/utils/CheckerUtils.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.models.Geocache;
 
 import android.util.Patterns;
@@ -15,15 +16,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 public final class CheckerUtils {
-    private static final String[] CHECKERS = {
-            "certitudes.org/certitude?",
-            "gc-apps.com/checker/",
-            "gccounter.com/gcchecker.php?",
-            "geocheck.org/geo_inputchkcoord.php?",
-            "geochecker.com/index.php?",
-            "geochecker.gps-cache.de/check.aspx?",
-            "geotjek.dk/geo_inputchkcoord.php?",
-            "geocache-planer.de/CAL/checker.php?",
+    private static GeoChecker[] CHECKERS = {
+        new GeoChecker("certitudes.org/certitude?"),
+        new GeoChecker("gc-apps.com/checker/"),
+        new GeoChecker("gccounter.com/gcchecker.php?"),
+        new GeoChecker("geocheck.org/geo_inputchkcoord.php?", "&coord=", GeopointFormatter.Format.GEOCHECKORG),
+        new GeoChecker("geochecker.com/index.php?", "&lastcoords=", GeopointFormatter.Format.GEOCHECKERCOM),
+        new GeoChecker("geochecker.gps-cache.de/check.aspx?"),
+        new GeoChecker("geotjek.dk/geo_inputchkcoord.php?", "&coord=", GeopointFormatter.Format.GEOCHECKORG),
+        new GeoChecker("geocache-planer.de/CAL/checker.php?")
     };
 
     private CheckerUtils() {
@@ -35,9 +36,12 @@ public final class CheckerUtils {
         final String description = cache.getDescription();
         final Matcher matcher = Patterns.WEB_URL.matcher(description);
         while (matcher.find()) {
-            final String url = matcher.group();
-            for (final String checker : CHECKERS) {
-                if (StringUtils.containsIgnoreCase(url, checker)) {
+            String url = matcher.group();
+            for (final GeoChecker checker : CHECKERS) {
+                if (StringUtils.containsIgnoreCase(url, checker.getUrlPattern())) {
+                    if (checker.getCoordinateFormat() != null) {
+                        url = url + checker.getUrlCoordinateParam() + cache.getCoords().format(checker.getCoordinateFormat());
+                    }
                     return StringEscapeUtils.unescapeHtml4(url);
                 }
             }
@@ -47,5 +51,33 @@ public final class CheckerUtils {
             return cache.getUrl();
         }
         return null;
+    }
+
+    public static class GeoChecker {
+        private String urlPattern;
+        private String urlCoordinateParam = "";
+        private GeopointFormatter.Format coordinateFormat = null;
+
+        public GeoChecker(String urlPattern) {
+            this.urlPattern = urlPattern;
+        }
+
+        public GeoChecker(String urlPattern, String coordinateParam, GeopointFormatter.Format coordinateFormat) {
+            this.urlPattern = urlPattern;
+            this.urlCoordinateParam = coordinateParam;
+            this.coordinateFormat = coordinateFormat;
+        }
+
+        public String getUrlPattern() {
+            return urlPattern;
+        }
+
+        public String getUrlCoordinateParam() {
+            return urlCoordinateParam;
+        }
+
+        public GeopointFormatter.Format getCoordinateFormat() {
+            return coordinateFormat;
+        }
     }
 }

--- a/main/src/cgeo/geocaching/utils/CheckerUtils.java
+++ b/main/src/cgeo/geocaching/utils/CheckerUtils.java
@@ -19,7 +19,6 @@ public final class CheckerUtils {
     private static GeoChecker[] CHECKERS = {
         new GeoChecker("certitudes.org/certitude?"),
         new GeoChecker("gc-apps.com/checker/"),
-        new GeoChecker("gccounter.com/gcchecker.php?"),
         new GeoChecker("geocheck.org/geo_inputchkcoord.php?", "&coord=", GeopointFormatter.Format.GEOCHECKORG),
         new GeoChecker("geochecker.com/index.php?", "&lastcoords=", GeopointFormatter.Format.GEOCHECKERCOM),
         new GeoChecker("geochecker.gps-cache.de/check.aspx?"),

--- a/main/src/cgeo/geocaching/utils/CheckerUtils.java
+++ b/main/src/cgeo/geocaching/utils/CheckerUtils.java
@@ -47,7 +47,9 @@ public final class CheckerUtils {
                         } else {
                             coordinateToCheck = cache.getCoords();
                         }
-                        url = url + checker.getUrlCoordinateParam() + coordinateToCheck.format(checker.getCoordinateFormat());
+                        if (coordinateToCheck != null) {
+                            url = url + checker.getUrlCoordinateParam() + coordinateToCheck.format(checker.getCoordinateFormat());
+                        }
                     }
                     return StringEscapeUtils.unescapeHtml4(url);
                 }


### PR DESCRIPTION
Pass the current cache coordinates to geocheckers for checkers supporting that.

## Description
Entering coordinates into the checker is quite annyoing on the small phone screen - but something done often to verify that the final coords are still correct or to get the spoiler image.
geocheck.org/geotjek.dk and geochecker.com support a url parameter to pass a coordinate to be checked.

## Related issues
fixes #6782