### PR TITLE
fix gc checker link for Android 12 (fix #12889)

### DIFF
--- a/main/res/drawable/geochecker_available.xml
+++ b/main/res/drawable/geochecker_available.xml
@@ -1,0 +1,11 @@
+<!-- taken from material icons / circle -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -43,6 +43,45 @@
                 android:indeterminateOnly="true" />
         </RelativeLayout>
 
+        <!-- geochecker box -->
+        <LinearLayout
+            android:id="@+id/description_checker"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <View
+                style="@style/separator_horizontal"
+                android:layout_marginBottom="9dp"
+                android:layout_marginTop="9dp" />
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:text="@string/geochecker_available"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_centerVertical="true"
+                    android:layout_gravity="left"
+                    android:layout_marginLeft="6dip"
+                    android:layout_marginRight="60dip"
+                    android:paddingRight="3dip"
+                    android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
+                    android:textIsSelectable="false" />
+
+                <Button
+                    android:id="@+id/description_checker_button"
+                    style="@style/button_icon"
+                    android:layout_alignParentRight="true"
+                    app:icon="@drawable/geochecker_available" />
+            </RelativeLayout>
+        </LinearLayout>
+
         <!-- Extra description box -->
         <LinearLayout
             android:id="@+id/extra_description_box"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2267,6 +2267,7 @@
         <item quantity="other">%d waypoints extracted</item>
     </plurals>
     <string name="link_gc_checker">geocaching.com coordinate checker available via browser</string>
+    <string name="geochecker_available">Geochecker available via browser</string>
 
     <!-- calendar adder -->
     <string name="event_fail">Failed to add event cache to calendar</string>

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -584,7 +584,7 @@ public final class GCParser {
         }
         String gcChecker = StringUtils.EMPTY;
         if (page.contains(GCConstants.PATTERN_GC_CHECKER)) {
-            gcChecker = "<br/><br/><a href=\"" + cache.getUrl() + "\">" + CgeoApplication.getInstance().getString(R.string.link_gc_checker) + "</a>";
+            gcChecker = "<!--" + CgeoApplication.getInstance().getString(R.string.link_gc_checker) + "-->";
         }
         cache.setDescription(longDescription + relatedWebPage + gcChecker);
 


### PR DESCRIPTION
## Description
- fixes gc checker link for Android 12
- no longer add such a link on reloading the cache
- display a "geochecker available in browser" button below the description where applicable (valid for all detected geocheckers, not only gc.com geochecker)

|gc checker link for stored cache, not updated|gc checker, listing updated|non-gc checker|
|:---:|:---:|:---:|
|![image](https://user-images.githubusercontent.com/3754370/166117789-516ee1f8-98af-46c8-b133-d754c925f32c.png)|![image](https://user-images.githubusercontent.com/3754370/166117796-f9d70da6-382d-4435-b90e-36326cd1a05c.png)|![image](https://user-images.githubusercontent.com/3754370/166117805-84c39fc5-9c3a-44f8-99ca-444475e91fe0.png)|
|1|2|3|

1) for stored caches, not updated: link is still shown, but reverted to same functionality as "open geochecker" menu entry (or button below)
2) on updating stored caches or storing new ones: link is no longer shown, only button below description
3) also non-gc geochecker will enable the new button below description
