### PR TITLE
show "log visit" menu entry in single cache map

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -61,6 +61,20 @@
         app:showAsAction="ifRoom|withText">
     </item>
     <item
+        android:id="@+id/menu_log_visit_offline"
+        android:icon="@drawable/ic_menu_edit"
+        android:title="@string/cache_menu_visit_offline"
+        android:visible="false"
+        app:showAsAction="ifRoom">
+    </item>
+    <item
+        android:id="@+id/menu_log_visit"
+        android:icon="@drawable/ic_menu_edit"
+        android:title="@string/cache_menu_visit"
+        android:visible="false"
+        app:showAsAction="ifRoom">
+    </item>
+    <item
         android:id="@+id/menu_store_caches"
         android:icon="@drawable/ic_menu_save"
         android:showAsAction="ifRoom|withText"

--- a/main/src/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/cgeo/geocaching/maps/CGeoMap.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.location.WaypointDistanceInfo;
+import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.maps.google.v2.GoogleGeoPoint;
 import cgeo.geocaching.maps.google.v2.GoogleMapProvider;
 import cgeo.geocaching.maps.google.v2.GooglePositionAndHistory;
@@ -735,7 +736,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
             menu.findItem(R.id.menu_hint).setVisible(mapOptions.mapMode == MapMode.SINGLE);
             menu.findItem(R.id.menu_compass).setVisible(mapOptions.mapMode == MapMode.SINGLE);
-
+            if (mapOptions.mapMode == MapMode.SINGLE) {
+                LoggingUI.onPrepareOptionsMenu(menu, getSingleModeCache());
+            }
             HistoryTrackUtils.onPrepareOptionsMenu(menu);
             // TrackUtils.onPrepareOptionsMenu is in maps/google/v2/GoogleMapActivity only
         } catch (final RuntimeException e) {
@@ -787,6 +790,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             menuShowHint();
         } else if (id == R.id.menu_compass) {
             menuCompass();
+        } else if (LoggingUI.onMenuItemSelected(item, activity, getSingleModeCache(), null)) {
+            return true;
         } else if (id == R.id.menu_check_routingdata) {
             final Viewport bb = mapView.getViewport();
             MapUtils.checkRoutingData(activity, bb.bottomLeft.getLatitude(), bb.bottomLeft.getLongitude(), bb.topRight.getLatitude(), bb.topRight.getLongitude());

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -22,6 +22,7 @@ import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.ProximityNotification;
 import cgeo.geocaching.location.Viewport;
+import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.maps.MapMode;
 import cgeo.geocaching.maps.MapOptions;
 import cgeo.geocaching.maps.MapProviderFactory;
@@ -415,6 +416,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
             menu.findItem(R.id.menu_hint).setVisible(mapOptions.mapMode == MapMode.SINGLE);
             menu.findItem(R.id.menu_compass).setVisible(mapOptions.mapMode == MapMode.SINGLE);
+            if (mapOptions.mapMode == MapMode.SINGLE) {
+                LoggingUI.onPrepareOptionsMenu(menu, getSingleModeCache());
+            }
             HistoryTrackUtils.onPrepareOptionsMenu(menu);
         } catch (final RuntimeException e) {
             Log.e("NewMap.onPrepareOptionsMenu", e);
@@ -473,6 +477,8 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             menuShowHint();
         } else if (id == R.id.menu_compass) {
             menuCompass();
+        } else if (LoggingUI.onMenuItemSelected(item, this, getSingleModeCache(), null)) {
+            return true;
         } else if (id == R.id.menu_check_routingdata) {
             final BoundingBox bb = mapView.getBoundingBox();
             MapUtils.checkRoutingData(this, bb.minLatitude, bb.minLongitude, bb.maxLatitude, bb.maxLongitude);


### PR DESCRIPTION
We already show quite some cache specific options if the map is displayed in single-cache mode. However, the mostly used feature "log visit" was missing...

This PR will add  "log visit" / "quick offline log" to the maps overflow menu, if only one specific cache should be displayed.

![grafik](https://user-images.githubusercontent.com/64581222/180315345-a8aff7e6-1552-4c3f-8555-740f0528f569.png)
