### PR TITLE
agp 7.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,8 +116,9 @@ allprojects {
                 force 'com.android.tools.build:aapt2-proto:4.2.2-7147631'
 
                 // grade 7.3 wants a beta version, which is not downloadable on google maven
-                force 'com.google.testing.platform:android-device-provider-local:0.0.7-dev'
                 force 'com.google.testing.platform:core:0.0.7-dev'
+                force 'com.google.testing.platform:launcher:0.0.7-dev'
+                force 'com.google.testing.platform:android-device-provider-local:0.0.7-dev'
                 force 'com.google.testing.platform:android-driver-instrumentation:0.0.7-dev'
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'

--- a/build.gradle
+++ b/build.gradle
@@ -124,9 +124,8 @@ allprojects {
  */
 subprojects {
     repositories {
-        mavenCentral()
-        // Android Support libraries are now in an online Maven repository
         google()
+        mavenCentral()
         // integrate as last one - for versions by commit ID
         maven {
             url 'https://jitpack.io'

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,9 @@ allprojects {
                 // force this version because of conflict to our resolutionStrategy from lint-gradle
                 // TODO check necessity after every gradle update (gradlew :main:lintBasicDebug)
                 force 'com.android.tools.build:aapt2-proto:4.2.2-7147631'
+
+                // grade 7.3 wants a beta version, which is not downloadable on google maven
+                force 'com.google.testing.platform:android-device-provider-local:0.0.7-dev'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ allprojects {
                 force 'com.google.testing.platform:launcher:0.0.7-dev'
                 force 'com.google.testing.platform:android-device-provider-local:0.0.7-dev'
                 force 'com.google.testing.platform:android-driver-instrumentation:0.0.7-dev'
+                force 'com.google.testing.platform:android-test-plugin:0.0.7-dev'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ allprojects {
 
                 // grade 7.3 wants a beta version, which is not downloadable on google maven
                 force 'com.google.testing.platform:android-device-provider-local:0.0.7-dev'
+                force 'com.google.testing.platform:core:0.0.7-dev'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ allprojects {
                 // grade 7.3 wants a beta version, which is not downloadable on google maven
                 force 'com.google.testing.platform:android-device-provider-local:0.0.7-dev'
                 force 'com.google.testing.platform:core:0.0.7-dev'
+                force 'com.google.testing.platform:android-driver-instrumentation:0.0.7-dev'
             }
         }
     }

--- a/cgeo-contacts/AndroidManifest.xml
+++ b/cgeo-contacts/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cgeo.contacts"
     android:versionCode="202010113"
     android:versionName="2020.10.13" >
 

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -5,6 +5,8 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'cgeo.contacts'
+
     compileSdkVersion 31
 
     // signing is handled via private.properties
@@ -24,7 +26,7 @@ android {
 
         // include only those language resources from libraries which we actively maintain ourselves in the translation project
         // not yet enough translations (~50%): "is","iw" (="he"),"zh"
-        resConfigs "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr","zh-rTW"
+        resConfigs 'en', 'ar', 'ca', 'ceb', 'cs', 'da', 'de', 'el', 'es', 'fi', 'fil', 'fr', 'hu', 'in', 'it', 'ja', 'ko', 'lt', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'tl', 'tr', 'zh-rTW'
     }
 
     sourceSets {
@@ -36,7 +38,7 @@ android {
         }
     }
 
-    lintOptions {
+    lint {
         // generally we accept lint errors when building
         abortOnError false
 

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="cgeo.geocaching"
     android:installLocation="auto">
 
     <uses-sdk tools:overrideLibrary="locus.api.android"/>

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,6 +19,8 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
+    namespace 'cgeo.geocaching'
+
     compileSdkVersion 31
 
     compileOptions {
@@ -51,7 +53,7 @@ android {
 
         // include only those language resources from libraries which we actively maintain ourselves in the translation project at https://crowdin.com/project/cgeo
         // not yet enough translations (~50%): "is","iw"(="he"),"lb"
-        def locales = [ "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr","uk","zh","zh-rTW" ]
+        def locales = [ 'en', 'ar', 'ca', 'ceb', 'cs', 'da', 'de', 'el', 'es', 'fi', 'fil', 'fr', 'hu', 'in', 'it', 'ja', 'ko', 'lt', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'tl', 'tr', 'uk', 'zh', 'zh-rTW' ]
 
         // needed for in-app language selector
         buildConfigField "String[]", "TRANSLATION_ARRAY", "new String[]{\""+locales.join("\",\"")+"\"}"
@@ -176,7 +178,7 @@ android {
         resultsDir = "$project.buildDir/build/test-results"
     }
 
-    lintOptions {
+    lint {
         // we do not accept lint errors when building
         abortOnError true
         // Warnings shall not fail build
@@ -196,39 +198,43 @@ android {
     }
 
     packagingOptions {
-        // you can double click an APK file in Android Studio 2.2+ to see what's in there
-        // license files of libs are not needed in our APK
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/dependencies'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/notice'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/license'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/license.txt'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/notice.txt'
-        exclude 'COPYING'
-        exclude 'COPYING.LESSER'
-        exclude '.readme'
-        // AndroidAnnotations
-        exclude 'androidannotations-api.properties'
-        // mapsforge
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.properties'
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.xml'
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map/pom.properties'
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map/pom.xml'
-        exclude 'COPYING.LESSER.v3'
-        exclude 'COPYING.v3'
-        // Play Services
-        exclude 'build-data.properties'
-        // rxjava
-        exclude 'META-INF/rxandroid.properties'
-        exclude 'META-INF/rxjava.properties'
+        resources {
+            excludes += [
+                    // you can double click an APK file in Android Studio 2.2+ to see what's in there
+                    // license files of libs are not needed in our APK
+                    'META-INF/DEPENDENCIES',
+                    'META-INF/dependencies',
+                    'META-INF/NOTICE',
+                    'META-INF/notice',
+                    'META-INF/LICENSE',
+                    'META-INF/license',
+                    'META-INF/LICENSE.txt',
+                    'META-INF/license.txt',
+                    'META-INF/NOTICE.txt',
+                    'META-INF/notice.txt',
+                    'COPYING',
+                    'COPYING.LESSER',
+                    '.readme',
+                    // AndroidAnnotations
+                    'androidannotations-api.properties',
+                    // mapsforge
+                    'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.properties',
+                    'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.xml',
+                    'META-INF/maven/org.mapsforge/mapsforge-map/pom.properties',
+                    'META-INF/maven/org.mapsforge/mapsforge-map/pom.xml',
+                    'COPYING.LESSER.v3',
+                    'COPYING.v3',
+                    // Play Services
+                    'build-data.properties',
+                    // rxjava
+                    'META-INF/rxandroid.properties',
+                    'META-INF/rxjava.properties'
+            ]
 
-        // vtm-themes
-        resources.pickFirsts.add("assets/symbols/**")
-        resources.pickFirsts.add("assets/patterns/**")
+            // vtm-themes
+            pickFirsts.add("assets/symbols/**")
+            pickFirsts.add("assets/patterns/**")
+        }
     }
 
     flavorDimensions "javaCompilerTime" // all flavours must be assigned a dimension

--- a/mapswithme-api/AndroidManifest.xml
+++ b/mapswithme-api/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mapwithme.maps.api"
     android:versionCode="1"
     android:versionName="1.0" >
 

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.mapwithme.maps.api'
 
     compileSdkVersion 31
 
@@ -21,7 +22,7 @@ android {
         res.srcDirs = ['res']
     }
 
-    lintOptions {
+    lint {
         // generally we accept lint errors when building
         abortOnError false
 

--- a/tests/AndroidManifest.xml
+++ b/tests/AndroidManifest.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cgeo.geocaching.test"
     android:versionCode="1"
     android:versionName="1.0" >
-
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="31" />
 
     <uses-feature
         android:name="android.hardware.screen.portrait"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,0 +1,11 @@
+android {
+    namespace 'cgeo.geocaching.test'
+
+    compileSdkVersion 31
+
+    defaultConfig {
+        minSdkVersion 21
+        //noinspection OldTargetApi
+        targetSdkVersion 31
+    }
+}


### PR DESCRIPTION
Move AGP from 4.2.2 to 7.3.1, partially using the assistent.

Implement some migration steps ans resolve deprecation warnings
- Rewrite deprecated operators
- Migrate packagingOptions DSL properties to sub-blocks
- Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated
