### PR TITLE
revert fa4087fa, always enable "Send" button

### DIFF
--- a/main/res/menu/abstract_logging_activity.xml
+++ b/main/res/menu/abstract_logging_activity.xml
@@ -4,7 +4,6 @@
 
     <item
         android:id="@+id/menu_send"
-        android:enabled="false"
         android:icon="@drawable/ic_menu_send"
         android:title="@string/send"
         app:showAsAction="ifRoom|withText">

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="log_posting_generic_trackable">Posting %1$s %2$d/%3$d</string>
     <string name="log_clear">Clear</string>
     <string name="log_templates">Found it: Log template…</string>
+    <string name="log_post_not_possible">Download of data in progress…\nPlease try again in a few seconds or check your internet connection.</string>
     <string name="log_date_future_not_allowed">Future log dates are not allowed.</string>
     <string name="log_add">Add</string>
     <string name="log_repeat">Repeat last log</string>

--- a/main/src/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/cgeo/geocaching/log/LogCacheActivity.java
@@ -99,7 +99,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     private final TextSpinner<LogType> logType = new TextSpinner<>();
     private final DateTimeEditor date = new DateTimeEditor();
 
-    private MenuItem sendButton;
+    private boolean readyToPost = false;
     private final TextSpinner<ReportProblemType> reportProblem = new TextSpinner<>();
     private final TextSpinner<LogTypeTrackable> trackableActionsChangeAll = new TextSpinner<>();
 
@@ -449,7 +449,7 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     }
 
     private void showProgress(final boolean loading) {
-        sendButton.setEnabled(!loading);
+        readyToPost = !loading;
         binding.progressBar.setVisibility(loading ? View.VISIBLE : View.GONE);
     }
 
@@ -543,6 +543,10 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     }
 
     private void sendLogAndConfirm() {
+        if (!readyToPost) {
+            SimpleDialog.of(this).setMessage(R.string.log_post_not_possible).show();
+            return;
+        }
         if (CalendarUtils.isFuture(date.getCalendar())) {
             SimpleDialog.of(this).setMessage(R.string.log_date_future_not_allowed).show();
             return;
@@ -565,7 +569,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);
-        sendButton = menu.findItem(R.id.menu_send);
         menu.findItem(R.id.menu_image).setVisible(cache.supportsLogImages());
         menu.findItem(R.id.save).setVisible(true);
         menu.findItem(R.id.clear).setVisible(true);

--- a/main/src/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/cgeo/geocaching/log/LogTrackableActivity.java
@@ -71,7 +71,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
     /**
      * As long as we still fetch the current state of the trackable from the Internet, the user cannot yet send a log.
      */
-    private MenuItem sendButton;
+    private boolean readyToPost = true;
     private final DateTimeEditor date = new DateTimeEditor();
     private LogTypeTrackable typeSelected = LogTypeTrackable.getById(Settings.getTrackableAction());
     private Trackable trackable;
@@ -349,7 +349,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
     }
 
     private void showProgress(final boolean loading) {
-        sendButton.setEnabled(!loading);
+        readyToPost = !loading;
         binding.progressBar.setVisibility(loading ? View.VISIBLE : View.GONE);
     }
 
@@ -520,6 +520,12 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
      * Do form validation then post the Log
      */
     private void sendLog() {
+        // Can logging?
+        if (!readyToPost) {
+            showToast(res.getString(R.string.log_post_not_possible));
+            return;
+        }
+
         // Check Tracking Code existence
         if (loggingManager.isTrackingCodeNeededToPostNote() && binding.tracking.getText().toString().isEmpty()) {
             showToast(res.getString(R.string.err_log_post_missing_tracking_code));
@@ -556,7 +562,6 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         final boolean result = super.onCreateOptionsMenu(menu);
-        sendButton = menu.findItem(R.id.menu_send);
         for (final LogTemplate template : LogTemplateProvider.getTemplatesWithoutSignature()) {
             if (template.getTemplateString().equals("NUMBER") || template.getTemplateString().equals("ONLINENUM")) {
                 menu.findItem(R.id.menu_templates).getSubMenu().removeItem(template.getItemId());


### PR DESCRIPTION
don't disable the send button in log screens anymore.
Now that the log screen has a progress indicator it's easily visible to the user that "something" is ongoing.
For those users that don't know that this prevents logging the dialog with explanation is more useful than a disabled send-button

fixes #13370