### PR TITLE
Restore old SeekbarPreference capabilities

### DIFF
--- a/main/res/layout/preference_seekbar.xml
+++ b/main/res/layout/preference_seekbar.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:paddingTop="8dp"
+    android:orientation="vertical"
+    tools:context=".settings.SettingsActivity" >
+
+    <TextView
+        android:id="@+id/preference_seekbar_label_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:visibility="gone"
+        android:gravity="left"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="0dp"
+        android:paddingRight="0dp"
+        android:paddingTop="0dp"
+        android:orientation="horizontal">
+
+        <SeekBar
+            android:id="@+id/preference_seekbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:layout_weight="1"
+            android:paddingLeft="0dp"
+            android:paddingRight="4dp"
+            tools:progress="25"/>
+
+        <TextView
+            android:id="@+id/preference_seekbar_value_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:singleLine="true"
+            android:layout_gravity="right"
+            android:layout_weight="5"
+            android:gravity="right"
+            tools:text="25"/>
+
+    </LinearLayout>
+</LinearLayout>
+

--- a/main/res/values/attrs.xml
+++ b/main/res/values/attrs.xml
@@ -56,6 +56,14 @@
         <attr name="defaultColor" format="color" />
     </declare-styleable>
 
+    <!-- attributes for SeekbarPreference -->
+    <declare-styleable name="SeekbarPreference">
+        <attr name="min" format="integer" />
+        <attr name="max" format="integer" />
+        <attr name="label" format="string" />
+        <attr name="hasDecimals" format="boolean" />
+    </declare-styleable>
+
     <!-- custom attributes for ProximityPreference -->
     <declare-styleable name="ProximityPreference">
         <attr name="highRes" format="boolean" />

--- a/main/res/xml/preferences_backup.xml
+++ b/main/res/xml/preferences_backup.xml
@@ -10,14 +10,17 @@
         android:title="@string/init_backup_title"
         app:iconSpaceReserved="false">
         <Preference android:summary="@string/init_backup_summary" app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:defaultValue="@integer/backup_history_length_default"
-            android:key="@string/pref_backups_backup_history_length"
-            android:max="@integer/backup_history_length_max"
-            android:min="0"
-            android:summary="@string/init_backup_history_length_summary"
+
+        <Preference
             android:title="@string/init_backup_history_length_title"
-            app:showSeekBarValue="true"
+            android:summary="@string/init_backup_history_length_summary"
+            app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.BackupSeekbarPreference
+            android:key="@string/pref_backups_backup_history_length"
+            android:defaultValue="@integer/backup_history_length_default"
+            app:min="0"
+            app:max="@integer/backup_history_length_max"
+            app:hasDecimals="false"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -25,14 +25,15 @@
             android:text="@string/downloadmap_info"
             app:iconSpaceReserved="false" />
 
-        <SeekBarPreference
+        <Preference
             android:summary="@string/init_updateinterval_description"
             android:title="@string/init_updateinterval_title"
-            android:defaultValue="@integer/map_updateinterval_default"
+            app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_mapAutoDownloadsInterval"
-            android:max="@integer/map_updateinterval_max"
-            android:min="0"
-            app:showSeekBarValue="true"
+            android:defaultValue="@integer/map_updateinterval_default"
+            app:min="0"
+            app:max="@integer/map_updateinterval_max"
             app:iconSpaceReserved="false" />
 
         <Preference
@@ -67,15 +68,16 @@
     <PreferenceCategory
         android:title="@string/settings_title_waypoints"
         app:iconSpaceReserved="false">
-        <SeekBarPreference
+        <Preference
             android:summary="@string/init_showwaypoint_description"
             android:title="@string/init_showwaypoints"
-            android:defaultValue="@integer/waypoint_threshold_default"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_showwaypointsthreshold"
-            android:max="@integer/waypoint_threshold_max"
-            android:min="0"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
+            android:defaultValue="@integer/waypoint_threshold_default"
+            app:min="0"
+            app:max="@integer/waypoint_threshold_max"
+            app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_excludeWpOriginal"
@@ -108,14 +110,15 @@
             android:summary="@string/init_summary_maptrail"
             android:title="@string/init_maptrail"
             app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:summary="@string/init_maptrail_length_summary"
