### PR TITLE
fix #12792: keep original coord on geocache merge

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -360,11 +360,13 @@ public class Geocache implements IWaypoint {
             logCounts = other.logCounts;
         }
 
+
+        final boolean takeOverUserModCoords = !hasUserModifiedCoords();
         if (userModifiedCoords == null) {
             userModifiedCoords = other.userModifiedCoords;
         }
 
-        if (!hasUserModifiedCoords() && other.hasUserModifiedCoords()) {
+        if (takeOverUserModCoords && other.hasUserModifiedCoords()) {
             final Waypoint original = other.getOriginalWaypoint();
             if (original != null) {
                 original.setCoords(getCoords());


### PR DESCRIPTION
fix #12792: keep original coord on geocache merge