### PR TITLE
Listing link and image handling

### DIFF
--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -162,6 +162,7 @@ import androidx.fragment.app.FragmentManager;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -1900,8 +1901,11 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                     @Override
                     public void onClick(final View textView) {
                         final String imageUrl = span.getSource();
+                        final Collection<Image> listingImages = cache.getNonStaticImages();
+                        CollectionUtils.filter(listingImages, i -> i.category == Image.ImageCategory.LISTING);
+
                         if (Settings.enableFeatureNewImageGallery()) {
-                            ImageViewActivity.openImageView(activity, cache.getGeocode(), Collections.singletonList(IterableUtils.find(cache.getImages(), i -> imageUrl.equals(i.getUrl()))), 0, null);
+                            ImageViewActivity.openImageView(activity, cache.getGeocode(), listingImages, IterableUtils.indexOf(listingImages, i -> imageUrl.equals(i.getUrl())), null);
                         }
                     }
 

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1904,8 +1904,10 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                         final Collection<Image> listingImages = cache.getNonStaticImages();
                         CollectionUtils.filter(listingImages, i -> i.category == Image.ImageCategory.LISTING);
 
+                        final int pos = IterableUtils.indexOf(listingImages, i -> ImageUtils.imageUrlForSpoilerCompare(imageUrl).equals(ImageUtils.imageUrlForSpoilerCompare(i.getUrl())));
+
                         if (Settings.enableFeatureNewImageGallery()) {
-                            ImageViewActivity.openImageView(activity, cache.getGeocode(), listingImages, IterableUtils.indexOf(listingImages, i -> imageUrl.equals(i.getUrl())), null);
+                            ImageViewActivity.openImageView(activity, cache.getGeocode(), listingImages, pos, null);
                         }
                     }
 

--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -54,7 +54,6 @@ import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
-import android.net.Uri;
 import android.os.Handler;
 import android.os.Message;
 import android.util.Pair;
@@ -985,25 +984,17 @@ public class Geocache implements IWaypoint {
             return Collections.emptyList();
         }
         final Set<String> listingUrls = new HashSet<>();
-        ImageUtils.forEachImageUrlInHtml(s -> listingUrls.add(imageUrlForSpoilerCompare(s)), getShortDescription(), getDescription());
+        ImageUtils.forEachImageUrlInHtml(s -> listingUrls.add(ImageUtils.imageUrlForSpoilerCompare(s)), getShortDescription(), getDescription());
         final List<Image> result = new ArrayList<>();
         for (Image spoilerCandidate : getSpoilers()) {
             final boolean spoilerInTitle = spoilerCandidate.getTitle() != null &&
                     spoilerCandidate.getTitle().toLowerCase(Locale.US).contains("spoiler");
-            final boolean containedInListing = listingUrls.contains(imageUrlForSpoilerCompare(spoilerCandidate.getUrl()));
+            final boolean containedInListing = listingUrls.contains(ImageUtils.imageUrlForSpoilerCompare(spoilerCandidate.getUrl()));
             if (spoilerInTitle || !containedInListing) {
                 result.add(spoilerCandidate);
             }
         }
         return result;
-    }
-
-    @NonNull
-    private String imageUrlForSpoilerCompare(@Nullable final String url) {
-        if (url == null) {
-            return "";
-        }
-        return StringUtils.defaultString(Uri.parse(url).getLastPathSegment());
     }
 
     /**

--- a/main/src/cgeo/geocaching/ui/AnchorAwareLinkMovementMethod.java
+++ b/main/src/cgeo/geocaching/ui/AnchorAwareLinkMovementMethod.java
@@ -1,10 +1,7 @@
 package cgeo.geocaching.ui;
 
-import android.content.ActivityNotFoundException;
-import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
-import android.provider.Browser;
+import cgeo.geocaching.utils.ShareUtils;
+
 import android.text.Layout;
 import android.text.Selection;
 import android.text.Spannable;
@@ -12,7 +9,6 @@ import android.text.method.LinkMovementMethod;
 import android.text.method.Touch;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.TextView;
@@ -63,18 +59,7 @@ public class AnchorAwareLinkMovementMethod extends LinkMovementMethod {
                 if (link.length != 0) {
                     if (action == MotionEvent.ACTION_UP) {
                         if (link[0] instanceof URLSpan) {
-                            // copied from URLSpan.java
-                            final Uri uri = Uri.parse(((URLSpan) link[0]).getURL());
-                            final Context context = widget.getContext();
-                            final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                            intent.putExtra(Browser.EXTRA_APPLICATION_ID, context.getPackageName());
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); // this is different from the original!
-                            try {
-                                context.startActivity(intent);
-                            } catch (ActivityNotFoundException e) {
-                                Log.w("URLSpan", "Actvity was not found for intent, " + intent);
-                            }
-                            // end copy from URLSpan.java
+                            ShareUtils.openUrl(widget.getContext(), ((URLSpan) link[0]).getURL());
                         } else {
                             link[0].onClick(widget);
                         }

--- a/main/src/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/cgeo/geocaching/utils/ImageUtils.java
@@ -441,6 +441,15 @@ public final class ImageUtils {
         return new BitmapDrawable(res, BitmapFactory.decodeResource(res, R.drawable.image_no_placement));
     }
 
+
+    @NonNull
+    public static String imageUrlForSpoilerCompare(@Nullable final String url) {
+        if (url == null) {
+            return "";
+        }
+        return StringUtils.defaultString(Uri.parse(url).getLastPathSegment());
+    }
+
     /**
      * Add images present in the HTML description to the existing collection.
      *
@@ -451,10 +460,10 @@ public final class ImageUtils {
     public static void addImagesFromHtml(final Collection<Image> images, final String geocode, final String... htmlText) {
         final Set<String> urls = new LinkedHashSet<>();
         for (final Image image : images) {
-            urls.add(image.getUrl());
+            urls.add(imageUrlForSpoilerCompare(image.getUrl()));
         }
         forEachImageUrlInHtml(source -> {
-                if (!urls.contains(source) && canBeOpenedExternally(source)) {
+                if (!urls.contains(imageUrlForSpoilerCompare(source)) && canBeOpenedExternally(source)) {
                     images.add(new Image.Builder()
                             .setUrl(source)
                             .setTitle(StringUtils.defaultString(geocode))


### PR DESCRIPTION
- Use ShareUtils for listing link handling (⇾ will use Chrome WebView if the relevant setting was enabled by the user)
- Open ImageViewActivity when clicking on listing images (fix #9019) 
   * ImageViewActivity will only be used if the image isn't wrapped into an `<a href="..">...</a>` link tag
-  avoid image duplication in image gallery (fix cgeo#13088) 


### Example:
![image_preview_compressed](https://user-images.githubusercontent.com/64581222/196035833-f6d8bc88-9d72-4085-a4a7-041f81ef18ab.gif)
