### PR TITLE
prevent long tap marker on OSM if map item got hit (fix #13168)

### DIFF
--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1048,7 +1048,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         }
     }
 
-    public void triggerLongTabContextMenu(final Point tapXY) {
+    public void triggerLongTapContextMenu(final Point tapXY) {
         if (Settings.isLongTapOnMapActivated()) {
 
             MapUtils.createMapLongClickPopupMenu(this, new Geopoint(tapHandlerLayer.getLongTabLatLong().latitude, tapHandlerLayer.getLongTabLatLong().longitude),

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/TapHandler.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/TapHandler.java
@@ -42,13 +42,16 @@ public class TapHandler {
         hitItems.clear();
     }
 
-    public void onLongPress(final Point tapXY) {
+    /** returns true if longTapContextMenu got triggered */
+    public boolean onLongPress(final Point tapXY) {
 
         final NewMap map = this.map.get();
 
         // show popup
         if (map != null && hitItems.isEmpty()) {
-            map.triggerLongTabContextMenu(tapXY);
+            map.triggerLongTapContextMenu(tapXY);
+            return true;
         }
+        return false;
     }
 }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
@@ -49,8 +49,10 @@ public class TapHandlerLayer extends Layer {
     @Override
     public boolean onLongPress(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
         longTabLatLong = tapLatLong;
+        if (!tapHandler.onLongPress(tapXY)) {
+            longTabLatLong = null;
+        }
         requestRedraw();
-        tapHandler.onLongPress(tapXY);
         tapHandler.finished();
 
         return true;


### PR DESCRIPTION
## Description
Prevent displaying a map marker on long tap if an existing map item got hit (OSM only).
