### PR TITLE
Don't show unit test directory in nightly builds

### DIFF
--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -30,7 +30,7 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
         setPrefClick(this, R.string.pref_fakekey_generate_infos_downloadmanager, () -> DownloaderUtils.dumpDownloadmanagerInfos(activity));
         setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
 
-        findPreference(getString(R.string.pref_persistablefolder_testdir)).setVisible(!BranchDetectionHelper.isProductionBuild());
+        findPreference(getString(R.string.pref_persistablefolder_testdir)).setVisible(BranchDetectionHelper.isDeveloperBuild());
 
         initPublicFolders(this, activity.getCsah());
     }

--- a/main/src/cgeo/geocaching/utils/BranchDetectionHelper.java
+++ b/main/src/cgeo/geocaching/utils/BranchDetectionHelper.java
@@ -24,4 +24,13 @@ public class BranchDetectionHelper {
         return !(BuildConfig.BUILD_TYPE.equals("debug") || BuildConfig.BUILD_TYPE.equals("nightly"));
     }
 
+    /**
+     * @return true, if BUILD_TYPE is a debug build. Nightly builds are **not** considered as developer build!
+     */
+    // BUILD_TYPE is detected as constant but can change depending on the build configuration
+    @SuppressWarnings("ConstantConditions")
+    public static boolean isDeveloperBuild() {
+        return BuildConfig.BUILD_TYPE.equals("debug");
+    }
+
 }


### PR DESCRIPTION
Currently, the unit test directory setting is displayed for developer and nightly builds. Show it only for developer builds instead.

![Screenshot_20220610_000148_cgeo geocaching](https://user-images.githubusercontent.com/64581222/172953323-25d34605-73d0-4078-8bbf-5990b1dd1932.png)
