### PR TITLE
fix #13141: make saved logs text non-selectable to fix double-click to edit

### DIFF
--- a/main/res/layout/logs_item.xml
+++ b/main/res/layout/logs_item.xml
@@ -70,7 +70,6 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:gravity="left"
-                android:textIsSelectable="true"
                 android:textSize="@dimen/textSize_detailsPrimary"
                 android:textColor="@color/colorText"/>
 

--- a/main/src/cgeo/geocaching/log/CacheLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/CacheLogsViewCreator.java
@@ -177,6 +177,8 @@ public class CacheLogsViewCreator extends LogsViewCreator {
             holder.binding.author.setOnClickListener(new EditOfflineLogListener(getCache(), (CacheDetailActivity) getActivity()));
             holder.binding.logMark.setVisibility(View.VISIBLE);
             holder.binding.logMark.setImageResource(R.drawable.mark_orange);
+        } else {
+            holder.binding.log.setTextIsSelectable(true);
         }
     }
 


### PR DESCRIPTION
Making log text selectable causes the first click to be consumed by the select-handler. Thus editing an offline log requires 2 clicks.
Doing setTextIsSelectable(false) on offline logs somehow doesn't work - no click handler is fired at all then, so instead setting setTextIsSelectable(true) on all but offline logs