### PR TITLE
catch IllegalStateException in map lifecycle (rel. to #12848)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -296,7 +296,11 @@ public abstract class AbstractCachesOverlay {
         synchronized (this.bundleRef.get().getMapView()) {
             for (final GeoitemLayer layer : layerList) {
                 geoEntries.remove(new GeoEntry(layer.getItemCode(), overlayId));
-                layers.remove(layer);
+                try {
+                    layers.remove(layer);
+                } catch (IllegalStateException e) {
+                    Log.d("Ignored exception on layer removal", e);
+                }
                 final Layer circle = layer.getCircle();
                 if (circle != null) {
                     layers.remove(circle);


### PR DESCRIPTION
## Description
Map throws an IllegalStateException on stopping the map (lifecycle method) if a layer is not assigned internally, leading to random crashes as described in #12848. This PR catches that exception, so that the map can be shut down normally.
