### PR TITLE
automatic backup reminder (fix #6315)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -16,13 +16,44 @@
         android:layout_marginTop="16dp"
         tools:layout="@layout/status" />
 
+    <FrameLayout
+        android:id="@+id/reminders"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dip"
+        android:layout_marginTop="16dp"
+        android:layout_below="@id/status">
+
+        <include
+            android:id="@+id/autobackup"
+            layout="@layout/mainactivity_action_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone" />
+
+        <include
+            android:id="@+id/mapupdate"
+            layout="@layout/mainactivity_action_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone" />
+
+        <include
+            android:id="@+id/tilesupdate"
+            layout="@layout/mainactivity_action_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone" />
+
+    </FrameLayout>
+
     <RelativeLayout
         android:id="@+id/info_notloggedin"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dip"
         android:layout_marginTop="16dip"
-        android:layout_below="@id/status"
+        android:layout_below="@id/reminders"
         android:background="@drawable/helper_bcg"
         android:visibility="gone">
 

--- a/main/res/layout/mainactivity_action_item.xml
+++ b/main/res/layout/mainactivity_action_item.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/helper_bcg">
+
+    <TextView
+        android:id="@+id/action_item_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_marginHorizontal="8dp"
+        android:layout_toLeftOf="@id/action_item_button"
+        android:gravity="center"
+        android:text="@string/init_backup_automatic_reminder"
+        android:textColor="@color/text_icon"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/textSize_detailsPrimary" />
+
+    <Button
+        android:id="@+id/action_item_button"
+        style="@style/button_icon"
+        android:layout_alignParentRight="true"
+        app:icon="@drawable/ic_menu_done"/>
+
+</RelativeLayout>

--- a/main/res/values/numbers.xml
+++ b/main/res/values/numbers.xml
@@ -20,6 +20,8 @@
     <integer name="proximitynotification_near_default">20</integer>
     <integer name="backup_history_length_default">4</integer>
     <integer name="backup_history_length_max">20</integer>
+    <integer name="backup_interval_default">14</integer>
+    <integer name="backup_interval_max">366</integer>
     <integer name="list_load_limit_default">0</integer>
     <integer name="list_load_limit_max">50000</integer>
 

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -357,6 +357,8 @@
     <string translatable="false" name="pref_fakekey_startrestore">fakekey_startrestore</string>
     <string translatable="false" name="pref_fakekey_startrestore_dirselect">fakekey_startrestore_dirselect</string>
 
+    <!-- category automatic backup -->
+    <string translatable="false" name="pref_backup_interval">backup_interval</string>
 
     <!-- ============================================================================================================================================================================== -->
     <!-- keys used for preference values -->
@@ -511,6 +513,7 @@
     <string translatable="false" name="pref_hideVisitedWaypoints">hideVisitedWaypoints</string>
     <string translatable="false" name="pref_cache_filter_config">cache_filter_config</string>
     <string translatable="false" name="pref_cache_sort_config">cache_sort_config</string>
+    <string translatable="false" name="pref_automaticBackupLastCheck">automaticBackupLastCheck</string>
 
     <string translatable="false" name="pref_caches_history">caches_history</string>
     <string translatable="false" name="pref_phone_model_and_sdk">phone_model_and_sdk</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -892,7 +892,7 @@
     <string name="init_backup_history_delete_warning">You have saved more backups than your configured maximum value allows. Do you really want to remove all excess backups?</string>
     <string name="init_backup_automatic">Automatic backup reminder</string>
     <string name="init_backup_automatic_summary">Reminds you every x days to create an automatic backup (in addition to any manually created backups), 0=off</string>
-    <string name="init_backup_automatic_reminder">Shall I create an automatic backup for you now? This will only take a short while.</string>
+    <string name="init_backup_automatic_reminder">Do you want to create an automatic backup? This will only take a short while.</string>
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -890,6 +890,9 @@
     <string name="init_backup_history_length_min">Only recent</string>
     <string name="init_backup_history_length_max">Keep all</string>
     <string name="init_backup_history_delete_warning">You have saved more backups than your configured maximum value allows. Do you really want to remove all excess backups?</string>
+    <string name="init_backup_automatic">Automatic backup reminder</string>
+    <string name="init_backup_automatic_summary">Reminds you every x days to create an automatic backup (in addition to any manually created backups), 0=off</string>
+    <string name="init_backup_automatic_reminder">Shall I create an automatic backup for you now? This will only take a short while.</string>
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>

--- a/main/res/xml/preferences_backup.xml
+++ b/main/res/xml/preferences_backup.xml
@@ -49,4 +49,20 @@
             android:title="@string/init_backup_restore_different_backup"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/init_backup_automatic"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:title="@string/init_backup_automatic"
+            android:summary="@string/init_backup_automatic_summary"
+            app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.BackupSeekbarPreference
+            android:key="@string/pref_backup_interval"
+            android:defaultValue="@integer/backup_interval_default"
+            app:min="0"
+            app:max="@integer/backup_interval_max"
+            app:hasDecimals="false"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/main/src/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/cgeo/geocaching/CgeoApplication.java
@@ -23,10 +23,14 @@ import androidx.annotation.NonNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CgeoApplication extends Application {
 
     private static CgeoApplication instance;
+    private static final AtomicInteger lowPrioNotificationCounter = new AtomicInteger(0);
+    private static final AtomicBoolean hasHighPrioNotification = new AtomicBoolean(false);
 
     public CgeoApplication() {
         setInstance(this);
@@ -129,6 +133,14 @@ public class CgeoApplication extends Application {
         config.locale = Settings.getApplicationLocale();
         final Resources resources = getResources();
         resources.updateConfiguration(config, resources.getDisplayMetrics());
+    }
+
+    public AtomicInteger getLowPrioNotificationCounter() {
+        return lowPrioNotificationCounter;
+    }
+
+    public AtomicBoolean getHasHighPrioNotification() {
+        return hasHighPrioNotification;
     }
 
 }

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -324,6 +324,10 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
             DownloaderUtils.checkForMapUpdates(this);
             cLog.add("mu");
+
+            // automated backup check
+            BackupUtils.checkForBackupReminder(this);
+            cLog.add("ab");
         }
 
         if (Log.isEnabled(Log.LogLevel.DEBUG)) {

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -63,10 +63,12 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.MenuCompat;
@@ -656,4 +658,20 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
     }
+
+    // display action notifications, e. g. update or backup reminders
+    public void displayActionItem(final int layout, final @StringRes int info, final Runnable action) {
+        final RelativeLayout l = findViewById(layout);
+        if (l != null) {
+            l.setVisibility(View.VISIBLE);
+            updateHomeBadge(1);
+            ((TextView) l.findViewById(R.id.action_item_info)).setText(info);
+            l.setOnClickListener(v -> {
+                action.run();
+                l.setVisibility(View.GONE);
+                updateHomeBadge(-1);
+            });
+        }
+    }
+
 }

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.downloader;
 
