### PR TITLE
Use lifecycle observers to clean up code

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -431,6 +431,11 @@ dependencies {
     // Settings Library
     implementation 'androidx.preference:preference:1.1.1'
 
+    // Support Library Lifecycle helpers
+    def lifecycleVersion = '2.4.1'
+    implementation "androidx.lifecycle:lifecycle-runtime:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
+
     // Support Annotations. use same version for the main app and the test app
     def annotationVersion = '1.3.0'
     implementation "androidx.annotation:annotation:$annotationVersion"

--- a/main/src/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/cgeo/geocaching/AbstractDialogFragment.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.CacheDetailsCreator;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
@@ -35,15 +36,16 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.Lifecycle;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 
 public abstract class AbstractDialogFragment extends DialogFragment implements CacheMenuHandler.ActivityInterface, INavigationSource {
     public static final int RESULT_CODE_SET_TARGET = Activity.RESULT_FIRST_USER;
     public static final int REQUEST_CODE_TARGET_INFO = 1;
     protected static final String GEOCODE_ARG = "GEOCODE";
     protected static final String WAYPOINT_ARG = "WAYPOINT";
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final DisposableContainer resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
     protected Resources res = null;
     protected String geocode;
     protected CacheDetailsCreator details;
@@ -109,13 +111,6 @@ public abstract class AbstractDialogFragment extends DialogFragment implements C
                     }
                 });
         init();
-    }
-
-
-    @Override
-    public void onPause() {
-        resumeDisposables.clear();
-        super.onPause();
     }
 
     protected final void addCacheDetails(final boolean showGeocode) {

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -90,6 +90,7 @@ import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.CheckerUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.ColorUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.CryptUtils;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.EmojiUtils;
@@ -159,6 +160,7 @@ import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.Lifecycle;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.lang.ref.WeakReference;
@@ -174,7 +176,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.apache.commons.collections4.CollectionUtils;
@@ -232,14 +234,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
     private ImageGalleryView imageGallery;
 
-    private final CompositeDisposable createDisposables = new CompositeDisposable();
+    private final DisposableContainer createDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_DESTROY);
     /**
      * waypoint selected in context menu. This variable will be gone when the waypoint context menu is a fragment.
      */
     private Waypoint selectedWaypoint;
 
     private boolean requireGeodata;
-    private final CompositeDisposable geoDataDisposable = new CompositeDisposable();
+    private final CompositeLifecycleDisposable geoDataDisposable = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
 
     private final EnumSet<TrackableBrand> processedBrands = EnumSet.noneOf(TrackableBrand.class);
 
@@ -437,14 +439,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     }
 
     @Override
