### PR TITLE
consolidate preference keys (without migration)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -5,129 +5,210 @@
     Preferences used in settings are defined as strings here, so we can use them in the preferences.xml
     and in the Java code as constants and avoid code duplication.
 
+    Preference keys are sorted and grouped by preference screens and categories
+
+
+    Name schemes:
+    ============
+
+    Generelly all keys should start with "pref_" in their name, and use the reminder part of the
+    variable name as key value (e. g.: name=pref_test123, key value=test123)
+
+    For internally adressing preference screens and preference categories, you should use the
+    name schemes of "preference_screen_xxx" and "preference_category_xxx_yyy" respectively,
+    with "xxx" being the preference section (e. g. "backup"), and "yyy" being the actual
+    category (e. g. "createbackup", leading to "fakekey_category_backup_createbackup" in this case).
+
+    For all other keys for internal use, their name should start with "pref_fakekey_" and their
+    key with "fakekey_" (e. g.: name=pref_fakekey_test123, key value=fakekey_test123).
+
+    Those pseudo-keys should never be used to actually store a value to our preferences!
+
+
+    Renaming preferences:
+    ====================
+
+    Renaming the key value for a preference, that is already released in an official version, and
+    that shall still be used, probably requires a migration, see Settings.migrateSettings().
+
+    Renaming the key value of a pseudo-key (as described under "name schemes") may happen at any
+    time, without migration, and c:geo shall NEVER rely on a specific key value for a pseudo key
+    being persistent.
+
+
+    Adding / removing preferences:
+    =============================
+
     If you add a preference key which stores sensitive data not to be included in settings backup
     by default, make sure to add the key to Settings.getSensitivePreferenceKeys()
 
-    If a preference key is no longer actively used, you can and should remove it.
+    If a preference key is no longer actively used anywhere, you can and should remove it.
     If a preference key is no longer actively used, but you still need the string for migration,
     add "old_" as prefix to the variable name (but leave the value unchanged).
     -->
 
-    <string translatable="false" name="preference_screen_main">fakekey_main_screen</string>
-    <string translatable="false" name="preference_screen_services">fakekey_services_screen</string>
-    <string translatable="false" name="pref_appearance">pref_appearance</string>
-    <string translatable="false" name="preference_screen_cachedetails">fakekey_cachedetails_screen</string>
-    <string translatable="false" name="preference_screen_map">fakekey_map_screen</string>
-    <string translatable="false" name="preference_screen_logging">fakekey_logging_screen</string>
-    <string translatable="false" name="preference_screen_offlinedata">fakekey_offlinedata_screen</string>
-    <string translatable="false" name="preference_screen_navigation">fakekey_navigation_screen</string>
-    <string translatable="false" name="preference_screen_system">fakekey_system_screen</string>
-    <string translatable="false" name="preference_screen_backup">fakekey_backup_screen</string>
+    <string translatable="false" name="preference_screen_main">preference_screen_main</string>
 
-    <string translatable="false" name="preference_screen_gc">preference_screen_gc</string>
-    <string translatable="false" name="preference_screen_basicmembers">fakekey_basicmembers_screen</string>
-    <string translatable="false" name="preference_screen_ocde">preference_screen_ocde</string>
-    <string translatable="false" name="preference_screen_ocpl">preference_screen_ocpl</string>
-    <string translatable="false" name="preference_screen_ocnl">preference_screen_ocnl</string>
-    <string translatable="false" name="preference_screen_ocus">preference_screen_ocus</string>
-    <string translatable="false" name="preference_screen_ocro">preference_screen_ocro</string>
-    <string translatable="false" name="preference_screen_ocuk">preference_screen_ocuk</string>
-    <string translatable="false" name="preference_screen_ec">preference_screen_ec</string>
-    <string translatable="false" name="preference_screen_lc">preference_screen_lc</string>
-    <string translatable="false" name="preference_screen_su">preference_screen_su</string>
-    <string translatable="false" name="preference_screen_twitter">preference_screen_twitter</string>
-    <string translatable="false" name="preference_screen_sendtocgeo">preference_screen_sendtocgeo</string>
-    <string translatable="false" name="preference_screen_gcvote">preference_screen_gcvote</string>
-    <string translatable="false" name="preference_screen_geokrety">preference_screen_geokrety</string>
-    <string translatable="false" name="pref_fakekey_ocde_authorization">fakekey_ocde_authorization</string>
-    <string translatable="false" name="pref_fakekey_ocpl_authorization">fakekey_ocpl_authorization</string>
-    <string translatable="false" name="pref_fakekey_ocnl_authorization">fakekey_ocnl_authorization</string>
-    <string translatable="false" name="pref_fakekey_ocus_authorization">fakekey_ocus_authorization</string>
-    <string translatable="false" name="pref_fakekey_ocro_authorization">fakekey_ocro_authorization</string>
-    <string translatable="false" name="pref_fakekey_ocuk_authorization">fakekey_ocuk_authorization</string>
-    <string translatable="false" name="pref_fakekey_twitter_authorization">fakekey_twitter_authorization</string>
-    <string translatable="false" name="pref_fakekey_geokrety_authorization">fakekey_geokrety_authorization</string>
-    <string translatable="false" name="pref_fakekey_gc_authorization">fakekey_gc_authorization</string>
-    <string translatable="false" name="pref_fakekey_ec_authorization">fakekey_ec_authorization</string>
-    <string translatable="false" name="pref_fakekey_su_authorization">fakekey_su_authorization</string>
-    <string translatable="false" name="pref_fakekey_gcvote_authorization">fakekey_gcvote_authorization</string>
-    <string translatable="false" name="preference_screen_navigation_menu">fakekey_navigation_menu_screen</string>
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for services main screens -->
+    <string translatable="false" name="preference_screen_services">preference_screen_services</string>
+    <!-- ============================================================================================================================================================================== -->
 
-    <string translatable="false" name="pref_connectorGCActive">connectorGCActive</string>
-    <string translatable="false" name="pref_username">username</string>
-    <string translatable="false" name="pref_password">password</string>
-    <string translatable="false" name="pref_connectorOCActive">connectorOCActive</string>
-    <string translatable="false" name="pref_connectorOCPLActive">connectorOCPLActive</string>
-    <string translatable="false" name="pref_connectorOCNLActive">connectorOCNLActive</string>
-    <string translatable="false" name="pref_connectorOCUSActive">connectorOCUSActive</string>
-    <string translatable="false" name="pref_connectorOCROActive">connectorOCROActive</string>
-    <string translatable="false" name="pref_connectorOCUKActive">connectorOCUKActive</string>
-    <string translatable="false" name="pref_connectorSUActive">connectorSUActive</string>
-    <string translatable="false" name="pref_ecusername">ecusername</string>
-    <string translatable="false" name="pref_ecpassword">ecpassword</string>
-    <string translatable="false" name="pref_ec_avatar">ec_avatar</string>
-    <string translatable="false" name="pref_gc_avatar">gc_avatar</string>
-    <string translatable="false" name="pref_gcvote_avatar">gcvote_avatar</string>
-    <string translatable="false" name="pref_connectorECActive">connectorECActive</string>
-    <string translatable="false" name="pref_connectorALActive">connectorLCActive</string><!-- variable stays with "LC" for compatibility reasons -->
-    <string translatable="false" name="pref_connectorGeokretyActive">connectorGeokretyActive</string>
-    <string translatable="false" name="pref_user_vote">user-vote</string>
-    <string translatable="false" name="pref_pass_vote">pass-vote</string>
-    <string translatable="false" name="pref_twitter">twitter</string>
-    <string translatable="false" name="pref_webDeviceName">webDeviceName</string>
+    <!-- category browser -->
     <string translatable="false" name="pref_nativeUa">nativeUa</string>
