### PR TITLE
fix #13452: avoid scanning inner formulas for normal coords

### DIFF
--- a/main/src/cgeo/geocaching/models/WaypointParser.java
+++ b/main/src/cgeo/geocaching/models/WaypointParser.java
@@ -137,7 +137,8 @@ public class WaypointParser {
     }
 
     private void parseWaypointsWithCoords(final String text) {
-        final Collection<GeopointWrapper> matches = GeopointParser.parseAll(text);
+        final String cleanedText = removeCalculatedCoords(text);
+        final Collection<GeopointWrapper> matches = GeopointParser.parseAll(cleanedText);
         for (final GeopointWrapper match : matches) {
             final Waypoint wp = parseSingleWaypoint(match, null);
             if (wp != null) {
@@ -145,6 +146,10 @@ public class WaypointParser {
                 count++;
             }
         }
+    }
+
+    private String removeCalculatedCoords(final String text) {
+        return text.replaceAll(Pattern.quote(PARSING_CALCULATED_COORD) + ".*?" + Pattern.quote("}"), "");
     }
 
     private void parseWaypointsWithSpecificCoords(final String text, final String parsingCoord, final Settings.CoordInputFormatEnum coordFormat) {
@@ -219,7 +224,7 @@ public class WaypointParser {
             final String configAndMore = text.substring(start);
             final CalculatedCoordinate cc = new CalculatedCoordinate();
             final int parseEnd = cc.setFromConfig(configAndMore);
-            if (parseEnd < 0 || parseEnd >= configAndMore.length() ||
+            if (parseEnd < 0 || parseEnd > configAndMore.length() ||
                     configAndMore.charAt(parseEnd - 1) != '}' || !cc.isFilled()) {
                 return null;
             }
@@ -423,7 +428,6 @@ public class WaypointParser {
      *
      * @param text      text to search and replace waypoints in
      * @param waypoints new waypoints to store
-     * @param maxSize   if >0 then total size of returned text may not exceed this parameter
      * @return new text, or null if waypoints could not be placed due to size restrictions
      */
     public static String putParseableWaypointsInText(final String text, final Collection<Waypoint> waypoints, final VariableList vars) {

--- a/tests/src/cgeo/geocaching/models/WaypointParserTest.java
+++ b/tests/src/cgeo/geocaching/models/WaypointParserTest.java
@@ -644,6 +644,38 @@ public class WaypointParserTest {
         }
         final Map<String, String> vars = parser.getParsedVariables();
         assertThat(vars).isEqualTo(expectedVarMap);
+    }
 
+    @Test
+    public void testParseFormulaContainingPlainCoords() {
+        final WaypointParser parser = createParser("Praefix");
+        assertWaypoint(parser.parseWaypoints("37.000 +0.123").iterator().next(), "Praefix 1", new Geopoint(37d, 0.123d));
+        assertWaypoint(parser.parseWaypoints("16.000 -0.321").iterator().next(), "Praefix 1", new Geopoint(16d, -0.321d));
+
+        //Formulas may contain text which would be parseable as standalone coord.
+        //In this case however, such standalone coord should NOT be parsed
+        final Collection<Waypoint> wps =
+                parser.parseWaypoints("@Finale (F) {CC|N47° (37.000 +0.123)|E012° (16.000 -0.321)}");
+        assertThat(wps).hasSize(1);
+        final Waypoint wp = wps.iterator().next();
+        assertThat(wp.getCalcStateConfig()).isEqualTo("{CC|N47° (37.000 +0.123)|E012° (16.000 -0.321)}");
+
+        final Collection<Waypoint> wps2 = parser.parseWaypoints("{CC|N48|E11} 13.5 8.3 {CC|N34|E09}");
+        assertThat(wps2).hasSize(3);
+        Waypoint nonCalc = null;
+        int nonCalcCnt = 0;
+        int calcCnt = 0;
+        for (Waypoint w : wps2) {
+            if (!w.isCalculated()) {
+                nonCalc = w;
+                nonCalcCnt++;
+            } else {
+                calcCnt++;
+            }
+        }
+        assertThat(calcCnt).isEqualTo(2);
+        assertThat(nonCalcCnt).isEqualTo(1);
+        assertThat(nonCalc).isNotNull();
+        assertThat(nonCalc.getCoords()).isEqualTo(new Geopoint(13.5, 8.3));
     }
 }


### PR DESCRIPTION
fix #13452: avoid scanning inner formulas for normal coords