### PR TITLE
add a preference category for hillshading, add explanatory text and link to wiki

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -187,6 +187,7 @@
     <string translatable="false" name="pref_persistablefolder_offlinemaps">persistablefolder_offlinemaps</string>
     <string translatable="false" name="pref_fakekey_info_offline_mapthemes">fakekey_info_offline_mapthemes</string>
     <string translatable="false" name="pref_persistablefolder_offlinemapthemes">persistablefolder_offlinemapthemes</string>
+    <string translatable="false" name="pref_fakekey_info_offline_maphillshading">fakekey_info_offline_maphillshading</string>
     <string translatable="false" name="pref_persistablefolder_offlinemapshading">persistablefolder_offlinemapshading</string>
     <string translatable="false" name="pref_renderthemefolder_synctolocal">renderthemefolder_synctolocal</string>
     <string translatable="false" name="pref_mapRotation">mapRotation</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1004,7 +1004,7 @@
     <string name="settings_info_themes_title">Info on Map Themes</string>
     <string name="settings_info_themes">c:geo supports custom themes for offline maps. These can be used to change the color style of the map (e.g. to have a nightview map) or to highlight certain objects like cycle paths or height lines within the map.\n\nWorking with non-zipped map themes might decrease map viewer opening performance. In this case, the theme folder may optionally be synchronized to an app-private local folder for faster access (at the cost of some storage space).</string>
     <string name="settings_info_hillshading_title">Info on Hillshading</string>
-    <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Sloped will be darkened/lightened to generate a 3D-effect. The source files containing the elevation information have to be obtained manually - click this item for sources - and placed in the sources folder defined below.</string>
+    <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Slopes will be darkened/lightened to generate a 3D-effect.\nThe source files containing the elevation information have to be obtained manually - click this item for sources - and placed in the sources folder defined below.</string>
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="init_local_file_system">Local File System</string>
     <string name="init_base_directory_description">Base folder for public local data</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -766,7 +766,8 @@
     <string name="settings_summary_map">Set map source, offline map settings and map details.</string>
     <string name="settings_title_map_data">Map Data</string>
     <string name="settings_title_offline_maps">Offline maps</string>
-    <string name="settings_title_map_themes">Offline map themes &amp; hillshading</string>
+    <string name="settings_title_map_themes">Offline map themes</string>
+    <string name="settings_title_map_hillshading">Offline maps hillshading</string>
     <string name="settings_title_offline_routing">Offline routing</string>
     <string name="settings_summary_offline_routing">Offline routing is available if either helper app \"BRouter\" is installed and configured or internal routing is enabled.</string>
     <string name="settings_title_map_rotation">Map rotation (Google Maps)</string>
@@ -1002,6 +1003,8 @@
     <string name="settings_info_offline_maps">c:geo supports maps for offline use. You can obtain maps from different providers or even create your own maps (from OSM data). First you have to select the folder in which offline maps are to be stored.</string>
     <string name="settings_info_themes_title">Info on Map Themes</string>
     <string name="settings_info_themes">c:geo supports custom themes for offline maps. These can be used to change the color style of the map (e.g. to have a nightview map) or to highlight certain objects like cycle paths or height lines within the map.\n\nWorking with non-zipped map themes might decrease map viewer opening performance. In this case, the theme folder may optionally be synchronized to an app-private local folder for faster access (at the cost of some storage space).</string>
+    <string name="settings_info_hillshading_title">Info on Hillshading</string>
+    <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Sloped will be darkened/lightened to generate a 3D-effect. The source files containing the elevation information have to be obtained manually - click this item for sources - and placed in the sources folder defined below.</string>
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="init_local_file_system">Local File System</string>
     <string name="init_base_directory_description">Base folder for public local data</string>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -65,6 +65,7 @@
     <string translatable="false" name="manual_url_settings_offline_maps">https://manual.cgeo.org/en/offlinemaps</string>
     <string translatable="false" name="faq_url_settings_themes">https://faq.cgeo.org/#theme-slow</string>
     <string translatable="false" name="manual_url_mapbehavior">https://manual.cgeo.org/en/mainmenu/settings#map_behavior</string>
