### PR TITLE
Use different parameter name for routing service profile (fix #12410)

### DIFF
--- a/main/src/cgeo/geocaching/brouter/BRouterConstants.java
+++ b/main/src/cgeo/geocaching/brouter/BRouterConstants.java
@@ -10,6 +10,8 @@ public class BRouterConstants {
 
     public static final String BROUTER_TILE_FILEEXTENSION = ".rd5";
 
+    public static final String PROFILE_PARAMTERKEY = "internal_routing_profile";
+
     private BRouterConstants() {
         // utility class
     }

--- a/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
+++ b/main/src/cgeo/geocaching/brouter/InternalRoutingService.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.brouter;
 import cgeo.geocaching.brouter.util.DefaultFilesUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
+import static cgeo.geocaching.brouter.BRouterConstants.PROFILE_PARAMTERKEY;
 
 import android.app.Service;
 import android.content.Intent;
@@ -21,7 +22,7 @@ public class InternalRoutingService extends Service {
         public String getTrackFromParams(final Bundle params) {
             final BRouterWorker worker = new BRouterWorker();
 
-            worker.profileFilename = params.getString("profile");
+            worker.profileFilename = params.getString(PROFILE_PARAMTERKEY);
             if (StringUtils.isBlank(worker.profileFilename)) {
                 return ""; // cannot calculate a route without a profile
             }

--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
+import static cgeo.geocaching.brouter.BRouterConstants.PROFILE_PARAMTERKEY;
 
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -208,7 +209,7 @@ public final class Routing {
         params.putDoubleArray("lats", new double[]{start.getLatitude(), dest.getLatitude()});
         params.putDoubleArray("lons", new double[]{start.getLongitude(), dest.getLongitude()});
         params.putString("v", Settings.getRoutingMode().parameterValue);
-        params.putString("profile", Settings.getRoutingProfile()); // profile filename, used only by internal routing engine
+        params.putString(PROFILE_PARAMTERKEY, Settings.getRoutingProfile()); // profile filename, used only by internal routing engine
 
         final String gpx = routingServiceConnection == null ? null : routingServiceConnection.getTrackFromParams(params);
 


### PR DESCRIPTION
## Description
Use a different parameter name for routing service profile as the one used so far seems to be in use now, starting with BRouter 1.63, effectively preventing c:geo to use the external routing service.