+import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.models.Download;
@@ -62,9 +63,9 @@ public class DownloaderUtils {
         return false;
     }
 
-    public static void checkForRoutingTileUpdates(final Activity activity) {
+    public static void checkForRoutingTileUpdates(final MainActivity activity) {
         if (Settings.useInternalRouting() && !PersistableFolder.ROUTING_TILES.isLegacy() && Settings.brouterAutoTileDownloadsNeedUpdate()) {
-            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, DownloaderUtils::returnFromTileUpdateCheck);
+            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.tilesupdate, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, DownloaderUtils::returnFromTileUpdateCheck);
         }
     }
 
@@ -72,9 +73,9 @@ public class DownloaderUtils {
         Settings.setBrouterAutoTileDownloadsLastCheck(!updateCheckAllowed);
     }
 
-    public static void checkForMapUpdates(final Activity activity) {
+    public static void checkForMapUpdates(final MainActivity activity) {
         if (Settings.mapAutoDownloadsNeedUpdate()) {
-            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, R.string.mapupdate_info, DownloaderUtils::returnFromMapUpdateCheck);
+            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.mapupdate, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, R.string.mapupdate_info, DownloaderUtils::returnFromMapUpdateCheck);
         }
     }
 
@@ -229,20 +230,19 @@ public class DownloaderUtils {
     }
 
     /**
-     * ask user whether to check for updates
-     * if yes: checks whether updates are available for the type specified
+     * displays an info to the user to check for updates
+     * if button pressed: checks whether updates are available for the type specified
      *      if yes: ask user to download them all
      *              if yes: trigger download(s)
-     * calls callback with user reaction (true=checked for updates / false=user delayed check)
      */