-    public void onPause() {
-        geoDataDisposable.clear();
-        super.onPause();
-    }
-
-    @Override
     public void onDestroy() {
-        createDisposables.clear();
         SpeechService.stopService(this);
         if (cache != null) {
             cache.setChangeNotificationHandler(null);

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -86,6 +86,7 @@ import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.CalendarUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.FilterUtils;
@@ -124,6 +125,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Consumer;
 import androidx.core.view.MenuItemCompat;
+import androidx.lifecycle.Lifecycle;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -142,7 +144,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.ObservableOnSubscribe;
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.apache.commons.collections4.CollectionUtils;
@@ -233,7 +235,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     private ContextMenuInfo lastMenuInfo;
     private String contextMenuGeocode = "";
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final DisposableContainer resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
     private final ListNameMemento listNameMemento = new ListNameMemento();
 
     private final Handler loadCachesHandler = new LoadCachesHandler(this);
@@ -715,12 +717,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     protected void onStop() {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(cacheRefreshedBroadcastReceiver);
         super.onStop();
-    }
-
-    @Override
-    public void onPause() {
-        resumeDisposables.clear();
-        super.onPause();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/ImagesActivity.java
+++ b/main/src/cgeo/geocaching/ImagesActivity.java
@@ -3,6 +3,7 @@ package cgeo.geocaching;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.ui.ImagesList;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 
 import android.content.Context;
 import android.content.Intent;
@@ -13,18 +14,19 @@ import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import org.apache.commons.collections4.CollectionUtils;
 
 public class ImagesActivity extends AbstractActionBarActivity {
 
     private List<Image> imageNames;
     private ImagesList imagesList;
-    private final CompositeDisposable createDisposables = new CompositeDisposable();
+    private final DisposableContainer createDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_STOP);
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -63,13 +65,6 @@ public class ImagesActivity extends AbstractActionBarActivity {
     public void onStart() {
         super.onStart();
         createDisposables.add(imagesList.loadImages(findViewById(R.id.spoiler_list), imageNames));
-    }
-
-    @Override
-    public void onStop() {
-        // Reclaim native memory faster than the finalizers would
-        createDisposables.clear();
-        super.onStop();
     }
 
     public static void startActivity(final Context fromActivity, final String geocode, final List<Image> logImages) {

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -43,6 +43,7 @@ import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.DisplayUtils;
@@ -82,6 +83,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.view.MenuCompat;
+import androidx.lifecycle.Lifecycle;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -92,7 +94,7 @@ import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import io.reactivex.rxjava3.functions.Consumer;
 import org.apache.commons.lang3.StringUtils;
 
@@ -119,7 +121,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
     /**
      * initialization with an empty subscription
      */
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final DisposableContainer resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
 
     private BackupUtils backupUtils = null;
 
@@ -527,7 +529,6 @@ public class MainActivity extends AbstractBottomNavigationActivity {
     @Override
     public void onPause() {
         initialized = false;
-        resumeDisposables.clear();
 
         super.onPause();
     }

--- a/main/src/cgeo/geocaching/StatusFragment.java
+++ b/main/src/cgeo/geocaching/StatusFragment.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.databinding.StatusBinding;
 import cgeo.geocaching.network.StatusUpdater;
 import cgeo.geocaching.network.StatusUpdater.Status;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.Log;
 
 import android.content.Intent;
@@ -16,12 +17,13 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Lifecycle;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 
 public class StatusFragment extends Fragment {
 
-    private final CompositeDisposable statusSubscription = new CompositeDisposable();
+    private final DisposableContainer statusSubscription = new CompositeLifecycleDisposable(getViewLifecycleOwner(), Lifecycle.Event.ON_DESTROY);
     private StatusBinding binding;
 
     @Override
@@ -70,12 +72,6 @@ public class StatusFragment extends Fragment {
                     }
                 }));
         return statusGroup;
-    }
-
-    @Override
-    public void onDestroyView() {
-        statusSubscription.clear();
-        super.onDestroyView();
     }
 
 }

--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -30,6 +30,7 @@ import cgeo.geocaching.ui.ImagesList;
 import cgeo.geocaching.ui.UserClickListener;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.HtmlUtils;
 import cgeo.geocaching.utils.ImageUtils;
@@ -58,6 +59,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.text.HtmlCompat;
+import androidx.lifecycle.Lifecycle;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,7 +67,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -110,8 +112,8 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
     private ImagesList imagesList = null;
     private ImageGalleryView imageGallery = null;
     private String fallbackKeywordSearch = null;
-    private final CompositeDisposable createDisposables = new CompositeDisposable();
-    private final CompositeDisposable geoDataDisposable = new CompositeDisposable();
+    private final DisposableContainer createDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_DESTROY);
+    private final DisposableContainer geoDataDisposable = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
     private static final GeoDirHandler locationUpdater = new GeoDirHandler() {
         @SuppressWarnings("EmptyMethod")
         @Override
@@ -232,12 +234,6 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
                         }
                     }
                 });
