### PR TITLE
maps: put filter context into savedInstanceState (fix #13147)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -144,6 +144,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private static final String BUNDLE_LIVE_ENABLED = "liveEnabled";
     private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
     private static final String BUNDLE_ROUTE = "route";
+    private static final String BUNDLE_FILTERCONTEXT = "filterContext";
 
     private static final String KEY_ELAPSED_MS = "elapsedMs";
     private static final String KEY_PROGRESS = "progress";
@@ -433,6 +434,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         if (individualRoute != null) {
             outState.putParcelable(BUNDLE_ROUTE, individualRoute);
         }
+        if (mapOptions.filterContext != null) {
+            outState.putParcelable(BUNDLE_FILTERCONTEXT, mapOptions.filterContext);
+        }
     }
 
     @Override
@@ -559,6 +563,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             currentSourceId = savedInstanceState.getInt(BUNDLE_MAP_SOURCE, Settings.getMapSource().getNumericalId());
             mapOptions.mapState = savedInstanceState.getParcelable(BUNDLE_MAP_STATE);
             mapOptions.isLiveEnabled = savedInstanceState.getBoolean(BUNDLE_LIVE_ENABLED, false);
+            mapOptions.filterContext = savedInstanceState.getParcelable(BUNDLE_FILTERCONTEXT);
             proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
             individualRoute = savedInstanceState.getParcelable(BUNDLE_ROUTE);
         } else {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -198,6 +198,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     private static final String BUNDLE_MAP_STATE = "mapState";
     private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
     private static final String BUNDLE_ROUTE = "route";
+    private static final String BUNDLE_FILTERCONTEXT = "filterContext";
 
     // Handler messages
     // DisplayHandler
@@ -247,6 +248,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         // Get fresh map information from the bundle if any
         if (savedInstanceState != null) {
             mapOptions.mapState = savedInstanceState.getParcelable(BUNDLE_MAP_STATE);
+            mapOptions.filterContext = savedInstanceState.getParcelable(BUNDLE_FILTERCONTEXT);
             proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
             individualRoute = savedInstanceState.getParcelable(BUNDLE_ROUTE);
             followMyLocation = mapOptions.mapState.followsMyLocation();
@@ -993,6 +995,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         }
         if (individualRoute != null) {
             outState.putParcelable(BUNDLE_ROUTE, individualRoute);
+        }
+        if (mapOptions.filterContext != null) {
+            outState.putParcelable(BUNDLE_FILTERCONTEXT, mapOptions.filterContext);
         }
     }
 


### PR DESCRIPTION
## Description
Store filter context in savedInstanceState of `NewMap` and `CGeoMap` and restore it in `onCreate` to avoid losing filters on config changes for temporary filters, as described in #13147
