### PR TITLE
for calendar entries if event shortdesc is very short use normal description

### DIFF
--- a/main/src/cgeo/geocaching/calendar/CalendarEntry.java
+++ b/main/src/cgeo/geocaching/calendar/CalendarEntry.java
@@ -29,6 +29,8 @@ class CalendarEntry {
     @NonNull
     private final String shortDesc;
     @NonNull
+    private final String longDesc;
+    @NonNull
     private final Date hiddenDate;
     @NonNull
     private final String url;
@@ -42,6 +44,7 @@ class CalendarEntry {
 
     CalendarEntry(@NonNull final Geocache cache, @NonNull final Date hiddenDate) {
         this(TextUtils.stripHtml(StringUtils.defaultString(cache.getShortDescription())),
+                TextUtils.stripHtml(StringUtils.defaultString(cache.getDescription())),
                 hiddenDate,
                 StringUtils.defaultString(cache.getUrl()),
                 StringUtils.defaultString(cache.getPersonalNote()),
@@ -50,10 +53,11 @@ class CalendarEntry {
                 cache.getEventTimeMinutes());
     }
 
-    private CalendarEntry(@NonNull final String shortDesc, @NonNull final Date hiddenDate, @NonNull final String url,
+    private CalendarEntry(@NonNull final String shortDesc, @NonNull final String longDesc, @NonNull final Date hiddenDate, @NonNull final String url,
                           @NonNull final String personalNote, @NonNull final String name, @NonNull final String coords,
                           final int startTimeMinutes) {
         this.shortDesc = shortDesc;
+        this.longDesc = longDesc;
         this.hiddenDate = hiddenDate;
         this.url = url;
         this.personalNote = personalNote;
@@ -88,13 +92,17 @@ class CalendarEntry {
     private String parseDescription() {
         final StringBuilder description = new StringBuilder();
         description.append(url);
-        if (StringUtils.isNotBlank(shortDesc)) {
+
+        // if shortdesc is very short (seems to have no info) use description instead
+        final String eventDesc = shortDesc.length() > 100 ? shortDesc : longDesc;
+
+        if (StringUtils.isNotBlank(eventDesc)) {
             // remove images in short description
-            final Spanned spanned = HtmlCompat.fromHtml(shortDesc, HtmlCompat.FROM_HTML_MODE_LEGACY);
+            final Spanned spanned = HtmlCompat.fromHtml(eventDesc.replaceAll("\n", "<br/>"), HtmlCompat.FROM_HTML_MODE_LEGACY);
             String text = spanned.toString();
             final ImageSpan[] spans = spanned.getSpans(0, spanned.length(), ImageSpan.class);
             for (int i = spans.length - 1; i >= 0; i--) {
-                text = text.substring(0, spanned.getSpanStart(spans[i])) + text.substring(spanned.getSpanEnd(spans[i]));
+                text = text.substring(0, spanned.getSpanStart(spans[i])) + text.substring(spanned.getSpanEnd(spans[i])) + "\n";
             }
             if (StringUtils.isNotBlank(text)) {
                 description.append("\n\n");


### PR DESCRIPTION
Creating a calendar entry for an event adds the URL and shortdesc as the entries description.
While for OC shortdesc usually contains some information for GC it has nothing but the date. With this PR if shortdesc doesn't have any meaningful content (defined by being <150 chars) description is used for the calendar entry instead.

Before:
![2022-10-07_10-28-25](https://user-images.githubusercontent.com/1258173/194518367-7f744ad0-5c87-4f02-9ef4-c9480a9b541a.png)

After:
![2022-10-07_10-27-09](https://user-images.githubusercontent.com/1258173/194518388-c59c0d0a-d0c1-4a10-b1b5-0211ff53eb04.png)
