### PR TITLE
Fix #12391 - Let CI ignore crowdin commits

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,5 @@
+commit_message: "[skip ci]"
+append_commit_message: true
 files:
   - source: /main/res/values/strings.xml
     translation: /main/res/values-%two_letters_code%/%original_file_name%


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Append keyword to commit messages to make CI pull request builder ignore those commits.

Needs to be checked in practice whether the PR builder still checks the PR once or how to achieve this (dont run a build for each commit but only once after all commits have been added to the PR).


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#12391


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->