### PR TITLE
Download caches as non blocking service

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -921,6 +921,8 @@
 
         <service android:name=".downloader.ReceiveDownloadService" />
 
+        <service android:name=".service.CacheDownloaderService" />
+
         <!-- Receiver for custom tabs share intent -->
         <receiver android:name=".settings.ShareBroadcastReceiver"/>
     </application>

--- a/main/res/menu/cache_list_options.xml
+++ b/main/res/menu/cache_list_options.xml
@@ -58,6 +58,12 @@
                 android:title="@string/cache_offline_refresh"
                 app:showAsAction="ifRoom|withText"/>
             <item
+                android:id="@+id/menu_store_caches_background"
+                android:title="@string/caches_store_background"
+                android:visible="false"
+                app:showAsAction="ifRoom|withText">
+            </item>
+            <item
                 android:id="@+id/menu_move_to_list"
                 android:title="@string/cache_menu_move_list"
                 app:showAsAction="ifRoom|withText"/>

--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -70,6 +70,12 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
+        android:id="@+id/menu_store_caches_background"
+        android:title="@string/caches_store_background"
+        android:visible="false"
+        app:showAsAction="ifRoom|withText">
+    </item>
+    <item
         android:id="@+id/menu_map_rotation"
         android:title="@string/map_rotation"
         android:visible="false"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -387,6 +387,8 @@
     <string name="caches_store_all">Store All</string>
     <string name="caches_store_unsaved">Store Unsaved</string>
     <string name="caches_store_selected">Store Selected</string>
+    <string name="caches_store_background">Background download (Experimental!)</string>
+    <string name="caches_store_background_title">Download caches</string>
     <string name="caches_history">History</string>
     <string name="caches_on_map">Show on map</string>
     <string name="caches_sort">Sort</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -388,6 +388,8 @@
     <string name="caches_store_unsaved">Store Unsaved</string>
     <string name="caches_store_selected">Store Selected</string>
     <string name="caches_store_background">Background download (Experimental!)</string>
+    <string name="caches_store_refresh_background">Background refresh (Experimental!)</string>
+    <string name="caches_store_background_should_force_refresh">Refresh already downloaded caches</string>
     <string name="caches_store_background_title">Download caches</string>
     <string name="caches_history">History</string>
     <string name="caches_on_map">Show on map</string>

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -78,6 +78,7 @@ import cgeo.geocaching.ui.CacheListAdapter;
 import cgeo.geocaching.ui.FastScrollListener;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.WeakReferenceHandler;
+import cgeo.geocaching.ui.dialog.CheckboxDialogConfig;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
@@ -1008,7 +1009,10 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         if (isNonDefaultList && !preventAskForDeletion && adapter.isEmpty()
             && DataStore.getAllStoredCachesCount(listId) == 0) {
             // ask user, if he wants to delete the now empty list
-            Dialogs.confirmWithCheckbox(this, getString(R.string.list_dialog_remove), getString(R.string.list_dialog_remove_nowempty), getString(R.string.list_dialog_do_not_ask_me_again),
+            Dialogs.confirmWithCheckbox(this, getString(R.string.list_dialog_remove), getString(R.string.list_dialog_remove_nowempty),
+                    CheckboxDialogConfig.newCheckbox(R.string.list_dialog_do_not_ask_me_again)
+                            .setActionButtonLabel(CheckboxDialogConfig.ActionButtonLabel.YES_NO)
+                            .setPositiveButtonCheckCondition(CheckboxDialogConfig.CheckCondition.UNCHECKED),
                 preventAskForDeletion -> removeListInternal(), this::setPreventAskForDeletion);
         }
     }