+        <Preference
             android:title="@string/init_maptrail_length"
-            android:defaultValue="@integer/historytrack_length_default"
+            android:summary="@string/init_maptrail_length_summary"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_maptrail_length"
-            android:max="@integer/historytrack_length_max"
-            android:min="100"
-            app:showSeekBarValue="true"
+            android:defaultValue="@integer/historytrack_length_default"
+            app:min="100"
+            app:max="@integer/historytrack_length_max"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
@@ -139,24 +142,22 @@
     <PreferenceCategory
         android:title="@string/settings_title_proximityNotification"
         app:iconSpaceReserved="false">
-        <SeekBarPreference
-            android:defaultValue="@integer/proximitynotification_far_default"
+        <cgeo.geocaching.settings.ProximityPreference
             android:key="@string/pref_proximityDistanceFar"
+            android:defaultValue="@integer/proximitynotification_far_default"
+            app:min="1"
+            app:max="@integer/proximitynotification_distance_max"
+            app:label="@string/far_distance"
             app:highRes="true"
-            android:title="@string/far_distance"
-            android:max="@integer/proximitynotification_distance_max"
-            android:min="1"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
-        <SeekBarPreference
-            android:defaultValue="@integer/proximitynotification_near_default"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.ProximityPreference
             android:key="@string/pref_proximityDistanceNear"
+            android:defaultValue="@integer/proximitynotification_near_default"
+            app:min="1"
+            app:max="@integer/proximitynotification_distance_max"
+            app:label="@string/near_distance"
             app:highRes="true"
-            android:title="@string/near_distance"
-            android:max="@integer/proximitynotification_distance_max"
-            android:min="1"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
+            app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_proximityNotificationGeneral"
@@ -186,81 +187,89 @@
         <cgeo.geocaching.settings.ColorpickerPreference
             android:dependency="@string/pref_maptrail"
             android:key="@string/pref_mapline_trailcolor"
-            android:summary="@string/init_trailcolor_summary"
             android:title="@string/init_trailcolor"
+            android:summary="@string/init_trailcolor_summary"
             app:defaultColor="@color/default_trailcolor"
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />
         <Preference
             android:dependency="@string/pref_maptrail"
-            android:selectable="false"
-            android:summary="@string/init_trailwidth_summary"
             android:title="@string/init_trailwidth"
+            android:summary="@string/init_trailwidth_summary"
             app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:defaultValue="@integer/default_trailwidth"
+        <cgeo.geocaching.settings.SeekbarPreference
             android:dependency="@string/pref_maptrail"
             android:key="@string/pref_mapline_trailwidth"
-            android:max="100"
-            android:min="0"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
+            android:defaultValue="@integer/default_trailwidth"
+            app:min="0"
+            app:max="100"
+            app:hasDecimals="false"
+            app:iconSpaceReserved="false" />
 
         <cgeo.geocaching.settings.ColorpickerPreference
             android:key="@string/pref_mapline_directioncolor"
-            android:summary="@string/init_directioncolor_summary"
             android:title="@string/init_directioncolor"
+            android:summary="@string/init_directioncolor_summary"
             app:defaultColor="@color/default_directioncolor"
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:summary="@string/init_directionwidth_summary"
-            android:title="@string/init_directionwidth"
-            android:defaultValue="@integer/default_directionwidth"
-            android:key="@string/pref_mapline_directionwidth"
-            android:max="100"
-            android:min="0"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
+            <Preference
+                android:title="@string/init_directionwidth"
+                android:summary="@string/init_directionwidth_summary"
+                app:iconSpaceReserved="false" />
+            <cgeo.geocaching.settings.SeekbarPreference
+                android:key="@string/pref_mapline_directionwidth"
+                android:defaultValue="@integer/default_directionwidth"
+                android:layout="@layout/preference_seekbar"
+                app:min="0"
+                app:max="100"
+                app:hasDecimals="false"
+                app:iconSpaceReserved="false" />
 
         <cgeo.geocaching.settings.ColorpickerPreference
             android:key="@string/pref_mapline_routecolor"
