### PR TITLE
fix lint: ignore 'uselessparent' in specific places

### DIFF
--- a/main/res/layout/imageview_image.xml
+++ b/main/res/layout/imageview_image.xml
@@ -65,7 +65,8 @@
         <RelativeLayout android:id="@+id/imageview_information"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/colorBackgroundTransparent">
+            android:background="@color/colorBackgroundTransparent"
+            tools:ignore="UselessParent">
             <TextView android:id="@+id/imageview_information_text"
                 style="@style/text_default"
                 android:layout_toLeftOf="@+id/imageview_information_icon_less"

--- a/main/res/layout/variable_list_view.xml
+++ b/main/res/layout/variable_list_view.xml
@@ -16,7 +16,8 @@
        work properly. See e.g. https://stackoverflow.com/questions/27475178/how-do-i-make-wrap-content-work-on-a-recyclerview -->
         <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            tools:ignore="UselessParent">
 
             <androidx.recyclerview.widget.RecyclerView
 


### PR DESCRIPTION
## Description
Stacking empty layouts is normally unnecessary. PR marks the exceptions.
