### PR TITLE
rel to #12146: introduce overflow character _ into calculator

### DIFF
--- a/main/src/cgeo/geocaching/utils/calc/CalculatorUtils.java
+++ b/main/src/cgeo/geocaching/utils/calc/CalculatorUtils.java
@@ -31,20 +31,6 @@ public class CalculatorUtils {
         //no instance
     }
 
-    public static Value concat(final ValueList values) {
-        values.checkCount(1, -1);
-
-        if (values.size() == 1) {
-            return values.get(0);
-        }
-
-        final StringBuilder sb = new StringBuilder();
-        for (Value v : values) {
-            sb.append(v.getAsString());
-        }
-        return Value.of(sb.toString());
-    }
-
     public static int random(final int max, final int min) {
         final int umax = max < 0 ? 10 : max;
         final int umin = Math.max(min, 0);

--- a/tests/src/cgeo/geocaching/utils/calc/CalculatorMapTest.java
+++ b/tests/src/cgeo/geocaching/utils/calc/CalculatorMapTest.java
@@ -128,7 +128,7 @@ public class CalculatorMapTest {
                 fail("no var to assert");
             } else if (prop instanceof Double) {
                 assertThat(state.getResult()).isNotNull();
-                assertThat(state.getResult().getRaw()).as(assertAs + "result " + prop).isEqualTo(prop);
+                assertThat(state.getResult().getAsDouble()).as(assertAs + "result " + prop).isEqualTo(prop);
                 assertThat(state.getState()).as(assertAs + "state OK").isEqualTo(OK);
                 assertThat(state.getError()).as(assertAs + "no error").isNull();
             } else if (prop instanceof CalculatorMap.State) {

--- a/tests/src/cgeo/geocaching/utils/calc/CalculatorTest.java
+++ b/tests/src/cgeo/geocaching/utils/calc/CalculatorTest.java
@@ -195,4 +195,26 @@ public class CalculatorTest {
         assertThat(Value.of("abcd").isInteger()).isFalse();
     }
 
+    @Test
+    public void overflow() {
+        assertThat(eval("A8.A2", "A", 10)).isEqualTo(108.102d);
+        assertThat(eval("_A8._A2", "A", 10)).isEqualTo(108.102d);
+        assertThat(eval("_A8._A2", "A", 8)).isEqualTo(88.082d);
+        assertThat(eval("8._1_A2", "A", 8)).isEqualTo(8.01082d);
+        assertThat(eval("8.A__A2", "A", 14)).isEqualTo(8.140142d);
+        assertThat(eval("_A._A", "A", 143)).isEqualTo(143.143d);
+        assertThat(eval("_A._A", "A", 14)).isEqualTo(14.14d);
+        assertThat(eval("_A._A", "A", 1)).isEqualTo(1.01d);
+
+        //handling of _ on more strange positions
+        assertThat(eval("5._1")).isEqualTo(5.01d);
+        assertThat(eval("5._12")).as("number should not spill over to _").isEqualTo(5.012d);
+        assertThat(eval("5._(8+1)")).as("expression results should spill over").isEqualTo(5.09d);
+        assertThat(eval("5._(8+5)")).as("expression results should spill over").isEqualTo(5.13d);
+        assertThat(eval("5_.12")).as("_ before . should have no effect").isEqualTo(5.12d);
+        assertThat(Calculator.evaluate("_5.12").getAsString()).as("_ at start should be removed").isEqualTo("5.12");
+        assertThat(Calculator.evaluate("5.12_").getAsString()).as("_ at end should be removed").isEqualTo("5.12");
+
+    }
+
 }

--- a/tests/src/cgeo/geocaching/utils/calc/CalculatorUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/calc/CalculatorUtilsTest.java
@@ -9,11 +9,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public class CalculatorUtilsTest {
 
     @Test
-    public void concat() {
-        assertThat(CalculatorUtils.concat(new ValueList().add(Value.of("a"), Value.of("b"))).getRaw()).isEqualTo("ab");
-    }
-
-    @Test
     public void substring() {
         assertThat(CalculatorUtils.substring("test", 1, 2)).isEqualTo("es");
         assertThat(CalculatorUtils.substring(null, 1, 2)).isEqualTo("");


### PR DESCRIPTION
rel to #12146: introduce overflow character _ into calculator

In order to replace the special "blank" symbol (used as an overflow/spillover placeholder) needed for button-bound calculated variable, we need to introduce same capacity to the new calculator engine. character _ is used for that