### PR TITLE
in attributes filter allow selecting from which connectors attributes are shown 

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -162,6 +162,7 @@
     <string translatable="false" name="pref_createUDCuseGivenList">createUDCuseGivenList</string>
     <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
     <string translatable="false" name="pref_bookmarklistsShowNewOnly">bookmarklistsShowNewOnly</string>
+    <string translatable="false" name="pref_attributeFilterSources">attributeFilterSources</string>
     <!-- preferences used internally -->
     <string translatable="false" name="pref_temp_twitter_token_secret">temp-token-secret</string>
     <string translatable="false" name="pref_temp_twitter_token_public">temp-token-public</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1998,12 +1998,17 @@
     <string name="attribute_unknown">Unknown attribute</string>
 
     <!-- cache attribute categories -->
-    <string name="cat_tools">Tools required</string>
+    <string name="cat_tools">Equipment</string>
     <string name="cat_type">Type</string>
     <string name="cat_location">Cache location</string>
     <string name="cat_duration">Distance / Duration</string>
     <string name="cat_surrounding">Around the cache</string>
     <string name="cat_permissions">Permissions</string>
+
+    <!-- cache attribute sources -->
+    <string name="attribute_source_all">All</string>
+    <string name="attribute_source_gc">GC</string>
+    <string name="attribute_source_oc">OC</string>
 
     <!-- next things -->
     <string name="quote">To make geocaching easier, to make users lazier.</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1272,34 +1272,31 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             }
             final HashSet<String> attributesSet = new HashSet<>(attributes);
             // traverse by category and attribute order