-            android:summary="@string/init_routecolor_summary"
             android:title="@string/init_routecolor"
+            android:summary="@string/init_routecolor_summary"
             app:defaultColor="@color/default_routecolor"
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:summary="@string/init_routewidth_summary"
-            android:title="@string/init_routewidth"
-            android:defaultValue="@integer/default_routewidth"
-            android:key="@string/pref_mapline_routewidth"
-            android:max="100"
-            android:min="0"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
+            <Preference
+                android:title="@string/init_routewidth"
+                android:summary="@string/init_routewidth_summary"
+                app:iconSpaceReserved="false" />
+            <cgeo.geocaching.settings.SeekbarPreference
+                android:key="@string/pref_mapline_routewidth"
+                android:defaultValue="@integer/default_routewidth"
+                android:layout="@layout/preference_seekbar"
+                app:min="0"
+                app:max="100"
+                app:hasDecimals="false"
+                app:iconSpaceReserved="false" />
 
         <cgeo.geocaching.settings.ColorpickerPreference
             android:key="@string/pref_mapline_trackcolor"
-            android:summary="@string/init_trackcolor_summary"
             android:title="@string/init_trackcolor"
+            android:summary="@string/init_trackcolor_summary"
             app:defaultColor="@color/default_trackcolor"
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:summary="@string/init_trackwidth_summary"
-            android:title="@string/init_trackwidth"
-            android:defaultValue="@integer/default_trackwidth"
-            android:key="@string/pref_mapline_trackwidth"
-            android:max="100"
-            android:min="0"
-            app:showSeekBarValue="true"
-            app:iconSpaceReserved="false"/>
+            <Preference
+                android:title="@string/init_trackwidth"
+                android:summary="@string/init_trackwidth_summary"
+                app:iconSpaceReserved="false" />
+            <cgeo.geocaching.settings.SeekbarPreference
+                android:key="@string/pref_mapline_trackwidth"
+                android:defaultValue="@integer/default_trackwidth"
+                android:layout="@layout/preference_seekbar"
+                app:min="0"
+                app:max="100"
+                app:hasDecimals="false"
+                app:iconSpaceReserved="false" />
 
         <cgeo.geocaching.settings.ColorpickerPreference
             android:key="@string/pref_mapline_circlecolor"
-            android:summary="@string/init_circlecolor_summary"
             android:title="@string/init_circlecolor"
+            android:summary="@string/init_circlecolor_summary"
             app:defaultColor="@color/default_circlecolor"
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />
@@ -274,8 +283,8 @@
 
         <cgeo.geocaching.settings.ColorpickerPreference
             android:key="@string/pref_mapline_accuracycirclecolor"
-            android:summary="@string/init_accuracycirclecolor_summary"
             android:title="@string/init_accuracycirclecolor"
+            android:summary="@string/init_accuracycirclecolor_summary"
             app:defaultColor="@color/default_accuracycirclecolor"
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />

--- a/main/res/xml/preferences_navigation.xml
+++ b/main/res/xml/preferences_navigation.xml
@@ -9,15 +9,19 @@
         android:title="@string/settings_title_offline_routing"
         app:iconSpaceReserved="false">
         <Preference android:summary="@string/settings_summary_offline_routing" app:iconSpaceReserved="false" />
-        <SeekBarPreference
-            android:summary="@string/init_brouterThreshold_description"
+
+        <Preference
+            android:key="@string/pref_fakekey_brouterDistanceThresholdTitle"
             android:title="@string/init_brouterThreshold"
-            android:defaultValue="@integer/brouter_threshold_default"
-            android:key="@string/pref_brouterDistanceThreshold"
-            android:max="@integer/brouter_threshold_max"
-            android:min="1"
-            app:showSeekBarValue="true"
+            android:summary="@string/init_brouterThreshold_description"
             app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.ProximityPreference
