### PR TITLE
use math f as 'insert function' symbol (fix #12494)

### DIFF
--- a/main/res/layout/variable_list_item_advanced.xml
+++ b/main/res/layout/variable_list_item_advanced.xml
@@ -49,9 +49,10 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:gravity="center"
-                    android:minWidth="2dp"
+                    android:minWidth="@dimen/textSize_buttonsPrimary"
                     android:layout_marginTop="6dp"
-                    android:text="⋯" />
+                    android:textSize="24sp"
+                    android:text="𝑓" />
 
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/variable_formula"


### PR DESCRIPTION
## Description
Use "𝑓" symbol instead of "..." as label for "insert function" button

![image](https://user-images.githubusercontent.com/3754370/151679039-11bc3e58-9cec-4588-a3e8-24725936cbd3.png)
