### PR TITLE
fix #13050: prevent npe, handle case when backup file can't be opened  for writing

### DIFF
--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -575,6 +575,9 @@ public class BackupUtils {
         try {
 
             final OutputStream os = ContentStorage.get().openForWrite(backupFile);
+            if (os == null) {
+                throw new IOException("Could not open backup file uri for writing:" + backupFile);
+            }
             writer = new OutputStreamWriter(os, StandardCharsets.UTF_8);
 
             final XmlSerializer xmlSerializer = Xml.newSerializer();


### PR DESCRIPTION
fix #13050: prevent npe, handle case when backup file can't be opened  for writing