### PR TITLE
Several extensions to UnifiedMap

### DIFF
--- a/main/res/menu/map_downloader.xml
+++ b/main/res/menu/map_downloader.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+
+    <group
+        android:id="@+id/menu_group_map_sources"
+        android:checkableBehavior="single" >
+    </group>
+    <item
+        android:id="@+id/menu_download_offlinemap"
+        android:visible="false" />
+</menu>

--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -232,6 +232,7 @@
 
     <!-- category other -->
     <string translatable="false" name="pref_map_osm_multithreaded">map_osm_multithreaded</string>
+    <string translatable="false" name="pref_useUnifiedMap">useUnifiedMap</string>
 
 
     <!-- ============================================================================================================================================================================== -->

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1075,6 +1075,8 @@
     <string name="init_map_other">Other</string>
     <string name="init_map_osm_multithreaded">Multi-threaded (OSM)</string>
     <string name="init_summary_map_osm_multithreaded">Use multiple threads to render OpenStreetMap maps</string>
+    <string name="init_title_useUnifiedMap">Use unified map</string>
+    <string name="init_summary_useUnifiedMap">Use new unified map instead of built-in Google Map / Mapsforge (OSM) maps (experimental / far from being complete / for testing only)</string>
     <string name="localstorage_migrate_title">Migration of local files</string>
     <string name="localstorage_migrate_status_major">Version %1$d</string>
 

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -326,5 +326,11 @@
             android:summary="@string/init_summary_map_osm_multithreaded"
             android:title="@string/init_map_osm_multithreaded"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_useUnifiedMap"
+            android:summary="@string/init_summary_useUnifiedMap"
+            android:title="@string/init_title_useUnifiedMap"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/main/src/cgeo/geocaching/downloader/ReceiveDownloadService.java
+++ b/main/src/cgeo/geocaching/downloader/ReceiveDownloadService.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.ui.notifications.NotificationChannels;
 import cgeo.geocaching.ui.notifications.Notifications;
