### PR TITLE
reenable signature editing

### DIFF
--- a/main/res/layout/template_preference_dialog.xml
+++ b/main/res/layout/template_preference_dialog.xml
@@ -7,24 +7,15 @@
     android:padding="8dp"
     tools:context=".settings.TemplateTextPreference" >
 
-    <EditText
-        android:id="@android:id/edit"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="top|left"
-        android:inputType="textMultiLine|textCapSentences"
-        android:minLines="3"
-        android:hint="@string/init_signature"
-        android:autofillHints="@string/init_signature"/>
-
-    <!-- @todo needs to get default button styling applied (button_full) as soon as preferences are migrated to PreferenceFragments etc. -->
-    <Button
-        android:id="@+id/signature_templates"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="right"
-        android:paddingTop="8dp"
-        android:text="@string/init_signature_template_button" />
+    <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
+        <EditText
+            android:id="@+id/edit"
+            style="@style/textinput_embedded"
+            android:inputType="textMultiLine|textCapSentences"
+            android:minLines="3"
+            android:hint="@string/init_signature"
+            android:autofillHints="@string/init_signature"/>
+    </com.google.android.material.textfield.TextInputLayout>
 
     <TextView
         android:layout_width="match_parent"

--- a/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
+++ b/main/src/cgeo/geocaching/settings/TemplateTextPreference.java
@@ -2,20 +2,27 @@ package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.log.LogTemplateProvider;
 import cgeo.geocaching.log.LogTemplateProvider.LogTemplate;
+import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.EditText;
 
