### PR TITLE
Fix formula scanning for GC93DAV

### DIFF
--- a/main/src/cgeo/geocaching/VariablesViewPageFragment.java
+++ b/main/src/cgeo/geocaching/VariablesViewPageFragment.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.VariableListView;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.ShareUtils;
+import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.formulas.FormulaUtils;
 import cgeo.geocaching.utils.formulas.VariableMap;
 
@@ -134,7 +135,7 @@ public class VariablesViewPageFragment extends TabbedViewPagerFragment<Cachedeta
 
     private void scanCache() {
         final List<String> toScan = new ArrayList<>();
-        toScan.add(activity.getCache().getDescription());
+        toScan.add(TextUtils.stripHtml(activity.getCache().getDescription()));
         toScan.add(activity.getCache().getHint());
         for (Waypoint w : activity.getCache().getWaypoints()) {
             toScan.add(w.getNote());

--- a/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 public class FormulaUtils {
 
     private static final Pattern TEXT_SCAN_PATTERN = Pattern.compile(
-        "[^a-zA-Z0-9(](( *\\( *)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7})((( *[()] *)*( *[-+/:*x] *)+)( *[()] *)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7}))+( *\\) *)*)[^a-zA-Z0-9)]");
+        "[^a-zA-Z0-9(]((\\h*\\(\\h*)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7})(((\\h*[()]\\h*)*(\\h*[-+/:*x]\\h*)+)(\\h*[()]\\h*)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7}))+(\\h*\\)\\h*)*)[^a-zA-Z0-9)]");
 
     private static final Pattern[] TEXT_SCAN_FALSE_POSITIVE_PATTERNS = new Pattern[] {
         Pattern.compile("^[0-9]+[:/.,][0-9]+([:/.,][0-9]+)?$"), // dates or times
@@ -143,7 +143,7 @@ public class FormulaUtils {
     }
 
     private static String processFoundText(final String text) {
-        final String trimmed = text.trim();
+        final String trimmed = text.replaceAll("\\h", " ").trim();
         return trimmed.replaceAll(" x ", " * "); // lowercase x is most likely a multiply char
     }
 

--- a/tests/src/cgeo/geocaching/utils/formulas/FormulaUtilsTest.java
+++ b/tests/src/cgeo/geocaching/utils/formulas/FormulaUtilsTest.java
@@ -108,6 +108,11 @@ public class FormulaUtilsTest {
     }
 
     @Test
+    public void scanForFormulasNoBreakSpaceDoesNotSplitFormulas() {
+        assertScanFormula("X\u00A0+\u00A0Y", "X + Y");
+    }
+
+    @Test
     public void scanForFormulasGC96KBEFindsAllFormulas() {
         assertScanFormula("N 48° (F-H)/2-1.((J-H)*I-2*A+E+9) E 008° (A/G+12).(A+D)*B/2-6*C+49", "(F-H)/2-1", "((J-H)*I-2*A+E+9)", "(A/G+12)", "(A+D)*B/2-6*C+49");
     }


### PR DESCRIPTION
The PR fixes two issues with the formula scanner:
- HTML tags are stripped before scanning for formulas
- The scanner now accepts not only spaces but all horizontal whitespace characters