### PR TITLE
fix displaying legend menu for unsupported maps/themes (fix #12704)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -108,7 +108,8 @@
     </item>
     <item
         android:id="@+id/menu_theme_legend"
-        android:title="@string/map_theme_legend">
+        android:title="@string/map_theme_legend"
+        android:visible="false">
     </item>
     <item
         android:id="@+id/menu_select_language"

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -406,7 +406,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             final boolean tileLayerHasThemes = tileLayerHasThemes();
             menu.findItem(R.id.menu_theme_mode).setVisible(tileLayerHasThemes);
             menu.findItem(R.id.menu_theme_options).setVisible(tileLayerHasThemes && this.renderThemeHelper.themeOptionsAvailable());
-            menu.findItem(R.id.menu_theme_legend).setVisible(tileLayerHasThemes);
+            menu.findItem(R.id.menu_theme_legend).setVisible(tileLayerHasThemes && RenderThemeLegend.supportsLegend());
 
             menu.findItem(R.id.menu_as_list).setVisible(!caches.isDownloading() && caches.getVisibleCachesCount() > 1);
 

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/legend/RenderThemeLegend.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/legend/RenderThemeLegend.java
@@ -211,4 +211,18 @@ public class RenderThemeLegend {
         }
     }
 
+    public static boolean supportsLegend() {
+        final RenderThemeHelper.RenderThemeType rtt = RenderThemeHelper.getRenderThemeType();
+        switch (rtt) {
+            case RTT_ELEVATE:
+            case RTT_FZK_BASE:
+            case RTT_FZK_OUTDOOR_CONTRAST:
+            case RTT_FZK_OUTDOOR_SOFT:
+                return true;
+            default:
+                return false;
+        }
+
+    }
+
 }


### PR DESCRIPTION
## Description
Fixes a few errors where "map legend" menu entry was displayed in situations not supporting a map legend:
- hide "map legend" menu entry by default (fixes displaying it on Google Maps)
- do not only check whether the current map supports themes, but additionally check whether the selected theme supports a legend
