### PR TITLE
introduce a new setting key for the extended "long tap on map" and update strings

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -207,7 +207,7 @@
     <string translatable="false" name="pref_dtMarkerOnCacheIcon">pref_dtMarkerOnCacheIcon</string>
 
     <!-- category map behavior -->
-    <string translatable="false" name="pref_longTapOnMapActivated">pref_longTapCreateUDC</string>
+    <string translatable="false" name="pref_longTapOnMap">pref_longTapOnMap</string>
 
     <!-- category proximity notfication -->
     <string translatable="false" name="pref_proximityDistanceFar">pref_proximityDistanceFar</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1468,9 +1468,9 @@
     <string name="internal_goto_targets_title">\'Go to\' targets</string>
     <string name="internal_goto_targets_description">This cache stores your recent \"Go to\" targets. It is automatically created once you have used the \"Go to\" function in the main menu. The coordinates entered there will be stored into waypoints of this cache. If you do no longer need these coordinates you can safely delete this cache or any of its waypoints. Also you can move the cache to any other list of your choice.</string>
     <string name="init_longtap_map">Long tap on map</string>
-    <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache)</string>
-    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings → Map → Map behavior</string>
-    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings → Map → Map behavior</string>
+    <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache / waypoint)</string>
+    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches and waypoints.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings → Map → Map behavior</string>
+    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches and waypoints.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings → Map → Map behavior</string>
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1469,8 +1469,8 @@
     <string name="internal_goto_targets_description">This cache stores your recent \"Go to\" targets. It is automatically created once you have used the \"Go to\" function in the main menu. The coordinates entered there will be stored into waypoints of this cache. If you do no longer need these coordinates you can safely delete this cache or any of its waypoints. Also you can move the cache to any other list of your choice.</string>
     <string name="init_longtap_map">Long tap on map</string>
     <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache / waypoint)</string>
-    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches and waypoints.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings → Map → Map behavior</string>
-    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches and waypoints.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings → Map → Map behavior</string>
+    <string name="onetime_info_longtap_disabled">By long tapping on map you can create individual routes and user-defined caches / waypoints.\n\nLong tap on map is currently disabled.\n\nYou can change this in Settings → Map → Map behavior</string>
+    <string name="onetime_info_longtap_enabled">By long tapping on map you can create individual routes and user-defined caches / waypoints.\n\nLong tap on map is currently enabled.\n\nYou can change this in Settings → Map → Map behavior</string>
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -148,7 +148,7 @@
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:defaultValue="true"
-            android:key="@string/pref_longTapOnMapActivated"
+            android:key="@string/pref_longTapOnMap"
             android:summary="@string/init_summary_longtap_map"
             android:title="@string/init_longtap_map"
             app:iconSpaceReserved="false" />

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1406,7 +1406,7 @@ public class Settings {
     }
 
     public static boolean isLongTapOnMapActivated() {
-        return getBoolean(R.string.pref_longTapOnMapActivated, true);
+        return getBoolean(R.string.pref_longTapOnMap, true);
     }
 
     public static boolean getCreateUDCuseGivenList() {


### PR DESCRIPTION
Introduce a new setting key for the now extended setting (https://github.com/moving-bits/cgeo/commit/5a2b8097dfec1544051f68c6e5936b503640ee9d) to avoid update-problems described in #12821

Also rename the strings to include "waypoints" which are now affected by this

fixes #12821