### PR TITLE
add category info for elevate theme options

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2339,6 +2339,7 @@
     <string name="mapserver_hylly_info">Detailed maps for Finland, require one of the \"Hylly\" map themes</string>
     <string name="mapserver_hylly_themes_info">Detailed map theme, built for \"Hylly\" maps</string>
     <string name="brouter_info">Offline routing service</string>
+    <string name="maptheme_elevate_categoryinfo">Relevant for: [A] Areas, [P] POI, [R] Routes, [W] Ways</string>
 
     <!-- history track -->
     <string name="map_clear_trailhistory">Clear history track</string>

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
@@ -1,17 +1,21 @@
 package cgeo.geocaching.maps.mapsforge.v6;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 
+import android.app.Activity;
 import android.os.Bundle;
 
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
 import org.mapsforge.map.rendertheme.XmlRenderThemeStyleMenu;
 
@@ -42,9 +46,11 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
     }
 
     private void createRenderthemeMenu() {
+        final Activity activity = getActivity();
+
         this.renderthemeMenu.removeAll();
 
-        this.baseLayerPreference = new ListPreference(getActivity());
+        this.baseLayerPreference = new ListPreference(activity);
         baseLayerPreference.setTitle(R.string.settings_title_map_style);
 
         // the id of the setting is the id of the stylemenu, that allows this
@@ -89,6 +95,14 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
         });
         renderthemeMenu.addPreference(baseLayerPreference);
 
+        // additional theme info
+        if (isElevateTheme()) {
+            final Preference info = new Preference(activity);
+            info.setSummary(R.string.maptheme_elevate_categoryinfo);
+            info.setIconSpaceReserved(false);
+            renderthemeMenu.addPreference(info);
+        }
+
         String selection = baseLayerPreference.getValue();
         // need to check that the selection stored is actually a valid getLayer in the current rendertheme.
         if (selection == null || !renderthemeOptions.getLayers().containsKey(selection)) {
@@ -98,7 +112,7 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
         baseLayerPreference.setSummary(renderthemeOptions.getLayer(selection).getTitle(language));
 
         for (final XmlRenderThemeStyleLayer overlay : this.renderthemeOptions.getLayer(selection).getOverlays()) {
-            final CheckBoxPreference checkbox = new CheckBoxPreference(getActivity());
+            final CheckBoxPreference checkbox = new CheckBoxPreference(activity);
             checkbox.setKey(overlay.getId());
             checkbox.setPersistent(true);
             checkbox.setTitle(overlay.getTitle(language));
@@ -111,4 +125,8 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
         }
     }
 
+    private boolean isElevateTheme() {
+        final String selectedMapRenderTheme = Settings.getSelectedMapRenderTheme();
+        return StringUtils.containsIgnoreCase(selectedMapRenderTheme, "elevate") || StringUtils.containsIgnoreCase(selectedMapRenderTheme, "elements");
+    }
 }


### PR DESCRIPTION
## Description
For setting map theme options, the "Elevate" and "Elements" themes have grouped the options and indicate that group by a prepended letter. This PR adds a short explanation to the map theme options menu, if either "Elevate" or "Elements" theme is selected:

![image](https://user-images.githubusercontent.com/3754370/145673907-40a5ef38-7118-4021-9c0c-b3c82146b39f.png)
