### PR TITLE
Make notifications less disturbing

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2356,6 +2356,8 @@
     <string name="notification_channel_foreground_description">notification is shown while c:geo is doing background work</string>
     <string name="notification_channel_downloader_name">c:geo downloader</string>
     <string name="notification_channel_downloader_description">result notifications for downloads (e.g. offline maps)</string>
+    <string name="notification_channel_cache_download_name">cache downloader</string>
+    <string name="notification_channel_cache_download_description">result notifications for caches background downloads</string>
     <string name="notification_proximity_title">c:geo proximity notification</string>
     <string name="notification_download_receiver_title">Importing download</string>
 

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -1213,7 +1213,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             if (BranchDetectionHelper.isProductionBuild()) {
                 refreshStored(Collections.singletonList(cache));
             } else {
-                CacheDownloaderService.refreshCache(this, cache.getGeocode(), itemId == R.id.menu_refresh);
+                CacheDownloaderService.refreshCache(this, cache.getGeocode(), itemId == R.id.menu_refresh, this::refreshCurrentList);
             }
         } else {
             // we must remember the menu info for the sub menu, there is a bug

--- a/main/src/cgeo/geocaching/downloader/ReceiveDownloadService.java
+++ b/main/src/cgeo/geocaching/downloader/ReceiveDownloadService.java
@@ -61,8 +61,7 @@ public class ReceiveDownloadService extends AbstractForegroundIntentService {
     @Override
     public NotificationCompat.Builder createInitialNotification() {
         return Notifications.createNotification(this, NotificationChannels.FOREGROUND_SERVICE_NOTIFICATION, R.string.notification_download_receiver_title)
-                .setProgress(100, 0, true)
-                .setOnlyAlertOnce(true);
+                .setProgress(100, 0, true);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/service/AbstractForegroundIntentService.java
+++ b/main/src/cgeo/geocaching/service/AbstractForegroundIntentService.java
@@ -38,7 +38,9 @@ public abstract class AbstractForegroundIntentService extends IntentService {
         Log.w(logTag + " - WakeLock acquired");
 
         notificationManager = Notifications.getNotificationManager(this);
-        notification = createInitialNotification();
+        notification = createInitialNotification()
+                .setOnlyAlertOnce(true)
+                .setSilent(true);
 
         startForeground(getForegroundNotificationId(), notification.build());
     }

--- a/main/src/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/cgeo/geocaching/service/CacheDownloaderService.java
@@ -120,8 +120,7 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
 
         return Notifications.createNotification(this, NotificationChannels.FOREGROUND_SERVICE_NOTIFICATION, R.string.caches_store_background_title)
                 .setProgress(100, 0, true)
-                .addAction(R.drawable.ic_menu_cancel, getString(android.R.string.cancel), actionCancelIntent)
-                .setOnlyAlertOnce(true);
+                .addAction(R.drawable.ic_menu_cancel, getString(android.R.string.cancel), actionCancelIntent);
     }
 
     @Override
@@ -200,7 +199,7 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
 
     private void showEndNotification(final String text) {
         notificationManager.notify(Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
-                this, NotificationChannels.DOWNLOADER_RESULT_NOTIFICATION, R.string.caches_store_background_title, text).build());
+                this, NotificationChannels.CACHES_DOWNLOADED_NOTIFICATION, R.string.caches_store_background_title, text).setSilent(true).build());
 
     }
 

--- a/main/src/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/cgeo/geocaching/service/CacheDownloaderService.java
@@ -66,8 +66,8 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
                 forceRedownload -> askForListsIfNecessaryAndDownload(context, geocodes, forceRedownload, isOffline, onStartCallback), null);
     }
 
-    public static void refreshCache(final Activity context, final String geocode, final boolean isOffline) {
-        askForListsIfNecessaryAndDownload(context, Collections.singleton(geocode), true, isOffline, null);
+    public static void refreshCache(final Activity context, final String geocode, final boolean isOffline, @Nullable final Runnable onStartCallback) {
+        askForListsIfNecessaryAndDownload(context, Collections.singleton(geocode), true, isOffline, onStartCallback);
     }
 
     private static void askForListsIfNecessaryAndDownload(final Activity context, final Set<String> geocodes, final boolean forceRedownload, final boolean isOffline, @Nullable final Runnable onStartCallback) {

--- a/main/src/cgeo/geocaching/ui/notifications/NotificationChannels.java
+++ b/main/src/cgeo/geocaching/ui/notifications/NotificationChannels.java
@@ -13,7 +13,8 @@ public enum NotificationChannels {
     // do not change channel enum names, as the channel id's are depending on it which would lead to duplicated channels in the android settings
     PROXIMITY_NOTIFICATION(R.string.notification_channel_proximity_name, R.string.notification_channel_proximity_description, NotificationManagerCompat.IMPORTANCE_HIGH),
     FOREGROUND_SERVICE_NOTIFICATION(R.string.notification_channel_foreground_name, R.string.notification_channel_foreground_description, NotificationManagerCompat.IMPORTANCE_LOW),
-    DOWNLOADER_RESULT_NOTIFICATION(R.string.notification_channel_downloader_name, R.string.notification_channel_downloader_description, NotificationManagerCompat.IMPORTANCE_HIGH);
+    DOWNLOADER_RESULT_NOTIFICATION(R.string.notification_channel_downloader_name, R.string.notification_channel_downloader_description, NotificationManagerCompat.IMPORTANCE_HIGH),
+    CACHES_DOWNLOADED_NOTIFICATION(R.string.notification_channel_cache_download_name, R.string.notification_channel_cache_download_description, NotificationManagerCompat.IMPORTANCE_DEFAULT);
 
     public final int channelDisplayableTitle;
     public final int channelDisplayableDescription;


### PR DESCRIPTION
IIRC there were support tickets claiming that the background downloader makes too much sound. This makes notifications silent and less intrusive. (Proximity notifications are not affected)

Furthermore, fix a bug where the "download pending" icon was not shown correctly.