### PR TITLE
offer label strings for ok and cancel (fix #12569)

### DIFF
--- a/main/res/layout/imageselect_activity.xml
+++ b/main/res/layout/imageselect_activity.xml
@@ -110,14 +110,14 @@
                 style="@style/button_full"
                 android:layout_width="0dip"
                 android:layout_weight="1"
-                android:text="@android:string/cancel" />
+                android:text="@string/cancel" />
 
             <Button
                 android:id="@+id/save"
                 style="@style/button_full"
                 android:layout_width="0dip"
                 android:layout_weight="1"
-                android:text="@android:string/ok" />
+                android:text="@string/ok" />
 
         </LinearLayout>
     </LinearLayout>

--- a/main/res/menu/menu_ok_cancel.xml
+++ b/main/res/menu/menu_ok_cancel.xml
@@ -22,7 +22,7 @@
     <item
         android:id="@+id/menu_item_cancel"
         android:icon="@drawable/ic_menu_cancel"
-        android:title="@string/waypoint_cancel_edit"
+        android:title="@string/cancel"
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction">
     </item>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1514,7 +1514,6 @@
     <string name="waypoint_set_visited">Waypoint set to visited</string>
     <string name="waypoint_unset_visited">Waypoint set to not visited</string>
     <string name="waypoint_save">Save</string>
-    <string name="waypoint_cancel_edit">Cancel</string>
     <string name="waypoint_loading">Loading waypoint…</string>
     <string name="waypoint_do_not_touch_cache_coordinates">No change to cache coordinates</string>
     <string name="waypoint_set_as_cache_coords">Set as cache coordinates in c:geo</string>
@@ -2429,6 +2428,8 @@
     <string name="finish">Finish</string>
     <string name="back">Back</string>
     <string name="later">Later</string>
+    <string name="cancel">Cancel</string>
+    <string name="ok">Ok</string>
 
     <!-- ChipChoiceGroup -->
     <string name="chipchoicegroup_selectall">Select All</string>


### PR DESCRIPTION
## Description
Fixes #12569 by supplying our own strings for "Ok" and "Cancel" (which we already did before, but the were not used by the buttons mentioned in the issue).
