### PR TITLE
make map/tile update info scrollable (fix #12165)

### DIFF
--- a/main/res/layout/downloader_confirmation.xml
+++ b/main/res/layout/downloader_confirmation.xml
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <TextView
-        android:id="@+id/download_info"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+    <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="20dp"
-        android:paddingLeft="8dp" />
+        android:layout_height="wrap_content">
 
-    <CheckBox
-        android:id="@+id/allow_metered_network"
-        style="@style/checkbox_full"
-        android:paddingTop="20dp"
-        android:paddingLeft="8dp"
-        android:text="@string/downloadmap_allow_metered_network" />
+        <TextView
+            android:id="@+id/download_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="20dp"
+            android:paddingLeft="8dp" />
 
-    <TextView
-        android:id="@+id/download_handling"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="20dp"
-        android:paddingLeft="8dp"
-        android:text="@string/downloadmap_handling"/>
+        <CheckBox
+            android:id="@+id/allow_metered_network"
+            style="@style/checkbox_full"
+            android:paddingTop="20dp"
+            android:paddingLeft="8dp"
+            android:text="@string/downloadmap_allow_metered_network" />
 
-</LinearLayout>
+        <TextView
+            android:id="@+id/download_handling"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="20dp"
+            android:paddingLeft="8dp"
+            android:text="@string/downloadmap_handling"/>
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Description
Make the `AlertDialog` window with routing/map update info scrollable

## Additional context
~@Lineflyer 
Can you cross-check (as time permits) - cannot test here, only have 20 or so tiles downloaded :-)~

Just did a retest with font size set to maximum - view is now scrollable as expected.