### PR TITLE
add bottom margin to quick launch buttons (fix #12817)

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -102,6 +102,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@id/location_area"
+        android:layout_marginBottom="16dp"
         android:gravity="center_horizontal"
         android:orientation="horizontal">
 


### PR DESCRIPTION
## Description
adds bottom margin to quick launch buttons (see https://github.com/cgeo/cgeo/pull/12817#issuecomment-1066425651):

![image](https://user-images.githubusercontent.com/3754370/158253459-9d187cdd-1826-499f-9194-39c0d3f8fee0.png)
