### PR TITLE
attributes sorting in cache details and attribute filter (fix #12189)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1971,6 +1971,7 @@
     <string name="attribute_historic_no">No abandoned structure / No ruin</string>
     <string name="attribute_blind_people_yes">Handicap: Blind</string>
     <string name="attribute_blind_people_no">No handicap: Blind</string>
+    <string name="attribute_unknown">Unknown attribute</string>
 
     <!-- cache attribute categories -->
     <string name="cat_tools">Tools required</string>

--- a/main/src/cgeo/geocaching/AttributesGridAdapter.java
+++ b/main/src/cgeo/geocaching/AttributesGridAdapter.java
@@ -76,9 +76,11 @@ public class AttributesGridAdapter extends BaseAdapter {
         if (attrib != null) {
             imageView.setImageDrawable(ResourcesCompat.getDrawable(resources, attrib.drawableId, null));
             ViewUtils.setTooltip(imageView, TextParam.text(attrib.getL10n(CacheAttribute.isEnabled(attributeName))));
+            imageView.setContentDescription(attrib.getL10n(CacheAttribute.isEnabled(attributeName)));
         } else {
             imageView.setImageDrawable(ResourcesCompat.getDrawable(resources, R.drawable.attribute_unknown, null));
             ViewUtils.setTooltip(imageView, TextParam.text(context.getString(R.string.attribute_unknown)));
+            imageView.setContentDescription(context.getString(R.string.attribute_unknown));
         }
     }
 

--- a/main/src/cgeo/geocaching/AttributesGridAdapter.java
+++ b/main/src/cgeo/geocaching/AttributesGridAdapter.java
@@ -2,6 +2,8 @@ package cgeo.geocaching;
 
 import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
 
 import android.app.Activity;
 import android.content.res.Resources;
@@ -65,16 +67,18 @@ public class AttributesGridAdapter extends BaseAdapter {
     }
 
     private void drawAttribute(final FrameLayout attributeLayout, final String attributeName) {
-        final ImageView imageView = (ImageView) attributeLayout.findViewById(R.id.attribute_image);
-        final ImageView strikeThrough = (ImageView) attributeLayout.findViewById(R.id.attribute_strikethru);
+        final ImageView imageView = attributeLayout.findViewById(R.id.attribute_image);
+        final ImageView strikeThrough = attributeLayout.findViewById(R.id.attribute_strikethru);
 
         strikeThrough.setVisibility(CacheAttribute.isEnabled(attributeName) ? View.INVISIBLE : View.VISIBLE);
 
         final CacheAttribute attrib = CacheAttribute.getByRawName(CacheAttribute.trimAttributeName(attributeName));
         if (attrib != null) {
             imageView.setImageDrawable(ResourcesCompat.getDrawable(resources, attrib.drawableId, null));
+            ViewUtils.setTooltip(imageView, TextParam.text(attrib.getL10n(CacheAttribute.isEnabled(attributeName))));
         } else {
             imageView.setImageDrawable(ResourcesCompat.getDrawable(resources, R.drawable.attribute_unknown, null));
+            ViewUtils.setTooltip(imageView, TextParam.text(context.getString(R.string.attribute_unknown)));
         }
     }
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1283,13 +1283,13 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                             if (attributesSet.contains(key)) {
                                 if (lastCategoryId != categoryId) {
                                     if (lastCategoryId != -1) {
-                                        text.append("\n\n");
+                                        text.append("<br /><br />");
                                     }
-                                    text.append(CacheAttributeCategory.getNameById(activity, categoryId));
+                                    text.append("<u>").append(CacheAttributeCategory.getNameById(activity, categoryId)).append("</u>");
                                     lastCategoryId = categoryId;
                                 }
                                 a.add(key);
-                                text.append('\n').append(attr.getL10n(enabled));
+                                text.append("<br />").append(attr.getL10n(enabled));
                             }
                         }
                     }
@@ -1300,7 +1300,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             binding.attributesGrid.setVisibility(View.VISIBLE);
             binding.attributesGrid.setOnItemClickListener((parent, view, position, id) -> toggleAttributesView());
 
-            binding.attributesText.setText(text);
+            binding.attributesText.setText(HtmlCompat.fromHtml(text.toString(), 0));
             binding.attributesText.setVisibility(View.GONE);
             binding.attributesText.setOnClickListener(v -> toggleAttributesView());
         }

