### PR TITLE
UnifiedMap: layer handling fixes + extensions

### DIFF
--- a/main/src/cgeo/geocaching/unifiedmap/LayerHelper.java
+++ b/main/src/cgeo/geocaching/unifiedmap/LayerHelper.java
@@ -1,0 +1,32 @@
+package cgeo.geocaching.unifiedmap;
+
+public class LayerHelper {
+
+    // constants for layer ordering (higher = more visible)
+    // layer index numbers must be consecutive, starting with 1 for ZINDEX_BASEMAP
+
+    public static final int ZINDEX_POSITION = 12;
+
+    public static final int ZINDEX_TRACK_ROUTE = 11;
+
+    public static final int ZINDEX_DIRECTION_LINE = 10;
+
+    public static final int ZINDEX_GEOCACHE = 9;
+    public static final int ZINDEX_POSITION_ACCURACY_CIRCLE = 8;
+    public static final int ZINDEX_WAYPOINT = 7;
+
+    public static final int ZINDEX_HISTORY = 6;
+
+    public static final int ZINDEX_CIRCLE = 5;
+
+    // some OSM-only layers
+    public static final int ZINDEX_LABELS = 4;
+    public static final int ZINDEX_BUILDINGS = 3;
+    public static final int ZINDEX_SCALEBAR = 2;
+    public static final int ZINDEX_BASEMAP = 1;     // this is hard-coded in VTM:Map.java
+
+    private LayerHelper() {
+        // helper class
+    }
+
+}

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -1,13 +1,11 @@
 package cgeo.geocaching.unifiedmap.googlemaps;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.CacheMarker;
-import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.IWaypoint;
 import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.unifiedmap.LayerHelper;
-import cgeo.geocaching.utils.MapMarkerUtils;
 
 import java.lang.ref.WeakReference;
 
@@ -26,25 +24,24 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
     }
 
     @Override
-    protected void add(final Geocache cache) {
+    protected void add(final IWaypoint item) {
         final GoogleMap map = mapRef.get();
         if (map == null) {
             return;
         }
+        super.add(item);
+    }
 
-        final Geopoint coords = cache.getCoords();
-        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, null);
-        final Marker item = map.addMarker(new MarkerOptions()
+    @Override
+    protected GeoItemCache<Marker> addInternal(final IWaypoint item, final boolean isCache, final Geopoint coords, final RouteItem routeItem, final CacheMarker cm) {
+        final GoogleMap map = mapRef.get();
+        final Marker marker = map.addMarker(new MarkerOptions()
             .position(new LatLng(coords.getLatitude(), coords.getLongitude()))
-            .title(cache.getGeocode())
             .anchor(0.5f, 1f)
             .icon(BitmapDescriptorFactory.fromBitmap(cm.getBitmap()))
-            .zIndex(LayerHelper.ZINDEX_GEOCACHE)
+            .zIndex(isCache ? LayerHelper.ZINDEX_GEOCACHE : LayerHelper.ZINDEX_WAYPOINT)
         );
-
-        synchronized (items) {
-            items.put(cache.getGeocode(), new GeoItemCache<>(new RouteItem(cache), item));
-        }
+        return new GeoItemCache<>(routeItem, marker);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleGeoitemLayer.java
@@ -6,7 +6,7 @@ import cgeo.geocaching.maps.CacheMarker;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
-import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.utils.MapMarkerUtils;
 
 import java.lang.ref.WeakReference;
@@ -39,9 +39,9 @@ class GoogleGeoitemLayer extends AbstractGeoitemLayer<Marker> {
             .title(cache.getGeocode())
             .anchor(0.5f, 1f)
             .icon(BitmapDescriptorFactory.fromBitmap(cm.getBitmap()))
+            .zIndex(LayerHelper.ZINDEX_GEOCACHE)
         );
 
-        Log.e("addGeoitem");
         synchronized (items) {
             items.put(cache.getGeocode(), new GeoItemCache<>(new RouteItem(cache), item));
         }

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.unifiedmap.googlemaps;
 import cgeo.geocaching.maps.google.v2.GoogleMapObjects;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.unifiedmap.AbstractPositionLayer;
+import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.utils.MapLineUtils;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_GOOGLE;
 
@@ -17,13 +18,6 @@ import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.PolylineOptions;
 
 class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
-
-    public static final float ZINDEX_POSITION = 10;
-    public static final float ZINDEX_TRACK = 6;
-    public static final float ZINDEX_ROUTE = 5;
-    public static final float ZINDEX_DIRECTION_LINE = 5;
-    public static final float ZINDEX_POSITION_ACCURACY_CIRCLE = 3;
-    public static final float ZINDEX_HISTORY = 2;
 
     private final GoogleMapObjects directionObjs;
     private final GoogleMapObjects positionObjs;
@@ -45,7 +39,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
                     .addAll(directionLine)
                     .color(MapLineUtils.getDirectionColor())
                     .width(MapLineUtils.getDirectionLineWidth(true))
-                    .zIndex(ZINDEX_DIRECTION_LINE)
+                    .zIndex(LayerHelper.ZINDEX_DIRECTION_LINE)
             );
         }, MAP_GOOGLE);
     }
