### PR TITLE
remove size-limit check while storing waypoints in PN

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1298,11 +1298,10 @@
     <string name="cache_personal_note_removedwaypoints">Waypoints removed</string>
     <string name="cache_personal_note_removewaypoints_nowaypoints">No waypoints found to remove</string>
     <string name="cache_personal_note_storewaypoints_success">Waypoints were added to personal note</string>
-    <string name="cache_personal_note_storewaypoints_limited_reduce">Waypoints were added to personal note (%d characters more than supported by Geocaching.com)</string>
     <string name="cache_personal_note_storewaypoints_nowaypoints">No storable waypoints found</string>
     <string name="cache_personal_note_preventWaypointsExtraction">Prevent waypoints extraction</string>
     <string name="cache_personal_note_limit">Personal note limit</string>
-    <string name="cache_personal_note_truncation" tools:ignore="PluralsCandidate">This personal note will be truncated after %d characters by Geocaching.com.</string>
+    <string name="cache_personal_note_truncated_by" tools:ignore="PluralsCandidate">This personal note will be truncated by approx. %1$d characters by %3$s (max size %2$d).</string>
     <string name="cache_personal_note_upload">Upload</string>
     <string name="cache_personal_note_uploading">Uploading personal note</string>
     <string name="cache_personal_note_upload_done">Personal note uploaded</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1298,8 +1298,7 @@
     <string name="cache_personal_note_removedwaypoints">Waypoints removed</string>
     <string name="cache_personal_note_removewaypoints_nowaypoints">No waypoints found to remove</string>
     <string name="cache_personal_note_storewaypoints_success">Waypoints were added to personal note</string>
-    <string name="cache_personal_note_storewaypoints_success_limited">Waypoints were added to note but had to be shortened (max personal note size: %1$d)</string>
-    <string name="cache_personal_note_storewaypoints_failed">Waypoints could not be stored in note due to size limits (max personal note size: %1$d)</string>
+    <string name="cache_personal_note_storewaypoints_limited_reduce">Waypoints were added to personal note (%d characters more than supported by Geocaching.com)</string>
     <string name="cache_personal_note_storewaypoints_nowaypoints">No storable waypoints found</string>
     <string name="cache_personal_note_preventWaypointsExtraction">Prevent waypoints extraction</string>
     <string name="cache_personal_note_limit">Personal note limit</string>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -2886,22 +2886,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         //if given maxSize is obviously bogus, then make length unlimited
