### PR TITLE
WIP make bugfix version number handling easier (fix #12852)

### DIFF
--- a/main/res/raw/changelog_bugfix.md
+++ b/main/res/raw/changelog_bugfix.md
@@ -1,8 +1,8 @@
-## 2022.03.10 Bugfix Release
+##
 
 - Fix: Crash on opening map when active track/route files are missing
 
-## 2022.03.09 Bugfix Release
+##
 
 - Fix: Keep position on switching from Google map to OpenStreetMap map
 - Fix: Rare crash in cache list attribute overview
@@ -14,6 +14,6 @@
 - Fix: Show better file name in c:geo after selecting a GPX track file
 - Fix: Remember "show/hide" setting for routes / tracks
 
-## 2022.02.16 Bugfix Release
+##
 
 - Fix: Rare crash on startup of cgeo

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -649,6 +649,7 @@
     <string name="about_changelog">Changelog</string>
     <string name="about_changelog_nightly_build">Nightly build</string>
     <string name="about_changelog_next_release">Next release</string>
+    <string name="about_changelog_bugfix_release">Bugfix Release</string>
     <string name="about_system">System</string>
     <string name="about_donate">Support us</string>
     <string name="about_donation_more">Visit website for info</string>

--- a/main/src/cgeo/geocaching/utils/BranchDetectionHelper.java
+++ b/main/src/cgeo/geocaching/utils/BranchDetectionHelper.java
@@ -7,6 +7,10 @@ public class BranchDetectionHelper {
     // should contain the version name of the last feature release
     public static final String FEATURE_VERSION_NAME = "2022.02.13";
 
+    // should contain version names of active bugfix releases since last feature release, oldest first
+    // empty the part within curly brackets when creating a new release branch from master
+    public static final String[] BUGFIX_VERSION_NAME = new String[]{"2022.02.16", "2022.03.09", "2022.03.10"};
+
     private BranchDetectionHelper() {
         // utility class
     }


### PR DESCRIPTION
## Description
Proposal for easier version number handling for bugfix releases - not to be merged yet.

@Lineflyer 
Please have a look at `BranchDetectionHelper.java` and `changelog_bugfix.md` - would this type of version number handling for bugfix releases be ok for you?
- `BranchDetectionHelper.java` contains a string array with version numbers for bugfix releases (will be empty´for feature release)
- `changelog_bugfix.md` contains `##` placeholders only at the places where version numbers will be inserted

Magic configuration line in `BranchDetectionHelper.java` would look like this for current release:
```
// should contain version names of active bugfix releases since last feature release, newest first
// leave curly brackets empty if not a bugfix release
public static final String[] BUGFIX_VERSION_NAME = new String[]{"2022.03.10", "2022.03.09", "2022.02.16"};
```

Results for current release:

![image](https://user-images.githubusercontent.com/3754370/157949202-837f7354-0a81-41f1-8100-f534745545a9.png)

Just a little thing to be discussed for fine-tuning:

Currently version numbers are inserted top-down, which ensures that the first placeholder always gets a version number (if at least one is configured in `BranchDetectionHelper.java`. Downside is, that we have to remember to add the placeholder `##` just before releasing, so two files need to be updated then.
Alternatively we could insert the version numbers bottom-up. This would enable us to always have `##` at the top of the `changelog_bugfix.md`, and reduces the need for files to be changed just before a bugfix release down to 1, but can lead to an empty version number at the changelog's start if we forgot to enter a version number in `BranchDetectionHelper.java` before releasing.