### PR TITLE
remove spacing after attribute group titles (fix #12601)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1281,7 +1281,10 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                         final String key = attr.getValue(enabled);
                         if (attributes.contains(key)) {
                             if (lastCategory != category) {
-                                attributesText.append("<h6>").append(category.getName(activity)).append("</h6>");
+                                if (lastCategory != null) {
+                                    attributesText.append("<br /><br />");
+                                }
+                                attributesText.append("<b><u>").append(category.getName(activity)).append("</u></b><br />");
                                 lastCategory = category;
                             } else {
                                 attributesText.append("<br />");

--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -307,7 +307,10 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
                     final Integer value = attributes.get(key);
                     if (value != null && value > 0) {
                         if (lastCategory != category) {
-                            attributesText.append("<h5>").append(category.getName(context)).append("</h5>");
+                            if (lastCategory != null) {
+                                attributesText.append("<br /><br />");
+                            }
+                            attributesText.append("<b><u>").append(category.getName(context)).append("</u></b><br />");
                             lastCategory = category;
                         } else {
                             attributesText.append("<br />");


### PR DESCRIPTION
## Description
Replaces `<h5>`/`<h6>` formatting of attribute category titles by bold/underline to remove spacing after title.

Cache details page:
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/150690326-04ccc28c-ac05-4798-b43e-da3011d3d2d9.png)|![image](https://user-images.githubusercontent.com/3754370/150690332-e8aa1e42-02f4-4ef6-bcf5-d113649bd937.png)|

Cache list page:
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/150690307-875fa968-0e61-45b8-af55-c4e8bd3d143a.png)|![image](https://user-images.githubusercontent.com/3754370/150690312-c58534c4-1e96-4d1a-b342-f6735f526472.png)|
