### PR TITLE
add generic browser query to manifest (fix #12209)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -911,6 +911,11 @@
         <package android:name="menion.android.whereyougo" />
         <package android:name="net.osmand" />
         <package android:name="net.osmand.plus" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 
 </manifest>


### PR DESCRIPTION
## Description
For testing whether the "open in browser not working" is related to not having listed those apps in our manifest, this PR adds
- Firefox browser
- Samsung browser
- Via browser

to the `<query>` section of our manifest to make those packages visible to c:geo

@Lineflyer 
Can you cross-check whether this works in your test scenario or in those of the two users on support?