### PR TITLE
put DownloadManager.enqueue in background in update check

### DIFF
--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.storage.extension.PendingDownload;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AsyncTaskWithProgressText;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Log;
@@ -312,7 +313,7 @@ public class DownloaderUtils {
                                         .setAllowedOverMetered(allowMeteredNetwork)
                                         .setAllowedOverRoaming(allowMeteredNetwork);
                                     Log.i("Download enqueued: " + Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/" + download.getName());
-                                    PendingDownload.add(downloadManager.enqueue(request), download.getName(), download.getUri().toString(), download.getDateInfo(), download.getType().id);
+                                    AndroidRxUtils.networkScheduler.scheduleDirect(() -> PendingDownload.add(downloadManager.enqueue(request), download.getName(), download.getUri().toString(), download.getDateInfo(), download.getType().id));
                                 }
                                 ActivityMixin.showShortToast(activity, R.string.download_started);
                             } else {


### PR DESCRIPTION
## Description
As discussed in our last dev call: Put the call to `DownloadManager.enqueue` into background when called by the automatic update check, trying to avoid the `NetworkOnMainThreadException` which occur on some Samsung devices running Android 10.

Attempts to fix the error described #11184, but let's keep the issue open to see if the error is really resolved (as we cannot reproduce it here).

The change should be non-problematic, but I've targeted it to `master` anyway, to not force it into our upcoming release without having seen it in a couple of nightlies before.