### PR TITLE
show only logtypes that are available online

### DIFF
--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -147,6 +147,8 @@ public class LogCacheActivity extends AbstractLoggingActivity {
         if (loggingManager.getPossibleLogTypes().isEmpty()) {
             showErrorLoadingData();
             return;
+        } else {
+            logType.setValues(loggingManager.getPossibleLogTypes());
         }
 
         refreshGui();


### PR DESCRIPTION
we're currently using only the cache type, status and connector to determine the available log types.
This leads to situations where more log types are available in c:geo than on the platform, e.g. archived events (https://github.com/cgeo/cgeo/issues/13080) but also normal GC caches where c:geo shows 5 logtypes, including NM and NA - which on GC are only available as a "report problem" option.

This PR updates the list of available log types to match what's available online.