### PR TITLE
Log templates in offline log dialog

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="log_posting_image">Posting images…</string>
     <string name="log_posting_generic_trackable">Posting %1$s %2$d/%3$d</string>
     <string name="log_clear">Clear</string>
-    <string name="log_templates">Found it: Log template …</string>
+    <string name="log_templates">Found it: Log template…</string>
     <string name="log_post_not_possible">Download of data in progress…\nPlease try again in a few seconds or check your internet connection.</string>
     <string name="log_date_future_not_allowed">Future log dates are not allowed.</string>
     <string name="log_add">Add</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="log_posting_image">Posting images…</string>
     <string name="log_posting_generic_trackable">Posting %1$s %2$d/%3$d</string>
     <string name="log_clear">Clear</string>
+    <string name="log_templates">Found it: Log template …</string>
     <string name="log_post_not_possible">Download of data in progress…\nPlease try again in a few seconds or check your internet connection.</string>
     <string name="log_date_future_not_allowed">Future log dates are not allowed.</string>
     <string name="log_add">Add</string>

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -95,7 +95,7 @@ public final class LoggingUI extends AbstractUIFactory {
             list.add(new LogTypeEntry(null, SpecialLogType.CLEAR_LOG, false));
         }
         list.add(new LogTypeEntry(null, SpecialLogType.LOG_CACHE, false));
-        if (Settings.getLogTemplates().size() > 0 && (logTypes.contains(LogType.FOUND_IT) || logTypes.contains(LogType.WEBCAM_PHOTO_TAKEN))) {
+        if (Settings.getLogTemplates().size() > 0 && logTypes.contains(LogType.FOUND_IT)) {
             list.add(1, new LogTypeEntry(null, SpecialLogType.TEMPLATES, false));
         }
 
@@ -159,7 +159,7 @@ public final class LoggingUI extends AbstractUIFactory {
             cache.logOffline(activity, new OfflineLogEntry.Builder<>()
                 .setLog(LogTemplateProvider.applyTemplates(logTemplate.getText(), new LogTemplateProvider.LogContext(cache, null, true)))
                 .setDate(Calendar.getInstance().getTimeInMillis())
-                .setLogType(cache.getPossibleLogTypes().contains(LogType.FOUND_IT) ? LogType.FOUND_IT : LogType.WEBCAM_PHOTO_TAKEN)
+                .setLogType(LogType.FOUND_IT)
                 .build()
             );
             dialog.dismiss();

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -157,7 +157,7 @@ public final class LoggingUI extends AbstractUIFactory {
         builder.setAdapter(adapter, (dialog, item) -> {
             final Settings.PrefLogTemplate logTemplate = adapter.getItem(item);
             cache.logOffline(activity, new OfflineLogEntry.Builder<>()
-                .setLog(logTemplate.getText())
+                .setLog(LogTemplateProvider.applyTemplates(logTemplate.getText(), new LogTemplateProvider.LogContext(cache, null, true)))
                 .setDate(Calendar.getInstance().getTimeInMillis())
                 .setLogType(LogType.FOUND_IT)
                 .build()

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
 public final class LoggingUI extends AbstractUIFactory {
@@ -55,7 +56,8 @@ public final class LoggingUI extends AbstractUIFactory {
 
     private enum SpecialLogType {
         LOG_CACHE(R.string.cache_menu_visit),
-        CLEAR_LOG(R.string.log_clear);
+        CLEAR_LOG(R.string.log_clear),
+        TEMPLATES(R.string.log_templates);
 
         private final int stringId;
 
@@ -93,6 +95,9 @@ public final class LoggingUI extends AbstractUIFactory {
             list.add(new LogTypeEntry(null, SpecialLogType.CLEAR_LOG, false));
         }
         list.add(new LogTypeEntry(null, SpecialLogType.LOG_CACHE, false));
+        if (Settings.getLogTemplates().size() > 0) {
+            list.add(1, new LogTypeEntry(null, SpecialLogType.TEMPLATES, false));
+        }
 
         final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(R.string.cache_menu_visit_offline);
@@ -109,6 +114,10 @@ public final class LoggingUI extends AbstractUIFactory {
 
                     case CLEAR_LOG:
                         cache.clearOfflineLog();
+                        break;
+
+                    case TEMPLATES:
+                        showOfflineTemplateMenu(cache, activity, listener);
                         break;
                 }
             } else {
@@ -129,6 +138,30 @@ public final class LoggingUI extends AbstractUIFactory {
                 }
                 cache.logOffline(activity, logType, reportProblem);
             }
+            dialog.dismiss();
+        });
+
+        final AlertDialog alertDialog = builder.create();
+        alertDialog.setOnDismissListener(listener);
+        alertDialog.show();
+    }
+
+    private static void showOfflineTemplateMenu(final Geocache cache, final Activity activity, final DialogInterface.OnDismissListener listener) {
+        final List<Settings.PrefLogTemplate> templates = Settings.getLogTemplates();
+
+        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
+        builder.setTitle(R.string.log_templates);
+
+        final ArrayAdapter<Settings.PrefLogTemplate> adapter = new ArrayAdapter<>(activity, android.R.layout.select_dialog_item, templates);
+
+        builder.setAdapter(adapter, (dialog, item) -> {
+            final Settings.PrefLogTemplate logTemplate = adapter.getItem(item);
+            cache.logOffline(activity, new OfflineLogEntry.Builder<>()
+                .setLog(logTemplate.getText())
+                .setDate(Calendar.getInstance().getTimeInMillis())
+                .setLogType(LogType.FOUND_IT)
+                .build()
+            );
             dialog.dismiss();
         });
 

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -95,7 +95,7 @@ public final class LoggingUI extends AbstractUIFactory {
             list.add(new LogTypeEntry(null, SpecialLogType.CLEAR_LOG, false));
         }
         list.add(new LogTypeEntry(null, SpecialLogType.LOG_CACHE, false));
-        if (Settings.getLogTemplates().size() > 0) {
+        if (Settings.getLogTemplates().size() > 0 && (logTypes.contains(LogType.FOUND_IT) || logTypes.contains(LogType.WEBCAM_PHOTO_TAKEN))) {
             list.add(1, new LogTypeEntry(null, SpecialLogType.TEMPLATES, false));
         }
 
@@ -159,7 +159,7 @@ public final class LoggingUI extends AbstractUIFactory {
             cache.logOffline(activity, new OfflineLogEntry.Builder<>()
                 .setLog(LogTemplateProvider.applyTemplates(logTemplate.getText(), new LogTemplateProvider.LogContext(cache, null, true)))
                 .setDate(Calendar.getInstance().getTimeInMillis())
-                .setLogType(LogType.FOUND_IT)
+                .setLogType(cache.getPossibleLogTypes().contains(LogType.FOUND_IT) ? LogType.FOUND_IT : LogType.WEBCAM_PHOTO_TAKEN)
                 .build()
             );
             dialog.dismiss();

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -213,6 +213,12 @@ public class Settings {
         public int hashCode() {
             return key.hashCode();
         }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return title;
+        }
     }
 
     //NO_APPLICATION_MODE will be true if Settings is used in context of local unit tests


### PR DESCRIPTION
add a menu item to the "Quick offline log" dialog to insert a Found log with text taken from template.
The menu item is shown only if any log template is defined.

![2022-01-30_19-30-56](https://user-images.githubusercontent.com/1258173/151712595-e0fb7ce6-1710-4544-aff6-97718eab5f67.png)
![image](https://user-images.githubusercontent.com/1258173/151712618-8f436e51-4743-4f80-8cb1-ce5874f5c39d.png)

