### PR TITLE
add option to delete offline maps (fix #13163)

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -20,9 +20,14 @@
                 android:id="@+id/menu_group_map_sources"
                 android:checkableBehavior="single" >
             </group>
-            <item
-                android:id="@+id/menu_download_offlinemap"
-                android:visible="false" />
+            <group android:id="@+id/menu_group_offlinemaps">
+                <item
+                    android:id="@+id/menu_download_offlinemap"
+                    android:visible="false" />
+                <item
+                    android:id="@+id/menu_delete_offlinemap"
+                    android:visible="false" />
+            </group>
         </menu>
     </item>
     <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2452,6 +2452,10 @@
 
     <!-- Download map preference and menu entry -->
     <string name="downloadmap_title">Download offline map</string>
+    <string name="delete_offlinemap_title">Delete offline map</string>
+    <string name="no_deletable_offlinemaps">No deletable offline maps</string>
+    <string name="delete_file_confirmation">Delete %s?</string>
+    <string name="file_deleted_info">%s deleted</string>
     <string name="download_title">Download file</string>
     <string name="downloadmap_info">Select a map file for your region by tapping the \"Save\" icon.\n\nThe download is performed in the background. When the transfer is complete, the file is copied to the c:geo map folder and set as the current map.\n\nBe careful: Downloading a map can cause high network traffic!</string>
     <string name="downloadmap_filename">Downloading %s</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -380,7 +380,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         }
 
         // temporarily add button for unified map, if enabled in settings
-        if (Settings.getBoolean(R.string.pref_showUnifiedMap, false)) {
+        if (Settings.showUnifiedMap()) {
             addButton(R.drawable.sc_icon_map, lp, () -> startActivity(new Intent(this, UnifiedMapActivity.class)), "Start unified map");
         }
     }

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.Intents;
 import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.maps.MapProviderFactory;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.network.Parameters;
@@ -17,6 +18,7 @@ import cgeo.geocaching.storage.extension.PendingDownload;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AsyncTaskWithProgressText;
 import cgeo.geocaching.utils.CalendarUtils;
@@ -61,9 +63,16 @@ public class DownloaderUtils {
         // utility class
     }
 
