### PR TITLE
restore 'restore a different backup' function (fix #12791)

### DIFF
--- a/main/src/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/cgeo/geocaching/settings/SettingsActivity.java
@@ -125,6 +125,10 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         setResult(NO_RESTART_NEEDED);
     }
 
+    public BackupUtils getBackupUtils() {
+        return backupUtils;
+    }
+
     private void handleIntent(final Bundle savedInstanceState) {
         if (savedInstanceState == null) {
             final Intent intent = getIntent();
@@ -288,12 +292,9 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         if (contentStorageHelper.onActivityResult(requestCode, resultCode, data)) {
             return;
         }
-        /* @todo - still needed here?
         if (backupUtils.onActivityResult(requestCode, resultCode, data)) {
             return;
         }
-        */
-
     }
 
     // search related extensions

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.BackupSeekbarPreference;
+import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.BackupUtils;
 
@@ -16,7 +17,7 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_backup, rootKey);
 
-        final BackupUtils backupUtils = new BackupUtils(getActivity(), savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
+        final BackupUtils backupUtils = ((SettingsActivity) getActivity()).getBackupUtils();
 
         findPreference(getString(R.string.pref_fakekey_preference_startbackup)).setOnPreferenceClickListener(preference -> {
             backupUtils.backup(this::updateSummary);


### PR DESCRIPTION
## Description
Restore the disabled "restore a different backup" function, which got uncoupled during settings migration

## Additional info
Due to migrating settings to fragments and the `BackupPreferenceFragment` using its own instance of `BackupUtils` ContentStorageActivityHelper was no longer able to identify the request correctly.