### PR TITLE
check for missing routing data for current viewport (fix #12172)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -167,6 +167,9 @@
         android:visible="false">
     </item>
     <item
+        android:id="@+id/menu_check_routingdata"
+        android:title="@string/check_tiles_missing" />
+    <item
         android:id="@+id/menu_as_list"
         android:icon="@drawable/ic_menu_list"
         android:title="@string/map_as_list">

--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -168,7 +168,7 @@
     </item>
     <item
         android:id="@+id/menu_check_routingdata"
-        android:title="@string/check_tiles_missing" />
+        android:title="@string/check_tiles_menu" />
     <item
         android:id="@+id/menu_as_list"
         android:icon="@drawable/ic_menu_list"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2331,6 +2331,9 @@
     <string name="downloadmap_checking_for_updates">Checking for updates…</string>
     <string name="downloadtile_title">Missing routing data</string>
     <string name="downloadtile_info">c:geo cannot calculate the requested route as there is some routing data file missing. Do you want to download missing routing data?</string>
+    <string name="check_tiles_menu">Check for missing routing data</string>
+    <string name="check_tiles_found">Routing data already present</string>
+    <string name="check_tiles_missing">Found missing routing data:\n%1$s\n\nDo you want to download those files?%2$s</string>
     <string name="tileupdate_info">Do you want to check for updates of downloaded routing data files?</string>
     <string name="mapupdate_info">Do you want to check for updates of map and theme files?</string>
     <string name="no_updates_found">No updates found</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2334,6 +2334,7 @@
     <string name="check_tiles_menu">Check for missing routing data</string>
     <string name="check_tiles_found">Routing data already present</string>
     <string name="check_tiles_missing">Found missing routing data:\n%1$s\n\nDo you want to download those files?%2$s</string>
+    <string name="check_tiles_unsupported">Warning: Routing data is at least partly not available for the chosen region</string>
     <string name="tileupdate_info">Do you want to check for updates of downloaded routing data files?</string>
     <string name="mapupdate_info">Do you want to check for updates of map and theme files?</string>
     <string name="no_updates_found">No updates found</string>

--- a/main/src/cgeo/geocaching/downloader/BRouterTileDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/BRouterTileDownloader.java
@@ -1,8 +1,10 @@
 package cgeo.geocaching.downloader;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.brouter.BRouterConstants;
 import cgeo.geocaching.models.Download;
+import cgeo.geocaching.network.Network;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Formatter;
@@ -13,6 +15,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -61,6 +65,22 @@ public class BRouterTileDownloader extends AbstractDownloader {
     @NonNull
     public static BRouterTileDownloader getInstance() {
         return INSTANCE;
+    }
+
+    // used for area tile checking, see MapUtils
+    public HashMap<String, Download> getAvailableTiles() {
+        final HashMap<String, Download> tiles = new HashMap<>();
+
+        final String url = CgeoApplication.getInstance().getString(R.string.brouter_downloadurl);
+        final String page = Network.getResponseData(Network.getRequest(url));
+        final List<Download> list = new ArrayList<>();
+        if (page != null) {
+            analyzePage(Uri.parse(url), list, page);
+        }
+        for (Download download : list) {
+            tiles.put(download.getName(), download);
+        }
+        return tiles;
     }
 
 }

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -826,6 +826,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             menuShowHint();
         } else if (id == R.id.menu_compass) {
             menuCompass();
+        } else if (id == R.id.menu_check_routingdata) {
+            final Viewport bb = mapView.getViewport();
+            MapUtils.checkRoutingData(activity, bb.bottomLeft.getLatitude(), bb.bottomLeft.getLongitude(), bb.topRight.getLatitude(), bb.topRight.getLongitude());
         } else if (HistoryTrackUtils.onOptionsItemSelected(activity, id, () -> mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null), this::clearTrailHistory)
                 || getTrackUtils().onOptionsItemSelected(id, tracks)
                 || getIndividualRouteUtils().onOptionsItemSelected(id, individualRoute, this::centerOnPosition, this::setTarget)

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -132,6 +132,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.MapPosition;
 import org.mapsforge.core.util.Parameters;
@@ -479,6 +480,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             menuShowHint();
         } else if (id == R.id.menu_compass) {
             menuCompass();
+        } else if (id == R.id.menu_check_routingdata) {
+            final BoundingBox bb = mapView.getBoundingBox();
+            MapUtils.checkRoutingData(this, bb.minLatitude, bb.minLongitude, bb.maxLatitude, bb.maxLongitude);
         } else if (HistoryTrackUtils.onOptionsItemSelected(this, id, () -> historyLayer.requestRedraw(), this::clearTrailHistory)
                 || this.trackUtils.onOptionsItemSelected(id, tracks)
                 || this.individualRouteUtils.onOptionsItemSelected(id, individualRoute, this::centerOnPosition, this::setTarget)


### PR DESCRIPTION
## Description
- adds a menu entry "Check for missing routing data" to the map
- if selected, c:geo checks whether routing data is available for the whole viewport currently visible, and offers to download missing files
- checking is done in background
- if you select to download missing files, this triggers our regular integrated downloader

![image](https://user-images.githubusercontent.com/3754370/147599598-d007bef4-4d67-41fb-80ef-f5b2776045fc.png).![image](https://user-images.githubusercontent.com/3754370/147599614-b06f40c5-fdb0-4dee-a71a-1bd08a1a53cd.png)
