### PR TITLE
enable search in preference screen (rel. to #12335)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -277,10 +277,16 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/settings_titlebar"
             android:parentActivityName="cgeo.geocaching.MainActivity"
-            android:theme="@style/settings" >
+            android:theme="@style/settings"
+            android:exported="false">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="cgeo.geocaching.MainActivity" />
+            <intent-filter>
+                <action android:name="android.intent.action.SEARCH"/>
+            </intent-filter>
+            <meta-data android:name="android.app.searchable"
+                android:resource="@xml/searchable_settings" />
         </activity>
         <activity android:name=".settings.ViewSettingsActivity" />
         <activity

--- a/main/res/menu/settings_activity_options.xml
+++ b/main/res/menu/settings_activity_options.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+
+    <item
+        android:id="@+id/menu_gosearch"
+        android:icon="@drawable/ic_menu_search"
+        android:title="@string/search_bar_hint_settings"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:iconifiedByDefault="true"
+        app:showAsAction="collapseActionView|always" />
+
+</menu>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -15,6 +15,15 @@
 
     <string translatable="false" name="preference_screen_main">fakekey_main_screen</string>
     <string translatable="false" name="preference_screen_services">fakekey_services_screen</string>
+    <string translatable="false" name="pref_appearance">pref_appearance</string>
+    <string translatable="false" name="preference_screen_cachedetails">fakekey_cachedetails_screen</string>
+    <string translatable="false" name="preference_screen_map">fakekey_map_screen</string>
+    <string translatable="false" name="preference_screen_logging">fakekey_logging_screen</string>
+    <string translatable="false" name="preference_screen_offlinedata">fakekey_offlinedata_screen</string>
+    <string translatable="false" name="preference_screen_navigation">fakekey_navigation_screen</string>
+    <string translatable="false" name="preference_screen_system">fakekey_system_screen</string>
+    <string translatable="false" name="preference_screen_backup">fakekey_backup_screen</string>
+
     <string translatable="false" name="preference_screen_gc">preference_screen_gc</string>
     <string translatable="false" name="preference_screen_basicmembers">fakekey_basicmembers_screen</string>
     <string translatable="false" name="preference_screen_ocde">preference_screen_ocde</string>
@@ -27,11 +36,9 @@
     <string translatable="false" name="preference_screen_lc">preference_screen_lc</string>
     <string translatable="false" name="preference_screen_su">preference_screen_su</string>
     <string translatable="false" name="preference_screen_twitter">preference_screen_twitter</string>
-    <string translatable="false" name="preference_screen_navigation_menu">fakekey_navigation_menu_screen</string>
     <string translatable="false" name="preference_screen_sendtocgeo">preference_screen_sendtocgeo</string>
     <string translatable="false" name="preference_screen_gcvote">preference_screen_gcvote</string>
     <string translatable="false" name="preference_screen_geokrety">preference_screen_geokrety</string>
-    <string translatable="false" name="preference_screen_backup">fakekey_backup_screen</string>
     <string translatable="false" name="pref_fakekey_ocde_authorization">fakekey_ocde_authorization</string>
     <string translatable="false" name="pref_fakekey_ocpl_authorization">fakekey_ocpl_authorization</string>
     <string translatable="false" name="pref_fakekey_ocnl_authorization">fakekey_ocnl_authorization</string>
@@ -44,6 +51,8 @@
     <string translatable="false" name="pref_fakekey_ec_authorization">fakekey_ec_authorization</string>
     <string translatable="false" name="pref_fakekey_su_authorization">fakekey_su_authorization</string>
     <string translatable="false" name="pref_fakekey_gcvote_authorization">fakekey_gcvote_authorization</string>
+    <string translatable="false" name="preference_screen_navigation_menu">fakekey_navigation_menu_screen</string>
+
     <string translatable="false" name="pref_connectorGCActive">connectorGCActive</string>
     <string translatable="false" name="pref_username">username</string>
     <string translatable="false" name="pref_password">password</string>
@@ -282,7 +291,6 @@
     <string translatable="false" name="pref_generate_logcat">generate_logcat</string>
     <string translatable="false" name="pref_generate_infos_downloadmanager">generate_infos_downloadmanager</string>
     <string translatable="false" name="pref_view_settings">view_settings</string>
-    <string translatable="false" name="pref_appearance">pref_appearance</string>
     <string translatable="false" name="pref_changelog_last_checksum">changelog_last_checksum</string>
     <string translatable="false" name="pref_caches_history">caches_history</string>
     <string translatable="false" name="pref_phone_model_and_sdk">phone_model_and_sdk</string>

--- a/main/res/xml/preferences_cachedetails.xml
+++ b/main/res/xml/preferences_cachedetails.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_details"
     android:title="@string/settings_title_cachedetails"
-    android:summary="@string/settings_summary_cachedetails" >
+    android:summary="@string/settings_summary_cachedetails"
+    app:key="@string/preference_screen_cachedetails">
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="@string/pref_friendlogswanted"

--- a/main/res/xml/preferences_logging.xml
+++ b/main/res/xml/preferences_logging.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_pen"
     android:summary="@string/settings_summary_logging"
-    android:title="@string/settings_title_logging">
+    android:title="@string/settings_title_logging"
+    app:key="@string/preference_screen_logging">
 
     <PreferenceCategory
         android:title="@string/init_signature"

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_map"
     android:summary="@string/settings_summary_map"
-    android:title="@string/settings_title_map">
+    android:title="@string/settings_title_map"
+    app:key="@string/preference_screen_map">
 
     <PreferenceCategory
         android:title="@string/settings_title_map_data"

--- a/main/res/xml/preferences_navigation.xml
+++ b/main/res/xml/preferences_navigation.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_arrow"
     android:summary="@string/settings_summary_navigation"
-    android:title="@string/settings_title_navigation">
+    android:title="@string/settings_title_navigation"
+    app:key="@string/preference_screen_navigation">
 
     <PreferenceCategory
         android:title="@string/settings_title_offline_routing"

--- a/main/res/xml/preferences_offlinedata.xml
+++ b/main/res/xml/preferences_offlinedata.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_sdcard"
     android:summary="@string/settings_summary_offlinedata"
-    android:title="@string/settings_title_offlinedata">
+    android:title="@string/settings_title_offlinedata"
+    app:key="@string/preference_screen_offlinedata">
     <CheckBoxPreference
         android:defaultValue="false"
         android:key="@string/pref_logimages"

--- a/main/res/xml/preferences_system.xml
+++ b/main/res/xml/preferences_system.xml
@@ -2,7 +2,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_nut"
     android:summary="@string/settings_summary_system"
-    android:title="@string/settings_title_system">
+    android:title="@string/settings_title_system"
+    app:key="@string/preference_screen_system">
 
     <PreferenceCategory
         android:key="@string/pref_group_localfilesystem"

--- a/main/res/xml/searchable_settings.xml
+++ b/main/res/xml/searchable_settings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchable xmlns:android="http://schemas.android.com/apk/res/android"
+    android:hint="@string/search_bar_hint_settings"
+    android:imeOptions="actionSearch"
+    android:inputType="textNoSuggestions"
+    android:label="@string/app_name"
+    android:voiceSearchMode="showVoiceSearchButton|launchRecognizer" >
+
+</searchable>

--- a/main/src/cgeo/geocaching/Intents.java
+++ b/main/src/cgeo/geocaching/Intents.java
@@ -61,6 +61,7 @@ public class Intents {
     private static final String PREFIX_ACTION = "cgeo.geocaching.intent.action.";
     public static final String ACTION_GEOCACHE = PREFIX_ACTION + "GEOCACHE";
     public static final String ACTION_TRACKABLE = PREFIX_ACTION + "TRACKABLE";
+    public static final String ACTION_SETTINGS = PREFIX_ACTION + "SETTINGS";
 
     private static final String PREFIX_OAUTH = "cgeo.geocaching.intent.oauth.";
     public static final String EXTRA_OAUTH_HOST = PREFIX_OAUTH + "host";

--- a/main/src/cgeo/geocaching/search/BaseSearchSuggestionCursor.java
+++ b/main/src/cgeo/geocaching/search/BaseSearchSuggestionCursor.java
@@ -1,26 +1,21 @@
 package cgeo.geocaching.search;
 
-import cgeo.geocaching.Intents;
-import cgeo.geocaching.enumerations.CacheType;
-
 import android.app.SearchManager;
 import android.database.MatrixCursor;
 import android.provider.BaseColumns;
-
-import androidx.annotation.NonNull;
 
 /**
  * Fixed fields cursor holding the necessary data for the search provider of the global search bar.
  *
  */
-public class SearchSuggestionCursor extends MatrixCursor {
+public class BaseSearchSuggestionCursor extends MatrixCursor {
 
     /**
      * id of the row for callbacks after selection
      */
-    private int rowId = 0;
+    protected int rowId = 0;
 
-    public SearchSuggestionCursor() {
+    public BaseSearchSuggestionCursor() {
         super(new String[] {
                 BaseColumns._ID,
                 SearchManager.SUGGEST_COLUMN_TEXT_1,
@@ -29,18 +24,4 @@ public class SearchSuggestionCursor extends MatrixCursor {
                 SearchManager.SUGGEST_COLUMN_QUERY,
                 SearchManager.SUGGEST_COLUMN_ICON_1 });
     }
-
-    public void addCache(@NonNull final String geocode, @NonNull final String name, final String type) {
-        final int icon = CacheType.getById(type).markerId;
-        addRow(new String[] {
-                String.valueOf(rowId),
-                name,
-                geocode,
-                Intents.ACTION_GEOCACHE,
-                geocode,
-                String.valueOf(icon)
-        });
-        rowId++;
-    }
-
 }

--- a/main/src/cgeo/geocaching/search/BaseSuggestionsAdapter.java
+++ b/main/src/cgeo/geocaching/search/BaseSuggestionsAdapter.java
@@ -1,0 +1,35 @@
+package cgeo.geocaching.search;
+
+import cgeo.geocaching.ui.GeoItemSelectorUtils;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.cursoradapter.widget.CursorAdapter;
+
+public abstract class BaseSuggestionsAdapter extends CursorAdapter {
+    protected String searchTerm;
+    protected Context context;
+
+    public BaseSuggestionsAdapter(final Context context, final Cursor c, final int flags) {
+        super(context, c, flags);
+        this.context = context;
+    }
+
+    @Override
+    public View newView(final Context context, final Cursor cursor, final ViewGroup parent) {
+        return GeoItemSelectorUtils.getOrCreateView(context, null, parent);
+    }
+
+    public void changeQuery(@NonNull final String searchTerm) {
+        this.searchTerm = searchTerm;
+        changeCursor(query(searchTerm));
+        //the following line would get new DB cursor asynchronous to GUI thread. Not used currently (see discussion in #11227)
+        //AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> query(searchTerm), this::changeCursor);
+    }
+
+    protected abstract Cursor query(String searchTerm);
+}

--- a/main/src/cgeo/geocaching/search/GeocacheSearchSuggestionCursor.java
+++ b/main/src/cgeo/geocaching/search/GeocacheSearchSuggestionCursor.java
@@ -1,0 +1,23 @@
+package cgeo.geocaching.search;
+
+import cgeo.geocaching.Intents;
+import cgeo.geocaching.enumerations.CacheType;
+
+import androidx.annotation.NonNull;
+
+public class GeocacheSearchSuggestionCursor extends BaseSearchSuggestionCursor {
+
+    public void addCache(@NonNull final String geocode, @NonNull final String name, final String type) {
+        final int icon = CacheType.getById(type).markerId;
+        addRow(new String[] {
+            String.valueOf(rowId),
+            name,
+            geocode,
+            Intents.ACTION_GEOCACHE,
+            geocode,
+            String.valueOf(icon)
+        });
+        rowId++;
+    }
+
+}

--- a/main/src/cgeo/geocaching/search/GeocacheSuggestionsAdapter.java
+++ b/main/src/cgeo/geocaching/search/GeocacheSuggestionsAdapter.java
@@ -10,19 +10,17 @@ import cgeo.geocaching.ui.GeoItemSelectorUtils;
 import android.content.Context;
 import android.database.Cursor;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.cursoradapter.widget.CursorAdapter;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class SuggestionsAdapter extends CursorAdapter {
+public class GeocacheSuggestionsAdapter extends BaseSuggestionsAdapter {
 
-    public SuggestionsAdapter(final Context context) {
+    public GeocacheSuggestionsAdapter(final Context context) {
         //initialize with empty cursor to reduce long startup time problem (see #11227)
-        super(context, new SearchSuggestionCursor(), 0);
+        super(context, new GeocacheSearchSuggestionCursor(), 0);
     }
 
     @Override
@@ -32,28 +30,15 @@ public class SuggestionsAdapter extends CursorAdapter {
         if (cache != null) {
             GeoItemSelectorUtils.createGeocacheItemView(context, cache, view);
         } else {
-            final TextView tv = (TextView) view.findViewById(R.id.text);
+            final TextView tv = view.findViewById(R.id.text);
             tv.setText(cursor.getString(1));
-
-            final TextView infoView = (TextView) view.findViewById(R.id.info);
-            infoView.setText(cursor.getString(2));
-
             tv.setCompoundDrawablesWithIntrinsicBounds(cursor.getInt(5), 0, 0, 0);
+            ((TextView) view.findViewById(R.id.info)).setText(cursor.getString(2));
         }
     }
 
     @Override
-    public View newView(final Context context, final Cursor cursor, final ViewGroup parent) {
-        return GeoItemSelectorUtils.getOrCreateView(context, null, parent);
-    }
-
-    public void changeQuery(@NonNull final String searchTerm) {
-        changeCursor(query(searchTerm));
-        //the following line would get new DB cursor asynchronous to GUI thread. Not used currently (see discussion in #11227)
-        //AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> query(searchTerm), this::changeCursor);
-    }
-
-    private static Cursor query(@NonNull final String searchTerm) {
+    protected Cursor query(@NonNull final String searchTerm) {
         if (StringUtils.isBlank(searchTerm)) {
             return getLastOpenedCaches();
         }
@@ -61,7 +46,7 @@ public class SuggestionsAdapter extends CursorAdapter {
     }
 
     private static Cursor getLastOpenedCaches() {
-        final SearchSuggestionCursor resultCursor = new SearchSuggestionCursor();
+        final GeocacheSearchSuggestionCursor resultCursor = new GeocacheSearchSuggestionCursor();
         for (final Geocache geocache : DataStore.getLastOpenedCaches()) {
             resultCursor.addCache(geocache.getGeocode(), geocache.getName(), geocache.getType().id);
         }

--- a/main/src/cgeo/geocaching/search/SearchUtils.java
+++ b/main/src/cgeo/geocaching/search/SearchUtils.java
@@ -1,0 +1,104 @@
+package cgeo.geocaching.search;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility;
+import cgeo.geocaching.utils.ClipboardUtils;
+
+import android.app.Activity;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.AutoCompleteTextView;
+
+import androidx.appcompat.widget.SearchView;
+
+public class SearchUtils {
+
+    private SearchUtils() {
+        // utility class
+    }
+
+    public static void hideKeyboardOnSearchClick(final SearchView searchView, final MenuItem menuSearch) {
+        searchView.setOnSuggestionListener(new SearchView.OnSuggestionListener() {
+
+            @Override
+            public boolean onSuggestionSelect(final int position) {
+                return false;
+            }
+
+            @Override
+            public boolean onSuggestionClick(final int position) {
+                // needs to run delayed, as it will otherwise change the SuggestionAdapter cursor which results in inconsistent datasets (see #11803)
+                searchView.postDelayed(() -> {
+                    menuSearch.collapseActionView();
+                    searchView.setIconified(true);
+                }, 1000);
+
+                // return false to invoke standard behavior of launching the intent for the search result
+                return false;
+            }
+        });
+
+        // Used to collapse searchBar on submit from virtual keyboard
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(final String s) {
+                menuSearch.collapseActionView();
+                searchView.setIconified(true);
+                return false;
+            }
+
+            @Override
+            public boolean onQueryTextChange(final String s) {
+                ((BaseSuggestionsAdapter) searchView.getSuggestionsAdapter()).changeQuery(s);
+                return true;
+            }
+        });
+    }
+
+    public static void hideActionIconsWhenSearchIsActive(final Activity activity, final Menu menu, final MenuItem menuSearch) {
+        menuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+
+            @Override
+            public boolean onMenuItemActionExpand(final MenuItem item) {
+                for (int i = 0; i < menu.size(); i++) {
+                    if (menu.getItem(i).getItemId() == R.id.menu_paste_search && ConnectorFactory.containsGeocode(ClipboardUtils.getText())) {
+                        menu.getItem(i).setVisible(true);
+                    } else if (menu.getItem(i).getItemId() != R.id.menu_gosearch) {
+                        menu.getItem(i).setVisible(false);
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public boolean onMenuItemActionCollapse(final MenuItem item) {
+                activity.invalidateOptionsMenu();
+                return true;
+            }
+        });
+    }
+
+    public static void handleDropDownVisibility(final Activity activity, final SearchView searchView, final MenuItem menuSearch) {
+        final AutoCompleteTextView searchAutoComplete = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
+        searchAutoComplete.setOnDismissListener(() -> {
+            if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
+                searchAutoComplete.showDropDown();
+            }
+        });
+        // only for bottom navigation activities
+        final RelativeLayoutWithInterceptTouchEventPossibility activityViewroot = activity.findViewById(R.id.bottomnavigation_activity_viewroot);
+        if (activityViewroot != null) {
+            activityViewroot.setOnInterceptTouchEventListener(ev -> {
+                if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
+                    menuSearch.collapseActionView();
+                    searchView.setIconified(true);
+                    return true; // intercept touch event to do not trigger an unwanted action
+                }
+                // In general, we don't want to intercept touch events...
+                return false;
+            });
+        }
+    }
+
+}

--- a/main/src/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -1,0 +1,86 @@
+package cgeo.geocaching.settings.fragments;
+
+import cgeo.geocaching.utils.functions.Action1;
+import cgeo.geocaching.utils.functions.Action2;
+
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+
+import java.util.ArrayList;
+
+ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
+
+     // callback data
+     protected Action1<ArrayList<PrefSearchDescriptor>> searchdataCallback = null;
+     protected Action2<String, String> scrolltoCallback = null;
+     protected String scrolltoBaseKey = null;
+     protected String scrolltoPrefKey = null;
+
+     public static class PrefSearchDescriptor {
+        public String baseKey;
+        public String prefKey;
+        public CharSequence prefTitle;
+        public CharSequence prefSummary;
+
+        PrefSearchDescriptor(final String baseKey, final String prefKey, final CharSequence prefTitle, final CharSequence prefSummary) {
+            this.baseKey = baseKey;
+            this.prefKey = prefKey;
+            this.prefTitle = prefTitle;
+            this.prefSummary = prefSummary;
+        }
+    }
+
+    // sets callback to deliver searchable info about prefs to SettingsActivity
+    public void setSearchdataCallback(final Action1<ArrayList<PrefSearchDescriptor>> searchdataCallback) {
+        this.searchdataCallback = searchdataCallback;
+    }
+
+    // sets a callback to scroll to a specific pref after view has been created
+    public void setScrollToPrefCallback(final Action2<String, String> scrolltoCallback, final String scrolltoBaseKey, final String scrolltoPrefKey) {
+        this.scrolltoCallback = scrolltoCallback;
+        this.scrolltoBaseKey = scrolltoBaseKey;
+        this.scrolltoPrefKey = scrolltoPrefKey;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        if (searchdataCallback != null) {
+            final PreferenceScreen prefScreen = getPreferenceScreen();
+            if (prefScreen != null) {
+                final String baseKey = prefScreen.getKey();
+                final ArrayList<PrefSearchDescriptor> data = new ArrayList<>();
+                doSearch(baseKey, data, prefScreen);
+                searchdataCallback.call(data);
+                searchdataCallback = null;
+            }
+        }
+        if (scrolltoCallback != null) {
+            scrolltoCallback.call(scrolltoBaseKey, scrolltoPrefKey);
+            scrolltoCallback = null;
+        }
+    }
+
+    /**
+     * searches recursively in all elements of given prefGroup for first occurrence of s
+     * returns found preference on success, null else
+     * (prefers preference entries over preference groups)
+     */
+    private void doSearch(final String baseKey, final ArrayList<PrefSearchDescriptor> data, final PreferenceGroup start) {
+        final int prefCount = start.getPreferenceCount();
+        for (int i = 0; i < prefCount; i++) {
+            final Preference pref = start.getPreference(i);
+            data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary()));
+            if (pref instanceof PreferenceGroup) {
+                doSearch(baseKey, data, (PreferenceGroup) pref);
+            }
+        }
+    }
+}

--- a/main/src/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.utils.functions.Action2;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.Preference;
@@ -22,19 +23,28 @@ import java.util.ArrayList;
      protected Action2<String, String> scrolltoCallback = null;
      protected String scrolltoBaseKey = null;
      protected String scrolltoPrefKey = null;
+     protected int icon = 0;
 
      public static class PrefSearchDescriptor {
         public String baseKey;
         public String prefKey;
         public CharSequence prefTitle;
         public CharSequence prefSummary;
+        public int prefCategoryIconRes;
 
-        PrefSearchDescriptor(final String baseKey, final String prefKey, final CharSequence prefTitle, final CharSequence prefSummary) {
+        PrefSearchDescriptor(final String baseKey, final String prefKey, final CharSequence prefTitle, final CharSequence prefSummary, @DrawableRes final int prefCategoryIconRes) {
             this.baseKey = baseKey;
             this.prefKey = prefKey;
             this.prefTitle = prefTitle;
             this.prefSummary = prefSummary;
+            this.prefCategoryIconRes = prefCategoryIconRes;
         }
+    }
+
+    // sets icon resource for search info
+    public BasePreferenceFragment setIcon(@DrawableRes final int icon) {
+         this.icon = icon;
+         return this;
     }
 
     // sets callback to deliver searchable info about prefs to SettingsActivity
@@ -77,7 +87,7 @@ import java.util.ArrayList;
         final int prefCount = start.getPreferenceCount();
         for (int i = 0; i < prefCount; i++) {
             final Preference pref = start.getPreference(i);
-            data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary()));
+            data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary(), icon));
             if (pref instanceof PreferenceGroup) {
                 doSearch(baseKey, data, (PreferenceGroup) pref);
             }

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -8,13 +8,13 @@ import android.os.Bundle;
 
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class PreferenceAppearanceFragment extends PreferenceFragmentCompat {
+public class PreferenceAppearanceFragment extends BasePreferenceFragment {
+
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_appearence, rootKey);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -8,9 +8,8 @@ import cgeo.geocaching.utils.BackupUtils;
 import android.os.Bundle;
 
 import androidx.preference.CheckBoxPreference;
-import androidx.preference.PreferenceFragmentCompat;
 
-public class PreferenceBackupFragment extends PreferenceFragmentCompat {
+public class PreferenceBackupFragment extends BasePreferenceFragment {
     public static final String STATE_BACKUPUTILS = "backuputils";
 
     @Override

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceCachedetailsFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceCachedetailsFragment.java
@@ -4,9 +4,7 @@ import cgeo.geocaching.R;
 
 import android.os.Bundle;
 
-import androidx.preference.PreferenceFragmentCompat;
-
-public class PreferenceCachedetailsFragment extends PreferenceFragmentCompat {
+public class PreferenceCachedetailsFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_cachedetails, rootKey);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
@@ -9,11 +9,10 @@ import android.os.Bundle;
 
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
-import androidx.preference.PreferenceFragmentCompat;
 
 import static java.util.UUID.randomUUID;
 
-public class PreferenceLoggingFragment extends PreferenceFragmentCompat {
+public class PreferenceLoggingFragment extends BasePreferenceFragment {
     PreferenceCategory logTemplatesCategory;
 
     @Override

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.ShareUtils;
-
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.ShareUtils;
+
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
@@ -16,11 +17,10 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.preference.ListPreference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.Collection;
 
-public class PreferenceMapFragment extends PreferenceFragmentCompat {
+public class PreferenceMapFragment extends BasePreferenceFragment {
     private ListPreference prefMapSources;
 
     @Override

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -17,13 +17,12 @@ import android.os.Bundle;
 import androidx.annotation.StringRes;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
-public class PreferenceNavigationFragment extends PreferenceFragmentCompat {
+public class PreferenceNavigationFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_navigation, rootKey);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -14,13 +14,12 @@ import android.app.ProgressDialog;
 import android.os.Bundle;
 
 import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-public class PreferenceOfflinedataFragment extends PreferenceFragmentCompat {
+public class PreferenceOfflinedataFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_offlinedata, rootKey);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceServicesFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceServicesFragment.java
@@ -6,9 +6,7 @@ import static cgeo.geocaching.utils.SettingsUtils.setPrefSummaryActiveStatus;
 
 import android.os.Bundle;
 
-import androidx.preference.PreferenceFragmentCompat;
-
-public class PreferenceServicesFragment extends PreferenceFragmentCompat {
+public class PreferenceServicesFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_services, rootKey);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -10,9 +10,7 @@ import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 import android.content.Intent;
 import android.os.Bundle;
 
-import androidx.preference.PreferenceFragmentCompat;
-
-public class PreferenceSystemFragment extends PreferenceFragmentCompat {
+public class PreferenceSystemFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_system, rootKey);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferencesFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferencesFragment.java
@@ -4,9 +4,7 @@ import cgeo.geocaching.R;
 
 import android.os.Bundle;
 
-import androidx.preference.PreferenceFragmentCompat;
-
-public class PreferencesFragment extends PreferenceFragmentCompat {
+public class PreferencesFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences, rootKey);

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -36,7 +36,7 @@ import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.network.HtmlImage;
-import cgeo.geocaching.search.SearchSuggestionCursor;
+import cgeo.geocaching.search.GeocacheSearchSuggestionCursor;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.sorting.CacheComparator;
 import cgeo.geocaching.storage.extension.DBDowngradeableVersions;
@@ -4661,7 +4661,7 @@ public class DataStore {
             return null;
         }
         init();
-        final SearchSuggestionCursor resultCursor = new SearchSuggestionCursor();
+        final GeocacheSearchSuggestionCursor resultCursor = new GeocacheSearchSuggestionCursor();
         try {
             final String selectionArg = getSuggestionArgument(searchTerm);
             findCaches(resultCursor, selectionArg);
@@ -4672,7 +4672,7 @@ public class DataStore {
         return resultCursor;
     }
 
-    private static void findCaches(final SearchSuggestionCursor resultCursor, final String selectionArg) {
+    private static void findCaches(final GeocacheSearchSuggestionCursor resultCursor, final String selectionArg) {
         final Cursor cursor = database.query(
                 dbTableCaches,
                 new String[] { "geocode", "name", "type" },


### PR DESCRIPTION
## Description
(updated description)

- enables search with preferences, using a suggestion provider
- at least three characters are required to trigger the search suggestion provider
- automatically scrolls to the selected preference
- highlights the title of that preference
- pressing enter in searchbar selects and opens the first found entry

(for screenshots see below: https://github.com/cgeo/cgeo/pull/12441#issuecomment-1003582062)

~Setting WIP label for now, as I'm not sure about the colors. I was looking for a color which highlights a text in both dark and light mode, and which is neither red nor green nor our accent color. A sort of turquoise is the best I've come up so far, but I'm open for other solutions.~
~Alternatively to a color, the found preference could be highlighted by a short animation or so - just don't know how to apply it.~

## Additional context
~I did not manage to search across all preferences, as the preference manager does load them on demand only, and asynchronally, so I would have to load each preference manually, wait for them to be displayed, and then perform the search I'm currently performing for the currently active preference. Any ideas?~