### PR TITLE
use high-res version of avatar image 

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCLogin.java
@@ -378,7 +378,11 @@ public class GCLogin extends AbstractLogin {
             Log.d("Setting member status to " + memberState);
             Settings.setGCMemberStatus(memberState);
 
-            AvatarUtils.changeAvatar(GCConnector.getInstance(), serverParameters.userInfo.avatarUrl);
+            if (StringUtils.isNotBlank(serverParameters.userInfo.avatarUrl)) {
+                final String avatarUrl = serverParameters.userInfo.avatarUrl.replace("/avatar/", "/user/large/");
+                Log.d("Setting avatar to " + avatarUrl);
+                AvatarUtils.changeAvatar(GCConnector.getInstance(), avatarUrl);
+            }
 
         } catch (final IOException e) {
             Settings.setGcCustomDate(GCConstants.DEFAULT_GC_DATE);


### PR DESCRIPTION
fix regression introduced by #12621

While using the latest nightly, I noticed that the avatar is displayed with a way worse resolution than before. Thus, this will change the code to use the high-res version of avatar image again...