### PR TITLE
Add additional entry point for settings (rel. to #13308)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -287,6 +287,10 @@
             </intent-filter>
             <meta-data android:name="android.app.searchable"
                 android:resource="@xml/searchable_settings" />
+            <intent-filter>
+                <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity android:name=".settings.ViewSettingsActivity" />
         <activity


### PR DESCRIPTION
## Description
Add an additional entry point to our settings to Android's app info for c:geo.

UX seems to be vendor specific, see the screenshot provided in https://github.com/cgeo/cgeo/issues/13308#issuecomment-1207195623 as well as this screenshot taken from emulated Nexus 5X:

![image](https://user-images.githubusercontent.com/3754370/183257778-3692ef44-fd84-4c36-b491-f320438ecc38.png)
