### PR TITLE
show lists on UnifiedMap, show title (rel. to #12926)

### DIFF
--- a/main/src/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/cgeo/geocaching/maps/DefaultMap.java
@@ -101,13 +101,24 @@ public final class DefaultMap {
     }
 
     public static void startActivitySearch(final Activity fromActivity, final Class<?> cls, final SearchResult search, final String title, final int fromList) {
-        new MapOptions(search, title, fromList).startIntent(fromActivity, cls);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in searchResult mode (item count: " + search.getGeocodes().size() + ", title='" + title + "', fromList=" + fromList + ")");
+            new UnifiedMapType(search, title, fromList).launchMap(fromActivity);
+        } else {
+            new MapOptions(search, title, fromList).startIntent(fromActivity, cls);
+        }
     }
 
     public static void startActivitySearch(final Activity fromActivity, final SearchResult search, final String title, final int fromList) {
-        final MapOptions mo = new MapOptions(search, title, fromList);
-        mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
-        mo.startIntent(fromActivity, getDefaultMapClass());
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in searchResult mode (item count: " + search.getGeocodes().size() + ", title='" + title + "', fromList=" + fromList + ")");
+            // @todo: filter
+            new UnifiedMapType(search, title, fromList).launchMap(fromActivity);
+        } else {
+            final MapOptions mo = new MapOptions(search, title, fromList);
+            mo.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
+            mo.startIntent(fromActivity, getDefaultMapClass());
+        }
     }
 
 

--- a/main/src/cgeo/geocaching/models/RouteItem.java
+++ b/main/src/cgeo/geocaching/models/RouteItem.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.MatcherWrapper;
+import cgeo.geocaching.utils.TextUtils;
 import static cgeo.geocaching.utils.Formatter.generateShortGeocode;
 
 import android.os.Parcel;
