### PR TITLE
Add view for pending downloads

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -903,6 +903,7 @@
             android:label="@string/search_bookmark_list">
         </activity>
         <activity android:name=".downloader.DownloadConfirmationActivity" android:exported="false" />
+        <activity android:name=".downloader.PendingDownloadsActivity" android:exported="false" />
         <activity
             android:name="cgeo.geocaching.downloader.DownloadSelectorActivity"
             android:label="@string/download_title">

--- a/main/res/layout/generic_recyclerview.xml
+++ b/main/res/layout/generic_recyclerview.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="0dip"
+        android:clipToPadding="false"
+        android:dividerHeight="1dip"
+        android:padding="0dip"
+        android:scrollbarStyle="outsideOverlay" />
+
+</LinearLayout>

--- a/main/res/layout/twotexts_twobuttons_item.xml
+++ b/main/res/layout/twotexts_twobuttons_item.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:minHeight="40sp"
     android:paddingTop="3dp"
     android:paddingLeft="3dp"

--- a/main/res/menu/main_activity_options.xml
+++ b/main/res/menu/main_activity_options.xml
@@ -77,6 +77,10 @@
                 </item>
             </menu>
         </item>
+        <item
+            android:id="@+id/menu_pending_downloads"
+            android:title="@string/downloader_pending_downloads">
+        </item>
     </group>
     <group android:id="@+id/menu_group_about">
         <item

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -716,7 +716,35 @@
     <string name="debug_user_error_report_title">Report a problem</string>
     <string name="debug_user_error_errortext">An unexpected problem has occured which we would request you to report to us:</string>
     <string name="debug_user_error_explain_options">Help us fixing c:geo problems by reporting them via email with system information and c:geo logfile included.\nPlease do always also include a detailed error description with your mail!\n\nBefore sending a mail please also check our FAQ and/or social media presence for known problems.\nOther contact options can be found at \'About c:geo\'</string>
+
+    <!-- download manager -->
     <string name="debug_current_downloads">Current downloads</string>
+    <string name="downloader_pending_downloads">Pending downloads</string>
+    <string name="downloader_no_pending_downloads">No pending downloads currently</string>
+    <string name="downloader_cancel_download">Cancel download</string>
+    <string name="downloader_cancel_file">Cancel pending download of "%s" and remove downloaded parts?</string>
+    <string name="downloader_cancelled_download">Cancelled download for "%s"</string>
+
+    <!-- Android system download manager status messages -->
+    <string name="asdm_status_failed">Download has failed (and will not be retried)</string>
+    <string name="asdm_status_paused">Download is waiting to retry or resume</string>
+    <string name="asdm_status_pending">Download is waiting to start</string>
+    <string name="asdm_status_running">Download is currently running</string>
+    <string name="asdm_status_successful">Download has successfully completed</string>
+
+    <string name="asdm_paused_queued_for_wifi">Paused: Waiting for Wifi</string>
+    <string name="asdm_paused_unknown">Paused for some other reason</string>
+    <string name="asdm_paused_waiting_for_network">Paused: Waiting for network connectivity to proceed</string>
+    <string name="asdm_paused_waiting_to_retry">Paused: Some network error occurred and the download manager is waiting before retrying the request</string>
+    <string name="asdm_error_cannot_resume">Error: Some possibly transient error occurred, but we can\'t resume the download</string>
+    <string name="asdm_error_device_not_found">Error: No external storage device was found. SD card mounted?</string>
+    <string name="asdm_error_file_already_exists">Error: Requested destination file already exists, will not be overwritten</string>
+    <string name="asdm_error_file_error">Error: Unknown storage issue</string>
+    <string name="asdm_error_http_data_error">Error: HTTP processing error at data level</string>
+    <string name="asdm_error_insufficient_space">Error: Insufficient storage space</string>
+    <string name="asdm_error_too_many_redirects">Error: Too many redirects</string>
+    <string name="asdm_error_unhandled_http_code">Error: Unhandled HTTP code</string>
+    <string name="asdm_error_unknwon">Error: Unknown error</string>
 
     <!-- settings -->
     <string name="settings_title_open_settings">Open settings?</string>

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.connector.gc.PocketQueryListActivity;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.databinding.MainActivityBinding;
 import cgeo.geocaching.downloader.DownloaderUtils;
