### PR TITLE
restrict displayed values to integers (rel. to #13517)

### DIFF
--- a/main/src/cgeo/geocaching/ui/ContinuousRangeSlider.java
+++ b/main/src/cgeo/geocaching/ui/ContinuousRangeSlider.java
@@ -125,7 +125,7 @@ public class ContinuousRangeSlider extends LinearLayout {
                             Toast.makeText(getContext(), R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
                         }
                     };
-                    SimpleDialog.ofContext(getContext()).setTitle(TextParam.id(R.string.number_input_title, slider.getValueFrom() * factor, slider.getValueTo() * factor)).input(inputType, defaultValue, null, "", listener);
+                    SimpleDialog.ofContext(getContext()).setTitle(TextParam.id(R.string.number_input_title, Math.round(slider.getValueFrom() * factor), Math.round(slider.getValueTo() * factor))).input(inputType, defaultValue, null, "", listener);
                 }
             }
         });


### PR DESCRIPTION
## Description
Restrict displayed values in edit mask of `ContinuousRangeSlider` to (rounded) integer values (but still allow entering exact values within the given range of the slider).

## Additional context
|---|---|
|favorite filter, percent mode|favorite filter, absolute mode|
|![image](https://user-images.githubusercontent.com/3754370/196049263-f21229bf-8471-4433-bcab-480847570b43.png)|![image](https://user-images.githubusercontent.com/3754370/196049253-03fbe821-2ba8-439f-a96c-57ed76bf06bd.png)|