-        final int maxSize = maxPersonalNotesChars == 0 ? -1 : maxPersonalNotesChars;
-
-        final String newNote = WaypointParser.putParseableWaypointsInText(note, userModifiedWaypoints, cache.getVariables(), maxSize);
-
-        if (newNote != null) {
-            setNewPersonalNote(newNote);
-            final String newNoteNonShorted = WaypointParser.putParseableWaypointsInText(note, userModifiedWaypoints, cache.getVariables(), -1);
-            if (newNoteNonShorted.length() > newNote.length()) {
-                showShortToast(getString(R.string.cache_personal_note_storewaypoints_success_limited, maxSize));
-            } else {
-                showShortToast(getString(R.string.cache_personal_note_storewaypoints_success));
-            }
+        final String newNote = WaypointParser.putParseableWaypointsInText(note, userModifiedWaypoints, cache.getVariables());
+        setNewPersonalNote(newNote);
+        final int reduceCount = newNote.length() - maxPersonalNotesChars;
+        if (reduceCount > 0) {
+            showShortToast(getString(R.string.cache_personal_note_storewaypoints_limited_reduce, reduceCount));
         } else {
-            showShortToast(getString(R.string.cache_personal_note_storewaypoints_failed, maxSize));
+            showShortToast(R.string.cache_personal_note_storewaypoints_success);
         }
-
     }
 
     private void setNewPersonalNote(final String newNote) {

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -302,7 +302,7 @@ public class GeocacheTest extends CGeoTestCase {
         wpList.add(createWaypointWithUserNote(new Geopoint("N51 13.888 E007 03.555"), "Final", "", "", WaypointType.FINAL));
         wpList.add(createWaypointWithUserNote(new Geopoint("N51 13.888 E007 03.666"), "Final", "", "", WaypointType.FINAL));
 
-        final String parseableText = WaypointParser.getParseableText(wpList, null, -1, false);
+        final String parseableText = WaypointParser.getParseableText(wpList, null, false);
         assertWaypointsParsed(cache, parseableText, wpList);
 
         removeCacheCompletely(geocode);

--- a/tests/src/cgeo/geocaching/models/WaypointParserTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointParserTest.java
@@ -183,12 +183,12 @@ public class WaypointParserTest {
         wp.setCoords(gp);
         wp.setPrefix("PR");
         wp.setUserNote("user note with \"escaped\" text");
-        assertThat(WaypointParser.getParseableText(wp, -1)).isEqualTo(
+        assertThat(WaypointParser.getParseableText(wp)).isEqualTo(
                 "@name (F) " + toParseableWpString(gp) + " " +
                         "\"user note with \\\"escaped\\\" text\"");
 
         final WaypointParser waypointParser = createParser("Prefix");
-        final Collection<Waypoint> parsedWaypoints = waypointParser.parseWaypoints(WaypointParser.getParseableText(wp, -1));
+        final Collection<Waypoint> parsedWaypoints = waypointParser.parseWaypoints(WaypointParser.getParseableText(wp));
         assertThat(parsedWaypoints).hasSize(1);
         final Iterator<Waypoint> iterator = parsedWaypoints.iterator();
         assertWaypoint(iterator.next(), wp);
@@ -201,12 +201,12 @@ public class WaypointParserTest {
         wp.setCoords(null);
         wp.setPrefix("EE");
         wp.setUserNote("user note with \"escaped\" text\nand a newline");
-        assertThat(WaypointParser.getParseableText(wp, -1)).isEqualTo(
+        assertThat(WaypointParser.getParseableText(wp)).isEqualTo(
                 "@[EE]name (F) (NO-COORD)\n" +
                         "\"user note with \\\"escaped\\\" text\nand a newline\"");
 
         final WaypointParser waypointParser = createParser("Prefix");
-        final Collection<Waypoint> parsedWaypoints = waypointParser.parseWaypoints(WaypointParser.getParseableText(wp, -1));
+        final Collection<Waypoint> parsedWaypoints = waypointParser.parseWaypoints(WaypointParser.getParseableText(wp));
         assertThat(parsedWaypoints).hasSize(1);
         final Iterator<Waypoint> iterator = parsedWaypoints.iterator();
         assertWaypoint(iterator.next(), wp);
@@ -219,7 +219,7 @@ public class WaypointParserTest {
         wp.setCoords(null);
         wp.setUserDefined();
         wp.setUserNote("user note with \"escaped\" text\nand a newline");
-        final String parseableText = WaypointParser.getParseableText(wp, -1);
+        final String parseableText = WaypointParser.getParseableText(wp);
         assertThat(parseableText).isEqualTo(
                 "@name (F) (NO-COORD)\n" +
                         "\"user note with \\\"escaped\\\" text\nand a newline\"");
@@ -259,7 +259,7 @@ public class WaypointParserTest {
         final Iterator<Waypoint> iterator = waypoints.iterator();
         final Waypoint wp = iterator.next();
 
-        final String parseableText = WaypointParser.getParseableText(wp, -1, true);
+        final String parseableText = WaypointParser.getParseableText(wp, true);
         assertThat(parseableText).isEqualTo(
                 "@name (F) " + WaypointParser.PARSING_COORD_FORMULA_PLAIN + " N 45° A.B(C+D)' E 9° (A-B).(2*D)EF' |A=a + b|a=2| \"this is the description\"");
     }
@@ -277,7 +277,7 @@ public class WaypointParserTest {
         final Iterator<Waypoint> iterator = waypoints.iterator();
         final Waypoint wp = iterator.next();
 
-        final String parseableText = WaypointParser.getParseableText(wp, -1, true);
+        final String parseableText = WaypointParser.getParseableText(wp, true);
         assertThat(parseableText).isEqualTo(
                 "@name (F) " + WaypointParser.PARSING_COORD_FORMULA_PLAIN + " N 45° A.B(C+D)' E 9° (A-B).(2*D)EF' |A=a + b|B=1|C=10|D=4|E=2|F=3|a=2|b=47| \"this is the description\"");
     }
@@ -504,7 +504,7 @@ public class WaypointParserTest {
     }
 
     @Test
-    public void testCreateReducedParseableWaypointText() {
+    public void testCreateNotReducedParseableWaypointText() {
         final Waypoint wp1 = new Waypoint("name", WaypointType.FINAL, true);
         final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
         wp1.setCoords(gp);
@@ -518,27 +518,18 @@ public class WaypointParserTest {
         wpColl.add(wp2);
         final String gpStr = toParseableWpString(gp);
 
-        assertThat(WaypointParser.getParseableText(wpColl, null, 10, false)).isNull();
+        assertThat(WaypointParser.getParseableText(wpColl, null, false)).isNotNull();
 
         final String fullExpected = "@name (F) " + gpStr + " \"This is a user note\"\n@name2 (H) " + gpStr + " \"This is a user note 2\"";
         //no limits
-        assertThat(WaypointParser.getParseableText(wpColl, null, -1, false)).isEqualTo(fullExpected);
+        assertThat(WaypointParser.getParseableText(wpColl, null, false)).isEqualTo(fullExpected);
 
         final WaypointParser waypointParser = createParser("Prefix");
-        final Collection<Waypoint> parsedWaypoints = waypointParser.parseWaypoints(WaypointParser.getParseableText(wpColl, null, -1, false));
+        final Collection<Waypoint> parsedWaypoints = waypointParser.parseWaypoints(WaypointParser.getParseableText(wpColl, null, false));
         assertThat(parsedWaypoints).hasSize(2);
         final Iterator<Waypoint> iterator = parsedWaypoints.iterator();
         assertWaypoint(iterator.next(), wp1);
         assertWaypoint(iterator.next(), wp2);
-
-        //limited user notes
-        String expected = "@name (F) " + gpStr + " \"This is a ...\"\n@name2 (H) " + gpStr + " \"This is a ...\"";
-        assertThat(WaypointParser.getParseableText(wpColl, null, expected.length(), false)).isEqualTo(expected);
-
-        //no user notes
-        expected = "@name (F) " + gpStr + "\n@name2 (H) " + gpStr;
-        assertThat(WaypointParser.getParseableText(wpColl, null, expected.length(), false)).isEqualTo(expected);
-
     }
 
     @Test
@@ -582,11 +573,11 @@ public class WaypointParserTest {
         final Collection<Waypoint> wps = waypointParser.parseWaypoints(waypoints);
 
         final String note = "";
-        final String noteAfter = WaypointParser.putParseableWaypointsInText(note, wps, null, -1);
+        final String noteAfter = WaypointParser.putParseableWaypointsInText(note, wps, null);
         assertThat(noteAfter).isEqualTo("{c:geo-start}\n" + waypoints + "\n{c:geo-end}");
 
         //check that continuous appliance of same waypoints will result in identical text
-        final String noteAfter2 = WaypointParser.putParseableWaypointsInText(noteAfter, wps, null, -1);
+        final String noteAfter2 = WaypointParser.putParseableWaypointsInText(noteAfter, wps, null);
         assertThat(noteAfter2).isEqualTo(noteAfter);
     }
 
@@ -602,11 +593,11 @@ public class WaypointParserTest {
         final Collection<Waypoint> wps = waypointParser.parseWaypoints(waypoints);
 
         final String note = "before {c:geo-start}" + waypoints + "{c:geo-end} after";
-        final String noteAfter = WaypointParser.putParseableWaypointsInText(note, wps, null, -1);
+        final String noteAfter = WaypointParser.putParseableWaypointsInText(note, wps, null);
         assertThat(noteAfter).isEqualTo("before  after\n\n{c:geo-start}\n" + waypoints + "\n{c:geo-end}");
 
         //check that continuous appliance of same waypoints will result in identical text
-        final String noteAfter2 = WaypointParser.putParseableWaypointsInText(noteAfter, wps, null, -1);
+        final String noteAfter2 = WaypointParser.putParseableWaypointsInText(noteAfter, wps, null);
         assertThat(noteAfter2).isEqualTo(noteAfter);
     }
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Remove the size-limitation on export of waypoints to personal note.
Instead show toast on upload with character-count, which exceeds the size-limit (so user knows, how many characters he has to remove to avoid shortening on upload)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #10981 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->