### PR TITLE
rel to #13138: make load of cache description asynchronous and limited

### DIFF
--- a/main/res/layout/cachedetail_description_page.xml
+++ b/main/res/layout/cachedetail_description_page.xml
@@ -27,6 +27,14 @@
             tools:text="This is the cache description. It might be very long..."
             tools:visibility="visible" />
 
+        <Button
+            android:id="@+id/description_render_fully"
+            style="@style/button_full"
+            android:clickable="true"
+            android:focusable="true"
+            android:visibility="gone"
+            android:text="@string/cache_description_render_fully" />
+
         <RelativeLayout
             android:id="@+id/loading"
             android:layout_width="fill_parent"

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1362,6 +1362,9 @@
     <string name="cache_personal_note_upload_cancelled">Personal note upload cancelled</string>
     <string name="cache_description">Description</string>
     <string name="cache_description_table_note">Description contains table formatting which may need to be viewed at %s to be seen correctly.</string>
+    <string name="cache_description_rendering">Rendering description, please wait…</string>
+    <string name="cache_description_render_restricted_warning">Warning: Description is very large (%1$d chars). Only first %2$d%% were rendered.</string>
+    <string name="cache_description_render_fully">Render complete description</string>
     <string name="cache_area_description">Area Description</string>
     <string name="cache_cache_description">Cache Description</string>
     <string name="cache_virtual_description">Virtual Question</string>


### PR DESCRIPTION
rel to #13138: make load of cache description asynchronous and limited

* Cache listings will now be rendered aynchronously. 
* Very long listings will now be shortened to first 100000 chars. A warning will be displayed that listing was cutted and option is given to re-render the full listing

![image](https://user-images.githubusercontent.com/6909759/197030891-6659bff8-91aa-4086-9a03-134f393f360f.png)