-    public static boolean onOptionsItemSelected(final Activity activity, final int id) {
+    public static boolean onOptionsItemSelected(final Activity activity, final int id, final boolean inUnifiedMap) {
         if (id == R.id.menu_download_offlinemap) {
             activity.startActivity(new Intent(activity, DownloadSelectorActivity.class));
+            return true;
+        } else if (id == R.id.menu_delete_offlinemap) {
+            if (inUnifiedMap) {
+                TileProviderFactory.showDeleteMenu(activity);
+            } else {
+                MapProviderFactory.showDeleteMenu(activity);
+            }
             return true;
         }
         return false;

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -884,7 +884,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             final Viewport bb = mapView.getViewport();
             MapUtils.checkRoutingData(activity, bb.bottomLeft.getLatitude(), bb.bottomLeft.getLongitude(), bb.topRight.getLatitude(), bb.topRight.getLongitude());
         } else if (HistoryTrackUtils.onOptionsItemSelected(activity, id, () -> mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null), this::clearTrailHistory)
-                || DownloaderUtils.onOptionsItemSelected(activity, id)) {
+                || DownloaderUtils.onOptionsItemSelected(activity, id, false)) {
             return true;
         } else if (id == R.id.menu_routetrack) {
             mapActivity.getRouteTrackUtils().showPopup(individualRoute, this::setTarget);

--- a/main/src/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/cgeo/geocaching/maps/MapProviderFactory.java
@@ -2,15 +2,23 @@ package cgeo.geocaching.maps;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.databinding.LocSwitchActionBinding;
+import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.maps.google.v2.GoogleMapProvider;
 import cgeo.geocaching.maps.interfaces.MapProvider;
 import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
+import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -19,11 +27,15 @@ import android.widget.CheckBox;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+import androidx.core.view.MenuCompat;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -79,6 +91,7 @@ public class MapProviderFactory {
 
     public static void addMapviewMenuItems(final Activity activity, final Menu menu) {
         final SubMenu parentMenu = menu.findItem(R.id.menu_select_mapview).getSubMenu();
+        MenuCompat.setGroupDividerEnabled(parentMenu, true);
 
         final int currentSource = Settings.getMapSource().getNumericalId();
         int i = 0;
@@ -88,7 +101,48 @@ public class MapProviderFactory {
             i++;
         }
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources, true, true);
-        parentMenu.add(R.id.menu_group_map_sources, R.id.menu_download_offlinemap, mapSources.size(), '<' + activity.getString(R.string.downloadmap_title) + '>');
+        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_download_offlinemap, mapSources.size(), '<' + activity.getString(R.string.downloadmap_title) + '>');
+        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_delete_offlinemap, mapSources.size() + 1, '<' + activity.getString(R.string.delete_offlinemap_title) + '>');
+    }
+
+    /** displays a list of offline map sources and deletes selected item after confirmation */
+    public static void showDeleteMenu(final Activity activity) {
+        final int currentSource = Settings.getMapSource().getNumericalId();
+
+        // build list of available offline map sources except currently active one
+        final List<Pair<String, Integer>> list = new ArrayList<>();
+        for (MapSource mapSource : mapSources.values()) {
+            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource && mapSource.getNumericalId() != currentSource) {
+                list.add(new Pair<>(mapSource.getName(), mapSource.getNumericalId()));
+            }
+        }
+        if (list.isEmpty()) {
+            ActivityMixin.showToast(activity, R.string.no_deletable_offlinemaps);
+            return;
+        }
+
+        SimpleDialog.of(activity).setTitle(TextParam.id(R.string.delete_offlinemap_title)).selectSingle(list, (l, pos) -> TextParam.text(l.first), -1, SimpleDialog.SingleChoiceMode.NONE, (l, pos) -> {
+            final MapsforgeMapProvider.OfflineMapSource mapSource = (MapsforgeMapProvider.OfflineMapSource) getMapSource(l.second);
+            if (mapSource != null) {
+                final ContentStorage cs = ContentStorage.get();
+                final ContentStorage.FileInformation fi = cs.getFileInfo(mapSource.getMapUri());
+                if (fi != null) {
+                    SimpleDialog.of(activity).setTitle(TextParam.id(R.string.delete_offlinemap_title)).setMessage(TextParam.text(String.format(activity.getString(R.string.delete_file_confirmation), fi.name))).confirm((dialog, which) -> {
+                        final Uri cf = CompanionFileUtils.companionFileExists(cs.list(PersistableFolder.OFFLINE_MAPS), fi.name);
+                        cs.delete(mapSource.getMapUri());
+                        if (cf != null) {
+                            cs.delete(cf);
+                        }
+                        ActivityMixin.showShortToast(activity, String.format(activity.getString(R.string.file_deleted_info), fi.name));
+                        MapsforgeMapProvider.getInstance().updateOfflineMaps();
+                        if (Settings.showUnifiedMap()) {
+                            TileProviderFactory.buildTileProviderList(true);
+                        }
+                        ActivityMixin.invalidateOptionsMenu(activity);
+                    });
+                }
+            }
+        });
     }
 
     public static CheckBox createLocSwitchMenuItem(final Activity activity, final Menu menu) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -506,7 +506,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             final BoundingBox bb = mapView.getBoundingBox();
             MapUtils.checkRoutingData(this, bb.minLatitude, bb.minLongitude, bb.maxLatitude, bb.maxLongitude);
         } else if (HistoryTrackUtils.onOptionsItemSelected(this, id, () -> historyLayer.requestRedraw(), this::clearTrailHistory)
-                || DownloaderUtils.onOptionsItemSelected(this, id)) {
+                || DownloaderUtils.onOptionsItemSelected(this, id, false)) {
             return true;
         } else if (id == R.id.menu_routetrack) {
             routeTrackUtils.showPopup(individualRoute, this::setTarget);

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -1178,6 +1178,12 @@ public class Settings {
         return StringUtils.isBlank(language) ? MAP_LANGUAGE_DEFAULT_ID : language.hashCode();
     }
 
+    /** display UnifiedMap icon on home screen? */
+    public static boolean showUnifiedMap() {
+        return getBoolean(R.string.pref_showUnifiedMap, false);
+    }
+
+    /** use UnifiedMap as default map in certain places */
     public static boolean useUnifiedMap() {
         return getBoolean(R.string.pref_useUnifiedMap, false);
     }

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -512,7 +512,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
             final BoundingBox bb = tileProvider.getMap().getBoundingBox();
             MapUtils.checkRoutingData(this, bb.getMinLatitude(), bb.getMinLongitude(), bb.getMaxLatitude(), bb.getMaxLongitude());
         } else if (HistoryTrackUtils.onOptionsItemSelected(this, id, () -> tileProvider.getMap().positionLayer.repaintHistory(), () -> tileProvider.getMap().positionLayer.clearHistory())
-                || DownloaderUtils.onOptionsItemSelected(this, id)) {
+                || DownloaderUtils.onOptionsItemSelected(this, id, true)) {
             return true;
         } else if (id == R.id.menu_theme_mode) {
             tileProvider.getMap().selectTheme(this);

--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
@@ -34,6 +34,10 @@ public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider
         }
     }
 
+    protected Uri getMapUri() {
+        return mapUri;
+    }
+
     @Override
     @NonNull
     public String getId() {


### PR DESCRIPTION
## Description
Add option to delete an installed offline map to map menu for all map types (GM, NewMap, UnifiedMap).
Removes both map file and its companion file (if present) and updates list of available offline maps.
Currently active map cannot be deleted.