### PR TITLE
remove local checkstyle error report in BackupUtils

### DIFF
--- a/main/src/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/cgeo/geocaching/utils/BackupUtils.java
@@ -242,7 +242,9 @@ public class BackupUtils {
 
     @SuppressWarnings("PMD.NPathComplexity") // split up would not help readability
     public void restoreInternal(final Activity activityContext, final Folder backupDir, final boolean database, final boolean settings) {
-        final Consumer<String> consumer = resultString -> {
+        final Consumer<String> consumer = rs -> {
+
+            String resultString = rs;
 
             boolean settingsChanged = false;
             final ArrayList<ImmutableTriple<PersistableFolder, String, String>> currentFolderValues = new ArrayList<>();


### PR DESCRIPTION
remove local checkstyle error report in BackupUtils

This removes a checkstyle error which I always get when running it locally. For whatever reason it does not seem to occur on server side:

![image](https://user-images.githubusercontent.com/6909759/199297620-1ca96bbe-926a-417a-aeee-b922bf793b25.png)
