### PR TITLE
allow manual setting of range slider values (fix #12808)

### DIFF
--- a/main/src/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
@@ -52,7 +52,7 @@ public class DistanceFilterViewHolder extends BaseFilterViewHolder<DistanceGeoca
                 return ">" + maxDistance;
             }
             return "" + Math.round(f);
-        }, 6);
+        }, 6, 1);
         slider.setRange(-0.2f, maxDistance + 0.2f);
 
         final LinearLayout.LayoutParams llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);

--- a/main/src/cgeo/geocaching/filters/gui/FavoritesFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/FavoritesFilterViewHolder.java
@@ -57,7 +57,7 @@ public class FavoritesFilterViewHolder extends BaseFilterViewHolder<FavoritesGeo
                     return ">1000";
                 }
                 return "" + Math.round(f);
-            }, 6);
+            }, 6, 1);
             slider.setRange(-0.2f, 1000.2f);
         } else {
             maxValue = 1;
@@ -70,7 +70,7 @@ public class FavoritesFilterViewHolder extends BaseFilterViewHolder<FavoritesGeo
                     return "100%";
                 }
                 return Math.round(f * 100) + "%";
-            }, 6);
+            }, 6, 100);
             slider.setRange(-0.002f, 1.002f);
         }
     }

--- a/main/src/cgeo/geocaching/filters/gui/LogsCountFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/LogsCountFilterViewHolder.java
@@ -60,7 +60,7 @@ public class LogsCountFilterViewHolder extends BaseFilterViewHolder<LogsCountGeo
                 return ">1000";
             }
             return "" + Math.round(f);
-        }, 6);
+        }, 6, 1);
         slider.setRange(0f, 1000.2f);
     }
 

--- a/main/src/cgeo/geocaching/settings/SeekbarPreference.java
+++ b/main/src/cgeo/geocaching/settings/SeekbarPreference.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.text.InputType;
@@ -234,24 +233,14 @@ public class SeekbarPreference extends Preference {
         });
 
         valueView.setOnClickListener(v2 -> {
-            final String title = String.format(context.getString(R.string.number_input_title), valueToShownValue(progressToValue(minProgress)), valueToShownValue(progressToValue(maxProgress)));
             final String defaultValue = valueToShownValue(progressToValue(seekBar.getProgress()));
             int inputType = InputType.TYPE_CLASS_NUMBER;
             if (useDecimals()) {
                 inputType |= InputType.TYPE_NUMBER_FLAG_DECIMAL;
             }
             final Consumer<String> listener = input -> {
-                int newValue;
                 try {
-                    newValue = valueToProgress(shownValueToValue(Float.parseFloat(input)));
-                    if (newValue > maxProgress) {
-                        newValue = maxProgress;
-                        Toast.makeText(context, R.string.number_input_err_boundarymax, Toast.LENGTH_SHORT).show();
-                    }
-                    if (newValue < minProgress) {
-                        newValue = minProgress;
-                        Toast.makeText(context, R.string.number_input_err_boundarymin, Toast.LENGTH_SHORT).show();
-                    }
+                    final int newValue = (int) SimpleDialog.checkInputRange(getContext(), valueToProgress(shownValueToValue(Float.parseFloat(input))), minProgress, maxProgress);
                     seekBar.setProgress(newValue);
                     saveSetting(seekBar.getProgress());
                     valueView.setText(getValueString(newValue));
@@ -259,7 +248,7 @@ public class SeekbarPreference extends Preference {
                     Toast.makeText(context, R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
                 }
             };
-            SimpleDialog.of((Activity) context).setTitle(TextParam.text(title)).input(inputType, defaultValue, null, getUnitString(), listener);
+            SimpleDialog.ofContext(context).setTitle(TextParam.id(R.string.number_input_title, valueToShownValue(progressToValue(minProgress)), valueToShownValue(progressToValue(maxProgress)))).input(inputType, defaultValue, null, getUnitString(), listener);
         });
     }
 }

--- a/main/src/cgeo/geocaching/ui/ContinuousRangeSlider.java
+++ b/main/src/cgeo/geocaching/ui/ContinuousRangeSlider.java
@@ -2,23 +2,31 @@ package cgeo.geocaching.ui;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.databinding.ContinuousrangesliderViewBinding;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.functions.Func1;
 
 import android.content.Context;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
