### PR TITLE
Fix NPE in CheckerUtils (fix #13112)

### DIFF
--- a/main/src/cgeo/geocaching/utils/CheckerUtils.java
+++ b/main/src/cgeo/geocaching/utils/CheckerUtils.java
@@ -38,7 +38,7 @@ public final class CheckerUtils {
     @Nullable
     public static String getCheckerUrl(@NonNull final Geocache cache) {
         final Geopoint coordinateToCheck;
-        if (!cache.hasUserModifiedCoords() && cache.hasFinalDefined()) {
+        if (!cache.hasUserModifiedCoords() && cache.getFirstMatchingWaypoint(Waypoint::isFinalWithCoords) != null) {
             coordinateToCheck = cache.getFirstMatchingWaypoint(Waypoint::isFinalWithCoords).getCoords();
         } else {
             coordinateToCheck = cache.getCoords();


### PR DESCRIPTION
The `Geocache.hasFinalDefined()` method seems to be unreliable. It sometimes returns true even if no final waypoint with coords can be found, which results in a NPE as described in #13112. 