### PR TITLE
Fix #13541 - Use better coloring for archived caches

### DIFF
--- a/main/res/raw/changelog_base.md
+++ b/main/res/raw/changelog_base.md
@@ -24,3 +24,4 @@ Due to upcoming restrictions in Play Store we have upgraded the targeted Android
 - New: Allow manual input of values in filters using sliders
 - New: Enable upload of modified coordinates for caches imported from GPX file, when cache has waypoint of type "ORIGINAL"
 - Change: Improve filter status line text
+- Change: User a better readable color for archived cache names in titles and remove coloring from cache details page

--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -6,6 +6,7 @@
     <color name="colorText">@color/just_white</color>
     <color name="colorTextDark">#AAFFFFFF</color>
     <color name="colorTextHint">#A0CCCCCC</color>
+    <color name="archived_cache_color">#3F51B5</color>
 
     <color name="colorTextHeadline">#88FFFFFF</color>
     <color name="colorTextHintActionBar">@color/colorTextHint</color>

--- a/main/res/values-night/colors_dark.xml
+++ b/main/res/values-night/colors_dark.xml
@@ -6,7 +6,7 @@
     <color name="colorText">@color/just_white</color>
     <color name="colorTextDark">#AAFFFFFF</color>
     <color name="colorTextHint">#A0CCCCCC</color>
-    <color name="archived_cache_color">#3F51B5</color>
+    <color name="archived_cache_color">#FFEA0000</color>
 
     <color name="colorTextHeadline">#88FFFFFF</color>
     <color name="colorTextHintActionBar">@color/colorTextHint</color>

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -12,7 +12,6 @@
 
     <color name="just_white">#FFFFFFFF</color>
     <color name="just_black">#FF000000</color>
-    <color name="archived_cache_color">#4CAF50</color>
     <color name="text_icon">#FFFFFFFF</color>
     <color name="shortcut_background">#FFF5F5F5</color>
 

--- a/main/res/values/colors.xml
+++ b/main/res/values/colors.xml
@@ -12,7 +12,7 @@
 
     <color name="just_white">#FFFFFFFF</color>
     <color name="just_black">#FF000000</color>
-    <color name="archived_cache_color">#FFAC0B0B</color>
+    <color name="archived_cache_color">#4CAF50</color>
     <color name="text_icon">#FFFFFFFF</color>
     <color name="shortcut_background">#FFF5F5F5</color>
 

--- a/main/res/values/colors_light.xml
+++ b/main/res/values/colors_light.xml
@@ -6,6 +6,7 @@
     <color name="colorText">@color/just_black</color>
     <color name="colorTextDark">#AA000000</color>
     <color name="colorTextHint">#FF666666</color>
+    <color name="archived_cache_color">#FFAC0B0B</color>
 
     <color name="colorTextHeadline">#88000000</color>
     <color name="colorTextHintActionBar">#FFAAAAAA</color>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1163,6 +1163,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             final CacheDetailsCreator details = new CacheDetailsCreator(activity, binding.detailsList);
 
             // cache name (full name), may be editable
