### PR TITLE
switch route sort icon to edit icon in route quick settings (fix #12812)

### DIFF
--- a/main/res/layout/routes_tracks_item.xml
+++ b/main/res/layout/routes_tracks_item.xml
@@ -10,16 +10,16 @@
         style="@style/text_default"
         android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
-        android:layout_toLeftOf="@id/item_sort"
+        android:layout_toLeftOf="@id/item_edit"
         android:text="@string/individual_route" />
 
     <ImageButton
-        android:id="@+id/item_sort"
+        android:id="@+id/item_edit"
         style="@style/button_icon"
         android:layout_centerVertical="true"
         android:layout_toLeftOf="@id/item_visibility"
         android:background="?android:attr/selectableItemBackgroundBorderless"
-        android:src="@drawable/ic_menu_swap_vert"
+        android:src="@drawable/ic_menu_edit"
         android:tooltipText="@string/map_sort_individual_route"
         android:visibility="gone" />
 

--- a/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -133,9 +133,9 @@ public class RouteTrackUtils {
         if (isRouteNonEmpty(individualRoute)) {
             dialog.findViewById(R.id.indivroute).setVisibility(View.VISIBLE);
 
-            final View vSort = dialog.findViewById(R.id.item_sort);
-            vSort.setVisibility(View.VISIBLE);
-            vSort.setOnClickListener(v1 -> activity.startActivityForResult(new Intent(activity, RouteSortActivity.class), REQUEST_SORT_INDIVIDUAL_ROUTE));
+            final View vEdit = dialog.findViewById(R.id.item_edit);
+            vEdit.setVisibility(View.VISIBLE);
+            vEdit.setOnClickListener(v1 -> activity.startActivityForResult(new Intent(activity, RouteSortActivity.class), REQUEST_SORT_INDIVIDUAL_ROUTE));
 
             dialog.findViewById(R.id.item_center).setOnClickListener(v1 -> individualRoute.setCenter(centerOnPosition));
 


### PR DESCRIPTION
## Description
Switches the "route sort" icon to a "route edit" icon in route/track quick settings:

![grafik](https://user-images.githubusercontent.com/3754370/156137926-822f8738-0ac8-4666-b7eb-af11856d41f7.png)
