### PR TITLE
fix label for vanity function

### DIFF
--- a/main/src/cgeo/geocaching/utils/formulas/FormulaFunction.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaFunction.java
@@ -50,7 +50,7 @@ public enum FormulaFunction {
         singleValueStringFunction(FormulaUtils::letterValue)),
     ROMAN("roman", FunctionGroup.COMPLEX_STRING, 0, "Roman", "''", 1,
         singleValueStringFunction(FormulaUtils::roman)),
-    VANITY(new String[]{ "vanity", "vanitycode", "vc" }, FunctionGroup.COMPLEX_STRING, 0, "Roman", "''", 1,
+    VANITY(new String[]{ "vanity", "vanitycode", "vc" }, FunctionGroup.COMPLEX_STRING, 0, "Vanity", "''", 1,
           singleValueStringFunction(FormulaUtils::vanity));
 
     public enum FunctionGroup {


### PR DESCRIPTION
## Description
Fixes wrong "Roman" label for "Vanity" function in "insert function" dialog on variables tab:

![image](https://user-images.githubusercontent.com/3754370/151679228-c81ba27d-2814-48e0-90cd-60fccfe62186.png)
