### PR TITLE
Add cache/list name to GPX file name (rel. to #2724)

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -736,7 +736,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 notifyDataSetChanged();
             }));
         } else if (menuItem == R.id.menu_export_gpx) {
-            new GpxExport().export(Collections.singletonList(cache), this);
+            new GpxExport().export(Collections.singletonList(cache), this, cache.getName());
         } else if (menuItem == R.id.menu_export_fieldnotes) {
             new FieldNoteExport().export(Collections.singletonList(cache), this);
         } else if (menuItem == R.id.menu_export_persnotes) {

--- a/main/src/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/cgeo/geocaching/CacheListActivity.java
@@ -869,7 +869,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         } else if (menuItem == R.id.menu_import_web) {
             importWeb();
         } else if (menuItem == R.id.menu_export_gpx) {
-            new GpxExport().export(adapter.getCheckedOrAllCaches(), this);
+            new GpxExport().export(adapter.getCheckedOrAllCaches(), this, title);
         } else if (menuItem == R.id.menu_export_fieldnotes) {
             new FieldNoteExport().export(adapter.getCheckedOrAllCaches(), this);
         } else if (menuItem == R.id.menu_export_persnotes) {

--- a/main/src/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/cgeo/geocaching/export/GpxExport.java
@@ -35,13 +35,22 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class GpxExport extends AbstractExport {
 
     private String fileName = "geocache.gpx"; // used in tests
+    private String title = null;
 
     public GpxExport() {
         super(R.string.export_gpx);
+    }
+
+    public void export(@NonNull final List<Geocache> caches, @Nullable final Activity activity, @Nullable final String title) {
+        if (StringUtils.isNotBlank(title)) {
+            this.title = title.replace("/", "_");
+        }
+        export(caches, activity);
     }
 
     @Override
@@ -62,9 +71,19 @@ public class GpxExport extends AbstractExport {
     private void calculateFileName(final String[] geocodes) {
         if (geocodes.length == 1) {
             // geocode as file name
-            fileName = geocodes[0] + ".gpx";
+            fileName = geocodes[0] + (StringUtils.isNotBlank(title) ? " " + title : "") + ".gpx";
         } else {
             fileName = FileNameCreator.GPX_EXPORT.createName();
+            if (StringUtils.isNotBlank(title)) {
+                final int pos = fileName.lastIndexOf(".");
+                if (pos >= 0) {
+                    final String first = fileName.substring(0, pos);
+                    final String last = fileName.substring(pos);
+                    fileName = first + " " + title + last;
+                } else {
+                    fileName += " " + title;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Adds cache / list name to filename on GPX export:

![image](https://user-images.githubusercontent.com/3754370/192163563-6d2d0e44-07d0-48c2-b99d-ff2642adb32d.png).![image](https://user-images.githubusercontent.com/3754370/192163566-25732207-5d7e-49a2-a776-50b2d87bcb4c.png)

This is a first step towards #2724 (actually fulfilling the original request). Next step would be to make the filename editable (as we have for individual routes).