### PR TITLE
get event end time for correct calendar entries

### DIFF
--- a/main/src/cgeo/geocaching/calendar/CalendarEntry.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarEntry.java
@@ -48,8 +48,8 @@ class CalendarEntry {
                 StringUtils.defaultString(cache.getPersonalNote()),
                 cache.getName(),
                 cache.getCoords() == null ? "" : cache.getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_RAW),
-                cache.getEventTimeMinutes(),
-                cache.getEventEndTimeMinutes()
+                cache.getEventStartTimeInMinutes(),
+                cache.getEventEndTimeInMinutes()
                 );
     }
 

--- a/main/src/cgeo/geocaching/calendar/CalendarEntry.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarEntry.java
@@ -39,6 +39,7 @@ class CalendarEntry {
     @NonNull
     private final String coords;
     private final int startTimeMinutes;
+    private final int endTimeMinutes;
 
     CalendarEntry(@NonNull final Geocache cache, @NonNull final Date hiddenDate) {
         this(TextUtils.stripHtml(StringUtils.defaultString(cache.getShortDescription())),
@@ -47,12 +48,14 @@ class CalendarEntry {
                 StringUtils.defaultString(cache.getPersonalNote()),
                 cache.getName(),
                 cache.getCoords() == null ? "" : cache.getCoords().format(GeopointFormatter.Format.LAT_LON_DECMINUTE_RAW),
-                cache.getEventTimeMinutes());
+                cache.getEventTimeMinutes(),
+                cache.getEventEndTimeMinutes()
+                );
     }
 
     private CalendarEntry(@NonNull final String shortDesc, @NonNull final Date hiddenDate, @NonNull final String url,
                           @NonNull final String personalNote, @NonNull final String name, @NonNull final String coords,
-                          final int startTimeMinutes) {
+                          final int startTimeMinutes, final int endTimeMinutes) {
         this.shortDesc = shortDesc;
         this.hiddenDate = hiddenDate;
         this.url = url;
@@ -60,6 +63,7 @@ class CalendarEntry {
         this.name = name;
         this.coords = coords;
         this.startTimeMinutes = startTimeMinutes;
+        this.endTimeMinutes = endTimeMinutes;
     }
 
     /**
@@ -123,6 +127,9 @@ class CalendarEntry {
         final int entryStartTimeMinutes = startTimeMinutes;
         if (entryStartTimeMinutes >= 0) {
             intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, eventTime + entryStartTimeMinutes * 60000L);
+            if (endTimeMinutes >= 0) {
+                intent.putExtra(CalendarContract.EXTRA_EVENT_END_TIME, eventTime + endTimeMinutes * 60000L);
+            }
         } else {
             intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, eventTime);
             intent.putExtra(CalendarContract.EXTRA_EVENT_ALL_DAY, true);

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -190,8 +190,7 @@ public class Geocache implements IWaypoint {
     private Boolean hasLogOffline = null;
     private OfflineLogEntry offlineLog = null;
 
-    private Integer eventStartTimeInMinutes = null;
-    private Integer eventEndTimeInMinutes = null;
+    private EventTimesInMin eventTimesInMin = new EventTimesInMin();
 
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
@@ -400,7 +399,7 @@ public class Geocache implements IWaypoint {
             searchContext = other.searchContext;
         }
 
-        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
+        this.eventTimesInMin.reset(); // will be recalculated if/when necessary
         return isEqualTo(other);
     }
 
@@ -899,7 +898,7 @@ public class Geocache implements IWaypoint {
 
     public void setDescription(final String description) {
         this.description = description;
-        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
+        this.eventTimesInMin.reset(); // will be recalculated if/when necessary
     }
 
     public boolean isFound() {
@@ -1116,7 +1115,7 @@ public class Geocache implements IWaypoint {
 
     public void setShortDescription(final String shortdesc) {
         this.shortdesc = shortdesc;
-        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
+        this.eventTimesInMin.reset(); // will be recalculated if/when necessary
     }
 
     public void setFavoritePoints(final int favoriteCnt) {
@@ -1484,7 +1483,7 @@ public class Geocache implements IWaypoint {
             throw new IllegalArgumentException("Illegal cache type");
         }
         this.cacheType = cacheType;
-        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
+        this.eventTimesInMin.reset(); // will be recalculated if/when necessary
     }
 
     public boolean hasDifficulty() {
@@ -2094,14 +2093,14 @@ public class Geocache implements IWaypoint {
     }
 
     public int getEventStartTimeInMinutes() {
-        if (eventStartTimeInMinutes == null) {
+        if (eventTimesInMin.start == null) {
             guessEventTimeMinutes();
         }
-        return eventStartTimeInMinutes;
+        return eventTimesInMin.start;
     }
 
     public int getEventEndTimeInMinutes() {
-        return eventEndTimeInMinutes == null ? -1 : eventEndTimeInMinutes;
+        return eventTimesInMin.end == null ? -1 : eventTimesInMin.end;
     }
 
     /**
@@ -2111,18 +2110,19 @@ public class Geocache implements IWaypoint {
      */
     private void guessEventTimeMinutes() {
         if (!isEventCache()) {
-            eventStartTimeInMinutes = -1;
+            eventTimesInMin.start = -1;
+            return;
         }
 
         // GC Listings have the start and end time in short description, try that first
         final int[] gcDates = EventTimeParser.getEventTimesFromGcShortDesc(getShortDescription());
         if (gcDates[0] >= 0 && gcDates[1] >= 0) {
-            eventStartTimeInMinutes = gcDates[0];
-            eventEndTimeInMinutes = gcDates[1];
+            eventTimesInMin.start = gcDates[0];
+            eventTimesInMin.end = gcDates[1];
         } else {
             // if not successful scan the whole description for what looks like a start time
             final String searchText = getShortDescription() + ' ' + getDescription();
-            eventStartTimeInMinutes = EventTimeParser.guessEventTimeMinutes(searchText);
+            eventTimesInMin.start = EventTimeParser.guessEventTimeMinutes(searchText);
         }
     }
 
@@ -2357,5 +2357,15 @@ public class Geocache implements IWaypoint {
      */
     public void setSearchContext(final Bundle searchContext) {
         this.searchContext = searchContext;
+    }
+
+    private class EventTimesInMin {
+        public Integer start = null;
+        public Integer end = null;
+
+        public void reset() {
+            this.start = null;
+            this.end = null;
+        }
     }
 }

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -189,8 +189,9 @@ public class Geocache implements IWaypoint {
 
     private Boolean hasLogOffline = null;
     private OfflineLogEntry offlineLog = null;
-    private Integer eventTimeMinutes = null;
-    private Integer eventEndTimeMinutes = -1;
+
+    private Integer eventStartTimeInMinutes = null;
+    private Integer eventEndTimeInMinutes = null;
 
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
@@ -399,7 +400,7 @@ public class Geocache implements IWaypoint {
             searchContext = other.searchContext;
         }
 
-        this.eventTimeMinutes = null; // will be recalculated if/when necessary
+        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
         return isEqualTo(other);
     }
 
@@ -898,7 +899,7 @@ public class Geocache implements IWaypoint {
 
     public void setDescription(final String description) {
         this.description = description;
-        this.eventTimeMinutes = null; // will be recalculated if/when necessary
+        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
     }
 
     public boolean isFound() {
@@ -1115,7 +1116,7 @@ public class Geocache implements IWaypoint {
 
     public void setShortDescription(final String shortdesc) {
         this.shortdesc = shortdesc;
-        this.eventTimeMinutes = null; // will be recalculated if/when necessary
+        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
     }
 
     public void setFavoritePoints(final int favoriteCnt) {
@@ -1483,7 +1484,7 @@ public class Geocache implements IWaypoint {
             throw new IllegalArgumentException("Illegal cache type");
         }
         this.cacheType = cacheType;
-        this.eventTimeMinutes = null; // will be recalculated if/when necessary
+        this.eventStartTimeInMinutes = null; // will be recalculated if/when necessary
     }
 
     public boolean hasDifficulty() {
@@ -2092,15 +2093,15 @@ public class Geocache implements IWaypoint {
         return !lists.isEmpty() && (lists.size() > 1 || lists.iterator().next() != StoredList.TEMPORARY_LIST.id);
     }
 
-    public int getEventTimeMinutes() {
-        if (eventTimeMinutes == null) {
+    public int getEventStartTimeInMinutes() {
+        if (eventStartTimeInMinutes == null) {
             guessEventTimeMinutes();
         }
-        return eventTimeMinutes;
+        return eventStartTimeInMinutes;
     }
 
-    public int getEventEndTimeMinutes() {
-        return eventEndTimeMinutes;
+    public int getEventEndTimeInMinutes() {
+        return eventEndTimeInMinutes == null ? -1 : eventEndTimeInMinutes;
     }
 
     /**
@@ -2110,18 +2111,18 @@ public class Geocache implements IWaypoint {
      */
     private void guessEventTimeMinutes() {
         if (!isEventCache()) {
-            eventTimeMinutes = -1;
+            eventStartTimeInMinutes = -1;
         }
 
         // GC Listings have the start and end time in short description, try that first
-        int[] gcDates = EventTimeParser.getEventTimesFromGcShortDesc(getShortDescription());
+        final int[] gcDates = EventTimeParser.getEventTimesFromGcShortDesc(getShortDescription());
         if (gcDates[0] >= 0 && gcDates[1] >= 0) {
-            eventTimeMinutes = gcDates[0];
-            eventEndTimeMinutes = gcDates[1];
+            eventStartTimeInMinutes = gcDates[0];
+            eventEndTimeInMinutes = gcDates[1];
         } else {
             // if not successful scan the whole description for what looks like a start time
             final String searchText = getShortDescription() + ' ' + getDescription();
-            eventTimeMinutes = EventTimeParser.guessEventTimeMinutes(searchText);
+            eventStartTimeInMinutes = EventTimeParser.guessEventTimeMinutes(searchText);
         }
     }
 

--- a/main/src/cgeo/geocaching/sorting/EventDateComparator.java
+++ b/main/src/cgeo/geocaching/sorting/EventDateComparator.java
@@ -11,7 +11,7 @@ public class EventDateComparator extends DateComparator {
 
     @Override
     protected int sortSameDate(final Geocache left, final Geocache right) {
-        return compare(left.getEventTimeMinutes(), right.getEventTimeMinutes());
+        return compare(left.getEventStartTimeInMinutes(), right.getEventStartTimeInMinutes());
     }
 
     /**

--- a/main/src/cgeo/geocaching/utils/EventTimeParser.java
+++ b/main/src/cgeo/geocaching/utils/EventTimeParser.java
@@ -4,8 +4,6 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -63,8 +61,8 @@ public class EventTimeParser {
     }
 
     public static int[] getEventTimesFromGcShortDesc(final String searchText) {
-        int[] times = new int[] { -1, -1 };
-        Pattern gcShortDescPattern = Pattern.compile("^<b>\\d{2} [A-Za-z]+ \\d{4}, (\\d{2}):(\\d{2}) - (\\d{2}):(\\d{2})</b>$");
+        final int[] times = new int[] { -1, -1 };
+        final Pattern gcShortDescPattern = Pattern.compile("^<b>\\d{2} [A-Za-z]+ \\d{4}, (\\d{2}):(\\d{2}) - (\\d{2}):(\\d{2})</b>$");
         final MatcherWrapper matcher = new MatcherWrapper(gcShortDescPattern, searchText);
         if (matcher.matches()) {
             times[0] = Integer.parseInt(matcher.group(1)) * 60 + Integer.parseInt(matcher.group(2));

--- a/main/src/cgeo/geocaching/utils/EventTimeParser.java
+++ b/main/src/cgeo/geocaching/utils/EventTimeParser.java
@@ -4,6 +4,8 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -58,6 +60,17 @@ public class EventTimeParser {
             }
         }
         return eventTimeMinutes;
+    }
+
+    public static int[] getEventTimesFromGcShortDesc(final String searchText) {
+        int[] times = new int[] { -1, -1 };
+        Pattern gcShortDescPattern = Pattern.compile("^<b>\\d{2} [A-Za-z]+ \\d{4}, (\\d{2}):(\\d{2}) - (\\d{2}):(\\d{2})</b>$");
+        final MatcherWrapper matcher = new MatcherWrapper(gcShortDescPattern, searchText);
+        if (matcher.matches()) {
+            times[0] = Integer.parseInt(matcher.group(1)) * 60 + Integer.parseInt(matcher.group(2));
+            times[1] = Integer.parseInt(matcher.group(3)) * 60 + Integer.parseInt(matcher.group(4));
+        }
+        return times;
     }
 
     /**

--- a/tests/src-android/cgeo/geocaching/utils/EventTimeParserTest.java
+++ b/tests/src-android/cgeo/geocaching/utils/EventTimeParserTest.java
@@ -84,7 +84,7 @@ public class EventTimeParserTest extends TestCase {
         cache.setType(CacheType.EVENT);
         cache.setDescription(StringUtils.EMPTY);
         cache.setShortDescription("text 14:20 text");
-        assertThat(cache.getEventTimeMinutes()).isEqualTo(14 * 60 + 20);
+        assertThat(cache.getEventStartTimeInMinutes()).isEqualTo(14 * 60 + 20);
     }
 
     private static void assertTime(final String description, final int hours, final int minutes) {


### PR DESCRIPTION
GC listings for some while now contain the events start and end time in a standard format. This allows for reliable determination of both these dates.

By knowing the end date we are now able to create calendar entries with the proper end time.

I chose to parse short description instead of the listing (where the same information is available in 2 more places) because that is already stored in DB - the other 2 places would require an additional DB entry with little additional value.

![image](https://user-images.githubusercontent.com/1258173/194508486-e5bd8dcb-25ef-46cf-abeb-636e77b51034.png)
