### PR TITLE
enable text selection in logs (fix #12911)

### DIFF
--- a/main/res/layout/logs_item.xml
+++ b/main/res/layout/logs_item.xml
@@ -70,6 +70,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:gravity="left"
+                android:textIsSelectable="true"
                 android:textSize="@dimen/textSize_detailsPrimary"
                 android:textColor="@color/colorText"/>
 


### PR DESCRIPTION
## Description
Enables selecting log texts (or part of it) by long-tapping on the text.
(Short tap on the log text still opens the context menu.)
