### PR TITLE
DO NOT MERGE, rel to #12340: emergency fix, skip migration

### DIFF
--- a/main/src/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/cgeo/geocaching/storage/LocalStorage.java
@@ -481,8 +481,9 @@ public final class LocalStorage {
             //delete theme files from outdated internal theme file dir
             if (currentVersion < 3) {
                 setMigratedVersion(3, "Move Mapsforge SVG Cache Dir");
-                FileUtils.deleteFilesWithPrefix(getInternalCgeoDirectory(), "svg-");
-                FileUtils.deleteFilesWithPrefix(new File(getInternalCgeoDirectory(), "files"), "svg-");
+                //emergency fix for #12340: SKIP actual migration
+                //FileUtils.deleteFilesWithPrefix(getInternalCgeoDirectory(), "svg-");
+                //FileUtils.deleteFilesWithPrefix(new File(getInternalCgeoDirectory(), "files"), "svg-");
             }
 
             return finalVersion;


### PR DESCRIPTION
rel to #12340: emergency fix, skip migration

This PR is an emergency fix for #12340: it simply SKIPS the migration to local storage version 3 (this means that there will be leftover svg files on the user's device from mapsforge cache. They won't do any harm except they take away device space)