+import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.FileNameCreator;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Formatter;
@@ -172,6 +173,7 @@ public class ReceiveDownloadService extends AbstractForegroundIntentService {
                 if (downloader.useCompanionFiles && StringUtils.isNotBlank(sourceURL)) {
                     CompanionFileUtils.writeInfo(sourceURL, filename, CompanionFileUtils.getDisplayName(fileinfo), sourceDate, offlineMapTypeId);
                 }
+                TileProviderFactory.buildTileProviderList(true);
                 break;
             case CANCELLED:
                 result = getString(R.string.receivedownload_cancelled);

--- a/main/src/cgeo/geocaching/maps/CacheMarker.java
+++ b/main/src/cgeo/geocaching/maps/CacheMarker.java
@@ -1,17 +1,26 @@
 package cgeo.geocaching.maps;
 
-
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
-
 
 public class CacheMarker {
 
     private final int hashCode;
     protected final Drawable drawable;
+    protected final Bitmap bitmap;
 
     public CacheMarker(final int hashCode, final Drawable drawable) {
         this.hashCode = hashCode;
         this.drawable = drawable;
+
+        // prepare bitmap from drawable (used as map markers)
+        int width = drawable.getIntrinsicWidth();
+        int height = drawable.getIntrinsicHeight();
+        bitmap = android.graphics.Bitmap.createBitmap(width, height, android.graphics.Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
     }
 
     /**
@@ -25,6 +34,10 @@ public class CacheMarker {
 
     public Drawable getDrawable() {
         return drawable;
+    }
+
+    public Bitmap getBitmap() {
+        return bitmap;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/maps/CacheMarker.java
+++ b/main/src/cgeo/geocaching/maps/CacheMarker.java
@@ -15,10 +15,8 @@ public class CacheMarker {
         this.drawable = drawable;
 
         // prepare bitmap from drawable (used as map markers)
-        int width = drawable.getIntrinsicWidth();
-        int height = drawable.getIntrinsicHeight();
-        bitmap = android.graphics.Bitmap.createBitmap(width, height, android.graphics.Bitmap.Config.ARGB_8888);
-        Canvas canvas = new Canvas(bitmap);
+        bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        final Canvas canvas = new Canvas(bitmap);
         drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
         drawable.draw(canvas);
     }

--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -6,6 +6,8 @@ import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.unifiedmap.UnifiedMapType;
+import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
 import android.content.Context;
@@ -34,33 +36,68 @@ public final class DefaultMap {
     }
 
     public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Waypoint waypoint) {
-        new MapOptions(waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName(), waypoint.getGeocode()).startIntent(fromActivity, cls);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in waypoint mode (1)");
+            new UnifiedMapType(waypoint.getGeocode()).launchMap(fromActivity);
+        } else {
+            new MapOptions(waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName(), waypoint.getGeocode()).startIntent(fromActivity, cls);
+        }
     }
 
     public static void startActivityCoords(final Context fromActivity, final Waypoint waypoint) {
-        startActivityCoords(fromActivity, getDefaultMapClass(), waypoint);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in waypoint mode (2)");
+            new UnifiedMapType(waypoint.getGeocode()).launchMap(fromActivity);
+        } else {
+            startActivityCoords(fromActivity, getDefaultMapClass(), waypoint);
+        }
     }
 
     public static void startActivityCoords(final Activity fromActivity, final Geopoint coords) {
-        startActivityCoords(fromActivity, getDefaultMapClass(), coords, null);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in coords mode");
+            new UnifiedMapType(coords).launchMap(fromActivity);
+        } else {
+            startActivityCoords(fromActivity, getDefaultMapClass(), coords, null);
+        }
     }
 
     public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Geopoint coords, final WaypointType type) {
-        new MapOptions(coords, type).startIntent(fromActivity, cls);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in coords with WaypointType mode");
+            new UnifiedMapType(coords).launchMap(fromActivity);
+        } else {
+            new MapOptions(coords, type).startIntent(fromActivity, cls);
+        }
     }
 
     public static void startActivityInitialCoords(final Context fromActivity, final Geopoint coords) {
-        new MapOptions(coords).startIntent(fromActivity, getDefaultMapClass());
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in coords mode");
+            new UnifiedMapType(coords).launchMap(fromActivity);
+        } else {
+            new MapOptions(coords).startIntent(fromActivity, getDefaultMapClass());
+        }
     }
 
     public static void startActivityGeoCode(final Context fromActivity, final Class<?> cls, final String geocode) {
-        final MapOptions mo = new MapOptions(geocode);
-        mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
-        mo.startIntent(fromActivity, cls);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in geocode mode");
+            new UnifiedMapType(geocode).launchMap(fromActivity);
+        } else {
+            final MapOptions mo = new MapOptions(geocode);
+            mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
+            mo.startIntent(fromActivity, cls);
+        }
     }
 
     public static void startActivityGeoCode(final Activity fromActivity, final String geocode) {
-        startActivityGeoCode(fromActivity, getDefaultMapClass(), geocode);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in geocode mode");
+            new UnifiedMapType(geocode).launchMap(fromActivity);
+        } else {
+            startActivityGeoCode(fromActivity, getDefaultMapClass(), geocode);
+        }
     }
 
     public static void startActivitySearch(final Activity fromActivity, final Class<?> cls, final SearchResult search, final String title, final int fromList) {

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1177,6 +1177,10 @@ public class Settings {
         return StringUtils.isBlank(language) ? MAP_LANGUAGE_DEFAULT_ID : language.hashCode();
     }
 
+    public static boolean useUnifiedMap() {
+        return getBoolean(R.string.pref_useUnifiedMap, false);
+    }
+
     public static void setMapDownloaderSource(final int source) {
         putInt(R.string.pref_mapdownloader_source, source);
     }

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -77,10 +77,9 @@ public class PreferenceMapFragment extends BasePreferenceFragment {
         });
 
         // display checkbox pref for unified map, if showUnifiedMap is enabled
-        Preference p = findPreference(activity.getString(R.string.pref_useUnifiedMap));
-        boolean showUnifiedMap = Settings.getBoolean(R.string.pref_showUnifiedMap, false);
+        final Preference p = findPreference(activity.getString(R.string.pref_useUnifiedMap));
         if (p != null) {
-            p.setVisible(showUnifiedMap);
+            p.setVisible(Settings.getBoolean(R.string.pref_showUnifiedMap, false));
         }
     }
 

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 
 import androidx.preference.ListPreference;
 import androidx.preference.MultiSelectListPreference;
+import androidx.preference.Preference;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -74,6 +75,13 @@ public class PreferenceMapFragment extends BasePreferenceFragment {
             MapMarkerUtils.clearCachedItems();
             return true;
         });
+
+        // display checkbox pref for unified map, if showUnifiedMap is enabled
+        Preference p = findPreference(activity.getString(R.string.pref_useUnifiedMap));
+        boolean showUnifiedMap = Settings.getBoolean(R.string.pref_showUnifiedMap, false);
+        if (p != null) {
+            p.setVisible(showUnifiedMap);
+        }
     }
 
     /**

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
@@ -1,13 +1,13 @@
 package cgeo.geocaching.unifiedmap;
 
-import androidx.annotation.Nullable;
-
-import java.util.HashMap;
-
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
+
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
 
 public abstract class AbstractGeoitemLayer<T> {
 
@@ -17,7 +17,7 @@ public abstract class AbstractGeoitemLayer<T> {
     protected abstract T add(Geocache cache);
 
     @Nullable
-    T add(String geocode) {
+    T add(final String geocode) {
         final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);  // @todo check load flags
         if (cache == null) {
             return null;
@@ -32,7 +32,7 @@ public abstract class AbstractGeoitemLayer<T> {
     }
 
     /** removes item from internal data structure, needs to be removed from actual layer by superclass */
-    protected void remove(String geocode) {
+    protected void remove(final String geocode) {
         synchronized (items) {
             items.remove(geocode);
         }

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
@@ -1,0 +1,41 @@
+package cgeo.geocaching.unifiedmap;
+
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.DataStore;
+
+public abstract class AbstractGeoitemLayer<T> {
+
+    protected final HashMap<String, T> items = new HashMap<>();
+
+    @Nullable
+    protected abstract T add(Geocache cache);
+
+    @Nullable
+    T add(String geocode) {
+        final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);  // @todo check load flags
+        if (cache == null) {
+            return null;
+        }
+
+        final Geopoint coords = cache.getCoords();
+        if (coords == null) {
+            return null;
+        }
+
+        return add(cache);
+    }
+
+    /** removes item from internal data structure, needs to be removed from actual layer by superclass */
+    protected void remove(String geocode) {
+        synchronized (items) {
+            items.remove(geocode);
+        }
+    };
+
+}

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
@@ -74,6 +74,8 @@ public abstract class AbstractUnifiedMapView<T> {
         }
     }
 
+    abstract protected AbstractGeoitemLayer createGeoitemLayers(AbstractTileProvider tileProvider);
+
     // ========================================================================
     // theme related methods
 

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
@@ -74,7 +74,7 @@ public abstract class AbstractUnifiedMapView<T> {
         }
     }
 
-    abstract protected AbstractGeoitemLayer createGeoitemLayers(AbstractTileProvider tileProvider);
+    protected abstract AbstractGeoitemLayer createGeoitemLayers(AbstractTileProvider tileProvider);
 
     // ========================================================================
     // theme related methods

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -55,6 +55,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
     private static final String STATE_ROUTETRACKUTILS = "routetrackutils";
     private static final String BUNDLE_ROUTE = "route";
+    private static final String BUNDLE_MAPTYPE = "maptype";
 
     private static final String ROUTING_SERVICE_KEY = "UnifiedMap";
 
@@ -68,6 +69,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     private IndividualRoute individualRoute = null;
     private Tracks tracks = null;
     private UnifiedMapPosition currentMapPosition = new UnifiedMapPosition();
+    private UnifiedMapType mapType = null;
 
     // rotation indicator
     protected Bitmap rotationIndicator = ImageUtils.convertToBitmap(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.bearing_indicator, null));
@@ -173,7 +175,9 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
         // Get fresh map information from the bundle if any
         if (savedInstanceState != null) {
-//            mapOptions.mapState = savedInstanceState.getParcelable(BUNDLE_MAP_STATE);
+            if (savedInstanceState.containsKey(BUNDLE_MAPTYPE)) {
+                mapType = savedInstanceState.getParcelable(BUNDLE_MAPTYPE);
+            }
 //            proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
             individualRoute = savedInstanceState.getParcelable(BUNDLE_ROUTE);
 //            followMyLocation = mapOptions.mapState.followsMyLocation();
@@ -185,6 +189,10 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 //            }
             individualRoute = null;
 //            proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
+        }
+        // make sure we have a defined mapType
+        if (mapType == null || mapType.type == UnifiedMapType.UnifiedMapTypeType.UMTT_Undefined) {
+            mapType = UnifiedMapType.getPlainMap();
         }
 
         Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true));
