### PR TITLE
Fix #12613 - Do not modify list action bar

### DIFF
--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -77,7 +77,6 @@ import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.ui.CacheListAdapter;
 import cgeo.geocaching.ui.FastScrollListener;
 import cgeo.geocaching.ui.TextParam;
-import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
@@ -748,8 +747,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     @Override
     public boolean onPrepareOptionsMenu(final Menu menu) {
         super.onPrepareOptionsMenu(menu);
-
-        ViewUtils.extendMenuActionBarDisplayItemCount(this, menu);
 
         final boolean isHistory = type == CacheListType.HISTORY;
         final boolean isOffline = type == CacheListType.OFFLINE;


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Don't use the extend method for the action bar on cache lists to allow wider list names (and reenable textual description if enough room (e.g. on landscape):

Portrait:
| Before | After |
| --- | --- |
| ![final_list_portrait_with](https://user-images.githubusercontent.com/949669/152638602-4d48e869-0918-4b34-ac14-5a16c98451fd.png)| ![final_list_portrait_wo](https://user-images.githubusercontent.com/949669/152638608-efa06dee-167d-4871-8135-d1a174a33256.png)|

Landscape:
| Before | After |
| --- | --- |
|![final_list_landscape_with](https://user-images.githubusercontent.com/949669/152638629-1fee28fc-6498-47e1-a682-ddc1bfc016c0.png)|![final_list_landscape_wo](https://user-images.githubusercontent.com/949669/152638623-67f743a8-251f-40c7-9373-6846b37fe344.png)|

For the map action bar the method is still used. The option here would be to still allow text to be shown, but this might be covered in another issue. 


## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fixes #12613

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->