### PR TITLE
raise compile SDK to 31

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,7 +19,7 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         // use the diamond operator and some other goodies in Android


### PR DESCRIPTION
## Description
- raise compile SDK to 31 to be able to upgrade some material libs to the most-recent versions
- leave target SDK at 30 for now to avoid behavioral changes (see #13036 for this)