### PR TITLE
support quick launch buttons on the home screen (fix #12790)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -88,7 +88,7 @@
         android:id="@+id/connectorstatus_area"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@id/location_area"
+        android:layout_above="@id/quicklaunchitems"
         android:layout_below="@id/info_notloggedin"
         android:layout_marginTop="32dp"
         android:layout_marginBottom="16dp"
@@ -96,6 +96,64 @@
         android:orientation="vertical"
         android:scrollbars="none"
         tools:listitem="@layout/main_activity_connectorstatus" />
+
+    <LinearLayout
+        android:id="@+id/quicklaunchitems"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/location_area"
+        android:gravity="center_horizontal"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb1"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb2"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb3"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb4"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb5"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb6"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb7"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qlb8"
+            style="@style/button_icon"
+            app:icon="@drawable/ic_menu_refresh"
+            android:layout_marginLeft="2dip"
+            android:visibility="visible" />
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/location_area"

--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -107,49 +107,47 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb1"
-            style="@style/button_icon"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
+            style="@style/quicklaunch_button"
+            android:visibility="visible"
+            app:icon="@drawable/ic_menu_refresh" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb2"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
             android:visibility="visible" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb3"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
             android:layout_marginLeft="2dip"
             android:visibility="visible" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb4"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
             android:layout_marginLeft="2dip"
             android:visibility="visible" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb5"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
             android:layout_marginLeft="2dip"
             android:visibility="visible" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb6"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
             android:layout_marginLeft="2dip"
             android:visibility="visible" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb7"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
             android:layout_marginLeft="2dip"
             android:visibility="visible" />
         <com.google.android.material.button.MaterialButton
             android:id="@+id/qlb8"
-            style="@style/button_icon"
+            style="@style/quicklaunch_button"
             app:icon="@drawable/ic_menu_refresh"
             android:layout_marginLeft="2dip"
             android:visibility="visible" />

--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -105,52 +105,8 @@
         android:gravity="center_horizontal"
         android:orientation="horizontal">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb1"
-            style="@style/quicklaunch_button"
-            android:visibility="visible"
-            app:icon="@drawable/ic_menu_refresh" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb2"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:visibility="visible" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb3"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb4"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb5"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb6"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb7"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/qlb8"
-            style="@style/quicklaunch_button"
-            app:icon="@drawable/ic_menu_refresh"
-            android:layout_marginLeft="2dip"
-            android:visibility="visible" />
+        <!-- will be filled dynamically with quick launch buttons -->
+
     </LinearLayout>
 
     <LinearLayout

--- a/main/res/values/attrs.xml
+++ b/main/res/values/attrs.xml
@@ -34,6 +34,9 @@
         <attr name="highRes" format="boolean" />
     </declare-styleable>
 
+    <!-- button style for home screen's quick launch buttons -->
+    <attr name="quickLaunchButtonStyle" format="reference"/>
+
     <!-- others -->
     <attr name="compass" format="integer" />
     <attr name="progressSpinnerLarge" format="integer" />

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -159,6 +159,7 @@
     <string translatable="false" name="pref_plainLogs">plainLogs</string>
     <string translatable="false" name="pref_selected_language">selectedLanguage</string>
     <string translatable="false" name="pref_units_imperial">units</string>
+    <string translatable="false" name="pref_quicklaunchitems">quicklaunchitems</string>
 
 
     <!-- ============================================================================================================================================================================== -->

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -189,6 +189,8 @@
     <string translatable="false" name="support_mail"><a href="">support@cgeo.org</a></string>
     <string translatable="false" name="manual_link"><a href="">manual.cgeo.org</a></string>
     <string translatable="false" name="github_link"><a href="">github.com/cgeo/cgeo/issues</a></string>
+    <string translatable="false" name="faq_link_full">https://faq.cgeo.org</string>
+    <string translatable="false" name="manual_link_full">https://manual.cgeo.org</string>
 
     <string translatable="false" name="ellipsis">…</string>
     <string translatable="false" name="triple_dash_vertical">┆</string>

--- a/main/res/values/styles.xml
+++ b/main/res/values/styles.xml
@@ -201,6 +201,15 @@
         <item name="materialThemeOverlay">@style/IconButtonThemeOverlay</item>
     </style>
 
+    <style name="quicklaunch_button" parent="button_icon_accent">
+        <item name="materialThemeOverlay">@style/IconButtonThemeOverlay</item>
+        <item name="backgroundTint">#38808080</item>
+        <item name="cornerRadius">12dip</item>
+        <item name="strokeWidth">0dip</item>
+        <item name="android:layout_margin">7dip</item>
+        <item name="iconSize">24dp</item>
+    </style>
+
     <style name="button_icon_colored" parent="button_icon_accent">
         <!-- display icon as colored image, without reverting all colors to tint color -->
         <item name="iconTint">#FFFFFFFF</item>

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -29,6 +29,9 @@
         <!-- some components aren't fully compatible with AppCompat, therefore we need these legacy style definitions -->
         <item name="android:indeterminateTint">@color/colorAccent</item>
         <item name="android:progressTint">@color/colorAccent</item>
+
+        <!-- forward style references to make them accessible in code -->
+        <item name="quickLaunchButtonStyle">@style/quicklaunch_button</item>
     </style>
 
     <!-- theme for alert dialogs -->

--- a/main/res/xml/preferences_appearence.xml
+++ b/main/res/xml/preferences_appearence.xml
@@ -42,4 +42,9 @@
         android:summary="@string/init_summary_units"
         android:title="@string/init_units"
         app:iconSpaceReserved="false" />
+    <MultiSelectListPreference
+        android:key="@string/pref_quicklaunchitems"
+        android:title="Quick launch buttons"
+        android:summary="Select one or more items as quick launch buttons on home screen"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -192,8 +192,8 @@ public class AboutActivity extends TabbedViewPagerActivity {
             setClickListener(binding.facebook, "https://www.facebook.com/pages/cgeo/297269860090");
             setClickListener(binding.fangroup, "https://facebook.com/groups/cgeo.fangruppe");
             setClickListener(binding.twitter, "https://twitter.com/android_gc");
-            setClickListener(binding.nutshellmanual, "https://manual.cgeo.org/");
-            setClickListener(binding.faq, "https://faq.cgeo.org/");
+            setClickListener(binding.nutshellmanual, getString(R.string.manual_link_full));
+            setClickListener(binding.faq, getString(R.string.faq_link_full));
             setClickListener(binding.github, "https://github.com/cgeo/cgeo/issues");
             binding.market.setOnClickListener(v -> ProcessUtils.openMarket(activity, activity.getPackageName()));
         }

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.connector.gc.PocketQueryListActivity;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.databinding.MainActivityBinding;
 import cgeo.geocaching.downloader.DownloaderUtils;
+import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.helper.UsefulAppsActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
@@ -60,23 +61,30 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.util.Pair;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.view.MenuCompat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import com.google.android.material.button.MaterialButton;
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -346,6 +354,30 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
     }
 
