### PR TITLE
fix map theme style options not updated on change (fix #12457)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
@@ -90,6 +90,8 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
         baseLayerPreference.setDefaultValue(renderthemeOptions.getDefaultValue());
         baseLayerPreference.setIconSpaceReserved(false);
         baseLayerPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            // need to persist the new value before recreating the renderthemeMenu
+            Settings.setSelectedMapRenderThemeStyle(preference.getKey(), newValue.toString());
             createRenderthemeMenu();
             return true;
         });

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1559,6 +1559,11 @@ public class Settings {
         putString(R.string.pref_renderthemefile, customRenderThemeFile);
     }
 
+    /** Shall SOLELY be used by {@link cgeo.geocaching.maps.mapsforge.v6.RenderThemeSettingsFragment}! */
+    public static void setSelectedMapRenderThemeStyle(final String prefKey, final String style) {
+        putStringDirect(prefKey, style);
+    }
+
     /** Shall SOLELY be used by {@link cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper}! */
     public static boolean getSyncMapRenderThemeFolder() {
         return getBoolean(R.string.pref_renderthemefolder_synctolocal, false);


### PR DESCRIPTION
## Description
Persists the selected new style value before updating the view