-    <string translatable="false" name="pref_showaddress">showaddress</string>
-    <string translatable="false" name="old_pref_useenglish">useenglish</string>
-    <string translatable="false" name="pref_units_imperial">units</string>
+
+    <!-- settings for geocaching.com service screen -->
+    <string translatable="false" name="preference_screen_gc">preference_screen_gc</string>
+    <string translatable="false" name="pref_connectorGCActive">connectorGCActive</string>
+    <string translatable="false" name="pref_fakekey_gc_authorization">fakekey_gc_authorization</string>
+    <string translatable="false" name="preference_screen_basicmembers">fakekey_basicmembers_screen</string>
+    <string translatable="false" name="pref_loaddirectionimg">loaddirectionimg</string>
+    <string translatable="false" name="pref_gc_fb_login_hint">gc_fb_login_hint</string>
+    <string translatable="false" name="pref_fakekey_gc_website">fakekey_gc_website</string>
+
+    <!-- settings for geocaching.com lab adventures screen -->
+    <string translatable="false" name="preference_screen_al">preference_screen_al</string>
+    <string translatable="false" name="pref_connectorALActive">connectorLCActive</string><!-- variable stays with "LC" for compatibility reasons -->
+    <string translatable="false" name="pref_fakekey_al_website">fakekey_al_website</string>
+
+    <!-- settings for opencaching.de screen -->
+    <string translatable="false" name="preference_screen_ocde">preference_screen_ocde</string>
+    <string translatable="false" name="pref_connectorOCActive">connectorOCActive</string>
+    <string translatable="false" name="pref_fakekey_ocde_authorization">fakekey_ocde_authorization</string>
+    <string translatable="false" name="pref_fakekey_ocde_website">fakekey_ocde_website</string>
+
+    <!-- settings for opencaching.pl screen -->
+    <string translatable="false" name="preference_screen_ocpl">preference_screen_ocpl</string>
+    <string translatable="false" name="pref_connectorOCPLActive">connectorOCPLActive</string>
+    <string translatable="false" name="pref_fakekey_ocpl_authorization">fakekey_ocpl_authorization</string>
+    <string translatable="false" name="pref_fakekey_ocpl_website">fakekey_ocpl_website</string>
+
+    <!-- settings for opencaching.nl screen -->
+    <string translatable="false" name="preference_screen_ocnl">preference_screen_ocnl</string>
+    <string translatable="false" name="pref_connectorOCNLActive">connectorOCNLActive</string>
+    <string translatable="false" name="pref_fakekey_ocnl_authorization">fakekey_ocnl_authorization</string>
+    <string translatable="false" name="pref_fakekey_ocnl_website">fakekey_ocnl_website</string>
+
+    <!-- settings for opencaching.us screen -->
+    <string translatable="false" name="preference_screen_ocus">preference_screen_ocus</string>
+    <string translatable="false" name="pref_connectorOCUSActive">connectorOCUSActive</string>
+    <string translatable="false" name="pref_fakekey_ocus_authorization">fakekey_ocus_authorization</string>
+    <string translatable="false" name="pref_fakekey_ocus_website">fakekey_ocus_website</string>
+
+    <!-- settings for opencaching.ro screen -->
+    <string translatable="false" name="preference_screen_ocro">preference_screen_ocro</string>
+    <string translatable="false" name="pref_connectorOCROActive">connectorOCROActive</string>
+    <string translatable="false" name="pref_fakekey_ocro_authorization">fakekey_ocro_authorization</string>
+    <string translatable="false" name="pref_fakekey_ocro_website">fakekey_ocro_website</string>
+
+    <!-- settings for opencache.uk screen -->
+    <string translatable="false" name="preference_screen_ocuk">preference_screen_ocuk</string>
+    <string translatable="false" name="pref_connectorOCUKActive">connectorOCUKActive</string>
+    <string translatable="false" name="pref_fakekey_ocuk_authorization">fakekey_ocuk_authorization</string>
+    <string translatable="false" name="pref_fakekey_ocuk_website">fakekey_ocuk_website</string>
+
+    <!-- settings for extremcaching.com screen -->
+    <string translatable="false" name="pref_fakekey_ec_authorization">fakekey_ec_authorization</string>
+    <string translatable="false" name="pref_connectorECActive">connectorECActive</string>
+    <string translatable="false" name="preference_screen_ec">preference_screen_ec</string>
+    <string translatable="false" name="pref_fakekey_ec_website">fakekey_ec_website</string>
+
+    <!-- settings for geocaching.su screen -->
+    <string translatable="false" name="pref_fakekey_su_authorization">fakekey_su_authorization</string>
+    <string translatable="false" name="pref_connectorSUActive">connectorSUActive</string>
+    <string translatable="false" name="preference_screen_su">preference_screen_su</string>
+    <string translatable="false" name="pref_fakekey_su_website">fakekey_su_website</string>
+
+    <!-- settings for gcvote.com screen -->
+    <string translatable="false" name="preference_screen_gcvote">preference_screen_gcvote</string>
     <string translatable="false" name="pref_ratingwanted">ratingwanted</string>
+    <string translatable="false" name="pref_fakekey_gcvote_authorization">fakekey_gcvote_authorization</string>
+    <string translatable="false" name="pref_fakekey_gcvote_website">fakekey_gcvote_website</string>
+
+    <!-- settings for geokrety.org screen -->
+    <string translatable="false" name="preference_screen_geokrety">preference_screen_geokrety</string>
+    <string translatable="false" name="pref_connectorGeokretyActive">connectorGeokretyActive</string>
+    <string translatable="false" name="pref_fakekey_geokrety_authorization">fakekey_geokrety_authorization</string>
+    <string translatable="false" name="pref_fakekey_geokrety_website">fakekey_geokrety_website</string>
+    <string translatable="false" name="pref_fakekey_geokretymap_website">fakekey_geokretymap_website</string>
+
+    <!-- settings for send2cgeo screen -->
+    <string translatable="false" name="preference_screen_sendtocgeo">preference_screen_sendtocgeo</string>
+    <string translatable="false" name="pref_webDeviceName">webDeviceName</string>
+    <string translatable="false" name="pref_fakekey_sendtocgeo_info">fakekey_sendtocgeo_info</string>
+    <string translatable="false" name="pref_fakekey_sendtocgeo_website">fakekey_sendtocgeo_website</string>
+
+    <!-- settings for twitter screen -->
+    <string translatable="false" name="preference_screen_twitter">preference_screen_twitter</string>
+    <string translatable="false" name="pref_twitter">twitter</string>
+    <string translatable="false" name="pref_fakekey_twitter_authorization">fakekey_twitter_authorization</string>
+    <string translatable="false" name="pref_twitter_cache_message">twitter_cache_message</string>
+    <string translatable="false" name="pref_twitter_trackable_message">twitter_trackable_message</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for appearance screen -->
+    <string translatable="false" name="preference_screen_appearance">preference_screen_appearance</string>
+    <!-- ============================================================================================================================================================================== -->
+    <string translatable="false" name="pref_theme_setting">theme_setting</string>
+    <string translatable="false" name="pref_showaddress">showaddress</string>
+    <string translatable="false" name="pref_plainLogs">plainLogs</string>
+    <string translatable="false" name="pref_selected_language">selectedLanguage</string>
+    <string translatable="false" name="pref_units_imperial">units</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for cachedetails screen -->
+    <string translatable="false" name="preference_screen_cachedetails">preference_screen_cachedetails</string>
+    <!-- ============================================================================================================================================================================== -->
     <string translatable="false" name="pref_friendlogswanted">friendlogswanted</string>
     <string translatable="false" name="pref_opendetailslastpage">opendetailslastpage</string>
+    <string translatable="false" name="pref_livelist">livelist</string>
     <string translatable="false" name="pref_global_wp_extraction_disable">globalWpExtractionDisable</string>
     <string translatable="false" name="pref_personal_cache_note_merge_disable">personalCacheNoteMergeDisable</string>
+    <string translatable="false" name="pref_customtabs_as_browser">customtabs_as_browser</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for map screen -->
+    <string translatable="false" name="preference_screen_map">preference_screen_map</string>
+    <!-- ============================================================================================================================================================================== -->
+
+    <!-- category map data -->
+    <string translatable="false" name="pref_mapsource">mapsource</string>
+    <string translatable="false" name="pref_fakekey_info_offline_maps">fakekey_info_offline_maps</string>
+    <string translatable="false" name="pref_fakekey_start_downloader">fakekey_start_downloader</string>
+    <string translatable="false" name="pref_mapAutoDownloadsInterval">mapAutoDownloadsInterval</string>
+    <string translatable="false" name="pref_persistablefolder_offlinemaps">persistablefolder_offlinemaps</string>
+    <string translatable="false" name="pref_fakekey_info_offline_mapthemes">fakekey_info_offline_mapthemes</string>
+    <string translatable="false" name="pref_persistablefolder_offlinemapthemes">persistablefolder_offlinemapthemes</string>
+    <string translatable="false" name="pref_renderthemefolder_synctolocal">renderthemefolder_synctolocal</string>
+    <string translatable="false" name="pref_mapRotation">mapRotation</string>
+
+    <!-- category waypoints -->
+    <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_excludeWpOriginal">excludeWpOriginal</string>
     <string translatable="false" name="pref_excludeWpParking">excludeWpParking</string>
     <string translatable="false" name="pref_excludeWpVisited">excludeWpVisited</string>
