### PR TITLE
cleanup some map theme legend strings

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2455,8 +2455,11 @@
     <string name="rtl_nature_reserve_strict">nature reserve (strict)</string>
     <string name="rtl_cliff">cliff</string>
     <string name="rtl_ridge">ridge</string>
+    <string name="rtl_reef">reef</string>
     <string name="rtl_dyke">dyke</string>
     <string name="rtl_embankment">embankment</string>
+    <string name="rtl_beach">beach</string>
+    <string name="rtl_beach_gravel">gravel beach</string>
     <string name="rtl_spring">spring</string>
     <string name="rtl_powerline">powerline</string>
 
@@ -2545,7 +2548,6 @@
     <string name="rtl_cinema">cinema</string>
     <string name="rtl_cross">cross</string>
     <string name="rtl_fountain">fountain</string>
-    <string name="rtl_library">library</string>
     <string name="rtl_memorial">memorial</string>
     <string name="rtl_memorial_plaque">memorial plaque</string>
     <string name="rtl_memorial_statue">memorial statue</string>
@@ -2561,6 +2563,14 @@
     <string name="rtl_wayside_cross">wayside cross</string>
     <string name="rtl_wayside_shrine">wayside shrine</string>
     <string name="rtl_zoo">zoo</string>
+    <string name="rtl_library">library</string>
+    <string name="rtl_arts_centre">arts centre</string>
+    <string name="rtl_casino">casino</string>
+    <string name="rtl_nightclub">nightclub</string>
+    <string name="rtl_community_centre">community centre</string>
+    <string name="rtl_social_facility">social facility</string>
+    <string name="rtl_townhall">town hall</string>
+    <string name="rtl_courthouse">courthouse</string>
 
     <string name="rtl_beach_resort">beach resort</string>
     <string name="rtl_cliff_diving">cliff diving</string>
@@ -2585,15 +2595,24 @@
     <string name="rtl_aerialway_station">aerialway station</string>
     <string name="rtl_airport">airport</string>
     <string name="rtl_cable_car">cable car</string>
-    <string name="rtl_car_shop">car shop</string>
     <string name="rtl_chair_lift">chair lift</string>
     <string name="rtl_drag_lift">drag lift</string>
     <string name="rtl_gondola">gondola</string>
     <string name="rtl_goods_lift">goods lift</string>
     <string name="rtl_helipad">helipad</string>
+    <string name="rtl_rail_funicular">funicular rail</string>
+
     <string name="rtl_parking">parking</string>
     <string name="rtl_parking_private">private parking</string>
-    <string name="rtl_rail_funicular">funicular rail</string>
+    <string name="rtl_bicycle_parking">bicycle parking</string>
+    <string name="rtl_bicycle_rental">bicycle rental</string>
+    <string name="rtl_bicycle_shop">bicycle shop</string>
+    <string name="rtl_car_rental">car rental</string>
+    <string name="rtl_car_sharing">car sharing</string>
+    <string name="rtl_car_wash">car wash</string>
+    <string name="rtl_car_shop">car shop</string>
+    <string name="rtl_fuel">fuel</string>
+    <string name="rtl_ferry_terminal">ferry terminal</string>
 
     <string name="rtl_alpine_hut">alpine hut</string>
     <string name="rtl_alpine_hut_private">private alpine hut</string>
@@ -2615,13 +2634,13 @@
     <string name="rtl_ice_cream">ice cream</string>
     <string name="rtl_pub">pub</string>
     <string name="rtl_restaurant">restaurant</string>
+    <string name="rtl_bbq">BBQ</string>
+    <string name="rtl_water_point">water point</string>
 
     <string name="rtl_atm">atm</string>
     <string name="rtl_bakery">bakery</string>
     <string name="rtl_bank">bank</string>
     <string name="rtl_beverages">beverages</string>
-    <string name="rtl_bicycle_rental">bicycle rental</string>
-    <string name="rtl_bicycle_shop">bicycle shop</string>
     <string name="rtl_books">books</string>
     <string name="rtl_butcher">butcher</string>
     <string name="rtl_chemist">chemist</string>
@@ -2645,8 +2664,11 @@
     <string name="rtl_firebrigade">fire brigade</string>
     <string name="rtl_emergency_access_point">emergency access point</string>
     <string name="rtl_hospital">hospital</string>
+    <string name="rtl_clinic">clinic</string>
     <string name="rtl_pharmacy">pharmacy</string>
     <string name="rtl_police">police</string>
+    <string name="rtl_emergency_fire_hydrant">fire hydrant</string>
+    <string name="rtl_emergency_suction_point">emergency suction point</string>
 
     <string name="rtl_adit">adit</string>
     <string name="rtl_petroleum_well">petroleum well</string>
@@ -2665,13 +2687,14 @@
     <string name="rtl_bunker">bunker</string>
     <string name="rtl_farmyard">farmyard</string>
     <string name="rtl_hunting_stand">hunting stand</string>
-    <string name="rtl_kindergarten">kindergarten</string>
     <string name="rtl_lighthouse">lighthouse</string>