+            android:key="@string/pref_brouterDistanceThreshold"
+            android:defaultValue="@integer/brouter_threshold_default"
+            app:min="1"
+            app:max="@integer/brouter_threshold_max"
+            app:highRes="false"
+            app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
             android:defaultValue="false"
@@ -47,15 +51,16 @@
             android:title="@string/init_autoDownloads"
             app:iconSpaceReserved="false" />
 
-        <SeekBarPreference
-            android:summary="@string/init_updateinterval_description"
+        <Preference
             android:title="@string/init_updateinterval_title"
-            android:defaultValue="@integer/brouter_updateinterval_default"
-            android:key="@string/pref_brouterAutoTileDownloadsInterval"
-            android:max="@integer/brouter_updateinterval_max"
-            android:min="0"
-            app:showSeekBarValue="true"
+            android:summary="@string/init_updateinterval_description"
             app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_brouterAutoTileDownloadsInterval"
+            android:defaultValue="@integer/brouter_updateinterval_default"
+            app:min="0"
+            app:max="@integer/brouter_updateinterval_max"
+            app:iconSpaceReserved="false" />
 
         <ListPreference
             android:dialogTitle="@string/init_brouterProfileWalk"

--- a/main/res/xml/preferences_offlinedata.xml
+++ b/main/res/xml/preferences_offlinedata.xml
@@ -23,15 +23,16 @@
         android:title="@string/init_listdisplay"
         app:iconSpaceReserved="false" />
 
-    <SeekBarPreference
-        android:defaultValue="@integer/list_load_limit_default"
-        android:summary="@string/init_summary_list_initial_load_limit"
+    <Preference
         android:title="@string/init_list_initial_load_limit"
-        android:key="@string/pref_list_initial_load_limit"
-        android:max="@integer/list_load_limit_max"
-        android:min="0"
-        app:showSeekBarValue="true"
+        android:summary="@string/init_summary_list_initial_load_limit"
         app:iconSpaceReserved="false"/>
+    <cgeo.geocaching.settings.SeekbarPreference
+        android:key="@string/pref_list_initial_load_limit"
+        android:defaultValue="@integer/list_load_limit_default"
+        app:min="0"
+        app:max="@integer/list_load_limit_max"
+        app:iconSpaceReserved="false" />
 
     <PreferenceCategory
         android:title="@string/settings_title_gpx"

--- a/main/src/cgeo/geocaching/settings/BackupSeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/BackupSeekbarPreference.java
@@ -1,0 +1,61 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.LinearLayout.LayoutParams;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import androidx.preference.PreferenceViewHolder;
+
+
+public class BackupSeekbarPreference extends SeekbarPreference {
+
+    private SeekBar seekBar;
+    private TextView valueView;
+
+
+    public BackupSeekbarPreference(final Context context) {
+        super(context);
+    }
+
+    public BackupSeekbarPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public BackupSeekbarPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    @Override
+    protected String getValueString(final int progress) {
+        if (progress == minProgress) {
+            return context.getString(R.string.init_backup_history_length_min);
+        } else if (progress == maxProgress) {
+            return context.getString(R.string.init_backup_history_length_max);
+        }
+        return super.getValueString(progress + 1);
+    }
+
+    @Override
+    public void onBindViewHolder(final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        valueView = (TextView) holder.findViewById(R.id.preference_seekbar_value_view);
+        valueView.setSingleLine(false);
+        final LayoutParams params = (LayoutParams) valueView.getLayoutParams();
+        params.weight = 3.0f;
+        valueView.setMinLines(2);
+        valueView.setOnClickListener(null);
+
+        seekBar = (SeekBar) holder.findViewById(R.id.preference_seekbar);
+    }
+
+    public void setValue(final int value) {
+        seekBar.setProgress(value);
+        valueView.setText(getValueString(value));
+        saveSetting(value);
+    }
+}