-    <string translatable="false" name="pref_hide_track">hideTrack</string>
-    <string translatable="false" name="pref_showCircles">showCircles</string>
-    <string translatable="false" name="pref_supersizeDistance">supersizeDistanceToggle</string>
-    <string translatable="false" name="pref_plainLogs">plainLogs</string>
-    <string translatable="false" name="pref_signature">signature</string>
-    <string translatable="false" name="pref_fakekey_category_logTemplate">fakekey_category_logTemplate</string>
-    <string translatable="false" name="pref_logTemplates">logTemplates</string>
-    <string translatable="false" name="pref_sigautoinsert">sigautoinsert</string>
-    <string translatable="false" name="pref_offlinelogs_homescreen">offlinelogs_homescreen</string>
-    <string translatable="false" name="pref_trackautovisit">trackautovisit</string>
-    <string translatable="false" name="pref_log_offline">log_offline</string>
-    <string translatable="false" name="pref_logimages">logimages</string>
-    <string translatable="false" name="pref_choose_list">choose_list</string>
-    <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
-    <string translatable="false" name="pref_mapsource">mapsource</string>
-    <string translatable="false" name="pref_mapLanguage">mapLanguage</string>
-    <string translatable="false" name="pref_mapRotation">mapRotation</string>
-    <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>
     <string translatable="false" name="pref_zoomincludingwaypoints">zoomincludingwaypoints</string>
-    <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
-    <string translatable="false" name="pref_fakekey_brouterDistanceThresholdTitle">fakekey_brouterDistanceThresholdTitle</string>
-    <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
-    <string translatable="false" name="pref_useInternalRouting">useInternalRouting</string>
-    <string translatable="false" name="pref_brouterAutoTileDownloads">brouterAutoTileDownloads</string>
-    <string translatable="false" name="pref_brouterAutoTileDownloadsInterval">brouterAutoTileDownloadsInterval</string>
-    <string translatable="false" name="pref_brouterAutoTileDownloadsLastCheck">brouterAutoTileDownloadsLastCheck</string>
-    <string translatable="false" name="pref_brouterProfileWalk">brouterProfileWalk</string>
-    <string translatable="false" name="pref_brouterProfileBike">brouterProfileBike</string>
-    <string translatable="false" name="pref_brouterProfileCar">brouterProfileCar</string>
-    <string translatable="false" name="pref_bigSmileysOnMap">pref_bigSmileysOnMap</string>
-    <string translatable="false" name="pref_dtMarkerOnCacheIcon">pref_dtMarkerOnCacheIcon</string>
-    <string translatable="false" name="pref_proximityNotificationGeneral">pref_proximityNotificationGeneral</string>
-    <string translatable="false" name="pref_proximityNotificationSpecific">pref_proximityNotificationSpecific</string>
-    <string translatable="false" name="pref_proximityDistanceFar">pref_proximityDistanceFar</string>
-    <string translatable="false" name="pref_proximityDistanceNear">pref_proximityDistanceNear</string>
-    <string translatable="false" name="pref_proximityNotificationType">pref_proximityNotificationType</string>
-    <string translatable="false" name="pref_value_pn_tone_only">1</string>
-    <string translatable="false" name="pref_value_pn_text_only">2</string>
-    <string translatable="false" name="pref_value_pn_tone_and_text">3</string>
+
+    <!-- category map content -->
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_maptrail_length">maptrail_length</string>
+    <string translatable="false" name="pref_bigSmileysOnMap">pref_bigSmileysOnMap</string>
+    <string translatable="false" name="pref_dtMarkerOnCacheIcon">pref_dtMarkerOnCacheIcon</string>
+
+    <!-- category map behavior -->
+    <string translatable="false" name="pref_longTapOnMapActivated">pref_longTapCreateUDC</string>
+
+    <!-- category proximity notfication -->
+    <string translatable="false" name="pref_proximityDistanceFar">pref_proximityDistanceFar</string>
+    <string translatable="false" name="pref_proximityDistanceNear">pref_proximityDistanceNear</string>
+    <string translatable="false" name="pref_proximityNotificationGeneral">pref_proximityNotificationGeneral</string>
+    <string translatable="false" name="pref_proximityNotificationSpecific">pref_proximityNotificationSpecific</string>
+    <string translatable="false" name="pref_proximityNotificationType">pref_proximityNotificationType</string>
+
+    <!-- category mapline customization -->
     <string translatable="false" name="pref_mapline_trailcolor">mapline_trailcolor</string>
     <string translatable="false" name="pref_mapline_trailwidth">mapline_trailwidth</string>
     <string translatable="false" name="pref_mapline_directioncolor">mapline_directioncolor</string>
@@ -140,78 +221,78 @@
     <string translatable="false" name="pref_mapline_circlefillcolor">mapline_circlefillcolor</string>
     <string translatable="false" name="pref_mapline_accuracycirclecolor">mapline_accuracycirclecolor</string>
     <string translatable="false" name="pref_mapline_accuracycirclefillcolor">mapline_accuracycirclefillcolor</string>
+
+    <!-- category other -->
     <string translatable="false" name="pref_map_osm_multithreaded">map_osm_multithreaded</string>
-    <string translatable="false" name="pref_map_osm_threads">map_osm_threads</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for logging screen -->
+    <string translatable="false" name="preference_screen_logging">preference_screen_logging</string>
+    <!-- ============================================================================================================================================================================== -->
+
+    <!-- category signature -->
+    <string translatable="false" name="pref_signature">signature</string>
+    <string translatable="false" name="pref_sigautoinsert">sigautoinsert</string>
+
+    <!-- category logging templates -->
+    <string translatable="false" name="preference_category_logging_logtemplates">preference_category_logging_logtemplates</string>
+
+    <!-- catgory other logging options -->
+    <string translatable="false" name="pref_trackautovisit">trackautovisit</string>
+    <string translatable="false" name="pref_log_offline">log_offline</string>
+    <string translatable="false" name="pref_offlinelogs_homescreen">offlinelogs_homescreen</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for offlinedata screen -->
+    <string translatable="false" name="preference_screen_offlinedata">preference_screen_offlinedata</string>
+    <!-- ============================================================================================================================================================================== -->
+    <string translatable="false" name="pref_logimages">logimages</string>
+    <string translatable="false" name="pref_choose_list">choose_list</string>
     <string translatable="false" name="pref_showListsInCacheList">showListsInCacheList</string>
-    <string translatable="false" name="pref_compactIconMode">compactIconMode</string>
+    <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
+
+    <!-- category gpx -->
+    <string translatable="false" name="pref_persistablefolder_gpx">persistablefolder_gpx</string>
+
+    <!-- category database location -->
+    <string translatable="false" name="pref_dbonsdcard">dbonsdcard</string>
+
+    <!-- category geocache data folder -->
+    <string translatable="false" name="pref_fakekey_dataDir">pref_fakekey_dataDir</string>
+
+    <!-- category maintenance -->
+    <string translatable="false" name="pref_fakekey_preference_maintenance_directories">pref_fakekey_preference_maintenance_directories</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for navigation screen -->
+    <string translatable="false" name="preference_screen_navigation">preference_screen_navigation</string>
+    <!-- ============================================================================================================================================================================== -->
+
+    <!-- category offlinerouting -->
+    <string translatable="false" name="pref_fakekey_brouterDistanceThresholdTitle">fakekey_brouterDistanceThresholdTitle</string>
+    <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
+    <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
+    <string translatable="false" name="pref_useInternalRouting">useInternalRouting</string>
+    <string translatable="false" name="pref_persistablefolder_routingtiles">persistablefolder_routingtiles</string>
+    <string translatable="false" name="pref_brouterAutoTileDownloads">brouterAutoTileDownloads</string>
+    <string translatable="false" name="pref_brouterAutoTileDownloadsInterval">brouterAutoTileDownloadsInterval</string>
+    <string translatable="false" name="pref_brouterAutoTileDownloadsLastCheck">brouterAutoTileDownloadsLastCheck</string><!-- internally used -->
+    <string translatable="false" name="pref_brouterProfileWalk">brouterProfileWalk</string>
+    <string translatable="false" name="pref_brouterProfileBike">brouterProfileBike</string>
+    <string translatable="false" name="pref_brouterProfileCar">brouterProfileCar</string>
+
+    <!-- categories default navigation / secondary navigation -->
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>
     <string translatable="false" name="pref_defaultNavigationTool2">defaultNavigationTool2</string>
