### PR TITLE
switch back to official mapsforge, v0.17.0.0 (fix #12524)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -335,16 +335,16 @@ dependencies {
     implementation "com.asamm:locus-api-android:0.9.32"
 
     // Mapsforge official version
-    //def mapsforgeSource = 'org.mapsforge'
-    //def mapsforgeVersion = '0.16.0'
+    def mapsforgeSource = 'org.mapsforge'
+    def mapsforgeVersion = '0.17.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     //def mapsforgeSource = 'com.github.mapsforge.mapsforge'
     //def mapsforgeVersion = '905e9d48bb' // master as of 31.3.21
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
-    def mapsforgeSource = 'com.github.cgeo.mapsforge'
-    def mapsforgeVersion = '91fa6e6254' // fix for #10128 + fix for #12145
+    // def mapsforgeSource = 'com.github.cgeo.mapsforge'
+    // def mapsforgeVersion = '91fa6e6254' // fix for #10128 + fix for #12145
 
     implementation "$mapsforgeSource:mapsforge-core:$mapsforgeVersion"
     implementation "$mapsforgeSource:mapsforge-map:$mapsforgeVersion"


### PR DESCRIPTION
## Description
Since our fixes are included in officially released mapsforge version, we scan switch our build back to the official release
