### PR TITLE
add visibility options to new route/track dialog

### DIFF
--- a/main/res/layout/routes_tracks_item.xml
+++ b/main/res/layout/routes_tracks_item.xml
@@ -20,6 +20,7 @@
         android:layout_toLeftOf="@id/item_visibility"
         style="@style/button_icon"
         android:visibility="gone"
+        android:hint="@string/map_sort_individual_route"
         android:layout_centerVertical="true"/>
 
     <ImageButton
@@ -27,14 +28,15 @@
         android:src="@drawable/visibility"
         android:layout_toLeftOf="@id/item_center"
         style="@style/button_icon"
-        android:visibility="gone"
-        android:layout_centerVertical="true"/><!-- @todo -->
+        android:hint="@string/make_visible"
+        android:layout_centerVertical="true"/>
 
     <ImageButton
         android:id="@+id/item_center"
         android:src="@drawable/center"
         android:layout_toLeftOf="@id/item_delete"
         style="@style/button_icon"
+        android:hint="@string/center_on_route_track"
         android:layout_centerVertical="true"/>
 
     <ImageButton
@@ -42,6 +44,7 @@
         android:src="@drawable/ic_menu_delete"
         android:layout_alignParentRight="true"
         style="@style/button_icon"
+        android:hint="@string/unload_route_track"
         android:layout_centerVertical="true"/>
 
 </RelativeLayout>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -456,7 +456,6 @@
     <string translatable="false" name="pref_webDeviceCode">webDeviceCode</string>
 
     <!-- additional map settings -->
-    <string translatable="false" name="pref_hide_track">hideTrack</string>
     <string translatable="false" name="pref_showCircles">showCircles</string>
     <string translatable="false" name="pref_supersizeDistance">supersizeDistanceToggle</string>
     <string translatable="false" name="pref_mapLanguage">mapLanguage</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2210,7 +2210,6 @@
     <string name="notification_download_receiver_title">Importing download</string>
 
     <!-- individual routes -->
-    <string name="routes_tracks_dialog_title">Routes / tracks options</string>
     <string name="individual_route">Individual route</string>
     <string name="individual_route_added">added to route</string>
     <string name="individual_route_removed">removed from route</string>
@@ -2218,8 +2217,6 @@
     <string name="individual_route_error_single_waypoint_mode">Not available in single waypoint mode</string>
     <string name="map_sort_individual_route">Sort individual route</string>
     <string name="map_export_individual_route">Export individual route</string>
-    <string name="route">Route</string>
-    <string name="track">Track</string>
     <string name="map_load_individual_route">Load individual route</string>
     <string name="map_load_individual_route_confirm">Overwrite existing route?</string>
     <string name="map_autotarget_individual_route">Set route start as target</string>
@@ -2240,7 +2237,6 @@
         <item quantity="many">Route loaded with %d route points</item>
         <item quantity="other">Route loaded with %d route points</item>
     </plurals>
-    <string name="center_on_route">Center on route</string>
     <string name="individual_route_set_as_start_title">Set as route start</string>
     <string name="individual_route_set_as_start_message">Set this item as route start and move all subsequent items to the top of the current route?</string>
 
@@ -2258,8 +2254,15 @@
         <item quantity="other">Track/route loaded (%d trackpoints)</item>
     </plurals>
     <string name="load_track_error">Error loading track/route</string>
-    <string name="map_unload_track">Unload track/route</string>
-    <string name="center_on_track">Center on track/route</string>
+
+    <!-- route/track commons -->
+    <string name="routes_tracks_dialog_title">Routes / tracks options</string>
+    <string name="center_on_route_track">Center on route/track</string>
+    <string name="unload_route_track">Unload route/track</string>
+    <string name="route">Route</string>
+    <string name="track">Track</string>
+    <string name="make_visible">make visible</string>
+    <string name="hide">hide</string>
 
     <!-- distance units -->
     <string name="unit_m">m</string>

