### PR TITLE
[Performance] possibility to vacuum and reindex db

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1051,6 +1051,7 @@
     <string name="init_maintenance_directories_note">c:geo stores images and other files related to a cache in a dedicated folder. In some cases (e.g. when importing/exporting the database) this folder may contain obsolete files that can be deleted here.</string>
     <string name="init_maintenance_directories">Delete orphaned files</string>
     <string name="init_maintenance_start">Maintenance started</string>
+    <string name="init_maintenance_ongoing">This may take some time…</string>
     <string name="init_maintenance_finished">Maintenance finished</string>
     <string name="init_location">Geolocation</string>
     <string name="init_location_note">On devices equipped with Google Play Services, c:geo can automatically use a better geolocation provider. However, this prevents the use of an external BlueTooth GPS receiver.</string>

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -28,12 +28,19 @@ public class PreferenceOfflinedataFragment extends BasePreferenceFragment {
         findPreference(getString(R.string.pref_fakekey_preference_maintenance_directories)).setOnPreferenceClickListener(preference -> {
             // disable the button, as the cleanup runs in background and should not be invoked a second time
             preference.setEnabled(false);
-            ActivityMixin.showShortToast(getActivity(), R.string.init_maintenance_start);
+
+            final ProgressDialog waitDialog = new ProgressDialog(getActivity());
+            waitDialog.setTitle(getString(R.string.init_maintenance_start));
+            waitDialog.setMessage(getString(R.string.init_maintenance_ongoing));
+            waitDialog.setCancelable(false);
+            waitDialog.show();
+
             AndroidRxUtils.andThenOnUi(Schedulers.io(), DataStore::removeObsoleteGeocacheDataDirectories, () -> {
                 final Activity activity = getActivity();
                 if (activity != null) {
                     ActivityMixin.showShortToast(activity, R.string.init_maintenance_finished);
                 }
+                waitDialog.dismiss();
             });
             return true;
         });

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -1924,6 +1924,16 @@ public class DataStore {
                 }
             });
         }
+
+        // Try to reclaim unused space and reindex all tables
+        try {
+            Log.d("Database clean: vacuuming the freed space");
+            database.execSQL("VACUUM");
+            Log.d("Database clean: recreate indices");
+            database.execSQL("REINDEX");
+        } catch (final Exception e) {
+            Log.w("DataStore.clean", e);
+        }
     }
 
     public static boolean isThere(final String geocode, final String guid, final boolean checkTime) {
@@ -3868,7 +3878,7 @@ public class DataStore {
                                 }
                                 if (!found) {
                                     // update prefix in database
-                                    ContentValues values = new ContentValues();
+                                    final ContentValues values = new ContentValues();
                                     values.put("prefix", newPrefix);
                                     database.update(dbTableWaypoints, values, "_id=?", new String[]{String.valueOf(cursor2.getInt(0))});
                                     usedPrefixes.add(newPrefix);


### PR DESCRIPTION
rel. to #11429

- add `VACUUM` and `REINDEX` to our manual maintenance routine
- add blocking progress dialog while maintenance is running