-    <string name="rtl_school">school</string>
     <string name="rtl_tower_communication">communication tower</string>
     <string name="rtl_tower_observation">observation tower</string>
-    <string name="rtl_townhall">town hall</string>
+
+    <string name="rtl_kindergarten">kindergarten</string>
+    <string name="rtl_school">school</string>
     <string name="rtl_university">university</string>
+    <string name="rtl_college">college</string>
 
     <string name="rtl_buddhist">buddhist</string>
     <string name="rtl_church">church</string>
@@ -2680,6 +2703,10 @@
     <string name="rtl_place_of_worship">place of worship</string>
     <string name="rtl_shinto">shinto</string>
     <string name="rtl_synagogue">synagogue</string>
+    <string name="rtl_pow">place of worship</string>
+    <string name="rtl_pow_christian">christian place of worship</string>
+    <string name="rtl_pow_jewish">jewish place of worship</string>
+    <string name="rtl_pow_muslim">muslim place of worship</string>
 
     <string name="rtl_block">block</string>
     <string name="rtl_bollard">bollard</string>
@@ -2746,11 +2773,6 @@
     <string name="rtl_ruin">ruin</string>
     <string name="rtl_saline">saline</string>
 
-    <string name="rtl_reef">reef</string>
-
-    <string name="rtl_beach">beach</string>
-    <string name="rtl_beach_gravel">gravel beach</string>
-
     <string name="rtl_freeway">freeway</string>
     <string name="rtl_freeway_similar">similar to freeway</string>
     <string name="rtl_interstate">interstate / A road</string>
@@ -2773,36 +2795,5 @@
     <string name="rtl_path_quality1">quality 1 (paved: asphalt, …)</string>
     <string name="rtl_path_quality23">quality 2/3 (paved: gravel, repaired, …)</string>
     <string name="rtl_path_quality45">quality 4/5 (unpaved)</string>
-
-    <string name="rtl_amenity_bicycle_parking">bicycle parking</string>
-    <string name="rtl_amenity_bicycle_rental">bicycle rental</string>
-    <string name="rtl_amenity_car_rental">car rental</string>
-    <string name="rtl_amenity_car_sharing">car sharing</string>
-    <string name="rtl_amenity_car_wash">car wash</string>
-    <string name="rtl_amenity_fuel">fuel</string>
-    <string name="rtl_amenity_ferry_terminal">ferry terminal</string>
-
-    <string name="rtl_amenity_bbq">amenity_bbq</string>
-
-    <string name="rtl_amenity_clinic">amenity_clinic</string>
-    <string name="rtl_emergency_fire_hydrant">emergency_fire_hydrant</string>
-    <string name="rtl_emergency_suction_point">emergency_suction_point</string>
-
-    <string name="rtl_amenity_college">amenity_college</string>
-
-    <string name="rtl_amenity_arts_centre">amenity_arts_centre</string>
-    <string name="rtl_amenity_casino">amenity_casino</string>
-    <string name="rtl_amenity_nightclub">amenity_nightclub</string>
-    <string name="rtl_amenity_community_centre">amenity_community_centre</string>
-    <string name="rtl_amenity_social_facility">amenity_social_facility</string>
-
-    <string name="rtl_amenity_courthouse">amenity_courthouse</string>
-
-    <string name="rtl_amenity_pow">place of worship</string>
-    <string name="rtl_amenity_pow_christian">christian place of worship</string>
-    <string name="rtl_amenity_pow_jewish">jewish place of worship</string>
-    <string name="rtl_amenity_pow_muslim">muslim place of worship</string>
-
-    <string name="rtl_amenity_water_point">water point</string>
 
 </resources>

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/legend/ThemeLegendFreizeitkarte.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/legend/ThemeLegendFreizeitkarte.java
@@ -60,7 +60,7 @@ class ThemeLegendFreizeitkarte implements ThemeLegend {
         entries.add(new RenderThemeLegend.LegendEntry(11, p, "fussgaengerzone", R.string.rtl_pedestrian_area));
         entries.add(new RenderThemeLegend.LegendEntry(11, p, "handel", R.string.rtl_trading));
         entries.add(new RenderThemeLegend.LegendEntry(11, p, "parken-eingeschraenkt", R.string.rtl_parking_restricted));
-        entries.add(new RenderThemeLegend.LegendEntry(11, p, "parken-fahrrad", R.string.rtl_amenity_bicycle_parking));
+        entries.add(new RenderThemeLegend.LegendEntry(11, p, "parken-fahrrad", R.string.rtl_bicycle_parking));
 
         entries.add(new RenderThemeLegend.LegendEntry(11, p, "gefaengnis", R.string.rtl_prison));
         if (isBasic) {
@@ -136,19 +136,19 @@ class ThemeLegendFreizeitkarte implements ThemeLegend {
         cats.add(new RenderThemeLegend.LegendCategory(41, 42, R.string.rtl_category_poi_symbols, 7, 7));
 
         // amenities: transport
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bicycle_parking", R.string.rtl_amenity_bicycle_parking));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bicycle_rental", R.string.rtl_amenity_bicycle_rental));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_car_rental", R.string.rtl_amenity_car_rental));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_car_sharing", R.string.rtl_amenity_car_sharing));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_car_wash", R.string.rtl_amenity_car_wash));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_fuel", R.string.rtl_amenity_fuel));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_ferry_terminal", R.string.rtl_amenity_ferry_terminal));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bicycle_parking", R.string.rtl_bicycle_parking));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bicycle_rental", R.string.rtl_bicycle_rental));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_car_rental", R.string.rtl_car_rental));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_car_sharing", R.string.rtl_car_sharing));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_car_wash", R.string.rtl_car_wash));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_fuel", R.string.rtl_fuel));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_ferry_terminal", R.string.rtl_ferry_terminal));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, isBasic ? "parken" : "amenity_parking", R.string.rtl_parking));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, isBasic ? "parken-eingeschraenkt" : "amenity_parking_private", isBasic ? R.string.rtl_parking_restricted : R.string.rtl_parking_private));
 
         // amenities: food & drink
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bar", R.string.rtl_bar));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bbq", R.string.rtl_amenity_bbq));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_bbq", R.string.rtl_bbq));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_biergarten", R.string.rtl_biergarten));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_cafe", R.string.rtl_cafe));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pub", R.string.rtl_pub));
@@ -159,7 +159,7 @@ class ThemeLegendFreizeitkarte implements ThemeLegend {
         // amenities: emergency
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pharmacy", R.string.rtl_pharmacy));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_hospital", R.string.rtl_hospital));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_clinic", R.string.rtl_amenity_clinic));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_clinic", R.string.rtl_clinic));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_police", R.string.rtl_police));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_fire_station", R.string.rtl_firebrigade));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "emergency_fire_hydrant", R.string.rtl_emergency_fire_hydrant));
@@ -168,20 +168,20 @@ class ThemeLegendFreizeitkarte implements ThemeLegend {
 
         // amenities: education
         if (!isBasic) {
-            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_college", R.string.rtl_amenity_college));
+            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_college", R.string.rtl_college));
             entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_kindergarten", R.string.rtl_kindergarten));
             entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_school", R.string.rtl_school));
             entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_university", R.string.rtl_university));
         }
 
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_arts_centre", R.string.rtl_amenity_arts_centre));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_arts_centre", R.string.rtl_arts_centre));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_library", R.string.rtl_library));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_theatre", R.string.rtl_theatre));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_cinema", R.string.rtl_cinema));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_casino", R.string.rtl_amenity_casino));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_nightclub", R.string.rtl_amenity_nightclub));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_community_centre", R.string.rtl_amenity_community_centre));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_social_facility", R.string.rtl_amenity_social_facility));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_casino", R.string.rtl_casino));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_nightclub", R.string.rtl_nightclub));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_community_centre", R.string.rtl_community_centre));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_social_facility", R.string.rtl_social_facility));
 
         // amenities
         entries.add(new RenderThemeLegend.LegendEntry(41, s, isBasic ? "geldautomat" : "amenity_atm", R.string.rtl_atm));
