### PR TITLE
disable the "Send" button in log activity while it's not yet available

### DIFF
--- a/main/res/menu/abstract_logging_activity.xml
+++ b/main/res/menu/abstract_logging_activity.xml
@@ -4,10 +4,10 @@
 
     <item
         android:id="@+id/menu_send"
-        android:enabled="true"
+        android:enabled="false"
         android:icon="@drawable/ic_menu_send"
         android:title="@string/send"
-        app:showAsAction="ifRoom|withText"> <!-- enabled=true, we show a message if logging is not possible -->
+        app:showAsAction="ifRoom|withText">
     </item>
     <item
         android:id="@+id/menu_templates"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -143,7 +143,6 @@
     <string name="log_posting_generic_trackable">Posting %1$s %2$d/%3$d</string>
     <string name="log_clear">Clear</string>
     <string name="log_templates">Found it: Log template…</string>
-    <string name="log_post_not_possible">Download of data in progress…\nPlease try again in a few seconds or check your internet connection.</string>
     <string name="log_date_future_not_allowed">Future log dates are not allowed.</string>
     <string name="log_add">Add</string>
     <string name="log_repeat">Repeat last log</string>

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -99,7 +99,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     private final TextSpinner<LogType> logType = new TextSpinner<>();
     private final DateTimeEditor date = new DateTimeEditor();
 
-    private boolean sendButtonEnabled;
+    private MenuItem sendButton;
     private final TextSpinner<ReportProblemType> reportProblem = new TextSpinner<>();
     private final TextSpinner<LogTypeTrackable> trackableActionsChangeAll = new TextSpinner<>();
 
@@ -151,7 +151,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
         }
 
         refreshGui();
-        enablePostButton(true);
+        sendButton.setEnabled(true);
         showProgress(false);
     }
 
@@ -210,10 +210,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
         final ArrayList<TrackableLog> sortedTrackables = new ArrayList<>(trackables);
         Collections.sort(sortedTrackables, comparator.getComparator());
         return sortedTrackables;
-    }
-
-    private void enablePostButton(final boolean enabled) {
-        sendButtonEnabled = enabled;
     }
 
     @Override
@@ -283,11 +279,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
         } else {
             fillViewFromEntry(lastSavedState);
         }
-
-        // TODO: Why is it disabled in onCreate?
-        // Probably it should be disabled only when there is some explicit issue.
-        // See https://github.com/cgeo/cgeo/issues/7188
-        enablePostButton(false);
 
         refreshGui();
 
@@ -548,10 +539,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     }
 
     private void sendLogAndConfirm() {
-        if (!sendButtonEnabled) {
-            SimpleDialog.of(this).setMessage(R.string.log_post_not_possible).show();
-            return;
-        }
         if (CalendarUtils.isFuture(date.getCalendar())) {
             SimpleDialog.of(this).setMessage(R.string.log_date_future_not_allowed).show();
             return;
@@ -574,6 +561,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);
+        sendButton = menu.findItem(R.id.menu_send);
         menu.findItem(R.id.menu_image).setVisible(cache.supportsLogImages());
         menu.findItem(R.id.save).setVisible(true);
         menu.findItem(R.id.clear).setVisible(true);

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -71,7 +71,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
     /**
      * As long as we still fetch the current state of the trackable from the Internet, the user cannot yet send a log.
      */
-    private boolean postReady = true;
+    private MenuItem sendButton;
     private final DateTimeEditor date = new DateTimeEditor();
     private LogTypeTrackable typeSelected = LogTypeTrackable.getById(Settings.getTrackableAction());
     private Trackable trackable;
@@ -113,7 +113,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
             }
         }
 
-        postReady = loggingManager.postReady(); // we're done, user can post log
+        sendButton.setEnabled(loggingManager.postReady()); // we're done, user can post log
 
         showProgress(false);
     }
@@ -517,12 +517,6 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
      * Do form validation then post the Log
      */
     private void sendLog() {
-        // Can logging?
-        if (!postReady) {
-            showToast(res.getString(R.string.log_post_not_possible));
-            return;
-        }
-
         // Check Tracking Code existence
         if (loggingManager.isTrackingCodeNeededToPostNote() && binding.tracking.getText().toString().isEmpty()) {
             showToast(res.getString(R.string.err_log_post_missing_tracking_code));
@@ -559,6 +553,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         final boolean result = super.onCreateOptionsMenu(menu);
+        sendButton = menu.findItem(R.id.menu_send);
         for (final LogTemplate template : LogTemplateProvider.getTemplatesWithoutSignature()) {
             if (template.getTemplateString().equals("NUMBER") || template.getTemplateString().equals("ONLINENUM")) {
                 menu.findItem(R.id.menu_templates).getSubMenu().removeItem(template.getItemId());


### PR DESCRIPTION
disable the "Send" button in log activity while it's not yet available (loading TBs and log types), enable it once that is loaded.

partially fixes #13337 - there's no progress shown yet during the operation to indicate to the user that something is happening.
I noticed showProgress(true) in the code of that class which sounds quite fitting, but not sure what it's supposed to do. Legacy stuff, broken?