### PR TITLE
[Autobackup] remove unnecessary toasts

### DIFF
--- a/main/res/layout/main_activity.xml
+++ b/main/res/layout/main_activity.xml
@@ -26,14 +26,6 @@
         android:orientation="vertical">
 
         <include
-            android:id="@+id/autobackup"
-            layout="@layout/mainactivity_action_item"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            android:visibility="gone" />
-
-        <include
             android:id="@+id/mapupdate"
             layout="@layout/mainactivity_action_item"
             android:layout_width="match_parent"

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -349,7 +349,6 @@ public class MainActivity extends AbstractBottomNavigationActivity {
 
             // automated backup check
             if (Settings.automaticBackupDue()) {
-                ActivityMixin.showShortToast(this, R.string.init_backup_automatic_performing);
                 new BackupUtils(this, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true);
             }
             cLog.add("ab");

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -629,6 +629,9 @@ public class BackupUtils {
         String msg;
         final String title;
         if (settingsResult && databaseResult) {
+            if (autobackup) {
+                return; // We don't need to inform the user if everything went right
+            }
             title = activityContext.getString(R.string.init_backup_finished);
             msg = activityContext.getString(R.string.backup_saved) + "\n" + backupDir.toUserDisplayableString();
         } else {
@@ -656,7 +659,7 @@ public class BackupUtils {
         }
 
         if (autobackup) {
-            ActivityMixin.showShortToast(activityContext, msg);
+            ActivityMixin.showToast(activityContext, msg);
         } else {
             SimpleDialog.of(activityContext).setTitle(TextParam.text(title)).setMessage(TextParam.text(msg))
                     .setButtons(0, 0, R.string.cache_share_field)


### PR DESCRIPTION
Make auto-backup less intrusive...

- remove toasts if everything went right
- if something went wrong, show the toast longer than currently 

This does only affect auto-backup, not the normal backup functionality!