@@ -85,7 +79,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
                     .strokeWidth(3)
                     .fillColor(MapLineUtils.getAccuracyCircleFillColor())
                     .radius(accuracy)
-                    .zIndex(ZINDEX_POSITION_ACCURACY_CIRCLE)
+                    .zIndex(LayerHelper.ZINDEX_POSITION_ACCURACY_CIRCLE)
             );
         }
 
@@ -96,7 +90,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
                 .rotation(currentHeading)
                 .anchor(0.5f, 0.5f)
                 .flat(true)
-                .zIndex(ZINDEX_POSITION)
+                .zIndex(LayerHelper.ZINDEX_POSITION)
         );
 
     }
@@ -108,7 +102,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
                 .addAll(points)
                 .color(MapLineUtils.getTrailColor())
                 .width(MapLineUtils.getHistoryLineWidth(true))
-                .zIndex(ZINDEX_HISTORY)
+                .zIndex(LayerHelper.ZINDEX_HISTORY)
         ));
     }
 
@@ -119,7 +113,7 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
                 .addAll(segment)
                 .color(isTrack ? MapLineUtils.getTrackColor() : MapLineUtils.getRouteColor())
                 .width(isTrack ? MapLineUtils.getTrackLineWidth(true) : MapLineUtils.getRouteLineWidth(true))
-                .zIndex(isTrack ? ZINDEX_TRACK : ZINDEX_ROUTE)
+                .zIndex(LayerHelper.ZINDEX_TRACK_ROUTE)
         ));
     }
 

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/ClearableVectorLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/ClearableVectorLayer.java
@@ -1,0 +1,15 @@
+package cgeo.geocaching.unifiedmap.mapsforgevtm;
+
+import org.oscim.layers.vector.VectorLayer;
+import org.oscim.map.Map;
+
+class ClearableVectorLayer extends VectorLayer {
+
+    ClearableVectorLayer(final Map map) {
+        super(map);
+    }
+
+    public void clear() {
+        mDrawables.clear();
+    }
+}

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeGeoitemLayer.java
@@ -4,11 +4,10 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.CacheMarker;
-import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.IWaypoint;
 import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.unifiedmap.AbstractGeoitemLayer;
 import cgeo.geocaching.unifiedmap.LayerHelper;
-import cgeo.geocaching.utils.MapMarkerUtils;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_MAPSFORGE;
 
 import android.graphics.BitmapFactory;
@@ -37,18 +36,15 @@ class MapsforgeGeoitemLayer extends AbstractGeoitemLayer<MarkerItem> {
     }
 
     @Override
-    protected void add(final Geocache cache) {
-        final Geopoint coords = cache.getCoords();
-        final MarkerItem item = new MarkerItem(cache.getGeocode(), "", new GeoPoint(coords.getLatitudeE6(), coords.getLongitudeE6())); // @todo add marker touch handling
-
-        final CacheMarker cm = MapMarkerUtils.getCacheMarker(CgeoApplication.getInstance().getResources(), cache, null);
-        final MarkerSymbol symbol = new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
-        item.setMarker(symbol);
-        mGeocacheLayer.addItem(item);
-
-        synchronized (items) {
-            items.put(cache.getGeocode(), new GeoItemCache<>(new RouteItem(cache), item));
+    protected GeoItemCache<MarkerItem> addInternal(final IWaypoint item, final boolean isCache, final Geopoint coords, final RouteItem routeItem, final CacheMarker cm) {
+        final MarkerItem marker = new MarkerItem(routeItem.getIdentifier(), "", new GeoPoint(coords.getLatitudeE6(), coords.getLongitudeE6()));
+        marker.setMarker(new MarkerSymbol(new AndroidBitmap(cm.getBitmap()), MarkerSymbol.HotspotPlace.BOTTOM_CENTER));
+        if (isCache) {
+            mGeocacheLayer.addItem(marker);
+        } else {
+            mWaypointLayer.addItem(marker);
         }
+        return new GeoItemCache<>(routeItem, marker);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgePositionLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgePositionLayer.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
 
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.unifiedmap.AbstractPositionLayer;
+import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.MapLineUtils;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_MAPSFORGE;
@@ -9,8 +10,6 @@ import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_M
 import android.graphics.Matrix;
 import android.location.Location;
 import android.view.View;
-
-import java.util.List;
 
 import org.oscim.android.canvas.AndroidBitmap;
 import org.oscim.backend.canvas.Bitmap;
@@ -67,22 +66,22 @@ class MapsforgePositionLayer extends AbstractPositionLayer<GeoPoint> {
 
         // position and heading arrow
         accuracyCircleLayer = new VectorLayer(map);
-        map.layers().add(accuracyCircleLayer);
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_POSITION_ACCURACY_CIRCLE, accuracyCircleLayer);
         arrowLayer = new ItemizedLayer(map, new MarkerSymbol(new AndroidBitmap(positionAndHeadingArrow), MarkerSymbol.HotspotPlace.CENTER));
-        map.layers().add(arrowLayer);
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_POSITION, arrowLayer);
         repaintPosition();
 
         // history
         historyLayer = new ClearableVectorLayer(map);
-        map.layers().add(historyLayer);
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_HISTORY, historyLayer);
 
-        // navigation
+        // direction line & navigation
         navigationLayer = new PathLayer(map, MapLineUtils.getDirectionColor(), MapLineUtils.getDirectionLineWidth(true));
-        map.layers().add(navigationLayer);
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_DIRECTION_LINE, navigationLayer);
 
         // tracks & routes
         trackLayer = new ClearableVectorLayer(map);
