### PR TITLE
Make details text line in compass scalable (fix #13420)

### DIFF
--- a/main/res/layout-land/compass_activity.xml
+++ b/main/res/layout-land/compass_activity.xml
@@ -63,7 +63,7 @@
          <RelativeLayout
             android:id="@+id/device_information"
             android:layout_width="fill_parent"
-            android:layout_height="16dip"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="false"
             android:layout_alignParentLeft="false"
             android:layout_alignParentTop="false"
@@ -147,7 +147,7 @@
         <RelativeLayout
             android:id="@+id/status"
             android:layout_width="fill_parent"
-            android:layout_height="16dip"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_alignParentLeft="false"
             android:layout_alignParentTop="false"

--- a/main/res/layout/compass_activity.xml
+++ b/main/res/layout/compass_activity.xml
@@ -50,7 +50,7 @@
 
          <RelativeLayout
             android:layout_width="fill_parent"
-            android:layout_height="16dip">
+            android:layout_height="wrap_content">
 
              <TextView
                  android:id="@+id/device_heading_label"
@@ -134,7 +134,7 @@
 
         <RelativeLayout
             android:layout_width="fill_parent"
-            android:layout_height="16dip" >
+            android:layout_height="wrap_content" >
 
             <TextView
                 android:id="@+id/nav_type"


### PR DESCRIPTION
## Description
Make details text line in compass views (portrait & landscape) scalable, so that it automatically adjusts its height according to font size setting:

||portrait|landscape|
|---|---|---|
|default font size|![image](https://user-images.githubusercontent.com/3754370/194136059-581066cf-56c2-4446-a3ef-e9ba0a1916cf.png)|![image](https://user-images.githubusercontent.com/3754370/194136155-b78e5cb2-caad-44ed-97af-341b90d0ef2e.png)|
|large font size|![image](https://user-images.githubusercontent.com/3754370/194136116-667e61ce-938b-4d0b-b6e0-ed6b81fa64de.png)|![image](https://user-images.githubusercontent.com/3754370/194136190-88ede473-090e-49ba-b1bf-0f1d41e45934.png)|