--- a/main/src/cgeo/geocaching/HandleLocalFilesActivity.java
+++ b/main/src/cgeo/geocaching/HandleLocalFilesActivity.java
@@ -56,7 +56,7 @@ public class HandleLocalFilesActivity extends AbstractActivity {
     private void continueWithForegroundService(@SuppressWarnings("rawtypes") final Class clazz, final Intent intent) {
         final Intent forwarder = new Intent(intent);
         forwarder.setClass(this, clazz);
-        ContextCompat.startForegroundService(this, intent);
+        ContextCompat.startForegroundService(this, forwarder);
         finish();
     }
 

--- a/main/src/cgeo/geocaching/downloader/ReceiveDownloadService.java
+++ b/main/src/cgeo/geocaching/downloader/ReceiveDownloadService.java
@@ -65,7 +65,15 @@ public class ReceiveDownloadService extends AbstractForegroundIntentService {
     }
 
     @Override
+    protected int getForegroundNotificationId() {
+        return Notifications.ID_FOREGROUND_NOTIFICATION_MAP_IMPORT;
+    }
+
+    @Override
     protected void onHandleIntent(final @Nullable Intent intent) {
+        if (intent == null) {
+            return;
+        }
 
         uri = intent.getData();
         final String preset = intent.getStringExtra(Intents.EXTRA_FILENAME);
@@ -251,7 +259,7 @@ public class ReceiveDownloadService extends AbstractForegroundIntentService {
                 bytesCopied += length;
                 if ((System.currentTimeMillis() - lastPublishTime) > 500) { // avoid message flooding
                     notification.setContentText(getString(R.string.receivedownload_amount_copied, Formatter.formatBytes(bytesCopied)));
-                    notificationManager.notify(foregroundNotificationId, notification.build());
+                    updateForegroundNotification();
                     lastPublishTime = System.currentTimeMillis();
                 }
             }

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -829,7 +829,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         } else if (id == R.id.menu_store_unsaved_caches) {
             return storeCaches(getUnsavedGeocodes(getGeocodesForCachesInViewport()));
         } else if (id == R.id.menu_store_caches_background) {
-            CacheDownloaderService.downloadCaches(activity, getGeocodesForCachesInViewport());
+            CacheDownloaderService.downloadCaches(activity, getGeocodesForCachesInViewport(), false, false);
         } else if (id == R.id.menu_theme_mode) {
             //this will never happen, Google does not support mapsforge themes -> do nothing
         } else if (id == R.id.menu_as_list) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -52,6 +52,7 @@ import cgeo.geocaching.permission.RestartLocationPermissionGrantedCallback;
 import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
+import cgeo.geocaching.service.CacheDownloaderService;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.ViewUtils;
@@ -59,6 +60,7 @@ import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.ApplicationSettings;
+import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.FilterUtils;
@@ -769,6 +771,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             final Set<String> geocodesInViewport = getGeocodesForCachesInViewport();
             menu.findItem(R.id.menu_store_caches).setVisible(!isLoading() && CollectionUtils.isNotEmpty(geocodesInViewport));
             menu.findItem(R.id.menu_store_unsaved_caches).setVisible(!isLoading() && CollectionUtils.isNotEmpty(getUnsavedGeocodes(geocodesInViewport)));
+            if (!BranchDetectionHelper.isProductionBuild()) {
+                menu.findItem(R.id.menu_store_caches_background).setVisible(!isLoading() && CollectionUtils.isNotEmpty(geocodesInViewport));
+            }
 
             menu.findItem(R.id.menu_theme_mode).setVisible(false); // Always false, this is only used for Google Maps
 
@@ -823,6 +828,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             return storeCaches(getGeocodesForCachesInViewport());
         } else if (id == R.id.menu_store_unsaved_caches) {
             return storeCaches(getUnsavedGeocodes(getGeocodesForCachesInViewport()));
+        } else if (id == R.id.menu_store_caches_background) {
+            CacheDownloaderService.downloadCaches(activity, getGeocodesForCachesInViewport());
         } else if (id == R.id.menu_theme_mode) {
             //this will never happen, Google does not support mapsforge themes -> do nothing
         } else if (id == R.id.menu_as_list) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -62,6 +62,7 @@ import cgeo.geocaching.permission.RestartLocationPermissionGrantedCallback;
 import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
