### PR TITLE
suppress nm/na log type defaults for gc connector (rel. to #13343)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConnector.java
@@ -643,6 +643,8 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
         if (geocache.isFound()) {
             result.removeAll(Arrays.asList(LogType.FOUND_IT, LogType.ATTENDED, LogType.WEBCAM_PHOTO_TAKEN));
         }
+        // since 2020 (?) needs maintenance and need archive logs are no longer separate log types (but presented in a submenu)
+        result.removeAll(Arrays.asList(LogType.NEEDS_MAINTENANCE, LogType.NEEDS_ARCHIVE));
         return result;
     }
 

--- a/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
+++ b/tests/src-android/cgeo/geocaching/models/GeocacheTest.java
@@ -802,7 +802,6 @@ public class GeocacheTest extends CGeoTestCase {
         gcCache.setGeocode("GC123");
         gcCache.setType(CacheType.WEBCAM);
         assertThat(gcCache.getPossibleLogTypes()).as("possible GC cache log types").contains(LogType.WEBCAM_PHOTO_TAKEN);
-        assertThat(gcCache.getPossibleLogTypes()).as("possible GC cache log types").contains(LogType.NEEDS_MAINTENANCE);
 
         final Geocache ocCache = new Geocache();
         ocCache.setGeocode("OC1234");


### PR DESCRIPTION
## Description
No longer present "needs maintenance" and "needs archive" log types for gc connetor
