### PR TITLE
add 'selext next 20 caches' to cache list (rel. to #12077)

### DIFF
--- a/main/res/drawable/ic_menu_select_next.xml
+++ b/main/res/drawable/ic_menu_select_next.xml
@@ -1,0 +1,14 @@
+<!-- taken from select and navigate_next / materialdesignicons.com -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:textColorPrimary">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,3H5V5H3V4A1,1 0 0,1 4,3M20,3A1,1 0 0,1 21,4V5H19V3H20M15,5V3H17V5H15M11,5V3H13V5H11M7,5V3H9V5H7M21,20A1,1 0 0,1 20,21H19V19H21V20M15,21V19H17V21H15M11,21V19H13V21H11M7,21V19H9V21H7M4,21A1,1 0 0,1 3,20V19H5V21H4M3,15H5V17H3V15M21,15V17H19V15H21M3,11H5V13H3V11M21,11V13H19V11H21M3,7H5V9H3V7M21,7V9H19V7H21Z"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -30,6 +30,11 @@
         android:title="@string/caches_select_invert"
         app:showAsAction="ifRoom|withText"/>
     <item
+        android:id="@+id/menu_select_next"
+        android:icon="@drawable/ic_menu_select_next"
+        android:title="@string/caches_select_next"
+        app:showAsAction="ifRoom|withText"/>
+    <item
         android:id="@+id/menu_cache_list_app"
         android:icon="@drawable/ic_menu_navigate"
         android:title="@null"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -408,6 +408,7 @@
     <string name="caches_sort_storage">Date stored on device</string>
     <string name="caches_sort_eventdate">Event date</string>
     <string name="caches_select_mode">Select mode</string>
+    <string name="caches_select_next">Select next 20 caches</string>
     <string name="caches_select_mode_exit">Exit select mode</string>
     <string name="caches_select_invert">Invert selection</string>
     <string name="caches_nearby">Nearby</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -790,6 +790,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setEnabled(menu, R.id.menu_switch_select_mode, !isEmpty);
             updateSelectSwitchMenuItem(menu.findItem(R.id.menu_switch_select_mode));
             setVisible(menu, R.id.menu_invert_selection, adapter.isSelectMode()); // exception to the general rule: only show in select mode
+            setVisible(menu, R.id.menu_select_next, adapter.isSelectMode()); // same here
 
             setVisibleEnabled(menu, R.id.menu_cache_list_app_provider, listNavigationApps.size() > 1, !isEmpty);
             setVisibleEnabled(menu, R.id.menu_cache_list_app, listNavigationApps.size() == 1, !isEmpty);
@@ -946,6 +947,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         } else if (menuItem == R.id.menu_invert_selection) {
             adapter.invertSelection();
             invalidateOptionsMenuCompatible();
+        } else if (menuItem == R.id.menu_select_next) {
+            adapter.selectNextCaches();
         } else if (menuItem == R.id.menu_filter) {
             showFilterMenu();
         } else if (menuItem == R.id.menu_import_web) {

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -226,6 +226,19 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
         notifyDataSetChanged();
     }
 
+    public void selectNextCaches() {
+        int remaining = 20; // how many caches are left to check?
+        final int max = list.size();
+        for (int i = 0; i < max && remaining > 0; i++) {
+            final Geocache cache = list.get(i);
+            if (!cache.isStatusChecked()) {
+                cache.setStatusChecked(true);
+                remaining--;
+            }
+        }
+        notifyDataSetChanged();
+    }
+
     public void forceSort() {
         if (CollectionUtils.isEmpty(list)) {
             return;


### PR DESCRIPTION
## Description
As discussed in #12077: Add an option to select the next 20 caches in the cache list.
Selecting this menu entry will check the first 20 unchecked caches, honoring the current sort order. Selecting this menu entry multiple times will select 40, 60, 80 etc. caches (20 more on each call).
