### PR TITLE
quick-load geocode from clipboard text

### DIFF
--- a/main/res/drawable/ic_menu_paste_search.xml
+++ b/main/res/drawable/ic_menu_paste_search.xml
@@ -1,0 +1,14 @@
+<!-- taken from https://fonts.google.com/icons?selected=Material%20Icons%3Acontent_paste_search%3A -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:pathData="M5,5h2v3h10V5h2v5h2V5c0,-1.1 -0.9,-2 -2,-2h-4.18C14.4,1.84 13.3,1 12,1S9.6,1.84 9.18,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h5v-2H5V5zM12,3c0.55,0 1,0.45 1,1s-0.45,1 -1,1s-1,-0.45 -1,-1S11.45,3 12,3z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M20.3,18.9c0.4,-0.7 0.7,-1.5 0.7,-2.4c0,-2.5 -2,-4.5 -4.5,-4.5S12,14 12,16.5s2,4.5 4.5,4.5c0.9,0 1.7,-0.3 2.4,-0.7l2.7,2.7l1.4,-1.4L20.3,18.9zM16.5,19c-1.4,0 -2.5,-1.1 -2.5,-2.5c0,-1.4 1.1,-2.5 2.5,-2.5s2.5,1.1 2.5,2.5C19,17.9 17.9,19 16.5,19z"
+      android:fillColor="#000000"/>
+</vector>

--- a/main/res/menu/main_activity_options.xml
+++ b/main/res/menu/main_activity_options.xml
@@ -12,6 +12,13 @@
         app:iconifiedByDefault="true"
         app:showAsAction="collapseActionView|always" />
     <item
+        android:id="@+id/menu_paste_search"
+        android:icon="@drawable/ic_menu_paste_search"
+        android:title="@string/menu_search_clipboard"
+        android:visible="false"
+        app:showAsAction="always">
+    </item>
+    <item
         android:id="@+id/menu_history"
         android:icon="@drawable/ic_menu_recent_history"
         android:title="@string/menu_history_longstring"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -344,6 +344,7 @@
     <string name="menu_update_mapdata">Map data</string>
     <string name="menu_dashboard">Login dashboard</string>
     <string name="menu_history">History</string>
+    <string name="menu_search_clipboard">Load geocode from clipboard</string>
     <string name="menu_history_longstring">Finds history</string>
     <string name="menu_filter">Filter</string>
     <string name="menu_lists_pocket_queries">Pocket queries</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -38,6 +38,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.BackupUtils;
