### PR TITLE
reenable setting base folder (fix #12123)

### DIFF
--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -12,7 +12,6 @@ import cgeo.geocaching.utils.ShareUtils;
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -37,13 +36,14 @@ public class PreferenceMapFragment extends PreferenceFragmentCompat {
     @Override
     public void onResume() {
         super.onResume();
-        final Activity activity = getActivity();
+        final SettingsActivity activity = (SettingsActivity) getActivity();
+        assert activity != null;
         activity.setTitle(R.string.settings_title_map);
         setPrefClick(this, R.string.pref_fakekey_info_offline_maps, () -> ShareUtils.openUrl(activity, activity.getString(R.string.manual_url_settings_offline_maps)));
         setPrefClick(this, R.string.pref_fakekey_start_downloader, () -> activity.startActivity(new Intent(activity, DownloadSelectorActivity.class)));
         setPrefClick(this, R.string.pref_fakekey_info_offline_mapthemes, () -> ShareUtils.openUrl(activity, activity.getString(R.string.faq_url_settings_themes)));
 
-        initPublicFolders(this, ((SettingsActivity) getActivity()).getCsah());
+        initPublicFolders(this, activity.getCsah());
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -30,15 +30,15 @@ public class PreferenceNavigationFragment extends PreferenceFragmentCompat {
 
         initDefaultNavigationPreferences();
         initOfflineRoutingPreferences();
-
-        // TODO: Logic for ProximityDistance needs to be reimplemented
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        getActivity().setTitle(R.string.settings_title_navigation);
-        initPublicFolders(this, ((SettingsActivity) getActivity()).getCsah());
+        final SettingsActivity activity = (SettingsActivity) getActivity();
+        assert activity != null;
+        activity.setTitle(R.string.settings_title_navigation);
+        initPublicFolders(this, activity.getCsah());
 
         final Preference tool1 = findPreference(getString(R.string.pref_defaultNavigationTool));
         assert tool1 != null;

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -22,7 +22,9 @@ public class PreferenceOfflinedataFragment extends PreferenceFragmentCompat {
     @Override
     public void onResume() {
         super.onResume();
+        final SettingsActivity activity = (SettingsActivity) getActivity();
+        assert activity != null;
         getActivity().setTitle(R.string.settings_title_offlinedata);
-        initPublicFolders(this, ((SettingsActivity) getActivity()).getCsah());
+        initPublicFolders(this, activity.getCsah());
     }
 }

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -1,11 +1,12 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.settings.ViewSettingsActivity;
 import cgeo.geocaching.utils.DebugUtils;
+import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -20,12 +21,15 @@ public class PreferenceSystemFragment extends PreferenceFragmentCompat {
     @Override
     public void onResume() {
         super.onResume();
-        final Activity activity = getActivity();
+        final SettingsActivity activity = (SettingsActivity) getActivity();
+        assert activity != null;
         activity.setTitle(R.string.settings_title_system);
 
         setPrefClick(this, R.string.pref_memory_dump, () -> DebugUtils.createMemoryDump(activity));
         setPrefClick(this, R.string.pref_generate_logcat, () -> DebugUtils.createLogcat(activity));
         setPrefClick(this, R.string.pref_generate_infos_downloadmanager, () -> DebugUtils.dumpDownloadmanagerInfos(activity));
         setPrefClick(this, R.string.pref_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
+
+        initPublicFolders(this, activity.getCsah());
     }
 }


### PR DESCRIPTION
## Description
Setting "base" folder was still missing in settings - this PR reenables it.

![image](https://user-images.githubusercontent.com/3754370/144744545-1408ee1e-114a-48ed-9520-69e9e55dbb1a.png)