-        map.layers().add(trackLayer);
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_TRACK_ROUTE, trackLayer);
     }
 
     protected void destroyLayer(final Map map) {
@@ -91,11 +90,6 @@ class MapsforgePositionLayer extends AbstractPositionLayer<GeoPoint> {
         map.layers().remove(historyLayer);
         map.layers().remove(navigationLayer);
         map.layers().remove(trackLayer);
-    }
-
-    private void clearLayers(final List<PathLayer> layers) {
-        map.layers().removeAll(layers);
-        layers.clear();
     }
 
     public void setCurrentPositionAndHeading(final Location location, final float heading) {

--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.unifiedmap.tileproviders;
 
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.unifiedmap.LayerHelper;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_MAPSFORGE;
 
 import android.net.Uri;
@@ -32,8 +33,8 @@ class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileProvider
         tileSource.setPreferredLanguage(Settings.getMapLanguage());
         tileSource.setMapFileInputStream((FileInputStream) ContentStorage.get().openForRead(mapUri));
         final VectorTileLayer tileLayer = (VectorTileLayer) MAP_MAPSFORGE.setBaseMap(tileSource);
-        MAP_MAPSFORGE.addLayer(new BuildingLayer(map, tileLayer));
-        MAP_MAPSFORGE.addLayer(new LabelLayer(map, tileLayer));
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_BUILDINGS, new BuildingLayer(map, tileLayer));
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_LABELS, new LabelLayer(map, tileLayer));
         MAP_MAPSFORGE.applyTheme();
 
         final MapInfo info = tileSource.getMapInfo();

--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -1,14 +1,13 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.unifiedmap.LayerHelper;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_MAPSFORGE;
 
 import android.net.Uri;
 
 import java.io.File;
 import java.util.Collections;
-
-import cgeo.geocaching.unifiedmap.LayerHelper;
 
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;

--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -8,6 +8,8 @@ import android.net.Uri;
 import java.io.File;
 import java.util.Collections;
 
+import cgeo.geocaching.unifiedmap.LayerHelper;
+
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 import org.oscim.layers.tile.bitmap.BitmapTileLayer;
@@ -37,7 +39,7 @@ class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTileProvider 
                 .build();
         tileSource.setHttpEngine(new OkHttpEngine.OkHttpFactory(httpBuilder));
         tileSource.setHttpRequestHeaders(Collections.singletonMap("User-Agent", "vtm-android-example"));
-        MAP_MAPSFORGE.addLayer(new BitmapTileLayer(map, tileSource));
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_BASEMAP, new BitmapTileLayer(map, tileSource));
     }
 
 }

--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeMultiOfflineTileProvider.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeMultiOfflineTileProvider.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.unifiedmap.LayerHelper;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_MAPSFORGE;
 
 import android.net.Uri;
@@ -64,8 +65,8 @@ class MapsforgeMultiOfflineTileProvider extends AbstractMapsforgeTileProvider {
         }
 
         final VectorTileLayer tileLayer = (VectorTileLayer) MAP_MAPSFORGE.setBaseMap(tileSource);
-        MAP_MAPSFORGE.addLayer(new BuildingLayer(map, tileLayer));
-        MAP_MAPSFORGE.addLayer(new LabelLayer(map, tileLayer));
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_BUILDINGS, new BuildingLayer(map, tileLayer));
+        MAP_MAPSFORGE.addLayer(LayerHelper.ZINDEX_LABELS, new LabelLayer(map, tileLayer));
         MAP_MAPSFORGE.applyTheme();
 
         if (boundingBox != null && !boundingBox.contains(map.getMapPosition().getGeoPoint())) {


### PR DESCRIPTION
## Description
- OSM: put all tracks + individual route on a single layer; same for history line, to have a constant number of layers
- GM/OSM: fix z-index order for elements / layers
- use identical z-indexes for GM and OSM
- GM/OSM: allow waypoints as cache markers