--- a/main/src/cgeo/geocaching/enumerations/CacheAttribute.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheAttribute.java
@@ -55,7 +55,7 @@ public enum CacheAttribute {
     JEEPS(CacheAttributeCategory.CAT_TRANSPORT.categoryId, 35, -1, "jeeps", R.drawable.attribute_jeeps, R.string.attribute_jeeps_yes, R.string.attribute_jeeps_no),
     SNOWMOBILES(CacheAttributeCategory.CAT_TRANSPORT.categoryId, 36, -1, "snowmobiles", R.drawable.attribute_snowmobiles, R.string.attribute_snowmobiles_yes, R.string.attribute_snowmobiles_no),
     HORSES(CacheAttributeCategory.CAT_TRANSPORT.categoryId, 37, -1, "horses", R.drawable.attribute_horses, R.string.attribute_horses_yes, R.string.attribute_horses_no),
-    CAMPFIRES(CacheAttributeCategory.CAT_DURATION.categoryId, 38, -1, "campfires", R.drawable.attribute_campfires, R.string.attribute_campfires_yes, R.string.attribute_campfires_no),
+    CAMPFIRES(CacheAttributeCategory.CAT_SURROUNDINGS.categoryId, 38, -1, "campfires", R.drawable.attribute_campfires, R.string.attribute_campfires_yes, R.string.attribute_campfires_no),
     THORN(CacheAttributeCategory.CAT_SURROUNDINGS.categoryId, 39, 63, "thorn", R.drawable.attribute_thorn, R.string.attribute_thorn_yes, R.string.attribute_thorn_no),
     STEALTH(CacheAttributeCategory.CAT_LOCATION.categoryId, 40, 74, "stealth", R.drawable.attribute_stealth, R.string.attribute_stealth_yes, R.string.attribute_stealth_no),
     STROLLER(CacheAttributeCategory.CAT_TRANSPORT.categoryId, 41, -1, "stroller", R.drawable.attribute_stroller, R.string.attribute_stroller_yes, R.string.attribute_stroller_no),

--- a/main/src/cgeo/geocaching/filters/gui/AttributesFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/AttributesFilterViewHolder.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.filters.gui;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheAttribute;
+import cgeo.geocaching.enumerations.CacheAttributeCategory;
 import cgeo.geocaching.filters.core.AttributesGeocacheFilter;
 import cgeo.geocaching.ui.ButtonToggleGroup;
 import cgeo.geocaching.ui.TextParam;
@@ -75,12 +76,16 @@ public class AttributesFilterViewHolder extends BaseFilterViewHolder<AttributesG
         final ChipGroup cg = new ChipGroup(getActivity());
         cg.setChipSpacing(dpToPixel(10));
 
-        for (CacheAttribute ca: CacheAttribute.values()) {
-            final View view = createAttributeIcon(ca);
-            view.setOnClickListener(v -> toggleAttributeIcon(ca));
-            this.attributeViews.put(ca, view);
-            this.attributeState.put(ca, null);
-            cg.addView(view);
+        for (int categoryId : CacheAttributeCategory.getOrderedCategoryIdList()) {
+            for (CacheAttribute ca : CacheAttribute.values()) {
+                if (ca.categoryId == categoryId) {
+                    final View view = createAttributeIcon(ca);
+                    view.setOnClickListener(v -> toggleAttributeIcon(ca));
+                    this.attributeViews.put(ca, view);
+                    this.attributeState.put(ca, null);
+                    cg.addView(view);
+                }
+            }
         }
 
         final LinearLayout ll = new LinearLayout(getActivity());

--- a/main/src/cgeo/geocaching/filters/gui/AttributesFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/AttributesFilterViewHolder.java
@@ -58,14 +58,17 @@ public class AttributesFilterViewHolder extends BaseFilterViewHolder<AttributesG
             icon.setColorFilter(Color.argb(150, 200, 200, 200));
             strikeThrough.setVisibility(View.INVISIBLE);
             setTooltip(v, TextParam.text(ca.getL10n(true)));
+            icon.setContentDescription(ca.getL10n(true));
         } else if (state) {
             icon.clearColorFilter();
             strikeThrough.setVisibility(View.INVISIBLE);
             setTooltip(v, TextParam.text(ca.getL10n(true)));
+            icon.setContentDescription(ca.getL10n(true));
         } else {
             icon.clearColorFilter();
             strikeThrough.setVisibility(View.VISIBLE);
             setTooltip(v, TextParam.text(ca.getL10n(false)));
+            icon.setContentDescription(ca.getL10n(false));
         }
     }
 


### PR DESCRIPTION
## Description
Sort attributes in cache details page and in attribute filter according to the attribute categories:

|cache details: icons|cache details: texts|attribute filter|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3754370/143786146-31047178-b2f7-41fb-bf56-9075237c452e.png)|![image](https://user-images.githubusercontent.com/3754370/143786150-090082b5-622d-48c8-b515-72fa6ec9b0a7.png)|![image](https://user-images.githubusercontent.com/3754370/143786155-f2de697b-ef29-4b27-a5b1-de52f85ab60e.png)|

(also fixes one category assignment)