### PR TITLE
fix #12741: restore coordinate button for trackable logs

### DIFF
--- a/main/res/layout/logtrackable_activity.xml
+++ b/main/res/layout/logtrackable_activity.xml
@@ -54,7 +54,10 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal" >
 
-            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/textinput_autocompletetextview"
+                android:layout_width="0dp"
+                android:layout_weight="1">
                 <AutoCompleteTextView
                     android:id="@+id/geocode"
                     style="@style/textinput_embedded"
@@ -65,6 +68,8 @@
             <Button
                 android:id="@+id/coordinates"
                 style="@style/button_full"
+                android:layout_width="0dp"
+                android:layout_weight="1"
                 android:hint="@string/cache_coordinates" />
         </LinearLayout>
 

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 /**
@@ -124,7 +125,7 @@ public class CoordinatesCalculateGlobalDialog extends DialogFragment {
         final String oldGeocode = geocode;
         geocode = inputData.getGeocode();
         if (!Objects.equals(oldGeocode, geocode)) {
-            if (geocode != null) {
+            if (!StringUtils.isBlank(geocode)) {
                 final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
                 if (cache != null) {
                     this.varList = cache.getVariables();

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -136,7 +136,7 @@ public class CoordinatesInputDialog extends DialogFragment {
         }
 
         final String geocode = inputData.getGeocode();
-        if (geocode != null) {
+        if (!StringUtils.isBlank(geocode)) {
             final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
             cacheCoords = cache == null ? null : cache.getCoords();
         }


### PR DESCRIPTION
fix #12741: restore coordinate button for trackable logs

![image](https://user-images.githubusercontent.com/6909759/153931832-476293eb-61c3-457d-a556-5c5a88b00dfb.png)
