### PR TITLE
fix #11941: allow loading more caches for new gc search and oc

### DIFF
--- a/main/src/cgeo/geocaching/SearchResult.java
+++ b/main/src/cgeo/geocaching/SearchResult.java
@@ -39,7 +39,7 @@ public class SearchResult implements Parcelable {
 
     public static final String SEARCHSTATE_FINDER = "ss_finder";
 
-    public static final String CON_TOTALCOUNT = "con_totalcount";
+    public static final String CON_LEFT_TO_FETCH = "con_lefttofetch";
     public static final String CON_URL = "con_url";
     public static final String CON_ERROR = "con_error";
 
@@ -98,15 +98,15 @@ public class SearchResult implements Parcelable {
      *
      * @param geocodes
      *            a non-null collection of geocodes
-     * @param totalCountGC
+     * @param totalCount
      *            the total number of caches matching that search on geocaching.com (as we always get only the next 20
      *            from a web page)
      */
-    public SearchResult(final IConnector con, final Collection<String> geocodes, final int totalCountGC) {
+    public SearchResult(final IConnector con, final Collection<String> geocodes, final int totalCount) {
         this.geocodes.clear();
         this.geocodes.addAll(geocodes);
         this.filteredGeocodes.clear();
-        this.setTotalCount(con, totalCountGC);
+        this.setLeftToFetch(con, Math.max(0, totalCount - geocodes.size()));
     }
 
     /**
@@ -195,13 +195,13 @@ public class SearchResult implements Parcelable {
     }
 
     public int getTotalCount() {
-        return reduceToContext(bb -> bb.getInt(CON_TOTALCOUNT), 0, (i1, i2) -> i1 + i2);
+        //this returns the total ACHIEVABLE count by adding the returned total count differences to the
+        return reduceToContext(bb -> bb.getInt(CON_LEFT_TO_FETCH, 0), getCount(), (i1, i2) -> i1 + i2);
     }
 
-    public void setTotalCount(final IConnector con, final int totalCountGC) {
-        setToContext(con, b -> b.putInt(CON_TOTALCOUNT, totalCountGC));
+    public void setLeftToFetch(final IConnector con, final int leftToFetch) {
+        setToContext(con, b -> b.putInt(CON_LEFT_TO_FETCH, leftToFetch));
     }
-
 
     public Bundle getConnectorContext(@Nullable final IConnector con) {
         return getConnectorContext(con == null ? "null" : con.getName());

--- a/main/src/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/cgeo/geocaching/connector/al/ALConnector.java
@@ -125,7 +125,6 @@ public class ALConnector extends AbstractConnector implements ISearchByGeocode, 
     public SearchResult searchByViewport(@NonNull final Viewport viewport) {
         final Collection<Geocache> caches = ALApi.searchByBBox(viewport);
         final SearchResult searchResult = new SearchResult(caches);
-        searchResult.setTotalCount(this, caches.size());
         return searchResult.putInCacheAndLoadRating();
     }
 

--- a/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.connector.gc;
 
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.enumerations.CacheSize;
@@ -115,6 +116,14 @@ class GCWebAPI {
             this.sort = sort;
             this.sortAsc = sortAsc;
             return this;
+        }
+
+        public int getTake() {
+            return take;
+        }
+
+        public int getSkip() {
+            return skip;
         }
 
         public SortType getSort() {
@@ -762,10 +771,11 @@ class GCWebAPI {
         return getAPI("/web/v1/geocache/" + StringUtils.lowerCase(geocode), CacheDetails.class);
     }
 
-    static SearchResult searchCaches(final WebApiSearch search, final boolean includeGcVote) {
+    static SearchResult searchCaches(final IConnector con, final WebApiSearch search, final boolean includeGcVote) {
         final SearchResult result = new SearchResult();
 
         final MapSearchResultSet mapSearchResultSet = search.execute();
+        result.setLeftToFetch(con, mapSearchResultSet.total - search.getTake() - search.getSkip());
         final List<Geocache> foundCaches = new ArrayList<>();
 
         if (mapSearchResultSet.results != null) {
@@ -870,11 +880,6 @@ class GCWebAPI {
             }
         }
     }
-
-    static SearchResult searchMap(@NonNull final Viewport viewport) {
-        return searchCaches(new WebApiSearch().setBox(viewport), false);
-    }
-
 
     @NonNull
     static ImmutablePair<StatusCode, String> postLog(final Geocache geocache,

--- a/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.connector.UserInfo.UserInfoStatus;
 import cgeo.geocaching.connector.capability.IIgnoreCapability;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.ISearchByFilter;
+import cgeo.geocaching.connector.capability.ISearchByNextPage;
 import cgeo.geocaching.connector.capability.ISearchByViewPort;
 import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
@@ -22,6 +23,8 @@ import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.utils.CryptUtils;
 import cgeo.geocaching.utils.Log;
 
+import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
@@ -30,7 +33,7 @@ import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class OCApiLiveConnector extends OCApiConnector implements ISearchByViewPort, ILogin, ISearchByFilter, WatchListCapability, IIgnoreCapability, PersonalNoteCapability {
+public class OCApiLiveConnector extends OCApiConnector implements ISearchByViewPort, ILogin, ISearchByFilter, ISearchByNextPage, WatchListCapability, IIgnoreCapability, PersonalNoteCapability {
 
     private final String cS;
     private final int isActivePrefKeyId;
@@ -186,8 +189,15 @@ public class OCApiLiveConnector extends OCApiConnector implements ISearchByViewP
     @NonNull
     @Override
     public SearchResult searchByFilter(@NonNull final GeocacheFilter filter) {
-        return OkapiClient.getCachesByFilter(filter, this);
+        return OkapiClient.getCachesByFilter(this, filter);
     }
+
+    @NonNull
+    @Override
+    public SearchResult searchByNextPage(final Bundle context) {
+        return OkapiClient.getCachesByNextPage(this, context);
+    }
+
 
     @Override
     public boolean isSearchForMyCaches(final String username) {

--- a/main/src/cgeo/geocaching/enumerations/CacheListType.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheListType.java
@@ -6,17 +6,17 @@ import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import androidx.annotation.NonNull;
 
 public enum CacheListType {
-    OFFLINE(true, GeocacheFilterContext.FilterType.OFFLINE, AbstractBottomNavigationActivity.MENU_LIST, true),
-    POCKET(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_HIDE_BOTTOM_NAVIGATION),
-    HISTORY(true, GeocacheFilterContext.FilterType.TRANSIENT, AbstractBottomNavigationActivity.MENU_LIST, true),
-    NEAREST(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_NEARBY),
-    COORDINATE(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH),
-    KEYWORD(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH),
-    ADDRESS(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH),
-    FINDER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH),
-    OWNER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH),
-    MAP(false, GeocacheFilterContext.FilterType.TRANSIENT, AbstractBottomNavigationActivity.MENU_MAP),
-    SEARCH_FILTER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH);
+    OFFLINE(true, GeocacheFilterContext.FilterType.OFFLINE, AbstractBottomNavigationActivity.MENU_LIST, true, false),
+    POCKET(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_HIDE_BOTTOM_NAVIGATION, false, true),
+    HISTORY(true, GeocacheFilterContext.FilterType.TRANSIENT, AbstractBottomNavigationActivity.MENU_LIST, true, false),
+    NEAREST(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_NEARBY, false, true),
+    COORDINATE(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
+    KEYWORD(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
+    ADDRESS(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
+    FINDER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
+    OWNER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
+    MAP(false, GeocacheFilterContext.FilterType.TRANSIENT, AbstractBottomNavigationActivity.MENU_MAP, false, false),
+    SEARCH_FILTER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true);
 
     /**
      * whether or not this list allows switching to another list type
@@ -32,16 +32,18 @@ public enum CacheListType {
      */
     public final int navigationMenuItem;
     public final boolean isStoredInDatabase;
+    public final boolean isOnline;
 
     CacheListType(final boolean canSwitch, @NonNull final GeocacheFilterContext.FilterType filterContextType, final int navigationMenuItem) {
-        this(canSwitch, filterContextType, navigationMenuItem, false);
+        this(canSwitch, filterContextType, navigationMenuItem, false, false);
     }
 
-    CacheListType(final boolean canSwitch, @NonNull final GeocacheFilterContext.FilterType filterContextType, final int navigationMenuItem, final boolean isStoredInDatabase) {
+    CacheListType(final boolean canSwitch, @NonNull final GeocacheFilterContext.FilterType filterContextType, final int navigationMenuItem, final boolean isStoredInDatabase, final boolean isOnline) {
         this.canSwitch = canSwitch;
         this.filterContextType = filterContextType;
         this.navigationMenuItem = navigationMenuItem;
         this.isStoredInDatabase = isStoredInDatabase;
+        this.isOnline = isOnline;
     }
 
 }

--- a/main/src/cgeo/geocaching/sorting/InverseComparator.java
+++ b/main/src/cgeo/geocaching/sorting/InverseComparator.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.sorting;
 
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.SqlBuilder;
 
 import androidx.annotation.NonNull;
 
@@ -32,5 +33,10 @@ public class InverseComparator implements CacheComparator {
     @Override
     public void sort(final List<Geocache> list) {
         Collections.sort(list, this);
+    }
+
+    @Override
+    public void addSortToSql(final SqlBuilder sql, final boolean sortDesc) {
+        originalComparator.addSortToSql(sql, !sortDesc);
     }
 }


### PR DESCRIPTION
fix #11941: allow loading more caches for new gc search and oc

This PR extends the "load more caches" functionality to the new GC search as well as OC search. Initially 200 caches are loaded per (active) connector, each "load more" will try to load 50 more caches from each connector