### PR TITLE
improve height display ( #13526)

### DIFF
--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -322,7 +322,7 @@ public class CompassActivity extends AbstractActionBarActivity {
                     binding.navAccuracy.setText(null);
                 }
 
-                binding.navLocation.setText(geo.getCoords() + GeoHeightUtils.getAverageHeight(geo, true, false));
+                binding.navLocation.setText(geo.getCoords() + GeoHeightUtils.getAverageHeight(geo, false));
 
                 updateDistanceInfo(geo);
 

--- a/main/src/cgeo/geocaching/CompassActivity.java
+++ b/main/src/cgeo/geocaching/CompassActivity.java
@@ -322,7 +322,7 @@ public class CompassActivity extends AbstractActionBarActivity {
                     binding.navAccuracy.setText(null);
                 }
 
-                binding.navLocation.setText(geo.getCoords() + GeoHeightUtils.getAverageHeight(geo, true));
+                binding.navLocation.setText(geo.getCoords() + GeoHeightUtils.getAverageHeight(geo, true, false));
 
                 updateDistanceInfo(geo);
 

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -239,7 +239,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             }
 
             currentCoords = geo.getCoords();
-            final String averageHeight = GeoHeightUtils.getAverageHeight(geo, true, true);
+            final String averageHeight = GeoHeightUtils.getAverageHeight(geo, true);
             if (Settings.isShowAddress()) {
                 if (addCoords == null) {
                     binding.navLocation.setText(R.string.loc_no_addr);

--- a/main/src/cgeo/geocaching/MainActivity.java
+++ b/main/src/cgeo/geocaching/MainActivity.java
@@ -239,7 +239,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             }
 
             currentCoords = geo.getCoords();
-            final String averageHeight = GeoHeightUtils.getAverageHeight(geo, true);
+            final String averageHeight = GeoHeightUtils.getAverageHeight(geo, true, true);
             if (Settings.isShowAddress()) {
                 if (addCoords == null) {
                     binding.navLocation.setText(R.string.loc_no_addr);

--- a/main/src/cgeo/geocaching/utils/GeoHeightUtils.java
+++ b/main/src/cgeo/geocaching/utils/GeoHeightUtils.java
@@ -14,17 +14,21 @@ public class GeoHeightUtils {
     }
 
     /** returns a formatted height string, empty, if height==0 */
-    public static String getAverageHeight(final GeoData geo, final boolean withSeparator) {
+    public static String getAverageHeight(final GeoData geo, final boolean withSeparator, final boolean onlyFullReadings) {
         // remember new altitude reading, and calculate average from past MAX_READINGS readings
         if (geo.hasAltitude() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || geo.getVerticalAccuracyMeters() > 0.0)) {
             altitudeReadings[altitudeReadingPos] = geo.getAltitude();
             altitudeReadingPos = (++altitudeReadingPos) % altitudeReadings.length;
         }
-        double averageAltitude = altitudeReadings[0];
-        for (int i = 1; i < altitudeReadings.length; i++) {
-            averageAltitude += altitudeReadings[i];
+        double averageAltitude = 0;
+        int countReadings = 0;
+        for (double altitude : altitudeReadings) {
+            averageAltitude += altitude;
+            if (altitude != 0) {
+                countReadings++;
+            }
         }
         averageAltitude /= (double) altitudeReadings.length;
-        return averageAltitude == 0 ? "" : (withSeparator ? Formatter.SEPARATOR : "") + Units.getDistanceFromMeters((float) averageAltitude);
+        return averageAltitude == 0 || (onlyFullReadings && countReadings < 5) ? "" : (withSeparator ? Formatter.SEPARATOR : "") + (countReadings < 5 ? "~ " : "") + Units.getDistanceFromMeters((float) averageAltitude);
     }
 }

--- a/main/src/cgeo/geocaching/utils/GeoHeightUtils.java
+++ b/main/src/cgeo/geocaching/utils/GeoHeightUtils.java
@@ -14,7 +14,7 @@ public class GeoHeightUtils {
     }
 
     /** returns a formatted height string, empty, if height==0 */
-    public static String getAverageHeight(final GeoData geo, final boolean withSeparator, final boolean onlyFullReadings) {
+    public static String getAverageHeight(final GeoData geo, final boolean onlyFullReadings) {
         // remember new altitude reading, and calculate average from past MAX_READINGS readings
         if (geo.hasAltitude() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || geo.getVerticalAccuracyMeters() > 0.0)) {
             altitudeReadings[altitudeReadingPos] = geo.getAltitude();
@@ -29,6 +29,6 @@ public class GeoHeightUtils {
             }
         }
         averageAltitude /= (double) altitudeReadings.length;
-        return averageAltitude == 0 || (onlyFullReadings && countReadings < 5) ? "" : (withSeparator ? Formatter.SEPARATOR : "") + (countReadings < 5 ? "~ " : "") + Units.getDistanceFromMeters((float) averageAltitude);
+        return averageAltitude == 0 || (onlyFullReadings && countReadings < 5) ? "" : Formatter.SEPARATOR + (countReadings < 5 ? "~ " : "") + Units.getDistanceFromMeters((float) averageAltitude);
     }
 }


### PR DESCRIPTION
## Description
- Displays height on home screen only when full readings (at least 5) are available
- Prepends "~" in compass height view, if less than five readings have been used
