### PR TITLE
update "set user modified coordinates" for cache on gpx-import 

### DIFF
--- a/main/src/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/cgeo/geocaching/files/GPXParser.java
@@ -322,6 +322,11 @@ abstract class GPXParser extends FileParser {
 
                         waypoint.setCoords(cache.getCoords());
 
+                        // set flag for user-modified coordinates of cache
+                        if (waypoint.getWaypointType() == WaypointType.ORIGINAL) {
+                            cacheForWaypoint.setUserModifiedCoords(true);
+                        }
+
                         // user defined waypoint does not have original empty coordinates
                         if (wptEmptyCoordinates || (!waypoint.isUserDefined() && null == waypoint.getCoords())) {
                             waypoint.setOriginalCoordsEmpty(true);

--- a/tests/res/raw/gc31j2h_wpts_original.gpx
+++ b/tests/res/raw/gc31j2h_wpts_original.gpx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gpx xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0" creator="Groundspeak, Inc. All Rights Reserved. http://www.groundspeak.com" xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd http://www.groundspeak.com/cache/1/0 http://www.groundspeak.com/cache/1/0/cache.xsd" xmlns="http://www.topografix.com/GPX/1/0">
+  <name>Waypoints for Cache Listings Generated from Geocaching.com</name>
+  <desc>This is a list of supporting waypoints for caches generated from Geocaching.com</desc>
+  <author>Various users from Geocaching.com</author>
+  <email>contact@geocaching.com</email>
+  <url>http://www.geocaching.com</url>
+  <urlname>Geocaching - High Tech Treasure Hunting</urlname>
+  <time>2011-09-16T21:13:24.7355791Z</time>
+  <keywords>cache, geocache, waypoints</keywords>
+  <bounds minlat="49.317517" minlon="8.545083" maxlat="49.317517" maxlon="8.545083" />
+  <wpt lat="49.317517" lon="8.545083">
+    <time>2011-08-05T11:35:49.217</time>
+    <name>0031J2H</name>
+    <cmt>Original Coordinatesy</cmt>
+    <desc>Original Coordinates</desc>
+    <sym>Original Coordinates</sym>
+    <type>Waypoint|Original Coordinates</type>
+  </wpt>
+</gpx>

--- a/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
+++ b/tests/src-android/cgeo/geocaching/files/GPXParserTest.java
@@ -130,6 +130,21 @@ public class GPXParserTest extends AbstractResourceInstrumentationTestCase {
         assertThat(wpEmpty.isOriginalCoordsEmpty()).as("OriginalCoordEmpty").isTrue();
     }
 
+    public void testGc31j2hWptsOriginal() throws IOException, ParserException {
+        removeCacheCompletely("GC31J2H");
+        final List<Geocache> caches = readGPX10(R.raw.gc31j2h, R.raw.gc31j2h_wpts_original);
+        assertThat(caches).hasSize(1);
+        final Geocache cache = caches.get(0);
+
+        final List<Waypoint> waypointList = cache.getWaypoints();
+        assertThat(waypointList).isNotNull();
+        assertThat(waypointList).as("Number of imported waypoints").hasSize(1);
+
+        final Waypoint wpOriginal = waypointList.get(0);
+        assertThat(wpOriginal.getWaypointType()).as("Waypoint-Type").isEqualTo(WaypointType.ORIGINAL);
+
+        assertThat(cache.hasUserModifiedCoords()).as("Has user modified coordinates").isTrue();
+    }
 
     public void testOCddd2WptsEmptyCoord() throws IOException, ParserException {
         removeCacheCompletely("OCDDD2");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
set the flag _setUserModifiedCoords_ if gpx contains a waypoint of type ORIGINAL, so the upload of modified coordinates works properly and on update the waypoint does not get lost

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #13302 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->