### PR TITLE
add housekeeping for stale downloads (rel. to #13438)

### DIFF
--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -455,14 +455,22 @@ public class MainActivity extends AbstractBottomNavigationActivity {
                 final DownloadManager.Query query = new DownloadManager.Query();
                 query.setFilterById(download.id);
                 try (Cursor c = downloadManager.query(query)) {
-                    while (c.moveToNext()) {
-                        final int colStatus = c.getColumnIndex(DownloadManager.COLUMN_STATUS);
-                        if (colStatus >= 0) {
-                            final int status = c.getInt(colStatus);
-                            if (status != DownloadManager.STATUS_RUNNING && status != DownloadManager.STATUS_SUCCESSFUL) {
-                                SimpleDialog.of(this).setTitle(R.string.downloader_pending_downloads).setMessage(R.string.downloader_pending_info).confirm((dialog, which) -> startActivity(new Intent(this, PendingDownloadsActivity.class)));
-                                Settings.setPendingDownloadsLastCheck(false);
-                                break;
+                    if (c.isAfterLast()) {
+                        if (download.date < 1665433698000L /* Oct 10th, 2022 */) {
+                            // entry is pretty old and no longer available in system's download manager, so do some housekeeping in our own database
+                            PendingDownload.remove(download.id);
+                            Log.w("removed stale download no longer recognized by download manager: id=" + download.id + ", fn=" + download.filename + ", date=" + Formatter.formatDate(download.date));
+                        }
+                    } else {
+                        while (c.moveToNext()) {
+                            final int colStatus = c.getColumnIndex(DownloadManager.COLUMN_STATUS);
+                            if (colStatus >= 0) {
+                                final int status = c.getInt(colStatus);
+                                if (status != DownloadManager.STATUS_RUNNING && status != DownloadManager.STATUS_SUCCESSFUL) {
+                                    SimpleDialog.of(this).setTitle(R.string.downloader_pending_downloads).setMessage(R.string.downloader_pending_info).confirm((dialog, which) -> startActivity(new Intent(this, PendingDownloadsActivity.class)));
+                                    Settings.setPendingDownloadsLastCheck(false);
+                                    break;
+                                }
                             }
                         }
                     }

--- a/main/src/cgeo/geocaching/storage/extension/PendingDownload.java
+++ b/main/src/cgeo/geocaching/storage/extension/PendingDownload.java
@@ -75,12 +75,14 @@ public class PendingDownload extends DataStore.DBExtension {
         public long id;
         public String filename;
         public String info;
+        public long date;
         public boolean isFailedDownload;
 
         PendingDownloadDescriptor(final PendingDownload download) {
             this.id = download.getDownloadId();
             this.filename = download.getFilename();
             this.info = "";
+            this.date = download.getDate();
             this.isFailedDownload = false;
         }
     }


### PR DESCRIPTION
## Description
Silently removes pending downloads no longer recognized by the system's download manager, if the download date is before app. Oct 10th, 2022.
