### PR TITLE
Fix #13473 - Better strings for download retry

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -727,7 +727,7 @@
     <string name="downloader_cancelled_download">Cancelled download for "%s"</string>
     <string name="downloader_pending_info">There is at least one pausing or failed download. Do you want to open the list of pending downloads?</string>
     <string name="downloader_retry_download">Retry download</string>
-    <string name="downloader_retry_download_details">Do you want to retry the download of</string>
+    <string name="downloader_retry_download_details">Please select the files you want to download again:</string>
 
     <!-- Android system download manager status messages -->
     <string name="asdm_status_failed">Download has failed (and will not be retried)</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -727,7 +727,7 @@
     <string name="downloader_cancelled_download">Cancelled download for "%s"</string>
     <string name="downloader_pending_info">There is at least one pausing or failed download. Do you want to open the list of pending downloads?</string>
     <string name="downloader_retry_download">Retry download</string>
-    <string name="downloader_retry_download_details">Please select the files you want to download again:</string>
+    <string name="downloader_retry_download_details">Do you want to retry the download of the following file?</string>
 
     <!-- Android system download manager status messages -->
     <string name="asdm_status_failed">Download has failed (and will not be retried)</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Adapt the string to accommodate the new feature, that files to retry download can now be selected. 

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#13473

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->