### PR TITLE
add setting for nearby search distance limit (fix #11489)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -54,6 +54,9 @@
     <string translatable="false" name="preference_screen_services">preference_screen_services</string>
     <!-- ============================================================================================================================================================================== -->
 
+    <!-- category nearby search -->
+    <string translatable="false" name="pref_nearbySearchLimit">nearbySearchLimit</string>
+
     <!-- category browser -->
     <string translatable="false" name="pref_nativeUa">nativeUa</string>
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -727,6 +727,10 @@
 
     <string name="settings_category_browser">Browser</string>
     <string name="settings_category_geocaching_platform">Geocaching Platform</string>
+    <string name="settings_category_nearbysearch">Nearby search</string>
+    <string name="init_nearbysearchlimit_title">Nearby search limit</string>
+    <string name="init_nearbysearchlimit_description">Limits the distance up to which caches are returned for with nearby search (0=unlimited)</string>
+
     <string name="settings_category_geocaching_additionals">Further services and addon</string>
     <string name="settings_category_social">Social media</string>
     <string name="settings_category_logging_other">Other Logging Options</string>

--- a/main/res/xml/preferences_services.xml
+++ b/main/res/xml/preferences_services.xml
@@ -83,6 +83,23 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/settings_category_nearbysearch"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:summary="@string/init_nearbysearchlimit_description"
+            android:title="@string/init_nearbysearchlimit_title"
+            app:allowDividerBelow="false"
+            app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.ProximityPreference
+            android:key="@string/pref_nearbySearchLimit"
+            android:defaultValue="0"
+            app:min="0"
+            app:max="999"
+            app:highRes="false"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/settings_category_geocaching_additionals"
         app:iconSpaceReserved="false" >
 

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -2009,12 +2009,12 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 case NEAREST:
                     title = res.getString(R.string.caches_nearby);
                     markerId = EmojiUtils.NO_EMOJI;
-                    loader = new CoordsGeocacheListLoader(this, coords);
+                    loader = new CoordsGeocacheListLoader(this, coords, true);
                     break;
                 case COORDINATE:
                     title = coords.toString();
                     markerId = EmojiUtils.NO_EMOJI;
-                    loader = new CoordsGeocacheListLoader(this, coords);
+                    loader = new CoordsGeocacheListLoader(this, coords, false);
                     break;
                 case KEYWORD:
                     final String keyword = extras.getString(Intents.EXTRA_KEYWORD);
@@ -2032,7 +2032,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                         title = coords.toString();
                     }
                     markerId = EmojiUtils.NO_EMOJI;
-                    loader = new CoordsGeocacheListLoader(this, coords);
+                    loader = new CoordsGeocacheListLoader(this, coords, false);
                     break;
                 case FINDER:
                     final String username = extras.getString(Intents.EXTRA_USERNAME);

--- a/main/src/cgeo/geocaching/loaders/CoordsGeocacheListLoader.java
+++ b/main/src/cgeo/geocaching/loaders/CoordsGeocacheListLoader.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.filters.core.DistanceGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.settings.Settings;
 
 import android.app.Activity;
 
@@ -11,10 +12,12 @@ import androidx.annotation.NonNull;
 
 public class CoordsGeocacheListLoader extends LiveFilterGeocacheListLoader {
     @NonNull public final Geopoint coords;
+    private final boolean applyNearbySearchLimit;
 
-    public CoordsGeocacheListLoader(final Activity activity, @NonNull final Geopoint coords) {
+    public CoordsGeocacheListLoader(final Activity activity, @NonNull final Geopoint coords, final boolean applyNearbySearchLimit) {
         super(activity);
         this.coords = coords;
+        this.applyNearbySearchLimit = applyNearbySearchLimit;
     }
 
     @Override
@@ -25,9 +28,14 @@ public class CoordsGeocacheListLoader extends LiveFilterGeocacheListLoader {
     @Override
     public IGeocacheFilter getAdditionalFilterParameter() {
         final DistanceGeocacheFilter distanceFilter = (DistanceGeocacheFilter) GeocacheFilterType.DISTANCE.create();
+        if (applyNearbySearchLimit) {
+            final int nearbySearchLimit = Settings.getNearbySearchLimit();
+            if (nearbySearchLimit > 0) {
+                distanceFilter.setMinMaxRange(0.0f, (float) nearbySearchLimit);
+            }
+        }
         distanceFilter.setCoordinate(coords);
         return distanceFilter;
     }
-
 
 }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1572,6 +1572,10 @@ public class Settings {
         putBoolean(R.string.pref_plainLogs, plainLogs);
     }
 
+    public static int getNearbySearchLimit() {
+        return getInt(R.string.pref_nearbySearchLimit, 0);
+    }
+
     public static boolean getUseNativeUa() {
         return getBoolean(R.string.pref_nativeUa, false);
     }


### PR DESCRIPTION
## Description
Adds a setting to Settings => Services => Nearby search to define a limit up to which the services return caches on nearby search. A value of 0 means "unlimited" and is the default.
(Limit will get applied for nearby search only, neither for coord search or address search.)