@@ -189,23 +189,23 @@ class ThemeLegendFreizeitkarte implements ThemeLegend {
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_post_office", R.string.rtl_postoffice));
 
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_townhall", R.string.rtl_townhall));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_courthouse", R.string.rtl_amenity_courthouse));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_courthouse", R.string.rtl_courthouse));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_embassy", R.string.rtl_embassy));
 
         // amenities: places of worship
         if (isBasic) {
-            entries.add(new RenderThemeLegend.LegendEntry(41, s, "kirche", R.string.rtl_amenity_pow));
+            entries.add(new RenderThemeLegend.LegendEntry(41, s, "kirche", R.string.rtl_pow));
         } else {
-            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pow", R.string.rtl_amenity_pow));
-            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pow_christian", R.string.rtl_amenity_pow_christian));
-            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pow_jewish", R.string.rtl_amenity_pow_jewish));
+            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pow", R.string.rtl_pow));
+            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pow_christian", R.string.rtl_pow_christian));
+            entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_pow_jewish", R.string.rtl_pow_jewish));
         }
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, isBasic ? "moschee" : "amenity_pow_muslim", R.string.rtl_amenity_pow_muslim));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, isBasic ? "moschee" : "amenity_pow_muslim", R.string.rtl_pow_muslim));
 
         // amenities: other
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_drinking_water", R.string.rtl_drinking_water));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_fountain", R.string.rtl_fountain));
-        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_water_point", R.string.rtl_amenity_water_point));
+        entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_water_point", R.string.rtl_water_point));
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_toilets", R.string.rtl_toilets));
 
         entries.add(new RenderThemeLegend.LegendEntry(41, s, "amenity_recycling", R.string.rtl_recycling));


### PR DESCRIPTION
Cleanup some of the strings for map theme legends:

- remove one duplicate
- remove some unnecessary prefixes in string values
- remove some unnecessary infixes in string names
- resort some of the strings (grouping)