+import cgeo.geocaching.service.CacheDownloaderService;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
@@ -71,6 +72,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.ApplicationSettings;
+import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.FilterUtils;
@@ -402,6 +404,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
             menu.findItem(R.id.menu_store_unsaved_caches).setVisible(false);
             menu.findItem(R.id.menu_store_unsaved_caches).setVisible(!caches.isDownloading() && new SearchResult(visibleCacheGeocodes).hasUnsavedCaches());
+            if (!BranchDetectionHelper.isProductionBuild()) {
+                menu.findItem(R.id.menu_store_caches_background).setVisible(!caches.isDownloading() && !visibleCacheGeocodes.isEmpty());
+            }
 
             final boolean tileLayerHasThemes = tileLayerHasThemes();
             menu.findItem(R.id.menu_theme_mode).setVisible(tileLayerHasThemes);
@@ -460,6 +465,8 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             return storeCaches(caches.getVisibleCacheGeocodes());
         } else if (id == R.id.menu_store_unsaved_caches) {
             return storeCaches(getUnsavedGeocodes(caches.getVisibleCacheGeocodes()));
+        } else if (id == R.id.menu_store_caches_background) {
+            CacheDownloaderService.downloadCaches(this, caches.getVisibleCacheGeocodes());
         } else if (id == R.id.menu_theme_mode) {
             this.renderThemeHelper.selectMapTheme(this.tileLayer, this.tileCache);
         } else if (id == R.id.menu_theme_options) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -466,7 +466,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         } else if (id == R.id.menu_store_unsaved_caches) {
             return storeCaches(getUnsavedGeocodes(caches.getVisibleCacheGeocodes()));
         } else if (id == R.id.menu_store_caches_background) {
-            CacheDownloaderService.downloadCaches(this, caches.getVisibleCacheGeocodes());
+            CacheDownloaderService.downloadCaches(this, caches.getVisibleCacheGeocodes(), false, false);
         } else if (id == R.id.menu_theme_mode) {
             this.renderThemeHelper.selectMapTheme(this.tileLayer, this.tileCache);
         } else if (id == R.id.menu_theme_options) {

--- a/main/src/cgeo/geocaching/service/AbstractForegroundIntentService.java
+++ b/main/src/cgeo/geocaching/service/AbstractForegroundIntentService.java
@@ -9,11 +9,10 @@ import android.os.PowerManager;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 
-public abstract class AbstractForegroundIntentService extends IntentService implements IAbstractForgreoundIntentService {
+public abstract class AbstractForegroundIntentService extends IntentService {
     protected static String logTag = "ForegroundIntentService";
 
     protected final int wakelockTimeout = 10 * 60 * 1000;
-    protected final int foregroundNotificationId = Notifications.ID_FOREGROUND_NOTIFICATION;
 
     protected NotificationCompat.Builder notification;
     protected NotificationManagerCompat notificationManager;
@@ -24,6 +23,9 @@ public abstract class AbstractForegroundIntentService extends IntentService impl
         setIntentRedelivery(true);
     }
 
+    protected abstract NotificationCompat.Builder createInitialNotification();
+
+    protected abstract int getForegroundNotificationId();
 
     @Override
     public void onCreate() {
@@ -38,7 +40,7 @@ public abstract class AbstractForegroundIntentService extends IntentService impl
         notificationManager = Notifications.getNotificationManager(this);
         notification = createInitialNotification();
 
-        startForeground(foregroundNotificationId, notification.build());
+        startForeground(getForegroundNotificationId(), notification.build());
     }
 
 
@@ -48,5 +50,9 @@ public abstract class AbstractForegroundIntentService extends IntentService impl
         Log.v(logTag + ".onDestroy");
         wakeLock.release();
         Log.v(logTag + " - WakeLock released");
+    }
+
+    protected void updateForegroundNotification() {
+        notificationManager.notify(getForegroundNotificationId(), notification.build());
     }
 }

