### PR TITLE
be more specific about location permission required

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -2348,7 +2348,7 @@
     <!-- permission handling -->
     <string name="close_app">Close app</string>
     <string name="ask_again">Ask me again</string>
-    <string name="location_permission_request_explanation">c:geo needs access to the GPS on your device to locate your position and calculate distance and direction to geocaches. It cannot be used without this permission.</string>
+    <string name="location_permission_request_explanation">c:geo needs access to the GPS (fine location) on your device to locate your position and calculate distance and direction to geocaches. It cannot be used without this permission.</string>
     <string name="storage_permission_request_explanation">c:geo will write data onto your phone storage or SD card as soon as you save geocaches for offline use. Furthermore c:geo will use your phone storage for import and export of files and reading of offline maps. It cannot be used without this permission.</string>
     <string name="storage_permission_needed">This function is not possible without storage permission.</string>
 


### PR DESCRIPTION
## Description
Android 12+ supports coarse and fine location permission. To be able to use GPS, c:geo needs to be granted fine location permission. It cannot be used without.
Therefore extend explanation to note "fine location".