+import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.Formatter;
@@ -503,6 +504,8 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             startActivityForResult(new Intent(this, SettingsActivity.class), Intents.SETTINGS_ACTIVITY_REQUEST_CODE);
         } else if (id == R.id.menu_backup) {
             SettingsActivity.openForScreen(R.string.preference_screen_backup, this);
+        } else if (id == R.id.menu_paste_search) {
+            startActivity(new Intent(this, SearchActivity.class).setAction(SearchActivity.ACTION_CLIPBOARD).putExtra(SearchManager.QUERY, ClipboardUtils.getText()));
         } else if (id == R.id.menu_history) {
             startActivity(CacheListActivity.getHistoryIntent(this));
             ActivityMixin.finishWithFadeTransition(this);
@@ -533,7 +536,9 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             @Override
             public boolean onMenuItemActionExpand(final MenuItem item) {
                 for (int i = 0; i < menu.size(); i++) {
-                    if (menu.getItem(i).getItemId() != R.id.menu_gosearch) {
+                    if (menu.getItem(i).getItemId() == R.id.menu_paste_search && ConnectorFactory.containsGeocode(ClipboardUtils.getText())) {
+                        menu.getItem(i).setVisible(true);
+                    } else if (menu.getItem(i).getItemId() != R.id.menu_gosearch) {
                         menu.getItem(i).setVisible(false);
                     }
                 }

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -240,10 +240,17 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
      */
     private void handlePotentialClipboardGeocode() {
         binding.geocodeInputLayout.postDelayed(() -> {
-            final String potentialGeocode = ClipboardUtils.getText();
+            final String clipboardText = ClipboardUtils.getText();
 
-            if (ConnectorFactory.getConnector(potentialGeocode) instanceof ISearchByGeocode) {
-                binding.geocode.setText(potentialGeocode);
+            String geocode;
+
+            if (ConnectorFactory.getConnector(clipboardText) instanceof ISearchByGeocode) {
+                geocode = clipboardText;
+            } else {
+                geocode = ConnectorFactory.getGeocodeFromText(clipboardText);
+            }
+            if (geocode != null && !geocode.isEmpty()) {
+                binding.geocode.setText(geocode);
                 binding.geocodeInputLayout.setHelperText(getString(R.string.search_geocode_from_clipboard));
 
                 // clear hint if text input get changed

--- a/main/src/cgeo/geocaching/SearchActivity.java
+++ b/main/src/cgeo/geocaching/SearchActivity.java
@@ -305,7 +305,7 @@ public class SearchActivity extends AbstractBottomNavigationActivity implements 
             } else {
                 geocode = ConnectorFactory.getGeocodeFromText(clipboardText);
             }
-            if (!geocode.isEmpty()) {
+            if (!StringUtils.isEmpty(geocode)) {
                 binding.geocode.setText(geocode);
                 binding.geocodeInputLayout.setHelperText(getString(R.string.search_geocode_from_clipboard));
 

--- a/main/src/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/cgeo/geocaching/connector/AbstractConnector.java
@@ -151,6 +151,12 @@ public abstract class AbstractConnector implements IConnector {
         return null;
     }
 
+    @Override
+    @Nullable
+    public String getGeocodeFromText(@NonNull final String text) {
+        return null;
+    }
+
     @NonNull
     protected abstract String getCacheUrlPrefix();
 

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -382,6 +382,15 @@ public final class ConnectorFactory {
         return null;
     }
 
+    /**
+     * Checks if text can be interpreted as a geocode, either directly or by extracting one
+     * @param text  String containing a geocode (or not)
+     * @return true if a geocode is found
+     */
+    public static boolean containsGeocode(@Nullable final String text) {
+        return (getGeocodeFromURL(text) != null || getGeocodeFromText(text) != null);
+    }
+
     @NonNull
     public static Collection<TrackableConnector> getTrackableConnectors() {
         return TRACKABLE_CONNECTORS;

--- a/main/src/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/cgeo/geocaching/connector/ConnectorFactory.java
@@ -368,6 +368,20 @@ public final class ConnectorFactory {
         return null;
     }
 
+    @Nullable
+    public static String getGeocodeFromText(@Nullable final String text) {
+        if (text == null) {
+            return null;
+        }
+        for (final IConnector connector : CONNECTORS) {
+            final String geocode = connector.getGeocodeFromText(text);
+            if (StringUtils.isNotBlank(geocode)) {
+                return StringUtils.upperCase(geocode);
+            }
+        }
+        return null;
+    }
+
     @NonNull
     public static Collection<TrackableConnector> getTrackableConnectors() {
         return TRACKABLE_CONNECTORS;

--- a/main/src/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/cgeo/geocaching/connector/IConnector.java
@@ -165,6 +165,13 @@ public interface IConnector {
     String getGeocodeFromUrl(@NonNull String url);
 
     /**
+     * extract a geocode from the given Text, if this connector can handle that text somehow
+     *
+     */
+    @Nullable
+    String getGeocodeFromText(@NonNull String text);
+
+    /**
      * enable/disable uploading modified coordinates to website
      *
      * @return true, when uploading is possible

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -42,6 +42,7 @@ import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ShareUtils;
+import cgeo.geocaching.utils.TextUtils;
 
 import android.os.Bundle;
 
@@ -83,7 +84,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
      * Pattern for GC codes
      */
     @NonNull
-    private static final Pattern PATTERN_GC_CODE = Pattern.compile("GC[0-9A-Z&&[^ILOSU]]+", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PATTERN_GC_CODE = Pattern.compile(GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE);
 
     private GCConnector() {
         // singleton
@@ -435,16 +436,15 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     @Nullable
     public String getGeocodeFromUrl(@NonNull final String url) {
-        final String noQueryString = StringUtils.substringBefore(url, "?");
         // coord.info URLs
-        final String afterCoord = StringUtils.substringAfterLast(noQueryString, "coord.info/");
-        if (canHandle(afterCoord)) {
-            return afterCoord;
+        final String coordinfoUrl = TextUtils.getMatch(url, Pattern.compile("coord.info/"+GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
+        if (canHandle(coordinfoUrl)) {
+            return coordinfoUrl;
         }
         // expanded geocaching.com URLs
-        final String afterGeocache = StringUtils.substringBetween(noQueryString, "/geocache/", "_");
-        if (afterGeocache != null && canHandle(afterGeocache)) {
-            return afterGeocache;
+        final String geocachingcomUrl = TextUtils.getMatch(url, Pattern.compile("geocache/"+GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
+        if (canHandle(geocachingcomUrl)) {
+            return geocachingcomUrl;
         }
         return null;
     }

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -442,7 +442,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
             return coordinfoUrl;
         }
         // expanded geocaching.com URLs
-        final String geocachingcomUrl = TextUtils.getMatch(url, Pattern.compile("geocache/"+GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
+        final String geocachingcomUrl = TextUtils.getMatch(url, Pattern.compile("geocaching.com/geocache/"+GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
         if (canHandle(geocachingcomUrl)) {
             return geocachingcomUrl;
         }

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -450,6 +450,17 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    @Nullable
+    public String getGeocodeFromText(@NonNull final String text) {
+        // Text containing a Geocode
+        final String geocodeInText = TextUtils.getMatch(text, Pattern.compile(GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
+        if (canHandle(geocodeInText)) {
+            return geocodeInText;
+        }
+        return null;
+    }
+
+    @Override
     public boolean isActive() {
         return Settings.isGCConnectorActive();
     }

--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -437,12 +437,12 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     @Nullable
     public String getGeocodeFromUrl(@NonNull final String url) {
         // coord.info URLs
-        final String coordinfoUrl = TextUtils.getMatch(url, Pattern.compile("coord.info/"+GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
+        final String coordinfoUrl = TextUtils.getMatch(url, Pattern.compile("coord.info/" + GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
         if (canHandle(coordinfoUrl)) {
             return coordinfoUrl;
         }
         // expanded geocaching.com URLs
-        final String geocachingcomUrl = TextUtils.getMatch(url, Pattern.compile("geocaching.com/geocache/"+GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
+        final String geocachingcomUrl = TextUtils.getMatch(url, Pattern.compile("geocaching.com/geocache/" + GCConstants.GEOCODE_PATTERN, Pattern.CASE_INSENSITIVE), false, "");
         if (canHandle(geocachingcomUrl)) {
             return geocachingcomUrl;
         }

--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -29,13 +29,14 @@ public final class GCConstants {
     @NonNull static final String URL_MAP_TILE = GC_TILE_URL + "map.png";
     /** Format used by geocaching.com when user is not logged in. */
     public static final String DEFAULT_GC_DATE = "MM/dd/yyyy";
+    public static final String GEOCODE_PATTERN = "(?<!\\w)(GC[0-9A-Z&&[^ILOSU]]{1,5})(?=$|\\W|\\s|_)";
 
     // Patterns for parsing the result of a (detailed) search
 
     static final Pattern PATTERN_HINT = Pattern.compile("<div id=\"div_hint\"[^>]*>(.*?)</div>", Pattern.DOTALL);
     static final Pattern PATTERN_DESC = Pattern.compile("<span id=\"ctl00_ContentBody_LongDescription\">(.*?)</span>\\s*</div>\\s*<(p|div) id=\"ctl00_ContentBody", Pattern.DOTALL);
     static final Pattern PATTERN_SHORTDESC = Pattern.compile("<span id=\"ctl00_ContentBody_ShortDescription\">(.*?)</span>\\s*</div>", Pattern.DOTALL);
-    static final Pattern PATTERN_GEOCODE = Pattern.compile("class=\"CoordInfoCode\">(GC[0-9A-Z&&[^ILOSU]]+)</span>");
+    static final Pattern PATTERN_GEOCODE = Pattern.compile("class=\"CoordInfoCode\">"+GEOCODE_PATTERN+"</span>");
     static final Pattern PATTERN_GUID = Pattern.compile(Pattern.quote("&wid=") + "([0-9a-z\\-]+)" + Pattern.quote("&"));
     static final Pattern PATTERN_SIZE = Pattern.compile("/icons/container/([a-z_]+)\\.");
     static final Pattern PATTERN_LATLON = Pattern.compile("<span id=\"uxLatLon\"[^>]*>(.*?)</span>");
@@ -131,7 +132,7 @@ public final class GCConstants {
     static final Pattern PATTERN_SEARCH_DIRECTION_DISTANCE = Pattern.compile("<img src=\"/images/icons/compass/([^\\.]+)\\.gif\"[^>]*>[^<]*<br />([0-9.,]+)\\s*?(m|km|ft|yd|mi|)?</span>");
     static final Pattern PATTERN_SEARCH_DIFFICULTY_TERRAIN = Pattern.compile("<span class=\"small\">([0-5]([\\.,]5)?)/([0-5]([\\.,]5)?)</span><br />");
     static final Pattern PATTERN_SEARCH_CONTAINER = Pattern.compile("<img src=\"/images/icons/container/([^\\.]+)\\.gif\"");
-    static final Pattern PATTERN_SEARCH_GEOCODE = Pattern.compile("\\|\\W*(GC[0-9A-Z&&[^ILOSU]]+)[^\\|]*\\|");
+    static final Pattern PATTERN_SEARCH_GEOCODE = Pattern.compile(GEOCODE_PATTERN);
     static final Pattern PATTERN_SEARCH_FAVORITE = Pattern.compile("favorite-rank\">([0-9,.]+)</span>");
     static final Pattern PATTERN_SEARCH_TOTALCOUNT = Pattern.compile("PageBuilderWidget\"><span>[^<]*?<b>(\\d+)<");
     static final Pattern PATTERN_SEARCH_HIDDEN_DATE = Pattern.compile("<td style=\"width:70px\" data-dateplaced=\"[^\"]+\">[^<]+<span class=\"small\">([^<]+)</span>");

--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -36,7 +36,7 @@ public final class GCConstants {
     static final Pattern PATTERN_HINT = Pattern.compile("<div id=\"div_hint\"[^>]*>(.*?)</div>", Pattern.DOTALL);
     static final Pattern PATTERN_DESC = Pattern.compile("<span id=\"ctl00_ContentBody_LongDescription\">(.*?)</span>\\s*</div>\\s*<(p|div) id=\"ctl00_ContentBody", Pattern.DOTALL);
     static final Pattern PATTERN_SHORTDESC = Pattern.compile("<span id=\"ctl00_ContentBody_ShortDescription\">(.*?)</span>\\s*</div>", Pattern.DOTALL);
-    static final Pattern PATTERN_GEOCODE = Pattern.compile("class=\"CoordInfoCode\">"+GEOCODE_PATTERN+"</span>");
+    static final Pattern PATTERN_GEOCODE = Pattern.compile("class=\"CoordInfoCode\">" + GEOCODE_PATTERN + "</span>");
     static final Pattern PATTERN_GUID = Pattern.compile(Pattern.quote("&wid=") + "([0-9a-z\\-]+)" + Pattern.quote("&"));
     static final Pattern PATTERN_SIZE = Pattern.compile("/icons/container/([a-z_]+)\\.");
     static final Pattern PATTERN_LATLON = Pattern.compile("<span id=\"uxLatLon\"[^>]*>(.*?)</span>");

--- a/main/src/cgeo/geocaching/connector/oc/OCConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCConnector.java
@@ -5,11 +5,13 @@ import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.connector.UserAction;
 import cgeo.geocaching.connector.capability.Smiley;
 import cgeo.geocaching.connector.capability.SmileyCapability;
+import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.utils.ShareUtils;
+import cgeo.geocaching.utils.TextUtils;
 
 import android.net.Uri;
 
@@ -176,6 +178,15 @@ public class OCConnector extends AbstractConnector implements SmileyCapability {
         // host.tld/viewcache.php?wp=geocode
         final String secondLevel = path.startsWith("/viewcache.php") ? uri.getQueryParameter("wp") : "";
         return (secondLevel != null && canHandle(secondLevel)) ? secondLevel : super.getGeocodeFromUrl(url);
+    }
+
+    @Override
+    @Nullable
+    public String getGeocodeFromText(@NonNull final String text) {
+        // Text containing a Geocode
+        final String geocodeInText = TextUtils.getMatch(text, Pattern.compile("((https?://|)(www.|)opencach[^\\s/$.?#].[^\\s]*)", Pattern.CASE_INSENSITIVE), false, "");
+        String a = getGeocodeFromUrl(geocodeInText);
+        return a;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/connector/oc/OCConnector.java
+++ b/main/src/cgeo/geocaching/connector/oc/OCConnector.java
@@ -5,7 +5,6 @@ import cgeo.geocaching.connector.AbstractConnector;
 import cgeo.geocaching.connector.UserAction;
 import cgeo.geocaching.connector.capability.Smiley;
 import cgeo.geocaching.connector.capability.SmileyCapability;
-import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.models.Geocache;
@@ -184,9 +183,7 @@ public class OCConnector extends AbstractConnector implements SmileyCapability {
     @Nullable
     public String getGeocodeFromText(@NonNull final String text) {
         // Text containing a Geocode
-        final String geocodeInText = TextUtils.getMatch(text, Pattern.compile("((https?://|)(www.|)opencach[^\\s/$.?#].[^\\s]*)", Pattern.CASE_INSENSITIVE), false, "");
-        String a = getGeocodeFromUrl(geocodeInText);
-        return a;
+        return getGeocodeFromUrl(TextUtils.getMatch(text, Pattern.compile("((https?://|)(www.|)opencach[^\\s/$.?#].[^\\s]*)", Pattern.CASE_INSENSITIVE), false, ""));
     }
 
     @Override

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -153,7 +153,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
      */
     @MediumTest
     public void testSearchByGeocodeNotExisting() {
-        final SearchResult search = Geocache.searchByGeocode("GC123456", null, true, null);
+        final SearchResult search = Geocache.searchByGeocode("GC1", null, true, null);
         assertThat(search).isNotNull();
         assertThat(search.getError()).isEqualTo(StatusCode.CACHE_NOT_FOUND);
     }

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
@@ -49,6 +49,7 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
 
     public static void testCanHandle() {
         assertCanHandle("GC2MEGA").isTrue();
+        assertCanHandle("GCAAAAAAAAAAAAA").isFalse();
         assertCanHandle("OXZZZZZ").isFalse();
         assertCanHandle("gc77").isTrue();
     }
@@ -96,9 +97,12 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
     public static void testGetGeocodeFromUrl() {
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("some string")).isNull();
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/GC12ABC")).isEqualTo("GC12ABC");
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/GC12ABC?test")).isEqualTo("GC12ABC");
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://www.coord.info/GC12ABC")).isEqualTo("GC12ABC");
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://coord.info/GC123_tset")).isEqualTo("GC123");
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("https://www.geocaching.com/geocache/GC12ABC_die-muhlen-im-schondratal-muhle-munchau")).isEqualTo("GC12ABC");
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://geocaching.com/geocache/GC12ABC_die-muhlen-im-schondratal-muhle-munchau")).isEqualTo("GC12ABC");
+        assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://geocaching.com/geocache/GC12ABC")).isEqualTo("GC12ABC");
 
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/TB1234")).isNull();
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://www.coord.info/TB1234")).isNull();
@@ -106,6 +110,7 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
 
         // uppercase is managed in ConnectorFactory
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/gc77")).isEqualTo("gc77");
+
     }
 
     public static void testHandledGeocodes() {

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java
@@ -110,7 +110,22 @@ public class GCConnectorTest extends AbstractResourceInstrumentationTestCase {
 
         // uppercase is managed in ConnectorFactory
         assertThat(GCConnector.getInstance().getGeocodeFromUrl("http://coord.info/gc77")).isEqualTo("gc77");
+    }
 
+    public static void testGetGeocodeFromText() {
+        // Matching a geocode in text
+        assertThat(GCConnector.getInstance().getGeocodeFromText("https://coord.info/GC123 tset")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("GC123asddd")).isNull();
+        assertThat(GCConnector.getInstance().getGeocodeFromText("Text GC123")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("GC123")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("GC123 Text")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("asdf GC123 asdf")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("Bla GC123tset")).isNull();
+        assertThat(GCConnector.getInstance().getGeocodeFromText("I can't find GC123 do you have a hint?")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("Check out GC123.")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("CheckoutGC123.")).isNull();
+        assertThat(GCConnector.getInstance().getGeocodeFromText(">GC123<")).isEqualTo("GC123");
+        assertThat(GCConnector.getInstance().getGeocodeFromText("Do you have a hint for GC123?")).isEqualTo("GC123");
     }
 
     public static void testHandledGeocodes() {

--- a/tests/src-android/cgeo/geocaching/connector/oc/OCConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/oc/OCConnectorTest.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.connector.oc;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.ConnectorFactoryTest;
 import cgeo.geocaching.connector.IConnector;
-import cgeo.geocaching.connector.gc.GCConnector;
 
 import java.util.Set;
 

--- a/tests/src-android/cgeo/geocaching/connector/oc/OCConnectorTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/oc/OCConnectorTest.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.connector.oc;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.ConnectorFactoryTest;
 import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
 
 import java.util.Set;
 
@@ -31,6 +32,16 @@ public class OCConnectorTest extends TestCase {
         final IConnector connector = ConnectorFactory.getConnector("OC0028");
         assertThat(connector.getGeocodeFromUrl("http://opencaching.de/OC0028")).isEqualTo("OC0028");
         assertThat(connector.getGeocodeFromUrl("http://www.opencaching.de/OC0028")).isEqualTo("OC0028");
+    }
+
+    public static void testGetGeocodeFromTextDe() throws Exception {
+        final IConnector connector = ConnectorFactory.getConnector("OC0028");
+        assertThat(connector.getGeocodeFromText("Bla http://www.opencaching.de/OC0028 Test")).isEqualTo("OC0028");
+    }
+
+    public static void testGetGeocodeFromTextUk() throws Exception {
+        final IConnector connector = ConnectorFactory.getConnector("OK04F8");
+        assertThat(connector.getGeocodeFromText("Bla https://opencache.uk/viewcache.php?wp=OK04F8 Test")).isEqualTo("OK04F8");
     }
 
     public static void testGetGeocodeFromInternalId() {


### PR DESCRIPTION
## Description
Improves loading a geocode from clipboard by "recognizing" geocodes in text.
There's 3 parts to this commit:
1. fixes to the pattern(s) used for recognizing a GC-code in URLs
2. extension of the existing functionality in "Search" activity to auto-fill the geocode field with a geocode from clipboard. This now works not just for plain geocodes but also geocode-urls (e.g. https://coord.info/GC123) and geocodes contained in text ("Check out GC123"), see https://github.com/cgeo/cgeo/blob/3e311ec09ffc46158781fa5572733639495b1d3f/tests/src-android/cgeo/geocaching/connector/gc/GCConnectorTest.java#L115 for some more text examples
![image](https://user-images.githubusercontent.com/1258173/144618868-47475730-ea11-4511-a9e1-4a48b276ce6a.png)
3. add a "paste" button to the quicksearch field in main activity. The button only shows up if clipboard contains a geocode (either pure, url or in text) and directly loads that geocode
![image](https://user-images.githubusercontent.com/1258173/144614324-b3a20cee-ea58-4a4c-b5ae-51523170010a.png)

## Related issues
fixes #12169
