### PR TITLE
Support generic mf-v4-map and mf-theme downloads (fix #13298)

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2488,6 +2488,8 @@
     <string name="downloadmap_mapfile">map file</string>
     <string name="downloadmap_themefile">theme file</string>
     <string name="downloadmap_tilefile">routing data file</string>
+    <string name="downloadmap_othermapdownload">other map download</string>
+    <string name="downloadmap_otherthemedownload">other theme download</string>
     <string name="downloadmap_download">download</string>
     <string name="downloadmap_retrieving_directory_data">Retrieving folder data…</string>
     <string name="downloadmap_checking_for_updates">Checking for updates…</string>

--- a/main/src/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -37,8 +37,8 @@ public abstract class AbstractDownloader {
 
     AbstractDownloader(final Download.DownloadType offlineMapType, final @StringRes int mapBase, final @StringRes int mapSourceName, final @StringRes int mapSourceInfo, final @StringRes int projectUrl, final @StringRes int likeItUrl, final PersistableFolder targetFolder) {
         this.offlineMapType = offlineMapType;
-        this.mapBase = Uri.parse(CgeoApplication.getInstance().getString(mapBase));
-        this.mapSourceName = CgeoApplication.getInstance().getString(mapSourceName);
+        this.mapBase = mapBase == 0 ? Uri.parse("") : Uri.parse(CgeoApplication.getInstance().getString(mapBase));
+        this.mapSourceName = mapSourceName == 0 ? "" : CgeoApplication.getInstance().getString(mapSourceName);
         this.mapSourceInfo = mapSourceInfo == 0 ? "" : CgeoApplication.getInstance().getString(mapSourceInfo);
         this.projectUrl = projectUrl == 0 ? "" : CgeoApplication.getInstance().getString(projectUrl);
         if (projectUrl != 0) {

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderJustDownload.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderJustDownload.java
@@ -1,0 +1,38 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Download;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+public class MapDownloaderJustDownload extends AbstractMapDownloader {
+
+    private static final MapDownloaderJustDownload INSTANCE = new MapDownloaderJustDownload();
+
+    private MapDownloaderJustDownload() {
+        super(Download.DownloadType.DOWNLOADTYPE_MAP_JUSTDOWNLOAD, 0, R.string.downloadmap_mapfile, 0, 0, 0);
+        useCompanionFiles = false; // use single uri, and no companion files
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<Download> list, final @NonNull String page) {
+        // do nothing
+    }
+
+    @Nullable
+    @Override
+    protected Download checkUpdateFor(final @NonNull String page, final String remoteUrl, final String remoteFilename) {
+        return null;
+    }
+
+    @NonNull
+    public static MapDownloaderJustDownload getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderJustDownloadThemes.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderJustDownloadThemes.java
@@ -1,0 +1,38 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Download;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+public class MapDownloaderJustDownloadThemes extends AbstractThemeDownloader {
+
+    private static final MapDownloaderJustDownloadThemes INSTANCE = new MapDownloaderJustDownloadThemes();
+
+    private MapDownloaderJustDownloadThemes() {
+        super(Download.DownloadType.DOWNLOADTYPE_THEME_JUSTDOWNLOAD, 0, R.string.downloadmap_themefile, 0, 0, 0);
+        useCompanionFiles = false; // use single uri, and no companion files
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<Download> list, final @NonNull String page) {
+        // do nothing
+    }
+
+    @Nullable
+    @Override
+    protected Download checkUpdateFor(final @NonNull String page, final String remoteUrl, final String remoteFilename) {
+        return null;
+    }
+
+    @NonNull
+    public static MapDownloaderJustDownloadThemes getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMap.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMap.java
@@ -27,12 +27,10 @@ public class MapDownloaderReceiverSchemeMap extends AbstractActivity {
             DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_MAP_OPENANDROMAPS.id, newUri, "", "", this::callback, null);
         } else if (host.equals("kartat-dl.hylly.org") && path.endsWith("/mtk_suomi.map")) {
             // check for Hylly maps - mf-v4-map://kartat-dl.hylly.org/2021-04-25/mtk_suomi.map
-            final Uri newUri = Uri.parse("https://" + host + path);
-            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_MAP_HYLLY.id, newUri, "", "", this::callback, null);
+            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_MAP_HYLLY.id, Uri.parse("https://" + host + path), "", "", this::callback, null);
         } else {
-            // generic map download
-            Log.w("MapDownloaderReceiverSchemeMap: Received map download intent from unknown source: " + uri.toString());
-            finish();
+            // generic map download - only pure download supported, no updates
+            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_MAP_JUSTDOWNLOAD.id, Uri.parse("https://" + host + path), "", "", this::callback, null);
         }
     }
 

--- a/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMapTheme.java
+++ b/main/src/cgeo/geocaching/downloader/MapDownloaderReceiverSchemeMapTheme.java
@@ -27,12 +27,10 @@ public class MapDownloaderReceiverSchemeMapTheme extends AbstractActivity {
             DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS.id, newUri, "", "", this::callback, null);
         } else if (host.equals("kartat-dl.hylly.org") && path.endsWith("kartta.zip")) {
             // check for Hylly map themes - mf-theme://kartat-dl.hylly.org/2021-04-25/peruskartta.zip
-            final Uri newUri = Uri.parse("https://" + host + path);
-            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY.id, newUri, "", "", this::callback, null);
+            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY.id, Uri.parse("https://" + host + path), "", "", this::callback, null);
         } else {
-            // generic map theme download - not yet supported
-            Log.w("MapDownloaderReceiverSchemeMapTheme: Received map theme download intent from unknown source: " + uri.toString());
-            finish();
+            // generic map theme download - only pure download supported, no updates
+            DownloaderUtils.triggerDownload(this, R.string.downloadmap_title, Download.DownloadType.DOWNLOADTYPE_THEME_JUSTDOWNLOAD.id, Uri.parse("https://" + host + path), "", "", this::callback, null);
         }
     }
 

