### PR TITLE
don't show distance circle for waypoints of archived caches

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -1799,7 +1799,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     }
 
     private CachesOverlayItemImpl getWaypointItem(final Waypoint waypoint, final boolean isDotMode) {
-        final CachesOverlayItemImpl item = mapItemFactory.getCachesOverlayItem(waypoint, waypoint.getWaypointType().applyDistanceRule());
+        final CachesOverlayItemImpl item = mapItemFactory.getCachesOverlayItem(waypoint, waypoint.applyDistanceRule());
         if (isDotMode) {
             item.setMarker(MapMarkerUtils.getWaypointDotMarker(getResources(), waypoint));
         } else {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -402,7 +402,7 @@ public abstract class AbstractCachesOverlay {
             } else {
                 marker = AndroidGraphicFactory.convertToBitmap(MapMarkerUtils.getWaypointMarker(CgeoApplication.getInstance().getResources(), waypoint, true).getDrawable());
             }
-            return new GeoitemLayer(waypoint.getGeoitemRef(), waypoint.getWaypointType().applyDistanceRule(), tapHandler, new LatLong(target.getLatitude(), target.getLongitude()), marker, 0, -marker.getHeight() / 2);
+            return new GeoitemLayer(waypoint.getGeoitemRef(), waypoint.applyDistanceRule(), tapHandler, new LatLong(target.getLatitude(), target.getLongitude()), marker, 0, -marker.getHeight() / 2);
         }
 
         return null;

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -2218,8 +2218,12 @@ public class Geocache implements IWaypoint {
     }
 
     public boolean applyDistanceRule() {
+        return mayApplyDistanceRule()
+                && (getType().applyDistanceRule() || hasUserModifiedCoords());
+    }
+
+    public boolean mayApplyDistanceRule() {
         return !isArchived()
-                && (getType().applyDistanceRule() || hasUserModifiedCoords())
                 && (getConnector() == GCConnector.getInstance() || getConnector() == InternalConnector.getInstance());
     }
 

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -523,7 +523,7 @@ public class Waypoint implements IWaypoint {
         if (applyDistanceRule) {
             final Geocache parentCache = getParentGeocache();
             if (parentCache != null) {
-                applyDistanceRule = parentCache.applyDistanceRule();
+                applyDistanceRule = parentCache.mayApplyDistanceRule();
             }
         }
         return applyDistanceRule;

--- a/main/src/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/cgeo/geocaching/models/Waypoint.java
@@ -518,4 +518,14 @@ public class Waypoint implements IWaypoint {
         return ConnectorFactory.getConnector(geocode).getCacheMapDotMarkerBackgroundId();
     }
 
+    public boolean applyDistanceRule() {
+        boolean applyDistanceRule = getWaypointType().applyDistanceRule();
+        if (applyDistanceRule) {
+            final Geocache parentCache = getParentGeocache();
+            if (parentCache != null) {
+                applyDistanceRule = parentCache.applyDistanceRule();
+            }
+        }
+        return applyDistanceRule;
+    }
 }

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -701,6 +701,142 @@ public class GeocacheTest extends CGeoTestCase {
         assertThat(livemap.getCoordZoomLevel()).as("merged zoomlevel").isEqualTo(12);
     }
 
+    /**
+     * distance circle should be shown for some cache-types only for GC- and internal connector.
+     */
+    public final void testShowDistanceCircleForCaches() {
+        final Geocache cache = new Geocache();
+        cache.setGeocode("GC12345");
+
+        cache.setType(CacheType.TRADITIONAL);
+        assertThat(cache.applyDistanceRule()).as("show for traditional").isTrue();
+
+        cache.setType(CacheType.USER_DEFINED);
+        assertThat(cache.applyDistanceRule()).as("show for user-defined").isTrue();
+
+        cache.setType(CacheType.MULTI);
+        assertThat(cache.applyDistanceRule()).as("don't show for multi").isFalse();
+
+        cache.setType(CacheType.MYSTERY);
+        assertThat(cache.applyDistanceRule()).as("don't show for mystery").isFalse();
+
+        cache.setGeocode("ZZ1234");
+        cache.setType(CacheType.TRADITIONAL);
+        assertThat(cache.applyDistanceRule()).as("show for Internal").isTrue();
+
+        cache.setGeocode("OC12345");
+        cache.setType(CacheType.TRADITIONAL);
+        assertThat(cache.applyDistanceRule()).as("don't show for OC").isFalse();
+    }
+
+    /**
+     * distance circle should be shown for some cache-types with user-modified-coordinates.
+     */
+    public final void testShowDistanceCircleForCacheWithUsermodifiedCoordinates() {
+        final Geocache cache = new Geocache();
+        cache.setGeocode("GC12345");
+        cache.setUserModifiedCoords(true);
+
+        cache.setType(CacheType.TRADITIONAL);
+        assertThat(cache.applyDistanceRule()).as("show for traditional").isTrue();
+
+        cache.setType(CacheType.USER_DEFINED);
+        assertThat(cache.applyDistanceRule()).as("show for user-defined").isTrue();
+
+        cache.setType(CacheType.MULTI);
+        assertThat(cache.applyDistanceRule()).as("show for multi with user-modified coords").isTrue();
+
+        cache.setType(CacheType.MYSTERY);
+        assertThat(cache.applyDistanceRule()).as("show for mystery with user-modified coords").isTrue();
+    }
+
+    /**
+     * distance circle must not be shown for archived caches.
+     */
+    public final void testShowDistanceCircleNotForArchivedCaches() {
+        final Geocache cache = new Geocache();
+        cache.setGeocode("GC12345");
+        cache.setArchived(true);
+
+        cache.setType(CacheType.TRADITIONAL);
+        assertThat(cache.applyDistanceRule()).as("don't show for archived traditional").isFalse();
+
+        cache.setType(CacheType.USER_DEFINED);
+        assertThat(cache.applyDistanceRule()).as("don't show for archived user-defined").isFalse();
+
+        cache.setType(CacheType.MULTI);
+        assertThat(cache.applyDistanceRule()).as("don't show for archived multi").isFalse();
+
+        cache.setType(CacheType.MYSTERY);
+        assertThat(cache.applyDistanceRule()).as("don't show for archived mystery").isFalse();
+
+
+        cache.setUserModifiedCoords(true);
+
+        cache.setType(CacheType.MULTI);
+        assertThat(cache.applyDistanceRule()).as("don't show for archived multi with user-modified coords").isFalse();
+
+        cache.setType(CacheType.MYSTERY);
+        assertThat(cache.applyDistanceRule()).as("don't show for archived mystery with user-modified coords").isFalse();
+    }
+
+    /**
+     * distance circle should be shown for some waypoint-types.
+     */
+    public final void testShowDistanceCircleForWaypoint() {
+        final Geocache cache = new Geocache();
+        cache.setGeocode("GC12345");
+        saveFreshCacheToDB(cache);
+
+        final Waypoint finalWaypoint = new Waypoint("Final", WaypointType.FINAL, true);
+        final Waypoint stageWaypoint = new Waypoint("Stage", WaypointType.STAGE, true);
+        final Waypoint parkingWaypoint = new Waypoint("Stage", WaypointType.PARKING, true);
+        final Waypoint ownWaypoint = new Waypoint("Stage", WaypointType.OWN, true);
+        cache.addOrChangeWaypoint(finalWaypoint, false);
+        cache.addOrChangeWaypoint(stageWaypoint, false);
+        cache.addOrChangeWaypoint(parkingWaypoint, false);
+        cache.addOrChangeWaypoint(ownWaypoint, false);
+
+        assertThat(finalWaypoint.applyDistanceRule()).as("show for final waypoint").isTrue();
+        assertThat(stageWaypoint.applyDistanceRule()).as("show for stage waypoint").isTrue();
+        assertThat(parkingWaypoint.applyDistanceRule()).as("don't show for parking waypoint").isFalse();
+        assertThat(ownWaypoint.applyDistanceRule()).as("don't show for own waypoint").isFalse();
+
+
+        final Geocache ocCache = new Geocache();
+        ocCache.setGeocode("OC12345");
+        saveFreshCacheToDB(ocCache);
+
+        final Waypoint ocFinalWaypoint = new Waypoint("Final", WaypointType.FINAL, true);
+        ocCache.addOrChangeWaypoint(ocFinalWaypoint, false);
+
+        assertThat(ocFinalWaypoint.applyDistanceRule()).as("don't show for final waypoint of OC-cache").isFalse();
+    }
+
+    /**
+     * distance circle must not be shown for waypoints of archived caches.
+     */
+    public final void testShowDistanceCircleForArchivedWaypoint() {
+        final Geocache cache = new Geocache();
+        cache.setGeocode("GC12345");
+        cache.setArchived(true);
+        saveFreshCacheToDB(cache);
+
+        final Waypoint finalWaypoint = new Waypoint("Final", WaypointType.FINAL, true);
+        final Waypoint stageWaypoint = new Waypoint("Stage", WaypointType.STAGE, true);
+        final Waypoint parkingWaypoint = new Waypoint("Stage", WaypointType.PARKING, true);
+        final Waypoint ownWaypoint = new Waypoint("Stage", WaypointType.OWN, true);
+        cache.addOrChangeWaypoint(finalWaypoint, false);
+        cache.addOrChangeWaypoint(stageWaypoint, false);
+        cache.addOrChangeWaypoint(parkingWaypoint, false);
+        cache.addOrChangeWaypoint(ownWaypoint, false);
+
+        assertThat(finalWaypoint.applyDistanceRule()).as("don't show for final waypoint").isFalse();
+        assertThat(stageWaypoint.applyDistanceRule()).as("don't show for stage waypoint").isFalse();
+        assertThat(parkingWaypoint.applyDistanceRule()).as("don't show for parking waypoint").isFalse();
+        assertThat(ownWaypoint.applyDistanceRule()).as("don't show for own waypoint").isFalse();
+    }
+
     public static void testNameForSorting() {
         final Geocache cache = new Geocache();
         cache.setName("GR8 01-01");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
don't show distance circles for waypoints, if the cache itselft does not need to show distance circles

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #13117 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->