### PR TITLE
fix #13579: catch outdated positions when accessing geocache list to prevent ioobe

### DIFF
--- a/main/src/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/cgeo/geocaching/ui/CacheListAdapter.java
@@ -751,6 +751,9 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
     @NonNull
     private String getComparable(final int position) {
+        if (position < 0 || position >= list.size()) {
+            return " ";
+        }
         try {
             return sortContext.getComparator().getSortableSection(list.get(position));
         } catch (NullPointerException e) {


### PR DESCRIPTION
fix #13579: catch outdated positions when accessing geocache list to prevent ioobe