### PR TITLE
reenable attribute view toggling in cache details (fix #12248)

### DIFF
--- a/main/src/cgeo/geocaching/AttributesGridAdapter.java
+++ b/main/src/cgeo/geocaching/AttributesGridAdapter.java
@@ -23,19 +23,22 @@ public class AttributesGridAdapter extends BaseAdapter {
     private final Resources resources;
     private final List<String> attributes;
     private final LayoutInflater inflater;
+    private final Runnable onClickListener;
 
     public AttributesGridAdapter(final Activity context, final Geocache cache) {
         this.context = context;
         resources = context.getResources();
         attributes = cache.getAttributes();
         inflater = LayoutInflater.from(context);
+        onClickListener = null;
     }
 
-    public AttributesGridAdapter(final Activity context, final List<String> attributesList) {
+    public AttributesGridAdapter(final Activity context, final List<String> attributesList, final Runnable onClickListener) {
         this.context = context;
         resources = context.getResources();
         attributes = attributesList;
         inflater = LayoutInflater.from(context);
+        this.onClickListener = onClickListener;
     }
 
     @Override
@@ -76,6 +79,9 @@ public class AttributesGridAdapter extends BaseAdapter {
         if (attrib != null) {
             imageView.setImageDrawable(ResourcesCompat.getDrawable(resources, attrib.drawableId, null));
             ViewUtils.setTooltip(imageView, TextParam.text(attrib.getL10n(CacheAttribute.isEnabled(attributeName))));
+            if (onClickListener != null) {
+                imageView.setOnClickListener(v -> onClickListener.run());
+            }
             imageView.setContentDescription(attrib.getL10n(CacheAttribute.isEnabled(attributeName)));
         } else {
             imageView.setImageDrawable(ResourcesCompat.getDrawable(resources, R.drawable.attribute_unknown, null));

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1296,9 +1296,8 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 }
             }
 
-            binding.attributesGrid.setAdapter(new AttributesGridAdapter(activity, a));
+            binding.attributesGrid.setAdapter(new AttributesGridAdapter(activity, a, () -> toggleAttributesView()));
             binding.attributesGrid.setVisibility(View.VISIBLE);
-            binding.attributesGrid.setOnItemClickListener((parent, view, position, id) -> toggleAttributesView());
 
             binding.attributesText.setText(HtmlCompat.fromHtml(text.toString(), 0));
             binding.attributesText.setVisibility(View.GONE);

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -305,7 +305,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
         final View v = LayoutInflater.from(context).inflate(R.layout.cachelist_attributeoverview, null);
         alertDialog.setView (v);
-        ((WrappingGridView) v.findViewById(R.id.attributes_grid)).setAdapter(new AttributesGridAdapter((Activity) context, a));
+        ((WrappingGridView) v.findViewById(R.id.attributes_grid)).setAdapter(new AttributesGridAdapter((Activity) context, a, null));
         ((TextView) v.findViewById(R.id.attributes_text)).setText(text);
         alertDialog.show();
     }


### PR DESCRIPTION
## Description
Seems that enabling a tooltip overrides short click set with `setOnItemClickListener`, therefore this PR set short clicks directly