-            final ArrayList<String> a = new ArrayList<>();
-            final StringBuilder text = new StringBuilder();
+            final ArrayList<String> orderedAttributeNames = new ArrayList<>();
+            final StringBuilder attributesText = new StringBuilder();
             CacheAttributeCategory lastCategory = null;
             for (CacheAttributeCategory category : CacheAttributeCategory.getOrderedCategoryList()) {
-                for (CacheAttribute attr : CacheAttribute.values()) {
-                    if (attr.category == category) {
-                        for (Boolean enabled : Arrays.asList(false, true)) {
-                            final String key = attr.getValue(enabled);
-                            if (attributesSet.contains(key)) {
-                                if (lastCategory != category) {
-                                    if (lastCategory != null) {
-                                        text.append("<br /><br />");
-                                    }
-                                    text.append("<u>").append(category.getName(activity)).append("</u>");
-                                    lastCategory = category;
-                                }
-                                a.add(key);
-                                text.append("<br />").append(attr.getL10n(enabled));
+                for (CacheAttribute attr : CacheAttribute.getByCategory(category)) {
+                    for (Boolean enabled : Arrays.asList(false, true, null)) {
+                        final String key = attr.getValue(enabled);
+                        if (attributes.contains(key)) {
+                            if (lastCategory != category) {
+                                attributesText.append("<h6>").append(category.getName(activity)).append("</h6>");
+                                lastCategory = category;
+                            } else {
+                                attributesText.append("<br />");
                             }
+                            orderedAttributeNames.add(key);
+                            attributesText.append(attr.getL10n(enabled == null ? true : enabled));
                         }
                     }
                 }
             }
 
-            binding.attributesGrid.setAdapter(new AttributesGridAdapter(activity, a, () -> toggleAttributesView()));
+            binding.attributesGrid.setAdapter(new AttributesGridAdapter(activity, orderedAttributeNames, () -> toggleAttributesView()));
             binding.attributesGrid.setVisibility(View.VISIBLE);
 
-            binding.attributesText.setText(HtmlCompat.fromHtml(text.toString(), 0));
+            binding.attributesText.setText(HtmlCompat.fromHtml(attributesText.toString(), 0));
             binding.attributesText.setVisibility(View.GONE);
             binding.attributesText.setOnClickListener(v -> toggleAttributesView());
         }

--- a/main/src/cgeo/geocaching/enumerations/CacheAttribute.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheAttribute.java
@@ -2,12 +2,15 @@ package cgeo.geocaching.enumerations;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 
 import android.util.SparseArray;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -230,6 +233,17 @@ public enum CacheAttribute {
         return FIND_BY_OCACODE.get(ocAcode);
     }
 
+    @Nullable
+    public static List<CacheAttribute> getByCategory(final CacheAttributeCategory category) {
+        final List<CacheAttribute> attributes = new ArrayList<>();
+        for (CacheAttribute attr : CacheAttribute.values()) {
+            if (attr.category == category) {
+                attributes.add(attr);
+            }
+        }
+        return attributes;
+    }
+
     @NonNull
     public static String trimAttributeName(@Nullable final String attributeName) {
         if (attributeName == null) {
@@ -255,8 +269,36 @@ public enum CacheAttribute {
     /**
      * get the value of this attribute for the given activation state, e.g. "dogs_yes" or "wheelchair_no".
      */
-    public String getValue(final boolean active) {
-        return rawName + (active ? INTERNAL_YES : INTERNAL_NO);
+    public String getValue(final Boolean active) {
+        if (active == null) {
+            return rawName;
+        } else {
+            return rawName + (active ? INTERNAL_YES : INTERNAL_NO);
+        }
+    }
+
+    /**
+     * Filter the list of attributes based on the associated connector
+     */
+    public static List<CacheAttribute> getAttributesByCategoryAndConnector(final CacheAttributeCategory cac) {
+        final boolean showGc = Settings.isAttributeFilterSourcesGC();
+        final boolean showOc = Settings.isAttributeFilterSourcesOkapi();
+
+        final List<CacheAttribute> filteredAttributes = new ArrayList<>();
+        final List<CacheAttribute> unfilteredAttributes;
+        if (cac == null) {
+            unfilteredAttributes = Arrays.asList(CacheAttribute.values());
+        } else {
+            unfilteredAttributes = getByCategory(cac);
+        }
+        for (CacheAttribute ca : unfilteredAttributes) {
+            if (showGc && ca.gcid > -1 && ca.gcid < 100) {
+                filteredAttributes.add(ca);
+            } else if (showOc && ca.ocacode > -1) {
+                filteredAttributes.add(ca);
+            }
+        }
+        return filteredAttributes;
     }
 
 }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -4,6 +4,8 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.apps.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.brouter.BRouterConstants;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.IAvatar;
 import cgeo.geocaching.connector.capability.ICredentials;
 import cgeo.geocaching.connector.gc.GCConnector;
@@ -2051,4 +2053,39 @@ public class Settings {
     public static boolean isDTMarkerEnabled() {
         return getBoolean(R.string.pref_dtMarkerOnCacheIcon, false);
     }
+
+    private static int getAttributeFilterSources() {
+        int setting = getInt(R.string.pref_attributeFilterSources, 0);
+        if (setting == 0) {
+            // guess a reasonable default value based on enabled connectors
+            boolean gc = false;
+            boolean okapi = false;
+            final List<IConnector> activeConnectors = ConnectorFactory.getActiveConnectors();
+            for (final IConnector conn : activeConnectors) {
+                if ("GC".equals(conn.getNameAbbreviated()) || "AL".equals(conn.getNameAbbreviated())) {
+                    gc = true;
+                } else {
+                    okapi = true;
+                }
+            }
+            setting = 3 - (!gc ? 1 : 0) + (!okapi ? 2 : 0);
+        }
+        return setting;
+    }
+
+    public static boolean isAttributeFilterSourcesGC() {
+        return getAttributeFilterSources() != 2;
+    }
+
+    public static boolean isAttributeFilterSourcesOkapi() {
+        return getAttributeFilterSources() >= 2;
+    }
+
+    /**
+     * For which connectors should attributes be shown: 1 GC, 2 Okapi, 3 Both
+     */
+    public static void setAttributeFilterSources(final int value) {
+        putInt(R.string.pref_attributeFilterSources, value);
+    }
+
 }


### PR DESCRIPTION
Allow filtering attributes by the connector that uses them in filters "Cache Attributes" dialog.
GC uses 70 attributes, OC (okapi) 89 for a total of 124. For a GC-only cacher that means there are currently 54 unused icons shown in the list.

This feature allows the user to have only those attributes relevant for him visible, controllable with buttons in the filter dialog itself.
The default setting is based on enabled connectors (I'm open to removing this depending on feedback - this is where it started but with a GUI element I'm not too fixed on it)

This also fixes #12425 and #12433 along with some layout changes to "Attributes Overview" and attributes text view in cache details

GC only:
![image](https://user-images.githubusercontent.com/1258173/147686549-d2b1354f-b453-417d-9490-b54fe806e06c.png)

OC only:
![image](https://user-images.githubusercontent.com/1258173/147686564-71c21117-b61c-4b69-a235-4d8f6c29793d.png)

GC + OC:
![image](https://user-images.githubusercontent.com/1258173/147686583-a105d10e-d9db-4f1e-8984-1cef0e7af159.png)

Attributes text view in cache:
![image](https://user-images.githubusercontent.com/1258173/147692269-c6bdf6a8-7441-44fe-bdce-dee61175b4d0.png)

Attribute overview:
![image](https://user-images.githubusercontent.com/1258173/147692301-4a28cca7-7a79-4e04-897f-e5c5c2cbf2b2.png)

