### PR TITLE
add count on friends/own logs tab

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2605,6 +2605,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 title += " (" + this.imageGallery.getCount() + ")";
             }
             return  title;
+        }  else if (pageId == Page.LOGSFRIENDS.id) {
+            final int logCount = cache == null ? 0 : cache.getFriendsLogs().size();
+            return this.getString(Page.LOGSFRIENDS.titleStringId) + " (" + logCount + ")";
         }
         return this.getString(Page.find(pageId).titleStringId);
     }


### PR DESCRIPTION
add the count of friends/own logs on that tab

Variables, waypoints and images tabs already have the count - friends/own logs tab shouldn't be discriminated against ;-)