### PR TITLE
fix UnifiedMap line widths (fix #13277)

### DIFF
--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -241,7 +241,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
 
     private PolylineOptions getDirectionPolyline(final Geopoint from, final Geopoint to) {
         final PolylineOptions options = new PolylineOptions()
-                .width(MapLineUtils.getDirectionLineWidth())
+                .width(MapLineUtils.getDirectionLineWidth(false))
                 .color(MapLineUtils.getDirectionColor())
                 .zIndex(ZINDEX_DIRECTION_LINE)
                 .add(new LatLng(from.getLatitude(), from.getLongitude()));
@@ -344,7 +344,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
                         historyObjs.addPolyline(new PolylineOptions()
                                 .addAll(points)
                                 .color(MapLineUtils.getTrailColor())
-                                .width(MapLineUtils.getHistoryLineWidth())
+                                .width(MapLineUtils.getHistoryLineWidth(false))
                                 .zIndex(ZINDEX_HISTORY)
                         );
                     }
@@ -383,7 +383,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
                 routeObjs.addPolyline(new PolylineOptions()
                         .addAll(segment)
                         .color(MapLineUtils.getRouteColor())
-                        .width(MapLineUtils.getRouteLineWidth())
+                        .width(MapLineUtils.getRouteLineWidth(false))
                         .zIndex(ZINDEX_ROUTE)
                 );
             }
