### PR TITLE
Support building nested filters

### DIFF
--- a/main/res/layout/button_icon_view.xml
+++ b/main/res/layout/button_icon_view.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/button_icon">
-
-</com.google.android.material.button.MaterialButton>
+<com.google.android.material.button.MaterialButton style="@style/button_icon" />

--- a/main/res/layout/button_view.xml
+++ b/main/res/layout/button_view.xml
@@ -3,6 +3,4 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:minWidth="32dp"
-    style="@style/button">
-
-</com.google.android.material.button.MaterialButton>
+    style="@style/button" />

--- a/main/res/layout/cache_filter_activity.xml
+++ b/main/res/layout/cache_filter_activity.xml
@@ -30,7 +30,7 @@
         <Button
             android:id="@+id/filter_additem"
             style="@style/button"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_toRightOf="@+id/filter_basic_advanced"
@@ -65,18 +65,17 @@
             android:layout_centerVertical="true"
             app:icon="@drawable/ic_menu_save" />
 
-        <TextView
-            android:id="@+id/filter_storage_name"
-            android:textSize="@dimen/textSize_detailsPrimary"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_marginLeft="5dp"
-            android:layout_toRightOf="@+id/filter_storage_save"
-            android:layout_alignParentRight="true"
-            android:ellipsize="end"
-            android:maxLines="1"
-            />
+         <TextView
+             android:id="@+id/filter_storage_name"
+             android:layout_width="wrap_content"
+             android:layout_height="wrap_content"
+             android:layout_alignParentRight="true"
+             android:layout_centerVertical="true"
+             android:layout_marginLeft="5dp"
+             android:layout_toRightOf="@+id/filter_storage_save"
+             android:ellipsize="end"
+             android:maxLines="1"
+             android:textSize="@dimen/textSize_detailsPrimary" />
 
     </RelativeLayout>
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -534,14 +534,17 @@
     <string name="cache_filter_stored_lists">Stored Lists</string>
     <string name="cache_filter_origin">Origin</string>
     <string name="cache_filter_stored_since">Last details update</string>
+    <string name="cache_filter_logical_filter_group">Nested Filter</string>
 
     <string name="cache_filtergroup_basic">Basic</string>
     <string name="cache_filtergroup_details">Details</string>
     <string name="cache_filtergroup_userspecific">User specific</string>
+    <string name="cache_filtergroup_special">Special</string>
 
     <string name="cache_filter_contexttype_live_title">Live Filter</string>
     <string name="cache_filter_contexttype_offline_title">Offline Filter</string>
     <string name="cache_filter_contexttype_transient_title">Filter</string>
+    <string name="cache_filter_contexttype_nestedfilter_title">Nested Filter</string>
 
 
     <string name="cache_filter_include">Include</string>
@@ -623,6 +626,9 @@
     <string name="cache_filter_status_exclude_archived">Exclude Archived</string>
 
     <string name="cache_filter_difficulty_terrain_include_caches_without_dt">Include caches without D/T</string>
+
+    <string name="cache_filter_nested_filter_modify">modify</string>
+    <string name="cache_filter_nested_filter_empty_filterconfic">The sub-filter is currently empty</string>
 
     <string name="cache_filter_log_entry_foundby">Found by</string>
     <string name="cache_filter_log_entry_logtext">Log text</string>

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilterContext.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilterContext.java
@@ -22,6 +22,7 @@ public class GeocacheFilterContext implements Parcelable {
         FilterType(@StringRes final int titleId) {
             this.titleId = titleId;
         }
+
     }
 
     private FilterType type;

