### PR TITLE
Fix #12449: Improve formula scan

### DIFF
--- a/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 public class FormulaUtils {
 
     private static final Pattern TEXT_SCAN_PATTERN = Pattern.compile(
-        "[^a-zA-Z0-9(](( *\\( *)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9.]{1,10})((( *[()] *)*( *[-+/:*x] *)+)( *[()] *)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9.]{1,10}))+( *\\) *)*)[^a-zA-Z0-9)]");
+        "[^a-zA-Z0-9(](( *\\( *)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7})((( *[()] *)*( *[-+/:*x] *)+)( *[()] *)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7}))+( *\\) *)*)[^a-zA-Z0-9)]");
 
     private static final Pattern[] TEXT_SCAN_FALSE_POSITIVE_PATTERNS = new Pattern[] {
         Pattern.compile("^[0-9]+[:/.,][0-9]+([:/.,][0-9]+)?$"), // dates or times
@@ -143,7 +143,8 @@ public class FormulaUtils {
     }
 
     private static String processFoundText(final String text) {
-        return text.replaceAll(" x ", " * "); // lowercase x is most likely a multiply char
+        final String trimmed = text.trim();
+        return trimmed.replaceAll(" x ", " * "); // lowercase x is most likely a multiply char
     }
 
     private static boolean checkCandidate(final String candidate) {

--- a/tests/src/cgeo/geocaching/utils/formulas/FormulaUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/formulas/FormulaUtilsTest.java
@@ -107,6 +107,11 @@ public class FormulaUtilsTest {
 
     }
 
+    @Test
+    public void scanForFormulasGC96KBEFindsAllFormulas() {
+        assertScanFormula("N 48° (F-H)/2-1.((J-H)*I-2*A+E+9) E 008° (A/G+12).(A+D)*B/2-6*C+49", "(F-H)/2-1", "((J-H)*I-2*A+E+9)", "(A/G+12)", "(A+D)*B/2-6*C+49");
+    }
+
     private void assertScanFormula(final String textToScan, final String ... expectedFinds) {
         final List<String> result = FormulaUtils.scanForFormulas(Collections.singleton(textToScan), null);
         if (expectedFinds == null || expectedFinds.length == 0) {


### PR DESCRIPTION
The PR fixes some issues with the formula scanner:
- The Regex doesn't accept trailing `.` anymore
- Trailing whitespace is removed from the resulting formulas