### PR TITLE
Replace misleading maps.me dialog (rel. to #13209)

### DIFF
--- a/mapswithme-api/src/com/mapswithme/maps/api/MapsWithMeApi.java
+++ b/mapswithme-api/src/com/mapswithme/maps/api/MapsWithMeApi.java
@@ -23,6 +23,7 @@
 package com.mapswithme.maps.api;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -67,7 +68,18 @@ public final class MapsWithMeApi {
       mwmIntent.setClassName(aInfo.packageName, aInfo.name);
       caller.startActivity(mwmIntent);
     } else {
-        (new DownloadMapsWithMeDialog(caller)).show();
+        // replace misleading/outdated maps.me dialog with c:geo warning message, see #13209
+        new AlertDialog.Builder(caller)
+            .setTitle("maps.me not found")
+            .setMessage("This may be due to maps.me not being installed or maps.me being installed in a version > 12.0, which is no longer compatible to their integration API.\n\nSee our FAQ for details.")
+            .setNeutralButton("Open FAQ", (dialog, which) -> {
+                final Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://faq.cgeo.org#13209"));
+                caller.startActivity(viewIntent);
+                })
+            .setPositiveButton(android.R.string.ok, ((dialog, which) -> { }))
+            .show();
+        // original code was:
+        // (new DownloadMapsWithMeDialog(caller)).show();
     }
   }
 


### PR DESCRIPTION
## Description
maps.me integration code displays a dialog box if it cannot find maps.me on the system. The dialog says something about "we have partnered with MAPS.ME" and asks the user to download the app (see screenshot below).

Since version 13.x of maps.me they seem to have changed their interface (without updating their integration code), so that the integration code is no longer able to detect maps.me. This leads to c:geo displaying this dialog on every call to maps.me API, even if maps.me is already installed. This is not only annoying, leading to many tickets on support, but also to negative reports on our Play Store entry.

This PR replaces the misleading maps.me message, explains the reason why it is not working currently, and links to our FAQ:

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/181946325-161f69cf-798f-4361-8ee4-651a933ff605.png)|![image](https://user-images.githubusercontent.com/3754370/181946431-427151c7-7abc-4e43-b1ec-c6373fb732d2.png)|

I propose to prepare a bugfix release soon, to give maps.me users of c:geo some in-app explanation on what's happening currently. (Or better: not happening, as we still have no response at all from maps.me)
If no one stops me I will create an update starting Sunday evening.