### PR TITLE
Improve strings for caches with chirp attribute

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1423,8 +1423,8 @@
 
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>
-    <string name="cache_chirpwolf_start">Open Chirp Wolf to read the chirp data for this cache</string>
-    <string name="cache_chirpwolf_install">Install Chirp Wolf to be able to read chirp data</string>
+    <string name="cache_chirpwolf_start">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can open Chirp Wolf.</string>
+    <string name="cache_chirpwolf_install">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can install Chirp Wolf.</string>
     <string name="cache_alc_start">Open Adventure Lab to start playing this adventure</string>
     <string name="cache_alc_install">Install Adventure Lab player to play this adventure</string>
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
A cache owner contacted us on support mail:
He owns and knows many caches, which use the "chirp attribute" but do not contain a chirp but some other transmitting related stuff like Wifi or NFC. As can be seen in many examples the attribute is also used for such kind of caches.

Users looking for such caches do contact him as they are confused by c:geo reporting, that CacheWolf is needed as it is a chirp cache, while it is not.

I suggest to give a short hint in the text used to link to CacheWolf, that it **might** be a chirp cache.


## Related issues
<!-- List the related issues fixed or improved by this PR -->
None

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Support ticket 463619