### PR TITLE
Add minimal formatting for definition lists (fix #6807)

### DIFF
--- a/main/src/cgeo/geocaching/utils/UnknownTagsHandler.java
+++ b/main/src/cgeo/geocaching/utils/UnknownTagsHandler.java
@@ -41,6 +41,10 @@ public class UnknownTagsHandler implements TagHandler {
             handleOl(opening);
         } else if ("li".equalsIgnoreCase(tag)) {
             handleLi(opening, output);
+        } else if ("dt".equalsIgnoreCase(tag)) {
+            handleDT(opening, output);
+        } else if ("dd".equalsIgnoreCase(tag)) {
+            handleDD(output);
         } else if ("hr".equalsIgnoreCase(tag)) {
             handleHr(opening, output);
         }
@@ -88,6 +92,14 @@ public class UnknownTagsHandler implements TagHandler {
         } else {
             listType = ListType.Unordered;
         }
+    }
+
+    private void handleDT(final boolean opening, final Editable output) {
+        output.append(opening ? "\n>> " : "");
+    }
+
+    private void handleDD(final Editable output) {
+        output.append("\n");
     }
 
     private void handleLi(final boolean opening, final Editable output) {


### PR DESCRIPTION
## Description
Adds some basic formatting for definition lists (new line, and some marker for definition titles).

## Additional context
Cache description from the related issue will then look like this:

![image](https://user-images.githubusercontent.com/3754370/196000499-62a09e12-7151-4cb1-8d88-9332eebfa4b1.png)
