### PR TITLE
add adaptive shortcut icons for SDK26+

### DIFF
--- a/main/res/drawable-v26/sc_map.xml
+++ b/main/res/drawable-v26/sc_map.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/shortcut_background" />
+    <foreground>
+        <inset android:drawable="@drawable/sc_icon_map" android:inset="32%" />
+    </foreground>
+</adaptive-icon>

--- a/main/res/drawable-v26/sc_nearby.xml
+++ b/main/res/drawable-v26/sc_nearby.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/shortcut_background" />
+    <foreground>
+        <inset android:drawable="@drawable/sc_icon_nearby" android:inset="32%" />
+    </foreground>
+</adaptive-icon>

--- a/main/res/drawable-v26/sc_search.xml
+++ b/main/res/drawable-v26/sc_search.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/shortcut_background" />
+    <foreground>
+        <inset android:drawable="@drawable/sc_icon_search" android:inset="32%" />
+    </foreground>
+</adaptive-icon>

--- a/main/res/drawable-v26/sc_stored.xml
+++ b/main/res/drawable-v26/sc_stored.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/shortcut_background" />
+    <foreground>
+        <inset android:drawable="@drawable/sc_icon_stored" android:inset="32%" />
+    </foreground>
+</adaptive-icon>

--- a/main/res/drawable/sc_goto.xml
+++ b/main/res/drawable/sc_goto.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@color/shortcut_background" />
-        </shape>
-    </item>
-    <item>
-        <inset android:drawable="@drawable/sc_icon_goto" android:inset="13.0dip" />
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0"
+      android:fillColor="@color/shortcut_background" />
+  <path
+      android:pathData="m29.742,27.227c-1.3894,0 -2.5156,1.1263 -2.5156,2.5156s1.1263,2.5156 2.5156,2.5156 2.5156,-1.1263 2.5156,-2.5156 -1.1263,-2.5156 -2.5156,-2.5156zM29.742,27.2582c1.3721,0 2.4844,1.1123 2.4844,2.4844s-1.1123,2.4844 -2.4844,2.4844 -2.4844,-1.1123 -2.4844,-2.4844 1.1123,-2.4844 2.4844,-2.4844zM32.242,29.7426c0,1.3807 -1.1193,2.5 -2.5,2.5 -1.3807,0 -2.5,-1.1193 -2.5,-2.5s1.1193,-2.5 2.5,-2.5c1.3807,0 2.5,1.1193 2.5,2.5zM15.742,18.5706 L18.5705,15.7422 24.2275,21.3991 26.056,19.5702 27.056,27.056 19.57,26.0562 21.399,24.2275z"
+      android:fillColor="@color/colorAccent"/>
+</vector>

--- a/main/res/drawable/sc_history.xml
+++ b/main/res/drawable/sc_history.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@color/shortcut_background" />
-        </shape>
-    </item>
-    <item>
-        <inset android:drawable="@drawable/sc_icon_history" android:inset="13.0dip"  />
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="49dp"
+    android:height="48dp"
+    android:viewportWidth="49"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0"
+      android:fillColor="@color/shortcut_background" />
+  <path
+      android:pathData="m25.5,15c-4.97,0 -9,4.03 -9,9h-3l3.89,3.89 0.07,0.14 4.04,-4.03h-3c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42c1.63,1.63 3.87,2.64 6.36,2.64 4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM24.5,20v5l4.28,2.54 0.72,-1.21 -3.5,-2.08v-4.25z"
+      android:fillColor="@color/colorAccent"/>
+</vector>

--- a/main/res/drawable/sc_map.xml
+++ b/main/res/drawable/sc_map.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@color/shortcut_background" />
-        </shape>
-    </item>
-    <item>
-        <inset android:drawable="@drawable/sc_icon_map" android:inset="13.0dip" />
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0"
+      android:fillColor="@color/shortcut_background" />
+  <path
+      android:pathData="m32.5,15 l-0.16,0.03 -5.34,2.07 -6,-2.1 -5.64,1.9c-0.21,0.07 -0.36,0.25 -0.36,0.48v15.12c0,0.28 0.22,0.5 0.5,0.5l0.16,-0.03 5.34,-2.07 6,2.1 5.64,-1.9c0.21,-0.07 0.36,-0.25 0.36,-0.48v-15.12c0,-0.28 -0.22,-0.5 -0.5,-0.5zM27,31 L21,28.89v-11.89l6,2.11z"
+      android:fillColor="@color/colorAccent"/>
+</vector>

