### PR TITLE
Make SpeechService more robust against getting killed 

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2147,6 +2147,7 @@
     <string name="tts_toggle">Toggle talking</string>
     <string name="tts_started">Started speech</string>
     <string name="tts_stopped">Stopped speech</string>
+    <string name="tts_running">Speech service is running…</string>
     <string name="err_tts_lang_not_supported">The current language is not supported by text-to-speech.</string>
     <string name="tts_one_kilometer">one kilometer</string>
     <plurals name="tts_kilometers">

--- a/main/src/cgeo/geocaching/service/AbstractForegroundIntentService.java
+++ b/main/src/cgeo/geocaching/service/AbstractForegroundIntentService.java
@@ -35,7 +35,7 @@ public abstract class AbstractForegroundIntentService extends IntentService {
         final PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
         wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "cgeo:" + logTag);
         wakeLock.acquire(wakelockTimeout); // set timeout in case something got really wrong. Will be released earlier if work is done.
-        Log.v(logTag + " - WakeLock acquired");
+        Log.w(logTag + " - WakeLock acquired");
 
         notificationManager = Notifications.getNotificationManager(this);
         notification = createInitialNotification();
@@ -46,10 +46,10 @@ public abstract class AbstractForegroundIntentService extends IntentService {
 
     @Override
     public void onDestroy() {
-        super.onDestroy();
         Log.v(logTag + ".onDestroy");
         wakeLock.release();
-        Log.v(logTag + " - WakeLock released");
+        Log.w(logTag + " - WakeLock released");
+        super.onDestroy();
     }
 
     protected void updateForegroundNotification() {

--- a/main/src/cgeo/geocaching/ui/notifications/Notifications.java
+++ b/main/src/cgeo/geocaching/ui/notifications/Notifications.java
@@ -17,6 +17,7 @@ public class Notifications {
 
     public static final int ID_FOREGROUND_NOTIFICATION_MAP_IMPORT = 111;
     public static final int ID_FOREGROUND_NOTIFICATION_CACHES_DOWNLOADER = 112;
+    public static final int ID_FOREGROUND_NOTIFICATION_SPEECH_SERVICE = 113;
 
     private Notifications() {
         // no instances


### PR DESCRIPTION
Running the SpeechService as foreground makes it less likely of getting killed if screen is off...

fix #7057
fix #10781