--- a/main/src/cgeo/geocaching/settings/ProximityPreference.java
+++ b/main/src/cgeo/geocaching/settings/ProximityPreference.java
@@ -1,0 +1,70 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.location.IConversion;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+
+import java.util.Locale;
+
+public class ProximityPreference extends SeekbarPreference {
+
+    private boolean highRes = false;
+
+    public ProximityPreference(final Context context) {
+        this(context, null);
+    }
+
+    public ProximityPreference(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.preferenceStyle);
+    }
+
+    public ProximityPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+
+        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ProximityPreference);
+        highRes = a.getBoolean(R.styleable.ProximityPreference_highRes, false);
+        a.recycle();
+    }
+
+    // init() gets called by super constructor, therefore before class constructor / class variable assignments!
+    @Override
+    protected void init() {
+        minProgress = 1;
+        maxProgress = valueToProgressHelper(Settings.getKeyInt(R.integer.proximitynotification_distance_max));
+    }
+
+    @Override
+    protected int valueToProgressHelper(final int value) {
+        return (int) Math.round(250.0 * Math.log10(value + 1));
+    }
+
+    @Override
+    protected int progressToValue(final int progress) {
+        final int value = (int) Math.pow(10, (double) progress / 250.0) - 1;
+        return Math.max(value, 0);
+    }
+
+    @Override
+    protected String valueToShownValue(final int value) {
+        return Settings.useImperialUnits() ? String.format(Locale.US, "%.2f", value / (highRes ? IConversion.FEET_TO_METER : IConversion.MILES_TO_KILOMETER)) : String.valueOf(value);
+    }
+
+    @Override
+    protected int shownValueToValue(final float shownValue) {
+        return Math.round(Settings.useImperialUnits() ? shownValue * (highRes ? IConversion.FEET_TO_METER : IConversion.MILES_TO_KILOMETER) : shownValue);
+    }
+
+    @Override
+    protected String getUnitString() {
+        return Settings.useImperialUnits() ? (highRes ? " ft" : " mi") : (highRes ? " m" : " km");
+    }
+
+    @Override
+    protected boolean useDecimals() {
+        // unit settings can be changed while ProximityPreference is already initialized
+        return Settings.useImperialUnits();
+    }
+}

