### PR TITLE
[NewMap] improve individual route rendering for coordinate-only-points

### DIFF
--- a/main/res/drawable/marker_routepoint.xml
+++ b/main/res/drawable/marker_routepoint.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="13dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+        android:fillColor="@color/dotBg_waypointOutline"/>
+    <path
+        android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+        android:fillColor="@color/just_black"/>
+    <path
+        android:pathData="M12,12m-6,0a6,6 0,1 1,12 0a6,6 0,1 1,-12 0"
+        android:fillColor="@color/just_white"/>
+</vector>

--- a/main/src/cgeo/geocaching/enumerations/CoordinatesType.java
+++ b/main/src/cgeo/geocaching/enumerations/CoordinatesType.java
@@ -2,5 +2,6 @@ package cgeo.geocaching.enumerations;
 
 public enum CoordinatesType {
     CACHE,
-    WAYPOINT
+    WAYPOINT,
+    COORDS
 }

--- a/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -191,7 +191,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
     }
 
     @Override
-    public void updateIndividualRoute(final Route route) {
+    public void updateIndividualRoute(final IndividualRoute route) {
         updateRoute(KEY_INDIVIDUAL_ROUTE, route);
         if (postRouteDistance != null) {
             postRouteDistance.postRealDistance(route.getDistance());

--- a/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -1,27 +1,51 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.CoordinatesType;
+import cgeo.geocaching.maps.mapsforge.v6.TapHandler;
+import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemLayer;
+import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.models.IndividualRoute;
-import cgeo.geocaching.models.Route;
+import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.utils.MapLineUtils;
 
+import android.graphics.drawable.Drawable;
+
+import androidx.core.content.res.ResourcesCompat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.mapsforge.core.graphics.Bitmap;
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.BoundingBox;
+import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.layer.Layer;
+import org.mapsforge.map.layer.LayerManager;
 
 public class RouteLayer extends AbstractRouteLayer implements IndividualRoute.UpdateIndividualRoute {
 
     private static final String KEY = "INDIVIDUALROUTE";
 
     private float distance = 0.0f;
-    private PostRealDistance postRealRouteDistance = null;
+
+    private final PostRealDistance postRealRouteDistance;
+    private final TapHandler tapHandler;
+    private final LayerManager layerManager;
+    private final Set<Layer> overlayLayers  = new HashSet<>();
 
     public interface PostRealDistance {
         void postRealDistance(float realDistance);
     }
 
-    public RouteLayer(final PostRealDistance postRealRouteDistance) {
+    public RouteLayer(final PostRealDistance postRealRouteDistance, final TapHandler tapHandler, final LayerManager layerManager) {
         super();
         this.postRealRouteDistance = postRealRouteDistance;
+        this.tapHandler = tapHandler;
+        this.layerManager = layerManager;
         resetColor();
         width = MapLineUtils.getRouteLineWidth();
     }
@@ -32,8 +56,23 @@ public class RouteLayer extends AbstractRouteLayer implements IndividualRoute.Up
     }
 
     @Override
-    public void updateIndividualRoute(final Route route) {
+    public void updateIndividualRoute(final IndividualRoute route) {
         super.updateRoute(KEY, route);
+
+        layerManager.getLayers().removeAll(overlayLayers);
+        overlayLayers.clear();
+
+        for (RouteItem item : route.getRouteItems()) {
+            if (item.getType() == RouteItem.RouteItemType.COORDS) {
+                final Drawable drawable = ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.marker_routepoint, null);
+                final Bitmap marker = AndroidGraphicFactory.convertToBitmap(drawable);
+                final Layer layer = new GeoitemLayer(new GeoitemRef(item.getIdentifier(), CoordinatesType.COORDS, null, 0, null, 0), false, tapHandler, new LatLong(item.getPoint().getLatitude(), item.getPoint().getLongitude()), marker, 0, 0);
+
+                layerManager.getLayers().add(layer);
+                overlayLayers.add(layer);
+            }
+        }
+
         this.distance = route.getDistance();
 
         if (postRealRouteDistance != null) {

--- a/main/src/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/cgeo/geocaching/models/IndividualRoute.java
@@ -35,7 +35,7 @@ public class IndividualRoute extends Route implements Parcelable {
     }
 
     public interface UpdateIndividualRoute {
-        void updateIndividualRoute(Route route);
+        void updateIndividualRoute(IndividualRoute route);
     }
 
     public interface SetTarget {
@@ -178,6 +178,16 @@ public class IndividualRoute extends Route implements Parcelable {
             }
         }
         return -1;
+    }
+
+    public ArrayList<RouteItem> getRouteItems () {
+        final ArrayList<RouteItem> items = new ArrayList<>();
+        if (segments != null) {
+            for (RouteSegment segment : segments) {
+                items.add(segment.getItem());
+            }
+        }
+        return items;
     }
 
     // Parcelable methods

--- a/main/src/cgeo/geocaching/models/RouteItem.java
+++ b/main/src/cgeo/geocaching/models/RouteItem.java
@@ -135,6 +135,9 @@ public class RouteItem implements Parcelable {
                     setDetails(buildIdentifier(waypoint), waypoint.getCoords(), RouteItemType.WAYPOINT, item.getGeocode(), item.getId());
                 }
                 break;
+            case COORDS:
+                setDetails(item.getItemCode(), parseCoordsFromIdentifier(item.getItemCode()), RouteItemType.COORDS, "", 0);
+                break;
             default:
                 throw new IllegalStateException("RouteItem: unknown item type");
         }
@@ -211,7 +214,11 @@ public class RouteItem implements Parcelable {
         return "COORDS!" + (null == point ? "" : " " + GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECMINUTE_SHORT, point));
     }
 
-    public enum RouteItemType {
+    private Geopoint parseCoordsFromIdentifier(final String identifier) {
+        return new Geopoint(identifier.substring("COORDS!".length()));
+    }
+
+    public enum RouteItemType { // todo: replace with generic CoordinatesType enum
         WAYPOINT,
         GEOCACHE,
         COORDS


### PR DESCRIPTION
For screenshots, see https://github.com/cgeo/cgeo/issues/13110#issuecomment-1204235834

@moving-bits as you've done quite some work in our map implementations recently + you're the inventor of "individual route": 

Do you think it's a good idea to squeeze coords-only routing points into the existing `GeoitemRef` model or should there be something own? Interestingly, our Google map doesn't use `GeoitemRef` at all, but is doing some really weird magic... So I'm a bit lost how to implement the long-click functionality there.

And are there any plans how taps will be handled in `UnifiedMap`? Ideally, there could be something way more flexible, allowing other map items like tracks to be clickable as well. We had discussed this some time ago in #11531

