### PR TITLE
fix #12745: prevent possible division by zero in looperlogger

### DIFF
--- a/main/src/cgeo/geocaching/LooperLogger.java
+++ b/main/src/cgeo/geocaching/LooperLogger.java
@@ -76,7 +76,7 @@ public class LooperLogger {
     }
 
     private String getStats() {
-        return "total:#" + totalMsgCount + "/" + totalTime + "ms/avg " + (totalTime / totalMsgCount) + "ms";
+        return "total:#" + totalMsgCount + "/" + totalTime + "ms/avg " + (totalTime / (totalMsgCount == 0 ? 1 : totalMsgCount)) + "ms";
     }
 
 }


### PR DESCRIPTION
fix #12745: prevent possible division by zero in looperlogger