### PR TITLE
move long tap popup slightly to the right to avoid overlap

### DIFF
--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -29,6 +29,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimplePopupMenu;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
+import cgeo.geocaching.utils.DisplayUtils;
 import cgeo.geocaching.utils.FilterUtils;
 import static cgeo.geocaching.brouter.BRouterConstants.BROUTER_TILE_FILEEXTENSION;
 
@@ -188,7 +189,7 @@ public class MapUtils {
 
         return SimplePopupMenu.of(activity)
                 .setMenuContent(R.menu.map_longclick)
-                .setPosition(new Point(tapX, tapY - offset), (int) (offset * 1.25))
+                .setPosition(new Point(tapX + DisplayUtils.getPxFromDp(CgeoApplication.getInstance().getResources(), 10f, 1f), tapY - offset), (int) (offset * 1.25))
                 .setOnCreatePopupMenuListener(menu -> {
                     menu.findItem(R.id.menu_add_waypoint).setVisible(currentTargetCache != null);
                     menu.findItem(R.id.menu_add_to_route_start).setVisible(individualRoute.getNumPoints() > 0);


### PR DESCRIPTION
## Description
Move long-tap popup slightly to the right (by 10 dp) of the tapped location to avoid overlapping the marker:

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/174471768-bf6e87d1-d7bc-4faf-9c32-6ed3b386758f.png)|![image](https://user-images.githubusercontent.com/3754370/174471787-4288a9f1-b4c7-434d-8dfd-bb58807bfac5.png)|

(I had tried to hit the hospital's red cross sign with my tap. With this PR you'll be able to see the map marker's origin beside the popup again.)