### PR TITLE
support setting found state for UnknownConnector (fix #13029)

### DIFF
--- a/main/src/cgeo/geocaching/connector/unknown/UnknownConnector.java
+++ b/main/src/cgeo/geocaching/connector/unknown/UnknownConnector.java
@@ -56,4 +56,8 @@ public class UnknownConnector extends AbstractConnector {
         return null;
     }
 
+    @Override
+    public boolean supportsSettingFoundState() {
+        return true;
+    }
 }


### PR DESCRIPTION
## Description
Activates setting found state for UnknownConnector (which gets triggered for all caches not related to one of the other connectors, thus especially for caches imported via Lab2Gpx when using one of the "free" prefixes)