--- a/main/src/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/cgeo/geocaching/service/CacheDownloaderService.java
@@ -1,0 +1,93 @@
+package cgeo.geocaching.service;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.ui.notifications.NotificationChannels;
+import cgeo.geocaching.ui.notifications.Notifications;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class CacheDownloaderService extends AbstractForegroundIntentService {
+    static {
+        logTag = "CacheDownloaderService";
+    }
+
+    private static final String GEOCODES = "extra_geocodes";
+    private static final String LIST_IDS = "extra_list_ids";
+
+    public static void downloadCaches(final Activity context, final Set<String> geocodes) {
+        if (geocodes.isEmpty()) {
+            ActivityMixin.showToast(context, context.getString(R.string.warn_save_nothing));
+            return;
+        }
+
+        SimpleDialog.of(context)
+                .setTitle(TextParam.text("Warning"))
+                .setMessage(TextParam.text("This feature is untested and can lead to unexpected behaviour or may even break your database.\n\nWe recommend to do a backup before using the feature, just to be save."))
+                .confirm((d, w) -> {
+                    if (Settings.getChooseList()) {
+                        // let user select list to store cache in
+                        new StoredList.UserInterface(context).promptForMultiListSelection(R.string.lists_title, selectedListIds -> downloadCachesInternal(context, geocodes, selectedListIds), true, Collections.emptySet(), false);
+                    } else {
+                        downloadCachesInternal(context, geocodes, Collections.singleton(StoredList.STANDARD_LIST_ID));
+                    }
+                });
+    }
+
+    private static void downloadCachesInternal(final Activity context, final Set<String> geocodes, final Set<Integer> listIds) {
+        final Intent intent = new Intent(context, CacheDownloaderService.class);
+        intent.putStringArrayListExtra(GEOCODES, new ArrayList<>(geocodes));
+        intent.putIntegerArrayListExtra(LIST_IDS, new ArrayList<>(listIds));
+        ContextCompat.startForegroundService(context, intent);
+    }
+
+    @Override
+    public NotificationCompat.Builder createInitialNotification() {
+        return Notifications.createNotification(this, NotificationChannels.FOREGROUND_SERVICE_NOTIFICATION, R.string.caches_store_background_title)
+                .setProgress(100, 0, true)
+                .setOnlyAlertOnce(true);
+    }
+
+    @Override
+    protected int getForegroundNotificationId() {
+        return Notifications.ID_FOREGROUND_NOTIFICATION_CACHES_DOWNLOADER;
+    }
+
+    @Override
+    protected void onHandleIntent(final @Nullable Intent intent) {
+        if (intent == null) {
+            return;
+        }
+
+        final ArrayList<String> geocodes = intent.getStringArrayListExtra(GEOCODES);
+        final Set<Integer> listIds = new HashSet<>(intent.getIntegerArrayListExtra(LIST_IDS));
+
+        for (int i = 0; i < geocodes.size(); i++) {
+            notification.setProgress(geocodes.size(), i, false);
+            notification.setContentText(geocodes.get(i));
+            updateForegroundNotification();
+
+            Geocache.storeCache(null, geocodes.get(i), listIds, false, null);
+        }
+
+        notificationManager.notify(Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
+                this, NotificationChannels.DOWNLOADER_RESULT_NOTIFICATION, R.string.caches_store_background_title, geocodes.size() + " caches downloaded")
+                .build());
+    }
+}

--- a/main/src/cgeo/geocaching/service/IAbstractForgreoundIntentService.java
+++ b/main/src/cgeo/geocaching/service/IAbstractForgreoundIntentService.java
@@ -1,7 +1,0 @@
-package cgeo.geocaching.service;
-
-import androidx.core.app.NotificationCompat;
-
-public interface IAbstractForgreoundIntentService {
-    NotificationCompat.Builder createInitialNotification();
-}