--- a/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.files;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Route;
-import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.utils.AndroidRxUtils;
@@ -38,7 +37,8 @@ public class GPXTrackOrRouteImporter {
                     AndroidSchedulers.mainThread().createWorker().schedule(() -> {
                         try {
                             if (resetVisibilitySetting) {
-                                Settings.setHideTrack(false);
+                                assert value != null;
+                                value.setHidden(true);
                             }
                             callback.updateRoute(value);
                         } catch (final Throwable t) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -771,7 +771,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
             menu.findItem(R.id.menu_as_list).setVisible(!isLoading() && caches.size() > 1);
 
-            getRouteTrackUtils().onPrepareOptionsMenu(menu, activity.findViewById(R.id.container_individualroute), individualRoute);
+            getRouteTrackUtils().onPrepareOptionsMenu(menu, activity.findViewById(R.id.container_individualroute), individualRoute, tracks);
 
             menu.findItem(R.id.menu_hint).setVisible(mapOptions.mapMode == MapMode.SINGLE);
             menu.findItem(R.id.menu_compass).setVisible(mapOptions.mapMode == MapMode.SINGLE);

--- a/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
 import cgeo.geocaching.models.IndividualRoute;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.ui.ImageParam;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
@@ -70,7 +69,6 @@ public class MapSettingsUtils {
         final SettingsCheckboxModel wpOriginalCb = createCb(allCbs, R.string.map_showwp_original, ImageParam.drawable(MapMarkerUtils.getWaypointTypeMarker(activity.getResources(), WaypointType.ORIGINAL)), Settings.isExcludeWpOriginal(), Settings::setExcludeWpOriginal, true);
         final SettingsCheckboxModel wpParkingCb = createCb(allCbs, R.string.map_showwp_parking, ImageParam.drawable(MapMarkerUtils.getWaypointTypeMarker(activity.getResources(), WaypointType.PARKING)), Settings.isExcludeWpParking(), Settings::setExcludeWpParking, true);
         final SettingsCheckboxModel wbVisitedCb = createCb(allCbs, R.string.map_showwp_visited, R.drawable.marker_visited, Settings.isExcludeWpVisited(), Settings::setExcludeWpVisited, true);
-        final SettingsCheckboxModel trackCb = !PersistableUri.TRACK.hasValue() ? null : createCb(allCbs, R.string.map_show_track, R.drawable.map_hidetrack, Settings.isHideTrack(), Settings::setHideTrack, true);
         final SettingsCheckboxModel circlesCb = createCb(allCbs, R.string.map_show_circles, R.drawable.map_circle, isShowCircles, Settings::setShowCircles, false);
 
         final MapSettingsDialogBinding dialogView = MapSettingsDialogBinding.inflate(LayoutInflater.from(Dialogs.newContextThemeWrapper(activity)));
@@ -93,9 +91,6 @@ public class MapSettingsUtils {
         wpParkingCb.addToViewGroup(activity, rightColumn);
         wbVisitedCb.addToViewGroup(activity, rightColumn);
         rightColumn.addView(ViewUtils.createTextItem(activity, R.style.map_quicksettings_subtitle, TextParam.id(R.string.map_show_other_title)));
-        if (trackCb != null) {
-            trackCb.addToViewGroup(activity, rightColumn);
-        }
         circlesCb.addToViewGroup(activity, rightColumn);
 
         final ToggleButtonWrapper<Integer> compactIconWrapper = new ToggleButtonWrapper<>(Settings.getCompactIconMode(), setCompactIconValue, dialogView.compacticonTooglegroup);

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -71,7 +71,9 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
     private ArrayList<ArrayList<LatLng>> route = null;
     private Viewport lastViewport = null;
+    private boolean routeIsHidden = false;
     private ArrayList<ArrayList<LatLng>> track = null;
+    private boolean trackIsHidden = false;
 
     public GooglePositionAndHistory(final GoogleMap googleMap, final GoogleMapView mapView, final GoogleMapView.PostRealDistance postRealDistance, final GoogleMapView.PostRealDistance postRouteDistance) {
         this.mapRef = new WeakReference<>(googleMap);
@@ -161,7 +163,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
     @Override
     public void updateIndividualRoute(final Route route) {
-        this.route = route.getAllPointsLatLng();
+        this.route = route == null ? null : route.getAllPointsLatLng();
+        this.routeIsHidden = route == null || route.isHidden();
         if (postRouteDistance != null) {
             postRouteDistance.postRealDistance(route.getDistance());
         }
@@ -170,7 +173,8 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
     @Override
     public void updateRoute(final Route track) {
-        this.track = null == track ? null : track.getAllPointsLatLng();
+        this.track = track == null ? null : track.getAllPointsLatLng();
+        this.trackIsHidden = track == null || track.isHidden();
         repaintRequired();
     }
 
@@ -305,7 +309,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
     private synchronized void drawRoute() {
         routeObjs.removeAll();
-        if (route != null && route.size() > 1) {
+        if (route != null && route.size() > 1 && !routeIsHidden) {
             for (ArrayList<LatLng> segment : route) {
                 routeObjs.addPolyline(new PolylineOptions()
                     .addAll(segment)
@@ -337,7 +341,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Route.Updat
 
     private synchronized void drawTrack() {
         trackObjs.removeAll();
-        if (track != null && track.size() > 1 && !Settings.isHideTrack()) {
+        if (track != null && track.size() > 1 && !trackIsHidden) {
             for (ArrayList<LatLng> segment : track) {
                 trackObjs.addPolyline(new PolylineOptions()
                     .addAll(segment)

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -417,7 +417,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
             menu.findItem(R.id.menu_as_list).setVisible(!caches.isDownloading() && caches.getVisibleCachesCount() > 1);
 
-            this.routeTrackUtils.onPrepareOptionsMenu(menu, findViewById(R.id.container_individualroute), individualRoute);
+            this.routeTrackUtils.onPrepareOptionsMenu(menu, findViewById(R.id.container_individualroute), individualRoute, tracks);
 
             menu.findItem(R.id.menu_hint).setVisible(mapOptions.mapMode == MapMode.SINGLE);
             menu.findItem(R.id.menu_compass).setVisible(mapOptions.mapMode == MapMode.SINGLE);
@@ -516,8 +516,12 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         Tile.cache.clear();
 
         if (null != trackLayer) {
-            trackLayer.setHidden(Settings.isHideTrack());
+            trackLayer.setHidden(tracks.isHidden());
             trackLayer.requestRedraw();
+        }
+        if (null != routeLayer) {
+            routeLayer.setHidden((individualRoute.isHidden()));
+            routeLayer.requestRedraw();
         }
         MapUtils.updateFilterBar(this, mapOptions.filterContext);
     }
@@ -743,6 +747,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             individualRoute.reloadRoute(routeLayer);
         } else {
             individualRoute.updateRoute(routeLayer);
+            routeLayer.setHidden(individualRoute.isHidden());
         }
     }
 
@@ -751,7 +756,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             this.routeTrackUtils.loadTracks(this::setTracks, false);
         } else if (null != trackLayer) {
             trackLayer.updateRoute(tracks);
-            trackLayer.setHidden(Settings.isHideTrack());
+            trackLayer.setHidden(tracks == null || tracks.isHidden());
         }
     }
 
@@ -792,7 +797,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         this.mapView.getLayerManager().getLayers().add(this.routeLayer);
 
         // TrackLayer
-        this.trackLayer = new TrackLayer(Settings.isHideTrack());
+        this.trackLayer = new TrackLayer(tracks == null || tracks.isHidden());
         this.mapView.getLayerManager().getLayers().add(this.trackLayer);
 
         // NavigationLayer

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -33,6 +33,7 @@ public class RouteLayer extends AbstractRouteLayer implements IndividualRoute.Up
     public void updateIndividualRoute(final Route route) {
         super.updateRoute(route);
         this.distance = route.getDistance();
+        this.isHidden = route.isHidden();
 
         if (postRealRouteDistance != null) {
             postRealRouteDistance.postRealDistance(distance);

--- a/main/src/cgeo/geocaching/models/Route.java
+++ b/main/src/cgeo/geocaching/models/Route.java
@@ -16,6 +16,7 @@ public class Route implements Parcelable {
     protected ArrayList<RouteSegment> segments = new ArrayList<>();
     private final boolean routeable;
     protected float distance = 0.0f;
+    protected boolean isHidden = false;
 
     public Route(final boolean routeable) {
         this.routeable = routeable;
@@ -52,6 +53,14 @@ public class Route implements Parcelable {
             }
         }
         return numPoints;
+    }
+
+    public boolean isHidden() {
+        return isHidden;
+    }
+
+    public void setHidden(final boolean hide) {
+        this.isHidden = hide;
     }
 
     public ArrayList<ArrayList<Geopoint>> getAllPoints() {
@@ -186,6 +195,7 @@ public class Route implements Parcelable {
         segments = parcel.readArrayList(RouteSegment.class.getClassLoader());
         routeable = parcel.readInt() != 0;
         distance = parcel.readFloat();
+        isHidden = parcel.readInt() != 0;
     }
 
     @Override
@@ -199,5 +209,6 @@ public class Route implements Parcelable {
         dest.writeList(segments);
         dest.writeInt(routeable ? 1 : 0);
         dest.writeFloat(distance);
+        dest.writeInt(isHidden ? 1 : 0);
     }
 }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -856,10 +856,6 @@ public class Settings {
         return getBoolean(R.string.pref_excludeWpVisited, false);
     }
 
-    public static boolean isHideTrack() {
-        return getBoolean(R.string.pref_hide_track, false);
-    }
-
     public static boolean isStoreLogImages() {
         return getBoolean(R.string.pref_logimages, false);
     }
@@ -1626,10 +1622,6 @@ public class Settings {
 
     public static void setExcludeWpVisited(final boolean exclude) {
         putBoolean(R.string.pref_excludeWpVisited, exclude);
-    }
-
-    public static void setHideTrack(final boolean hide) {
-        putBoolean(R.string.pref_hide_track, hide);
     }
 
     static void setLogin(final String username, final String password) {


### PR DESCRIPTION
- adds option to set/unset visibility of tracks and routes (new for individual routes)
- visibility values are not persisted yet
- also activates the "routes/tracks" quick access button when only a track is loaded

![image](https://user-images.githubusercontent.com/3754370/148656759-4bcece16-5870-46ff-a2f3-27d1e6fa9594.png)


