### PR TITLE
fix #12242: name viewroots uniquely to allow correct state reconstruction on resume

### DIFF
--- a/main/res/layout/cache_filter_activity.xml
+++ b/main/res/layout/cache_filter_activity.xml
@@ -2,12 +2,12 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/activity_viewroot"
+    android:id="@+id/cachefilter_activity_viewroot"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:layout_marginTop="10dip"
-    tools:context=".filter.FilterActivity" >
+    tools:context=".filters.gui.GeocacheFilterActivity" >
 
     <LinearLayout
         android:layout_width="fill_parent"

--- a/main/res/layout/cachedetail_variables_page.xml
+++ b/main/res/layout/cachedetail_variables_page.xml
@@ -2,7 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/activity_viewroot"
+    android:id="@+id/variable_page_viewroot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"

--- a/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -89,7 +89,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setThemeAndContentView(R.layout.cache_filter_activity);
-        binding = CacheFilterActivityBinding.bind(findViewById(R.id.activity_viewroot));
+        binding = CacheFilterActivityBinding.bind(findViewById(R.id.cachefilter_activity_viewroot));
 
         binding.filterPropsCheckboxes.removeAllViews();
         this.andOrFilterCheckbox = ViewUtils.addCheckboxItem(this, binding.filterPropsCheckboxes, TextParam.id(R.string.cache_filter_option_and_or), R.drawable.ic_menu_logic);


### PR DESCRIPTION
fix #12242: name viewroots uniquely to allow correct state reconstruction on resume