-    }
-
-    @Override
-    public void onPause() {
-        geoDataDisposable.clear();
-        super.onPause();
     }
 
     private void act(final Trackable newTrackable) {
@@ -750,7 +746,6 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
 
     @Override
     protected void onDestroy() {
-        createDisposables.clear();
         if (imageGallery != null) {
             imageGallery.clear();
         }

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.EditUtils;
 import cgeo.geocaching.utils.HtmlUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -45,6 +46,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.lifecycle.Lifecycle;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.viewbinding.ViewBinding;
 
@@ -52,7 +54,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import org.apache.commons.lang3.StringUtils;
 
@@ -60,7 +61,7 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
 
     protected CgeoApplication app = null;
     protected Resources res = null;
-    private final CompositeDisposable resumeDisposable = new CompositeDisposable();
+    private final CompositeLifecycleDisposable resumeDisposable = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
 
     private final String logToken = "[" + this.getClass().getName() + "]";
 
@@ -125,7 +126,6 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
     @Override
     public void onPause() {
         Log.v(logToken + ".onPause");
-        resumeDisposable.clear();
         super.onPause();
     }
 

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -43,6 +43,7 @@ import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AsyncTaskWithProgressText;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.CollectionStream;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.Log;
@@ -63,6 +64,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -74,7 +76,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import io.reactivex.rxjava3.functions.Function;
 import org.apache.commons.lang3.StringUtils;
 
@@ -104,7 +106,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     private final TextSpinner<ReportProblemType> reportProblem = new TextSpinner<>();
     private final TextSpinner<LogTypeTrackable> trackableActionsChangeAll = new TextSpinner<>();
 
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final DisposableContainer resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
     private final GeoDirHandler geoUpdate = new GeoDirHandler() {
 
         @Override
@@ -318,13 +320,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
                         resumeDisposables.add(geoUpdate.start(GeoDirHandler.UPDATE_GEODATA));
                     }
                 });
