### PR TITLE
display 'off' state in autobackup slider (fix #12624)

### DIFF
--- a/main/res/xml/preferences_backup.xml
+++ b/main/res/xml/preferences_backup.xml
@@ -57,12 +57,10 @@
             android:title="@string/init_backup_automatic"
             android:summary="@string/init_backup_automatic_summary"
             app:iconSpaceReserved="false"/>
-        <cgeo.geocaching.settings.BackupSeekbarPreference
+        <cgeo.geocaching.settings.SeekbarPreference0Off
             android:key="@string/pref_backup_interval"
             android:defaultValue="@integer/backup_interval_default"
-            app:min="0"
             app:max="@integer/backup_interval_max"
-            app:hasDecimals="false"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -32,10 +32,9 @@
             android:title="@string/init_updateinterval_title"
             app:allowDividerBelow="false"
             app:iconSpaceReserved="false"/>
-        <cgeo.geocaching.settings.SeekbarPreference
+        <cgeo.geocaching.settings.SeekbarPreference0Off
             android:key="@string/pref_mapAutoDownloadsInterval"
             android:defaultValue="@integer/map_updateinterval_default"
-            app:min="0"
             app:max="@integer/map_updateinterval_max"
             app:iconSpaceReserved="false" />
 

--- a/main/res/xml/preferences_navigation.xml
+++ b/main/res/xml/preferences_navigation.xml
@@ -58,10 +58,9 @@
             android:summary="@string/init_updateinterval_description"
             app:allowDividerBelow="false"
             app:iconSpaceReserved="false"/>
-        <cgeo.geocaching.settings.SeekbarPreference
+        <cgeo.geocaching.settings.SeekbarPreference0Off
             android:key="@string/pref_brouterAutoTileDownloadsInterval"
             android:defaultValue="@integer/brouter_updateinterval_default"
-            app:min="0"
             app:max="@integer/brouter_updateinterval_max"
             app:iconSpaceReserved="false" />
 

--- a/main/src/cgeo/geocaching/settings/SeekbarPreference0Off.java
+++ b/main/src/cgeo/geocaching/settings/SeekbarPreference0Off.java
@@ -1,0 +1,36 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+/**
+ * Displays a regular seekbar with 0="Off"
+ * You can set android:defaultValue and app:max attributes.
+ */
+public class SeekbarPreference0Off extends SeekbarPreference {
+
+    public SeekbarPreference0Off(final Context context) {
+        this(context, null);
+    }
+
+    public SeekbarPreference0Off(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.preferenceStyle);
+    }
+
+    public SeekbarPreference0Off(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        minProgress = 0;
+        hasDecimals = false;
+    }
+
+    @Override
+    protected String getValueString(final int progress) {
+        if (progress == 0) {
+            return context.getString(R.string.switch_off);
+        }
+        return super.getValueString(progress);
+    }
+
+}


### PR DESCRIPTION
## Description
Displays "off" for value 0 instead of reusing the regular backup slider's value of "only recent"

![image](https://user-images.githubusercontent.com/3754370/151657914-289b9ed4-e857-46a3-8e46-939524d5e58f.png)