--- a/main/src/cgeo/geocaching/settings/SeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/SeekbarPreference.java
@@ -1,0 +1,215 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.text.InputType;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.core.util.Consumer;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+import java.util.Locale;
+
+public class SeekbarPreference extends Preference {
+
+    private TextView valueView;
+    protected int minProgress = 0;
+    protected int maxProgress = 100;
+    protected int startProgress = 0;
+    protected final int defaultValue = 10;
+    protected boolean hasDecimals = false;
+    protected String label = "";
+    protected Context context = null;
+
+    public SeekbarPreference(final Context context) {
+        this(context, null);
+    }
+
+    public SeekbarPreference(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.preferenceStyle);
+    }
+
+    public SeekbarPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        this.context = context;
+        setPersistent(true);
+        setLayoutResource(R.layout.preference_seekbar);
+
+        // analyze given parameters
+        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SeekbarPreference);
+        minProgress = valueToProgress(a.getInt(R.styleable.SeekbarPreference_min, minProgress));
+        maxProgress = valueToProgress(a.getInt(R.styleable.SeekbarPreference_max, maxProgress));
+        final String temp = a.getString(R.styleable.SeekbarPreference_label);
+        if (null != temp) {
+            label = temp;
+        }
+        hasDecimals = a.getBoolean(R.styleable.SeekbarPreference_hasDecimals, useDecimals());
+        a.recycle();
+
+        init();
+    }
+
+    // naming convention:
+    // progress     - the internal value of the android widget (0 to max) - always int
+    // value        - actual value (may differ from "progress" if non linear or other boundaries) - always int
+    // shownValue   - displayed value (may differ from "value", if conversions are involved) - in:float out:float or int converted to string
+
+    protected int valueToProgressHelper(final int value) {
+        return value;
+    }
+
+    protected int valueToProgress(final int value) {
+        return valueToProgressHelper(value);
+    }
+
+    protected int progressToValue(final int progress) {
+        return progress;
+    }
+
+    protected String valueToShownValue(final int value) {
+        return useDecimals() ? String.format(Locale.US, "%.2f", (float) value) : String.valueOf(value);
+    }
+
+    protected int shownValueToValue(final float shownValue) {
+        return Math.round(shownValue);
+    }
+
+    protected void init() {
+        // init method gets called once by the constructor,
+        // so override and put initialization stuff in there (if needed)
+    }
+
+    protected String getValueString(final int progress) {
+        return valueToShownValue(progressToValue(progress)) + getUnitString();
+    }
+
+    /**
+     * Get unit-label for progress value.
+     * @return string for the unit label
+     */
+    protected String getUnitString() {
+        return "";
+    }
+
+    /**
+     * hasDecimals is parameter from SeekbarPreference, but can be overwritten.
+     * So use useDecimals instead of member
+     * @return hasDecimals
+     */
+    protected boolean useDecimals() {
+        return hasDecimals;
+    }
+
+    private boolean atLeastMin(final SeekBar seekBar, final int progress) {
+        if (progress < minProgress) {
+            seekBar.setProgress(minProgress);
+            return false;
+        }
+        return true;
+    }
+
+    protected void saveSetting(final int progress) {
+        if (callChangeListener(progress)) {
+            persistInt(progressToValue(progress));
+            notifyChanged();
+            // workaround for Android 7, as onCreateView() gets called unexpectedly after saveSetting(),
+            // and the the old startValue would be used, leading to a jumping slider
+            startProgress = progress;
+        }
+    }
+
+    @Override
+    protected void onSetInitialValue(final boolean restoreValue, final Object defaultValue) {
+        final int defValue = null != defaultValue ? (Integer) defaultValue : this.defaultValue;
+        final int defaultProgress = valueToProgress(restoreValue ? getPersistedInt(defValue) : defValue);
+        startProgress = defaultProgress < minProgress ? minProgress : Math.min(defaultProgress, maxProgress);
+    }
+
+    @Override
+    protected Object onGetDefaultValue(final TypedArray a, final int index) {
+        return a.getInt(index, defaultValue);
+    }
+
+    @Override
+    public void onBindViewHolder(final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+
+        // get views
+        final SeekBar seekBar = (SeekBar) holder.findViewById(R.id.preference_seekbar);
+        valueView = (TextView) holder.findViewById(R.id.preference_seekbar_value_view);
+
+        // init seekbar
+        seekBar.setMax(maxProgress);
+
+        // set initial value
+        final int threshold = startProgress;
+        valueView.setText(getValueString(threshold));
+        seekBar.setProgress(threshold);
+
+        // set label (if given)
+        if (null != label && !label.isEmpty()) {
+            final TextView labelView = (TextView) holder.findViewById(R.id.preference_seekbar_label_view);
+            labelView.setVisibility(View.VISIBLE);
+            labelView.setText(label);
+        }
+
+        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
+                if (fromUser && atLeastMin(seekBar, progress)) {
+                    valueView.setText(getValueString(progress));
+                }
+            }
+            @Override
+            public void onStartTrackingTouch(final SeekBar seekBar) {
+                // abstract method needs to be implemented, but is not used here
+            }
+            @Override
+            public void onStopTrackingTouch(final SeekBar seekBar) {
+                if (atLeastMin(seekBar, seekBar.getProgress())) {
+                    saveSetting(seekBar.getProgress());
+                }
+            }
+        });
+
+        valueView.setOnClickListener(v2 -> {
+            final String title = String.format(context.getString(R.string.number_input_title), valueToShownValue(progressToValue(minProgress)), valueToShownValue(progressToValue(maxProgress)));
+            final String defaultValue = valueToShownValue(progressToValue(seekBar.getProgress()));
+            int inputType = InputType.TYPE_CLASS_NUMBER;
+            if (useDecimals()) {
+                inputType |= InputType.TYPE_NUMBER_FLAG_DECIMAL;
+            }
+            final Consumer<String> listener = input -> {
+                int newValue;
+                try {
+                    newValue = valueToProgress(shownValueToValue(Float.parseFloat(input)));
+                    if (newValue > maxProgress) {
+                        newValue = maxProgress;
+                        Toast.makeText(context, R.string.number_input_err_boundarymax, Toast.LENGTH_SHORT).show();
+                    }
+                    if (newValue < minProgress) {
+                        newValue = minProgress;
+                        Toast.makeText(context, R.string.number_input_err_boundarymin, Toast.LENGTH_SHORT).show();
+                    }
+                    seekBar.setProgress(newValue);
+                    saveSetting(seekBar.getProgress());
+                    valueView.setText(getValueString(newValue));
+                } catch (NumberFormatException e) {
+                    Toast.makeText(context, R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
+                }
+            };
+            SimpleDialog.of((Activity) context).setTitle(TextParam.text(title)).input(inputType, defaultValue, null, getUnitString(), listener);
+        });
+    }
+}

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -1,15 +1,14 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.BackupSeekbarPreference;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.BackupUtils;
 
 import android.os.Bundle;
 
 import androidx.preference.CheckBoxPreference;
