### PR TITLE
remove track load/success toasts (fix #12761)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2243,15 +2243,6 @@
 
     <!-- individual track -->
     <string name="map_load_track">Load track/route from GPX</string>
-    <string name="map_load_track_wait">Loading track/route in background…</string>
-    <plurals name="load_track_success">
-        <item quantity="zero">Track/route loaded (%d trackpoints)</item>
-        <item quantity="one">Track/route loaded (%d trackpoint)</item>
-        <item quantity="two">Track/route loaded (%d trackpoints)</item>
-        <item quantity="few">Track/route loaded (%d trackpoints)</item>
-        <item quantity="many">Track/route loaded (%d trackpoints)</item>
-        <item quantity="other">Track/route loaded (%d trackpoints)</item>
-    </plurals>
     <string name="load_track_error">Error loading track/route</string>
     <string name="map_clear_track">Clear route/track</string>
     <string name="map_clear_track_confirm">Do you want to remove route/track \"%s\"?</string>

--- a/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -27,7 +27,6 @@ public class GPXTrackOrRouteImporter {
 
     public static void doImport(final Context context, final Uri uri, final Route.UpdateRoute callback) {
         final AtomicBoolean success = new AtomicBoolean(false);
-        Toast.makeText(context, R.string.map_load_track_wait, Toast.LENGTH_SHORT).show();
         AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
             try {
                 final Route value = doInBackground(uri);

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -907,7 +907,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     public void setTrack(final String key, final Route route) {
         mapActivity.getTracks().setRoute(key, route);
         resumeTrack(key, null == route);
-        mapActivity.getRouteTrackUtils().showTrackInfo(route);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -29,7 +29,6 @@ import android.widget.CheckBox;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.appcompat.widget.TooltipCompat;
 
@@ -239,13 +238,6 @@ public class RouteTrackUtils {
             updateDialogTracks(popup, tracks);
             updateTrack.updateRoute(key, route);
         });
-    }
-
-    public void showTrackInfo(final Route route) {
-        if (null != route) {
-            final int numPoints = route.getNumPoints();
-            Toast.makeText(activity, activity.getResources().getQuantityString(R.plurals.load_track_success, numPoints, numPoints), Toast.LENGTH_SHORT).show();
-        }
     }
 
     public void onPrepareOptionsMenu(final Menu menu, final View anchor, final IndividualRoute route, final Tracks tracks) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1631,7 +1631,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     private void setTrack(final String key, final Route route) {
         tracks.setRoute(key, route);
         resumeTrack(key, null == route);
-        this.routeTrackUtils.showTrackInfo(route);
     }
 
     private void reloadIndividualRoute() {


### PR DESCRIPTION
## Description
- removes "loading track/route in background" toast, and
- removes "track/route loaded (xxx trackpoints)" toast, but
- keeps toast on error
