### PR TITLE
resume finished downloads (fix #12109)

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -330,6 +330,10 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             // automated backup check
             BackupUtils.checkForBackupReminder(this);
             cLog.add("ab");
+
+            // check for finished, but unreceived downloads
+            DownloaderUtils.checkPendingDownloads(this);
+
         }
 
         if (Log.isEnabled(Log.LogLevel.DEBUG)) {

--- a/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
+++ b/main/src/cgeo/geocaching/downloader/DownloadNotificationReceiver.java
@@ -1,6 +1,5 @@
 package cgeo.geocaching.downloader;
 
-import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.storage.extension.PendingDownload;
@@ -11,9 +10,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
-import android.net.Uri;
-
-import androidx.core.content.ContextCompat;
 
 public class DownloadNotificationReceiver extends BroadcastReceiver {
 
@@ -35,15 +31,7 @@ public class DownloadNotificationReceiver extends BroadcastReceiver {
                             final int status = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
                             switch (status) {
                                 case DownloadManager.STATUS_SUCCESSFUL:
-                                    PendingDownload.remove(pendingDownload);
-                                    final Intent copyFileIntent = new Intent(context, ReceiveDownloadService.class);
-                                    final Uri uri = downloadManager.getUriForDownloadedFile(pendingDownload);
-                                    copyFileIntent.setData(uri);
-                                    copyFileIntent.putExtra(Intents.EXTRA_FILENAME, p.getFilename());
-                                    copyFileIntent.putExtra(DownloaderUtils.RESULT_CHOSEN_URL, p.getRemoteUrl());
-                                    copyFileIntent.putExtra(DownloaderUtils.RESULT_DATE, p.getDate());
-                                    copyFileIntent.putExtra(DownloaderUtils.RESULT_TYPEID, p.getOfflineMapTypeId());
-                                    ContextCompat.startForegroundService(context, copyFileIntent);
+                                    DownloaderUtils.startReceive(context, downloadManager, pendingDownload, p);
                                     Log.d("download #" + pendingDownload + " successful");
                                     break;
                                 case DownloadManager.STATUS_FAILED:

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.downloader.DownloaderUtils;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.settings.ViewSettingsActivity;
 import cgeo.geocaching.utils.DebugUtils;
@@ -25,7 +26,7 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
 
         setPrefClick(this, R.string.pref_fakekey_memory_dump, () -> DebugUtils.createMemoryDump(activity));
         setPrefClick(this, R.string.pref_fakekey_generate_logcat, () -> DebugUtils.createLogcat(activity));
-        setPrefClick(this, R.string.pref_fakekey_generate_infos_downloadmanager, () -> DebugUtils.dumpDownloadmanagerInfos(activity));
+        setPrefClick(this, R.string.pref_fakekey_generate_infos_downloadmanager, () -> DownloaderUtils.dumpDownloadmanagerInfos(activity));
         setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
 
         initPublicFolders(this, activity.getCsah());

--- a/main/src/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/cgeo/geocaching/utils/DebugUtils.java
@@ -8,9 +8,6 @@ import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 
 import android.app.Activity;
-import android.app.DownloadManager;
-import android.content.Context;
-import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
@@ -84,86 +81,6 @@ public class DebugUtils {
                     (dialog, which) -> createLogcatHelper(activity, true, false, null)
                 );
         }
-    }
-
-    public static void dumpDownloadmanagerInfos(@NonNull final Activity activity) {
-        final DownloadManager downloadManager = (DownloadManager) activity.getSystemService(Context.DOWNLOAD_SERVICE);
-        final DownloadManager.Query query = new DownloadManager.Query();
-        final StringBuilder sb = new StringBuilder();
-        try (Cursor c = downloadManager.query(query)) {
-            final int columnStatus = c.getColumnIndex(DownloadManager.COLUMN_STATUS);
-            final int columnReason = c.getColumnIndex(DownloadManager.COLUMN_REASON);
-            final int[] columns = {
-                c.getColumnIndex(DownloadManager.COLUMN_ID),
-                c.getColumnIndex(DownloadManager.COLUMN_TITLE),
-                columnStatus,
-                columnReason,
-                c.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR),
-                c.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES),
-                c.getColumnIndex(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP),
-                c.getColumnIndex(DownloadManager.COLUMN_MEDIA_TYPE),
-                c.getColumnIndex(DownloadManager.COLUMN_URI),
-                c.getColumnIndex(DownloadManager.COLUMN_MEDIAPROVIDER_URI),
-                c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
-            };
-            while (c.moveToNext()) {
-                for (int column : columns) {
-                    sb.append("- ").append(c.getColumnName(column)).append(" = ");
-                    if (column == columnStatus) {
-                        sb.append(c.getString(column));
-                        final int status = c.getInt(column);
-                        if (status == DownloadManager.STATUS_FAILED) {
-                            sb.append(" - download has failed (and will not be retried)");
-                        } else if (status == DownloadManager.STATUS_PAUSED) {
-                            sb.append(" - download is waiting to retry or resume");
-                        } else if (status == DownloadManager.STATUS_PENDING) {
-                            sb.append(" - download is waiting to start");
-                        } else if (status == DownloadManager.STATUS_RUNNING) {
-                            sb.append(" - download is currently running");
-                        } else if (status == DownloadManager.STATUS_SUCCESSFUL) {
-                            sb.append(" - download has successfully completed");
-                        }
-                    } else if (column == columnReason) {
-                        final int reason = c.getInt(column);
-                        sb.append(reason);
-                        if (reason == DownloadManager.PAUSED_QUEUED_FOR_WIFI) {
-                            sb.append(" - paused: download exceeds a size limit for downloads over mobile network / waiting for Wifi");
-                        } else if (reason == DownloadManager.PAUSED_UNKNOWN) {
-                            sb.append(" - paused: for some other reason");
-                        } else if (reason == DownloadManager.PAUSED_WAITING_FOR_NETWORK) {
-                            sb.append(" - paused: waiting for network connectivity to proceed");
-                        } else if (reason == DownloadManager.PAUSED_WAITING_TO_RETRY) {
-                            sb.append(" - paused: some network error occurred and the download manager is waiting before retrying the request");
-                        } else if (reason == DownloadManager.ERROR_CANNOT_RESUME) {
-                            sb.append(" - error: some possibly transient error occurred but we can't resume the download");
-                        } else if (reason == DownloadManager.ERROR_DEVICE_NOT_FOUND) {
-                            sb.append(" - error: no external storage device was found. SD card mounted?");
-                        } else if (reason == DownloadManager.ERROR_FILE_ALREADY_EXISTS) {
-                            sb.append(" - error: requested destination file already exists, will not be overwritten");
-                        } else if (reason == DownloadManager.ERROR_FILE_ERROR) {
-                            sb.append(" - error: unknown storage issue");
-                        } else if (reason == DownloadManager.ERROR_HTTP_DATA_ERROR) {
-                            sb.append(" - error: HTTP processing error at data level");
-                        } else if (reason == DownloadManager.ERROR_INSUFFICIENT_SPACE) {
-                            sb.append(" - error: insufficient storage space");
-                        } else if (reason == DownloadManager.ERROR_TOO_MANY_REDIRECTS) {
-                            sb.append(" - error: too many redirects");
-                        } else if (reason == DownloadManager.ERROR_UNHANDLED_HTTP_CODE) {
-                            sb.append(" - error: unhandled HTTP cod");
-                        } else if (reason == DownloadManager.ERROR_UNKNOWN) {
-                            sb.append(" - error: unknown error");
-                        }
-
-                    } else {
-                        sb.append(c.getString(column));
-                    }
-                    sb.append("\n");
-                }
-                sb.append("\n---\n\n");
-            }
-        }
-
-        SimpleDialog.of(activity).setTitle(R.string.debug_current_downloads).setMessage(TextParam.text(sb.toString()).setMarkdown(true)).show();
     }
 
 


### PR DESCRIPTION
## Description
Sometimes (map / routing data) downloads are finished, but somehow c:geo did not get triggered, as described in the related issue.

This PR adds a check to program start to query the system's `DownloadManager` for any finished, but not yet transmitted downloads, and ~asks the user, if they want to import them now~ directly triggers receiving such files, if any are pending.

~Currently it's realized as a dialog box, but will be changed to a dashboard notification, after PR #12632 has been merged. Therefore setting WIP label for now.~

(Additionally moves the `dumpDownloadmanagerInfos` method from `DebugUtils` to `DownloaderUtils` as it has a closer relationship.)
