### PR TITLE
fix duplicate lifecycle.viewmodel class build error

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -413,6 +413,7 @@ dependencies {
     // Support Library Lifecycle Helpers
     def lifecycleVersion = '2.4.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-reactivestreams:$lifecycleVersion"


### PR DESCRIPTION
## Description
After updating some of the AndroidX classes suddenly kotlin version of lifecycle defaults to a different version, leading to class duplication. Fix it by explicitly stating the same version number for both, Java and Kotlin, version of the lib.