### PR TITLE
fix lint: allow text concatenation in certain places

### DIFF
--- a/main/src/cgeo/geocaching/ImageViewActivity.java
+++ b/main/src/cgeo/geocaching/ImageViewActivity.java
@@ -21,6 +21,7 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.SharedElementCallback;
 import android.content.Context;
@@ -319,6 +320,7 @@ public class ImageViewActivity extends AbstractActionBarActivity {
 
     // splitting up that method would not help improve readability
     @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
+    @SuppressLint("SetTextI18n")
     private void loadImageView(final int pagerPos, final int loadImagePos, final ImageviewImageBinding binding) {
         final Image currentImage = imageList.get(loadImagePos);
         if (currentImage == null) {

--- a/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -25,6 +25,7 @@ import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.functions.Action1;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Context;
@@ -155,6 +156,7 @@ public class DownloaderUtils {
                 .show();
     }
 
+    @SuppressLint("SetTextI18n")
     public static void triggerDownloads(final Activity activity, @StringRes final int title, @StringRes final int confirmation, final List<Download> downloads, @Nullable final Action1<Boolean> downloadTriggered) {
         final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(title);


### PR DESCRIPTION
## Description
Normally manual text concatenation should not be used due to internationalization issues, but it may be ok in specific situations. Declare exceptions for those places.