### PR TITLE
Auto-disconnect Routing using Lifecycle observer

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -410,6 +410,11 @@ dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.1.4'
     implementation "io.reactivex.rxjava3:rxandroid:3.0.0"
 
+    // Support Library Lifecycle Helpers
+    def lifecycleVersion = '2.4.1'
+    implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
+
     // Support Library AppCompat
     implementation 'androidx.appcompat:appcompat:1.3.1'
 

--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -90,7 +90,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        Routing.connect();
+        Routing.connect(this);
         systemInformationTask.execute();
 
         int startPage = 0;
@@ -483,7 +483,6 @@ public class AboutActivity extends TabbedViewPagerActivity {
 
     @Override
     protected void onDestroy() {
-        Routing.disconnect();
         super.onDestroy();
         systemInformationTask.onDestroy();
     }

--- a/main/src/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/cgeo/geocaching/maps/AbstractMap.java
@@ -61,7 +61,7 @@ public abstract class AbstractMap {
 
     public void onCreate(final Bundle savedInstanceState) {
         mapActivity.superOnCreate(savedInstanceState);
-        Routing.connect();
+        Routing.connect(getActivity());
     }
 
     public void onResume() {
@@ -82,7 +82,6 @@ public abstract class AbstractMap {
 
     public void onDestroy() {
         mapActivity.superOnDestroy();
-        Routing.disconnect();
     }
 
     public boolean onCreateOptionsMenu(@NonNull final Menu menu) {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -362,7 +362,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         FilterUtils.initializeFilterBar(this, this);
         MapUtils.updateFilterBar(this, mapOptions.filterContext);
 
-        Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true));
+        Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true), this);
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 
         MapsforgeMapProvider.getInstance().updateOfflineMaps();
@@ -985,7 +985,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         this.mapView.destroy();
         ResourceBitmapCacheMonitor.release();
 
-        Routing.disconnect(ROUTING_SERVICE_KEY);
         if (this.mapAttribution != null) {
             this.mapAttribution.setOnClickListener(null);
         }

--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -19,6 +19,8 @@ import android.util.Xml;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,13 +61,28 @@ public final class Routing {
         connect(null, null);
     }
 
+    public static synchronized void connect(@Nullable final LifecycleOwner owner) {
+        connect(null, null, owner);
+    }
 
-    public static synchronized void connect(final String callbackKey, final Runnable onServiceConnectedCallback) {
+    public static synchronized void connect(@Nullable final String callbackKey, @Nullable final Runnable onServiceConnectedCallback) {
+        connect(callbackKey, onServiceConnectedCallback, null);
+    }
+
+    public static synchronized void connect(
+        @Nullable final String callbackKey,
+        @Nullable final Runnable onServiceConnectedCallback,
+        @Nullable final LifecycleOwner owner
+    ) {
 
         connectCount++;
 
         if (callbackKey != null && onServiceConnectedCallback != null) {
             REGISTERED_CALLBACKS.put(callbackKey, onServiceConnectedCallback);
+        }
+
+        if (owner != null) {
+            owner.getLifecycle().addObserver(new RoutingObserver(callbackKey));
         }
 
         if (isConnected()) {
@@ -322,5 +339,20 @@ public final class Routing {
      */
     public static String getExternalRoutingPackageName() {
         return getContext().getString(R.string.package_brouter);
+    }
+
+    private static class RoutingObserver implements DefaultLifecycleObserver {
+
+        @Nullable
+        private final String callbackKey;
+
+        RoutingObserver(@Nullable final String callbackKey) {
+            this.callbackKey = callbackKey;
+        }
+
+        @Override
+        public void onDestroy(@NonNull LifecycleOwner owner) {
+            disconnect(callbackKey);
+        }
     }
 }

--- a/main/src/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/cgeo/geocaching/maps/routing/Routing.java
@@ -351,7 +351,7 @@ public final class Routing {
         }
 
         @Override
-        public void onDestroy(@NonNull LifecycleOwner owner) {
+        public void onDestroy(@NonNull final LifecycleOwner owner) {
             disconnect(callbackKey);
         }
     }

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -211,7 +211,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         }
         changeMapSource(Settings.getTileProvider());
 
-        Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true));
+        Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true), this);
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 
 //        MapUtils.showMapOneTimeMessages(this, mapMode);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Uses lifecycle observers to automatically call `Routing.disconnect()`. This uses the Lifecycle aware component API to listen for `onDestroy()` and call disconnect without relying on the activity.

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
https://developer.android.com/topic/libraries/architecture/lifecycle