### PR TITLE
check pending downloads on init

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -725,6 +725,8 @@
     <string name="downloader_cancel_file">Cancel pending download of "%s" and remove downloaded parts?</string>
     <string name="downloader_cancelled_download">Cancelled download for "%s"</string>
     <string name="downloader_pending_info">There is at least one pausing or failed download. Do you want to open the list of pending downloads?</string>
+    <string name="downloader_retry_download">Retry download</string>
+    <string name="downloader_retry_download_details">Do you want to retry the download of:\n%1$s</string>
 
     <!-- Android system download manager status messages -->
     <string name="asdm_status_failed">Download has failed (and will not be retried)</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -724,6 +724,7 @@
     <string name="downloader_cancel_download">Cancel download</string>
     <string name="downloader_cancel_file">Cancel pending download of "%s" and remove downloaded parts?</string>
     <string name="downloader_cancelled_download">Cancelled download for "%s"</string>
+    <string name="downloader_pending_info">There is at least one pausing or failed download. Do you want to open the list of pending downloads?</string>
 
     <!-- Android system download manager status messages -->
     <string name="asdm_status_failed">Download has failed (and will not be retried)</string>

--- a/main/src/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/cgeo/geocaching/maps/MapUtils.java
@@ -150,7 +150,7 @@ public class MapUtils {
                 if (hasUnsupportedTiles.get()) {
                     ActivityMixin.showShortToast(activity, R.string.check_tiles_unsupported);
                 }
-                DownloaderUtils.triggerDownloads(activity, R.string.downloadtile_title, R.string.check_tiles_missing, missingDownloads);
+                DownloaderUtils.triggerDownloads(activity, R.string.downloadtile_title, R.string.check_tiles_missing, missingDownloads, null);
             }
         });
     }

--- a/main/src/cgeo/geocaching/models/Download.java
+++ b/main/src/cgeo/geocaching/models/Download.java
@@ -14,6 +14,7 @@ import cgeo.geocaching.downloader.MapDownloaderJustDownloadThemes;
 import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
+import cgeo.geocaching.storage.extension.PendingDownload;
 import cgeo.geocaching.utils.CalendarUtils;
 
 import android.net.Uri;
@@ -45,6 +46,19 @@ public class Download {
         this.dateInfo = CalendarUtils.parseYearMonthDay(dateISO);
         this.type = type;
         this.iconRes = iconRes;
+    }
+
+    public Download(final PendingDownload pendingDownload) {
+        final DownloadTypeDescriptor desc = DownloadType.fromTypeId(pendingDownload.getOfflineMapTypeId());
+
+        this.name = CompanionFileUtils.getDisplayName(pendingDownload.getFilename());
+        this.uri = Uri.parse(pendingDownload.getRemoteUrl());
+        this.isDir = false;
+        this.sizeInfo = "";
+        this.addInfo = "";
+        this.dateInfo = pendingDownload.getDate();
+        this.type = desc == null ? DownloadType.DOWNLOADTYPE_ALL_MAPRELATED : desc.type;
+        this.iconRes = R.drawable.ic_menu_file;
     }
 
     public String getName() {

--- a/main/src/cgeo/geocaching/storage/extension/PendingDownload.java
+++ b/main/src/cgeo/geocaching/storage/extension/PendingDownload.java
@@ -75,11 +75,13 @@ public class PendingDownload extends DataStore.DBExtension {
         public long id;
         public String filename;
         public String info;
+        public boolean isFailedDownload;
 
         PendingDownloadDescriptor(final PendingDownload download) {
             this.id = download.getDownloadId();
             this.filename = download.getFilename();
             this.info = "";
+            this.isFailedDownload = false;
         }
     }
 }


### PR DESCRIPTION
## Description
Checks on c:geo startup whether there are any pending downloads not currently running (ie: being paused or failed). Prompts the user to open the "pending downloads view" if such downloads have been found. Within that view the user can cancel downloads.

![image](https://user-images.githubusercontent.com/3754370/192136510-aecf32fd-e870-4e36-bdc9-5c6b3aab5294.png).![image](https://user-images.githubusercontent.com/3754370/192136515-8dcc2ffa-4efb-4b67-821b-8bdc36395176.png)
