### PR TITLE
Fix #9992 - Reduce fast scroll bar active time

### DIFF
--- a/main/src/cgeo/geocaching/ui/FastScrollListener.java
+++ b/main/src/cgeo/geocaching/ui/FastScrollListener.java
@@ -11,7 +11,7 @@ import android.widget.ListView;
  */
 public class FastScrollListener implements AbsListView.OnScrollListener {
     private static final int MIN_COVERED_ENTRIES = 3;       // in number of entries
-    private static final int AUTO_DISABLE_ON_IDLE = 1000;   // is ms
+    private static final int AUTO_DISABLE_ON_IDLE = 500;    // is ms
 
     private long mLastScroll = 0;
     private int mScrollState = 0;


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
- Reduce the time until fast scroll is disabled from 1000ms to 500ms to decrease the probability to interfere with nearby touch targets (see #9992).
- Could also help to improve #11497


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#9992 
#11497

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
The alternative would be to disable the fastscroll for the waypoint tab, but this would mean there is no longer any possibility to quickly scroll through a long list (e.g. caches with hundreds of waypoints). Therefore I think this workaround is the way to go for now.