### PR TITLE
Adjust info text for 'solved mystery' status filter (fix #13285)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -627,7 +627,7 @@
     <string name="cache_filter_status_select_label_has_offline_found_log">Has Offline Found Log</string>
     <string name="cache_filter_status_select_label_solved_mystery">Solved Mystery</string>
     <string name="cache_filter_status_select_label_has_user_defined_waypoints">Has User Defined Waypoints</string>
-    <string name="cache_filter_status_select_infotext_solved_mystery">This filter setting will only affect mystery caches.\n\n A mystery is considered \'solved\' if it has either changed coordinates or a valid final waypoint filled with coordinates.</string>
+    <string name="cache_filter_status_select_infotext_solved_mystery">This filter setting will only affect mystery caches. If you like to exclude other cache types, please define an appropriate cache type filter.\n\nA mystery is considered \'solved\' if it has either changed coordinates or a valid final waypoint filled with coordinates.</string>
 
     <string name="cache_filter_status_active">Active</string>
     <string name="cache_filter_status_disabled">Disabled</string>


### PR DESCRIPTION
Adjusts the info text for "solved mystery" status filter as described in #13285.
Also removes a leading space before the second sentence which lead to unwanted indentation.

@eddiemuc: Is this text ok for you?