### PR TITLE
set targetSDK to 31 (rel. to #13036)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -29,8 +29,8 @@ android {
 
     defaultConfig {
         minSdkVersion 21
+        targetSdk 31
         //noinspection OldTargetApi
-        targetSdkVersion 30
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 


### PR DESCRIPTION
## Description
Sets `targetSDK` to 31 as required by Play Store guidelines starting Nov 1st, 2022 to be able to upload new versions. For details see related issue #13036.

## Additional context
November 1st is closing in, so I propose to get this change into the nightlies to check whether there are any loose ends not being taken care of yet.