### PR TITLE
fix #13459, fix #13460: consider nbsp as whitespace when parsing formulas

### DIFF
--- a/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.TextUtils;
+import cgeo.geocaching.utils.formulas.DegreeFormula;
 import cgeo.geocaching.utils.formulas.FormulaUtils;
 import cgeo.geocaching.utils.formulas.VariableList;
 import cgeo.geocaching.utils.formulas.VariableMap;
@@ -255,8 +256,8 @@ public class CoordinatesCalculateGlobalDialog extends DialogFragment {
             SimpleDialog.of(this.getActivity()).setTitle(R.string.calccoord_plain_tools_title)
                     .selectSingle(options, (i, i2) -> TextParam.id(i), -1, SimpleDialog.SingleChoiceMode.NONE, (o, p) -> {
                         if (o == R.string.calccoord_remove_spaces) {
-                            binding.PlainLat.setText(binding.PlainLat.getText().toString().replaceAll(" ", ""));
-                            binding.PlainLon.setText(binding.PlainLon.getText().toString().replaceAll(" ", ""));
+                            binding.PlainLat.setText(DegreeFormula.removeSpaces(binding.PlainLat.getText().toString()));
+                            binding.PlainLon.setText(DegreeFormula.removeSpaces(binding.PlainLon.getText().toString()));
                         } else if (o == R.string.calccoord_paste_from_clipboard) {
                             final String clip = ClipboardUtils.getText();
                             final List<Pair<String, String>> patterns = FormulaUtils.scanForCoordinates(Collections.singleton(clip), null);

--- a/main/src/cgeo/geocaching/utils/TextParser.java
+++ b/main/src/cgeo/geocaching/utils/TextParser.java
@@ -97,9 +97,14 @@ public final class TextParser {
     }
 
     public void skipWhitespaces() {
-        while (Character.isWhitespace(ch)) {
+        while (isFormulaWhitespace(ch)) {
             next();
         }
+    }
+
+    public static boolean isFormulaWhitespace(final int codePoint) {
+        //note that Character.isWhitespace() will NOT return true for nbsp!
+        return Character.isWhitespace(codePoint) || Character.isSpaceChar(codePoint);
     }
 
     public void nextNonWhitespace() {

--- a/main/src/cgeo/geocaching/utils/formulas/DegreeFormula.java
+++ b/main/src/cgeo/geocaching/utils/formulas/DegreeFormula.java
@@ -92,7 +92,7 @@ public class DegreeFormula {
     }
 
     private boolean isParserOnHemisphereChar(final boolean checkEof) {
-        return isHemisphereChar(parser.chInt(), false) && (!checkEof || parser.peek() == TextParser.END_CHAR || Character.isWhitespace(parser.peek()));
+        return isHemisphereChar(parser.chInt(), false) && (!checkEof || parser.peek() == TextParser.END_CHAR || TextParser.isFormulaWhitespace(parser.peek()));
     }
 
     private Formula parseFormula(final KeyableCharSet kcs) {
@@ -395,6 +395,10 @@ public class DegreeFormula {
                 css.add(TextUtils.setSpan(cs.toString(), Formula.createErrorSpan()));
             }
         }
+    }
+
+    public static String removeSpaces(final String formula) {
+        return formula == null ? "" : formula.replaceAll("\\s", "");
     }
 
 }

--- a/tests/src/cgeo/geocaching/utils/formulas/DegreeFormulaTest.java
+++ b/tests/src/cgeo/geocaching/utils/formulas/DegreeFormulaTest.java
@@ -108,6 +108,11 @@ public class DegreeFormulaTest {
         assertParse("S53 33.6", null, -53d - 33.006 / 60, "S53°33.<00>6'");
     }
 
+    @Test
+    public void parseFormulaWithWhitespaces() {
+        assertParse("N\f46°\u00A0(C+E+F+1).\n0\t(C+F-E)", s -> Value.of(0), 46.0166666666666666666d, "N46°1.<0>00'");
+    }
+
 
     //this is a test to copy/paste single tests into for local analysis e.g. using Debugging
     @Test
@@ -143,5 +148,12 @@ public class DegreeFormulaTest {
         assertThat(DegreeFormula.compile("N48 12", false).evaluateToDouble(null)).isEqualTo(48d + 12d / 60);
         assertThat(DegreeFormula.compile("N48 12.345", false).evaluateToDouble(null)).isEqualTo(48d + 12.345d / 60);
         assertThat(DegreeFormula.compile("N48 12.A45", false).evaluateToDouble(x -> Value.of(3))).isEqualTo(48.20575d);
+    }
+
+    @Test
+    public void removeSpaces() {
+        //formula includes all sorts of whitespace
+        assertThat(DegreeFormula.removeSpaces("E10° 0 ( c\t ). (\ne*3\r+ d )"))
+                .isEqualTo("E10°0(c).(e*3+d)");
     }
 }


### PR DESCRIPTION
fix #13459, fix #13460: consider nbsp as whitespace when parsing formulas

Both issues show symptoms of this bug. The formula  of the cache in question contains nbsp characters in HTML sourcecode.