### PR TITLE
Fix #12577 - Downgrade commons-lang3 to 3.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       # Ignore some updates to the apache 'commons-io' package
       # commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
       - dependency-name: "commons-io:commons-io"
+      # Ignore some updates to the apache 'commons-lang3' package
+      # commons-lang3 3.12.0 uses StringJoiner which is first contained in Android API24
+      - dependency-name: "org.apache.commons:commons-lang3"
       # Ignore some updates to the 'assertj' package
       # Ignore only new versions for >= 3.x
       - dependency-name: "org.assertj:assertj-core"

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -54,7 +54,8 @@ android {
 
 dependencies {
     // Apache Commons
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    // commons-lang3 3.12.0 uses StringJoiner which is first contained in API24. See https://github.com/cgeo/cgeo/issues/12577
+    implementation 'org.apache.commons:commons-lang3:3.11'
     // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
     // could be replaced by Storage Access Framework
     //noinspection GradleDependency

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -287,7 +287,8 @@ dependencies {
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.commons:commons-compress:1.20'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    // commons-lang3 3.12.0 uses StringJoiner which is first contained in API24. See https://github.com/cgeo/cgeo/issues/12577
+    implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'
 
     // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -287,7 +287,9 @@ dependencies {
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'org.apache.commons:commons-compress:1.20'
-    // commons-lang3 3.12.0 uses StringJoiner which is first contained in API24. See https://github.com/cgeo/cgeo/issues/12577
+    // commons-lang3 3.12.0 uses StringJoiner which is first contained in Android API24
+    // See https://github.com/cgeo/cgeo/issues/12577
+    //noinspection GradleDependency
     implementation 'org.apache.commons:commons-lang3:3.11'
     implementation 'org.apache.commons:commons-text:1.9'
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Downgrade used version of commons-lang3 to 3.11 which was tested to make c:geo work again on API 21-23

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fixes #12577 
Reverts #10100


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Please check if any `noinspection` or similar needs to be defined.
