### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -13,9 +13,14 @@ env:
   RELEASE_BRANCH: release
   MASTER_BRANCH: master
 
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "merge-branches"
   merge-branches:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
