### PR TITLE
Improve in which cases a bottom navigation should be shown

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -577,19 +577,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     }
 
     @Override
-    protected void onNewIntent(final Intent intent) {
-        // switching between nearby/offline via bottom navigation.
-        // CacheListActivity is the only one which is used for multiple totally different tasks.
-        // TODO: maybe someone has a better idea instead of closing and reopening the activity with the new intent...
-        if ((intent.getFlags() & Intent.FLAG_ACTIVITY_REORDER_TO_FRONT) != 0) {
-            startActivity(intent);
-            ActivityMixin.finishWithFadeTransition(this);
-        } else {
-            super.onNewIntent(intent);
-        }
-    }
-
-    @Override
     public void onSaveInstanceState(@NonNull final Bundle savedInstanceState) {
         // Always call the superclass so it can save the view hierarchy state
         super.onSaveInstanceState(savedInstanceState);

--- a/main/src/cgeo/geocaching/enumerations/CacheListType.java
+++ b/main/src/cgeo/geocaching/enumerations/CacheListType.java
@@ -15,7 +15,7 @@ public enum CacheListType {
     ADDRESS(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
     FINDER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
     OWNER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true),
-    MAP(false, GeocacheFilterContext.FilterType.TRANSIENT, AbstractBottomNavigationActivity.MENU_MAP, false, false),
+    MAP(false, GeocacheFilterContext.FilterType.TRANSIENT, AbstractBottomNavigationActivity.MENU_HIDE_BOTTOM_NAVIGATION, false, false),
     SEARCH_FILTER(false, GeocacheFilterContext.FilterType.LIVE, AbstractBottomNavigationActivity.MENU_SEARCH, false, true);
 
     /**

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -802,6 +802,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 Settings.setLiveMap(mapOptions.isLiveEnabled);
             }
             if (mapOptions.isLiveEnabled) {
+                mapOptions.isStoredEnabled = true;
                 mapOptions.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.LIVE);
                 refreshMapData(false);
             }
@@ -809,9 +810,11 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             lastSearchResult = null;
             mapOptions.searchResult = null;
             ActivityMixin.invalidateOptionsMenu(activity);
-            if (mapOptions.mapMode != MapMode.SINGLE) {
-                mapOptions.title = StringUtils.EMPTY;
+            if (mapOptions.mapMode == MapMode.SINGLE) {
+                setTarget(mapOptions.coords, mapOptions.geocode);
             }
+            mapOptions.mapMode = MapMode.LIVE;
+            mapOptions.title = StringUtils.EMPTY;
             updateMapTitle();
         } else if (id == R.id.menu_store_caches) {
             return storeCaches(getGeocodesForCachesInViewport());

--- a/main/src/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/cgeo/geocaching/maps/MapOptions.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class MapOptions {
 
-    public final MapMode mapMode;
+    public MapMode mapMode;
     public boolean isLiveEnabled;
     public boolean isStoredEnabled;
     public SearchResult searchResult;

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -4,13 +4,12 @@ import cgeo.geocaching.AbstractDialogFragment;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
-import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.maps.AbstractMap;
 import cgeo.geocaching.maps.CGeoMap;
-import cgeo.geocaching.maps.DefaultMap;
+import cgeo.geocaching.maps.MapMode;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.maps.RouteTrackUtils;
 import cgeo.geocaching.maps.interfaces.MapActivityImpl;
@@ -108,7 +107,12 @@ public class GoogleMapActivity extends AbstractBottomNavigationActivity implemen
 
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
-        return mapBase.onOptionsItemSelected(item);
+        final boolean result = mapBase.onOptionsItemSelected(item);
+        // in case enable/disable live was selected which is handled in our mapBase implementation
+        if (item.getItemId() == R.id.menu_map_live) {
+            updateSelectedBottomNavItemId();
+        }
+        return result;
     }
 
     @Override
@@ -256,14 +260,6 @@ public class GoogleMapActivity extends AbstractBottomNavigationActivity implemen
 
     @Override
     public int getSelectedBottomItemId() {
-        return MENU_MAP;
-    }
-
-    @Override
-    public void onNavigationItemReselected(@NonNull final MenuItem item) {
-        if (item.getItemId() == MENU_MAP && !mapBase.getMapOptions().isLiveEnabled && !mapBase.getMapOptions().isStoredEnabled) {
-            startActivity(DefaultMap.getLiveMapIntent(this));
-            ActivityMixin.finishWithFadeTransition(this);
-        }
+        return mapBase.getMapOptions().mapMode == MapMode.LIVE ? MENU_MAP : MENU_HIDE_BOTTOM_NAVIGATION;
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -26,7 +26,6 @@ import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Viewport;
-import cgeo.geocaching.maps.DefaultMap;
 import cgeo.geocaching.maps.MapMode;
 import cgeo.geocaching.maps.MapOptions;
 import cgeo.geocaching.maps.MapProviderFactory;
@@ -366,15 +365,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
     @Override
     public int getSelectedBottomItemId() {
-        return MENU_MAP;
-    }
-
-    @Override
-    public void onNavigationItemReselected(@NonNull final MenuItem item) {
-        if (item.getItemId() == MENU_MAP && !mapOptions.isLiveEnabled && !mapOptions.isStoredEnabled) {
-            startActivity(DefaultMap.getLiveMapIntent(this));
-            ActivityMixin.finishWithFadeTransition(this);
-        }
+        return mapOptions.mapMode == MapMode.LIVE ? MENU_MAP : MENU_HIDE_BOTTOM_NAVIGATION;
     }
 
     @Override
@@ -454,12 +445,12 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             caches.handleStoredLayers(this, mapOptions);
             caches.handleLiveLayers(this, mapOptions);
             ActivityMixin.invalidateOptionsMenu(this);
-            if (mapOptions.mapMode != MapMode.SINGLE) {
-                mapOptions.title = StringUtils.EMPTY;
-            } else {
-                // reset target cache on single mode map
-                targetGeocode = mapOptions.geocode;
+            if (mapOptions.mapMode == MapMode.SINGLE) {
+                setTarget(mapOptions.coords, mapOptions.geocode);
             }
+            mapOptions.mapMode = MapMode.LIVE;
+            updateSelectedBottomNavItemId();
+            mapOptions.title = StringUtils.EMPTY;
             setTitle();
         } else if (id == R.id.menu_filter) {
             showFilterMenu();


### PR DESCRIPTION
(dev call agreement: https://github.com/cgeo/cgeo/issues/12443#issuecomment-1008432061)

fix #12443, fix #12423

Furthermore in this PR:
- don't manipulate activity stack, even if bottom navigation activity was already alive (rel. to #11926)
- don't show cache name in map action bar but rather in our 'target view' after 'live' was turned on

