### PR TITLE
display elevation on home screen (fix #13470)

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -25,6 +25,7 @@ import cgeo.geocaching.ui.TextSpinner;
 import cgeo.geocaching.ui.WaypointSelectionActionProvider;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.GeoHeightUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.annotation.SuppressLint;
@@ -32,7 +33,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.media.AudioManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -309,9 +309,6 @@ public class CompassActivity extends AbstractActionBarActivity {
         }
     };
 
-    private static final double[] altitudeReadings = {0.0d, 0.0d, 0.0d, 0.0d, 0.0d};
-    private static int altitudeReadingPos = 0;
-
     @SuppressLint("SetTextI18n")
     private final GeoDirHandler geoDirHandler = new GeoDirHandler() {
         @Override
@@ -325,19 +322,7 @@ public class CompassActivity extends AbstractActionBarActivity {
                     binding.navAccuracy.setText(null);
                 }
 
-                // remember new altitude reading, and calculate average from past MAX_READINGS readings
-                if (geo.hasAltitude() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || geo.getVerticalAccuracyMeters() > 0.0)) {
-                    altitudeReadings[altitudeReadingPos] = geo.getAltitude();
-                    altitudeReadingPos = (++altitudeReadingPos) % altitudeReadings.length;
-                }
-                double averageAltitude = altitudeReadings[0];
-                for (int i = 1; i < altitudeReadings.length; i++) {
-                    averageAltitude += altitudeReadings[i];
-                }
-                if (altitudeReadings.length > 0) {
-                    averageAltitude /= (double) altitudeReadings.length;
-                }
-                binding.navLocation.setText(geo.getCoords().toString() + Formatter.SEPARATOR + Units.getDistanceFromMeters((float) averageAltitude));
+                binding.navLocation.setText(geo.getCoords().toString() + GeoHeightUtils.getAverageHeight(geo, true));
 
                 updateDistanceInfo(geo);
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -49,6 +49,7 @@ import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.DisplayUtils;
 import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.GeoHeightUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ShareUtils;
@@ -239,6 +240,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             }
 
             currentCoords = geo.getCoords();
+            final String averageHeight = GeoHeightUtils.getAverageHeight(geo, true);
             if (Settings.isShowAddress()) {
                 if (addCoords == null) {
                     binding.navLocation.setText(R.string.loc_no_addr);
@@ -248,10 +250,10 @@ public class MainActivity extends AbstractBottomNavigationActivity {
                     final Single<String> address = (new AndroidGeocoder(MainActivity.this).getFromLocation(currentCoords)).map(MainActivity::formatAddress).onErrorResumeWith(Single.just(currentCoords.toString()));
                     AndroidRxUtils.bindActivity(MainActivity.this, address)
                             .subscribeOn(AndroidRxUtils.networkScheduler)
-                            .subscribe(address12 -> binding.navLocation.setText(address12));
+                            .subscribe(address12 -> binding.navLocation.setText(address12 + averageHeight));
                 }
             } else {
-                binding.navLocation.setText(currentCoords.toString());
+                binding.navLocation.setText(currentCoords.toString() + averageHeight);
             }
         }
     }

--- a/main/src/cgeo/geocaching/utils/GeoHeightUtils.java
+++ b/main/src/cgeo/geocaching/utils/GeoHeightUtils.java
@@ -1,0 +1,30 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.location.Units;
+import cgeo.geocaching.sensors.GeoData;
+
+import android.os.Build;
+
+public class GeoHeightUtils {
+    private static final double[] altitudeReadings = {0.0d, 0.0d, 0.0d, 0.0d, 0.0d};
+    private static int altitudeReadingPos = 0;
+
+    private GeoHeightUtils() {
+        // utility class
+    }
+
+    /** returns a formatted height string, empty, if height==0 */
+    public static String getAverageHeight(final GeoData geo, final boolean withSeparator) {
+        // remember new altitude reading, and calculate average from past MAX_READINGS readings
+        if (geo.hasAltitude() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || geo.getVerticalAccuracyMeters() > 0.0)) {
+            altitudeReadings[altitudeReadingPos] = geo.getAltitude();
+            altitudeReadingPos = (++altitudeReadingPos) % altitudeReadings.length;
+        }
+        double averageAltitude = altitudeReadings[0];
+        for (int i = 1; i < altitudeReadings.length; i++) {
+            averageAltitude += altitudeReadings[i];
+        }
+        averageAltitude /= (double) altitudeReadings.length;
+        return averageAltitude == 0 ? "" : (withSeparator ? Formatter.SEPARATOR : "") + Units.getDistanceFromMeters((float) averageAltitude);
+    }
+}


### PR DESCRIPTION
## Description
- Display current elevation on home screen (right of location info), if available
- As in compass mode we display an averaged elevation (arithmetic mean of last five readings)
- If no elevation info is available (as is the case for AS emulator) no elevation info is displayed
