### PR TITLE
add bearing indicator for VTM/UnifiedMap (fix #12925)

### DIFF
--- a/main/res/drawable/bearing_indicator.xml
+++ b/main/res/drawable/bearing_indicator.xml
@@ -1,0 +1,28 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#ffffff"
+      android:strokeColor="#ccb8b8b8"
+      android:fillAlpha="0.7529412"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12.0005,3.5156 L8.9029,12H11.1997A0.8,0.8 0,0 1,12.0005 11.1992,0.8 0.8,0 0,1 12.8013,12h2.2969z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1"
+      android:fillColor="#c62828"
+      android:strokeColor="#00000000"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="M8.9023,12L12,20.4844L15.0977,12L12.8008,12A0.8,0.8 0,0 1,12 12.8008A0.8,0.8 0,0 1,11.1992 12L8.9023,12z"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1"
+      android:fillColor="#666666"
+      android:strokeColor="#00000000"
+      android:strokeLineCap="butt"/>
+</vector>

--- a/main/res/layout/map_bearingindicator.xml
+++ b/main/res/layout/map_bearingindicator.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/bearingIndicator"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginLeft="6dp"
+        android:layout_marginTop="6dp"
+        android:scaleType="center"
+        android:layout_gravity="center"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true" />
+
+</RelativeLayout>

--- a/main/res/layout/unifiedmap_mapsforgevtm.xml
+++ b/main/res/layout/unifiedmap_mapsforgevtm.xml
@@ -16,6 +16,7 @@
             android:layout_width="fill_parent"
             android:layout_height="fill_parent" />
 
+        <include layout="@layout/map_bearingindicator" />
         <include layout="@layout/map_distanceinfo" />
         <include layout="@layout/map_settings_button" />
         <include layout="@layout/map_progressbar" />

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
@@ -21,6 +21,7 @@ public abstract class AbstractUnifiedMapView<T> {
     protected int delayedZoomTo = -1;
     protected Geopoint delayedCenterTo = null;
     protected Runnable onMapReadyTasks = null;
+    protected boolean usesOwnBearingIndicator = true;
 
     public void init(final AppCompatActivity activity, final int delayedZoomTo, @Nullable final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         mapRotation = Settings.getMapRotation();

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
@@ -58,6 +58,7 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
         mMapView = activity.findViewById(R.id.mapViewVTM);
         mMap = mMapView.map();
         setMapRotation(mapRotation);
+        usesOwnBearingIndicator = false; // let UnifiedMap handle bearing indicator
         activity.findViewById(R.id.map_zoomin).setOnClickListener(v -> zoomInOut(true));
         activity.findViewById(R.id.map_zoomout).setOnClickListener(v -> zoomInOut(false));
         themeHelper = new MapsforgeThemeHelper(activity);


### PR DESCRIPTION
## Description
Display a bearing indicator on UnifiedMap VTM, if bearing != 0.
Tapping on bearing indicator resets bearing to 0 (and hides bearing indicator until bearing != 0).

## Additional context
![image](https://user-images.githubusercontent.com/3754370/169666461-69501696-363f-42f2-904a-44811602bb5d.png)
