### PR TITLE
display routes/tracks button if target is set (fix #12701)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -146,7 +146,7 @@
     </item>
     <item
         android:id="@+id/menu_routetrack"
-        android:title="Routes / Tracks" />
+        android:title="@string/routes_tracks_menu" />
     <item
         android:id="@+id/menu_check_routingdata"
         android:title="@string/check_tiles_menu" />

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2258,6 +2258,7 @@
 
     <!-- route/track commons -->
     <string name="routes_tracks_dialog_title">Routes / tracks options</string>
+    <string name="routes_tracks_menu">Routes / Tracks</string>
     <string name="center_on_route_track">Center on route/track</string>
     <string name="unload_route_track">Unload route/track</string>
     <string name="route">Route</string>

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -520,6 +520,16 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         if (mapOptions.geocode != null || mapOptions.searchResult != null || savedCoords != null || mapOptions.mapState != null) {
             centerMap(mapOptions.geocode, mapOptions.searchResult, savedCoords, mapOptions.mapState);
         }
+
+
+        if (StringUtils.isNotEmpty(mapOptions.geocode) && mapOptions.mapMode != MapMode.COORDS) {
+            targetGeocode = mapOptions.geocode;
+            final Geocache temp = getCurrentTargetCache();
+            if (temp != null) {
+                lastNavTarget = temp.getCoords();
+            }
+        }
+
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -249,7 +249,7 @@ public class RouteTrackUtils {
     }
 
     public void onPrepareOptionsMenu(final Menu menu, final View anchor, final IndividualRoute route, final Tracks tracks) {
-        final AtomicBoolean someTrackAvailable = new AtomicBoolean(isRouteNonEmpty(route));
+        final AtomicBoolean someTrackAvailable = new AtomicBoolean(isRouteNonEmpty(route) || isTargetSet.call());
         tracks.traverse((key, r) -> {
             if (!someTrackAvailable.get() && isRouteNonEmpty(r)) {
                 someTrackAvailable.set(true);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -326,6 +326,10 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
                 postZoomToViewport(viewport);
             }
             targetGeocode = mapOptions.geocode;
+            final Geocache temp = getCurrentTargetCache();
+            if (temp != null) {
+                lastNavTarget = temp.getCoords();
+            }
         } else if (mapOptions.coords != null) {
             postZoomToViewport(new Viewport(mapOptions.coords, 0, 0));
             if (mapOptions.mapMode == MapMode.LIVE) {


### PR DESCRIPTION
## Description
Enables the "routes/tracks" quick button when a navigation target is set, which gives you a quick access to the "clear manual targets" option.
Also fixes a hard-coded label for the "Routes / Tracks" menu item.

## Additional context
The whole `mapOptions` and setting a target is pretty confusing to me. In the end I basically added something like 
```
final Geocache temp = getCurrentTargetCache();
if (temp != null) {
    lastNavTarget = temp.getCoords();
}
```
to both map implementations (under certain conditions).
A review / some testing would be welcomed to check whether this has unwanted side-effects.
