### PR TITLE
Bump okhttp from 4.9.2 to 4.9.3 on release branch

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -351,7 +351,7 @@ dependencies {
     // Metadata Extractor, EXIF location extraction from images
     implementation 'com.drewnoakes:metadata-extractor:2.16.0'
 
-    implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 
     // Play Services
     implementation 'com.google.android.gms:play-services-location:18.0.0'


### PR DESCRIPTION
from changelog:
- Fix: Don't fail HTTP/2 responses if they complete before a RST_STREAM is sent.

This should go to the release branch to have this bug fix in the next release

supersedes #12158
