### PR TITLE
rel to #12783: make image detection more reliable

### DIFF
--- a/main/src/cgeo/geocaching/ImageViewActivity.java
+++ b/main/src/cgeo/geocaching/ImageViewActivity.java
@@ -278,7 +278,7 @@ public class ImageViewActivity extends AbstractActionBarActivity {
         mainBinding.imageOpenFile.setOnClickListener(v -> {
             final Image img = imageList.get(imagePos);
 
-            if (img.isImageUri()) {
+            if (img.isImageOrUnknownUri()) {
                 ImageUtils.viewImageInStandardApp(ImageViewActivity.this, img.getUri(), imageContextCode);
             } else {
                 ShareUtils.openContentForView(this, img.getUrl());
@@ -332,9 +332,9 @@ public class ImageViewActivity extends AbstractActionBarActivity {
 
         final List<CharSequence> imageInfos = new ArrayList<>();
         if (!StringUtils.isEmpty(currentImage.title)) {
-            imageInfos.add(Html.fromHtml("<b>" + currentImage.title + (currentImage.isImageUri() ? "" : " (" + currentImage.getMimeFileExtension() + ")") + "</b>"));
+            imageInfos.add(Html.fromHtml("<b>" + currentImage.title + (currentImage.isImageOrUnknownUri() ? "" : " (" + currentImage.getMimeFileExtension() + ")") + "</b>"));
         }
-        if (!currentImage.isImageUri()) {
+        if (!currentImage.isImageOrUnknownUri()) {
             imageInfos.add(Html.fromHtml("<b>" + LocalizationUtils.getString(R.string.imageview_mimetype) + ":</b> " + currentImage.getMimeType()));
         }
         if (!StringUtils.isEmpty(currentImage.getDescription())) {
@@ -355,7 +355,7 @@ public class ImageViewActivity extends AbstractActionBarActivity {
         });
         setInfoShowHide(binding, showImageInformation);
 
-        if (!currentImage.isImageUri()) {
+        if (!currentImage.isImageOrUnknownUri()) {
             binding.imageFull.setImageResource(UriUtils.getMimeTypeIcon(currentImage.getMimeType()));
             showImage(pagerPos, binding);
         } else {

--- a/main/src/cgeo/geocaching/models/Image.java
+++ b/main/src/cgeo/geocaching/models/Image.java
@@ -390,9 +390,9 @@ public class Image implements Parcelable {
         return mimeInformation.second;
     }
 
-    public boolean isImageUri() {
+    public boolean isImageOrUnknownUri() {
         final String mimeType = getMimeType();
-        return mimeType != null && mimeType.startsWith("image/");
+        return mimeType == null || mimeType.startsWith("image/");
     }
 
     private void ensureMimeInformation() {

--- a/main/src/cgeo/geocaching/ui/ImageGalleryView.java
+++ b/main/src/cgeo/geocaching/ui/ImageGalleryView.java
@@ -174,7 +174,7 @@ public class ImageGalleryView extends LinearLayout {
         setImageLayoutSizes(binding, imageSizeDp);
         binding.imageDescriptionMarker.setVisibility(img.hasDescription() ? View.VISIBLE : View.GONE);
 
-        if (!img.isImageUri()) {
+        if (!img.isImageOrUnknownUri()) {
             binding.imageTitle.setText(TextUtils.concat(binding.imageTitle.getText(), " (" + UriUtils.getMimeFileExtension(img.getUri()) + ")"));
             binding.imageImage.setImageResource(UriUtils.getMimeTypeIcon(img.getMimeType()));
             binding.imageImage.setVisibility(View.VISIBLE);
@@ -204,7 +204,7 @@ public class ImageGalleryView extends LinearLayout {
         }
 
         binding.imageWrapper.setOnClickListener(v -> {
-            if (imgData.image.isImageUri()) {
+            if (imgData.image.isImageOrUnknownUri()) {
                 openImageViewer(imgData, binding);
             } else {
                 ShareUtils.openContentForView(getContext(), img.getUrl());

--- a/main/src/cgeo/geocaching/utils/UriUtils.java
+++ b/main/src/cgeo/geocaching/utils/UriUtils.java
@@ -88,10 +88,17 @@ public final class UriUtils {
         if (context != null && context.getContentResolver() != null) {
             mimeType = context.getContentResolver().getType(uri);
         }
-        if (mimeType == null) {
+        if (StringUtils.isBlank(mimeType)) {
             mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(MimeTypeMap.getFileExtensionFromUrl(uri.toString()));
         }
-        return mimeType;
+        if (StringUtils.isBlank(mimeType)) {
+            final String uriString = uri.toString();
+            final int lidx = uriString.lastIndexOf(".");
+            if (lidx >= 0) {
+                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(uriString.substring(lidx + 1));
+            }
+        }
+        return StringUtils.isBlank(mimeType) ? null : mimeType;
     }
 
     /**


### PR DESCRIPTION
rel to #12783: make image detection more reliable

URLs where Mime-Type is not discoverable (e.g. without suffix) were handled as non-image-URLs by ImageGallery before. With this PR they are handled as images (making this the default)