### PR TITLE
avoid flicker in cache description page (fix #10985)

### DIFF
--- a/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
+++ b/main/src/cgeo/geocaching/activity/TabbedViewPagerFragment.java
@@ -59,6 +59,7 @@ public abstract class TabbedViewPagerFragment<ViewBindingClass extends ViewBindi
             contentIsUpToDate = false;
             // do an update anyway to catch situations where currently active view gets updated (and thus no onResume gets called)
             setContent();
+            contentIsUpToDate = true;
         }
     }
 


### PR DESCRIPTION
## Description
avoid flicker in cache description page

## Additional context
This should be tested in the nightlies before publishing a new bugfix release. The bug fix seems to be too obvious, but maybe the now added line had been left out to avoid some side-effects, can't say any more. A quick test in both standard mode and "show last detail page as default" mode seem to work fine, though.