### PR TITLE
remove blank lines at beginning of personal note (fix #12838)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2840,7 +2840,10 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
      * @param newPreventWaypointsFromNote new preventWaypointsFromNote flag to set
      */
     private void setNewPersonalNote(final String newNote, final boolean newPreventWaypointsFromNote) {
-        cache.setPersonalNote(newNote);
+        // trim note to avoid unnecessary uploads for whitespace only changes
+        final String trimmedNote = StringUtils.trim(newNote);
+
+        cache.setPersonalNote(trimmedNote);
         cache.setPreventWaypointsFromNote(newPreventWaypointsFromNote);
         if (cache.addWaypointsFromNote()) {
             reinitializePage(Page.WAYPOINTS.id);
@@ -2856,7 +2859,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         final TextView personalNoteView = findViewById(R.id.personalnote);
         final View separator = findViewById(R.id.personalnote_button_separator);
         if (personalNoteView != null) {
-            setPersonalNote(personalNoteView, separator, newNote);
+            setPersonalNote(personalNoteView, separator, trimmedNote);
         } else {
             reinitializePage(Page.DESCRIPTION.id);
         }

--- a/main/src/cgeo/geocaching/models/WaypointParser.java
+++ b/main/src/cgeo/geocaching/models/WaypointParser.java
@@ -427,7 +427,10 @@ public class WaypointParser {
      * @return new text, or null if waypoints could not be placed due to size restrictions
      */
     public static String putParseableWaypointsInText(final String text, final Collection<Waypoint> waypoints, final VariableList vars, final int maxSize) {
-        final String cleanText = removeParseableWaypointsFromText(text) + "\n\n";
+        String cleanText = removeParseableWaypointsFromText(text);
+        if (!cleanText.isEmpty()) {
+            cleanText = cleanText + "\n\n";
+        }
         if (maxSize > -1 && cleanText.length() > maxSize) {
             return null;
         }

--- a/main/src/cgeo/geocaching/ui/dialog/EditNoteDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/EditNoteDialog.java
@@ -80,9 +80,7 @@ public class EditNoteDialog extends AbstractFullscreenDialog {
         toolbar.inflateMenu(R.menu.menu_ok_cancel);
         toolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.menu_item_save) {
-                // trim note to avoid unnecessary uploads for whitespace only changes
-                final String personalNote = StringUtils.trim(mEditText.getText().toString());
-                ((EditNoteDialogListener) requireActivity()).onFinishEditNoteDialog(personalNote, mPreventCheckbox.isChecked());
+                ((EditNoteDialogListener) requireActivity()).onFinishEditNoteDialog(mEditText.getText().toString(), mPreventCheckbox.isChecked());
             }
             dismiss();
             return true;

--- a/tests/src/cgeo/geocaching/models/WaypointParserTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointParserTest.java
@@ -569,6 +569,26 @@ public class WaypointParserTest {
     }
 
     @Test
+    public void putParseableWaypointsInText() {
+        final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
+        final String gpStr = toParseableWpString(gp);
+        final Geopoint gp2 = new Geopoint("N 45°49.745 E 9°45.038");
+        final String gp2Str = toParseableWpString(gp2);
+
+        final String waypoints = "@wp1 (X) " + gpStr + " \"note\"\n@wp2 (F) " + gp2Str + " \"note2\"";
+        final WaypointParser waypointParser = createParser("Prefix");
+        final Collection<Waypoint> wps = waypointParser.parseWaypoints(waypoints);
+
+        final String note = "";
+        final String noteAfter = WaypointParser.putParseableWaypointsInText(note, wps, null, -1);
+        assertThat(noteAfter).isEqualTo("{c:geo-start}\n" + waypoints + "\n{c:geo-end}");
+
+        //check that continuous appliance of same waypoints will result in identical text
+        final String noteAfter2 = WaypointParser.putParseableWaypointsInText(noteAfter, wps, null, -1);
+        assertThat(noteAfter2).isEqualTo(noteAfter);
+    }
+
+    @Test
     public void testGetAndReplaceExistingStoredWaypoints() {
         final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
         final String gpStr = toParseableWpString(gp);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
* don't add doubled new line at beginning of personal note when adding parseable waypoint
* trim personal note 

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #12838

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
trimming the personal note on setting it would make the removing of the doubled new line superfluous, but I thought it would be clearer to have both code-locations adpated