+            // Not using colored cache names at this place to have at least one place without any formatting to support visually impaired users
             final TextView cachename = details.add(R.string.cache_name, cache.getName()).valueView;
             activity.addContextMenu(cachename);
             if (cache.supportsNamechange()) {

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -1163,8 +1163,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             final CacheDetailsCreator details = new CacheDetailsCreator(activity, binding.detailsList);
 
             // cache name (full name), may be editable
-            final SpannableString span = TextUtils.coloredCacheText(cache, cache.getName());
-            final TextView cachename = details.add(R.string.cache_name, span).valueView;
+            final TextView cachename = details.add(R.string.cache_name, cache.getName()).valueView;
             activity.addContextMenu(cachename);
             if (cache.supportsNamechange()) {
                 cachename.setOnClickListener(v -> Dialogs.input(activity, activity.getString(R.string.cache_name_set), cache.getName(), activity.getString(R.string.caches_sort_name), name -> {

--- a/main/src/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/cgeo/geocaching/CachePopupFragment.java
@@ -137,7 +137,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
                 return false;
             });
 
-            binding.title.setText(TextUtils.coloredCacheText(cache, cache.getName()));
+            binding.title.setText(TextUtils.coloredCacheText(getActivity(), cache, cache.getName()));
             details = new CacheDetailsCreator(getActivity(), binding.detailsList);
 
             addCacheDetails(false);

--- a/main/src/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/cgeo/geocaching/WaypointPopupFragment.java
@@ -81,7 +81,7 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
             binding.toolbar.toolbar.setTitle(wpCode);
             binding.toolbar.toolbar.setLogo(MapMarkerUtils.getWaypointMarker(res, waypoint, false).getDrawable());
 
-            binding.title.setText(TextUtils.coloredCacheText(cache, cache.getName()));
+            binding.title.setText(TextUtils.coloredCacheText(getActivity(), cache, cache.getName()));
             details = new CacheDetailsCreator(getActivity(), binding.waypointDetailsList);
 
             //Waypoint name

--- a/main/src/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/cgeo/geocaching/activity/AbstractActivity.java
@@ -309,7 +309,7 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
      * change the titlebar icon and text to show the current geocache
      */
     protected void setCacheTitleBar(@NonNull final Geocache cache) {
-        setTitle(TextUtils.coloredCacheText(cache, cache.getName() + " (" + cache.getShortGeocode() + ")"));
+        setTitle(TextUtils.coloredCacheText(this, cache, cache.getName() + " (" + cache.getShortGeocode() + ")"));
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowHomeEnabled(true);

--- a/main/src/cgeo/geocaching/utils/TextUtils.java
+++ b/main/src/cgeo/geocaching/utils/TextUtils.java
@@ -1,10 +1,10 @@
 package cgeo.geocaching.utils;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.functions.Func1;
 
+import android.content.Context;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -291,13 +291,13 @@ public final class TextUtils {
         return containsHtml(html) ? trimSpanned(HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY)).toString() : html;
     }
 
-    public static SpannableString coloredCacheText(@NonNull final Geocache cache, @NonNull final String text) {
+    public static SpannableString coloredCacheText(final Context context, @NonNull final Geocache cache, @NonNull final String text) {
         final SpannableString span = new SpannableString(text);
         if (cache.isDisabled() || cache.isArchived()) { // strike
             span.setSpan(new StrikethroughSpan(), 0, span.toString().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
         if (cache.isArchived()) {
-            span.setSpan(new ForegroundColorSpan(ContextCompat.getColor(CgeoApplication.getInstance(), R.color.archived_cache_color)), 0, span.toString().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+            span.setSpan(new ForegroundColorSpan(ContextCompat.getColor(context, R.color.archived_cache_color)), 0, span.toString().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
         return span;
     }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
- Apply different colors for name of archived caches for dark/light theme
- Remove coloring in cache details list (only show it in top bar of cache view and map popup)

This is draft and DNM, because its not applying the correct theme color for top bar and popup.
Its however working in list and in dropdown on home screen.

For better debugging I temporarily assigned 
GREEN = light theme
BLUE = dark theme

It looks like this now..dark theme is not applied everywhere:
| Dark | Light |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/949669/197186590-d0dbd33e-dfd4-45d6-9584-c4d1fa7071a1.png) | ![image](https://user-images.githubusercontent.com/949669/197187015-dc4ec537-7377-4dad-b41b-acf9a834246f.png) |
| ![image](https://user-images.githubusercontent.com/949669/197186750-cd295a45-bd85-45a8-8f95-66c5f48865d8.png) | ![image](https://user-images.githubusercontent.com/949669/197187062-92bea570-4565-4757-af53-e05319573131.png) | 

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#13541 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->