+    <string translatable="false" name="manual_url_hillshading">https://manual.cgeo.org/en/offlinemaps#hillshading</string>
 
     <!-- contributors -->
     <string translatable="false" name="contributors_carnero">carnero</string>

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -70,6 +70,15 @@
             android:summary="@string/init_summary_renderthemefolder_synctolocal"
             android:title="@string/init_renderthemefolder_synctolocal"
             app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:title="@string/settings_title_map_hillshading"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:key="@string/pref_fakekey_info_offline_maphillshading"
+            android:text="@string/settings_info_hillshading"
+            android:title="@string/settings_info_hillshading_title"
+            app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_persistablefolder_offlinemapshading"
             android:text="@string/settings_info_themes"

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -28,12 +28,12 @@
         <Preference
             android:key="@string/pref_fakekey_info_offline_maps"
             android:title="@string/settings_info_offline_maps_title"
-            android:text="@string/settings_info_offline_maps"
+            android:summary="@string/settings_info_offline_maps"
             app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_fakekey_start_downloader"
             android:title="@string/downloadmap_title"
-            android:text="@string/downloadmap_info"
+            android:summary="@string/downloadmap_info"
             app:iconSpaceReserved="false" />
 
         <Preference
@@ -57,7 +57,7 @@
         app:iconSpaceReserved="false">
         <Preference
             android:key="@string/pref_fakekey_info_offline_mapthemes"
-            android:text="@string/settings_info_themes"
+            android:summary="@string/settings_info_themes"
             android:title="@string/settings_info_themes_title"
             app:iconSpaceReserved="false" />
         <Preference
@@ -76,12 +76,12 @@
         app:iconSpaceReserved="false">
         <Preference
             android:key="@string/pref_fakekey_info_offline_maphillshading"
-            android:text="@string/settings_info_hillshading"
+            android:summary="@string/settings_info_hillshading"
             android:title="@string/settings_info_hillshading_title"
             app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_persistablefolder_offlinemapshading"
-            android:text="@string/settings_info_themes"
+            android:summary="@string/settings_info_themes"
             android:title="@string/init_mapshading_folder"
             app:iconSpaceReserved="false" />
         <SeekBarPreference

--- a/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/res/xml/preferences_services_geocaching_com.xml
@@ -47,7 +47,7 @@
         <Preference
             android:key="@string/pref_gc_fb_login_hint"
             android:title="@string/settings_info_facebook_login_title"
-            android:text="@string/settings_info_facebook_login"
+            android:summary="@string/settings_info_facebook_login"
             app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_fakekey_gc_website"

--- a/main/res/xml/preferences_services_send_to_cgeo.xml
+++ b/main/res/xml/preferences_services_send_to_cgeo.xml
@@ -26,7 +26,7 @@
         <Preference
             android:key="@string/pref_fakekey_sendtocgeo_info"
             android:title="@string/settings_info_send2cgeo_title"
-            android:text="@string/init_sendToCgeo_description"
+            android:summary="@string/init_sendToCgeo_description"
             app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_fakekey_sendtocgeo_website"

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -63,6 +63,7 @@ public class PreferenceMapFragment extends BasePreferenceFragment {
         setPrefClick(this, R.string.pref_fakekey_info_offline_maps, () -> ShareUtils.openUrl(activity, activity.getString(R.string.manual_url_settings_offline_maps)));
         setPrefClick(this, R.string.pref_fakekey_start_downloader, () -> activity.startActivity(new Intent(activity, DownloadSelectorActivity.class)));
         setPrefClick(this, R.string.pref_fakekey_info_offline_mapthemes, () -> ShareUtils.openUrl(activity, activity.getString(R.string.faq_url_settings_themes)));
+        setPrefClick(this, R.string.pref_fakekey_info_offline_maphillshading, () -> ShareUtils.openUrl(activity, activity.getString(R.string.manual_url_hillshading)));
 
         initPublicFolders(this, activity.getCsah());
 


### PR DESCRIPTION
This ALSO addresses #13547 by replacing all android:text with android:summary in preference pages