### PR TITLE
set contacts compileSDK to 31

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     // signing is handled via private.properties
     signingConfigs {


### PR DESCRIPTION
## Description
Set compileSDK for cgeo-contacts to 31, same value as in the main cgeo project.
(Required to mitigate build errors on rebuild)
