### PR TITLE
centerCrop wallpaper on home screen (fix #12654)

### DIFF
--- a/main/res/layout-h390dp-land/activity_bottom_navigation.xml
+++ b/main/res/layout-h390dp-land/activity_bottom_navigation.xml
@@ -5,6 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ImageView
+        android:id="@+id/background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop" />
+
     <FrameLayout
         android:id="@+id/activity_content"
         android:layout_width="wrap_content"

--- a/main/res/layout-land/activity_bottom_navigation.xml
+++ b/main/res/layout-land/activity_bottom_navigation.xml
@@ -5,6 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ImageView
+        android:id="@+id/background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop" />
+
     <FrameLayout
         android:id="@+id/activity_content"
         android:layout_width="wrap_content"

--- a/main/res/layout/activity_bottom_navigation.xml
+++ b/main/res/layout/activity_bottom_navigation.xml
@@ -5,6 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <ImageView
+        android:id="@+id/background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop" />
+
     <FrameLayout
         android:id="@+id/activity_content"
         android:layout_width="match_parent"

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -410,7 +410,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             updateUserInfoHandler.sendEmptyMessage(-1);
             cLog.add("perm");
 
-            binding.getRoot().setBackground(Settings.isWallpaper() ? WallpaperManager.getInstance(this).getDrawable() : null);
+            ((ImageView) findViewById(R.id.background)).setImageDrawable(Settings.isWallpaper() ? WallpaperManager.getInstance(this).getDrawable() : null);
 
             init();
         }


### PR DESCRIPTION
## Description
Instead of using the wallpaper image as background drawable add an `ImageView` to the bottom navigation activity, so that we are able to use `scaleType=centerCrop`, which centers the image and crops everything that got too large. It's probably still not 100% the same for some launchers, but comes pretty close to what the default launcher does with the wallpaper.

|Resulting image is like this:|instead of this:|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/152238620-94b2e244-d488-4584-951b-a409bbb8603c.png)|![image](https://user-images.githubusercontent.com/3754370/151707413-899a88da-a069-4158-9442-08eda66e5143.png)|
