### PR TITLE
remove empty db check on backup (fix #13207)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -932,7 +932,6 @@
     <string name="init_user_confirmation">I know what I\'m doing</string>
     <string name="init_backup_success">c:geo\'s database was successfully copied to:</string>
     <string name="init_backup_failed">Backup of c:geo\'s database failed.</string>
-    <string name="init_backup_unnecessary">Database is empty, no backup necessary. Still create a backup?</string>
     <string name="init_backup_folder_exists_error">Unable to create a new backup folder. Did you already perform a backup in the last minute?</string>
     <string name="init_backup_no_backup_available">There is no backup file available.</string>
     <string name="backup_confirm_overwrite">This will delete your oldest existing backup folder from %s. \nDo you want to continue?</string>

--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -352,18 +352,6 @@ public class BackupUtils {
      * Create a backup after confirming to overwrite the existing backup.
      */
     public void backup(final Runnable runAfterwards, final boolean autobackup) {
-
-        // avoid overwriting an existing backup with an empty database
-        // (can happen directly after reinstalling the app)
-        if (DataStore.getAllCachesCount() == 0) {
-            SimpleDialog.of(activityContext).setTitle(R.string.init_backup_backup).setMessage(R.string.init_backup_unnecessary)
-                    .setButtons(SimpleDialog.ButtonTextSet.YES_NO).confirm((dialog, which) -> backupStep2(runAfterwards, autobackup));
-        } else {
-            backupStep2(runAfterwards, autobackup);
-        }
-    }
-
-    private void backupStep2(final Runnable runAfterwards, final boolean autobackup) {
         final List<ContentStorage.FileInformation> dirs = getDirsToRemove(autobackup ? MAX_AUTO_BACKUPS : Settings.allowedBackupsNumber(), autobackup);
         if (dirs != null) {
             if (autobackup) {


### PR DESCRIPTION
## Description
Removes the check for "empty DB" before running a backup