-    <string translatable="false" name="pref_dataDir">pref_dataDir</string>
-    <string translatable="false" name="pref_fakekey_dataDir">pref_fakekey_dataDir</string>
-    <string translatable="false" name="pref_loaddirectionimg">loaddirectionimg</string>
-    <string translatable="false" name="pref_fakekey_preference_backup">fakekey_preference_backup</string>
-    <string translatable="false" name="pref_fakekey_preference_restore">fakekey_preference_restore</string>
-    <string translatable="false" name="pref_fakekey_preference_restore_dirselect">fakekey_preference_restore_dirselect</string>
-    <string translatable="false" name="pref_backups_backup_history_length">backup_history_length</string>
-    <string translatable="false" name="pref_backup_logins">backup_logins_enabled</string>
-    <string translatable="false" name="pref_fakekey_preference_maintenance_directories">pref_fakekey_preference_maintenance_directories</string>
-    <string translatable="false" name="pref_dbonsdcard">dbonsdcard</string>
-    <string translatable="false" name="pref_debug">debug</string>
-    <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
-    <string translatable="false" name="pref_longTapOnMapActivated">pref_longTapCreateUDC</string>
-    <string translatable="false" name="pref_createUDCuseGivenList">createUDCuseGivenList</string>
-    <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
-    <string translatable="false" name="pref_bookmarklistsShowNewOnly">bookmarklistsShowNewOnly</string>
-    <string translatable="false" name="pref_attributeFilterSources">attributeFilterSources</string>
-    <!-- preferences used internally -->
-    <string translatable="false" name="pref_temp_twitter_token_secret">temp-token-secret</string>
-    <string translatable="false" name="pref_temp_twitter_token_public">temp-token-public</string>
-    <string translatable="false" name="pref_help_shown">helper</string>
-    <string translatable="false" name="pref_anylongitude">anylongitude</string>
-    <string translatable="false" name="pref_anylatitude">anylatitude</string>
-    <string translatable="false" name="pref_webDeviceCode">webDeviceCode</string>
-    <string translatable="false" name="pref_maplive">maplive</string>
-    <string translatable="false" name="pref_lastmapzoom">mapzoom</string>
-    <string translatable="false" name="pref_cache_zoom">cachezoom</string>
-    <string translatable="false" name="pref_lastmaplat">maplat</string>
-    <string translatable="false" name="pref_lastmaplon">maplon</string>
-    <string translatable="false" name="pref_livelist">livelist</string>
-    <string translatable="false" name="pref_lastusedlist">lastlist</string>
-    <string translatable="false" name="pref_last_selected_lists">last_selected_lists</string>
-    <string translatable="false" name="pref_twitter_token_secret">tokensecret</string>
-    <string translatable="false" name="pref_twitter_token_public">tokenpublic</string>
-    <string translatable="false" name="pref_version">version</string>
-    <string translatable="false" name="pref_usecompass">usecompass</string>
-    <string translatable="false" name="pref_mapfile">mfmapfile</string>
-    <string translatable="false" name="pref_mapdownloader_source">mapdownloader_source</string>
-    <string translatable="false" name="old_pref_mapAutoDownloads">mapAutoDownloads</string>
-    <string translatable="false" name="pref_mapAutoDownloadsInterval">mapAutoDownloadsInterval</string>
-    <string translatable="false" name="pref_mapAutoDownloadsLastCheck">mapAutoDownloadsLastCheck</string>
-    <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>
-    <string translatable="false" name="pref_memberstatus">memberstatus</string>
-    <string translatable="false" name="pref_coordinputformat">coordinputformat</string>
-    <string translatable="false" name="pref_gccustomdate">gccustomdate</string>
-    <string translatable="false" name="pref_customtabs_as_browser">customtabs_as_browser</string>
-    <string translatable="false" name="pref_googleplayservices">googleplayservices</string>
-    <string translatable="false" name="pref_lowpowermode">lowpowerlocation</string>
-    <string translatable="false" name="pref_lastdetailspage">lastdetailspage</string>
-    <string translatable="false" name="pref_logtrackablewithoutgeocodeshowcount">logtrackablewithoutgeocodeshowcount</string>
-    <string translatable="false" name="pref_settingsversion">settingsversion</string>
-    <string translatable="false" name="pref_trackableaction">trackableaction</string>
-    <string translatable="false" name="pref_trackable_inventory_sort">trackableComparator</string>
-    <string translatable="false" name="pref_includefoundstatus">includefoundstatus</string>
-    <string translatable="false" name="pref_cleartrailafterexportstatus">cleartrailafterexportstatus</string>
-    <string translatable="false" name="pref_renderthemefile">renderthemefile</string>
-    <string translatable="false" name="pref_renderthemefolder_synctolocal">renderthemefolder_synctolocal</string>
-    <string translatable="false" name="pref_logImageScale">logImageScale</string>
-    <string translatable="false" name="pref_ocde_tokensecret">ocde_tokensecret</string>
-    <string translatable="false" name="pref_ocde_tokenpublic">ocde_tokenpublic</string>
-    <string translatable="false" name="pref_temp_ocde_token_secret">ocde-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_ocde_token_public">ocde-temp-token-public</string>
-    <string translatable="false" name="pref_fieldNoteExportDate">fieldnoteExportDate</string>
-    <string translatable="false" name="pref_fieldNoteExportUpload">fieldnoteExportUpload</string>
-    <string translatable="false" name="pref_fieldNoteExportOnlyNew">fieldnoteExportOnlyNew</string>
-    <string translatable="false" name="pref_hideVisitedWaypoints">hideVisitedWaypoints</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for navigation menu screen -->
+    <string translatable="false" name="preference_screen_navigation_menu">preference_screen_navigation_menu</string>
+    <!-- ============================================================================================================================================================================== -->
     <string translatable="false" name="pref_navigation_menu_compass">navigationCompass</string>
     <string translatable="false" name="pref_navigation_menu_radar">navigationRadar</string>
     <string translatable="false" name="pref_navigation_menu_internal_map">navigationInternalMap</string>
@@ -231,112 +312,69 @@
     <string translatable="false" name="pref_navigation_menu_where_you_go">navigationWhereYouGo</string>
     <string translatable="false" name="pref_navigation_menu_pebble">navigationPebble</string>
     <string translatable="false" name="pref_navigation_menu_mapswithme">navigationMapsWithMe</string>
-    <string translatable="false" name="pref_ocpl_tokensecret">ocpl_tokensecret</string>
-    <string translatable="false" name="pref_ocpl_tokenpublic">ocpl_tokenpublic</string>
-    <string translatable="false" name="pref_temp_ocpl_token_secret">ocpl-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_ocpl_token_public">ocpl-temp-token-public</string>
-    <string translatable="false" name="pref_ocnl_tokensecret">ocnl_tokensecret</string>
-    <string translatable="false" name="pref_ocnl_tokenpublic">ocnl_tokenpublic</string>
-    <string translatable="false" name="pref_temp_ocnl_token_secret">ocnl-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_ocnl_token_public">ocnl-temp-token-public</string>
-    <string translatable="false" name="pref_ocus_tokensecret">ocus_tokensecret</string>
-    <string translatable="false" name="pref_ocus_tokenpublic">ocus_tokenpublic</string>
-    <string translatable="false" name="pref_temp_ocus_token_secret">ocus-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_ocus_token_public">ocus-temp-token-public</string>
-    <string translatable="false" name="pref_ocro_tokensecret">ocro_tokensecret</string>
-    <string translatable="false" name="pref_ocro_tokenpublic">ocro_tokenpublic</string>
-    <string translatable="false" name="pref_temp_ocro_token_secret">ocro-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_ocro_token_public">ocro-temp-token-public</string>
-    <string translatable="false" name="pref_ocuk2_tokensecret">ocuk2_tokensecret</string>
-    <string translatable="false" name="pref_ocuk2_tokenpublic">ocuk2_tokenpublic</string>
-    <string translatable="false" name="pref_temp_ocuk2_token_secret">ocuk2-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_ocuk2_token_public">ocuk2-temp-token-public</string>
-    <string translatable="false" name="pref_fakekey_gc_website">fakekey_gc_website</string>
-    <string translatable="false" name="pref_fakekey_ocde_register">fakekey_ocde_register</string>
-    <string translatable="false" name="pref_fakekey_ocde_website">fakekey_ocde_website</string>
-    <string translatable="false" name="pref_fakekey_ocpl_register">fakekey_ocpl_register</string>
-    <string translatable="false" name="pref_fakekey_ocpl_website">fakekey_ocpl_website</string>
-    <string translatable="false" name="pref_fakekey_ocnl_register">fakekey_ocnl_register</string>
-    <string translatable="false" name="pref_fakekey_ocnl_website">fakekey_ocnl_website</string>
-    <string translatable="false" name="pref_fakekey_ocus_register">fakekey_ocus_register</string>
-    <string translatable="false" name="pref_fakekey_ocus_website">fakekey_ocus_website</string>
-    <string translatable="false" name="pref_fakekey_ocro_register">fakekey_ocro_register</string>
-    <string translatable="false" name="pref_fakekey_ocro_website">fakekey_ocro_website</string>
-    <string translatable="false" name="pref_fakekey_ocuk_register">fakekey_ocuk_register</string>
-    <string translatable="false" name="pref_fakekey_ocuk_website">fakekey_ocuk_website</string>
-    <string translatable="false" name="pref_fakekey_ec_website">fakekey_ec_website</string>
-    <string translatable="false" name="pref_fakekey_al_website">fakekey_al_website</string>
-    <string translatable="false" name="pref_fakekey_su_website">fakekey_su_website</string>
-    <string translatable="false" name="pref_su_tokensecret">su_tokensecret</string>
-    <string translatable="false" name="pref_su_tokenpublic">su_tokenpublic</string>
-    <string translatable="false" name="pref_temp_su_token_secret">su-temp-token-secret</string>
-    <string translatable="false" name="pref_temp_su_token_public">su-temp-token-public</string>
-    <string translatable="false" name="pref_cache_filter_config">cache_filter_config</string>
-    <string translatable="false" name="pref_cache_sort_config">cache_sort_config</string>
 