-import androidx.preference.EditTextPreference;
+import androidx.appcompat.app.AlertDialog;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class TemplateTextPreference extends EditTextPreference {
-
-    // TODO
+public class TemplateTextPreference extends Preference {
 
     /**
      * default value, if none is given in the preference XML.
@@ -27,66 +34,60 @@ public class TemplateTextPreference extends EditTextPreference {
 
     public TemplateTextPreference(final Context context, final AttributeSet attrs) {
         super(context, attrs);
-        init();
     }
 
     public TemplateTextPreference(final Context context, final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
-        init();
     }
 
-    private void init() {
-        setDialogLayoutResource(R.layout.template_preference_dialog);
+    @Override
+    public void onBindViewHolder(final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        final Preference pref = findPreferenceInHierarchy(getKey());
+        if (pref != null) {
+            pref.setOnPreferenceClickListener(preference -> {
+                editSignature();
+                return false;
+            });
+        }
     }
 
-    /*@Override
-    protected void onBindDialogView(final View view) {
+    private void editSignature() {
         settingsActivity = (SettingsActivity) this.getContext();
 
-        // TODO: replace with android id
-        editText = view.findViewById(R.id.signature_dialog_text);
+        final View v = LayoutInflater.from(getContext()).inflate(R.layout.template_preference_dialog, null);
+        editText = v.findViewById(R.id.edit);
         editText.setText(getPersistedString(initialValue != null ? initialValue : StringUtils.EMPTY));
         Dialogs.moveCursorToEnd(editText);
 
-        final Button button = view.findViewById(R.id.signature_templates);
-        button.setOnClickListener(button1 -> {
-            final AlertDialog.Builder alert = Dialogs.newBuilder(TemplateTextPreference.this.getContext());
-            alert.setTitle(R.string.init_signature_template_button);
+        final AlertDialog dialog = Dialogs.newBuilder(getContext())
+            .setView(v)
+            .setPositiveButton(android.R.string.ok, (dialog1, which) -> {
+                final String text = editText.getText().toString();
+                persistString(text);
+                callChangeListener(text);
+            })
+            .setNeutralButton(R.string.init_signature_template_button, null)
+            .show();
+
+        // override onClick listener to prevent closing dialog on pressing the "default" button
+        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(v2 -> {
+            final AlertDialog.Builder templateBuilder = Dialogs.newBuilder(TemplateTextPreference.this.getContext());
+            templateBuilder.setTitle(R.string.init_signature_template_button);
             final List<LogTemplate> templates = LogTemplateProvider.getTemplatesWithSignatureAndLogText();
             final String[] items = new String[templates.size()];
             for (int i = 0; i < templates.size(); i++) {
                 items[i] = settingsActivity.getString(templates.get(i).getResourceId());
             }
-            alert.setItems(items, (dialog, position) -> {
-                dialog.dismiss();
-                final LogTemplate template = templates.get(position);
-                insertSignatureTemplate(template);
+            templateBuilder.setItems(items, (dialog3, position) -> {
+                dialog3.dismiss();
+                final String insertText = "[" + templates.get(position).getTemplateString() + "]";
+                ActivityMixin.insertAtPosition(editText, insertText, true);
             });
-            alert.create().show();
+            templateBuilder.create().show();
         });
 
-        super.onBindDialogView(view);
     }
-
-    */
-
-    private void insertSignatureTemplate(final LogTemplate template) {
-        final String insertText = "[" + template.getTemplateString() + "]";
-        ActivityMixin.insertAtPosition(editText, insertText, true);
-    }
-
-    /*
-
-    @Override
-    protected void onDialogClosed(final boolean positiveResult) {
-        if (positiveResult) {
-            final String text = editText.getText().toString();
-            persistString(text);
-            callChangeListener(text);
-        }
-        super.onDialogClosed(positiveResult);
-    }*/
-
 
     @Override
     protected void onSetInitialValue(final Object defaultValue) {

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.SettingsUtils;
 
 import android.os.Bundle;
 
@@ -16,5 +18,10 @@ public class PreferenceLoggingFragment extends PreferenceFragmentCompat {
     public void onResume() {
         super.onResume();
         getActivity().setTitle(R.string.settings_title_logging);
+        SettingsUtils.setPrefSummary(this, R.string.pref_signature, Settings.getSignature());
+        findPreference(getString(R.string.pref_signature)).setOnPreferenceChangeListener((preference, newValue) -> {
+            SettingsUtils.setPrefSummary(this, R.string.pref_signature, Settings.getSignature());
+            return true;
+        });
     }
 }

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -4,11 +4,8 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.downloader.DownloadSelectorActivity;
 import cgeo.geocaching.maps.MapProviderFactory;
 import cgeo.geocaching.maps.interfaces.MapSource;
-import cgeo.geocaching.settings.DialogPrefFragCompat;
 import cgeo.geocaching.settings.SettingsActivity;
-import cgeo.geocaching.settings.TemplateTextPreference;
 import cgeo.geocaching.utils.ShareUtils;
-
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
@@ -16,9 +13,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
-import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.Collection;
@@ -44,23 +39,6 @@ public class PreferenceMapFragment extends PreferenceFragmentCompat {
         setPrefClick(this, R.string.pref_fakekey_info_offline_mapthemes, () -> ShareUtils.openUrl(activity, activity.getString(R.string.faq_url_settings_themes)));
 
         initPublicFolders(this, ((SettingsActivity) getActivity()).getCsah());
-    }
-
-    @Override
-    public void onDisplayPreferenceDialog(final Preference preference) {
-        if (preference instanceof TemplateTextPreference) {
-            final DialogFragment dialogFragment = DialogPrefFragCompat.newInstance(preference.getKey());
-            // FIXME: Don't use setTargetFragment
-            // Instead of using a target fragment to pass results, the fragment requesting a result should use
-            // FragmentManager.setFragmentResultListener(String, LifecycleOwner, FragmentResultListener) to register a
-            // FragmentResultListener with a requestKey using its parent fragment manager. The fragment delivering a
-            // result should then call FragmentManager.setFragmentResult(String, Bundle) using the same requestKey.
-            // Consider using setArguments to pass the requestKey if you need to support dynamic request keys.
-            dialogFragment.setTargetFragment(this, 0);
-            dialogFragment.show(getParentFragmentManager(), null);
-        } else {
-            super.onDisplayPreferenceDialog(preference);
-        }
     }
 
     /**

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.settings.fragments;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
-
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 
 import android.os.Bundle;


### PR DESCRIPTION
## Description
- show current signature as summary (fix #12118)
- fix signature edit dialog (fix #12243)
- apply material design to signature edit dialog
- fix template insert dialog

|Edit dialog|Templates inserted|Summary updated|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3754370/144741641-9a914fb9-6ab1-4716-94ec-418f8516f422.png)|![image](https://user-images.githubusercontent.com/3754370/144741673-4af503f1-3c07-4157-9316-390b56eda508.png)|![image](https://user-images.githubusercontent.com/3754370/144741686-481d34d1-a72b-482d-960b-4a10bde496fd.png)