-import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.SeekBarPreference;
 
 public class PreferenceBackupFragment extends PreferenceFragmentCompat {
     public static final String STATE_BACKUPUTILS = "backuputils";
@@ -20,20 +19,17 @@ public class PreferenceBackupFragment extends PreferenceFragmentCompat {
 
         final BackupUtils backupUtils = new BackupUtils(getActivity(), savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
 
-        final Preference backup = findPreference(getString(R.string.pref_fakekey_preference_backup));
-        backup.setOnPreferenceClickListener(preference -> {
+        findPreference(getString(R.string.pref_fakekey_preference_backup)).setOnPreferenceClickListener(preference -> {
             backupUtils.backup(this::updateSummary);
             return true;
         });
 
-        final Preference restore = findPreference(getString(R.string.pref_fakekey_preference_restore));
-        restore.setOnPreferenceClickListener(preference -> {
+        findPreference(getString(R.string.pref_fakekey_preference_restore)).setOnPreferenceClickListener(preference -> {
             backupUtils.restore(BackupUtils.newestBackupFolder());
             return true;
         });
 
-        final Preference restoreFromDir = findPreference(getString(R.string.pref_fakekey_preference_restore_dirselect));
-        restoreFromDir.setOnPreferenceClickListener(preference -> {
+        findPreference(getString(R.string.pref_fakekey_preference_restore_dirselect)).setOnPreferenceClickListener(preference -> {
             backupUtils.selectBackupDirIntent();
             return true;
         });
@@ -49,10 +45,8 @@ public class PreferenceBackupFragment extends PreferenceFragmentCompat {
 
         updateSummary();
 
-        final SeekBarPreference keepOld = (SeekBarPreference) findPreference(getString(R.string.pref_backups_backup_history_length));
-
-        keepOld.setOnPreferenceChangeListener((preference, value) -> {
-            backupUtils.deleteBackupHistoryDialog((SeekBarPreference) preference, (int) value);
+        findPreference(getString(R.string.pref_backups_backup_history_length)).setOnPreferenceChangeListener((preference, value) -> {
+            backupUtils.deleteBackupHistoryDialog((BackupSeekbarPreference) preference, (int) value);
             return true;
         });
 

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.InstallWizardActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.settings.BackupSeekbarPreference;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.ContentStorageActivityHelper;
@@ -39,7 +40,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Consumer;
-import androidx.preference.SeekBarPreference;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -316,7 +316,7 @@ public class BackupUtils {
         }
     }
 
-    public void deleteBackupHistoryDialog(final SeekBarPreference preference, final int newValue) {
+    public void deleteBackupHistoryDialog(final BackupSeekbarPreference preference, final int newValue) {
         final List<ContentStorage.FileInformation> dirs = getDirsToRemove(newValue + 1);
 
         if (dirs != null) {


### PR DESCRIPTION
## Description
Restoring some old settings' code, upgrading it to AndroidX, to reenable our former `SeekbarPreference` capabilities:
- enable setting value by tapping on the value field right beside the slider
- enable logarithmic scaling (where applicable)
- enable value conversion (where applicable)
- enable displaying texts for min/max value in `BackupSeekbarPreference`