@@ -14,12 +15,16 @@ import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
 public class RouteItem implements Parcelable {
+    public static final Comparator<? super RouteItem> NAME_COMPARATOR = (Comparator<RouteItem>) (left, right) -> TextUtils.COLLATOR.compare(left.identifier, right.identifier);
+
+
     // groups: 1=geocode, 3=wp prefix, 4=additional text
     private static final Pattern GEOINFO_PATTERN = Pattern.compile("^([A-Za-z]{1,2}[0-9A-Za-z]{1,6})(-([A-Za-z0-9]{1,10}))?( .*)?$");
     private static final Pattern AL_GEOINFO_PATTERN = Pattern.compile("^AL([A-Za-z0-9]+)(-[A-Za-z0-9]+)+( .*)?$");

--- a/main/src/cgeo/geocaching/ui/GeoItemSelectorUtils.java
+++ b/main/src/cgeo/geocaching/ui/GeoItemSelectorUtils.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IWaypoint;
+import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.CalendarUtils;
@@ -114,6 +115,32 @@ public class GeoItemSelectorUtils {
         tv.setCompoundDrawablesWithIntrinsicBounds(geoitemRef.getMarkerId(), 0, 0, 0);
 
 
+        return view;
+    }
+
+    public static View createRouteItemView(final Context context, final RouteItem routeItem, final View view) {
+        if (StringUtils.isNotEmpty(routeItem.getGeocode())) {
+            if (routeItem.getType() == RouteItem.RouteItemType.GEOCACHE) {
+                final Geocache cache = DataStore.loadCache(routeItem.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);
+                if (cache != null) {
+                    return createGeocacheItemView(context, cache, view);
+                }
+            } else if (routeItem.getType() == RouteItem.RouteItemType.WAYPOINT) {
+                final Waypoint waypoint = DataStore.loadWaypoint(routeItem.getWaypointId());
+                if (waypoint != null) {
+                    return createWaypointItemView(context, waypoint, view);
+                }
+            }
+        }
+
+        // Fallback - neither a cache nor waypoint. should never happen...
+        final TextView tv = view.findViewById(R.id.text);
+        tv.setText(routeItem.getIdentifier());
+
+        final TextView infoView = view.findViewById(R.id.info);
+        infoView.setText(routeItem.getGeocode());
+
+        // tv.setCompoundDrawablesWithIntrinsicBounds(routeItem.getMarkerId(), 0, 0, 0);
         return view;
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.unifiedmap;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.storage.DataStore;
 
 import java.util.HashMap;
@@ -16,11 +17,11 @@ public abstract class AbstractGeoitemLayer<T> {
     protected final HashMap<String, GeoItemCache<T>> items = new HashMap<>();
 
     public static class GeoItemCache<T> {
-        public GeoPoint geopoint;
+        public RouteItem routeItem;
         public T mapItem;
 
-        public GeoItemCache(final Geopoint geopoint, final T mapItem) {
-            this.geopoint = new GeoPoint(geopoint.getLatitudeE6(), geopoint.getLongitudeE6());
+        public GeoItemCache(final RouteItem routeItem, final T mapItem) {
+            this.routeItem = routeItem;
             this.mapItem = mapItem;
         }
     }
@@ -48,13 +49,15 @@ public abstract class AbstractGeoitemLayer<T> {
         }
     }
 
-    public LinkedList<String> find(final BoundingBox boundingBox) {
-        final LinkedList<String> result = new LinkedList<>();
+    public LinkedList<RouteItem> find(final BoundingBox boundingBox) {
+        final LinkedList<RouteItem> result = new LinkedList<>();
         synchronized (items) {
             for (String geocode : items.keySet()) {
                 final GeoItemCache<T> item = items.get(geocode);
-                if (item != null && boundingBox.contains(item.geopoint)) {
-                    result.add(geocode);
+                assert item != null;
+                final Geopoint geopoint = item.routeItem.getPoint();
+                if (boundingBox.contains(new GeoPoint(geopoint.getLatitudeE6(), geopoint.getLongitudeE6()))) {
+                    result.add(item.routeItem);
                 }
             }
         }

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractGeoitemLayer.java
@@ -5,30 +5,40 @@ import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 
-import androidx.annotation.Nullable;
-
 import java.util.HashMap;
+import java.util.LinkedList;
+
+import org.oscim.core.BoundingBox;
+import org.oscim.core.GeoPoint;
 
 public abstract class AbstractGeoitemLayer<T> {
 
-    protected final HashMap<String, T> items = new HashMap<>();
+    protected final HashMap<String, GeoItemCache<T>> items = new HashMap<>();
 
-    @Nullable
-    protected abstract T add(Geocache cache);
+    public static class GeoItemCache<T> {
+        public GeoPoint geopoint;
+        public T mapItem;
 
-    @Nullable
-    T add(final String geocode) {
+        public GeoItemCache(final Geopoint geopoint, final T mapItem) {
+            this.geopoint = new GeoPoint(geopoint.getLatitudeE6(), geopoint.getLongitudeE6());
+            this.mapItem = mapItem;
+        }
+    }
+
+    protected abstract void add(Geocache cache);
+
+    void add(final String geocode) {
         final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);  // @todo check load flags
         if (cache == null) {
-            return null;
+            return;
         }
 
         final Geopoint coords = cache.getCoords();
         if (coords == null) {
-            return null;
+            return;
         }
 
-        return add(cache);
+        add(cache);
     }
 
     /** removes item from internal data structure, needs to be removed from actual layer by superclass */
@@ -36,6 +46,19 @@ public abstract class AbstractGeoitemLayer<T> {
         synchronized (items) {
             items.remove(geocode);
         }
+    }
+
+    public LinkedList<String> find(final BoundingBox boundingBox) {
+        final LinkedList<String> result = new LinkedList<>();
+        synchronized (items) {
+            for (String geocode : items.keySet()) {
+                final GeoItemCache<T> item = items.get(geocode);
+                if (item != null && boundingBox.contains(item.geopoint)) {
+                    result.add(geocode);
+                }
+            }
+        }
+        return result;
     }
 
 }

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractPositionLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractPositionLayer.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.PositionHistory;
 import cgeo.geocaching.maps.routing.Routing;
+import cgeo.geocaching.models.IndividualRoute;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.TrailHistoryElement;
 import cgeo.geocaching.settings.Settings;
@@ -43,7 +44,7 @@ import org.oscim.core.GeoPoint;
  *
  * T is the type the map expects its coordinates in (LatLng for Google Maps, GeoPoint for Mapsforge)
  */
-public abstract class AbstractPositionLayer<T> {
+public abstract class AbstractPositionLayer<T> implements IndividualRoute.UpdateIndividualRoute {
 
     protected Location currentLocation = null;
     protected float currentHeading = 0.0f;

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
+import android.view.View;
 
 import androidx.annotation.Nullable;
 
@@ -27,6 +28,7 @@ public abstract class AbstractUnifiedMapView<T> {
     protected Geopoint delayedCenterTo = null;
     protected Runnable onMapReadyTasks = null;
     protected boolean usesOwnBearingIndicator = true;
+    protected View mMapView = null;
 
     public void init(final UnifiedMapActivity activity, final int delayedZoomTo, @Nullable final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         activityRef = new WeakReference<>(activity);
@@ -136,12 +138,12 @@ public abstract class AbstractUnifiedMapView<T> {
     // Map tap handling
 
     /** transmits tap on map to activity */
-    protected void onTapCallback(final double latitude, final double longitude, final boolean isLongTap) {
+    protected void onTapCallback(final int latitudeE6, final int longitudeE6, final boolean isLongTap) {
         final UnifiedMapActivity activity = activityRef.get();
         if (activity == null) {
             throw new IllegalStateException("map tap handler: lost connection to map activity");
         }
-        activity.onTap(latitude, longitude, isLongTap);
+        activity.onTap(latitudeE6, longitudeE6, isLongTap);
     }
 
     // ========================================================================

--- a/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/AbstractUnifiedMapView.java
@@ -9,12 +9,15 @@ import cgeo.geocaching.utils.functions.Action1;
 import android.app.Activity;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+
+import java.lang.ref.WeakReference;
 
 import org.oscim.core.BoundingBox;
 
+
 public abstract class AbstractUnifiedMapView<T> {
 
+    protected WeakReference<UnifiedMapActivity> activityRef;
     protected AbstractTileProvider currentTileProvider;
     protected AbstractPositionLayer<T> positionLayer;
     protected Action1<UnifiedMapPosition> activityMapChangeListener = null;
@@ -25,7 +28,8 @@ public abstract class AbstractUnifiedMapView<T> {
     protected Runnable onMapReadyTasks = null;
     protected boolean usesOwnBearingIndicator = true;
 
-    public void init(final AppCompatActivity activity, final int delayedZoomTo, @Nullable final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
+    public void init(final UnifiedMapActivity activity, final int delayedZoomTo, @Nullable final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
+        activityRef = new WeakReference<>(activity);
         mapRotation = Settings.getMapRotation();
         this.delayedZoomTo = delayedZoomTo;
         this.delayedCenterTo = delayedCenterTo;
@@ -126,6 +130,18 @@ public abstract class AbstractUnifiedMapView<T> {
             setZoom(Math.max(Math.min(delayedZoomTo, getZoomMax()), getZoomMin()));
             delayedZoomTo = -1;
         }
+    }
+
+    // ========================================================================
+    // Map tap handling
+
+    /** transmits tap on map to activity */
+    protected void onTapCallback(final double latitude, final double longitude, final boolean isLongTap) {
+        final UnifiedMapActivity activity = activityRef.get();
+        if (activity == null) {
+            throw new IllegalStateException("map tap handler: lost connection to map activity");
+        }
+        activity.onTap(latitude, longitude, isLongTap);
     }
 
     // ========================================================================

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -653,6 +653,14 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
     }
 
     // ========================================================================
+    // Map tap handling
+
+    public void onTap(final double latitude, final double longitude, final boolean isLongTap) {
+        Log.e("registered " + (isLongTap ? "long " : "") + " tap on map @ (" + latitude + ", " + longitude + ")");
+
+    }
+
+    // ========================================================================
     // Lifecycle methods
 
     @Override

--- a/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.unifiedmap;
 
+import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.location.Geopoint;
 
 import android.content.Context;
@@ -15,13 +16,17 @@ public class UnifiedMapType implements Parcelable {
         UMTT_Undefined,         // invalid state
         UMTT_PlainMap,          // open map (from bottom navigation)
         UMTT_TargetGeocode,     // set cache or waypoint as target
-        UMTT_TargetCoords       // set coords as target
+        UMTT_TargetCoords,      // set coords as target
+        UMTT_SearchResult       // show and scale to searchresult
         // to be extended
     }
 
     public UnifiedMapTypeType type = UnifiedMapTypeType.UMTT_Undefined;
     public String target = null;
     public Geopoint coords = null;
+    public SearchResult searchResult = null;
+    public String title = null;
+    public int fromList = 0;
     // reminder: add additional fields to parcelable methods below
 
     /** default UnifiedMapType is PlainMap with no further data */
@@ -41,6 +46,14 @@ public class UnifiedMapType implements Parcelable {
         this.coords = coords;
     }
 
+    /** show and scale to search result */
+    public UnifiedMapType(final SearchResult searchResult, final String title, final int fromList) {
+        type = UnifiedMapTypeType.UMTT_SearchResult;
+        this.searchResult = searchResult;
+        this.title = title;
+        this.fromList = fromList;
+    }
+
     /** launch fresh map with current settings */
     public void launchMap(final Context fromActivity) {
         final Intent intent = new Intent(fromActivity, UnifiedMapActivity.class);
@@ -55,6 +68,9 @@ public class UnifiedMapType implements Parcelable {
         type = UnifiedMapTypeType.values()[in.readInt()];
         target = in.readString();
         coords = in.readParcelable(Geopoint.class.getClassLoader());
+        searchResult = in.readParcelable(SearchResult.class.getClassLoader());
+        title = in.readString();
+        fromList = in.readInt();
         // ...
     }
 
@@ -68,6 +84,9 @@ public class UnifiedMapType implements Parcelable {
         dest.writeInt(type.ordinal());
         dest.writeString(target);
         dest.writeParcelable(coords, 0);
+        dest.writeParcelable(searchResult, 0);
+        dest.writeString(title);
+        dest.writeInt(fromList);
         // ...
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.unifiedmap.googlemaps;
 
 import cgeo.geocaching.CgeoApplication;
-import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
@@ -26,10 +25,10 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
     }
 
     @Override
-    protected Marker add(final Geocache cache) {
+    protected void add(final Geocache cache) {
         final GoogleMap map = mapRef.get();
         if (map == null) {
-            return null;
+            return;
         }
 
         final Geopoint coords = cache.getCoords();
@@ -43,9 +42,8 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
 
         Log.e("addGeoitem");
         synchronized (items) {
-            items.put(cache.getGeocode(), item);
+            items.put(cache.getGeocode(), new GeoItemCache<>(coords, item));
         }
-        return item;
     }
 
     @Override
@@ -53,9 +51,9 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
         final GoogleMap map = mapRef.get();
         if (map != null) {
             synchronized (items) {
-                final Marker item = items.get(geocode);
+                final GeoItemCache<Marker> item = items.get(geocode);
                 if (item != null) {
-                    item.remove();
+                    item.mapItem.remove();
                 }
             }
         }

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -33,7 +33,7 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
         }
 
         final Geopoint coords = cache.getCoords();
-        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
+        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, null);
         final Marker item = map.addMarker(new MarkerOptions()
             .position(new LatLng(coords.getLatitude(), coords.getLongitude()))
             .title(cache.getGeocode())

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
@@ -42,7 +43,7 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
 
         Log.e("addGeoitem");
         synchronized (items) {
-            items.put(cache.getGeocode(), new GeoItemCache<>(coords, item));
+            items.put(cache.getGeocode(), new GeoItemCache<>(new RouteItem(cache), item));
         }
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.maps.google.v2.GoogleMapController;
 import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.unifiedmap.AbstractPositionLayer;
 import cgeo.geocaching.unifiedmap.AbstractUnifiedMapView;
+import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.unifiedmap.UnifiedMapPosition;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractGoogleTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
@@ -17,7 +18,6 @@ import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 import android.view.View;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -32,14 +32,14 @@ import org.oscim.core.BoundingBox;
  * GoogleMapsView - Contains the view handling parts specific to Google Maps
  * To be called by UnifiedMapActivity (mostly)
  */
-public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements OnMapReadyCallback {
+public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements OnMapReadyCallback, GoogleMap.OnMapClickListener, GoogleMap.OnMapLongClickListener {
 
     private GoogleMap mMap;
     private View rootView;
     private final GoogleMapController mapController = new GoogleMapController();
 
     @Override
-    public void init(final AppCompatActivity activity, final int delayedZoomTo, final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
+    public void init(final UnifiedMapActivity activity, final int delayedZoomTo, final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         super.init(activity, delayedZoomTo, delayedCenterTo, onMapReadyTasks);
         activity.setContentView(R.layout.unifiedmap_googlemaps);
         rootView = activity.findViewById(R.id.unifiedmap_gm);
@@ -91,7 +91,19 @@ public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements On
         configMapChangeListener(true);
         setMapRotation(mapRotation);
         positionLayer = configPositionLayer(true);
+        mMap.setOnMapClickListener(this);
+        mMap.setOnMapLongClickListener(this);
         onMapReadyTasks.run();
+    }
+
+    @Override
+    public void onMapClick(final LatLng point) {
+        onTapCallback(point.latitude, point.longitude, false);
+    }
+
+    @Override
+    public void onMapLongClick(final LatLng point) {
+        onTapCallback(point.latitude, point.longitude, true);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.Log;
@@ -45,7 +46,7 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
 
         Log.e("addGeoitem");
         synchronized (items) {
-            items.put(cache.getGeocode(), new GeoItemCache<>(coords, item));
+            items.put(cache.getGeocode(), new GeoItemCache<>(new RouteItem(cache), item));
         }
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
-import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
@@ -35,7 +34,7 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
     }
 
     @Override
-    protected MarkerItem add(final Geocache cache) {
+    protected void add(final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         final MarkerItem item = new MarkerItem(cache.getGeocode(), "", new GeoPoint(coords.getLatitudeE6(), coords.getLongitudeE6())); // @todo add marker touch handling
 
@@ -43,22 +42,21 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
         final MarkerSymbol symbol = new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
         item.setMarker(symbol);
         mMarkerLayer.addItem(item);
+
         Log.e("addGeoitem");
         synchronized (items) {
-            items.put(cache.getGeocode(), item);
+            items.put(cache.getGeocode(), new GeoItemCache<>(coords, item));
         }
-        return item;
     }
 
     @Override
     protected void remove(final String geocode) {
         if (mMarkerLayer != null) {
-            final MarkerItem item;
             synchronized (items) {
-                item = items.get(geocode);
-            }
-            if (item != null) {
-                mMarkerLayer.removeItem(item);
+                final GeoItemCache<MarkerItem> item = items.get(geocode);
+                if (item != null) {
+                    mMarkerLayer.removeItem(item.mapItem);
+                }
             }
         }
         super.remove(geocode);

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
@@ -39,7 +39,7 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
         final Geopoint coords = cache.getCoords();
         final MarkerItem item = new MarkerItem(cache.getGeocode(), "", new GeoPoint(coords.getLatitudeE6(), coords.getLongitudeE6())); // @todo add marker touch handling
 
-        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, CacheListType.MAP);
+        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, null);
         final MarkerSymbol symbol = new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
         item.setMarker(symbol);
         mMarkerLayer.addItem(item);

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
@@ -59,13 +59,13 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
         activity.setContentView(R.layout.unifiedmap_mapsforgevtm);
         rootView = activity.findViewById(R.id.unifiedmap_vtm);
         mMapView = activity.findViewById(R.id.mapViewVTM);
+        super.mMapView = mMapView;
         mMap = mMapView.map();
         setMapRotation(mapRotation);
         usesOwnBearingIndicator = false; // let UnifiedMap handle bearing indicator
         activity.findViewById(R.id.map_zoomin).setOnClickListener(v -> zoomInOut(true));
         activity.findViewById(R.id.map_zoomout).setOnClickListener(v -> zoomInOut(false));
         themeHelper = new MapsforgeThemeHelper(activity);
-        mMap.layers().add(new MapEventsReceiver(mMap));
         onMapReadyTasks.run();
     }
 
@@ -278,11 +278,11 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
         public boolean onGesture(final Gesture g, final MotionEvent e) {
             if (g instanceof Gesture.Tap) {
                 final GeoPoint p = mMap.viewport().fromScreenPoint(e.getX(), e.getY());
-                onTapCallback(p.getLatitude(), p.getLongitude(), false);
+                onTapCallback(p.latitudeE6, p.longitudeE6, false);
                 return true;
             } else if (g instanceof Gesture.LongPress) {
                 final GeoPoint p = mMap.viewport().fromScreenPoint(e.getX(), e.getY());
-                onTapCallback(p.getLatitude(), p.getLongitude(), true);
+                onTapCallback(p.latitudeE6, p.longitudeE6, true);
                 return true;
             }
             return false;
@@ -295,9 +295,9 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
     @Override
     protected void onResume() {
         super.onResume();
-        // @todo: There must be a less resource-intensive way of applying style-changes...
-        applyTheme();
+        applyTheme(); // @todo: There must be a less resource-intensive way of applying style-changes...
         mMapView.onResume();
+        mMap.layers().add(new MapEventsReceiver(mMap));
     }
 
     @Override


### PR DESCRIPTION
## Description
- enable display of `SearchResult` on UnifiedMap (used for displaying both lists and actual search results)
- calculate & show map title
- handle tap events (cache/waypoint popups and selection popup)
