### PR TITLE
Improve handling of th elements in table formatting (fix #13498)

### DIFF
--- a/main/src/cgeo/geocaching/utils/UnknownTagsHandler.java
+++ b/main/src/cgeo/geocaching/utils/UnknownTagsHandler.java
@@ -31,7 +31,7 @@ public class UnknownTagsHandler implements TagHandler {
             handleStrike(opening, output);
         } else if ("table".equalsIgnoreCase(tag)) {
             handleProblematic();
-        } else if ("td".equalsIgnoreCase(tag)) {
+        } else if ("td".equalsIgnoreCase(tag) || "th".equalsIgnoreCase(tag)) {
             handleTd(opening, output);
         } else if ("tr".equalsIgnoreCase(tag)) {
             handleTr(opening, output);


### PR DESCRIPTION
## Description
Currently, table cells identified by `<td>` are separated by a "|" for displaying a cache listing.
This PR adds the same for table cells identified by `<th>`.
