### PR TITLE
fix #13313: use long instead of int in formulas, make int parsing aware of long-limits

### DIFF
--- a/main/src/cgeo/geocaching/utils/formulas/Formula.java
+++ b/main/src/cgeo/geocaching/utils/formulas/Formula.java
@@ -586,7 +586,7 @@ public final class Formula {
 
         if (p.eat('!')) {
             x = createNumeric("!", new FormulaNode[]{x}, (nums, vars) -> {
-                final int facValue = nums.getAsInt(0, 0);
+                final int facValue = (int) nums.getAsInt(0, 0);
                 if (!nums.get(0).isInteger() || facValue < 0) {
                     throw new FormulaException(WRONG_TYPE, "positive Integer", nums.get(0), nums.get(0).getType());
                 }

--- a/main/src/cgeo/geocaching/utils/formulas/FormulaFunction.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaFunction.java
@@ -31,7 +31,7 @@ public enum FormulaFunction {
     ABS("abs", FunctionGroup.SIMPLE_NUMERIC, R.string.formula_function_abs, "Absolute Value", null, 0,
             singleValueNumericFunction(Math::abs)),
     ROUND(new String[]{"round", "rd"}, FunctionGroup.SIMPLE_NUMERIC, R.string.formula_function_round, "Round", null, 0,
-            p -> Value.of(FormulaUtils.round(p.getAsDouble(0, -1), p.getAsInt(1, 0)))),
+            p -> Value.of(FormulaUtils.round(p.getAsDouble(0, -1), (int) p.getAsInt(1, 0)))),
 
     IF("if", FunctionGroup.COMPLEX_NUMERIC, R.string.formula_function_if, "If", null, 0,
             minMaxParamFunction(2, -1, FormulaUtils::ifFunction)),
@@ -39,12 +39,12 @@ public enum FormulaFunction {
     LENGTH(new String[]{"length", "len"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_length, "String Length", "''", 1,
             singleValueStringFunction(String::length)),
     SUBSTRING(new String[]{"substring", "sub"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_substring, "Substring", "'';0;1", 1,
-            minMaxParamFunction(1, 3, p -> FormulaUtils.substring(p.getAsString(0, ""), p.getAsInt(1, 0), p.getAsInt(2, 1)))),
+            minMaxParamFunction(1, 3, p -> FormulaUtils.substring(p.getAsString(0, ""), (int) p.getAsInt(1, 0), (int) p.getAsInt(2, 1)))),
 
     ROT13("rot13", FunctionGroup.COMPLEX_STRING, R.string.formula_function_rot13, "Rotate characters by 13", "''", 1,
             minMaxParamFunction(1, 1, p -> Value.of(FormulaUtils.rot(p.get(0).getAsString(), 13)))),
     ROT("rot", FunctionGroup.COMPLEX_STRING, R.string.formula_function_rot, "Rotate characters by x", "'';13", 1,
-            minMaxParamFunction(1, 2, p -> Value.of(FormulaUtils.rot(p.get(0).getAsString(), p.getAsInt(1, 13))))),
+            minMaxParamFunction(1, 2, p -> Value.of(FormulaUtils.rot(p.get(0).getAsString(), (int) p.getAsInt(1, 13))))),
     CHECKSUM(new String[]{"checksum", "cs"}, FunctionGroup.COMPLEX_NUMERIC, R.string.formula_function_checksum, "Checksum", null, 0,
             minMaxParamFunction(1, 1, p -> FormulaUtils.valueChecksum(p.get(0), false))),
     ICHECKSUM(new String[]{"ichecksum", "ics"}, FunctionGroup.COMPLEX_NUMERIC, R.string.formula_function_ichecksum, "Iterative Checksum", null, 0,

--- a/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -90,13 +90,13 @@ public class FormulaUtils {
         return hasElse ? values.get(values.size() - 1) : Value.of(0);
     }
 
-    public static int valueChecksum(final Value value, final boolean iterative) {
-        final int cs = value.isInteger() ? checksum(value.getAsInt(), false) : letterValue(value.getAsString());
+    public static long valueChecksum(final Value value, final boolean iterative) {
+        final long cs = value.isInteger() ? checksum(value.getAsInt(), false) : letterValue(value.getAsString());
         return iterative ? checksum(cs, true) : cs;
     }
 
-    public static int checksum(final int value, final boolean iterative) {
-        int result = Math.abs(value);
+    public static long checksum(final long value, final boolean iterative) {
+        long result = Math.abs(value);
         do {
             int cs = 0;
             while (result > 0) {

--- a/main/src/cgeo/geocaching/utils/formulas/Value.java
+++ b/main/src/cgeo/geocaching/utils/formulas/Value.java
@@ -27,7 +27,7 @@ public class Value {
     //some caching
     private String asString;
     private Double asDouble;
-    private Integer asInteger;
+    private Long asInteger;
 
     public static Value of(final Object value) {
         return new Value(value);
@@ -49,7 +49,7 @@ public class Value {
 
     public boolean isInteger() {
         getAsInt();
-        return !asInteger.equals(Integer.MIN_VALUE);
+        return !asInteger.equals(Long.MIN_VALUE);
     }
 
     public boolean isString() {
@@ -78,22 +78,26 @@ public class Value {
         return isDouble() ? getAsDouble() > 0d + DOUBLE_DELTA : !StringUtils.isBlank(getAsString());
     }
 
-    public int getAsInt() {
+    public long getAsInt() {
         if (asInteger == null) {
-            if (raw instanceof Integer) {
-                asInteger = ((Number) raw).intValue();
+            if (raw instanceof Integer || raw instanceof Long) {
+                asInteger = ((Number) raw).longValue();
             } else if (raw instanceof Number && Math.abs(Math.round(((Number) raw).doubleValue()) - ((Number) raw).doubleValue()) < DOUBLE_DELTA) {
-                asInteger = ((Number) raw).intValue();
+                asInteger = ((Number) raw).longValue();
             } else {
-                final double d = getAsDouble();
-                if (isDouble() && (Math.abs(Math.round(d) - d) < DOUBLE_DELTA)) {
-                    asInteger = (int) Math.round(d);
-                } else {
-                    asInteger = Integer.MIN_VALUE;
+                try {
+                    asInteger = Long.parseLong(getAsString());
+                } catch (NumberFormatException nfe) {
+                    final double d = getAsDouble();
+                    if (isDouble() && d <= Long.MAX_VALUE && d >= Long.MIN_VALUE && Math.abs(Math.round(d) - d) < DOUBLE_DELTA) {
+                        asInteger = Math.round(d);
+                    } else {
+                        asInteger = Long.MIN_VALUE;
+                    }
                 }
             }
         }
-        return asInteger.equals(Integer.MIN_VALUE) ? 0 : asInteger;
+        return asInteger.equals(Long.MIN_VALUE) ? 0L : asInteger;
     }
 
     public double getAsDouble() {

--- a/main/src/cgeo/geocaching/utils/formulas/ValueList.java
+++ b/main/src/cgeo/geocaching/utils/formulas/ValueList.java
@@ -46,7 +46,7 @@ public class ValueList implements Iterable<Value> {
         return isValidIdx(idx) && list.get(idx).isDouble() ? list.get(idx).getAsDouble() : defaultValue;
     }
 
-    public int getAsInt(final int idx, final int defaultValue) {
+    public long getAsInt(final int idx, final int defaultValue) {
         return isValidIdx(idx) && list.get(idx).isInteger() ? list.get(idx).getAsInt() : defaultValue;
     }
 

--- a/tests/src/cgeo/geocaching/utils/formulas/FormulaTest.java
+++ b/tests/src/cgeo/geocaching/utils/formulas/FormulaTest.java
@@ -41,6 +41,26 @@ public class FormulaTest {
     }
 
     @Test
+    public void bigIntegers() {
+        //Long value
+        final String longMax = String.valueOf(Long.MAX_VALUE); // this should be 9223372036854775807
+        final int longMaxCs = 88; // manually calculated checksum of Long.MAX_VALUE
+
+        assertThat(Formula.evaluate(longMax).isInteger()).isTrue();
+        assertThat(Formula.evaluate(longMax).getAsInt()).isEqualTo(Long.MAX_VALUE);
+        //Beyond Long Value
+        final String longMaxBeyond = longMax + "1";
+        final Value longMaxBeyondValue = Formula.evaluate(longMaxBeyond);
+        assertThat(longMaxBeyondValue.isInteger()).isFalse();
+        assertThat(longMaxBeyondValue.getAsInt()).isEqualTo(0L); // if too long for parsing -> return 0
+
+        //Long value checksums
+        assertThat(Formula.evaluate("cs(" + longMax + ")").getAsInt()).isEqualTo(longMaxCs);
+        assertThat(FormulaUtils.valueChecksum(longMaxBeyondValue, false)).isEqualTo(longMaxCs + 1);
+        assertThat(Formula.evaluate("cs(" + longMaxBeyond + ")").getAsInt()).isEqualTo(longMaxCs + 1);
+    }
+
+    @Test
     public void complex() {
         assertThat(eval("-2.5 + 3 * (4-1) + 3^3")).isEqualTo(33.5d);
     }
@@ -59,7 +79,10 @@ public class FormulaTest {
 
     @Test
     public void singleTestForDebug() {
-        assertThat(eval("A+1 4", "A", 12)).isEqualTo(134d);
+        final Value v = Value.of("345b");
+        v.getAsInt();
+        v.getAsDouble();
+
     }
 
     @Test
@@ -317,6 +340,9 @@ public class FormulaTest {
         assertThat(Value.of("345").isInteger()).isTrue();
         assertThat(Value.of("345b").isInteger()).isFalse();
         assertThat(Value.of("abcd").isInteger()).isFalse();
+
+        assertThat(Formula.evaluate("123.00").isInteger()).isTrue();
+        assertThat(Formula.evaluate("123.00").getAsInt()).isEqualTo(123L);
     }
 
     @Test


### PR DESCRIPTION
fix #13313: use long instead of int in formulas, make int parsing aware of long-limits