-    <string translatable="false" name="pref_fakekey_gcvote_website">fakekey_gcvote_website</string>
-    <string translatable="false" name="pref_fakekey_geokrety_website">fakekey_geokrety_website</string>
-    <string translatable="false" name="pref_fakekey_geokretymap_website">fakekey_geokretymap_website</string>
-    <string translatable="false" name="pref_fakekey_sendtocgeo_info">fakekey_sendtocgeo_info</string>
-    <string translatable="false" name="pref_fakekey_sendtocgeo_website">fakekey_sendtocgeo_website</string>
 
-    <string translatable="false" name="pref_fakekey_info_offline_maps">fakekey_info_offline_maps</string>
-    <string translatable="false" name="pref_fakekey_start_downloader">fakekey_start_downloader</string>
-    <string translatable="false" name="pref_fakekey_info_offline_mapthemes">fakekey_info_offline_mapthemes</string>
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for system screen -->
+    <string translatable="false" name="preference_screen_system">preference_screen_system</string>
+    <!-- ============================================================================================================================================================================== -->
 
-    <string translatable="false" name="pref_twitter_cache_message">twitter_cache_message</string>
-    <string translatable="false" name="pref_twitter_trackable_message">twitter_trackable_message</string>
-    <string translatable="false" name="pref_gc_fb_login_hint">gc_fb_login_hint</string>
-    <string translatable="false" name="pref_ec_icons">ec_icons</string>
-    <string translatable="false" name="pref_memory_dump">memory_dump</string>
-    <string translatable="false" name="pref_generate_logcat">generate_logcat</string>
-    <string translatable="false" name="pref_generate_infos_downloadmanager">generate_infos_downloadmanager</string>
-    <string translatable="false" name="pref_view_settings">view_settings</string>
-    <string translatable="false" name="pref_changelog_last_checksum">changelog_last_checksum</string>
-    <string translatable="false" name="pref_caches_history">caches_history</string>
-    <string translatable="false" name="pref_phone_model_and_sdk">phone_model_and_sdk</string>
-    <string translatable="false" name="pref_last_cache_log">last_cache_log</string>
-    <string translatable="false" name="pref_last_trackable_log">last_trackable_log</string>
-    <string translatable="false" name="pref_home_location">home_location</string>
-    <string translatable="false" name="pref_map_routing">map_routing</string>
-    <string translatable="false" name="pref_theme_menu">theme_menu</string>
-    <string translatable="false" name="pref_localstorage_version">localstorage_version</string>
-    <string translatable="false" name="pref_alc_advanced">alc_advanced</string>
-    <string translatable="false" name="pref_alc_launcher">alc_launcher</string>
-    <string translatable="false" name="pref_next_unique_notification_id">next_unique_notification_id</string>
-
-    <!-- ids for persistable folder prefs -->
-    <string translatable="false" name="pref_group_localfilesystem">group_localfilesystem</string>
+    <!-- category local filesystem -->
     <string translatable="false" name="pref_persistablefolder_basedir">persistablefolder_basedir</string>
-    <string translatable="false" name="pref_persistablefolder_logfiles">persistablefolder_logfiles</string>
-    <string translatable="false" name="pref_persistablefolder_offlinemaps">persistablefolder_offlinemaps</string>
-    <string translatable="false" name="pref_persistablefolder_offlinemapthemes">persistablefolder_offlinemapthemes</string>
-    <string translatable="false" name="pref_persistablefolder_gpx">persistablefolder_gpx</string>
-    <string translatable="false" name="pref_persistablefolder_backup">persistablefolder_backup</string>
-    <string translatable="false" name="pref_persistablefolder_fieldnotes">persistablefolder_fieldnotes</string>
-    <string translatable="false" name="pref_persistablefolder_spoilerimages">persistablefolder_spoilerimages</string>
-    <string translatable="false" name="pref_persistablefolder_routingbase">persistablefolder_routingbase</string>
-    <string translatable="false" name="pref_persistablefolder_routingtiles">persistablefolder_routingtiles</string>
     <string translatable="false" name="pref_persistablefolder_testdir">persistablefolder_testdir</string>
 
-    <!-- ids for persistable uri prefs -->
-    <string translatable="false" name="pref_persistableuri_track">persistableuri_track</string>
+    <!-- category geolocation -->
+    <string translatable="false" name="pref_googleplayservices">googleplayservices</string>
 
-    <!-- preference values -->
+    <!-- category low power mode -->
+    <string translatable="false" name="pref_lowpowermode">lowpowerlocation</string>
+
+    <!-- category orientation sensor -->
+    <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
+
+    <!-- category debug -->
+    <string translatable="false" name="pref_debug">debug</string>
+    <string translatable="false" name="pref_fakekey_generate_logcat">fakekey_generate_logcat</string>
+    <string translatable="false" name="pref_fakekey_memory_dump">fakekey_memory_dump</string>
+    <string translatable="false" name="pref_fakekey_generate_infos_downloadmanager">fakekey_generate_infos_downloadmanager</string>
+    <string translatable="false" name="pref_fakekey_view_settings">fakekey_view_settings</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys for backup/restore screen -->
+    <string translatable="false" name="preference_screen_backup">preference_screen_backup</string>
+    <!-- ============================================================================================================================================================================== -->
+
+    <!-- category create backup -->
+    <string translatable="false" name="pref_backup_backup_history_length">backup_history_length</string>
+    <string translatable="false" name="pref_backup_logins">backup_logins_enabled</string>
+    <string translatable="false" name="pref_fakekey_preference_startbackup">fakekey_preference_startbackup</string>
+
+    <!-- category restore backup -->
+    <string translatable="false" name="pref_fakekey_startrestore">fakekey_startrestore</string>
+    <string translatable="false" name="pref_fakekey_startrestore_dirselect">fakekey_startrestore_dirselect</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- keys used for preference values -->
+    <!-- ============================================================================================================================================================================== -->
+
+    <!-- map => proximity notification -->
+    <string translatable="false" name="pref_value_pn_tone_only">1</string>
+    <string translatable="false" name="pref_value_pn_text_only">2</string>
+    <string translatable="false" name="pref_value_pn_tone_and_text">3</string>
+
+    <!-- map => maprotation -->
     <string translatable="false" name="pref_maprotation_off">off</string>
     <string translatable="false" name="pref_maprotation_manual">manual</string>
     <string translatable="false" name="pref_maprotation_auto">auto</string>
 
+    <!-- map => compact icons -->
     <string translatable="false" name="pref_compacticon_off">off</string>
     <string translatable="false" name="pref_compacticon_on">manual</string>
     <string translatable="false" name="pref_compacticon_auto">auto</string>
 
-    <string translatable="false" name="pref_selected_language">selectedLanguage</string>
-
-    <!-- theme preferences -->
-    <string translatable="false" name="old_pref_skin">skin</string>
-
-    <string translatable="false" name="pref_theme_setting">theme_setting</string>
+    <!-- appearance => theme -->
     <string translatable="false" name="pref_value_theme_light">LIGHT</string>
     <string translatable="false" name="pref_value_theme_dark">DARK</string>
     <string translatable="false" name="pref_value_theme_system_default">SYSTEM_DEFAULT</string>
@@ -345,4 +383,145 @@
         <item>@string/pref_value_theme_light</item>
         <item>@string/pref_value_theme_dark</item>
     </string-array>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- other preference keys (not used directly in our preferences) -->
