### PR TITLE
Fix checkstyle problems

### DIFF
--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -54,12 +54,6 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.preference.PreferenceManager;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
@@ -72,6 +66,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
@@ -1,7 +1,5 @@
 package cgeo.geocaching.settings.fragments;
 
-import static java.util.UUID.randomUUID;
-
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.TemplateTextPreference;
@@ -12,6 +10,8 @@ import android.os.Bundle;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
+
+import static java.util.UUID.randomUUID;
 
 public class PreferenceLoggingFragment extends PreferenceFragmentCompat {
     PreferenceCategory logTemplatesCategory;


### PR DESCRIPTION
Latest CI runs are showing this checkstyle report:
~~~
> Task :main:checkstyle
[ant:checkstyle] [INFO] /home/jenkins/slave/workspace/cgeo-CI_PR-build/main/src/cgeo/geocaching/settings/Settings.java:63:1: Wrong order for 'java.io.File' import. [ImportOrder]
[ant:checkstyle] [INFO] /home/jenkins/slave/workspace/cgeo-CI_PR-build/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java:5:1: Wrong order for 'cgeo.geocaching.R' import. [ImportOrder]
Checkstyle rule violations were found. See the report at: file:///home/jenkins/slave/workspace/cgeo-CI_PR-build/main/build/reports/checkstyle/checkstyle.html
Checkstyle files with violations: 2
Checkstyle violations by severity: [info:2]
~~~

Fixed now.
