### PR TITLE
extend map's 'long tap' setting to waypoints (fix #12821)

### DIFF
--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -142,7 +142,7 @@
         android:title="@string/settings_title_map_behavior"
         app:iconSpaceReserved="false">
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="@string/pref_longTapOnMapActivated"
             android:summary="@string/init_summary_longtap_map"
             android:title="@string/init_longtap_map"

--- a/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -130,24 +130,24 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
             return true;
         });
         googleMap.setOnMapLongClickListener(tapLatLong -> {
-            boolean hitWaypoint = false;
-            final GoogleCacheOverlayItem closest = closest(new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
-            if (closest != null) {
-                final Point waypointPoint = googleMap.getProjection().toScreenLocation(new LatLng(closest.getCoord().getCoords().getLatitude(), closest.getCoord().getCoords().getLongitude()));
-                final Point tappedPoint = googleMap.getProjection().toScreenLocation(tapLatLong);
-                if (insideCachePointDrawable(tappedPoint, waypointPoint, closest.getMarker(0).getDrawable())) {
-                    hitWaypoint = true;
-                    if (Settings.isLongTapOnMapActivated()) {
+            if (Settings.isLongTapOnMapActivated()) {
+                boolean hitWaypoint = false;
+                final GoogleCacheOverlayItem closest = closest(new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
+                if (closest != null) {
+                    final Point waypointPoint = googleMap.getProjection().toScreenLocation(new LatLng(closest.getCoord().getCoords().getLatitude(), closest.getCoord().getCoords().getLongitude()));
+                    final Point tappedPoint = googleMap.getProjection().toScreenLocation(tapLatLong);
+                    if (insideCachePointDrawable(tappedPoint, waypointPoint, closest.getMarker(0).getDrawable())) {
+                        hitWaypoint = true;
                         ((CGeoMap) onCacheTapListener).toggleRouteItem(closest.getCoord());
                     }
                 }
-            }
-            if (!hitWaypoint) {
-                final Geocache cache = ((CGeoMap) onCacheTapListener).getSingleModeCache();
-                if (null != cache) {
-                    EditWaypointActivity.startActivityAddWaypoint(this.getContext(), cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
-                } else if (Settings.isLongTapOnMapActivated()) {
-                    InternalConnector.interactiveCreateCache(this.getContext(), new Geopoint(tapLatLong.latitude, tapLatLong.longitude), fromList, true);
+                if (!hitWaypoint) {
+                    final Geocache cache = ((CGeoMap) onCacheTapListener).getSingleModeCache();
+                    if (null != cache) {
+                        EditWaypointActivity.startActivityAddWaypoint(this.getContext(), cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
+                    } else {
+                        InternalConnector.interactiveCreateCache(this.getContext(), new Geopoint(tapLatLong.latitude, tapLatLong.longitude), fromList, true);
+                    }
                 }
             }
         });

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1029,11 +1029,13 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     }
 
     public void showAddWaypoint(final LatLong tapLatLong) {
-        final Geocache cache = getCurrentTargetCache();
-        if (cache != null) {
-            EditWaypointActivity.startActivityAddWaypoint(this, cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
-        } else if (Settings.isLongTapOnMapActivated()) {
-            InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), mapOptions.fromList, true);
+        if (Settings.isLongTapOnMapActivated()) {
+            final Geocache cache = getCurrentTargetCache();
+            if (cache != null) {
+                EditWaypointActivity.startActivityAddWaypoint(this, cache, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
+            } else {
+                InternalConnector.interactiveCreateCache(this, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), mapOptions.fromList, true);
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Make map's "long tap adds waypoint" function honor the map's "long tap enabled/disabled" setting.
