### PR TITLE
fix #13311: decimal values separated by = shall not be parsed as coords

### DIFF
--- a/main/src/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/cgeo/geocaching/location/GeopointParser.java
@@ -201,7 +201,7 @@ public class GeopointParser {
 
         //                                        (   1  )    (  2  )
         private static final String STRING_LON = "([WEO]?)\\s*(\\d++)\\b°";
-        private static final String STRING_SEPARATOR = "[^\\w'′\"″°]*";
+        private static final String STRING_SEPARATOR = "[^\\w'′\"″°=]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile("\\b" + STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);
@@ -388,7 +388,7 @@ public class GeopointParser {
 
         //                                        (       1       )
         private static final String STRING_LON = "(-?\\d++\\.\\d++)\\b°?";
-        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.-]*";
+        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.=-]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
fix #13311: decimal values separated by = shall not be parsed as coords