+import cgeo.geocaching.downloader.PendingDownloadsActivity;
 import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.helper.UsefulAppsActivity;
 import cgeo.geocaching.location.Geopoint;
@@ -604,6 +605,8 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, DownloaderUtils::returnFromTileUpdateCheck);
         } else if (id == R.id.menu_update_mapdata) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, DownloaderUtils::returnFromMapUpdateCheck);
+        } else if (id == R.id.menu_pending_downloads) {
+            startActivity(new Intent(this, PendingDownloadsActivity.class));
         } else {
             return super.onOptionsItemSelected(item);
         }

--- a/main/src/cgeo/geocaching/downloader/PendingDownloadsActivity.java
+++ b/main/src/cgeo/geocaching/downloader/PendingDownloadsActivity.java
@@ -1,0 +1,216 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActionBarActivity;
+import cgeo.geocaching.storage.extension.PendingDownload;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.functions.Func1;
+import static cgeo.geocaching.utils.Formatter.formatBytes;
+import static cgeo.geocaching.utils.Formatter.formatDateForFilename;
+
+import android.annotation.SuppressLint;
+import android.app.DownloadManager;
+import android.content.Context;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+import com.google.android.material.button.MaterialButton;
+import io.noties.markwon.Markwon;
+
+public class PendingDownloadsActivity extends AbstractActionBarActivity {
+
+    RecyclerView recyclerView;
+    PendingDownloadsAdapter adapter;
+    DownloadManager downloadManager;
+    ArrayList<PendingDownload.PendingDownloadDescriptor> pendingDownloads;
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.generic_recyclerview);
+        setTitle(R.string.debug_current_downloads);
+
+        // retrieve list of pending downloads
+        pendingDownloads = PendingDownload.getAllPendingDownloads();
+        if (pendingDownloads.size() == 0) {
+            SimpleDialog.of(this).setTitle(R.string.debug_current_downloads).setMessage(R.string.downloader_no_pending_downloads).confirm((dialog, which) -> finish());
+        } else {
+            // get detailed info
+            downloadManager = (DownloadManager) getSystemService(Context.DOWNLOAD_SERVICE);
+            for (PendingDownload.PendingDownloadDescriptor download : pendingDownloads) {
+                final DownloadManager.Query query = new DownloadManager.Query();
+                query.setFilterById(download.id);
+
+                final StringBuilder sb = new StringBuilder();
+                try (Cursor c = downloadManager.query(query)) {
+                    while (c.moveToNext()) {
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_STATUS), "Status", (i) -> formatStatus(c.getInt(i)));
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_REASON), "Reason", (i) -> formatReason(c.getInt(i)));
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES), "Bytes Total", (i) -> formatBytes(c.getLong(i)));
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR), "Bytes Current", (i) -> formatBytes(c.getLong(i)));
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP), "Last Modified", (i) -> formatDateForFilename(c.getLong(i)));
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_URI), "Remote URI", c::getString);
+                        append(sb, c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI), "Local URI", c::getString);
+                    }
+                }
+                download.info = sb.toString();
+            }
+
+            // create view
+            recyclerView = findViewById(R.id.list);
+            adapter = new PendingDownloadsAdapter(this, downloadManager, pendingDownloads);
+            recyclerView.setAdapter(adapter);
+            recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        }
+    }
+
+    private String formatStatus(final int statusCode) {
+        int value = 0;
+        if (statusCode == DownloadManager.STATUS_FAILED) {
+            value = R.string.asdm_status_failed;
+        } else if (statusCode == DownloadManager.STATUS_PAUSED) {
+            value = R.string.asdm_status_paused;
+        } else if (statusCode == DownloadManager.STATUS_PENDING) {
+            value = R.string.asdm_status_pending;
+        } else if (statusCode == DownloadManager.STATUS_RUNNING) {
+            value = R.string.asdm_status_running;
+        } else if (statusCode == DownloadManager.STATUS_SUCCESSFUL) {
+            value = R.string.asdm_status_successful;
+        }
+        return (value > 0 ? getString(value) + " (" : "(") + statusCode + ")";
+    }
+
+    private String formatReason(final int reasonCode) {
+        int value = 0;
+        if (reasonCode == DownloadManager.PAUSED_QUEUED_FOR_WIFI) {
+            value = R.string.asdm_paused_queued_for_wifi;
+        } else if (reasonCode == DownloadManager.PAUSED_UNKNOWN) {
+            value = R.string.asdm_paused_unknown;
+        } else if (reasonCode == DownloadManager.PAUSED_WAITING_FOR_NETWORK) {
+            value = R.string.asdm_paused_waiting_for_network;
+        } else if (reasonCode == DownloadManager.PAUSED_WAITING_TO_RETRY) {
+            value = R.string.asdm_paused_waiting_to_retry;
+        } else if (reasonCode == DownloadManager.ERROR_CANNOT_RESUME) {
+            value = R.string.asdm_error_cannot_resume;
+        } else if (reasonCode == DownloadManager.ERROR_DEVICE_NOT_FOUND) {
+            value = R.string.asdm_error_device_not_found;
+        } else if (reasonCode == DownloadManager.ERROR_FILE_ALREADY_EXISTS) {
+            value = R.string.asdm_error_file_already_exists;
+        } else if (reasonCode == DownloadManager.ERROR_FILE_ERROR) {
+            value = R.string.asdm_error_file_error;
+        } else if (reasonCode == DownloadManager.ERROR_HTTP_DATA_ERROR) {
+            value = R.string.asdm_error_http_data_error;
+        } else if (reasonCode == DownloadManager.ERROR_INSUFFICIENT_SPACE) {
+            value = R.string.asdm_error_insufficient_space;
+        } else if (reasonCode == DownloadManager.ERROR_TOO_MANY_REDIRECTS) {
+            value = R.string.asdm_error_too_many_redirects;
+        } else if (reasonCode == DownloadManager.ERROR_UNHANDLED_HTTP_CODE) {
+            value = R.string.asdm_error_unhandled_http_code;
+        } else if (reasonCode == DownloadManager.ERROR_UNKNOWN) {
+            value = R.string.err_unknown;
+        }
+        return (value > 0 ? getString(value) + " (" : "(") + reasonCode + ")";
+    }
+
+    private void append(final StringBuilder sb, final int colIndex, final String prefix, final Func1<Integer, String> formatter) {
+        sb.append("- ").append(prefix).append(": ");
+        if (colIndex >= 0) {
+            sb.append(formatter.call(colIndex));
+        } else {
+            sb.append("(data not available)");
+        }
+        sb.append("\n");
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    public void cancelDownload(final long id) {
+        int pos = -1;
+        for (int i = 0; i < pendingDownloads.size(); i++) {
+            if (pendingDownloads.get(i).id == id) {
+                pos = i;
+                break;
+            }
+        }
+        if (pos >= 0) {
+            final PendingDownload.PendingDownloadDescriptor download = pendingDownloads.get(pos);
+            pendingDownloads.remove(pos);
+            adapter.notifyDataSetChanged();
+
+            // cancel selected download
+            PendingDownload.remove(id);
+            downloadManager.remove(id);
+            Toast.makeText(this, String.format(getString(R.string.downloader_cancelled_download), download.filename), Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private static class PendingDownloadsViewholder extends RecyclerView.ViewHolder {
+        TextView title;
+        TextView detail;
+        MaterialButton buttonDelete;
+
+        PendingDownloadsViewholder(final View itemView) {
+            super(itemView);
+            title = itemView.findViewById(R.id.title);
+            detail = itemView.findViewById(R.id.detail);
+            itemView.findViewById(R.id.button_left).setVisibility(View.GONE);
+
+            buttonDelete = itemView.findViewById(R.id.button_right);
+            buttonDelete.setIconResource(R.drawable.ic_menu_delete);
+            buttonDelete.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private static class PendingDownloadsAdapter extends RecyclerView.Adapter<PendingDownloadsViewholder> {
+
+        final PendingDownloadsActivity activity;
+        final DownloadManager downloadManager;
+        final ArrayList<PendingDownload.PendingDownloadDescriptor> pendingDownloads;
+        final Markwon markwon;
+
+        PendingDownloadsAdapter(final PendingDownloadsActivity activity, final DownloadManager downloadManager, final ArrayList<PendingDownload.PendingDownloadDescriptor> pendingDownloads) {
+            this.activity = activity;
+            this.downloadManager = downloadManager;
+            this.pendingDownloads = pendingDownloads;
+            this.markwon = Markwon.create(activity);
+        }
+
+        @Override
+        @NonNull
+        public PendingDownloadsViewholder onCreateViewHolder(@NonNull final ViewGroup parent, final int viewType) {
+            final View downloadView = LayoutInflater.from(parent.getContext()).inflate(R.layout.twotexts_twobuttons_item, parent, false);
+            return new PendingDownloadsViewholder(downloadView);
+        }
+
+        @Override
+        public void onBindViewHolder(final PendingDownloadsViewholder viewHolder, final int position) {
+            final PendingDownload.PendingDownloadDescriptor download = pendingDownloads.get(position);
+            viewHolder.title.setText(download == null ? "" : download.filename + " (# " + download.id + ")");
+            if (download != null) {
+                markwon.setMarkdown(viewHolder.detail, download.info);
+                viewHolder.buttonDelete.setOnClickListener(v -> SimpleDialog.of(activity).setTitle(R.string.downloader_cancel_download).setMessage(TextParam.text(String.format(activity.getString(R.string.downloader_cancel_file), download.filename))).confirm((dialog, which) -> activity.cancelDownload(download.id)));
+            } else {
+                viewHolder.detail.setText("");
+                viewHolder.buttonDelete.setVisibility(View.GONE);
+            }
+        }
+
+        @Override
+        public int getItemCount() {
+            return pendingDownloads.size();
+        }
+
+    }
+
+}

--- a/main/src/cgeo/geocaching/storage/extension/PendingDownload.java
+++ b/main/src/cgeo/geocaching/storage/extension/PendingDownload.java
@@ -5,6 +5,8 @@ import cgeo.geocaching.storage.DataStore;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+
 public class PendingDownload extends DataStore.DBExtension {
 
     private static final DataStore.DBExtensionType type = DataStore.DBExtensionType.DBEXTENSION_PENDING_DOWNLOAD;
@@ -33,6 +35,15 @@ public class PendingDownload extends DataStore.DBExtension {
         return (int) getLong2();
     }
 
+    /** to be used by PendingDownloadsActivity primarily */
+    public static ArrayList<PendingDownloadDescriptor> getAllPendingDownloads() {
+        final ArrayList<PendingDownloadDescriptor> result = new ArrayList<>();
+        for (DataStore.DBExtension item : getAll(type, null)) {
+            result.add(new PendingDownloadDescriptor(new PendingDownload(item)));
+        }
+        return result;
+    }
+
     @Nullable
     public static PendingDownload load(final long pendingDownload) {
         final DataStore.DBExtension temp = load(type, String.valueOf(pendingDownload));
@@ -50,7 +61,6 @@ public class PendingDownload extends DataStore.DBExtension {
         return null;
     }
 
-
     public static void add(final long downloadId, @NonNull final String filename, @NonNull final String remoteUrl, final long date, final int offlineMapTypeId) {
         final String key = String.valueOf(downloadId);
         removeAll(type, key);
@@ -59,5 +69,17 @@ public class PendingDownload extends DataStore.DBExtension {
 
     public static void remove(final long downloadId) {
         removeAll(type, String.valueOf(downloadId));
+    }
+
+    public static class PendingDownloadDescriptor {
+        public long id;
+        public String filename;
+        public String info;
+
+        PendingDownloadDescriptor(final PendingDownload download) {
+            this.id = download.getDownloadId();
+            this.filename = download.getFilename();
+            this.info = "";
+        }
     }
 }


### PR DESCRIPTION
## Description
Adds a view for pending downloads to the main menu. This view lists all pending downloads handled by the internal download manager (eg: maps, routing tiles) with current status info. Pending downloads can be cancelled.

![image](https://user-images.githubusercontent.com/3754370/192107611-67841f0e-9b13-40d7-87ce-732e9fc50465.png).![image](https://user-images.githubusercontent.com/3754370/192107619-c3a2d99f-7d25-4968-b3f0-e27ecb60fff0.png)

In the long run this shall be extended with an automatic check for pending downloads at start of c:geo, offering this view optionally, if there are any stuck or broken downloads currently.
This will also replace our current debug view for pending downloads in the future.