### PR TITLE
Automatically stop speech service on destroy

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -445,7 +445,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     @Override
     public void onDestroy() {
         createDisposables.clear();
-        SpeechService.stopService(this);
         if (cache != null) {
             cache.setChangeNotificationHandler(null);
         }

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -172,12 +172,6 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
     }
 
     @Override
-    public void onDestroy() {
-        SpeechService.stopService(getActivity());
-        super.onDestroy();
-    }
-
-    @Override
     public void onConfigurationChanged(@NonNull final Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 

--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -148,7 +148,6 @@ public class CompassActivity extends AbstractActionBarActivity {
     @Override
     public void onDestroy() {
         binding.rose.destroyDrawingCache();
-        SpeechService.stopService(this);
         super.onDestroy();
     }
 

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -134,12 +134,6 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
         return false;
     }
 
-    @Override
-    public void onDestroy() {
-        SpeechService.stopService(getActivity());
-        super.onDestroy();
-    }
-
     /**
      * Tries to navigate to the {@link Geocache} of this activity.
      */


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
Using lifecycle observers to automatically check for `onDestroy`. This lets us make the start/stop functions private in SpeechService.