+import com.google.android.material.slider.RangeSlider;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 /**
  * View displays and maintains a slider where user can select single or range of items from a sorted item list.
+ * Tapping on a thumb allows manual value input
  */
 public class ContinuousRangeSlider extends LinearLayout {
 
@@ -29,6 +37,7 @@ public class ContinuousRangeSlider extends LinearLayout {
 
     private Func1<Float, String> labelMapper;
     private int axisLabelCount = 10;
+    private int factor = 1;
 
     private ContinuousrangesliderViewBinding binding;
 
@@ -63,23 +72,79 @@ public class ContinuousRangeSlider extends LinearLayout {
         final ContextThemeWrapper ctw = new ContextThemeWrapper(getContext(), R.style.cgeo);
         inflate(ctw, R.layout.continuousrangeslider_view, this);
         binding = ContinuousrangesliderViewBinding.bind(this);
-        setScale(0f, 100f, null, 11);
+        setScale(0f, 100f, null, 11, factor);
+        binding.sliderInternal.addOnSliderTouchListener(new RangeSlider.OnSliderTouchListener() {
+            int lastThumb = -1;
+            Float lastValue = -1.0f;
+            Float grace = null;
+
+            @Override
+            public void onStartTrackingTouch(final @NonNull RangeSlider slider) {
+                if (grace == null) {
+                    grace = (slider.getValueTo() - slider.getValueFrom()) / 20.0f;
+                }
+                lastThumb = slider.getActiveThumbIndex(); // on touch start it's the active thumb
+                final List<Float> values = slider.getValues();
+                if (lastThumb >= 0 && lastThumb < values.size()) {
+                    lastValue = values.get(lastThumb);
+                } else {
+                    lastValue = null;
+                }
+            }
+
+            @Override
+            public void onStopTrackingTouch(final @NonNull RangeSlider slider) {
+                final List<Float> values = slider.getValues();
+                // on touch end it's the focussed thumb, though!
+                // still on the same thumb, and not having moved it out of grace area?
+                if (slider.getFocusedThumbIndex() == lastThumb && lastThumb >= 0 && lastThumb < values.size() && Math.abs(lastValue - values.get(lastThumb)) < grace) {
+                    final String defaultValue = String.format(Locale.getDefault(), "%d", Math.round(lastValue * factor));
+                    int inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
+                    if (slider.getValueFrom() < 0) {
+                        inputType |= InputType.TYPE_NUMBER_FLAG_SIGNED;
+                    }
+                    final Consumer<String> listener = input -> {
+                        try {
+                            final float newValue = SimpleDialog.checkInputRange(getContext(), Float.parseFloat(input), slider.getValueFrom() * factor, slider.getValueTo() * factor) / factor;
+                            if (lastThumb == 0) {
+                                // we want to set lower bound, but new value is larger than current upper bound, so swap
+                                if (newValue > values.get(1)) {
+                                    slider.setValues(values.get(1), newValue);
+                                } else {
+                                    slider.setValues(newValue, values.get(1));
+                                }
+                            } else {
+                                // we want to set upper bound, but new value is smaller than current lower bound, so swap
+                                if (newValue < values.get(0)) {
+                                    slider.setValues(newValue, values.get(0));
+                                } else {
+                                    slider.setValues(values.get(0), newValue);
+                                }
+                            }
+                        } catch (NumberFormatException e) {
+                            Toast.makeText(getContext(), R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
+                        }
+                    };
+                    SimpleDialog.ofContext(getContext()).setTitle(TextParam.id(R.string.number_input_title, slider.getValueFrom() * factor, slider.getValueTo() * factor)).input(inputType, defaultValue, null, "", listener);
+                }
+            }
+        });
     }
 
-    public void setScale(final float min, final float max, final Func1<Float, String> labelMapper, final int axisLabelCount) {
+    /** @param displayFactor is only used in context of value input / validation, but not for labels */
+    public void setScale(final float min, final float max, final Func1<Float, String> labelMapper, final int axisLabelCount, final int displayFactor) {
         this.min = min;
         this.max = max;
         this.minSelected = Math.max(this.min, this.minSelected);
         this.maxSelected = Math.min(this.max, this.maxSelected);
         this.labelMapper = labelMapper;
         this.axisLabelCount = axisLabelCount;
+        this.factor = displayFactor;
 
         redesign();
     }
 
     private void redesign() {
-
-
         binding.sliderInternal.setValueFrom(min);
         binding.sliderInternal.setValueTo(max);
         binding.sliderInternal.setLabelFormatter(f -> {

--- a/main/src/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -24,6 +24,7 @@ import android.widget.EditText;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -637,5 +638,17 @@ public class SimpleDialog {
         return new Pair<>(result, indexMap::get);
     }
 
-
+    /** checks a float value and restricts it to given bounds, emitting a short warning message if necessary */
+    public static float checkInputRange(final Context context, final float currentValue, final float minValue, final float maxValue) {
+        float newValue = currentValue;
+        if (newValue > maxValue) {
+            newValue = maxValue;
+            Toast.makeText(context, R.string.number_input_err_boundarymax, Toast.LENGTH_SHORT).show();
+        }
+        if (newValue < minValue) {
+            newValue = minValue;
+            Toast.makeText(context, R.string.number_input_err_boundarymin, Toast.LENGTH_SHORT).show();
+        }
+        return newValue;
+    }
 }


### PR DESCRIPTION
## Description
Tapping on either thumb of a range slider allows manual setting of its value.
Ranges of given slider are honored. Out-of-bound values are reset to slider's min/max values.

![image](https://user-images.githubusercontent.com/3754370/195954509-7d55a2ae-bece-4911-ac0e-69929b3b4056.png)

Setting this to draft for now, as it always uses the given range, not the "display version of given range", which makes a difference for a percentage-based range, where internal range is 0.0 to 1.0, whereas displayed range is 0 to 100 (percent).

@eddiemuc : Would it be sufficient to apply the `labelMapper` function to the internal min/max value?