### PR TITLE
Bugfix Search caches nearby from adressbook: housenumber,zip was inte…

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -297,7 +297,7 @@ dependencies {
 
     // License: Apache-2.0. https://github.com/k3b/k3b-geoHelper/
     // decode geo-uris and web-map-service-urls
-    implementation('com.github.k3b:k3b-geoHelper:1.1.9') {
+    implementation('com.github.k3b:k3b-geoHelper:1.1.10') {
         // do not get transitive 'commons-io:commons-io:2.6' as c:geo uses 2.5 to be compatible with older android versions
         exclude group: 'commons-io', module: 'commons-io'
     }


### PR DESCRIPTION
…rpreted as lat/lon

Introduced in #11510: #11977: , fixed in https://github.com/k3b/k3b-geoHelper/issues/7

How to reproduce: 

* Lauch android addressbook
* Create a test address (Street+Housenumber, zipcode+city)
  * Gasse 13, A1090 Wien
  * Save Address
* In android addressbook: Click the "share address Button"
  * Select "Search caches nearby"
    * CGEO-Address-Search for "Gasse 13, A1090 Wien" is execuded
  * => works as expected.

---

* Lauch android addressbook
* Modify the test address (remove the "A" in the zip code)
  * Gasse 13, 1090 Wien
  * Save Address
* In android addressbook: Click the "share address Button"
  * Select "Search caches nearby"
    * CGEO-Lat/Lon-Search for "13, 1090" is execuded
  * => cgeo reports: Not found

