### PR TITLE
fix lint 'labelFor' in editWaypoint layout

### DIFF
--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -78,7 +78,7 @@
             <AutoCompleteTextView
                 android:id="@+id/name"
                 style="@style/textinput_embedded_singleline"
-                />
+                tools:ignore="LabelFor" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -90,7 +90,8 @@
                 style="@style/textinput_embedded"
 
                 android:inputType="textMultiLine|textCapSentences"
-                android:minLines="5"/>
+                android:minLines="5"
+                tools:ignore="LabelFor" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext"
@@ -99,7 +100,8 @@
                 android:id="@+id/user_note"
                 style="@style/textinput_embedded"
                 android:inputType="textMultiLine|textCapSentences"
-                android:minLines="5" />
+                android:minLines="5"
+                tools:ignore="LabelFor" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <CheckBox


### PR DESCRIPTION
## Description
fixes three lint errors in editWaypoint layout
(ignore message, as label is provided by surrounding element)
