### PR TITLE
fix #12652 - "routes" button sporadically missing

### DIFF
--- a/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -24,7 +24,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.Menu;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.ImageButton;
@@ -251,14 +250,14 @@ public class RouteTrackUtils {
         });
     }
 
-    public void onPrepareOptionsMenu(final Menu menu, final View anchor, final IndividualRoute route, final Tracks tracks) {
+    public void updateRouteTrackButtonVisibility(final View button, final IndividualRoute route, final Tracks tracks) {
         final AtomicBoolean someTrackAvailable = new AtomicBoolean(isRouteNonEmpty(route) || isTargetSet.call());
         tracks.traverse((key, r) -> {
             if (!someTrackAvailable.get() && isRouteNonEmpty(r)) {
                 someTrackAvailable.set(true);
             }
         });
-        anchor.setVisibility(someTrackAvailable.get() ? View.VISIBLE : View.GONE);
+        button.setVisibility(someTrackAvailable.get() ? View.VISIBLE : View.GONE);
     }
 
     public boolean onActivityResult(final int requestCode, final int resultCode, final Intent data) {

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -462,19 +462,23 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     private void setTrack(final String key, final Route route) {
         tracks.setRoute(key, route);
         resumeTrack(key, null == route);
+        routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
     }
 
     private void reloadIndividualRoute() {
         individualRoute.reloadRoute((route) -> {
             if (tileProvider.getMap().positionLayer != null) {
                 tileProvider.getMap().positionLayer.updateIndividualRoute(route);
+                routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
             }
         });
     }
 
     private void clearIndividualRoute() {
-        individualRoute.clearRoute((route) -> tileProvider.getMap().positionLayer.updateIndividualRoute(route));
-//        ActivityMixin.invalidateOptionsMenu(this); // @todo still needed since introduction of route popup?
+        individualRoute.clearRoute((route) -> {
+            tileProvider.getMap().positionLayer.updateIndividualRoute(route);
+            routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
+        });
         showToast(res.getString(R.string.map_individual_route_cleared));
     }
 
@@ -493,7 +497,6 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     public boolean onPrepareOptionsMenu(final Menu menu) {
         final boolean result = super.onPrepareOptionsMenu(menu);
         TileProviderFactory.addMapViewLanguageMenuItems(menu);
-        this.routeTrackUtils.onPrepareOptionsMenu(menu, findViewById(R.id.container_individualroute), individualRoute, tracks);
         ViewUtils.extendMenuActionBarDisplayItemCount(this, menu);
 
         // map rotation state


### PR DESCRIPTION
fix "routes" button sporadically missing by replacing lazy `invalidateOptionsMenu` calls with explicit triggering of the show/hide commands

