### PR TITLE
Add trim to bugfix changelog to avoid empty release block

### DIFF
--- a/main/src/cgeo/geocaching/AboutActivity.java
+++ b/main/src/cgeo/geocaching/AboutActivity.java
@@ -262,7 +262,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             changelog = changelog.substring(0, pos.first) + "\r\n## " + (current < max ? BUGFIX_VERSION_NAME[current] + " " + activity.getString(R.string.about_changelog_bugfix_release) : activity.getString(R.string.about_changelog_next_release)) + "\r\n" + changelog.substring(pos.second);
             current++;
         }
-        return changelog;
+        return changelog.trim();
     }
 
     public static class SystemViewCreator extends TabbedViewPagerFragment<AboutSystemPageBinding> {


### PR DESCRIPTION
## Description
Add `trim()` on reading bugfix changelog, as we would get an empty `Next release` block before otherwise.
