### PR TITLE
fix lint: false positive on sql syntax error

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -507,6 +507,7 @@ public class DataStore {
             + "longitude DOUBLE "
             + "); ";
 
+    @SuppressWarnings("SyntaxError")
     private static final String dbCreateExtension
             = "CREATE TABLE IF NOT EXISTS " + dbTableExtension + " ("
             + "_id INTEGER PRIMARY KEY AUTOINCREMENT, "


### PR DESCRIPTION
## Description
Lint SQL syntax checking cannot cope with concatenating a const value so it reports a false-positive syntax error => PR suppresses it for the variable declaration involved.
