### PR TITLE
move CGeoMap BroadcastReceiver code to deferred map initialization (fix #13209)

### DIFF
--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -418,19 +418,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     public CGeoMap(@NonNull final MapActivityImpl activity) {
         super(activity);
-        // only add cache if it is currently visible
-        getActivity().getLifecycle().addObserver(new GeocacheRefreshedBroadcastReceiver(mapView.getContext()) {
-            @Override
-            protected void onReceive(final Context context, final String geocode) {
-                final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-
-                // only add cache if it is currently visible
-                if (caches.remove(cache)) {
-                    caches.add(cache);
-                    displayExecutor.execute(new DisplayRunnable(CGeoMap.this));
-                }
-            }
-        });
     }
 
     protected void countVisibleCaches() {
@@ -487,6 +474,20 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         mapView.setBuiltInZoomControls(true);
         mapView.displayZoomControls(true);
         mapView.setOnDragListener(new MapDragListener(this));
+
+        // only add cache if it is currently visible
+        getActivity().getLifecycle().addObserver(new GeocacheRefreshedBroadcastReceiver(mapView.getContext()) {
+            @Override
+            protected void onReceive(final Context context, final String geocode) {
+                final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+
+                // only add cache if it is currently visible
+                if (caches.remove(cache)) {
+                    caches.add(cache);
+                    displayExecutor.execute(new DisplayRunnable(CGeoMap.this));
+                }
+            }
+        });
 
         // initialize overlays
         mapView.clearOverlays();


### PR DESCRIPTION
## Description
The new BroadcastReceiver init code from #13184 had been placed in CGeoMap class initialization, but needs to be called after async map view initialization has been finished. Therefore moving it to `initializeMap()`.