--- a/main/res/drawable/sc_nearby.xml
+++ b/main/res/drawable/sc_nearby.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@color/shortcut_background" />
-        </shape>
-    </item>
-    <item>
-        <inset android:drawable="@drawable/sc_icon_nearby" android:inset="13.0dip"  />
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0"
+      android:fillColor="@color/shortcut_background" />
+  <path
+      android:pathData="m31.74,30.33c1.41,-1.73 2.26,-3.93 2.26,-6.33 0,-5.52 -4.48,-10 -10,-10s-10,4.48 -10,10 4.48,10 10,10c2.4,0 4.6,-0.85 6.33,-2.26 0.27,-0.22 0.53,-0.46 0.78,-0.71 0.03,-0.03 0.05,-0.06 0.07,-0.08 0.2,-0.2 0.39,-0.41 0.56,-0.62zM24,32c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8c0,1.85 -0.63,3.54 -1.69,4.9l-1.43,-1.43c0.69,-0.98 1.1,-2.17 1.1,-3.46 0,-3.31 -2.69,-6 -6,-6s-6,2.69 -6,6 2.69,6 6,6c1.3,0 2.51,-0.42 3.49,-1.13l1.42,1.42c-1.35,1.07 -3.04,1.7 -4.89,1.7zM25.92,24.51c0.17,-0.66 0.02,-1.38 -0.49,-1.9l-0.02,-0.02c-0.77,-0.77 -2,-0.78 -2.78,-0.04 -0.01,0.01 -0.03,0.02 -0.05,0.04 -0.78,0.78 -0.78,2.05 0,2.83l0.02,0.02c0.52,0.51 1.25,0.67 1.91,0.49l1.51,1.51c-0.6,0.36 -1.29,0.58 -2.04,0.58 -2.21,0 -4,-1.79 -4,-4s1.79,-4 4,-4 4,1.79 4,4c0,0.73 -0.21,1.41 -0.56,2z"
+      android:fillColor="@color/colorAccent"/>
+</vector>

--- a/main/res/drawable/sc_search.xml
+++ b/main/res/drawable/sc_search.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@color/shortcut_background" />
-        </shape>
-    </item>
-    <item>
-        <inset android:drawable="@drawable/sc_icon_search" android:inset="13.0dip"  />
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0"
+      android:fillColor="@color/shortcut_background" />
+  <path
+      android:pathData="m21.75,15.25a6.5,6.5 0,0 1,6.5 6.5c0,1.61 -0.59,3.09 -1.56,4.23l0.27,0.27h0.79l5,5 -1.5,1.5 -5,-5v-0.79l-0.27,-0.27c-1.14,0.97 -2.62,1.56 -4.23,1.56a6.5,6.5 0,0 1,-6.5 -6.5,6.5 6.5,0 0,1 6.5,-6.5m0,2c-2.5,0 -4.5,2 -4.5,4.5s2,4.5 4.5,4.5 4.5,-2 4.5,-4.5 -2,-4.5 -4.5,-4.5z"
+      android:fillColor="@color/colorAccent"/>
+</vector>

--- a/main/res/drawable/sc_stored.xml
+++ b/main/res/drawable/sc_stored.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@color/shortcut_background" />
-        </shape>
-    </item>
-    <item>
-        <inset android:drawable="@drawable/sc_icon_stored" android:inset="13.0dip" />
-    </item>
-</layer-list>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M24,24m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0"
+      android:fillColor="@color/shortcut_background" />
+  <path
+      android:pathData="m16.25,22.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM16.25,16.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM16.25,28.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5zM19.25,31h14v-2h-14zM19.25,25h14v-2h-14zM19.25,17v2h14v-2z"
+      android:fillColor="@color/colorAccent"/>
+</vector>

--- a/main/src/cgeo/geocaching/CreateShortcutActivity.java
+++ b/main/src/cgeo/geocaching/CreateShortcutActivity.java
@@ -127,8 +127,7 @@ public class CreateShortcutActivity extends AbstractActionBarActivity {
             ResourcesCompat.getDrawable(res, drawableResourceId, null),
             ResourcesCompat.getDrawable(res, R.drawable.cgeo_borderless, null)
         });
-        layerDrawable.setLayerInset(0, 0, 0, 10, 10);
-        layerDrawable.setLayerInset(1, 70, 70, 0, 0);
+        layerDrawable.setLayerInset(1, 140, 140, 0, 0);
         return ImageUtils.convertToBitmap(layerDrawable);
     }
 


### PR DESCRIPTION
supports adaptive icon shapes for shortcuts in SDK26+
fixes display of Widgets

follow-up on https://github.com/cgeo/cgeo/pull/12623#issuecomment-1025009003

Widget icons are always round as they must be generated from static resourcves

![image](https://user-images.githubusercontent.com/1258173/151709359-6f9ec04c-0ba9-4ece-b27a-c1a28a6d4486.png)
