### PR TITLE
avoid usage of string references

### DIFF
--- a/main/res/menu/bottom_navigation_menu.xml
+++ b/main/res/menu/bottom_navigation_menu.xml
@@ -15,7 +15,7 @@
         android:id="@+id/page_map"
         android:enabled="true"
         android:icon="@drawable/ic_menu_mapmode"
-        android:title="@string/live_map_button" />
+        android:title="@string/map_map" />
     <item
         android:id="@+id/page_search"
         android:enabled="true"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -349,7 +349,6 @@
 
     <!-- main screen -->
     <string name="home_button">Home</string>
-    <string name="live_map_button">@string/map_map</string>
     <string name="caches_nearby_button">Nearby</string>
     <string name="advanced_search_button">Search</string>
     <string name="stored_caches_button">Stored</string>

--- a/main/res/xml/shortcuts.xml
+++ b/main/res/xml/shortcuts.xml
@@ -4,7 +4,7 @@
         android:shortcutId="live_map"
         android:enabled="true"
         android:icon="@drawable/sc_map"
-        android:shortcutShortLabel="@string/live_map_button">
+        android:shortcutShortLabel="@string/map_map">
         <intent
             android:action="android.intent.action.VIEW"
             android:targetPackage="cgeo.geocaching"

--- a/main/src/cgeo/geocaching/CreateShortcutActivity.java
+++ b/main/src/cgeo/geocaching/CreateShortcutActivity.java
@@ -68,7 +68,7 @@ public class CreateShortcutActivity extends AbstractActionBarActivity {
     private void promptForShortcut() {
         final List<Shortcut> shortcuts = new ArrayList<>();
 
-        shortcuts.add(new Shortcut(R.string.live_map_button, R.drawable.sc_map, new Intent(this, MapActivity.class)));
+        shortcuts.add(new Shortcut(R.string.map_map, R.drawable.sc_map, new Intent(this, MapActivity.class)));
         shortcuts.add(new Shortcut(R.string.caches_nearby_button, R.drawable.sc_nearby, CacheListActivity.getNearestIntent(this)));
 
         // TODO: make logging activities ask for cache/trackable when being invoked externally


### PR DESCRIPTION
rel. to #12725
- Use `Map` for bottom navigation
- Continue using the old `Live-Map` label for launcher shortcuts (is this the wanted behavior? IMHO "live" makes it sound more like c:geo, so I would prefer this on as launcher shortcut label. Last but not least to avoid unnecessary confusion for our users ;-))

@Lineflyer 