@@ -398,7 +398,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
                         trackObjs.addPolyline(new PolylineOptions()
                                 .addAll(segment)
                                 .color(MapLineUtils.getTrackColor())
-                                .width(MapLineUtils.getTrackLineWidth())
+                                .width(MapLineUtils.getTrackLineWidth(false))
                                 .zIndex(ZINDEX_TRACK)
                         );
                     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -44,7 +44,7 @@ public class HistoryLayer extends Layer {
 
     public void resetColor() {
         historyLine = AndroidGraphicFactory.INSTANCE.createPaint();
-        historyLine.setStrokeWidth(MapLineUtils.getHistoryLineWidth());
+        historyLine.setStrokeWidth(MapLineUtils.getHistoryLineWidth(false));
         historyLine.setStyle(Style.STROKE);
         historyLine.setColor(MapLineUtils.getTrailColor());
     }

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -37,7 +37,7 @@ public class NavigationLayer extends Layer {
 
     public void resetColor() {
         paint = AndroidGraphicFactory.INSTANCE.createPaint();
-        paint.setStrokeWidth(MapLineUtils.getDirectionLineWidth());
+        paint.setStrokeWidth(MapLineUtils.getDirectionLineWidth(false));
         paint.setStyle(Style.STROKE);
         paint.setColor(MapLineUtils.getDirectionColor());
         paint.setTextSize(20);

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -23,7 +23,7 @@ public class RouteLayer extends AbstractRouteLayer implements IndividualRoute.Up
         super();
         this.postRealRouteDistance = postRealRouteDistance;
         resetColor();
-        width = MapLineUtils.getRouteLineWidth();
+        width = MapLineUtils.getRouteLineWidth(false);
     }
 
     public void resetColor() {

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TrackLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/TrackLayer.java
@@ -6,7 +6,7 @@ import cgeo.geocaching.utils.MapLineUtils;
 public class TrackLayer extends AbstractRouteLayer implements Tracks.UpdateTrack {
 
     public TrackLayer() {
-        width = MapLineUtils.getTrackLineWidth();
+        width = MapLineUtils.getTrackLineWidth(false);
         resetColor();
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
@@ -44,7 +44,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
             directionObjs.addPolyline(new PolylineOptions()
                     .addAll(directionLine)
                     .color(MapLineUtils.getDirectionColor())
-                    .width(MapLineUtils.getDirectionLineWidth())
+                    .width(MapLineUtils.getDirectionLineWidth(true))
                     .zIndex(ZINDEX_DIRECTION_LINE)
             );
         }, MAP_GOOGLE);
@@ -107,7 +107,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
         repaintHistoryHelper((points) -> historyObjs.addPolyline(new PolylineOptions()
                 .addAll(points)
                 .color(MapLineUtils.getTrailColor())
-                .width(MapLineUtils.getHistoryLineWidth())
+                .width(MapLineUtils.getHistoryLineWidth(true))
                 .zIndex(ZINDEX_HISTORY)
         ));
     }
@@ -118,7 +118,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
         repaintRouteAndTracksHelper((segment, isTrack) -> trackObjs.addPolyline(new PolylineOptions()
                 .addAll(segment)
                 .color(isTrack ? MapLineUtils.getTrackColor() : MapLineUtils.getRouteColor())
-                .width(isTrack ? MapLineUtils.getTrackLineWidth() : MapLineUtils.getRouteLineWidth())
+                .width(isTrack ? MapLineUtils.getTrackLineWidth(true) : MapLineUtils.getRouteLineWidth(true))
                 .zIndex(isTrack ? ZINDEX_TRACK : ZINDEX_ROUTE)
         ));
     }

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgePositionLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgePositionLayer.java
@@ -60,7 +60,7 @@ class MapsforgePositionLayer extends AbstractPositionLayer<GeoPoint> {
         repaintPosition();
 
         // navigation
-        navigationLayer = new PathLayer(map, MapLineUtils.getDirectionColor(), MapLineUtils.getDirectionLineWidth());
+        navigationLayer = new PathLayer(map, MapLineUtils.getDirectionColor(), MapLineUtils.getDirectionLineWidth(true));
         map.layers().add(navigationLayer);
     }
 
@@ -125,7 +125,7 @@ class MapsforgePositionLayer extends AbstractPositionLayer<GeoPoint> {
     protected void repaintHistory() {
         clearLayers(historyLayers);
         repaintHistoryHelper((points) -> {
-            final PathLayer historyLayer = new PathLayer(map, MapLineUtils.getTrailColor(), MapLineUtils.getHistoryLineWidth());
+            final PathLayer historyLayer = new PathLayer(map, MapLineUtils.getTrailColor(), MapLineUtils.getHistoryLineWidth(true));
             historyLayers.add(historyLayer);
             map.layers().add(historyLayer);
             historyLayer.setPoints(points);
@@ -136,7 +136,7 @@ class MapsforgePositionLayer extends AbstractPositionLayer<GeoPoint> {
     protected void repaintRouteAndTracks() {
         clearLayers(trackLayers);
         repaintRouteAndTracksHelper((segment, isTrack) -> {
-            final PathLayer trackLayer = new PathLayer(map, isTrack ? MapLineUtils.getTrackColor() : MapLineUtils.getRouteColor(), isTrack ? MapLineUtils.getTrackLineWidth() : MapLineUtils.getRouteLineWidth());
+            final PathLayer trackLayer = new PathLayer(map, isTrack ? MapLineUtils.getTrackColor() : MapLineUtils.getRouteColor(), isTrack ? MapLineUtils.getTrackLineWidth(true) : MapLineUtils.getRouteLineWidth(true));
             trackLayers.add(trackLayer);
             map.layers().add(trackLayer);
             trackLayer.setPoints(segment);

--- a/main/src/cgeo/geocaching/utils/MapLineUtils.java
+++ b/main/src/cgeo/geocaching/utils/MapLineUtils.java
@@ -13,8 +13,8 @@ public class MapLineUtils {
 
     // history trail line
 
-    public static float getHistoryLineWidth() {
-        return getWidth(R.string.pref_mapline_trailwidth, R.integer.default_trailwidth);
+    public static float getHistoryLineWidth(final boolean unifiedMap) {
+        return getWidth(R.string.pref_mapline_trailwidth, R.integer.default_trailwidth, unifiedMap);
     }
 
     public static int getTrailColor() {
@@ -23,8 +23,8 @@ public class MapLineUtils {
 
     // direction line
 
-    public static float getDirectionLineWidth() {
-        return getWidth(R.string.pref_mapline_directionwidth, R.integer.default_directionwidth);
+    public static float getDirectionLineWidth(final boolean unifiedMap) {
+        return getWidth(R.string.pref_mapline_directionwidth, R.integer.default_directionwidth, unifiedMap);
     }
 
     public static int getDirectionColor() {
@@ -33,8 +33,8 @@ public class MapLineUtils {
 
     // route line
 
-    public static float getRouteLineWidth() {
-        return getWidth(R.string.pref_mapline_routewidth, R.integer.default_routewidth);
+    public static float getRouteLineWidth(final boolean unifiedMap) {
+        return getWidth(R.string.pref_mapline_routewidth, R.integer.default_routewidth, unifiedMap);
     }
 
     public static int getRouteColor() {
@@ -43,8 +43,8 @@ public class MapLineUtils {
 
     // track line
 
-    public static float getTrackLineWidth() {
-        return getWidth(R.string.pref_mapline_trackwidth, R.integer.default_trackwidth);
+    public static float getTrackLineWidth(final boolean unifiedMap) {
+        return getWidth(R.string.pref_mapline_trackwidth, R.integer.default_trackwidth, unifiedMap);
     }
 
     public static int getTrackColor() {
@@ -84,8 +84,8 @@ public class MapLineUtils {
 
     // helper methods
 
-    private static float getWidth(final int prefKeyId, final int defaultValueKeyId) {
-        return (Settings.getMapLineValue(prefKeyId, defaultValueKeyId) / 2.0f + 1.0f) * DisplayUtils.getDisplayDensity();
+    private static float getWidth(final int prefKeyId, final int defaultValueKeyId, final boolean unifiedMap) {
+        return (Settings.getMapLineValue(prefKeyId, defaultValueKeyId) / (unifiedMap ? 4.0f : 2.0f) + 1.0f) * DisplayUtils.getDisplayDensity();
     }
 
 }


### PR DESCRIPTION
Make map line widths in `UnifiedMap` a bit smaller to make them comparable in size to `NewMap`