### PR TITLE
fix #12537: calc coords: parse formulas correctly for guided input, default to plain if not parseable

### DIFF
--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
@@ -237,6 +237,12 @@ public class CoordinatesCalculateGlobalDialog extends DialogFragment { // implem
             binding.PlainLat.setText(binding.PlainLat.getText().toString().replaceAll(" ", ""));
         });
 
+        //check if type from config is applicable
+        if (calcCoord.getType() != PLAIN) {
+            final CalculatedCoordinateType type = binding.NonPlainFormat.guessType(calcCoord.getLatitudePattern(), calcCoord.getLongitudePattern());
+            calcCoord.setType(type == null ? PLAIN : type);
+        }
+
         refreshType(calcCoord.getType(), true);
 
         return binding.getRoot();
@@ -253,6 +259,7 @@ public class CoordinatesCalculateGlobalDialog extends DialogFragment { // implem
         if (!initialLoad && calcCoord.getType() == newType) {
             return;
         }
+
         calcCoord.setType(newType);
 
         Geopoint currentGp = null;

--- a/main/src/cgeo/geocaching/utils/formulas/Formula.java
+++ b/main/src/cgeo/geocaching/utils/formulas/Formula.java
@@ -293,11 +293,11 @@ public final class Formula {
         NUMBERS.add((int) ',');
     }
 
-    public static Formula compile(final String expression) {
+    public static Formula compile(final String expression) throws FormulaException {
         return compile(expression, 0, null);
     }
 
-    public static Formula compile(final String expression, final int startPos, final KeyableCharSet stopChars) {
+    public static Formula compile(final String expression, final int startPos, final KeyableCharSet stopChars) throws FormulaException {
         final KeyableCharSet stopCharSet = stopChars == null ? KeyableCharSet.EMPTY : stopChars;
         final String cacheKey = expression + "-" + startPos + "-" + stopCharSet.getKey();
         final Pair<Formula, FormulaException> entry = FORMULA_CACHE.get(cacheKey);

--- a/tests/src/cgeo/geocaching/ui/CalculatedCoordinateInputGuideViewTest.java
+++ b/tests/src/cgeo/geocaching/ui/CalculatedCoordinateInputGuideViewTest.java
@@ -1,0 +1,21 @@
+package cgeo.geocaching.ui;
+
+import static cgeo.geocaching.models.CalculatedCoordinateType.DEGREE_MINUTE;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class CalculatedCoordinateInputGuideViewTest {
+
+    @Test
+    public void guessNullPatterns() {
+        assertThat(CalculatedCoordinateInputGuideView.guessType(null, null)).isNull();
+    }
+
+    @Test
+    public void guessDegreeMinute() {
+        //assertThat(CalculatedCoordinateInputGuideView.guessType("N51° 27.234'", "E006° 57.123'")).isEqualTo(DEGREE_MINUTE);
+        assertThat(CalculatedCoordinateInputGuideView.guessType("N51° 27.((C*4)+A+9)00'", "E006° 57.(C+B-7)00'")).isEqualTo(DEGREE_MINUTE);
+        assertThat(CalculatedCoordinateInputGuideView.guessType("N51° 27.((C*4)+A+9)__'", "E006° 57.(C+B-7)__'")).isEqualTo(DEGREE_MINUTE);
+    }
+}


### PR DESCRIPTION
fix #12537: calc coords: parse formulas correctly for guided input, default to plain if not parseable