### PR TITLE
fine-tune dashboard status messages (fix #12631)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -16,19 +16,21 @@
         android:layout_marginTop="16dp"
         tools:layout="@layout/status" />
 
-    <FrameLayout
+    <LinearLayout
         android:id="@+id/reminders"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dip"
         android:layout_marginTop="16dp"
-        android:layout_below="@id/status">
+        android:layout_below="@id/status"
+        android:orientation="vertical">
 
         <include
             android:id="@+id/autobackup"
             layout="@layout/mainactivity_action_item"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
             android:visibility="gone" />
 
         <include
@@ -36,6 +38,7 @@
             layout="@layout/mainactivity_action_item"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
             android:visibility="gone" />
 
         <include
@@ -43,9 +46,10 @@
             layout="@layout/mainactivity_action_item"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
             android:visibility="gone" />
 
-    </FrameLayout>
+    </LinearLayout>
 
     <RelativeLayout
         android:id="@+id/info_notloggedin"

--- a/main/res/layout/mainactivity_action_item.xml
+++ b/main/res/layout/mainactivity_action_item.xml
@@ -7,7 +7,6 @@
     android:padding="8dp"
     android:background="@drawable/helper_bcg"
     android:gravity="center"
-    android:text="@string/init_backup_automatic_reminder"
     android:textColor="@color/text_icon"
     android:textIsSelectable="false"
     android:textSize="@dimen/textSize_detailsPrimary" />

--- a/main/res/layout/mainactivity_action_item.xml
+++ b/main/res/layout/mainactivity_action_item.xml
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/action_item_info"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/helper_bcg">
-
-    <TextView
-        android:id="@+id/action_item_info"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:layout_marginHorizontal="8dp"
-        android:layout_toLeftOf="@id/action_item_button"
-        android:gravity="center"
-        android:text="@string/init_backup_automatic_reminder"
-        android:textColor="@color/text_icon"
-        android:textIsSelectable="false"
-        android:textSize="@dimen/textSize_detailsPrimary" />
-
-    <Button
-        android:id="@+id/action_item_button"
-        style="@style/button_icon"
-        android:layout_alignParentRight="true"
-        app:icon="@drawable/ic_menu_done"/>
-
-</RelativeLayout>
+    android:layout_marginHorizontal="8dp"
+    android:padding="8dp"
+    android:background="@drawable/helper_bcg"
+    android:gravity="center"
+    android:text="@string/init_backup_automatic_reminder"
+    android:textColor="@color/text_icon"
+    android:textIsSelectable="false"
+    android:textSize="@dimen/textSize_detailsPrimary" />

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -891,8 +891,8 @@
     <string name="init_backup_history_length_max">Keep all</string>
     <string name="init_backup_history_delete_warning">You have saved more backups than your configured maximum value allows. Do you really want to remove all excess backups?</string>
     <string name="init_backup_automatic">Automatic backup reminder</string>
-    <string name="init_backup_automatic_summary">Reminds you every x days to create an automatic backup (in addition to any manually created backups), 0=off</string>
-    <string name="init_backup_automatic_reminder">Tap here to create an automatic backup. This will only take a short while. Long-tap to postpone.</string>
+    <string name="init_backup_automatic_summary">Performs an automatic backup every x days (in addition to any manually created backups), 0=off</string>
+    <string name="init_backup_automatic_performing">Creating backup…</string>
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -892,7 +892,7 @@
     <string name="init_backup_history_delete_warning">You have saved more backups than your configured maximum value allows. Do you really want to remove all excess backups?</string>
     <string name="init_backup_automatic">Automatic backup reminder</string>
     <string name="init_backup_automatic_summary">Reminds you every x days to create an automatic backup (in addition to any manually created backups), 0=off</string>
-    <string name="init_backup_automatic_reminder">Tap here to create an automatic backup. This will only take a short while.</string>
+    <string name="init_backup_automatic_reminder">Tap here to create an automatic backup. This will only take a short while. Long-tap to postpone.</string>
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>
@@ -2351,8 +2351,8 @@
     <string name="check_tiles_found">Routing data already present</string>
     <string name="check_tiles_missing">Found missing routing data:\n%1$s\n\nDo you want to download those files?%2$s</string>
     <string name="check_tiles_unsupported">Warning: Routing data is at least partly not available for the chosen region</string>
-    <string name="tileupdate_info">Tap here to check for updates of downloaded routing data files.</string>
-    <string name="mapupdate_info">Tap here to check for updates of map and theme files.</string>
+    <string name="tileupdate_info">Tap here to check for updates of downloaded routing data files. Long-tap to postpone.</string>
+    <string name="mapupdate_info">Tap here to check for updates of map and theme files. Long-tap to postpone.</string>
     <string name="no_updates_found">No updates found</string>
     <string name="updates_check">Updates check</string>
     <string name="mapserver_mapsforge_info">Basic maps, no map themes required</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -892,7 +892,7 @@
     <string name="init_backup_history_delete_warning">You have saved more backups than your configured maximum value allows. Do you really want to remove all excess backups?</string>
     <string name="init_backup_automatic">Automatic backup reminder</string>
     <string name="init_backup_automatic_summary">Reminds you every x days to create an automatic backup (in addition to any manually created backups), 0=off</string>
-    <string name="init_backup_automatic_reminder">Do you want to create an automatic backup? This will only take a short while.</string>
+    <string name="init_backup_automatic_reminder">Tap here to create an automatic backup. This will only take a short while.</string>
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>
@@ -2351,8 +2351,8 @@
     <string name="check_tiles_found">Routing data already present</string>
     <string name="check_tiles_missing">Found missing routing data:\n%1$s\n\nDo you want to download those files?%2$s</string>
     <string name="check_tiles_unsupported">Warning: Routing data is at least partly not available for the chosen region</string>
-    <string name="tileupdate_info">Do you want to check for updates of downloaded routing data files?</string>
-    <string name="mapupdate_info">Do you want to check for updates of map and theme files?</string>
+    <string name="tileupdate_info">Tap here to check for updates of downloaded routing data files.</string>
+    <string name="mapupdate_info">Tap here to check for updates of map and theme files.</string>
     <string name="no_updates_found">No updates found</string>
     <string name="updates_check">Updates check</string>
     <string name="mapserver_mapsforge_info">Basic maps, no map themes required</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -63,7 +63,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -661,11 +660,11 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
     // display action notifications, e. g. update or backup reminders
     public void displayActionItem(final int layout, final @StringRes int info, final Runnable action) {
-        final RelativeLayout l = findViewById(layout);
+        final TextView l = findViewById(layout);
         if (l != null) {
             l.setVisibility(View.VISIBLE);
             updateHomeBadge(1);
-            ((TextView) l.findViewById(R.id.action_item_info)).setText(info);
+            l.setText(info);
             l.setOnClickListener(v -> {
                 action.run();
                 l.setVisibility(View.GONE);

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -328,7 +328,10 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             cLog.add("mu");
 
             // automated backup check
-            BackupUtils.checkForBackupReminder(this);
+            if (Settings.automaticBackupDue()) {
+                ActivityMixin.showShortToast(this, R.string.init_backup_automatic_performing);
+                new BackupUtils(this, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true);
+            }
             cLog.add("ab");
         }
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -45,6 +45,7 @@ import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.Version;
+import cgeo.geocaching.utils.functions.Action1;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -658,17 +659,27 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         }
     }
 
-    // display action notifications, e. g. update or backup reminders
-    public void displayActionItem(final int layout, final @StringRes int info, final Runnable action) {
+    /**
+     * display action notifications, e. g. update or backup reminders
+     * action callback accepts true, if action got performed / false if postponed
+     */
+
+    public void displayActionItem(final int layout, final @StringRes int info, final Action1<Boolean> action) {
         final TextView l = findViewById(layout);
         if (l != null) {
             l.setVisibility(View.VISIBLE);
             updateHomeBadge(1);
             l.setText(info);
             l.setOnClickListener(v -> {
-                action.run();
+                action.call(true);
                 l.setVisibility(View.GONE);
                 updateHomeBadge(-1);
+            });
+            l.setOnLongClickListener(v -> {
+                action.call(false);
+                l.setVisibility(View.GONE);
+                updateHomeBadge(-1);
+                return true;
             });
         }
     }

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -234,9 +234,11 @@ public class DownloaderUtils {
      *              if yes: trigger download(s)
      */
     public static void checkForUpdatesAndDownloadAll(final MainActivity activity, final int layout, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, final Action1<Boolean> callback) {
-        activity.displayActionItem(layout, info, () -> {
-            new CheckForDownloadsTask(activity, title, type).execute();
-            callback.call(true);
+        activity.displayActionItem(layout, info, (actionRequested) -> {
+            if (actionRequested) {
+                new CheckForDownloadsTask(activity, title, type).execute();
+            }
+            callback.call(actionRequested);
         });
     }
 

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -757,7 +757,13 @@ public class BackupUtils {
 
     public static void checkForBackupReminder(final MainActivity activity) {
         if (Settings.automaticBackupDue()) {
-            activity.displayActionItem(R.id.autobackup, R.string.init_backup_automatic_reminder, () -> new BackupUtils(activity, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true));
+            activity.displayActionItem(R.id.autobackup, R.string.init_backup_automatic_reminder, (actionPerformed) -> {
+                if (actionPerformed) {
+                    new BackupUtils(activity, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true);
+                } else {
+                    Settings.setAutomaticBackupLastCheck(true);
+                }
+            });
         }
     }
 }

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.InstallWizardActivity;
 import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.settings.BackupSeekbarPreference;
@@ -549,7 +550,7 @@ public class BackupUtils {
         }
         final boolean settingsResult = createSettingsBackupInternal(backupDir, Settings.getBackupLoginData());
         final Consumer<Boolean> consumer = dbResult -> {
-            showBackupCompletedStatusDialog(backupDir, settingsResult, dbResult);
+            showBackupCompletedStatusDialog(backupDir, settingsResult, dbResult, autobackup);
 
             if (runAfterwards != null) {
                 runAfterwards.run();
@@ -624,7 +625,7 @@ public class BackupUtils {
         });
     }
 
-    private void showBackupCompletedStatusDialog(final Folder backupDir, final Boolean settingsResult, final Boolean databaseResult) {
+    private void showBackupCompletedStatusDialog(final Folder backupDir, final Boolean settingsResult, final Boolean databaseResult, final boolean autobackup) {
         String msg;
         final String title;
         if (settingsResult && databaseResult) {
@@ -654,9 +655,13 @@ public class BackupUtils {
             files.add(fi.uri);
         }
 
-        SimpleDialog.of(activityContext).setTitle(TextParam.text(title)).setMessage(TextParam.text(msg))
-            .setButtons(0, 0, R.string.cache_share_field)
-            .show(SimpleDialog.DO_NOTHING, null, (dialog, which) -> ShareUtils.shareMultipleFiles(activityContext, files, R.string.init_backup_backup));
+        if (autobackup) {
+            ActivityMixin.showShortToast(activityContext, msg);
+        } else {
+            SimpleDialog.of(activityContext).setTitle(TextParam.text(title)).setMessage(TextParam.text(msg))
+                .setButtons(0, 0, R.string.cache_share_field)
+                .show(SimpleDialog.DO_NOTHING, null, (dialog, which) -> ShareUtils.shareMultipleFiles(activityContext, files, R.string.init_backup_backup));
+        }
     }
 
 
@@ -755,15 +760,4 @@ public class BackupUtils {
         return subfolder;
     }
 
-    public static void checkForBackupReminder(final MainActivity activity) {
-        if (Settings.automaticBackupDue()) {
-            activity.displayActionItem(R.id.autobackup, R.string.init_backup_automatic_reminder, (actionPerformed) -> {
-                if (actionPerformed) {
-                    new BackupUtils(activity, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true);
-                } else {
-                    Settings.setAutomaticBackupLastCheck(true);
-                }
-            });
-        }
-    }
 }


### PR DESCRIPTION
## Description
Fine-tuning for dashboard messages regarding backup & update reminder:
- remove action button => tapping on message activates action
- adapted messages accordingly
- fix: only one message could be shown at a time - now all (up to three) can be displayed

![image](https://user-images.githubusercontent.com/3754370/151676163-ac60c171-f56d-4a31-af9f-2a0bb4a25f4b.png)
