### PR TITLE
add missing null check (fix #12846)

### DIFF
--- a/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -235,9 +235,11 @@ public class RouteTrackUtils {
     public void reloadTrack(final Trackfiles trackfile, final Tracks.UpdateTrack updateTrack) {
         final Uri uri = Trackfiles.getUriFromKey(trackfile.getKey());
         GPXTrackOrRouteImporter.doImport(activity, uri, (route) -> {
-            route.setHidden(trackfile.isHidden());
-            updateDialogTracks(popup, tracks);
-            updateTrack.updateRoute(trackfile.getKey(), route);
+            if (route != null) {
+                route.setHidden(trackfile.isHidden());
+                updateDialogTracks(popup, tracks);
+                updateTrack.updateRoute(trackfile.getKey(), route);
+            }
         });
     }
 


### PR DESCRIPTION
## Description
If a trackfile cannot be read any longer, returned route is `null` which leads to a crash on trying to apply the hidden flag to it. This PR fixes this.

