### PR TITLE
New navigation app 'other (coords only)' (rel. to #12810)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -306,7 +306,8 @@
     <string translatable="false" name="pref_navigation_menu_radar">navigationRadar</string>
     <string translatable="false" name="pref_navigation_menu_internal_map">navigationInternalMap</string>
     <string translatable="false" name="pref_navigation_menu_locus">navigationLocus</string>
-    <string translatable="false" name="pref_navigation_menu_google_maps">navigationGoogleMaps</string>
+    <string translatable="false" name="pref_navigation_menu_other">navigationGoogleMaps</string>
+    <string translatable="false" name="pref_navigation_menu_other_nolabel">navigationOtherNolabel</string>
     <string translatable="false" name="pref_navigation_menu_google_navigation">navigationGoogleNav</string>
     <string translatable="false" name="pref_navigation_menu_google_streetview">navigationStreetView</string>
     <string translatable="false" name="pref_navigation_menu_oruxmaps">navigationOruxmaps</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1382,6 +1382,7 @@
     <string name="cache_menu_radar">Radar</string>
     <string name="cache_menu_map">Map</string>
     <string name="cache_menu_map_ext">Other external apps</string>
+    <string name="cache_menu_map_ext_nolabel">Other external apps (coords only)</string>
     <string name="cache_menu_streetview">Street View</string>
     <string name="cache_menu_browser">Open in browser</string>
     <string name="no_browser_found">No browser found</string>

--- a/main/res/xml/preferences_navigation_navigation.xml
+++ b/main/res/xml/preferences_navigation_navigation.xml
@@ -32,8 +32,14 @@
     <CheckBoxPreference
         android:defaultValue="true"
         android:enabled="false"
-        android:key="@string/pref_navigation_menu_google_maps"
+        android:key="@string/pref_navigation_menu_other"
         android:title="@string/cache_menu_map_ext"
+        app:iconSpaceReserved="false" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:enabled="false"
+        android:key="@string/pref_navigation_menu_other_nolabel"
+        android:title="@string/cache_menu_map_ext_nolabel"
         app:iconSpaceReserved="false" />
     <CheckBoxPreference
         android:defaultValue="true"

--- a/main/src/cgeo/geocaching/apps/navi/NavigationAppFactory.java
+++ b/main/src/cgeo/geocaching/apps/navi/NavigationAppFactory.java
@@ -54,9 +54,13 @@ public final class NavigationAppFactory {
          */
         LOCUS(new LocusApp(), 4, R.string.pref_navigation_menu_locus),
         /**
-         * Google Maps
+         * Other external map app (label included)
          */
-        GOOGLE_MAPS(new GoogleMapsApp(), 6, R.string.pref_navigation_menu_google_maps),
+        OTHER_MAP(new OtherMapsApp.OtherMapsAppWithLabel(), 6, R.string.pref_navigation_menu_other),
+        /**
+         * Other external map app (coordinates only)
+         */
+        OTHER_MAP_NOLABEL(new OtherMapsApp.OtherMapsAppWithoutLabel(), 27, R.string.pref_navigation_menu_other_nolabel),
         /**
          * Google Navigation
          */

--- a/main/src/cgeo/geocaching/apps/navi/OtherMapsApp.java
+++ b/main/src/cgeo/geocaching/apps/navi/OtherMapsApp.java
@@ -14,11 +14,15 @@ import android.content.Intent;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
-class GoogleMapsApp extends AbstractPointNavigationApp {
+abstract class OtherMapsApp extends AbstractPointNavigationApp {
 
-    GoogleMapsApp() {
-        super(getString(R.string.cache_menu_map_ext), null);
+    boolean withLabel = false;
+
+    OtherMapsApp(@StringRes final int title, final boolean withLabel) {
+        super(getString(title), null);
+        this.withLabel = withLabel;
     }
 
     @Override
@@ -31,19 +35,19 @@ class GoogleMapsApp extends AbstractPointNavigationApp {
         navigate(context, point, context.getString(R.string.waypoint));
     }
 
-    private static void navigate(final Context context, final Geopoint point, final String label) {
+    private void navigate(final Context context, final Geopoint point, final String label) {
         try {
             final String latitude = GeopointFormatter.format(GeopointFormatter.Format.LAT_DECDEGREE_RAW, point);
             final String longitude = GeopointFormatter.format(Format.LON_DECDEGREE_RAW, point);
             final String geoLocation = "geo:" + latitude + "," + longitude;
-            final String query = latitude + "," + longitude + "(" + label + ")";
+            final String query = latitude + "," + longitude + (withLabel ? "(" + label + ")" : "");
             final String uriString = geoLocation + "?q=" + Uri.encode(query);
             context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(uriString)));
             return;
         } catch (final RuntimeException ignored) {
             // nothing
         }
-        Log.i("GoogleMapsApp.navigate: No maps application available.");
+        Log.i("OtherMapsApp.navigate: No maps application available.");
 
         ActivityMixin.showToast(context, getString(R.string.err_application_no));
     }
@@ -56,5 +60,17 @@ class GoogleMapsApp extends AbstractPointNavigationApp {
     @Override
     public void navigate(@NonNull final Context context, @NonNull final Waypoint waypoint) {
         navigate(context, waypoint.getCoords(), waypoint.getName());
+    }
+
+    static class OtherMapsAppWithLabel extends OtherMapsApp {
+        OtherMapsAppWithLabel() {
+            super(R.string.cache_menu_map_ext, true);
+        }
+    }
+
+    static class OtherMapsAppWithoutLabel extends OtherMapsApp {
+        OtherMapsAppWithoutLabel() {
+            super(R.string.cache_menu_map_ext_nolabel, false);
+        }
     }
 }


### PR DESCRIPTION
## Description
Adds a new navigation app to the navigation menu: "Other external apps (coords only)"

This is for navigation apps like Here WeGo, which start an (unwanted) textual search for the label text if both coords and label are given. This new navigation entry triggers the external app with coordinates only, which does work even with more recent versions of Here WeGo.

## Related issues
related to #12810 (actually a workaround, as you will have to use the new menu entry instead of navigation (driving))
