### PR TITLE
[MultiTrackFiles] use better "center" icon

### DIFF
--- a/main/res/drawable/center.xml
+++ b/main/res/drawable/center.xml
@@ -1,4 +1,4 @@
-<!-- material.op / adjust -->
+<!-- take from materialdesignicons.com / image-filter-center-focus -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
@@ -7,5 +7,5 @@
     android:tint="?android:textColorPrimary">
   <path
       android:fillColor="@android:color/white"
-      android:pathData="M12,2C6.49,2 2,6.49 2,12s4.49,10 10,10 10,-4.49 10,-10S17.51,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM15,12c0,1.66 -1.34,3 -3,3s-3,-1.34 -3,-3 1.34,-3 3,-3 3,1.34 3,3z"/>
+      android:pathData="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M19,19H15V21H19A2,2 0 0,0 21,19V15H19M19,3H15V5H19V9H21V5A2,2 0 0,0 19,3M5,5H9V3H5A2,2 0 0,0 3,5V9H5M5,15H3V19A2,2 0 0,0 5,21H9V19H5V15Z"/>
 </vector>


### PR DESCRIPTION
IMHO, the meaning of the old center icon was not clear enough, so I suggest using a different one... 

|before|now|
-|-
![grafik](https://user-images.githubusercontent.com/64581222/150004805-d51d476f-3b19-4557-8022-66cc0d0eafde.png)|![grafik](https://user-images.githubusercontent.com/64581222/150004950-ddeb1728-e9c7-4e2b-a862-e22b6e7a374e.png)