--- a/main/src/cgeo/geocaching/models/Download.java
+++ b/main/src/cgeo/geocaching/models/Download.java
@@ -9,6 +9,8 @@ import cgeo.geocaching.downloader.MapDownloaderFreizeitkarte;
 import cgeo.geocaching.downloader.MapDownloaderFreizeitkarteThemes;
 import cgeo.geocaching.downloader.MapDownloaderHylly;
 import cgeo.geocaching.downloader.MapDownloaderHyllyThemes;
+import cgeo.geocaching.downloader.MapDownloaderJustDownload;
+import cgeo.geocaching.downloader.MapDownloaderJustDownloadThemes;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
@@ -102,6 +104,9 @@ public class Download {
         DOWNLOADTYPE_MAP_HYLLY(6, R.string.downloadmap_mapfile),
         DOWNLOADTYPE_THEME_HYLLY(7, R.string.downloadmap_themefile),
 
+        DOWNLOADTYPE_MAP_JUSTDOWNLOAD(50, R.string.downloadmap_othermapdownload),
+        DOWNLOADTYPE_THEME_JUSTDOWNLOAD(51, R.string.downloadmap_otherthemedownload),
+
         DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile);
 
         public final int id;
@@ -158,6 +163,8 @@ public class Download {
                 offlineMapTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_MAP_HYLLY, MapDownloaderHylly.getInstance(), R.string.mapserver_hylly_name));
 
                 // all other download types
+                downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_MAP_JUSTDOWNLOAD, MapDownloaderJustDownload.getInstance(), R.string.downloadmap_mapfile));
+                downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_THEME_JUSTDOWNLOAD, MapDownloaderJustDownloadThemes.getInstance(), R.string.downloadmap_themefile));
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_BROUTER_TILES, BRouterTileDownloader.getInstance(), R.string.brouter_name));
 
                 // adding maps and map themes to download types for completeness


### PR DESCRIPTION
## Description
Support downloading of generic `mf-v4-map://` prefixed map files / `mf-theme://` prefixed map theme files using the internal downloader.
As the update mechanism for the specific source is unknown, this is "download only", no upgrades supported.
