### PR TITLE
use material progress indicator for better visibility on map

### DIFF
--- a/main/res/layout/map_progressbar.xml
+++ b/main/res/layout/map_progressbar.xml
@@ -1,7 +1,6 @@
-<ProgressBar
+<com.google.android.material.progressindicator.LinearProgressIndicator
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:id="@+id/map_progressbar"
-	style="@style/map_progressbar"
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
 	android:indeterminateOnly="true"

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -454,14 +454,6 @@
         <item name="android:progressTint">@color/colorAccent</item>
     </style>
 
-    <!-- map progressbar style -->
-    <style name="map_progressbar" parent="@style/Widget.AppCompat.ProgressBar.Horizontal">
-        <item name="android:height">8dp</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:padding">0dp</item>
-        <item name="android:layout_marginTop">-4dp</item>
-    </style>
-
     <!-- map distance info styles -->
     <style name="map_distanceinfo_no_background">
         <item name="android:paddingTop">0dp</item>


### PR DESCRIPTION
Use Material progress bar for better visibility, as suggested in https://github.com/cgeo/cgeo/issues/12573#issuecomment-1025196125

It has a 2x stroke width compared to the old one and is directly attached to the top instead of being floating inside the map.

Before:
![IMG_20220130_185852.jpg](https://user-images.githubusercontent.com/4508228/151711453-0c04b2f9-5129-477c-86c5-df193c0cdb36.jpg)

Now: 
![grafik](https://user-images.githubusercontent.com/64581222/152046961-f26324bf-fbbd-4f14-a9a2-63b6b73d3728.png)

