### PR TITLE
Adapt FZK-download test to increased file size

### DIFF
--- a/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
@@ -126,9 +126,9 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         // check one named entry
         final Download d = findByName(list, "Freizeitkarte Hamburg");
         assertThat(d).isNotNull();
-        final String sizeInfoString = d.getSizeInfo(); // 17.9 MB
+        final String sizeInfoString = d.getSizeInfo(); // 18.64 MB
         final float sizeInfoFloat = Float.parseFloat(sizeInfoString.substring(0, sizeInfoString.length() - 3));
-        assertThat(sizeInfoFloat).isBetween(17.8F, 18.5F);
+        assertThat(sizeInfoFloat).isBetween(17.8F, 20.0F);
     }
 
     public static void testFreizeitkarteThemes() {


### PR DESCRIPTION
## Description
Currently build on CI fails due to a specific FZK map file having exceeded the file size limits being tested against.
This PR increases the limit (with some buffer for further growth).
