### PR TITLE
update avatar when loading server params

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -80,8 +80,6 @@ public final class GCConstants {
     /** Use replaceAll("[,.]","") on the resulting string before converting to an int */
     static final Pattern PATTERN_CACHES_FOUND = Pattern.compile("\\swindow(?>\\.|\\[')(?:headerSettings|chromeSettings)(?>'\\])?\\s*=\\s*\\{[\\S\\s]*\"findCount\":\\s*([0-9]*)[\\S\\s]*\\}");
 
-    static final Pattern PATTERN_AVATAR_IMAGE_SERVERPARAMETERS = Pattern.compile("\"(https?:\\/\\/(img(?:cdn)?\\.geocaching\\.com|[^>\\\"]+\\.cloudfront\\.net)\\/avatar\\/[0-9a-f-]+\\.(" + IMAGE_FORMATS + "))\\\"");
-
     // Patterns for parsing trackables
 
     static final Pattern PATTERN_TRACKABLE_GUID = Pattern.compile("<a id=\"ctl00_ContentBody_lnkPrint\" aria-labelledby=\"[^\"]*\" href=\".*sheet\\.aspx\\?guid=([a-z0-9\\-]+)\"[^>]*>[^<]*</a>");

--- a/main/src/cgeo/geocaching/settings/GCAuthorizationActivity.java
+++ b/main/src/cgeo/geocaching/settings/GCAuthorizationActivity.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCLogin;
 import cgeo.geocaching.enumerations.StatusCode;
-import cgeo.geocaching.ui.AvatarUtils;
 
 public class GCAuthorizationActivity extends AbstractCredentialsAuthorizationActivity {
 
@@ -35,7 +34,7 @@ public class GCAuthorizationActivity extends AbstractCredentialsAuthorizationAct
 
         final StatusCode status = GCLogin.getInstance().login(credentials);
         if (status == StatusCode.NO_ERROR) {
-            AvatarUtils.changeAvatar(GCConnector.getInstance(), GCLogin.getInstance().getAvatarUrl());
+            GCLogin.getInstance().getServerParameters(); // This will initialize some settings
         }
         return  status;
     }

--- a/main/src/cgeo/geocaching/ui/AvatarUtils.java
+++ b/main/src/cgeo/geocaching/ui/AvatarUtils.java
@@ -9,6 +9,8 @@ import android.graphics.drawable.BitmapDrawable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.Objects;
+
 import org.apache.commons.lang3.StringUtils;
 
 /** Class to retrieve Avatar images from. This class handles e.g. in-memory image caching */
@@ -21,7 +23,9 @@ public class AvatarUtils {
     }
 
     public static void changeAvatar(@NonNull final IAvatar avatar, final String newUrl) {
-        Settings.setAvatarUrl(avatar, newUrl);
+        if (!Objects.equals(Settings.getAvatarUrl(avatar), newUrl)) {
+            Settings.setAvatarUrl(avatar, newUrl);
+        }
     }
 
 

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCLoginTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCLoginTest.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector.gc;
 
 import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.ui.AvatarUtils;
 import cgeo.geocaching.utils.TextUtils;
 
 import junit.framework.TestCase;
@@ -36,7 +37,11 @@ public class GCLoginTest extends TestCase {
     }
 
     public void testAvatar() {
-        assertThat(instance.downloadAvatar()).isNotNull();
+        instance.resetServerParameters();
+        AvatarUtils.changeAvatar(GCConnector.getInstance(), null);
+        assertThat(AvatarUtils.getAvatar(GCConnector.getInstance())).isNull();
+        instance.getServerParameters(); // avatar should automatically be updated here...
+        assertThat(AvatarUtils.getAvatar(GCConnector.getInstance())).isNotNull();
     }
 
 }


### PR DESCRIPTION
fix #12620

While with this PR the avatar image will always stay in sync, we will even do less network requests. Reason is, that the avatar URL is always contained in the so called `serverparams` which we request all the time anyway, so no separate request is needed...

This also removes some legacy code which is no longer in use.