### PR TITLE
avoid error log entries due to Toast.setGravity on API > 29

### DIFF
--- a/main/src/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/cgeo/geocaching/activity/ActivityMixin.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.utils.Log;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
 import android.view.Window;
@@ -95,7 +96,9 @@ public final class ActivityMixin {
         Log.v("[" + context.getClass().getName() + "].showToast(" + text + "){" + toastDuration + "}");
         try {
             final Toast toast = Toast.makeText(context, text, toastDuration);
-            toast.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM, 0, 100);
+            if (Build.VERSION.SDK_INT < 30) {
+                toast.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM, 0, 100);
+            }
             toast.show();
         } catch (RuntimeException re) {
             //this can happen e.g. in Unit tests when thread has no called Looper.prepare()

--- a/main/src/cgeo/geocaching/calendar/CalendarEntry.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarEntry.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.utils.TextUtils;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.CalendarContract;
 import android.text.Spanned;
 import android.text.style.ImageSpan;
@@ -144,8 +145,9 @@ class CalendarEntry {
     public void showToast(final Context context, final int res) {
         final String text = context.getResources().getString(res);
         final Toast toast = Toast.makeText(context, text, Toast.LENGTH_LONG);
-
-        toast.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM, 0, 100);
+        if (Build.VERSION.SDK_INT < 30) {
+            toast.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM, 0, 100);
+        }
         toast.show();
     }
 }


### PR DESCRIPTION
## Description
API 30 changes `Toast` behavior:

Doing a `Toast.setGravity` is not only ignored visually starting API 30, but additionally leads to an error entry in the log file for every toast being decorated that way.

This PR skips `setGravity` for toasts when running on API 30+