-    public static void checkForUpdatesAndDownloadAll(final Activity activity, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, final Action1<Boolean> callback) {
-        SimpleDialog.of(activity).setTitle(title).setMessage(info).setNegativeButton(TextParam.id(R.string.later)).confirm((dialog, which) -> {
+    public static void checkForUpdatesAndDownloadAll(final MainActivity activity, final int layout, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, final Action1<Boolean> callback) {
+        activity.displayActionItem(layout, info, () -> {
             new CheckForDownloadsTask(activity, title, type).execute();
             callback.call(true);
-        }, (dialog, w) -> callback.call(false));
+        });
     }
 
-    // same as checkForUpdatesAndDownloadAll above, but without question
+    // execute download check
     public static void checkForUpdatesAndDownloadAll(final Activity activity, final Download.DownloadType type, @StringRes final int title, final Action1<Boolean> callback) {
         new CheckForDownloadsTask(activity, title, type).execute();
         callback.call(true);

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1821,6 +1821,31 @@ public class Settings {
         return getInt(R.string.pref_backup_backup_history_length, getKeyInt(R.integer.backup_history_length_default));
     }
 
+    public static boolean automaticBackupDue() {
+        // update check disabled?
+        final int interval = getAutomaticBackupInterval();
+        if (interval < 1) {
+            return false;
+        }
+        // initialization on first run
+        final long lastCheck = getLong(R.string.pref_automaticBackupLastCheck, 0);
+        if (lastCheck == 0) {
+            setAutomaticBackupLastCheck(false);
+            return false;
+        }
+        // check if interval is completed
+        final long now = System.currentTimeMillis() / 1000;
+        return (lastCheck + (interval * DAYS_TO_SECONDS)) <= now;
+    }
+
+    private static int getAutomaticBackupInterval() {
+        return getInt(R.string.pref_backup_interval, CgeoApplication.getInstance().getResources().getInteger(R.integer.backup_interval_default));
+    }
+
+    public static void setAutomaticBackupLastCheck(final boolean delay) {
+        putLong(R.string.pref_automaticBackupLastCheck, calculateNewTimestamp(delay, getAutomaticBackupInterval()));
+    }
+
     /**
      * sets the user-defined folder-config for a persistable folder. Can be set to null
      * should be called by PersistableFolder class only

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -19,7 +19,7 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
         final BackupUtils backupUtils = new BackupUtils(getActivity(), savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
 
         findPreference(getString(R.string.pref_fakekey_preference_startbackup)).setOnPreferenceClickListener(preference -> {
-            backupUtils.backup(this::updateSummary);
+            backupUtils.backup(this::updateSummary, false);
             return true;
         });
 
@@ -45,7 +45,7 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
         updateSummary();
 
         findPreference(getString(R.string.pref_backup_backup_history_length)).setOnPreferenceChangeListener((preference, value) -> {
-            backupUtils.deleteBackupHistoryDialog((BackupSeekbarPreference) preference, (int) value);
+            backupUtils.deleteBackupHistoryDialog((BackupSeekbarPreference) preference, (int) value, false);
             return true;
         });
 

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -754,23 +754,16 @@ public class BackupUtils {
         final Folder folder = autobackup ? Folder.fromPersistableFolder(PersistableFolder.BACKUP, AUTO_BACKUP_FOLDER) : PersistableFolder.BACKUP.getFolder();
         final String subfoldername = Formatter.formatDateForFilename(timestamp);
         if (ContentStorage.get().exists(folder, subfoldername)) {
-            return null; // We don't want to overwrite a existing backup
+            return null; // We don't want to overwrite an existing backup
         }
         final Folder subfolder = Folder.fromFolder(folder, subfoldername);
         ContentStorage.get().ensureFolder(subfolder, true);
         return subfolder;
     }
 
-    public static void checkForBackupReminder(final Activity activity) {
+    public static void checkForBackupReminder(final MainActivity activity) {
         if (Settings.automaticBackupDue()) {
-            SimpleDialog.of(activity).setTitle(R.string.init_backup_automatic).setMessage(R.string.init_backup_automatic_reminder).setNegativeButton(TextParam.id(R.string.later)).confirm((dialog, which) -> {
-                new BackupUtils(activity, null).backup(() -> returnFromAutomaticBackupCheck(true), true);
-            }, (dialog, w) -> returnFromAutomaticBackupCheck(false));
+            activity.displayActionItem(R.id.autobackup, R.string.init_backup_automatic_reminder, () -> new BackupUtils(activity, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true));
         }
     }
-
-    private static void returnFromAutomaticBackupCheck(final boolean updateCheckAllowed) {
-        Settings.setAutomaticBackupLastCheck(!updateCheckAllowed);
-    }
-
 }


### PR DESCRIPTION
(screenshots in this entry are outdated, the reminder is no longer being shown as a modal `AlertDialog`)

## Description
Adds an automatic backup reminder to c:geo which offers you to either create an automated backup now or postpone it a bit:

![image](https://user-images.githubusercontent.com/3754370/150604889-c2e3e762-4ead-45ee-ae58-decaba191687.png)

There's not much to configure: You can set the interval to 0 (effectively disabling automatic backup reminders) or to a certain amount of days when to be reminded next:

![image](https://user-images.githubusercontent.com/3754370/150604866-c4e977a7-57f2-4d1a-a54e-fb2e5b54228d.png)

The default interval is "14 days", and you will be reminded for your first automatic backup 14 days after your first start of the new version (at least if you do not reset the preference value for `automaticBackupLastCheck` manually).

The maximum number of backups is set to 5, and "include account data" setting will be shared with manual backups.
Automatic backups are stored in a subfolder `auto` beneath the configured backup folder, so they won't interfere with manual backups. If the maximum number of automatic backups is reached, the oldest automatic backup will be deleted automatically.

This PR is targeted to `master`, but based on `release`, so that we could cherry-pick it to the upcoming release if requested.