### PR TITLE
use gradle-versions-filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ plugins {
 
     // check for updates of gradle plugin dependencies
     id 'com.github.ben-manes.versions' version '0.42.0'
+    id 'se.ascp.gradle.gradle-versions-filter' version "0.1.10"
 
     // use SpotBugs instead of FindBugs, see https://plugins.gradle.org/plugin/com.github.spotbugs
     id 'com.github.spotbugs' version '4.7.6'


### PR DESCRIPTION
Optimize the output of `gradlew dependencyUpdates` by applying default exclude rules (e.g. for RC or alpha versions).

So there are excluded now
 - com.android.tools.build:gradle [4.2.2 -> 7.3.0-alpha04]
 - com.squareup.okhttp3:mockwebserver [4.9.3 -> 4.10.0-RC1]
 - com.squareup.okhttp3:okhttp [4.9.3 -> 4.10.0-RC1]