+    <!-- ============================================================================================================================================================================== -->
+
+    <!-- ids for persistable folder/uri prefs -->
+    <string translatable="false" name="pref_persistablefolder_logfiles">persistablefolder_logfiles</string>
+    <string translatable="false" name="pref_persistablefolder_backup">persistablefolder_backup</string>
+    <string translatable="false" name="pref_persistablefolder_fieldnotes">persistablefolder_fieldnotes</string>
+    <string translatable="false" name="pref_persistablefolder_spoilerimages">persistablefolder_spoilerimages</string>
+    <string translatable="false" name="pref_persistablefolder_routingbase">persistablefolder_routingbase</string>
+    <string translatable="false" name="pref_persistableuri_track">persistableuri_track</string>
+
+    <!-- services => authentification (grouped by service) -->
+    <string translatable="false" name="pref_username">username</string>
+    <string translatable="false" name="pref_password">password</string>
+    <string translatable="false" name="pref_gc_avatar">gc_avatar</string>
+    <string translatable="false" name="pref_memberstatus">memberstatus</string>
+    <string translatable="false" name="pref_gccustomdate">gccustomdate</string>
+
+    <string translatable="false" name="pref_ocde_tokensecret">ocde_tokensecret</string>
+    <string translatable="false" name="pref_ocde_tokenpublic">ocde_tokenpublic</string>
+    <string translatable="false" name="pref_temp_ocde_token_secret">ocde-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_ocde_token_public">ocde-temp-token-public</string>
+
+    <string translatable="false" name="pref_ocpl_tokensecret">ocpl_tokensecret</string>
+    <string translatable="false" name="pref_ocpl_tokenpublic">ocpl_tokenpublic</string>
+    <string translatable="false" name="pref_temp_ocpl_token_secret">ocpl-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_ocpl_token_public">ocpl-temp-token-public</string>
+
+    <string translatable="false" name="pref_ocnl_tokensecret">ocnl_tokensecret</string>
+    <string translatable="false" name="pref_ocnl_tokenpublic">ocnl_tokenpublic</string>
+    <string translatable="false" name="pref_temp_ocnl_token_secret">ocnl-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_ocnl_token_public">ocnl-temp-token-public</string>
+
+    <string translatable="false" name="pref_ocus_tokensecret">ocus_tokensecret</string>
+    <string translatable="false" name="pref_ocus_tokenpublic">ocus_tokenpublic</string>
+    <string translatable="false" name="pref_temp_ocus_token_secret">ocus-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_ocus_token_public">ocus-temp-token-public</string>
+
+    <string translatable="false" name="pref_ocro_tokensecret">ocro_tokensecret</string>
+    <string translatable="false" name="pref_ocro_tokenpublic">ocro_tokenpublic</string>
+    <string translatable="false" name="pref_temp_ocro_token_secret">ocro-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_ocro_token_public">ocro-temp-token-public</string>
+
+    <string translatable="false" name="pref_ocuk2_tokensecret">ocuk2_tokensecret</string>
+    <string translatable="false" name="pref_ocuk2_tokenpublic">ocuk2_tokenpublic</string>
+    <string translatable="false" name="pref_temp_ocuk2_token_secret">ocuk2-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_ocuk2_token_public">ocuk2-temp-token-public</string>
+
+    <string translatable="false" name="pref_ecusername">ecusername</string>
+    <string translatable="false" name="pref_ecpassword">ecpassword</string>
+
+    <string translatable="false" name="pref_su_tokensecret">su_tokensecret</string>
+    <string translatable="false" name="pref_su_tokenpublic">su_tokenpublic</string>
+    <string translatable="false" name="pref_temp_su_token_secret">su-temp-token-secret</string>
+    <string translatable="false" name="pref_temp_su_token_public">su-temp-token-public</string>
+
+    <string translatable="false" name="pref_twitter_token_secret">tokensecret</string>
+    <string translatable="false" name="pref_twitter_token_public">tokenpublic</string>
+    <string translatable="false" name="pref_temp_twitter_token_secret">temp-token-secret</string>
+    <string translatable="false" name="pref_temp_twitter_token_public">temp-token-public</string>
+
+    <!-- services => additional settings -->
+    <string translatable="false" name="pref_alc_advanced">alc_advanced</string>
+    <string translatable="false" name="pref_alc_launcher">alc_launcher</string>
+    <string translatable="false" name="pref_ec_icons">ec_icons</string>
+    <string translatable="false" name="pref_user_vote">user-vote</string>
+    <string translatable="false" name="pref_pass_vote">pass-vote</string>
+    <string translatable="false" name="pref_webDeviceCode">webDeviceCode</string>
+
+    <!-- additional map settings -->
+    <string translatable="false" name="pref_hide_track">hideTrack</string>
+    <string translatable="false" name="pref_showCircles">showCircles</string>
+    <string translatable="false" name="pref_supersizeDistance">supersizeDistanceToggle</string>
+    <string translatable="false" name="pref_mapLanguage">mapLanguage</string>
+    <string translatable="false" name="pref_map_osm_threads">map_osm_threads</string>
+    <string translatable="false" name="pref_compactIconMode">compactIconMode</string>
+    <string translatable="false" name="pref_maplive">maplive</string>
+    <string translatable="false" name="pref_lastmapzoom">mapzoom</string>
+    <string translatable="false" name="pref_cache_zoom">cachezoom</string>
+    <string translatable="false" name="pref_lastmaplat">maplat</string>
+    <string translatable="false" name="pref_lastmaplon">maplon</string>
+    <string translatable="false" name="pref_usecompass">usecompass</string>
+    <string translatable="false" name="pref_mapfile">mfmapfile</string>
+    <string translatable="false" name="pref_mapdownloader_source">mapdownloader_source</string>
+    <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>
+    <string translatable="false" name="pref_mapAutoDownloadsLastCheck">mapAutoDownloadsLastCheck</string>
+    <string translatable="false" name="pref_renderthemefile">renderthemefile</string>
+    <string translatable="false" name="pref_map_routing">map_routing</string>
+    <string translatable="false" name="pref_theme_menu">theme_menu</string>
+
+    <!-- pq/bookmark list: show downloadable/new only -->
+    <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
+    <string translatable="false" name="pref_bookmarklistsShowNewOnly">bookmarklistsShowNewOnly</string>
+
+    <!-- internal version numbers and counters -->
+    <string translatable="false" name="pref_version">version</string>
+    <string translatable="false" name="pref_settingsversion">settingsversion</string>
+    <string translatable="false" name="pref_localstorage_version">localstorage_version</string>
+    <string translatable="false" name="pref_next_unique_notification_id">next_unique_notification_id</string>
+    <string translatable="false" name="pref_changelog_last_checksum">changelog_last_checksum</string>
+
+    <!-- other preferences, used internally -->
+    <string translatable="false" name="pref_dataDir">pref_dataDir</string>
+    <string translatable="false" name="pref_logTemplates">logTemplates</string>
+    <string translatable="false" name="pref_createUDCuseGivenList">createUDCuseGivenList</string>
+    <string translatable="false" name="pref_attributeFilterSources">attributeFilterSources</string>
+    <string translatable="false" name="pref_lastusedlist">lastlist</string>
+    <string translatable="false" name="pref_last_selected_lists">last_selected_lists</string>
+    <string translatable="false" name="pref_help_shown">helper</string>
+    <string translatable="false" name="pref_coordinputformat">coordinputformat</string>
+    <string translatable="false" name="pref_lastdetailspage">lastdetailspage</string>
+    <string translatable="false" name="pref_logtrackablewithoutgeocodeshowcount">logtrackablewithoutgeocodeshowcount</string>
+    <string translatable="false" name="pref_trackableaction">trackableaction</string>
+    <string translatable="false" name="pref_trackable_inventory_sort">trackableComparator</string>
+    <string translatable="false" name="pref_includefoundstatus">includefoundstatus</string>
+    <string translatable="false" name="pref_cleartrailafterexportstatus">cleartrailafterexportstatus</string>
+    <string translatable="false" name="pref_logImageScale">logImageScale</string>
+    <string translatable="false" name="pref_fieldNoteExportDate">fieldnoteExportDate</string>
+    <string translatable="false" name="pref_fieldNoteExportUpload">fieldnoteExportUpload</string>
+    <string translatable="false" name="pref_fieldNoteExportOnlyNew">fieldnoteExportOnlyNew</string>
+    <string translatable="false" name="pref_hideVisitedWaypoints">hideVisitedWaypoints</string>
+    <string translatable="false" name="pref_cache_filter_config">cache_filter_config</string>
+    <string translatable="false" name="pref_cache_sort_config">cache_sort_config</string>
+
+    <string translatable="false" name="pref_caches_history">caches_history</string>
+    <string translatable="false" name="pref_phone_model_and_sdk">phone_model_and_sdk</string>
+    <string translatable="false" name="pref_last_cache_log">last_cache_log</string>
+    <string translatable="false" name="pref_last_trackable_log">last_trackable_log</string>
+    <string translatable="false" name="pref_home_location">home_location</string>
+
+
+    <!-- ============================================================================================================================================================================== -->
+    <!-- old keys, used only for migration -->
+    <!-- ============================================================================================================================================================================== -->
+    <string translatable="false" name="old_pref_useenglish">useenglish</string>
+    <string translatable="false" name="old_pref_mapAutoDownloads">mapAutoDownloads</string>
+    <string translatable="false" name="old_pref_skin">skin</string>
+
 </resources>

--- a/main/res/xml/preferences_appearence.xml
+++ b/main/res/xml/preferences_appearence.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:icon="@drawable/settings_eye"
-    android:key="@string/pref_appearance"
+    android:key="@string/preference_screen_appearance"
     android:title="@string/settings_title_appearance"
     android:summary="@string/settings_summary_appearance" >
     <ListPreference

--- a/main/res/xml/preferences_backup.xml
+++ b/main/res/xml/preferences_backup.xml
@@ -16,7 +16,7 @@
             android:summary="@string/init_backup_history_length_summary"
             app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.BackupSeekbarPreference
