### PR TITLE
optimize string for cache downloader and fix capitalization mistakes

### DIFF
--- a/main/res/menu/map_activity.xml
+++ b/main/res/menu/map_activity.xml
@@ -78,7 +78,7 @@
         android:id="@+id/menu_store_caches"
         android:icon="@drawable/ic_menu_save"
         android:showAsAction="ifRoom|withText"
-        android:title="@string/caches_store_all"
+        android:title="@string/caches_store_offline_map"
         app:showAsAction="ifRoom|withText">
     </item>
     <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -386,9 +386,9 @@
         <item quantity="other">%d minutes</item>
     </plurals>
 
-    <string name="caches_store_offline">Store Offline</string>
-    <string name="caches_store_all">Store All</string>
-    <string name="caches_store_selected">Store Selected</string>
+    <string name="caches_store_offline">Store offline</string>
+    <string name="caches_store_offline_map">Store caches offline</string>
+    <string name="caches_store_selected">Store selected</string>
     <string name="caches_store_background_title">Download caches</string>
     <string name="caches_store_background_already_stored">Some caches are already stored. What should happen with them?</string>
     <string name="caches_store_background_option_nothing">Do nothing</string>


### PR DESCRIPTION
- optimize string for cache downloader (the previous string "Store all" is no longer fitting and not understandable enough IMHO)
- fix capitalization mistakes (make capitalization more consistent with other menu items)

![grafik](https://user-images.githubusercontent.com/64581222/190255275-296bf324-2734-4daf-abdf-a93877ff8ee2.png)
