### PR TITLE
adapt lint config for false positives on cache rating markers

### DIFF
--- a/main/lint.xml
+++ b/main/lint.xml
@@ -46,10 +46,19 @@
 
     <!-- resources loaded by dynamic name lookup -->
     <issue id="UnusedResources">
-        <ignore path="res/drawable-mdpi/attribute_maintenance.png" />
+        <!-- used for notification system -->
+        <ignore path="res/drawable-xhdpi/attribute_maintenance.png" />
+
+        <!-- translations no longer used -->
+        <ignore path="res/values-*/strings.xml" />
+
+        <!-- cache rating markers (drawables and color values used by the drawables) -->
+        <ignore path="res/drawable/marker_rating_*.xml" />
+        <ignore regexp="R\.color\.marker_rating_[0-5]{1,2}" />
+
+        <!-- other -->
         <ignore path="res/*/ic_launcher_*round.xml" />
         <ignore path="res/values/vpi__colors.xml" />
-        <ignore path="res/values-*/strings.xml" />
     </issue>
 
     <issue id="MissingDefaultResource" severity="informational"/>

--- a/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -28,7 +28,6 @@ import android.util.Pair;
 import android.util.SparseArray;
 import android.view.Gravity;
 
-import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.res.ResourcesCompat;
@@ -51,35 +50,6 @@ public final class MapMarkerUtils {
     private static final SparseArray<CacheMarker> overlaysCache = new SparseArray<>();
     private static EmojiUtils.EmojiPaint cPaint = null; // cache icons
     private static EmojiUtils.EmojiPaint lPaint = null; // list markers
-
-    // this enum solely serves to make static code analysis happy
-    private enum LintUseCacheRatingDrawables {
-        D00 (R.drawable.marker_rating_d_0),
-        D05 (R.drawable.marker_rating_d_5),
-        D10 (R.drawable.marker_rating_d_10),
-        D15 (R.drawable.marker_rating_d_15),
-        D20 (R.drawable.marker_rating_d_20),
-        D25 (R.drawable.marker_rating_d_25),
-        D30 (R.drawable.marker_rating_d_30),
-        D35 (R.drawable.marker_rating_d_35),
-        D40 (R.drawable.marker_rating_d_40),
-        D45 (R.drawable.marker_rating_d_45),
-        D50 (R.drawable.marker_rating_d_50),
-        T00 (R.drawable.marker_rating_t_0),
-        T05 (R.drawable.marker_rating_t_5),
-        T10 (R.drawable.marker_rating_t_10),
-        T15 (R.drawable.marker_rating_t_15),
-        T20 (R.drawable.marker_rating_t_20),
-        T25 (R.drawable.marker_rating_t_25),
-        T30 (R.drawable.marker_rating_t_30),
-        T35 (R.drawable.marker_rating_t_35),
-        T40 (R.drawable.marker_rating_t_40),
-        T45 (R.drawable.marker_rating_t_45),
-        T50 (R.drawable.marker_rating_t_50);
-
-        LintUseCacheRatingDrawables(@DrawableRes final int res) {
-        }
-    }
 
     private MapMarkerUtils() {
         // Do not instantiate


### PR DESCRIPTION
related to #12533

## Description
instead of adding code to reference the cache rating markers config lint to ignore those seemingly unused resources