-    }
-
-    @Override
-    public void onPause() {
-        resumeDisposables.clear();
-        super.onPause();
-
     }
 
     private void setLogText(final String newText) {

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -31,6 +31,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AsyncTaskWithProgress;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.Log;
 
 import android.R.string;
@@ -49,20 +50,21 @@ import android.widget.CheckBox;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import androidx.lifecycle.Lifecycle;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class LogTrackableActivity extends AbstractLoggingActivity implements CoordinateUpdate, LoaderManager.LoaderCallbacks<List<LogTypeTrackable>> {
     private LogtrackableActivityBinding binding;
 
-    private final CompositeDisposable createDisposables = new CompositeDisposable();
+    private final DisposableContainer createDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_DESTROY);
 
     private List<LogTypeTrackable> possibleLogTypesTrackable = new ArrayList<>();
     private String geocode = null;

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -26,7 +26,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.LifecycleRegistry;
 
 import java.util.Collection;
 
@@ -38,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public abstract class AbstractMap implements LifecycleOwner {
 
+    @NonNull
     final MapActivityImpl mapActivity;
     protected MapViewImpl<CachesOverlayItemImpl> mapView;
 
@@ -46,9 +46,7 @@ public abstract class AbstractMap implements LifecycleOwner {
     public Geopoint lastNavTarget = null;
     public TargetView targetView;
 
-    private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
-
-    protected AbstractMap(final MapActivityImpl activity) {
+    protected AbstractMap(@NonNull final MapActivityImpl activity) {
         mapActivity = activity;
     }
 
@@ -65,33 +63,27 @@ public abstract class AbstractMap implements LifecycleOwner {
     }
 
     public void onCreate(final Bundle savedInstanceState) {
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
         mapActivity.superOnCreate(savedInstanceState);
         Routing.connect();
     }
 
     public void onStart() {
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START);
         mapActivity.superOnStart();
     }
 
     public void onResume() {
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
         mapActivity.superOnResume();
     }
 
     public void onPause() {
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
         mapActivity.superOnPause();
     }
 
     public void onStop() {
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
         mapActivity.superOnStop();
     }
 
     public void onDestroy() {
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
         mapActivity.superOnDestroy();
         Routing.disconnect();
     }
@@ -99,7 +91,7 @@ public abstract class AbstractMap implements LifecycleOwner {
     @NonNull
     @Override
     public Lifecycle getLifecycle() {
-        return lifecycleRegistry;
+        return mapActivity.getActivity().getLifecycle();
     }
 
     public boolean onCreateOptionsMenu(@NonNull final Menu menu) {

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -46,7 +46,7 @@ public abstract class AbstractMap implements LifecycleOwner {
     public Geopoint lastNavTarget = null;
     public TargetView targetView;
 
-    final private LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
+    private final LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
 
     protected AbstractMap(final MapActivityImpl activity) {
         mapActivity = activity;

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -24,6 +24,9 @@ import android.view.MenuItem;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
 
 import java.util.Collection;
 
@@ -33,7 +36,7 @@ import org.apache.commons.lang3.StringUtils;
  * Base class for the map activity. Delegates base class calls to the
  * provider-specific implementation.
  */
-public abstract class AbstractMap {
+public abstract class AbstractMap implements LifecycleOwner {
 
     final MapActivityImpl mapActivity;
     protected MapViewImpl<CachesOverlayItemImpl> mapView;
@@ -42,6 +45,8 @@ public abstract class AbstractMap {
     public String targetGeocode = null;
     public Geopoint lastNavTarget = null;
     public TargetView targetView;
+
+    final private LifecycleRegistry lifecycleRegistry = new LifecycleRegistry(this);
 
     protected AbstractMap(final MapActivityImpl activity) {
         mapActivity = activity;
@@ -60,29 +65,41 @@ public abstract class AbstractMap {
     }
 
     public void onCreate(final Bundle savedInstanceState) {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
         mapActivity.superOnCreate(savedInstanceState);
         Routing.connect();
     }
 
-    public void onResume() {
-        mapActivity.superOnResume();
-    }
-
     public void onStart() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START);
         mapActivity.superOnStart();
     }
 
-    public void onStop() {
-        mapActivity.superOnStop();
+    public void onResume() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+        mapActivity.superOnResume();
     }
 
     public void onPause() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
         mapActivity.superOnPause();
     }
 
+    public void onStop() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+        mapActivity.superOnStop();
+    }
+
     public void onDestroy() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
         mapActivity.superOnDestroy();
         Routing.disconnect();
+    }
+
+    @NonNull
+    @Override
+    public Lifecycle getLifecycle() {
+        return lifecycleRegistry;
     }
 
     public boolean onCreateOptionsMenu(@NonNull final Menu menu) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -64,6 +64,7 @@ import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.CompactIconModeUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.Formatter;
@@ -99,6 +100,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Lifecycle;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.lang.ref.WeakReference;
@@ -134,7 +136,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     /**
      * initialization with an empty subscription to make static code analysis tools more happy
      */
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final CompositeLifecycleDisposable resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
 
     /**
      * Handler Messages
@@ -218,19 +220,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private static final BlockingQueue<Runnable> loadQueue = new ArrayBlockingQueue<>(1);
     private static final ThreadPoolExecutor loadExecutor = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS, loadQueue, new ThreadPoolExecutor.DiscardOldestPolicy());
     private MapOptions mapOptions;
-
-    private final GeocacheRefreshedBroadcastReceiver cacheRefreshedBroadcastReceiver = new GeocacheRefreshedBroadcastReceiver(mapView.getContext()) {
-        @Override
-        protected void onReceive(final Context context, final String geocode) {
-            final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-
-            // only add cache if it is currently visible
-            if (caches.remove(cache)) {
-                caches.add(cache);
-                displayExecutor.execute(new DisplayRunnable(CGeoMap.this));
-            }
-        }
-    };
 
     // handlers
 
@@ -435,6 +424,19 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     public CGeoMap(final MapActivityImpl activity) {
         super(activity);
+        // only add cache if it is currently visible
+        getLifecycle().addObserver(new GeocacheRefreshedBroadcastReceiver(mapView.getContext()) {
+            @Override
+            protected void onReceive(final Context context, final String geocode) {
+                final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+
+                // only add cache if it is currently visible
+                if (caches.remove(cache)) {
+                    caches.add(cache);
+                    displayExecutor.execute(new DisplayRunnable(CGeoMap.this));
+                }
+            }
+        });
     }
 
     protected void countVisibleCaches() {
@@ -732,7 +734,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     @Override
     public void onPause() {
-        resumeDisposables.clear();
         savePrefs();
 
         mapView.destroyDrawingCache();
@@ -746,14 +747,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     }
 
     @Override
-    public void onStart() {
-        LocalBroadcastManager.getInstance(activity).registerReceiver(cacheRefreshedBroadcastReceiver, new IntentFilter(Intents.ACTION_GEOCACHE_REFRESHED));
-        super.onStart();
-    }
-
-    @Override
     public void onStop() {
-        LocalBroadcastManager.getInstance(activity).unregisterReceiver(cacheRefreshedBroadcastReceiver);
         // Ensure that handlers will not try to update the dialog once the view is detached.
         waitDialog = null;
         super.onStop();

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -417,7 +417,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private int currentSourceId;
 
 
-    public CGeoMap(final MapActivityImpl activity) {
+    public CGeoMap(@NonNull final MapActivityImpl activity) {
         super(activity);
         // only add cache if it is currently visible
         getLifecycle().addObserver(new GeocacheRefreshedBroadcastReceiver(mapView.getContext()) {

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -54,6 +54,7 @@ import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.service.CacheDownloaderService;
+import cgeo.geocaching.service.GeocacheRefreshedBroadcastReceiver;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.ViewUtils;
@@ -218,10 +219,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private static final ThreadPoolExecutor loadExecutor = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS, loadQueue, new ThreadPoolExecutor.DiscardOldestPolicy());
     private MapOptions mapOptions;
 
-    private final BroadcastReceiver cacheRefreshedBroadcastReceiver = new BroadcastReceiver() {
+    private final GeocacheRefreshedBroadcastReceiver cacheRefreshedBroadcastReceiver = new GeocacheRefreshedBroadcastReceiver(mapView.getContext()) {
         @Override
-        public void onReceive(final Context context, final Intent intent) {
-            final String geocode = intent.getStringExtra(Intents.EXTRA_GEOCODE);
+        protected void onReceive(final Context context, final String geocode) {
             final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
 
             // only add cache if it is currently visible

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -3,7 +3,6 @@ package cgeo.geocaching.maps;
 import cgeo.geocaching.CacheListActivity;
 import cgeo.geocaching.CachePopup;
 import cgeo.geocaching.CompassActivity;
-import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.WaypointPopup;
@@ -75,10 +74,7 @@ import cgeo.geocaching.utils.MapMarkerUtils;
 import static cgeo.geocaching.location.Viewport.containingGCliveCaches;
 
 import android.app.ProgressDialog;
-import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.location.Location;
 import android.os.Bundle;
@@ -101,7 +97,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Lifecycle;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -88,11 +88,9 @@ import static cgeo.geocaching.maps.mapsforge.v6.caches.CachesBundle.NO_OVERLAY_I
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ProgressDialog;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.content.res.Resources.NotFoundException;
 import android.location.Location;
@@ -120,7 +118,6 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.text.HtmlCompat;
 import androidx.core.util.Supplier;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -63,6 +63,7 @@ import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.Sensors;
 import cgeo.geocaching.service.CacheDownloaderService;
+import cgeo.geocaching.service.GeocacheRefreshedBroadcastReceiver;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
@@ -219,10 +220,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
     private RouteTrackUtils routeTrackUtils = null;
 
-    private final BroadcastReceiver cacheRefreshedBroadcastReceiver = new BroadcastReceiver() {
+    private final GeocacheRefreshedBroadcastReceiver cacheRefreshedBroadcastReceiver = new GeocacheRefreshedBroadcastReceiver(this) {
         @Override
-        public void onReceive(final Context context, final Intent intent) {
-            final String geocode = intent.getStringExtra(Intents.EXTRA_GEOCODE);
+        protected void onReceive(final Context context, final String geocode) {
             caches.invalidate(Collections.singleton(geocode));
         }
     };
@@ -367,6 +367,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         MapsforgeMapProvider.getInstance().updateOfflineMaps();
 
         MapUtils.showMapOneTimeMessages(this, mapMode);
+        getLifecycle().addObserver(cacheRefreshedBroadcastReceiver);
     }
 
     private void postZoomToViewport(final Viewport viewport) {
@@ -798,7 +799,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         Log.d("NewMap: onStart");
 
         initializeLayers();
-        LocalBroadcastManager.getInstance(this).registerReceiver(cacheRefreshedBroadcastReceiver, new IntentFilter(Intents.ACTION_GEOCACHE_REFRESHED));
     }
 
     private void initializeLayers() {
@@ -909,7 +909,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
         waitDialog = null;
         terminateLayers();
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(cacheRefreshedBroadcastReceiver);
 
         super.onStop();
     }

--- a/main/src/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/cgeo/geocaching/service/CacheDownloaderService.java
@@ -1,6 +1,5 @@
 package cgeo.geocaching.service;
 
-import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -23,7 +22,6 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -173,7 +171,7 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
             // download...
             if (Geocache.storeCache(null, geocode, combinedListIds, properties.forceDownload, null)) {
                 // send a broadcast so that foreground activities know that they might need to update their content
-                LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(Intents.ACTION_GEOCACHE_REFRESHED).putExtra(Intents.EXTRA_GEOCODE, geocode));
+                GeocacheRefreshedBroadcastReceiver.sendBroadcast(this, geocode);
                 // check whether the download properties are still null,
                 // otherwise there is a new download task...
                 synchronized (downloadQuery) {

--- a/main/src/cgeo/geocaching/service/GeocacheRefreshedBroadcastReceiver.java
+++ b/main/src/cgeo/geocaching/service/GeocacheRefreshedBroadcastReceiver.java
@@ -1,0 +1,45 @@
+package cgeo.geocaching.service;
+
+import static cgeo.geocaching.Intents.ACTION_GEOCACHE_REFRESHED;
+import static cgeo.geocaching.Intents.EXTRA_GEOCODE;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+public abstract class GeocacheRefreshedBroadcastReceiver extends BroadcastReceiver implements DefaultLifecycleObserver {
+
+    private final Context applicationContext;
+
+    public GeocacheRefreshedBroadcastReceiver(final Context context) {
+        applicationContext = context.getApplicationContext();
+    }
+
+    protected abstract void onReceive(final Context context, final String geocode);
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String geocode = intent.getStringExtra(EXTRA_GEOCODE);
+        onReceive(context, geocode);
+    }
+
+    @Override
+    public void onStart(@NonNull LifecycleOwner owner) {
+        LocalBroadcastManager.getInstance(applicationContext).registerReceiver(this, new IntentFilter(ACTION_GEOCACHE_REFRESHED));
+    }
+
+    @Override
+    public void onStop(@NonNull LifecycleOwner owner) {
+        LocalBroadcastManager.getInstance(applicationContext).unregisterReceiver(this);
+    }
+
+    public static void sendBroadcast(final Context context, final String geocode) {
+        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(ACTION_GEOCACHE_REFRESHED).putExtra(EXTRA_GEOCODE, geocode));
+    }
+}

--- a/main/src/cgeo/geocaching/service/GeocacheRefreshedBroadcastReceiver.java
+++ b/main/src/cgeo/geocaching/service/GeocacheRefreshedBroadcastReceiver.java
@@ -21,21 +21,21 @@ public abstract class GeocacheRefreshedBroadcastReceiver extends BroadcastReceiv
         applicationContext = context.getApplicationContext();
     }
 
-    protected abstract void onReceive(final Context context, final String geocode);
+    protected abstract void onReceive(Context context, String geocode);
 
     @Override
-    public void onReceive(Context context, Intent intent) {
+    public void onReceive(final Context context, final Intent intent) {
         final String geocode = intent.getStringExtra(EXTRA_GEOCODE);
         onReceive(context, geocode);
     }
 
     @Override
-    public void onStart(@NonNull LifecycleOwner owner) {
+    public void onStart(@NonNull final LifecycleOwner owner) {
         LocalBroadcastManager.getInstance(applicationContext).registerReceiver(this, new IntentFilter(ACTION_GEOCACHE_REFRESHED));
     }
 
     @Override
-    public void onStop(@NonNull LifecycleOwner owner) {
+    public void onStop(@NonNull final LifecycleOwner owner) {
         LocalBroadcastManager.getInstance(applicationContext).unregisterReceiver(this);
     }
 

--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.Settings.CoordInputFormatEnum;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.EditUtils;
 
 import android.app.Activity;
@@ -55,13 +56,14 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.Lifecycle;
 
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.List;
 
 import com.google.android.material.textfield.TextInputLayout;
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import org.apache.commons.lang3.StringUtils;
 
 public class CoordinatesInputDialog extends DialogFragment {
@@ -99,7 +101,7 @@ public class CoordinatesInputDialog extends DialogFragment {
 
     private FragmentActivity myContext;
 
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final DisposableContainer resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_PAUSE);
     private final GeoDirHandler geoUpdate = new GeoDirHandler() {
         @Override
         public void updateGeoData(final GeoData geo) {
@@ -164,7 +166,6 @@ public class CoordinatesInputDialog extends DialogFragment {
     @Override
     public void onPause() {
         super.onPause();
-        resumeDisposables.clear();
         Keyboard.hide(getActivity());
 
     }

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -29,6 +29,7 @@ import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.CompactIconModeUtils;
+import cgeo.geocaching.utils.CompositeLifecycleDisposable;
 import cgeo.geocaching.utils.HistoryTrackUtils;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.Log;
@@ -52,10 +53,11 @@ import android.widget.ImageView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.lifecycle.Lifecycle;
 
 import java.lang.ref.WeakReference;
 
-import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
 import org.oscim.core.BoundingBox;
 import org.oscim.core.GeoPoint;
 
@@ -70,7 +72,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     private AbstractGeoitemLayer geoitemLayer = null;
 
     private final UpdateLoc geoDirUpdate = new UpdateLoc(this);
-    private final CompositeDisposable resumeDisposables = new CompositeDisposable();
+    private final DisposableContainer resumeDisposables = new CompositeLifecycleDisposable(this, Lifecycle.Event.ON_STOP);
     private static boolean followMyLocation = Settings.isLiveMap();
     private MenuItem followMyLocationItem = null;
 
@@ -599,12 +601,6 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
                         resumeDisposables.add(geoDirUpdate.start(GeoDirHandler.UPDATE_GEODIR));
                     }
                 });
-    }
-
-    @Override
-    protected void onStop() {
-        this.resumeDisposables.clear();
-        super.onStop();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/utils/CompositeLifecycleDisposable.java
+++ b/main/src/cgeo/geocaching/utils/CompositeLifecycleDisposable.java
@@ -1,0 +1,58 @@
+package cgeo.geocaching.utils;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.disposables.DisposableContainer;
+
+/**
+ * Collect {@link Disposable} and clear them when a certain lifecycle event is reached.
+ */
+public class CompositeLifecycleDisposable implements LifecycleEventObserver, DisposableContainer {
+
+    private final Lifecycle.Event untilEvent;
+    private final CompositeDisposable disposable = new CompositeDisposable();
+
+    public CompositeLifecycleDisposable(final Lifecycle.Event untilEvent) {
+        this.untilEvent = untilEvent;
+    }
+
+    public CompositeLifecycleDisposable(final LifecycleOwner source, final Lifecycle.Event untilEvent) {
+        this.untilEvent = untilEvent;
+        source.getLifecycle().addObserver(this);
+    }
+
+    @Override
+    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+        if (event == untilEvent) {
+            disposable.clear();
+        }
+    }
+
+    @Override
+    public boolean add(@NonNull Disposable d) {
+        return disposable.add(d);
+    }
+
+    public boolean addAll(@NonNull Disposable... disposables) {
+        return disposable.addAll(disposables);
+    }
+
+    @Override
+    public boolean remove(@NonNull Disposable d) {
+        return disposable.remove(d);
+    }
+
+    @Override
+    public boolean delete(@NonNull Disposable d) {
+        return disposable.delete(d);
+    }
+
+    public void clear() {
+        disposable.clear();
+    }
+}

--- a/main/src/cgeo/geocaching/utils/CompositeLifecycleDisposable.java
+++ b/main/src/cgeo/geocaching/utils/CompositeLifecycleDisposable.java
@@ -27,28 +27,28 @@ public class CompositeLifecycleDisposable implements LifecycleEventObserver, Dis
     }
 
     @Override
-    public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Lifecycle.Event event) {
+    public void onStateChanged(@NonNull final LifecycleOwner source, @NonNull final Lifecycle.Event event) {
         if (event == untilEvent) {
             disposable.clear();
         }
     }
 
     @Override
-    public boolean add(@NonNull Disposable d) {
+    public boolean add(@NonNull final Disposable d) {
         return disposable.add(d);
     }
 
-    public boolean addAll(@NonNull Disposable... disposables) {
+    public boolean addAll(@NonNull final Disposable... disposables) {
         return disposable.addAll(disposables);
     }
 
     @Override
-    public boolean remove(@NonNull Disposable d) {
+    public boolean remove(@NonNull final Disposable d) {
         return disposable.remove(d);
     }
 
     @Override
-    public boolean delete(@NonNull Disposable d) {
+    public boolean delete(@NonNull final Disposable d) {
         return disposable.delete(d);
     }
 


### PR DESCRIPTION
## Description
Adding LifecycleObservers so consumers of a class don't need to remember to call it in onPause/onDestroy.
