### PR TITLE
optionally use wallpaper as dashboard background (fix #11867)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -154,6 +154,7 @@
     <string translatable="false" name="preference_screen_appearance">preference_screen_appearance</string>
     <!-- ============================================================================================================================================================================== -->
     <string translatable="false" name="pref_theme_setting">theme_setting</string>
+    <string translatable="false" name="pref_wallpaper">wallpaper</string>
     <string translatable="false" name="pref_showaddress">showaddress</string>
     <string translatable="false" name="pref_plainLogs">plainLogs</string>
     <string translatable="false" name="pref_selected_language">selectedLanguage</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -864,6 +864,8 @@
         <item>Light</item>
         <item>Dark</item>
     </string-array>
+    <string name="init_wallpaper">Wallpaper</string>
+    <string name="init_summary_wallpaper">Display wallpaper as dashboard background</string>
 
     <!-- backup / restore -->
     <string name="init_backup_title">Create Backup</string>

--- a/main/res/xml/preferences_appearence.xml
+++ b/main/res/xml/preferences_appearence.xml
@@ -15,6 +15,12 @@
         android:summary="%s"
         app:iconSpaceReserved="false" />
     <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/pref_wallpaper"
+        android:summary="@string/init_summary_wallpaper"
+        android:title="@string/init_wallpaper"
+        app:iconSpaceReserved="false" />
+    <CheckBoxPreference
         android:defaultValue="true"
         android:key="@string/pref_showaddress"
         android:summary="@string/init_summary_address"

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -49,6 +49,7 @@ import cgeo.geocaching.utils.Version;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.SearchManager;
+import android.app.WallpaperManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -408,6 +409,8 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
             updateUserInfoHandler.sendEmptyMessage(-1);
             cLog.add("perm");
+
+            binding.getRoot().setBackground(Settings.isWallpaper() ? WallpaperManager.getInstance(this).getDrawable() : null);
 
             init();
         }

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -840,6 +840,10 @@ public class Settings {
                 GCConstants.DEFAULT_GC_DATE);
     }
 
+    public static boolean isWallpaper() {
+        return getBoolean(R.string.pref_wallpaper, false);
+    }
+
     public static boolean isShowAddress() {
         return getBoolean(R.string.pref_showaddress, true);
     }


### PR DESCRIPTION
## Description
Allow users to activate current system wallpaper as dashboard background

![image](https://user-images.githubusercontent.com/3754370/151707406-a20baeda-9c5f-4c0e-b145-7ee07d669e45.png).![image](https://user-images.githubusercontent.com/3754370/151707413-899a88da-a069-4158-9442-08eda66e5143.png)

Default value is `false` = "do not use wallpaper as background"