@@ -480,7 +488,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         outState.putBundle(STATE_ROUTETRACKUTILS, routeTrackUtils.getState());
 
 //        final MapState state = prepareMapState();
-//        outState.putParcelable(BUNDLE_MAP_STATE, state);
+        outState.putParcelable(BUNDLE_MAPTYPE, mapType);
 //        if (proximityNotification != null) {
 //            outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
 //        }

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -43,11 +43,14 @@ import android.graphics.Bitmap;
 import android.graphics.Matrix;
 import android.location.Location;
 import android.os.Bundle;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.PopupMenu;
 import androidx.core.content.res.ResourcesCompat;
 
 import java.lang.ref.WeakReference;
@@ -439,7 +442,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         TileProviderFactory.addMapViewLanguageMenuItems(menu);
         this.routeTrackUtils.onPrepareOptionsMenu(menu, findViewById(R.id.container_individualroute), individualRoute, tracks);
         ViewUtils.extendMenuActionBarDisplayItemCount(this, menu);
-        
+
         // map rotation state
         menu.findItem(R.id.menu_map_rotation).setVisible(true); // @todo: can be visible always when CGeoMap/NewMap is removed
         final int mapRotation = Settings.getMapRotation();
@@ -469,8 +472,6 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     public boolean onCreateOptionsMenu(@NonNull final Menu menu) {
         final boolean result = super.onCreateOptionsMenu(menu);
         getMenuInflater().inflate(R.menu.map_activity, menu);
-
-        TileProviderFactory.addMapviewMenuItems(this, menu);
 
         followMyLocationItem = menu.findItem(R.id.menu_toggle_mypos);
         initFollowMyLocationButton();
@@ -517,6 +518,16 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
             // RenderThemeLegend.showLegend(this, this.renderThemeHelper, mapView.getModel().displayModel);
         } else if (id == R.id.menu_routetrack) {
             routeTrackUtils.showPopup(individualRoute, this::setTarget);
+        } else if (id == R.id.menu_select_mapview) {
+            // dynamically create submenu to reflect possible changes in map sources
+            final View v = findViewById(R.id.menu_select_mapview);
+            if (v != null) {
+                final PopupMenu menu = new PopupMenu(this, v, Gravity.TOP);
+                menu.inflate(R.menu.map_downloader);
+                TileProviderFactory.addMapviewMenuItems(this, menu);
+                menu.setOnMenuItemClickListener(this::onOptionsItemSelected);
+                menu.show();
+            }
         } else {
             final String language = TileProviderFactory.getLanguage(id);
             if (language != null || id == MAP_LANGUAGE_DEFAULT_ID) {

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -178,7 +178,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         super.onCreate(savedInstanceState);
 
         // get data from intent
-        Bundle extras = getIntent().getExtras();
+        final Bundle extras = getIntent().getExtras();
         if (extras != null) {
             mapType = extras.getParcelable(BUNDLE_MAPTYPE);
         }
@@ -253,12 +253,12 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
             geoitemLayer = tileProvider.getMap().createGeoitemLayers(tileProvider);
 
             // react to mapType
-            switch(mapType.type) {
+            switch (mapType.type) {
                 case UMTT_PlainMap:
                     // @todo: set bounds to last known viewport
                     break;
                 case UMTT_TargetGeocode:
-                    Geocache cache = DataStore.loadCache(mapType.target, LoadFlags.LOAD_CACHE_OR_DB);
+                    final Geocache cache = DataStore.loadCache(mapType.target, LoadFlags.LOAD_CACHE_OR_DB);
                     if (cache != null && cache.getCoords() != null) {
                         geoitemLayer.add(cache);
                         tileProvider.getMap().setCenter(cache.getCoords());

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.AngleUtils;
@@ -437,7 +438,8 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         final boolean result = super.onPrepareOptionsMenu(menu);
         TileProviderFactory.addMapViewLanguageMenuItems(menu);
         this.routeTrackUtils.onPrepareOptionsMenu(menu, findViewById(R.id.container_individualroute), individualRoute, tracks);
-
+        ViewUtils.extendMenuActionBarDisplayItemCount(this, menu);
+        
         // map rotation state
         menu.findItem(R.id.menu_map_rotation).setVisible(true); // @todo: can be visible always when CGeoMap/NewMap is removed
         final int mapRotation = Settings.getMapRotation();

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -60,6 +60,8 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     private static final String ROUTING_SERVICE_KEY = "UnifiedMap";
 
     private AbstractTileProvider tileProvider = null;
+    private AbstractGeoitemLayer geoitemLayer = null;
+
     private final UpdateLoc geoDirUpdate = new UpdateLoc(this);
     private final CompositeDisposable resumeDisposables = new CompositeDisposable();
     private static boolean followMyLocation = Settings.isLiveMap();
@@ -236,6 +238,17 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
             // routes / tracks popup
             findViewById(R.id.map_individualroute_popup).setOnClickListener(v -> routeTrackUtils.showPopup(individualRoute, this::setTarget));
+
+            // create geoitem layers
+            geoitemLayer = tileProvider.getMap().createGeoitemLayers(tileProvider);
+            // @todo for testing purposes only
+            if (geoitemLayer != null) {
+                geoitemLayer.add("GC9C8G5");
+                geoitemLayer.add("GC9RZT2");
+                geoitemLayer.add("GC37RRG");
+                geoitemLayer.add("GC360D1");
+                geoitemLayer.add("GC8902H");
+            }
         }
 
         // refresh options menu and routes/tracks display

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -1,11 +1,11 @@
 package cgeo.geocaching.unifiedmap;
 
+import cgeo.geocaching.location.Geopoint;
+
 import android.content.Context;
 import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
-
-import cgeo.geocaching.location.Geopoint;
 
 public class UnifiedMapType implements Parcelable {
 

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -1,47 +1,60 @@
 package cgeo.geocaching.unifiedmap;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-class UnifiedMapType implements Parcelable {
+import cgeo.geocaching.location.Geopoint;
+
+public class UnifiedMapType implements Parcelable {
+
+    public static final String BUNDLE_MAPTYPE = "maptype";
 
     public enum UnifiedMapTypeType {
         UMTT_Undefined,         // invalid state
         UMTT_PlainMap,          // open map (from bottom navigation)
-        UMTT_SetTarget          // set cache or waypoint as target
+        UMTT_TargetGeocode,     // set cache or waypoint as target
+        UMTT_TargetCoords       // set coords as target
         // to be extended
     }
 
-    public UnifiedMapTypeType type;
-    public String target;
+    public UnifiedMapTypeType type = UnifiedMapTypeType.UMTT_Undefined;
+    public String target = null;
+    public Geopoint coords = null;
+    // reminder: add additional fields to parcelable methods below
 
-    /**
-     * initializes a UnifiedMapType object with defaults
-     * (called internally only, use public static methods to create a UnifiedMapType)
-     */
-    private UnifiedMapType() {
-        type = UnifiedMapTypeType.UMTT_Undefined;
-        target = null;
+    /** default UnifiedMapType is PlainMap with no further data */
+    public UnifiedMapType() {
+        type = UnifiedMapTypeType.UMTT_PlainMap;
     }
 
-    public static UnifiedMapType getPlainMap() {
-        UnifiedMapType umt = new UnifiedMapType();
-        umt.type = UnifiedMapTypeType.UMTT_PlainMap;
-        return umt;
+    /** set geocode as target */
+    public UnifiedMapType(final String geocode) {
+        type = UnifiedMapTypeType.UMTT_TargetGeocode;
+        target = geocode;
     }
 
-    public static UnifiedMapType getTarget(final String geocode) {
-        UnifiedMapType umt = new UnifiedMapType();
-        umt.type = UnifiedMapTypeType.UMTT_SetTarget;
-        umt.target = geocode;
-        return umt;
+    /** set coords as target */
+    public UnifiedMapType(final Geopoint coords) {
+        type = UnifiedMapTypeType.UMTT_TargetCoords;
+        this.coords = coords;
     }
 
+    /** launch fresh map with current settings */
+    public void launchMap(final Context fromActivity) {
+        final Intent intent = new Intent(fromActivity, UnifiedMapActivity.class);
+        intent.putExtra(BUNDLE_MAPTYPE, this);
+        fromActivity.startActivity(intent);
+    }
+
+    // ========================================================================
     // parcelable methods
 
     UnifiedMapType(final Parcel in) {
         type = UnifiedMapTypeType.values()[in.readInt()];
         target = in.readString();
+        coords = in.readParcelable(Geopoint.class.getClassLoader());
         // ...
     }
 
@@ -54,6 +67,7 @@ class UnifiedMapType implements Parcelable {
     public void writeToParcel(final Parcel dest, final int flags) {
         dest.writeInt(type.ordinal());
         dest.writeString(target);
+        dest.writeParcelable(coords, 0);
         // ...
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -1,0 +1,72 @@
+package cgeo.geocaching.unifiedmap;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+class UnifiedMapType implements Parcelable {
+
+    public enum UnifiedMapTypeType {
+        UMTT_Undefined,         // invalid state
+        UMTT_PlainMap,          // open map (from bottom navigation)
+        UMTT_SetTarget          // set cache or waypoint as target
+        // to be extended
+    }
+
+    public UnifiedMapTypeType type;
+    public String target;
+
+    /**
+     * initializes a UnifiedMapType object with defaults
+     * (called internally only, use public static methods to create a UnifiedMapType)
+     */
+    private UnifiedMapType() {
+        type = UnifiedMapTypeType.UMTT_Undefined;
+        target = null;
+    }
+
+    public static UnifiedMapType getPlainMap() {
+        UnifiedMapType umt = new UnifiedMapType();
+        umt.type = UnifiedMapTypeType.UMTT_PlainMap;
+        return umt;
+    }
+
+    public static UnifiedMapType getTarget(final String geocode) {
+        UnifiedMapType umt = new UnifiedMapType();
+        umt.type = UnifiedMapTypeType.UMTT_SetTarget;
+        umt.target = geocode;
+        return umt;
+    }
+
+    // parcelable methods
+
+    UnifiedMapType(final Parcel in) {
+        type = UnifiedMapTypeType.values()[in.readInt()];
+        target = in.readString();
+        // ...
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeInt(type.ordinal());
+        dest.writeString(target);
+        // ...
+    }
+
+    public static final Parcelable.Creator<UnifiedMapType> CREATOR = new Parcelable.Creator<UnifiedMapType>() {
+        @Override
+        public UnifiedMapType createFromParcel(final Parcel in) {
+            return new UnifiedMapType(in);
+        }
+
+        @Override
+        public UnifiedMapType[] newArray(final int size) {
+            return new UnifiedMapType[size];
+        }
+    };
+
+}

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -1,0 +1,65 @@
+package cgeo.geocaching.unifiedmap.googlemaps;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.enumerations.CacheListType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.maps.CacheMarker;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
+import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MapMarkerUtils;
+
+import java.lang.ref.WeakReference;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.MarkerOptions;
+
+class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
+
+    WeakReference<GoogleMap> mapRef;
+
+    GoogleGeoitemLayer(GoogleMap map) {
+        this.mapRef = new WeakReference<>(map);
+    }
+
+    @Override
+    protected Marker add(final Geocache cache) {
+        GoogleMap map = mapRef.get();
+        if (map == null) {
+            return null;
+        }
+
+        Geopoint coords = cache.getCoords();
+        CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
+        Marker item = map.addMarker(new MarkerOptions()
+            .position(new LatLng(coords.getLatitude(), coords.getLongitude()))
+            .title(cache.getGeocode())
+            .anchor(0.5f, 1f)
+            .icon(BitmapDescriptorFactory.fromBitmap(cm.getBitmap()))
+        );
+
+        Log.e("addGeoitem");
+        synchronized (items) {
+            items.put(cache.getGeocode(), item);
+        }
+        return item;
+    }
+
+    @Override
+    protected void remove(final String geocode) {
+        GoogleMap map = mapRef.get();
+        if (map != null) {
+            synchronized (items) {
+                Marker item = items.get(geocode);
+                if (item != null) {
+                    item.remove();
+                }
+            }
+        }
+        super.remove(geocode);
+    }
+
+}

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -21,20 +21,20 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
 
     WeakReference<GoogleMap> mapRef;
 
-    GoogleGeoitemLayer(GoogleMap map) {
+    GoogleGeoitemLayer(final GoogleMap map) {
         this.mapRef = new WeakReference<>(map);
     }
 
     @Override
     protected Marker add(final Geocache cache) {
-        GoogleMap map = mapRef.get();
+        final GoogleMap map = mapRef.get();
         if (map == null) {
             return null;
         }
 
-        Geopoint coords = cache.getCoords();
-        CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
-        Marker item = map.addMarker(new MarkerOptions()
+        final Geopoint coords = cache.getCoords();
+        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
+        final Marker item = map.addMarker(new MarkerOptions()
             .position(new LatLng(coords.getLatitude(), coords.getLongitude()))
             .title(cache.getGeocode())
             .anchor(0.5f, 1f)
@@ -50,10 +50,10 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
 
     @Override
     protected void remove(final String geocode) {
-        GoogleMap map = mapRef.get();
+        final GoogleMap map = mapRef.get();
         if (map != null) {
             synchronized (items) {
-                Marker item = items.get(geocode);
+                final Marker item = items.get(geocode);
                 if (item != null) {
                     item.remove();
                 }

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.google.v2.GoogleGeoPoint;
 import cgeo.geocaching.maps.google.v2.GoogleMapController;
+import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.unifiedmap.AbstractPositionLayer;
 import cgeo.geocaching.unifiedmap.AbstractUnifiedMapView;
 import cgeo.geocaching.unifiedmap.UnifiedMapPosition;
@@ -90,6 +91,11 @@ public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements On
         setMapRotation(mapRotation);
         positionLayer = configPositionLayer(true);
         onMapReadyTasks.run();
+    }
+
+    @Override
+    protected AbstractGeoitemLayer createGeoitemLayers(final AbstractTileProvider tileProvider) {
+        return new GoogleGeoitemLayer(mMap);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
@@ -1,0 +1,67 @@
+package cgeo.geocaching.unifiedmap.mapsforgevtm;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.CacheListType;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.maps.CacheMarker;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
+import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
+import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MapMarkerUtils;
+
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+
+import org.oscim.android.canvas.AndroidBitmap;
+import org.oscim.backend.canvas.Bitmap;
+import org.oscim.core.GeoPoint;
+import org.oscim.layers.marker.ItemizedLayer;
+import org.oscim.layers.marker.MarkerItem;
+import org.oscim.layers.marker.MarkerSymbol;
+import org.oscim.map.Map;
+
+class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
+
+    ItemizedLayer mMarkerLayer;
+    MarkerSymbol mDefaultMarkerSymbol;
+
+    MapsforgeGeoitemLayer(final AbstractTileProvider tileProvider, final Map map) {
+        Bitmap bitmap = new AndroidBitmap(BitmapFactory.decodeResource(CgeoApplication.getInstance().getResources(), R.drawable.cgeo_notification));
+        mDefaultMarkerSymbol = new MarkerSymbol(bitmap, MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
+        mMarkerLayer = new ItemizedLayer(map, mDefaultMarkerSymbol);
+        ((MapsforgeVtmView) tileProvider.getMap()).addLayer(mMarkerLayer);
+        Log.e("addGeoitemLayer");
+    }
+
+    @Override
+    protected MarkerItem add(final Geocache cache) {
+        Geopoint coords = cache.getCoords();
+        final MarkerItem item = new MarkerItem(cache.getGeocode(), "", new GeoPoint(coords.getLatitudeE6(), coords.getLongitudeE6())); // @todo add marker touch handling
+
+        CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
+        MarkerSymbol symbol = new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
+        item.setMarker(symbol);
+        mMarkerLayer.addItem(item);
+        Log.e("addGeoitem");
+        synchronized (items) {
+            items.put(cache.getGeocode(), item);
+        }
+        return item;
+    }
+
+    @Override
+    protected void remove(final String geocode) {
+        if (mMarkerLayer != null) {
+            final MarkerItem item;
+            synchronized (items) {
+                item = items.get(geocode);
+            }
+            if (item != null) {
+                mMarkerLayer.removeItem(item);
+            }
+        }
+        super.remove(geocode);
+    }
+}

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
@@ -12,7 +12,6 @@ import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 
 import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
 
 import org.oscim.android.canvas.AndroidBitmap;
 import org.oscim.backend.canvas.Bitmap;
@@ -28,7 +27,7 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
     MarkerSymbol mDefaultMarkerSymbol;
 
     MapsforgeGeoitemLayer(final AbstractTileProvider tileProvider, final Map map) {
-        Bitmap bitmap = new AndroidBitmap(BitmapFactory.decodeResource(CgeoApplication.getInstance().getResources(), R.drawable.cgeo_notification));
+        final Bitmap bitmap = new AndroidBitmap(BitmapFactory.decodeResource(CgeoApplication.getInstance().getResources(), R.drawable.cgeo_notification));
         mDefaultMarkerSymbol = new MarkerSymbol(bitmap, MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
         mMarkerLayer = new ItemizedLayer(map, mDefaultMarkerSymbol);
         ((MapsforgeVtmView) tileProvider.getMap()).addLayer(mMarkerLayer);
@@ -37,11 +36,11 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
 
     @Override
     protected MarkerItem add(final Geocache cache) {
-        Geopoint coords = cache.getCoords();
+        final Geopoint coords = cache.getCoords();
         final MarkerItem item = new MarkerItem(cache.getGeocode(), "", new GeoPoint(coords.getLatitudeE6(), coords.getLongitudeE6())); // @todo add marker touch handling
 
-        CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
-        MarkerSymbol symbol = new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
+        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
+        final MarkerSymbol symbol = new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
         item.setMarker(symbol);
         mMarkerLayer.addItem(item);
         Log.e("addGeoitem");

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.unifiedmap.AbstractPositionLayer;
 import cgeo.geocaching.unifiedmap.AbstractUnifiedMapView;
 import cgeo.geocaching.unifiedmap.UnifiedMapPosition;
@@ -145,6 +146,11 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
             }
         }
         baseMap = null;
+    }
+
+    @Override
+    protected AbstractGeoitemLayer createGeoitemLayers(final AbstractTileProvider tileProvider) {
+        return new MapsforgeGeoitemLayer(tileProvider, mMap);
     }
 
     private void startMap() {

--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -21,6 +21,7 @@ import android.view.SubMenu;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.PopupMenu;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,8 +50,8 @@ public class TileProviderFactory {
         return Holder.INSTANCE;
     }
 
-    public static void addMapviewMenuItems(final Activity activity, final Menu menu) {
-        final SubMenu parentMenu = menu.findItem(R.id.menu_select_mapview).getSubMenu();
+    public static void addMapviewMenuItems(final Activity activity, final PopupMenu menu) {
+        final Menu parentMenu = menu.getMenu();
 
         final int currentTileProvider = Settings.getTileProvider().getNumericalId();
         final Set<String> hideTileproviders = Settings.getHideTileproviders();
@@ -77,7 +78,7 @@ public class TileProviderFactory {
         return tileProviders;
     }
 
-    private static void buildTileProviderList(final boolean force) {
+    public static void buildTileProviderList(final boolean force) {
         if (!(tileProviders.isEmpty() || force)) {
             return;
         }


### PR DESCRIPTION
## Description
- define `UnifiedMapType` for transmitting and storing map type state (rel. to #13041)
- add global integration setting for `UnifiedMap` (rel. to #12975) - adds checkbox entry (`useUnifiedMap`) to Settings => Map, when setting `showUnifiedMap` is true; can be used as switch for `CacheDetailActivity` and others to switch between map implementations
- add `UnifiedGeoitemLayer` as prerequisite to display geoitems (caches so far) (rel. to #12928)
- display a single cache (including its overlays) on the map, activated via cache details => navigate => map (rel. to #12926)
- allow more toolbar icons (fix #13066)
- add downloaded map to selection (fix #13067)