+    private void prepareQuickLaunchItems() {
+        int currentId = 1;
+        final Set<String> quicklaunchitems = Settings.getQuicklaunchitems();
+        for (QuickLaunchItem item : QuickLaunchItem.values()) {
+            if (quicklaunchitems.contains(item.name())) {
+                final MaterialButton b = findViewById(getResources().getIdentifier("qlb" + currentId, "id", getPackageName()));
+                if (b != null) {
+                    b.setIconResource(item.iconRes);
+                    b.setVisibility(View.VISIBLE);
+                    TooltipCompat.setTooltipText(b, item.info);
+                    currentId++;
+
+                    // @todo perform action on click
+                }
+            }
+        }
+        // hide all other buttons
+        for (int i = currentId; i <= 8; i++) {
+            findViewById(getResources().getIdentifier("qlb" + i, "id", getPackageName())).setVisibility(View.GONE);
+        }
+        // show or hide quicklaunchitems area
+        binding.quicklaunchitems.setVisibility(currentId > 1 ? View.VISIBLE : View.GONE);
+    }
+
     private void init() {
         if (initialized) {
             return;
@@ -356,6 +388,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         checkRestore();
         DataStore.cleanIfNeeded(this);
         updateCacheCounter();
+        prepareQuickLaunchItems();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -43,6 +43,7 @@ import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.DebugUtils;
+import cgeo.geocaching.utils.DisplayUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
@@ -63,7 +64,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.util.Pair;
-import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -71,13 +71,11 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.AppCompatButton;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.view.MenuCompat;
@@ -357,26 +355,26 @@ public class MainActivity extends AbstractBottomNavigationActivity {
     }
 
     private void prepareQuickLaunchItems() {
-        int currentId = 1;
+        final int dimSize = DisplayUtils.getPxFromDp(getResources(), 48.0f, 1.0f);
+        final int dimMargin = DisplayUtils.getPxFromDp(getResources(), 7.0f, 1.0f);
+        final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(dimSize, dimSize);
+        lp.setMargins(dimMargin, 0, dimMargin, 0);
+
         final Set<String> quicklaunchitems = Settings.getQuicklaunchitems();
+        binding.quicklaunchitems.removeAllViews();
+        binding.quicklaunchitems.setVisibility(View.GONE);
         for (QuickLaunchItem item : QuickLaunchItem.values()) {
             if (quicklaunchitems.contains(item.name()) && (!item.gcPremiumOnly || Settings.isGCPremiumMember())) {
-                final MaterialButton b = findViewById(getResources().getIdentifier("qlb" + currentId, "id", getPackageName()));
-                if (b != null) {
-                    b.setIconResource(item.iconRes);
-                    b.setVisibility(View.VISIBLE);
-                    b.setOnClickListener(view -> launchQuickLaunchItem(item));
-                    TooltipCompat.setTooltipText(b, getString(item.info));
-                    currentId++;
-                }
+                final MaterialButton b = new MaterialButton(this, null, R.attr.quickLaunchButtonStyle);
+                b.setIconResource(item.iconRes);
+                b.setLayoutParams(lp);
+                b.setVisibility(View.VISIBLE);
+                b.setOnClickListener(view -> launchQuickLaunchItem(item));
+                TooltipCompat.setTooltipText(b, getString(item.info));
+                binding.quicklaunchitems.addView(b);
+                binding.quicklaunchitems.setVisibility(View.VISIBLE);
             }
         }
-        // hide all other buttons
-        for (int i = currentId; i <= 8; i++) {
-            findViewById(getResources().getIdentifier("qlb" + i, "id", getPackageName())).setVisibility(View.GONE);
-        }
-        // show or hide quicklaunchitems area
-        binding.quicklaunchitems.setVisibility(currentId > 1 ? View.VISIBLE : View.GONE);
     }
 
     private void launchQuickLaunchItem(final QuickLaunchItem which) {

--- a/main/src/cgeo/geocaching/enumerations/QuickLaunchItem.java
+++ b/main/src/cgeo/geocaching/enumerations/QuickLaunchItem.java
@@ -1,0 +1,39 @@
+package cgeo.geocaching.enumerations;
+
+import androidx.annotation.DrawableRes;
+
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nullable;
+
+import cgeo.geocaching.R;
+
+public enum QuickLaunchItem {
+    // item names must not be changed
+    GOTO("Go to", R.drawable.ic_menu_goto),
+    POCKETQUERY("Pocket Queries", R.drawable.ic_menu_pocket_query),
+    BOOKMARKLIST("Bookmark Lists", R.drawable.ic_menu_bookmarks),
+    SETTINGS("Settings", R.drawable.settings_nut),
+    BACKUPRESTORE("Backup / Restore", R.drawable.settings_backup),
+    MANUAL("c:geo manual", R.drawable.ic_menu_info_details),
+    FAQ("c:geo FAQ", R.drawable.ic_menu_hint),
+    VIEWSETTINGS("View Settings", R.drawable.settings_eye);
+
+    public final String info;
+    @DrawableRes public int iconRes;
+
+    QuickLaunchItem(final String info, final @DrawableRes int iconRes) {
+        this.info = info;
+        this.iconRes = iconRes;
+    }
+
+    @Nullable
+    public static QuickLaunchItem getByName(final String name) {
+        for (QuickLaunchItem item : values()) {
+            if (StringUtils.equals(item.name(), name)) {
+                return item;
+            }
+        }
+        return null;
+    }
+}

--- a/main/src/cgeo/geocaching/enumerations/QuickLaunchItem.java
+++ b/main/src/cgeo/geocaching/enumerations/QuickLaunchItem.java
@@ -1,30 +1,33 @@
 package cgeo.geocaching.enumerations;
 
-import androidx.annotation.DrawableRes;
+import cgeo.geocaching.R;
 
-import org.apache.commons.lang3.StringUtils;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.StringRes;
 
 import javax.annotation.Nullable;
 
-import cgeo.geocaching.R;
+import org.apache.commons.lang3.StringUtils;
 
 public enum QuickLaunchItem {
     // item names must not be changed
-    GOTO("Go to", R.drawable.ic_menu_goto),
-    POCKETQUERY("Pocket Queries", R.drawable.ic_menu_pocket_query),
-    BOOKMARKLIST("Bookmark Lists", R.drawable.ic_menu_bookmarks),
-    SETTINGS("Settings", R.drawable.settings_nut),
-    BACKUPRESTORE("Backup / Restore", R.drawable.settings_backup),
-    MANUAL("c:geo manual", R.drawable.ic_menu_info_details),
-    FAQ("c:geo FAQ", R.drawable.ic_menu_hint),
-    VIEWSETTINGS("View Settings", R.drawable.settings_eye);
+    GOTO(R.string.any_button, R.drawable.ic_menu_goto, false),
+    POCKETQUERY(R.string.menu_lists_pocket_queries, R.drawable.ic_menu_pocket_query, true),
+    BOOKMARKLIST(R.string.menu_lists_bookmarklists, R.drawable.ic_menu_bookmarks, true),
+    SETTINGS(R.string.menu_settings, R.drawable.settings_nut, false),
+    BACKUPRESTORE(R.string.menu_backup, R.drawable.settings_backup, false),
+    MANUAL(R.string.about_nutshellmanual, R.drawable.ic_menu_info_details, false),
+    FAQ(R.string.faq_title, R.drawable.ic_menu_hint, false),
+    VIEWSETTINGS(R.string.view_settings, R.drawable.settings_eye, false);
 
-    public final String info;
+    @StringRes public final int info;
     @DrawableRes public int iconRes;
+    public boolean gcPremiumOnly;
 
-    QuickLaunchItem(final String info, final @DrawableRes int iconRes) {
+    QuickLaunchItem(final @StringRes int info, final @DrawableRes int iconRes, final boolean gcPremiumOnly) {
         this.info = info;
         this.iconRes = iconRes;
+        this.gcPremiumOnly = gcPremiumOnly;
     }
 
     @Nullable

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -73,6 +73,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -1805,6 +1807,14 @@ public class Settings {
 
     public static void putUserLanguage(final String language) {
         putString(R.string.pref_selected_language, language);
+    }
+
+    public static Set<String> getQuicklaunchitems() {
+        final Set<String> empty = Collections.emptySet();
+        if (sharedPrefs == null) {
+            return empty;
+        }
+        return sharedPrefs.getStringSet(getKey(R.string.pref_quicklaunchitems), empty);
     }
 
     public static void setRoutingMode(@NonNull final RoutingMode mode) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -73,8 +73,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -2,11 +2,13 @@ package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.BuildConfig;
 import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.settings.Settings;
 
 import android.os.Bundle;
 
 import androidx.preference.ListPreference;
+import androidx.preference.MultiSelectListPreference;
 import androidx.preference.Preference;
 
 import java.util.Locale;
@@ -48,6 +50,19 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
             return true;
         });
         setLanguageSummary(languagePref, Settings.getUserLanguage());
+
+        final MultiSelectListPreference quickLaunchItemsPref = findPreference(getString(R.string.pref_quicklaunchitems));
+        final String[] qlEntries = new String[QuickLaunchItem.values().length];
+        final String[] qlValues =  new String[QuickLaunchItem.values().length];
+        int i = 0;
+        for (QuickLaunchItem qlItem : QuickLaunchItem.values()) {
+            qlEntries[i] = qlItem.info;
+            qlValues[i] = qlItem.name();
+            i++;
+        }
+        quickLaunchItemsPref.setEntries(qlEntries);
+        quickLaunchItemsPref.setEntryValues(qlValues);
+
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -56,7 +56,7 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
         final String[] qlValues =  new String[QuickLaunchItem.values().length];
         int i = 0;
         for (QuickLaunchItem qlItem : QuickLaunchItem.values()) {
-            qlEntries[i] = qlItem.info;
+            qlEntries[i] = getString(qlItem.info);
             qlValues[i] = qlItem.name();
             i++;
         }


### PR DESCRIPTION
## Description
Add support for quick launch icons on homescreen.

- set of up to eight buttons, in a fixed order
- being displayed at the bottom of the home screen, centered horizontally, above location info
- configurable using settings => appearance => quick launch buttons
- button sections being displayed only if at least one quick launch setting is selected
- default configuration is "none selected"

|home screen|settings|select items|none selected|
|---|---|---|---|
|![image](https://user-images.githubusercontent.com/3754370/155897081-63bd8e47-84e5-4cbe-a8bb-425eeb7ec643.png)|![image](https://user-images.githubusercontent.com/3754370/155897103-e6915deb-ff1b-451f-84b6-1283f18e997d.png)|![image](https://user-images.githubusercontent.com/3754370/155897112-be334dd7-82b1-4601-9bc7-e991628e913e.png)|![image](https://user-images.githubusercontent.com/3754370/155897219-a391c00f-c264-4961-8cb5-64785f630aa8.png)|