--- a/main/src/cgeo/geocaching/filters/core/GeocacheFilterType.java
+++ b/main/src/cgeo/geocaching/filters/core/GeocacheFilterType.java
@@ -32,7 +32,8 @@ public enum GeocacheFilterType {
     LOCATION("location", R.string.cache_filter_location, R.string.cache_filtergroup_details, LocationGeocacheFilter::new),
     STORED_LISTS("stored_list", R.string.cache_filter_stored_lists, R.string.cache_filtergroup_userspecific, StoredListGeocacheFilter::new),
     ORIGIN("origin", R.string.cache_filter_origin, R.string.cache_filtergroup_details, OriginGeocacheFilter::new),
-    STORED_SINCE("stored_since", R.string.cache_filter_stored_since, R.string.cache_filtergroup_userspecific, StoredSinceGeocacheFilter::new);
+    STORED_SINCE("stored_since", R.string.cache_filter_stored_since, R.string.cache_filtergroup_userspecific, StoredSinceGeocacheFilter::new),
+    LOGICAL_FILTER_GROUP(null, R.string.cache_filter_logical_filter_group, R.string.cache_filtergroup_special, AndGeocacheFilter::new);
 
 
     private final String typeId;

--- a/main/src/cgeo/geocaching/filters/core/LogicalGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/LogicalGeocacheFilter.java
@@ -7,12 +7,12 @@ import cgeo.geocaching.utils.expressions.ExpressionConfig;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class LogicalGeocacheFilter implements IGeocacheFilter {
+public abstract class LogicalGeocacheFilter extends BaseGeocacheFilter {
 
     private final List<IGeocacheFilter> children = new ArrayList<>();
 
-    public GeocacheFilterType getType() {
-        return null;
+    LogicalGeocacheFilter() {
+        setType(GeocacheFilterType.LOGICAL_FILTER_GROUP);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -125,6 +125,9 @@ public class FilterViewHolderCreator {
             case STORED_SINCE:
                 result = createStoredSinceFilterViewHolder();
                 break;
+            case LOGICAL_FILTER_GROUP:
+                result = new LogicalFilterViewHolder();
+                break;
             default:
                 result = null;
                 break;
@@ -219,4 +222,3 @@ public class FilterViewHolderCreator {
     }
 
 }
-

--- a/main/src/cgeo/geocaching/filters/gui/LogicalFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/LogicalFilterViewHolder.java
@@ -1,0 +1,56 @@
+package cgeo.geocaching.filters.gui;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.filters.core.LogicalGeocacheFilter;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.google.android.material.button.MaterialButton;
+import org.apache.commons.lang3.StringUtils;
+
+public class LogicalFilterViewHolder extends BaseFilterViewHolder<LogicalGeocacheFilter> {
+
+    private LogicalGeocacheFilter filter;
+    private TextView textView;
+
+    @Override
+    public View createView() {
+        final LinearLayout ll = new LinearLayout(getActivity());
+        ll.setOrientation(LinearLayout.VERTICAL);
+
+        final LayoutInflater inflater = LayoutInflater.from(getActivity());
+
+        final View infoLine = inflater.inflate(R.layout.checkbox_item, ll, false);
+        ((ImageView) infoLine.findViewById(R.id.item_icon)).setImageResource(R.drawable.ic_menu_filter);
+        infoLine.findViewById(R.id.item_checkbox).setVisibility(View.GONE);
+        textView = infoLine.findViewById(R.id.item_text);
+        ll.addView(infoLine);
+
+        final MaterialButton modify = (MaterialButton) inflater.inflate(R.layout.button_view, ll, false);
+        modify.setText(R.string.cache_filter_nested_filter_modify);
+        modify.setOnClickListener(v -> ((GeocacheFilterActivity) getActivity()).selectNestedFilter(this));
+        ll.addView(modify);
+
+        // restore state
+        setViewFromFilter(createFilterFromView());
+
+        return ll;
+    }
+
+    @Override
+    public void setViewFromFilter(final LogicalGeocacheFilter filter) {
+        this.filter = filter != null ? filter : createFilter();
+        final String text = this.filter.toUserDisplayableString(0);
+        textView.setText(StringUtils.isNotBlank(text) ? text : getActivity().getString(R.string.cache_filter_nested_filter_empty_filterconfic));
+    }
+
+    @Override
+    public LogicalGeocacheFilter createFilterFromView() {
+        return filter;
+    }
+
+}

--- a/main/src/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/cgeo/geocaching/utils/SystemInformation.java
@@ -22,7 +22,6 @@ import cgeo.geocaching.storage.FolderUtils;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.storage.PersistableUri;
-import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.TRANSIENT;
 
 import android.Manifest;
 import android.content.Context;
@@ -153,7 +152,7 @@ public final class SystemInformation {
 
     private static void appendFilters(@NonNull final StringBuilder body) {
         for (GeocacheFilterContext.FilterType filterType : GeocacheFilterContext.FilterType.values()) {
-            if (TRANSIENT.equals(filterType)) {
+            if (filterType == GeocacheFilterContext.FilterType.TRANSIENT) {
                 continue;
             }
             body.append("\n- ").append(filterType.name()).append(": ");


### PR DESCRIPTION
Advantage: Users can now combine `AND` and `OR` within one filter.

- Fix #11275
- Fixes #12090 implicitly as well

|Normal "toplevel" filter|Sub-filter|
-|-
![grafik](https://user-images.githubusercontent.com/64581222/168026536-5b96e4d3-e0dc-4699-8074-61c8971dbe9c.png)|![grafik](https://user-images.githubusercontent.com/64581222/168026623-402f41fc-5678-4a50-a106-c15af70e0b8a.png)

This example will evaluate to `([:inconclusive=false:advanced=true]AND(OR(difficulty_terrain:d=-:d=3.0:t=-:t=3.0;status:found_yes);type:TRADITIONAL))`

There is no limit how deep a filter can be nested, so users can get really creative. ;-)
Example (build with the new UI): `([:inconclusive=false:advanced=true]AND(OR(NOT(AND(name::contains)))))`

Sidenote: This was rather easy to implement, as the backend luckily had already supported the parsing of nested filters. Only the frontend was missing until now. 