### PR TITLE
fix long tap popup position (fix #13168)

### DIFF
--- a/main/res/layout/filter_sort_bar.xml
+++ b/main/res/layout/filter_sort_bar.xml
@@ -3,7 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:id="@+id/filterbar"
+    android:background="@color/colorBackgroundActionBar">
 
     <LinearLayout
         android:id="@+id/filter_bar"

--- a/main/res/layout/map_distanceinfo.xml
+++ b/main/res/layout/map_distanceinfo.xml
@@ -3,7 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/distanceinfo"
+    android:layout_below="@id/filterbar">
 
     <TextView
         android:id="@+id/target"

--- a/main/res/layout/map_google.xml
+++ b/main/res/layout/map_google.xml
@@ -1,48 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical"
-    tools:context=".maps.google.v2.GoogleMapProvider" >
+    tools:context=".maps.google.v2.GoogleMapProvider">
+
+    <TextView
+        android:id="@+id/number"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="5dip"
+        android:background="@drawable/icon_bcg"
+        android:ellipsize="end"
+        android:gravity="center_horizontal"
+        android:lines="1"
+        android:paddingLeft="5dip"
+        android:paddingRight="5dip"
+        android:scrollHorizontally="true"
+        android:textSize="@dimen/textSize_detailsSecondary"
+        android:visibility="gone"
+        android:maxLines="1" />
+
+    <view
+        android:id="@+id/map"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        class="cgeo.geocaching.maps.google.v2.GoogleMapView"
+        android:apiKey="@string/maps_api2_key"
+        android:clickable="true"
+        android:focusable="true"
+        android:enabled="true"
+        android:keepScreenOn="true" />
 
     <include layout="@layout/filter_sort_bar" />
+    <include layout="@layout/map_distanceinfo" />
+    <include layout="@layout/map_settings_button" />
+    <include layout="@layout/map_progressbar" />
 
-    <RelativeLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" >
-
-        <TextView
-            android:id="@+id/number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="5dip"
-            android:background="@drawable/icon_bcg"
-            android:ellipsize="end"
-            android:gravity="center_horizontal"
-            android:lines="1"
-            android:paddingLeft="5dip"
-            android:paddingRight="5dip"
-            android:scrollHorizontally="true"
-            android:textSize="@dimen/textSize_detailsSecondary"
-            android:visibility="gone"
-            android:maxLines="1" />
-
-        <view
-            android:id="@+id/map"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            class="cgeo.geocaching.maps.google.v2.GoogleMapView"
-            android:apiKey="@string/maps_api2_key"
-            android:clickable="true"
-            android:focusable="true"
-            android:enabled="true"
-            android:keepScreenOn="true" />
-
-        <include layout="@layout/map_distanceinfo" />
-        <include layout="@layout/map_settings_button" />
-        <include layout="@layout/map_progressbar" />
-
-    </RelativeLayout>
-
-</LinearLayout>
+</RelativeLayout>

--- a/main/res/layout/map_mapsforge_v6.xml
+++ b/main/res/layout/map_mapsforge_v6.xml
@@ -1,43 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:orientation="vertical">
+    android:layout_height="fill_parent" >
+
+    <view
+        android:id="@+id/mfmapv5"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        class="cgeo.geocaching.maps.mapsforge.v6.MfMapView"
+        android:clickable="true"
+        android:focusable="true"
+        android:enabled="true"
+        android:keepScreenOn="true" />
+
+    <ImageView
+        android:id="@+id/map_attribution"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginLeft="6dp"
+        android:layout_marginBottom="11dp"
+        android:scaleType="centerInside"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentBottom="true"
+        android:layout_gravity="left"
+        android:src="@drawable/copyright"
+        tools:src="@drawable/copyright"/>
 
     <include layout="@layout/filter_sort_bar" />
+    <include layout="@layout/map_distanceinfo" />
+    <include layout="@layout/map_settings_button" />
+    <include layout="@layout/map_progressbar" />
 
-    <RelativeLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" >
-
-        <view
-            android:id="@+id/mfmapv5"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            class="cgeo.geocaching.maps.mapsforge.v6.MfMapView"
-            android:clickable="true"
-            android:focusable="true"
-            android:enabled="true"
-            android:keepScreenOn="true" />
-
-        <ImageView
-            android:id="@+id/map_attribution"
-            android:layout_width="20dp"
-            android:layout_height="20dp"
-            android:layout_marginLeft="6dp"
-            android:layout_marginBottom="11dp"
-            android:scaleType="centerInside"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentBottom="true"
-            android:layout_gravity="left"
-            android:src="@drawable/copyright"
-            tools:src="@drawable/copyright"/>
-
-        <include layout="@layout/map_distanceinfo" />
-        <include layout="@layout/map_settings_button" />
-        <include layout="@layout/map_progressbar" />
-
-    </RelativeLayout>
-
-</LinearLayout>
+</RelativeLayout>

--- a/main/res/layout/map_progressbar.xml
+++ b/main/res/layout/map_progressbar.xml
@@ -4,5 +4,5 @@
 	android:layout_width="match_parent"
 	android:layout_height="wrap_content"
 	android:indeterminateOnly="true"
-	android:layout_alignParentTop="true"
+	android:layout_below="@id/filterbar"
 	/>


### PR DESCRIPTION
## Description
Fixes map lon tap popup positioning problem described in #13171 and #13168 by changing filter bar into a map overlay, positioning the following map overlays relative to it.

This PR superseeds #13171.