### PR TITLE
avoid repeated update checks for interval=0 (fix #12153)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -7,6 +7,10 @@
 
     If you add a preference key which stores sensitive data not to be included in settings backup
     by default, make sure to add the key to Settings.getSensitivePreferenceKeys()
+
+    If a preference key is no longer actively used, you can and should remove it.
+    If a preference key is no longer actively used, but you still need the string for migration,
+    add "old_" as prefix to the variable name (but leave the value unchanged).
     -->
 
     <string translatable="false" name="preference_screen_main">fakekey_main_screen</string>
@@ -166,7 +170,7 @@
     <string translatable="false" name="pref_usecompass">usecompass</string>
     <string translatable="false" name="pref_mapfile">mfmapfile</string>
     <string translatable="false" name="pref_mapdownloader_source">mapdownloader_source</string>
-    <string translatable="false" name="pref_mapAutoDownloads">mapAutoDownloads</string>
+    <string translatable="false" name="old_pref_mapAutoDownloads">mapAutoDownloads</string>
     <string translatable="false" name="pref_mapAutoDownloadsInterval">mapAutoDownloadsInterval</string>
     <string translatable="false" name="pref_mapAutoDownloadsLastCheck">mapAutoDownloadsLastCheck</string>
     <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -801,7 +801,6 @@
     <string name="init_brouterShowBothDistances">Show straight distance</string>
     <string name="init_autoDownloads">Automatic download</string>
     <string name="init_brouterAutoTileDownloads_description">Automatically offer to download missing routing tile data.</string>
-    <string name="init_mapAutoDownloads_description">Automatically check for update of map and theme files. (Valid only for files you have downloaded with the integrated downloader.)</string>
     <string name="init_brouterProfileWalk">\"Walk\" profile</string>
     <string name="init_brouterProfileBike">\"Bike\" profile</string>
     <string name="init_brouterProfileCar">\"Car\" profile</string>
@@ -909,7 +908,8 @@
     <string name="init_map_directory_description">Folder with offline maps</string>
     <string name="init_brouter_directory_description">Folder with BRouter routing data</string>
     <string name="init_updateinterval_title">Update interval</string>
-    <string name="init_updateinterval_description">Reminds you every x days for an update check</string>
+    <string name="init_updateinterval_description">Reminds you every x days for an update check (valid only for files you have downloaded from within c:geo), 0=off</string>
+
     <string name="init_gpx_importexportdir">GPX Folder</string>
     <string name="init_dataDir">Select data folder</string>
     <string name="init_dataDir_note">You may choose to store the additional data for geocaches (spoilers, log images, …) on your external storage (emulated or real external SD card depending on your device).</string>

--- a/main/res/xml/preferences.xml
+++ b/main/res/xml/preferences.xml
@@ -576,23 +576,15 @@
                 android:text="@string/downloadmap_info"
                 android:title="@string/downloadmap_title"
                 app:urlButton="@string/downloadmap_choose" />
-
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="@string/pref_mapAutoDownloads"
-                android:summary="@string/init_mapAutoDownloads_description"
-                android:title="@string/init_autoDownloads" />
             <Preference
                 android:selectable="false"
                 android:summary="@string/init_updateinterval_description"
-                android:title="@string/init_updateinterval_title"
-                android:dependency="@string/pref_mapAutoDownloads" />
+                android:title="@string/init_updateinterval_title" />
             <cgeo.geocaching.settings.SeekbarPreference
                 android:key="@string/pref_mapAutoDownloadsInterval"
                 app:min="0"
                 app:max="@integer/map_updateinterval_max"
-                android:defaultValue="@integer/map_updateinterval_default"
-                android:dependency="@string/pref_mapAutoDownloads" />
+                android:defaultValue="@integer/map_updateinterval_default" />
 
             <Preference
                 android:key="@string/pref_persistablefolder_offlinemaps"
@@ -984,14 +976,12 @@
             <Preference
                 android:selectable="false"
                 android:summary="@string/init_updateinterval_description"
-                android:title="@string/init_updateinterval_title"
-                android:dependency="@string/pref_brouterAutoTileDownloads" />
+                android:title="@string/init_updateinterval_title" />
             <cgeo.geocaching.settings.SeekbarPreference
                 android:key="@string/pref_brouterAutoTileDownloadsInterval"
                 app:min="0"
                 app:max="@integer/brouter_updateinterval_max"
-                android:defaultValue="@integer/brouter_updateinterval_default"
-                android:dependency="@string/pref_brouterAutoTileDownloads" />
+                android:defaultValue="@integer/brouter_updateinterval_default" />
 
             <ListPreference
                 android:dialogTitle="@string/init_brouterProfileWalk"

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -63,7 +63,7 @@ public class DownloaderUtils {
     }
 
     public static void checkForRoutingTileUpdates(final Activity activity) {
-        if (Settings.useInternalRouting() && Settings.isBrouterAutoTileDownloads() && !PersistableFolder.ROUTING_TILES.isLegacy() && Settings.brouterAutoTileDownloadsNeedUpdate()) {
+        if (Settings.useInternalRouting() && !PersistableFolder.ROUTING_TILES.isLegacy() && Settings.brouterAutoTileDownloadsNeedUpdate()) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(activity, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, DownloaderUtils::returnFromTileUpdateCheck);
         }
     }
@@ -73,7 +73,7 @@ public class DownloaderUtils {
     }
 
     public static void checkForMapUpdates(final Activity activity) {
-        if (Settings.isMapAutoDownloads() && Settings.mapAutoDownloadsNeedUpdate()) {
+        if (Settings.mapAutoDownloadsNeedUpdate()) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(activity, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, R.string.mapupdate_info, DownloaderUtils::returnFromMapUpdateCheck);
         }
     }


### PR DESCRIPTION
## Description
As described in https://github.com/cgeo/cgeo/issues/12153#issuecomment-978190309:

- change settings => navigation => update interval to "0 = no update check at all" ("automatic download" does not have to be active to trigger query for update, but update check will only cover tiles downloaded by the automatic download, as only then the required metadata is created)
- change settings => map = >update interval in the same way
- remove "automatic download" checkbox on map page (as its use-case is covered by aforementioned's setting being 0 or non-zero)

![image](https://user-images.githubusercontent.com/3754370/143312436-d6683e84-e852-4b51-9630-a05ed12f9e37.png).![image](https://user-images.githubusercontent.com/3754370/143312452-7e767c2f-80dd-4cd8-bd15-17e47598c8d4.png)

Additionally migrate related settings:
- if `mapAutoDownloads` have been disabled: set `mapAutoDownloadInterval` to 0
- remove `mapAutoDownloads` key
- if `routingTileAutoDownloads` have been disabled: set `routingTileAutoDownloadsInterval` to 0
- do NOT remove `routingTileAutoDownloads` key, as it is still used to decide whether to offer downloads of missing routing tiles

