### PR TITLE
enable line breaks in cache popup stars (fix #12164)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -375,6 +375,9 @@ dependencies {
     // Support Library core (used for eg. HtmlCompat)
     implementation 'androidx.core:core:1.6.0'
 
+    // Support Library constraintlayout
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+
     // Support Library ExifInterface
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
 

--- a/main/res/layout/cache_information_item.xml
+++ b/main/res/layout/cache_information_item.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="3dip" >
+    android:layout_marginBottom="3dip">
 
     <TextView
         android:id="@+id/name"
         android:layout_width="100sp"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="false"
-        android:layout_centerVertical="false"
         android:layout_gravity="left|top"
         android:layout_marginRight="8dip"
         android:ellipsize="end"
@@ -24,56 +23,70 @@
         android:textColor="@color/colorTextHint"
         tools:text="property"/>
 
-    <TextView
-        android:id="@+id/value"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_height="wrap_content"
-        android:layout_centerVertical="false"
-        android:layout_marginRight="5dip"
-        android:layout_toRightOf="@+id/name"
-        android:gravity="center_vertical"
-        android:textSize="@dimen/textSize_detailsPrimary"
-        android:textIsSelectable="false"
-        android:textColor="@color/colorText"
-        tools:text="value"/>
-
-    <RatingBar
-        android:id="@+id/stars"
-        style="@style/cacheRatingBar"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:layout_gravity="center_horizontal"
-        android:layout_toRightOf="@+id/value"
-        android:baselineAligned="false"
-        android:gravity="center_vertical"
-        android:numStars="5"
-        android:visibility="gone"
-        tools:rating="2"
-        tools:visibility="visible"/>
+        android:orientation="horizontal"
+        android:layout_toRightOf="@id/name">
 
-    <TextView
-        android:id="@+id/addition"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerVertical="false"
-        android:layout_marginLeft="5dip"
-        android:layout_toRightOf="@+id/stars"
-        android:gravity="center_vertical"
-        android:textIsSelectable="false"
-        android:maxLines="1"
-        android:visibility="gone"
-        android:textColor="@color/colorText"
-        tools:text="additional text"
-        tools:visibility="visible"/>
+        <TextView
+            android:id="@+id/value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:textSize="@dimen/textSize_detailsPrimary"
+            android:textIsSelectable="false"
+            android:textColor="@color/colorText"
+            android:visibility="gone"
+            tools:text="value"/>
 
-    <LinearLayout
-        android:id="@+id/linearlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@+id/name"
-        android:gravity="bottom"
-        android:paddingTop="3dp"
-        android:orientation="horizontal" />
+        <RatingBar
+            android:id="@+id/stars"
+            style="@style/cacheRatingBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:baselineAligned="true"
+            android:gravity="center_vertical"
+            android:numStars="5"
+            android:visibility="gone"
+            tools:rating="2"
+            tools:visibility="visible"
+            tools:ignore="MissingConstraints"/>
 
+        <TextView
+            android:id="@+id/addition"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:textIsSelectable="false"
+            android:maxLines="1"
+            android:visibility="gone"
+            android:textColor="@color/colorText"
+            tools:text="additional text"
+            tools:visibility="visible"
+            tools:ignore="MissingConstraints"/>
+
+        <LinearLayout
+            android:id="@+id/linearlayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="bottom|left"
+            android:paddingTop="3dp"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:ignore="MissingConstraints"/>
+
+        <androidx.constraintlayout.helper.widget.Flow
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:flow_wrapMode="chain"
+            app:flow_horizontalStyle="packed"
+            app:flow_horizontalBias="0"
+            app:flow_horizontalGap="5dip"
+            app:constraint_referenced_ids="value, stars, addition, linearlayout" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </RelativeLayout>

--- a/main/src/cgeo/geocaching/ui/CacheDetailsCreator.java
+++ b/main/src/cgeo/geocaching/ui/CacheDetailsCreator.java
@@ -60,6 +60,9 @@ public final class CacheDetailsCreator {
     public ImmutablePair<RelativeLayout, TextView> add(final int nameId, final CharSequence value) {
         final ImmutablePair<RelativeLayout, TextView> nameValue = createNameValueLine(nameId);
         nameValue.getRight().setText(value);
+        if (StringUtils.isNotBlank(value)) {
+            nameValue.getRight().setVisibility(View.VISIBLE);
+        }
         return nameValue;
     }
 
@@ -75,6 +78,9 @@ public final class CacheDetailsCreator {
         final ImmutablePair<RelativeLayout, TextView> nameValue = createNameValueLine(nameId);
         final TextView valueView = nameValue.getRight();
         valueView.setText(HtmlCompat.fromHtml(value.toString(), HtmlCompat.FROM_HTML_MODE_LEGACY, new SmileyImage(geocode, valueView), new UnknownTagsHandler()), TextView.BufferType.SPANNABLE);
+        if (StringUtils.isNotBlank(value)) {
+            nameValue.getRight().setVisibility(View.VISIBLE);
+        }
         return nameValue;
     }
 
@@ -99,6 +105,7 @@ public final class CacheDetailsCreator {
 
         nameView.setText(activity.getString(nameId));
         valueView.setText(String.format(Locale.getDefault(), activity.getString(R.string.cache_rating_of_new), value, max));
+        valueView.setVisibility(View.VISIBLE);
 
         final RatingBar layoutStars = layout.findViewById(R.id.stars);
         layoutStars.setNumStars(max);
@@ -254,6 +261,7 @@ public final class CacheDetailsCreator {
         }
         if (markers.getChildCount() > 0) {
             parentView.addView(layout);
+            markers.setVisibility(View.VISIBLE);
         }
     }
 }


### PR DESCRIPTION
## Description
Enable content of right column in cache popup to wrap

|regular font size|largest font size|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/143784457-56954a5e-d00d-4781-a3d9-29a8d0b69bd6.png)|![image](https://user-images.githubusercontent.com/3754370/143784450-b0c6b8a3-f609-421d-80e3-2ec36729c502.png)|

Tested in emulator with a Pixel 2 (at 480 x 800 px resolution)