### PR TITLE
allow change of track's display name (fix #12587)

### DIFF
--- a/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -24,6 +24,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.InputType;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.ImageButton;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+import org.apache.commons.lang3.StringUtils;
 
 public class RouteTrackUtils {
 
@@ -181,7 +183,14 @@ public class RouteTrackUtils {
 
         tracks.traverse((key, route) -> {
             final View vt = activity.getLayoutInflater().inflate(R.layout.routes_tracks_item, null);
-            ((TextView) vt.findViewById(R.id.item_title)).setText(tracks.getDisplayname(key));
+            final TextView displayName = vt.findViewById(R.id.item_title);
+            displayName.setText(tracks.getDisplayname(key));
+            displayName.setOnClickListener(v -> SimpleDialog.ofContext(dialog.getContext()).setTitle(TextParam.text("Change name")).input(InputType.TYPE_CLASS_TEXT, displayName.getText().toString(), null, null, newName -> {
+                if (StringUtils.isNotBlank(newName)) {
+                    tracks.setDisplayname(key, newName);
+                    displayName.setText(newName);
+                }
+            }));
             vt.findViewById(R.id.item_center).setOnClickListener(v1 -> {
                 if (null != route) {
                     route.setCenter(centerOnPosition);

--- a/main/src/cgeo/geocaching/maps/Tracks.java
+++ b/main/src/cgeo/geocaching/maps/Tracks.java
@@ -105,6 +105,14 @@ public class Tracks {
         return null;
     }
 
+    public void setDisplayname(@NonNull final String key, @NonNull final String newName) {
+        for (Track track : data) {
+            if (track.trackfile.getKey().equals(key)) {
+                track.trackfile.setDisplayname(newName);
+            }
+        }
+    }
+
     public Route getRoute(@NonNull final String key) {
         for (Track track : data) {
             if (track.trackfile.getKey().equals(key)) {

--- a/main/src/cgeo/geocaching/storage/extension/Trackfiles.java
+++ b/main/src/cgeo/geocaching/storage/extension/Trackfiles.java
@@ -65,6 +65,15 @@ public class Trackfiles extends DataStore.DBExtension {
     /**
      * to be called by Tracks only, not intended for direct usage
      */
+    public void setDisplayname(@NonNull final String newName) {
+        string1 = newName;
+        removeAll(type, key);
+        add(type, key, 0, 0, 0, 0, newName, "", "", "");
+    }
+
+    /**
+     * to be called by Tracks only, not intended for direct usage
+     */
     public static void removeTrackfile(@NonNull final String filename) {
         removeAll(type, filename);
         FileUtils.delete(new File(LocalStorage.getTrackfilesDir(), filename));


### PR DESCRIPTION
## Description
Tapping on a track's display name opens a dialog box where the user can change the display name.
The (copied) file in the (private part of the) file system will not be renamed.
