### PR TITLE
remove language switch

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -68,7 +68,6 @@
     <string translatable="false" name="pref_loaddirectionimg">loaddirectionimg</string>
     <string translatable="false" name="pref_gc_fb_login_hint">gc_fb_login_hint</string>
     <string translatable="false" name="pref_fakekey_gc_website">fakekey_gc_website</string>
-    <string translatable="false" name="pref_gc_lang_switch">gc_lang_switch</string>
 
     <!-- settings for geocaching.com lab adventures screen -->
     <string translatable="false" name="preference_screen_al">preference_screen_al</string>

--- a/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/res/xml/preferences_services_geocaching_com.xml
@@ -39,13 +39,6 @@
                 android:title="@string/init_loaddirectionimg"
                 app:iconSpaceReserved="false" />
         </PreferenceScreen>
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="@string/pref_gc_lang_switch"
-            android:title="SWITCH LANGUAGE TO ENGLISH"
-            android:summary="This is a development feature which is not intended for normal usage. Leave it enabled."
-            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -862,10 +862,6 @@ public class Settings {
         return !isGCPremiumMember() && getBoolean(R.string.pref_loaddirectionimg, true);
     }
 
-    public static boolean getGcLanguageSwitchEnabled() {
-        return getBoolean(R.string.pref_gc_lang_switch, true);
-    }
-
     public static void setGcCustomDate(final String format) {
         putString(R.string.pref_gccustomdate, format);
     }

--- a/tests/src-android/cgeo/geocaching/connector/gc/GCLoginTest.java
+++ b/tests/src-android/cgeo/geocaching/connector/gc/GCLoginTest.java
@@ -36,6 +36,25 @@ public class GCLoginTest extends TestCase {
         assertThat(homeLocation).isEqualTo(TextUtils.stripHtml(homeLocation));
     }
 
+    public static void testLanguageSwitch() {
+        final String userLanguage = GCLogin.getInstance().getWebsiteLanguage();
+        assertThat(userLanguage).isNotNull();
+
+        // make sure language is set to english
+        if (!userLanguage.equals("en-US")) {
+            GCLogin.getInstance().switchToLanguage("en-US");
+        }
+        assertThat(GCLogin.getInstance().getWebsiteLanguage()).isEqualTo("en-US");
+
+        // test switching
+        assertThat(GCLogin.getInstance().switchToLanguage("de-DE")).isTrue();
+        assertThat(GCLogin.getInstance().getWebsiteLanguage()).isEqualTo("de-DE");
+
+        // reset to user preference
+        GCLogin.getInstance().switchToLanguage(userLanguage);
+        assertThat(GCLogin.getInstance().getWebsiteLanguage()).isEqualTo(userLanguage);
+    }
+
     public void testAvatar() {
         instance.resetServerParameters();
         AvatarUtils.changeAvatar(GCConnector.getInstance(), null);


### PR DESCRIPTION
Remove language switch. Language switch will from now on only be used by unit tests (which should be extended to test parsing in multiple languages). See #13228 for reference.