### PR TITLE
avoid NPE on VTM map destroy if no theme is loaded

### DIFF
--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
@@ -171,7 +171,9 @@ class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
     protected void disposeTheme() {
-        mTheme.dispose();
+        if (mTheme != null) {
+            mTheme.dispose();
+        }
     }
 
     private ThemeFile createThemeFor(@NonNull final ThemeData theme) throws IOException {


### PR DESCRIPTION
## Description
Avoid NPE in `MapsforgeVtmView.onDestroy` if no theme is loaded (or not yet loaded).
