### PR TITLE
replace usages of deprecated GCConstants.gccodeToGCId

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -225,15 +225,6 @@ public final class GCConstants {
      */
     static final int NUMBER_OF_LOGS = 35;
 
-    /**
-     * Convert GCCode (geocode) to (old) GCIds
-     * Deprecated: use {@link GCUtils#gcLikeCodeToGcLikeId(String)}  instead
-     */
-    @Deprecated
-    public static long gccodeToGCId(final String gccode) {
-        return GCUtils.gcLikeCodeToGcLikeId(gccode);
-    }
-
     private GCConstants() {
         // this class shall not have instances
     }

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -265,7 +265,7 @@ public final class GCParser {
             cache.setFound(row.contains("/images/icons/16/found.png") || row.contains("uxUserLogDate\" class=\"Success\""));
 
             // infer cache id from geocode
-            cache.setCacheId(String.valueOf(GCConstants.gccodeToGCId(cache.getGeocode())));
+            cache.setCacheId(String.valueOf(GCUtils.gcLikeCodeToGcLikeId(cache.getGeocode())));
             cids.add(cache.getCacheId());
 
             // favorite count
@@ -459,7 +459,7 @@ public final class GCParser {
         cache.setGeocode(TextUtils.getMatch(page, GCConstants.PATTERN_GEOCODE, true, cache.getGeocode()));
 
         // cache id
-        cache.setCacheId(String.valueOf(GCConstants.gccodeToGCId(cache.getGeocode())));
+        cache.setCacheId(String.valueOf(GCUtils.gcLikeCodeToGcLikeId(cache.getGeocode())));
 
         // cache guid
         cache.setGuid(TextUtils.getMatch(page, GCConstants.PATTERN_GUID, true, cache.getGuid()));

--- a/main/src/cgeo/geocaching/files/FileParser.java
+++ b/main/src/cgeo/geocaching/files/FileParser.java
@@ -2,7 +2,7 @@ package cgeo.geocaching.files;
 
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.gc.GCConnector;
-import cgeo.geocaching.connector.gc.GCConstants;
+import cgeo.geocaching.connector.gc.GCUtils;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.utils.DisposableHandler;
@@ -86,7 +86,7 @@ abstract class FileParser {
 
         // fix potentially bad cache id
         if (GCConnector.getInstance().equals(ConnectorFactory.getConnector(cache))) {
-            cache.setCacheId(String.valueOf(GCConstants.gccodeToGCId(cache.getGeocode())));
+            cache.setCacheId(String.valueOf(GCUtils.gcLikeCodeToGcLikeId(cache.getGeocode())));
         }
     }
 }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -11,7 +11,7 @@ import cgeo.geocaching.connector.capability.IFavoriteCapability;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.capability.WatchListCapability;
 import cgeo.geocaching.connector.gc.GCConnector;
-import cgeo.geocaching.connector.gc.GCConstants;
+import cgeo.geocaching.connector.gc.GCUtils;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.su.SuConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
@@ -818,7 +818,7 @@ public class Geocache implements IWaypoint {
         // For some connectors ID can be calculated out of geocode
         if (StringUtils.isBlank(cacheId)) {
             if (getConnector() instanceof GCConnector) {
-                return String.valueOf(GCConstants.gccodeToGCId(geocode));
+                return String.valueOf(GCUtils.gcLikeCodeToGcLikeId(geocode));
             }
             if (getConnector() instanceof SuConnector) {
                 return SuConnector.geocodeToId(geocode);

--- a/main/src/cgeo/geocaching/sorting/AbstractCacheComparator.java
+++ b/main/src/cgeo/geocaching/sorting/AbstractCacheComparator.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.sorting;
 
-import cgeo.geocaching.connector.gc.GCConstants;
+import cgeo.geocaching.connector.gc.GCUtils;
 import cgeo.geocaching.models.Geocache;
 
 import java.util.Collections;
@@ -26,8 +26,8 @@ abstract class AbstractCacheComparator implements CacheComparator {
     private static int fallbackToGeocode(final Geocache cache1, final Geocache cache2) {
         final int comparePrefix = StringUtils.compareIgnoreCase(StringUtils.substring(cache1.getGeocode(), 0, 2), StringUtils.substring(cache2.getGeocode(), 0, 2));
         if (comparePrefix == 0) {
-            final long l1 = GCConstants.gccodeToGCId(cache1.getGeocode());
-            final long l2 = GCConstants.gccodeToGCId(cache2.getGeocode());
+            final long l1 = GCUtils.gcLikeCodeToGcLikeId(cache1.getGeocode());
+            final long l2 = GCUtils.gcLikeCodeToGcLikeId(cache2.getGeocode());
             if (l1 != l2) {
                 return l1 > l2 ? 1 : -1;
             }


### PR DESCRIPTION
## Description
replace usages of deprecated `GCConstants.gccodeToGCId` by `GCUtils.gcLikeCodeToGcLikeId` (which is also deprecated, but then you have one indirection less)