--- a/main/src/cgeo/geocaching/ui/dialog/CheckboxDialogConfig.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CheckboxDialogConfig.java
@@ -1,0 +1,93 @@
+package cgeo.geocaching.ui.dialog;
+
+import cgeo.geocaching.utils.functions.Func1;
+
+import androidx.annotation.StringRes;
+
+public class CheckboxDialogConfig {
+    private final @StringRes int textRes;
+
+    private boolean isVisible = true;
+    private boolean isCheckedOnInit = false;
+    private CheckCondition positiveCondition = CheckCondition.NONE;
+    private CheckCondition negativeCondition = CheckCondition.NONE;
+    private ActionButtonLabel actionButtonLabel = ActionButtonLabel.OK_CANCEL;
+
+    public enum CheckCondition {
+        CHECKED(isChecked -> isChecked),
+        UNCHECKED(isChecked -> !isChecked),
+        NONE(isChecked -> true);
+
+        private final Func1<Boolean, Boolean> condition;
+
+        CheckCondition (final Func1<Boolean, Boolean> condition) {
+            this.condition = condition;
+        }
+
+        public boolean eval(final boolean isChecked) {
+            return condition.call(isChecked);
+        }
+    }
+
+    public enum ActionButtonLabel {
+        OK_CANCEL,
+        YES_NO
+    }
+
+    private CheckboxDialogConfig(final @StringRes int textRes) {
+        this.textRes = textRes;
+    }
+
+    public static CheckboxDialogConfig newCheckbox(final @StringRes int textRes) {
+        return new CheckboxDialogConfig(textRes);
+    }
+
+    public CheckboxDialogConfig setVisible(final boolean visible) {
+        this.isVisible = visible;
+        return this;
+    }
+
+    public CheckboxDialogConfig setCheckedOnInit(final boolean checked) {
+        this.isCheckedOnInit = checked;
+        return this;
+    }
+
+    public CheckboxDialogConfig setPositiveButtonCheckCondition(final CheckCondition checkCondition) {
+        this.positiveCondition = checkCondition;
+        return this;
+    }
+
+    public CheckboxDialogConfig setNegativeButtonCheckCondition(final CheckCondition checkCondition) {
+        this.negativeCondition = checkCondition;
+        return this;
+    }
+
+    public CheckboxDialogConfig setActionButtonLabel(final ActionButtonLabel labelType) {
+        this.actionButtonLabel = labelType;
+        return this;
+    }
+
+    public int getTextRes() {
+        return textRes;
+    }
+
+    public boolean isVisible() {
+        return isVisible;
+    }
+
+    public boolean isCheckedOnInit() {
+        return isCheckedOnInit;
+    }
+
+    public CheckCondition getPositiveCheckCondition() {
+        return positiveCondition;
+    }
+
+    public CheckCondition getNegativeCheckCondition() {
+        return negativeCondition;
+    }
+
+    public ActionButtonLabel getActionButtonLabel() {
+        return actionButtonLabel;
+    }
+}

--- a/main/src/cgeo/geocaching/ui/notifications/Notifications.java
+++ b/main/src/cgeo/geocaching/ui/notifications/Notifications.java
@@ -14,7 +14,9 @@ public class Notifications {
     public static final int UNIQUE_ID_RANGE_START = 1000;
 
     public static final int ID_PROXIMITY_NOTIFICATION = 101;
-    public static final int ID_FOREGROUND_NOTIFICATION = 111;
+
+    public static final int ID_FOREGROUND_NOTIFICATION_MAP_IMPORT = 111;
+    public static final int ID_FOREGROUND_NOTIFICATION_CACHES_DOWNLOADER = 112;
 
     private Notifications() {
         // no instances


### PR DESCRIPTION
First alpha version for #330

From some quick tests in the emulator, I can tell that it already works quite good.

The only bug / intended feature (?) I've discovered is, that refreshed caches will only reflect the update if the foreground activity gets restarted.

However, I've decided to start as "nightly only" feature for now and have added some deterrent warning ;-)

![grafik](https://user-images.githubusercontent.com/64581222/152655709-c7a01ae9-89f4-4c03-9aac-46eebef56687.png)

|download running|download finished|
-|-
![grafik](https://user-images.githubusercontent.com/64581222/152655754-a8031522-fb23-4ee5-907c-ef5307d26303.png)|![grafik](https://user-images.githubusercontent.com/64581222/152655762-c36d99de-4e39-4173-ba0e-5c716201f452.png)
