### PR TITLE
set android:exported="true" if this is required

### DIFF
--- a/cgeo-contacts/AndroidManifest.xml
+++ b/cgeo-contacts/AndroidManifest.xml
@@ -19,7 +19,8 @@
         <activity
             android:name=".ContactsActivity"
             android:label="@string/app_name"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" >
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="cgeo.contacts.FIND" />
 

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -231,7 +231,7 @@
             android:label="@string/auth_twitter"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -437,7 +437,7 @@
             android:name="cgeo.geocaching.log.LogTrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/trackable_touch"
-            android:exported="false">
+            android:exported="true">
 
             <!-- GeoKrety.org QRCode-->
             <intent-filter>
@@ -463,7 +463,7 @@
             android:name=".CacheDetailActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="wikitudeapi.arcallback" />
 
@@ -660,7 +660,7 @@
             android:name="cgeo.geocaching.TrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
-            android:exported="false">
+            android:exported="true">
 
             <!-- TravelBug URL via coord.info redirection -->
             <intent-filter>
@@ -752,7 +752,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -769,7 +769,7 @@
             android:name=".CreateShortcutActivity"
             android:label="@string/cgeo_shortcut"
             android:parentActivityName="cgeo.geocaching.MainActivity"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
 
@@ -793,7 +793,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -807,7 +807,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -821,7 +821,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -835,7 +835,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -854,7 +854,7 @@
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -923,7 +923,7 @@
 
         <!-- Receiver for downloaded (map) files -->
         <receiver android:name=".downloader.DownloadNotificationReceiver"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
             </intent-filter>

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -230,7 +230,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/auth_twitter"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -435,7 +436,8 @@
         <activity
             android:name="cgeo.geocaching.log.LogTrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:label="@string/trackable_touch" >
+            android:label="@string/trackable_touch"
+            android:exported="false">
 
             <!-- GeoKrety.org QRCode-->
             <intent-filter>
@@ -460,7 +462,8 @@
         <activity
             android:name=".CacheDetailActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="false">
             <intent-filter>
                 <action android:name="wikitudeapi.arcallback" />
 
@@ -656,7 +659,8 @@
         <activity
             android:name="cgeo.geocaching.TrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="false">
 
             <!-- TravelBug URL via coord.info redirection -->
             <intent-filter>
@@ -747,7 +751,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -763,7 +768,8 @@
         <activity
             android:name=".CreateShortcutActivity"
             android:label="@string/cgeo_shortcut"
-            android:parentActivityName="cgeo.geocaching.MainActivity" >
+            android:parentActivityName="cgeo.geocaching.MainActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
 
@@ -786,7 +792,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -799,7 +806,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -812,7 +820,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -825,7 +834,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -843,7 +853,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -911,7 +922,8 @@
         </provider>
 
         <!-- Receiver for downloaded (map) files -->
-        <receiver android:name=".downloader.DownloadNotificationReceiver">
+        <receiver android:name=".downloader.DownloadNotificationReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
             </intent-filter>


### PR DESCRIPTION
fixes #12354

Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined.

We already set `android:exported="true"` if this is necessary.
Add this value also for the remaining intents.

(edited)