-            android:key="@string/pref_backups_backup_history_length"
+            android:key="@string/pref_backup_backup_history_length"
             android:defaultValue="@integer/backup_history_length_default"
             app:min="0"
             app:max="@integer/backup_history_length_max"
@@ -29,7 +29,7 @@
             android:title="@string/init_backup_logins"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_fakekey_preference_backup"
+            android:key="@string/pref_fakekey_preference_startbackup"
             android:layout="@layout/preference_button"
             android:title="@string/init_backup_now"
             app:iconSpaceReserved="false" />
@@ -39,12 +39,12 @@
         android:title="@string/init_restore_title"
         app:iconSpaceReserved="false">
         <Preference
-            android:key="@string/pref_fakekey_preference_restore"
+            android:key="@string/pref_fakekey_startrestore"
             android:layout="@layout/preference_button"
             android:title="@string/init_backup_start_restore"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_fakekey_preference_restore_dirselect"
+            android:key="@string/pref_fakekey_startrestore_dirselect"
             android:layout="@layout/preference_button"
             android:title="@string/init_backup_restore_different_backup"
             app:iconSpaceReserved="false" />

--- a/main/res/xml/preferences_logging.xml
+++ b/main/res/xml/preferences_logging.xml
@@ -21,7 +21,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="@string/pref_fakekey_category_logTemplate"
+        android:key="@string/preference_category_logging_logtemplates"
         android:title="@string/init_log_templates"
         app:iconSpaceReserved="false">
         <!-- Filled dynamically -->

--- a/main/res/xml/preferences_offlinedata.xml
+++ b/main/res/xml/preferences_offlinedata.xml
@@ -43,13 +43,6 @@
             android:key="@string/pref_persistablefolder_gpx"
             android:title="@string/init_gpx_importexportdir"
             app:iconSpaceReserved="false" />
-        <!--
-                    <Preference
-                        android:key="@string/pref_gpxExportDir"
-                        android:title="@string/init_gpx_exportdir" />
-                    <Preference
-                        android:key="@string/pref_gpxImportDir"
-                        android:title="@string/init_gpx_importdir" /> -->
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/main/res/xml/preferences_services_geocaching_com_adventure_lab.xml
+++ b/main/res/xml/preferences_services_geocaching_com_adventure_lab.xml
@@ -2,7 +2,7 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:key="@string/preference_screen_lc"
+    android:key="@string/preference_screen_al"
     android:title="@string/settings_title_lc" >
 
     <PreferenceCategory

--- a/main/res/xml/preferences_system.xml
+++ b/main/res/xml/preferences_system.xml
@@ -6,7 +6,6 @@
     app:key="@string/preference_screen_system">
 
     <PreferenceCategory
-        android:key="@string/pref_group_localfilesystem"
         android:title="@string/init_local_file_system"
         app:iconSpaceReserved="false">
         <Preference
@@ -62,22 +61,22 @@
             android:title="@string/init_debug"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_generate_logcat"
+            android:key="@string/pref_fakekey_generate_logcat"
             android:layout="@layout/preference_button"
             android:title="@string/about_system_write_logcat"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_memory_dump"
+            android:key="@string/pref_fakekey_memory_dump"
             android:layout="@layout/preference_button"
             android:title="@string/init_create_memory_dump"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_generate_infos_downloadmanager"
+            android:key="@string/pref_fakekey_generate_infos_downloadmanager"
             android:layout="@layout/preference_button"
             android:title="@string/about_system_write_infos_downloadmanager"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_view_settings"
+            android:key="@string/pref_fakekey_view_settings"
             android:layout="@layout/preference_button"
             android:title="@string/view_settings"
             app:iconSpaceReserved="false" />

