### PR TITLE
replace usages of deprecated LogEntry.getType()

### DIFF
--- a/main/src/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/cgeo/geocaching/TrackableActivity.java
@@ -592,7 +592,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
                 // days since last spotting
                 if (showTimeSpan) {
                     for (final LogEntry log : trackable.getLogs()) {
-                        if (log.getType() == LogType.RETRIEVED_IT || log.getType() == LogType.GRABBED_IT || log.getType() == LogType.DISCOVERED_IT || log.getType() == LogType.PLACED_IT) {
+                        if (log.logType == LogType.RETRIEVED_IT || log.logType == LogType.GRABBED_IT || log.logType == LogType.DISCOVERED_IT || log.logType == LogType.PLACED_IT) {
                             text.append(" (").append(Formatter.formatDaysAgo(log.date)).append(')');
                             break;
                         }

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -1869,7 +1869,7 @@ public final class GCParser {
         mergedLogs.subscribe(logEntries -> DataStore.saveLogs(cache.getGeocode(), logEntries, true));
         if (cache.isFound() || cache.isDNF()) {
             ownLogs.subscribe(logEntry -> {
-                if (logEntry.getType().isFoundLog() || (!cache.isFound() && cache.isDNF() && logEntry.getType() == LogType.DIDNT_FIND_IT)) {
+                if (logEntry.logType.isFoundLog() || (!cache.isFound() && cache.isDNF() && logEntry.logType == LogType.DIDNT_FIND_IT)) {
                     cache.setVisitedDate(logEntry.date);
                 }
             });

--- a/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
+++ b/main/src/cgeo/geocaching/connector/trackable/GeokretyParser.java
@@ -448,7 +448,7 @@ class GeokretyParser {
      */
     static String getLastSpottedUsername(final List<LogEntry> logsEntries) {
         for (final LogEntry log : logsEntries) {
-            final LogType logType = log.getType();
+            final LogType logType = log.logType;
             if (logType == LogType.GRABBED_IT || logType == LogType.VISIT) {
                 return log.author;
             }

--- a/main/src/cgeo/geocaching/export/FieldNotes.java
+++ b/main/src/cgeo/geocaching/export/FieldNotes.java
@@ -44,7 +44,7 @@ class FieldNotes {
                 .append(',')
                 .append(FIELD_NOTE_DATE_FORMAT.format(new Date(log.date)))
                 .append(',')
-                .append(StringUtils.capitalize(log.getType().type))
+                .append(StringUtils.capitalize(log.logType.type))
                 .append(",\"")
                 .append(StringUtils.replaceChars(log.log, '"', '\''))
                 .append("\"\n");

--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -635,8 +635,8 @@ abstract class GPXParser extends FileParser {
 
         gcLog.setEndElementListener(() -> {
             final LogEntry log = logBuilder.build();
-            if (log.getType() != LogType.UNKNOWN) {
-                if (log.getType().isFoundLog() && StringUtils.isNotBlank(log.author)) {
+            if (log.logType != LogType.UNKNOWN) {
+                if (log.logType.isFoundLog() && StringUtils.isNotBlank(log.author)) {
                     final IConnector connector = ConnectorFactory.getConnector(cache);
                     if (connector instanceof ILogin && StringUtils.equals(log.author, ((ILogin) connector).getUserName())) {
                         cache.setFound(true);
@@ -795,8 +795,8 @@ abstract class GPXParser extends FileParser {
 
         terraLog.setEndElementListener(() -> {
             final LogEntry log = logBuilder.build();
-            if (log.getType() != LogType.UNKNOWN) {
-                if (log.getType().isFoundLog() && StringUtils.isNotBlank(log.author)) {
+            if (log.logType != LogType.UNKNOWN) {
+                if (log.logType.isFoundLog() && StringUtils.isNotBlank(log.author)) {
                     final IConnector connector = ConnectorFactory.getConnector(cache);
                     if (connector instanceof ILogin && StringUtils.equals(log.author, ((ILogin) connector).getUserName())) {
                         cache.setFound(true);

--- a/main/src/cgeo/geocaching/log/LogEntry.java
+++ b/main/src/cgeo/geocaching/log/LogEntry.java
@@ -417,17 +417,6 @@ public class LogEntry implements Parcelable {
     }
 
     /**
-     * Get the {@link LogType}
-     *
-     * @return The {@link LogType}
-     * @deprecated use read-only property "logType" direclty
-     */
-    @Deprecated
-    public LogType getType() {
-        return logType;
-    }
-
-    /**
      * Get the {@link Image} for log
      *
      * @return The {@link Image}s List

--- a/main/src/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/cgeo/geocaching/log/LoggingUI.java
@@ -84,7 +84,7 @@ public final class LoggingUI extends AbstractUIFactory {
 
     private static void showOfflineMenu(final Geocache cache, final Activity activity, final DialogInterface.OnDismissListener listener) {
         final LogEntry currentLog = DataStore.loadLogOffline(cache.getGeocode());
-        final LogType currentLogType = currentLog == null ? null : currentLog.getType();
+        final LogType currentLogType = currentLog == null ? null : currentLog.logType;
 
         final List<LogType> logTypes = cache.getPossibleLogTypes();
         final ArrayList<LogTypeEntry> list = new ArrayList<>();

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -512,7 +512,7 @@ public class Geocache implements IWaypoint {
         boolean willAttend = false;
         final List<LogEntry> logs = getLogs();
         for (final LogEntry logEntry : logs) {
-            final LogType logType = logEntry.getType();
+            final LogType logType = logEntry.logType;
             if (logType == LogType.ATTENDED) {
                 return false;
             } else if (logType == LogType.WILL_ATTEND && logEntry.isOwn()) {
@@ -2155,7 +2155,7 @@ public class Geocache implements IWaypoint {
      */
     public boolean hasOwnLog(final LogType logType) {
         for (final LogEntry logEntry : getLogs()) {
-            if (logEntry.getType() == logType && logEntry.isOwn()) {
+            if (logEntry.logType == logType && logEntry.isOwn()) {
                 return true;
             }
         }

--- a/tests/src-android/cgeo/geocaching/connector/gc/TrackablesTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/TrackablesTest.java
@@ -98,7 +98,7 @@ public class TrackablesTest extends AbstractResourceInstrumentationTestCase {
         assertThat(logs).isNotNull();
         assertThat(logs).isNotEmpty();
         final LogEntry marked = logs.get(0);
-        assertThat(marked.getType()).isEqualTo(LogType.MARKED_MISSING);
+        assertThat(marked.logType).isEqualTo(LogType.MARKED_MISSING);
     }
 
     private Trackable getTB2R124() {

--- a/tests/src-android/cgeo/geocaching/connector/su/SuParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/su/SuParserTest.java
@@ -236,7 +236,7 @@ public class SuParserTest extends AbstractResourceInstrumentationTestCase {
 
     public void testCanParseLogType() throws Exception {
         parseCache(cacheJson);
-        assertThat(cache.getLogs().get(2).getType()).isEqualTo(LogType.OWNER_MAINTENANCE);
+        assertThat(cache.getLogs().get(2).logType).isEqualTo(LogType.OWNER_MAINTENANCE);
     }
 
     public void testCanParseLogDateTime() throws Exception {

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
@@ -177,7 +177,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(log6.id).isEqualTo(673734);
         assertThat(log6.date).isEqualTo(dateFormat.parse("2015-03-29 14:10").getTime());
         assertThat(log6.getDisplayText()).isEqualTo("Test");
-        assertThat(log6.getType()).isEqualTo(LogType.NOTE);
+        assertThat(log6.logType).isEqualTo(LogType.NOTE);
         assertThat(log6.cacheName).isNullOrEmpty();
         assertThat(log6.cacheGeocode).isNullOrEmpty();
 
@@ -186,7 +186,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(log5.id).isEqualTo(722027);
         assertThat(log5.date).isEqualTo(dateFormat.parse("2015-07-04 00:00").getTime());
         assertThat(log5.getDisplayText()).isEqualTo("Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of \"de Finibus Bonorum et Malorum\" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, \"Lorem ipsum dolor sit amet..\", comes from a line in section 1.10.32.");
-        assertThat(log5.getType()).isEqualTo(LogType.VISIT);
+        assertThat(log5.logType).isEqualTo(LogType.VISIT);
         assertThat(log5.cacheName).isEqualTo("GC2E895");
         assertThat(log5.cacheGeocode).isEqualTo("GC2E895");
 
@@ -195,7 +195,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(log4.id).isEqualTo(912063);
         assertThat(log4.date).isEqualTo(dateFormat.parse("2016-01-03 12:00").getTime());
         assertThat(log4.getDisplayText()).isEqualTo("test drop");
-        assertThat(log4.getType()).isEqualTo(LogType.PLACED_IT);
+        assertThat(log4.logType).isEqualTo(LogType.PLACED_IT);
         assertThat(log4.cacheName).isEqualTo("GC5BRQK");
         assertThat(log4.cacheGeocode).isEqualTo("GC5BRQK");
 
@@ -211,7 +211,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
                 "<br />" +
                 "<br />" +
                 "Multiline 4");
-        assertThat(log3.getType()).isEqualTo(LogType.DISCOVERED_IT);
+        assertThat(log3.logType).isEqualTo(LogType.DISCOVERED_IT);
         assertThat(log3.cacheName).isEqualTo("GC5BRQK");
         assertThat(log3.cacheGeocode).isEqualTo("GC5BRQK");
 
@@ -220,7 +220,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(log2.id).isEqualTo(967656);
         assertThat(log2.date).isEqualTo(dateFormat.parse("2016-03-21 18:31").getTime());
         assertThat(log2.getDisplayText()).isEqualTo("Grabbed");
-        assertThat(log2.getType()).isEqualTo(LogType.GRABBED_IT);
+        assertThat(log2.logType).isEqualTo(LogType.GRABBED_IT);
         assertThat(log2.cacheName).isNullOrEmpty();
         assertThat(log2.cacheGeocode).isNullOrEmpty();
 
@@ -229,7 +229,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(log1.id).isEqualTo(911689);
         assertThat(log1.date).isEqualTo(dateFormat.parse("2016-05-02 12:00").getTime());
         assertThat(log1.getDisplayText()).isEqualTo("test images in log");
-        assertThat(log1.getType()).isEqualTo(LogType.NOTE);
+        assertThat(log1.logType).isEqualTo(LogType.NOTE);
         assertThat(log1.cacheName).isNullOrEmpty();
         assertThat(log1.cacheGeocode).isNullOrEmpty();
 
@@ -341,7 +341,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         final LogEntry logNocybe = logs.get(2);
         assertThat(logNocybe.id).isEqualTo(855750);
         assertThat(logNocybe.author).isEqualTo("nocybe1810");
-        assertThat(logNocybe.getType()).isEqualTo(LogType.GRABBED_IT);
+        assertThat(logNocybe.logType).isEqualTo(LogType.GRABBED_IT);
         assertThat(logNocybe.cacheName).isNullOrEmpty();
         assertThat(logNocybe.cacheGeocode).isNullOrEmpty();
     }

--- a/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
@@ -557,7 +557,7 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
 
         final LogEntry log = logs.get(0);
         assertThat(log.author).isEqualTo("toubiV");
-        assertThat(log.getType()).isEqualTo(LogType.FOUND_IT);
+        assertThat(log.logType).isEqualTo(LogType.FOUND_IT);
         assertThat(log.log).startsWith("Visited the nearby Geocache");
         assertThat(log.log).endsWith("Nice location.");
         assertThat(log.date).isNotEqualTo(0);

--- a/tests/src-android/cgeo/geocaching/log/LogEntryTest.java
+++ b/tests/src-android/cgeo/geocaching/log/LogEntryTest.java
@@ -24,7 +24,7 @@ public class LogEntryTest extends CGeoTestCase {
         final LogEntry logEntry = new LogEntry.Builder().setDate(100).setLogType(LogType.FOUND_IT).setLog("LOGENTRY").build();
 
         assertThat(logEntry.date).isEqualTo(100);
-        assertThat(logEntry.getType()).isEqualTo(LogType.FOUND_IT);
+        assertThat(logEntry.logType).isEqualTo(LogType.FOUND_IT);
         assertThat(logEntry.log).isEqualTo("LOGENTRY");
     }
 


### PR DESCRIPTION
## Description
Replace usages of deprecated `LogEntry.getType()` by accessing the final property `logType` directly