### PR TITLE
replace usages of deprecated LogEntry.getLogImages()

### DIFF
--- a/main/src/cgeo/geocaching/log/LogEntry.java
+++ b/main/src/cgeo/geocaching/log/LogEntry.java
@@ -417,18 +417,6 @@ public class LogEntry implements Parcelable {
     }
 
     /**
-     * Get the {@link Image} for log
-     *
-     * @return The {@link Image}s List
-     * @deprecated use rad-only property "logImages" direclty
-     */
-    @NonNull
-    @Deprecated
-    public List<Image> getLogImages() {
-        return logImages;
-    }
-
-    /**
      * Get the hashCode of a LogEntry Object.
      *
      * @return The object's hash code

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -2010,7 +2010,7 @@ public class Geocache implements IWaypoint {
             if (Settings.isStoreLogImages()) {
                 for (final LogEntry log : cache.getLogs()) {
                     if (log.hasLogImages()) {
-                        for (final Image oneLogImg : log.getLogImages()) {
+                        for (final Image oneLogImg : log.logImages) {
                             imgGetter.getDrawable(oneLogImg.getUrl());
                         }
                     }

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -2565,7 +2565,7 @@ public class DataStore {
                 final long logId = insertLog.executeInsert();
                 if (log.hasLogImages()) {
                     final SQLiteStatement insertImage = PreparedStatement.INSERT_LOG_IMAGE.getStatement();
-                    for (final Image img : log.getLogImages()) {
+                    for (final Image img : log.logImages) {
                         imgCnt++;
                         insertImage.bindLong(1, logId);
                         insertImage.bindString(2, StringUtils.defaultIfBlank(img.title, ""));

--- a/tests/src-android/cgeo/geocaching/connector/gc/TrackablesTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/TrackablesTest.java
@@ -35,7 +35,7 @@ public class TrackablesTest extends AbstractResourceInstrumentationTestCase {
         assertThat(log).isNotNull();
         assertThat(log).hasSize(10);
 
-        final List<Image> logImages = log.get(5).getLogImages();
+        final List<Image> logImages = log.get(5).logImages;
         assertThat(logImages).isNotNull();
         assertThat(logImages).hasSize(1);
         assertThat(logImages.get(0).getUrl()).isEqualTo("https://img.geocaching.com/track/log/large/3dc286d2-671e-4502-937a-f1bd35a13813.jpg");

--- a/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/oc/OkapiClientTest.java
@@ -125,7 +125,7 @@ public class OkapiClientTest extends CGeoTestCase {
             }
         }
         assertThat(logWithImage).isNotNull();
-        assertThat(logWithImage.getLogImages()).isNotEmpty();
+        assertThat(logWithImage.logImages).isNotEmpty();
     }
 
 }

--- a/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/trackable/GeokretyParserTest.java
@@ -233,7 +233,7 @@ public class GeokretyParserTest extends AbstractResourceInstrumentationTestCase 
         assertThat(log1.cacheName).isNullOrEmpty();
         assertThat(log1.cacheGeocode).isNullOrEmpty();
 
-        final List<Image> logImages1 = log1.getLogImages();
+        final List<Image> logImages1 = log1.logImages;
         assertThat(logImages1).hasSize(2);
         final Image image1 = logImages1.get(0);
         assertThat(image1.getTitle()).isEqualTo("test logo 2");

--- a/tests/src-android/cgeo/geocaching/log/LogEntryTest.java
+++ b/tests/src-android/cgeo/geocaching/log/LogEntryTest.java
@@ -60,13 +60,13 @@ public class LogEntryTest extends CGeoTestCase {
 
         LogEntry logEntry = new LogEntry.Builder().setDate(100).setLogType(LogType.FOUND_IT).setLog("LOGENTRY").build();
 
-        assertThat(logEntry.getLogImages()).hasSize(0);
+        assertThat(logEntry.logImages).hasSize(0);
         assertThat(logEntry.getImageTitles()).isEqualTo(defaultTitle);
 
         final Image mockedImage1 = new Image.Builder().setTitle("").build();
         logEntry = logEntry.buildUpon().addLogImage(mockedImage1).build();
 
-        assertThat(logEntry.getLogImages()).hasSize(1);
+        assertThat(logEntry.logImages).hasSize(1);
         assertThat(logEntry.getImageTitles()).isEqualTo(defaultTitle);
 
         final Image mockedImage2 = new Image.Builder().setTitle("TITLE 1").build();
@@ -74,7 +74,7 @@ public class LogEntryTest extends CGeoTestCase {
         final Image mockedImage3 = new Image.Builder().setTitle("TITLE 2").build();
         logEntry = logEntry.buildUpon().addLogImage(mockedImage3).build();
 
-        assertThat(logEntry.getLogImages()).hasSize(3);
+        assertThat(logEntry.logImages).hasSize(3);
         final String titlesWanted = "• TITLE 1\n• TITLE 2";
         assertThat(logEntry.getImageTitles()).isEqualTo(titlesWanted);
     }


### PR DESCRIPTION
## Description
Replace usages of deprecated `LogEntry.getLogImages()` by directly accessing the final property `logImages`
