### PR TITLE
Fix #12431 - Increase detection of cache series to a max of 500 caches

### DIFF
--- a/main/res/raw/changelog_base.md
+++ b/main/res/raw/changelog_base.md
@@ -11,6 +11,7 @@
 - New: Attributes overview (see Manage Caches => Attributes overview)
 - New: Add import from bookmark lists (GC premium only)
 - New: Invert sort-order on long click on sort bar
+- Change: Also perform automatic sorting by distance for lists containing cache series with more than 50 caches (up to 500)
 
 ### Cache details
 - New: Pass current cache coordinates to geochecker (if supported by geochecker)

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -665,7 +665,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
      */
     private void checkSeries() {
         boolean series = false;
-        if (list.size() < 3 || list.size() > 50) {
+        if (list.size() < 3 || list.size() > 500) {
             return;
         }
         final ArrayList<String> names = new ArrayList<>();


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Increase the limit for detection whether a cache list contains a series of caches (`isSeriesList`) from 50 to 500 caches.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#12431
## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->