### PR TITLE
prevent dependabot updates for jts-core to stay vtm-compatible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,6 @@ updates:
       # Ignore updates to the 'guava' package
       # found no way to instead integrate listenablefuture/9999.0-empty-to-avoid-conflict-with-guava
       - dependency-name: "com.google.guava:guava"
+      # Ignore updates to the 'jts-core' package
+      # jts-core 1.17.0 includes a API breaking change not supported by VTM
+      - dependency-name: "org.locationtech.jts:jts-core"


### PR DESCRIPTION
## Description
VTM uses jts-core 1.15.1 and accepts up to 1.16.1 due to an API-breaking change in jts-core 1.17. So let's dependabot ignore any upcoming changes to jts-core for now.

See https://github.com/mapsforge/vtm/discussions/935 for details