### PR TITLE
Make activity stack broadcasts local

### DIFF
--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -150,16 +150,16 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
             throw e;
         }
         onCreateCommon();
-        registerReceiver(finisBroadcastReceiver, new IntentFilter(ACTION_CLEAR_BACKSTACK));
+        LocalBroadcastManager.getInstance(this).registerReceiver(finisBroadcastReceiver, new IntentFilter(ACTION_CLEAR_BACKSTACK));
     }
 
     public void clearBackStack() {
-        sendBroadcast(new Intent(ACTION_CLEAR_BACKSTACK));
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ACTION_CLEAR_BACKSTACK));
     }
 
     @Override
     protected void onDestroy() {
-        unregisterReceiver(finisBroadcastReceiver);
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(finisBroadcastReceiver);
         super.onDestroy();
     }
 


### PR DESCRIPTION
I noticed that using normal broadcasts to manipulate our activity stack isn't a good idea. Broadcasts are global, thus every app could theoretically listen to whether a user currently navigates in c:geo (→ privacy issue) and - IMHO even worse - kill cgeo at any time by sending this broadcast. 

This security fix should be included into the beta.