### PR TITLE
remove emoji compat (bundled)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -415,11 +415,6 @@ dependencies {
     implementation "androidx.annotation:annotation:$annotationVersion"
     androidTestImplementation "androidx.annotation:annotation:$annotationVersion"
 
-    // emoji compat support
-    def emojiVersion = '1.1.0'
-    implementation "androidx.emoji:emoji:$emojiVersion"
-    implementation "androidx.emoji:emoji-bundled:$emojiVersion"
-
     // Testing Support Libraries
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/main/src/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/cgeo/geocaching/CgeoApplication.java
@@ -20,8 +20,6 @@ import android.os.UserManager;
 import android.view.ViewConfiguration;
 
 import androidx.annotation.NonNull;
-import androidx.emoji.bundled.BundledEmojiCompatConfig;
-import androidx.emoji.text.EmojiCompat;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -74,10 +72,6 @@ public class CgeoApplication extends Application {
             Cookies.restoreCookies();
 
             LooperLogger.startLogging(Looper.getMainLooper());
-
-            // initialization for log smileys
-            final EmojiCompat.Config config = new BundledEmojiCompatConfig(this);
-            EmojiCompat.init(config);
         }
     }
 

--- a/main/src/cgeo/geocaching/log/AbstractLoggingActivity.java
+++ b/main/src/cgeo/geocaching/log/AbstractLoggingActivity.java
@@ -21,7 +21,6 @@ import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.emoji.text.EmojiCompat;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +44,7 @@ public abstract class AbstractLoggingActivity extends AbstractActionBarActivity 
 
         final SubMenu menuSmileys = menu.findItem(R.id.menu_smileys).getSubMenu();
         for (final Smiley smiley : getSmileys()) {
-            menuSmileys.add(Menu.NONE, smiley.getItemId(), Menu.NONE, EmojiCompat.get().process(smiley.emoji + "  [" + smiley.symbol + "]  " + getString(smiley.meaning)));
+            menuSmileys.add(Menu.NONE, smiley.getItemId(), Menu.NONE, smiley.emoji + "  [" + smiley.symbol + "]  " + getString(smiley.meaning));
         }
         menu.findItem(R.id.menu_sort_trackables_by).setVisible(false);
 


### PR DESCRIPTION
fixes #12856

Removal of complete emoji compat Implementation.
Disadvantage: Up to API 27, two emoji are without a picture.
![2022-04-25 22_17_05-cgeo – build gradle (_main) 2](https://user-images.githubusercontent.com/32555742/165170912-7880bdd2-38b9-4d89-a335-4ea2d8121fec.png)

This is a alternative implementation compared to #12897.