--- a/main/src/cgeo/geocaching/settings/OCPreferenceKeys.java
+++ b/main/src/cgeo/geocaching/settings/OCPreferenceKeys.java
@@ -12,34 +12,19 @@ import java.util.Map;
 
 public enum OCPreferenceKeys {
 
-    OC_DE("oc.de", R.string.pref_connectorOCActive, R.string.preference_screen_ocde,
- R.string.pref_fakekey_ocde_authorization, R.string.pref_fakekey_ocde_website, R.string.pref_fakekey_ocde_register,
-            R.string.pref_ocde_tokenpublic, R.string.pref_ocde_tokensecret, OCAuthParams.OC_DE_AUTH_PARAMS),
-    OC_PL("oc.pl", R.string.pref_connectorOCPLActive, R.string.preference_screen_ocpl,
- R.string.pref_fakekey_ocpl_authorization, R.string.pref_fakekey_ocpl_website, R.string.pref_fakekey_ocpl_register,
-            R.string.pref_ocpl_tokenpublic, R.string.pref_ocpl_tokensecret, OCAuthParams.OC_PL_AUTH_PARAMS),
-    OC_US("oc.us", R.string.pref_connectorOCUSActive, R.string.preference_screen_ocus,
- R.string.pref_fakekey_ocus_authorization, R.string.pref_fakekey_ocus_website, R.string.pref_fakekey_ocus_register,
-            R.string.pref_ocus_tokenpublic, R.string.pref_ocus_tokensecret, OCAuthParams.OC_US_AUTH_PARAMS),
-    OC_NL("oc.nl", R.string.pref_connectorOCNLActive, R.string.preference_screen_ocnl,
- R.string.pref_fakekey_ocnl_authorization, R.string.pref_fakekey_ocnl_website, R.string.pref_fakekey_ocnl_register,
-            R.string.pref_ocnl_tokenpublic, R.string.pref_ocnl_tokensecret, OCAuthParams.OC_NL_AUTH_PARAMS),
-    OC_RO("oc.ro", R.string.pref_connectorOCROActive, R.string.preference_screen_ocro,
- R.string.pref_fakekey_ocro_authorization, R.string.pref_fakekey_ocro_website, R.string.pref_fakekey_ocro_register,
-            R.string.pref_ocro_tokenpublic, R.string.pref_ocro_tokensecret, OCAuthParams.OC_RO_AUTH_PARAMS),
-    OC_UK("oc.uk", R.string.pref_connectorOCUKActive, R.string.preference_screen_ocuk,
- R.string.pref_fakekey_ocuk_authorization, R.string.pref_fakekey_ocuk_website, R.string.pref_fakekey_ocuk_register,
-            R.string.pref_ocuk2_tokenpublic, R.string.pref_ocuk2_tokensecret, OCAuthParams.OC_UK_AUTH_PARAMS);
+    OC_DE("oc.de", R.string.pref_connectorOCActive, R.string.preference_screen_ocde, R.string.pref_fakekey_ocde_authorization, R.string.pref_fakekey_ocde_website, R.string.pref_ocde_tokenpublic, R.string.pref_ocde_tokensecret, OCAuthParams.OC_DE_AUTH_PARAMS),
+    OC_PL("oc.pl", R.string.pref_connectorOCPLActive, R.string.preference_screen_ocpl, R.string.pref_fakekey_ocpl_authorization, R.string.pref_fakekey_ocpl_website, R.string.pref_ocpl_tokenpublic, R.string.pref_ocpl_tokensecret, OCAuthParams.OC_PL_AUTH_PARAMS),
+    OC_US("oc.us", R.string.pref_connectorOCUSActive, R.string.preference_screen_ocus, R.string.pref_fakekey_ocus_authorization, R.string.pref_fakekey_ocus_website, R.string.pref_ocus_tokenpublic, R.string.pref_ocus_tokensecret, OCAuthParams.OC_US_AUTH_PARAMS),
+    OC_NL("oc.nl", R.string.pref_connectorOCNLActive, R.string.preference_screen_ocnl, R.string.pref_fakekey_ocnl_authorization, R.string.pref_fakekey_ocnl_website, R.string.pref_ocnl_tokenpublic, R.string.pref_ocnl_tokensecret, OCAuthParams.OC_NL_AUTH_PARAMS),
+    OC_RO("oc.ro", R.string.pref_connectorOCROActive, R.string.preference_screen_ocro, R.string.pref_fakekey_ocro_authorization, R.string.pref_fakekey_ocro_website, R.string.pref_ocro_tokenpublic, R.string.pref_ocro_tokensecret, OCAuthParams.OC_RO_AUTH_PARAMS),
+    OC_UK("oc.uk", R.string.pref_connectorOCUKActive, R.string.preference_screen_ocuk, R.string.pref_fakekey_ocuk_authorization, R.string.pref_fakekey_ocuk_website, R.string.pref_ocuk2_tokenpublic, R.string.pref_ocuk2_tokensecret, OCAuthParams.OC_UK_AUTH_PARAMS);
 
-
-    OCPreferenceKeys(final String siteId, final int isActivePrefId, final int prefScreenId, final int authPrefId,
- final int websitePrefId, final int registerPrefId, final int publicTokenPrefId, final int privateTokenPrefId, final OCAuthParams authParams) {
+    OCPreferenceKeys(final String siteId, final int isActivePrefId, final int prefScreenId, final int authPrefId, final int websitePrefId, final int publicTokenPrefId, final int privateTokenPrefId, final OCAuthParams authParams) {
         this.siteId = siteId;
         this.isActivePrefId = isActivePrefId;
         this.prefScreenId = prefScreenId;
         this.authPrefId = authPrefId;
         this.websitePrefId = websitePrefId;
-        this.registerPrefId = registerPrefId;
         this.publicTokenPrefId = publicTokenPrefId;
         this.privateTokenPrefId = privateTokenPrefId;
         this.authParams = authParams;
@@ -77,7 +62,6 @@ public enum OCPreferenceKeys {
     public final int isActivePrefId;
     public final int prefScreenId;
     public final int websitePrefId;
-    public final int registerPrefId;
     public final int authPrefId;
     public final int publicTokenPrefId;
     public final int privateTokenPrefId;

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -276,8 +276,6 @@ public class Settings {
             e.putString(getKey(R.string.pref_temp_twitter_token_secret), prefsV0.getString(getKey(R.string.pref_temp_twitter_token_secret), null));
             e.putString(getKey(R.string.pref_temp_twitter_token_public), prefsV0.getString(getKey(R.string.pref_temp_twitter_token_public), null));
             e.putBoolean(getKey(R.string.pref_help_shown), prefsV0.getInt(getKey(R.string.pref_help_shown), 0) != 0);
-            e.putFloat(getKey(R.string.pref_anylongitude), prefsV0.getFloat(getKey(R.string.pref_anylongitude), 0));
-            e.putFloat(getKey(R.string.pref_anylatitude), prefsV0.getFloat(getKey(R.string.pref_anylatitude), 0));
             e.putString(getKey(R.string.pref_webDeviceCode), prefsV0.getString(getKey(R.string.pref_webDeviceCode), null));
             e.putString(getKey(R.string.pref_webDeviceName), prefsV0.getString(getKey(R.string.pref_webDeviceName), null));
             e.putBoolean(getKey(R.string.pref_maplive), prefsV0.getInt(getKey(R.string.pref_maplive), 1) != 0);
@@ -1174,25 +1172,6 @@ public class Settings {
         return getBoolean(R.string.pref_bookmarklistsShowNewOnly, false);
     }
 
-    public static void setAnyCoordinates(final Geopoint coords) {
-        if (coords != null) {
-            putFloat(R.string.pref_anylatitude, (float) coords.getLatitude());
-            putFloat(R.string.pref_anylongitude, (float) coords.getLongitude());
-        } else {
-            remove(R.string.pref_anylatitude);
-            remove(R.string.pref_anylongitude);
-        }
-    }
-
-    public static Geopoint getAnyCoordinates() {
-        if (contains(R.string.pref_anylatitude) && contains(R.string.pref_anylongitude)) {
-            final float lat = getFloat(R.string.pref_anylatitude, 0);
-            final float lon = getFloat(R.string.pref_anylongitude, 0);
-            return new Geopoint(lat, lon);
-        }
-        return null;
-    }
-
     public static boolean isUseCompass() {
         return useCompass;
     }
@@ -1843,7 +1822,7 @@ public class Settings {
     }
 
     public static int allowedBackupsNumber() {
-        return getInt(R.string.pref_backups_backup_history_length, getKeyInt(R.integer.backup_history_length_default));
+        return getInt(R.string.pref_backup_backup_history_length, getKeyInt(R.integer.backup_history_length_default));
     }
 
     /**

--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -192,7 +192,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         Fragment preferenceFragment = new PreferencesFragment();
         if (StringUtils.equals(baseKey, getString(R.string.preference_screen_services))) {
             preferenceFragment = new PreferenceServicesFragment();
-        } else if (StringUtils.equals(baseKey, getString(R.string.pref_appearance))) {
+        } else if (StringUtils.equals(baseKey, getString(R.string.preference_screen_appearance))) {
             preferenceFragment = new PreferenceAppearanceFragment();
         } else if (StringUtils.equals(baseKey, getString(R.string.preference_screen_cachedetails))) {
             preferenceFragment = new PreferenceCachedetailsFragment();

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -18,17 +18,17 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
 
         final BackupUtils backupUtils = new BackupUtils(getActivity(), savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
 
-        findPreference(getString(R.string.pref_fakekey_preference_backup)).setOnPreferenceClickListener(preference -> {
+        findPreference(getString(R.string.pref_fakekey_preference_startbackup)).setOnPreferenceClickListener(preference -> {
             backupUtils.backup(this::updateSummary);
             return true;
         });
 
-        findPreference(getString(R.string.pref_fakekey_preference_restore)).setOnPreferenceClickListener(preference -> {
+        findPreference(getString(R.string.pref_fakekey_startrestore)).setOnPreferenceClickListener(preference -> {
             backupUtils.restore(BackupUtils.newestBackupFolder());
             return true;
         });
 
-        findPreference(getString(R.string.pref_fakekey_preference_restore_dirselect)).setOnPreferenceClickListener(preference -> {
+        findPreference(getString(R.string.pref_fakekey_startrestore_dirselect)).setOnPreferenceClickListener(preference -> {
             backupUtils.selectBackupDirIntent();
             return true;
         });
@@ -44,7 +44,7 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
 
         updateSummary();
 
-        findPreference(getString(R.string.pref_backups_backup_history_length)).setOnPreferenceChangeListener((preference, value) -> {
+        findPreference(getString(R.string.pref_backup_backup_history_length)).setOnPreferenceChangeListener((preference, value) -> {
             backupUtils.deleteBackupHistoryDialog((BackupSeekbarPreference) preference, (int) value);
             return true;
         });
@@ -64,6 +64,6 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
         } else {
             textRestore = getString(R.string.init_backup_last_no);
         }
-        findPreference(getString(R.string.pref_fakekey_preference_restore)).setSummary(textRestore);
+        findPreference(getString(R.string.pref_fakekey_startrestore)).setSummary(textRestore);
     }
 }

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
@@ -18,7 +18,7 @@ public class PreferenceLoggingFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_logging, rootKey);
-        logTemplatesCategory = findPreference(getString(R.string.pref_fakekey_category_logTemplate));
+        logTemplatesCategory = findPreference(getString(R.string.preference_category_logging_logtemplates));
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComAdventureLabsFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComAdventureLabsFragment.java
@@ -40,7 +40,7 @@ public class PreferenceServiceGeocachingComAdventureLabsFragment extends Prefere
 
     private void initLCServicePreference(final boolean gcConnectorActive) {
         final boolean isActiveGCPM = gcConnectorActive && Settings.isGCPremiumMember();
-        findPreference(getString((R.string.preference_screen_lc))).setSummary(
+        findPreference(getString((R.string.preference_screen_al))).setSummary(
             getLcServiceSummary(Settings.isALConnectorActive(), gcConnectorActive));
         if (isActiveGCPM) {
             findPreference(getString(R.string.pref_connectorALActive)).setEnabled(true);

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -23,10 +23,10 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
         assert activity != null;
         activity.setTitle(R.string.settings_title_system);
 
-        setPrefClick(this, R.string.pref_memory_dump, () -> DebugUtils.createMemoryDump(activity));
-        setPrefClick(this, R.string.pref_generate_logcat, () -> DebugUtils.createLogcat(activity));
-        setPrefClick(this, R.string.pref_generate_infos_downloadmanager, () -> DebugUtils.dumpDownloadmanagerInfos(activity));
-        setPrefClick(this, R.string.pref_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
+        setPrefClick(this, R.string.pref_fakekey_memory_dump, () -> DebugUtils.createMemoryDump(activity));
+        setPrefClick(this, R.string.pref_fakekey_generate_logcat, () -> DebugUtils.createLogcat(activity));
+        setPrefClick(this, R.string.pref_fakekey_generate_infos_downloadmanager, () -> DebugUtils.dumpDownloadmanagerInfos(activity));
+        setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
 
         initPublicFolders(this, activity.getCsah());
     }


### PR DESCRIPTION
While working on #12488 I've stumbled upon our somewhat messy list of preferences. This PR does a cleanup/consolidation as far as possible without migration:
- sorted and grouped all preference keys according to preference screen and category
- consolidate all preference screen keys to name scheme "preference_screen_xxx"
- consolidate all category keys (not many given) to name scheme "preference_category_xxx_yyy"
- consolidate preference keys given in `preferences.xml`, but not actually storing a value, to name scheme "pref_fakekey_xxx" as variable name and "fakekey_xxx" as value
- did not consolidate all other prefs except some grouping
- deleted preference keys no longer in use
  - related to this: remove opencaching "register" pref keys and configuration
  - related to this: removes "anywhere location" settings and old migration routine for it
