### PR TITLE
Remove one-off methods from Geocache

### DIFF
--- a/main/src/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/cgeo/geocaching/CacheMenuHandler.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.AbstractUIFactory;
 import cgeo.geocaching.ui.NavigationActionProvider;
+import cgeo.geocaching.utils.ShareUtils;
 
 import android.app.Activity;
 import android.view.Menu;
@@ -77,13 +78,13 @@ public final class CacheMenuHandler extends AbstractUIFactory {
             BookmarkUtils.askAndUploadCachesToBookmarkList(activity, Collections.singletonList(cache));
             return true;
         } else if (menuItem == R.id.menu_show_in_browser) {
-            cache.openInBrowser(activity);
+            ShareUtils.openUrl(activity, cache.getUrl(), true);
             return true;
         } else if (menuItem == R.id.menu_log_in_browser) {
-            cache.openCreateNewLogInBrowser(activity);
+            ShareUtils.openUrl(activity, cache.getCreateNewLogUrl(), true);
             return true;
         } else if (menuItem == R.id.menu_share || menuItem == R.id.menu_share_from_popup) {
-            cache.shareCache(activity, res);
+            ShareUtils.shareLink(activity, cache.getShareSubject(), cache.getUrl());
             return true;
         } else if (menuItem == R.id.menu_calendar) {
             CalendarAdder.addToCalendar(activity, cache);
@@ -125,7 +126,7 @@ public final class CacheMenuHandler extends AbstractUIFactory {
             NavigationSelectionActionProvider.initialize(menu.findItem(R.id.menu_navigate), cache);
         }
         menu.findItem(R.id.menu_log_visit).setVisible(cache.supportsLogging() && !Settings.getLogOffline());
-        menu.findItem(R.id.menu_log_in_browser).setVisible(cache.supportsLoggingOnline());
+        menu.findItem(R.id.menu_log_in_browser).setVisible(cache.getCreateNewLogUrl() != null);
         menu.findItem(R.id.menu_log_visit_offline).setVisible(cache.supportsLogging() && Settings.getLogOffline());
         menu.findItem(R.id.menu_set_found).setVisible(cache.supportsSettingFoundState() && !cache.isFound());
         menu.findItem(R.id.menu_set_DNF).setVisible(cache.supportsSettingFoundState() && !cache.isDNF());

--- a/main/src/cgeo/geocaching/calendar/CalendarAdder.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarAdder.java
@@ -3,12 +3,14 @@ package cgeo.geocaching.calendar;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
 
+import java.util.Calendar;
 import java.util.Date;
 
 public class CalendarAdder {
@@ -26,7 +28,7 @@ public class CalendarAdder {
             return;
         }
         final CalendarEntry entry = new CalendarEntry(cache, hiddenDate);
-        if (cache.isPastEvent()) {
+        if (CalendarUtils.isPastEvent(cache)) {
             // Event is in the past, only add to calendar after confirmation
             SimpleDialog.of(activity).setTitle(R.string.helper_calendar_pastevent_title).setMessage(R.string.helper_calendar_pastevent_question).setButtons(SimpleDialog.ButtonTextSet.YES_NO).confirm(
                     (dialog, id) -> entry.addEntryToCalendar(activity));

--- a/main/src/cgeo/geocaching/calendar/CalendarAdder.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarAdder.java
@@ -10,7 +10,6 @@ import android.app.Activity;
 
 import androidx.annotation.NonNull;
 
-import java.util.Calendar;
 import java.util.Date;
 
 public class CalendarAdder {

--- a/main/src/cgeo/geocaching/log/CacheLogsViewCreator.java
+++ b/main/src/cgeo/geocaching/log/CacheLogsViewCreator.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.UserClickListener;
 import cgeo.geocaching.ui.dialog.ContextMenuDialog;
+import cgeo.geocaching.utils.ShareUtils;
 
 import android.annotation.SuppressLint;
 import android.content.res.Resources;
@@ -18,6 +19,7 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.TooltipCompat;
 
 import java.util.ArrayList;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 public class CacheLogsViewCreator extends LogsViewCreator {
@@ -138,12 +141,14 @@ public class CacheLogsViewCreator extends LogsViewCreator {
     }
 
     @Override
-    protected ContextMenuDialog extendContextMenu(final ContextMenuDialog ctxMenu, final LogEntry log) {
+    protected ContextMenuDialog extendContextMenu(final ContextMenuDialog ctxMenu, @NonNull final LogEntry log) {
         final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
-        if (getCache().canShareLog(log)) {
-            ctxMenu.addItem(R.string.context_share_as_link, R.drawable.ic_menu_share, it -> getCache().shareLog(activity, log));
+        final String logUrl = getCache().getLogUrl(log);
+        final boolean canShareLog = StringUtils.isNotBlank(logUrl);
+        if (canShareLog) {
+            ctxMenu.addItem(R.string.context_share_as_link, R.drawable.ic_menu_share, it -> ShareUtils.shareLink(activity, getCache().getShareSubject(), logUrl));
             ctxMenu.addItem(activity.getString(R.string.cache_menu_browser),
-                    R.drawable.ic_menu_info_details, it -> getCache().openLogInBrowser(activity, log));
+                    R.drawable.ic_menu_info_details, it -> ShareUtils.openUrl(activity, logUrl, true));
         }
         if (isOfflineLog(log)) {
             ctxMenu.addItem(R.string.cache_personal_note_edit, R.drawable.ic_menu_edit, it -> new EditOfflineLogListener(getCache(), activity).onClick(null));

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -481,17 +481,6 @@ public class Geocache implements IWaypoint {
         return isEventCache() && hidden != null;
     }
 
-    public boolean isPastEvent() {
-        final Calendar cal = Calendar.getInstance();
-        cal.setTime(new Date());
-        cal.set(Calendar.HOUR_OF_DAY, 0);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.MILLISECOND, 0);
-        assert hidden != null; // Android Studio compiler issue
-        return hidden.compareTo(cal.getTime()) < 0;
-    }
-
     public boolean isEventCache() {
         return cacheType.isEvent();
     }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -47,12 +47,10 @@ import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.LazyInitializedList;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
-import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.functions.Func1;
 import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
@@ -606,16 +604,20 @@ public class Geocache implements IWaypoint {
         return getConnector().getPossibleLogTypes(this);
     }
 
-    public void openInBrowser(final Context context) {
-        ShareUtils.openUrl(context, getUrl(), true);
+    /**
+     * Get the browser URL for the given LogEntry. May return null if no url available or identifiable.
+     */
+    @Nullable
+    public String getLogUrl(@NonNull final LogEntry logEntry) {
+        return getConnector().getCacheLogUrl(this, logEntry);
     }
 
-    public void openLogInBrowser(final Context context, final LogEntry logEntry) {
-        ShareUtils.openUrl(context, getConnector().getCacheLogUrl(this, logEntry), true);
-    }
-
-    public void openCreateNewLogInBrowser(final Context context) {
-        ShareUtils.openUrl(context, getConnector().getCacheCreateNewLogUrl(this), true);
+    /**
+     * Get a browser URL to create a new log entry. May return null if connector does not support this.
+     */
+    @Nullable
+    public String getCreateNewLogUrl() {
+        return getConnector().getCacheCreateNewLogUrl(this);
     }
 
     @NonNull
@@ -640,11 +642,6 @@ public class Geocache implements IWaypoint {
     public boolean supportsLogging() {
         return getConnector().supportsLogging();
     }
-
-    public boolean supportsLoggingOnline() {
-        return getConnector().getCacheCreateNewLogUrl(this) != null;
-    }
-
 
     public boolean supportsLogImages() {
         return getConnector().supportsLogImages();
@@ -845,7 +842,7 @@ public class Geocache implements IWaypoint {
         return getConnector().supportsSettingFoundState();
     }
 
-    private String getShareSubject() {
+    public String getShareSubject() {
         final StringBuilder subject = new StringBuilder("Geocache ");
         subject.append(geocode);
         if (StringUtils.isNotBlank(name)) {
@@ -854,23 +851,11 @@ public class Geocache implements IWaypoint {
         return subject.toString();
     }
 
-    public void shareCache(@NonNull final Activity fromActivity, final Resources res) {
-        ShareUtils.shareLink(fromActivity, getShareSubject(), getUrl());
-    }
-
-    public boolean canShareLog(final LogEntry logEntry) {
-        return StringUtils.isNotBlank(getConnector().getCacheLogUrl(this, logEntry));
-    }
-
     public String getServiceSpecificLogId(final LogEntry logEntry) {
         if (logEntry == null) {
             return null;
         }
         return getConnector().getServiceSpecificLogId(logEntry.serviceLogId);
-    }
-
-    public void shareLog(@NonNull final Activity fromActivity, final LogEntry logEntry) {
-        ShareUtils.shareLink(fromActivity, getShareSubject(), getConnector().getCacheLogUrl(this, logEntry));
     }
 
     @Nullable

--- a/main/src/cgeo/geocaching/utils/CalendarUtils.java
+++ b/main/src/cgeo/geocaching/utils/CalendarUtils.java
@@ -9,6 +9,8 @@ import android.content.Intent;
 import android.net.Uri;
 import android.provider.CalendarContract;
 
+import androidx.annotation.NonNull;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -51,7 +53,11 @@ public final class CalendarUtils {
         return daysSince(date.getTimeInMillis());
     }
 
-    public static boolean isPastEvent(final Geocache cache) {
+    /**
+     * Check if this cache is an event cache for an event in the past.
+     * If the event is on the same day, true is returned even if the event already started.
+     */
+    public static boolean isPastEvent(@NonNull final Geocache cache) {
         if (!cache.isEventCache()) {
             return false;
         }

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.utils.CalendarUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,11 +35,11 @@ public class GeocacheTest extends CGeoTestCase {
     public static void testIsPastEvent() {
         final Date today = new Date();
         final Geocache cacheToday = new MockedEventCache(today);
-        assertThat(cacheToday.isPastEvent()).isFalse();
+        assertThat(CalendarUtils.isPastEvent(cacheToday)).isFalse();
 
         final Date yesterday = new Date(today.getTime() - 86400 * 1000);
         final MockedEventCache cacheYesterday = new MockedEventCache(yesterday);
-        assertThat(cacheYesterday.isPastEvent()).isTrue();
+        assertThat(CalendarUtils.isPastEvent(cacheYesterday)).isTrue();
     }
 
     public static void testEquality() {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Trying to make Geocache more of a data container and less of a god class. This change removes some methods dedicated to sharing that were each only used in one location, and replaces the method `isPastEvent` with the equivalent CalendarUtils method.
