### PR TITLE
fix #12824: include waypoints in gpx for IndividualRouteExport

### DIFF
--- a/main/src/cgeo/geocaching/export/IndividualRouteExport.java
+++ b/main/src/cgeo/geocaching/export/IndividualRouteExport.java
@@ -134,6 +134,10 @@ public class IndividualRouteExport {
                 XmlUtils.simpleText(gpx, NS_GPX, "time", timeInfo);
                 gpx.endTag(NS_GPX, "metadata");
 
+                for (RouteSegment loc : trail) {
+                    exportPoint(gpx, "wpt", loc.getItem().getPoint(), loc.getItem().getIdentifier());
+                }
+
                 gpx.startTag(NS_GPX, exportAsTrack ? "trk" : "rte");
                 XmlUtils.simpleText(gpx, NS_GPX, "name", "c:geo individual route " + timeInfo);
                 for (RouteSegment loc : trail) {


### PR DESCRIPTION
Add caches as waypoint, when exporting an individual route as track/route. This makes the exported GPX useful in context of other outdoor apps:

Individual Route in c:geo|Garmin Cycle Computer |Locus
-|-|-
![Screenshot_20220306_015704_cgeo geocaching_copy_540x1170](https://user-images.githubusercontent.com/64581222/156917140-fe128a65-e1f0-4606-a7c1-5022fe24e9a4.jpg)|![IMG_20220306_020301-01_copy_960x1280](https://user-images.githubusercontent.com/64581222/156916868-6ba37758-e69a-4e1a-be02-daa0205e10c5.jpeg)|![Screenshot_20220306_020136_menion android locus pro computerBild_copy_540x1170](https://user-images.githubusercontent.com/64581222/156916872-7e50e1e1-325e-4462-a150-47c696d32ea6.jpg)

Note: This is the MVP approach currently. Only a waypoint with the geocode as name is added to the GPX, not the full cache...

fix #12824