### PR TITLE
add a small padding-left on waypoints to avoid the waypoint icon bein…

### DIFF
--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -16,6 +16,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:descendantFocusability="blocksDescendants"
+        android:paddingLeft="5dip"
         android:orientation="horizontal" >
 
         <LinearLayout


### PR DESCRIPTION
dd a small padding-left on waypoints to avoid the waypoint icon being "glued" to the edge of the screen

Before
![image](https://user-images.githubusercontent.com/1258173/165173282-ab49ede8-3d6c-4118-af5a-93ab747d2f94.png)

After
![image](https://user-images.githubusercontent.com/1258173/165173446-a99059d4-4198-46f5-8e28-e97e27a6bead.png)