### PR TITLE
language-independent 'tb spotted' parsing (rel. to #13552)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCConstants.java
@@ -122,13 +122,13 @@ public final class GCConstants {
     /**
      * Two groups !
      */
-    static final Pattern PATTERN_TRACKABLE_SPOTTEDCACHE = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\" title=\"[^\"]*\" href=\"[^\"]*/seek/cache_details.aspx\\?guid=([a-z0-9\\-]+)\">In ([^<]+)</a>"); //TODO: language dependent
+    static final Pattern PATTERN_TRACKABLE_SPOTTEDCACHE = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\" title=\"[^\"]*\" data-name=\"([^\"]+)\" data-status=\"Cache\" href=\"[^\"]*/seek/cache_details.aspx\\?guid=([a-z0-9\\-]+)\">[^<]+</a>");
     /**
      * Three groups !
      */
-    static final Pattern PATTERN_TRACKABLE_SPOTTEDUSER = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\" href=\"[^\"]*/p(rofile)?/\\?guid=([a-z0-9\\-]+)\">In the hands of ([^<]+).</a>"); //TODO: language dependent
-    static final Pattern PATTERN_TRACKABLE_SPOTTEDUNKNOWN = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\">Unknown Location[^<]*</a>"); //TODO: language dependent
-    static final Pattern PATTERN_TRACKABLE_SPOTTEDOWNER = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\">In the hands of the owner[^<]*</a>"); //TODO: language dependent
+    static final Pattern PATTERN_TRACKABLE_SPOTTEDUSER = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\" data-name=\"([^\"]+)\" data-status=\"User\" href=\"[^\"]*/p(rofile)?/\\?guid=([a-z0-9\\-]+)\">");
+    static final Pattern PATTERN_TRACKABLE_SPOTTEDUNKNOWN = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\" data-status=\"Unknown\">[^<]*</a>");
+    static final Pattern PATTERN_TRACKABLE_SPOTTEDOWNER = Pattern.compile("<a id=\"ctl00_ContentBody_BugDetails_BugLocation\" data-status=\"Owner\">[^<]*</a>");
     static final Pattern PATTERN_TRACKABLE_GOAL = Pattern.compile("<div id=\"TrackableGoal\">[^<]*<p>(.*?)</p>[^<]*</div>", Pattern.DOTALL);
     /**
      * Four groups

--- a/main/src/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCParser.java
@@ -1489,15 +1489,15 @@ public final class GCParser {
         try {
             final MatcherWrapper matcherSpottedCache = new MatcherWrapper(GCConstants.PATTERN_TRACKABLE_SPOTTEDCACHE, page);
             if (matcherSpottedCache.find()) {
-                trackable.setSpottedGuid(matcherSpottedCache.group(1));
-                trackable.setSpottedName(matcherSpottedCache.group(2).trim());
+                trackable.setSpottedGuid(matcherSpottedCache.group(2));
+                trackable.setSpottedName(matcherSpottedCache.group(1).trim());
                 trackable.setSpottedType(Trackable.SPOTTED_CACHE);
             }
 
             final MatcherWrapper matcherSpottedUser = new MatcherWrapper(GCConstants.PATTERN_TRACKABLE_SPOTTEDUSER, page);
             if (matcherSpottedUser.find()) {
-                trackable.setSpottedGuid(matcherSpottedUser.group(2));
-                trackable.setSpottedName(matcherSpottedUser.group(3).trim());
+                trackable.setSpottedGuid(matcherSpottedUser.group(3));
+                trackable.setSpottedName(matcherSpottedUser.group(1).trim());
                 trackable.setSpottedType(Trackable.SPOTTED_USER);
             }
 

--- a/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
+++ b/tests/src-android/cgeo/geocaching/CgeoApplicationTest.java
@@ -85,9 +85,7 @@ public class CgeoApplicationTest extends CGeoTestCase {
         // Following data can change over time
         assertThat(tb.getDistance()).isGreaterThanOrEqualTo(10617.8f);
         assertThat(tb.getLogs().size()).isGreaterThanOrEqualTo(10);
-/* temporarily disabled due to language switch migration
         assertThat(tb.getSpottedType() == Trackable.SPOTTED_CACHE || tb.getSpottedType() == Trackable.SPOTTED_USER || tb.getSpottedType() == Trackable.SPOTTED_UNKNOWN).isTrue();
-*/
         // no assumption possible: assertThat(tb.getSpottedGuid()).isEqualTo("faa2d47d-19ea-422f-bec8-318fc82c8063");
         // no assumption possible: assertThat(tb.getSpottedName()).isEqualTo("Nice place for a break cache");
 
@@ -121,11 +119,9 @@ public class CgeoApplicationTest extends CGeoTestCase {
         assertThat(tb.getOwnerGuid()).isEqualTo("5888ea6c-413b-4b60-959d-d3d729ad642b");
 
         // Following data can potentially change over time. However, is's very unlikely as the trackable is lost since years
-/* temporarily disabled due to language switch migration
         assertThat(tb.getSpottedType()).isEqualTo(Trackable.SPOTTED_USER);
         assertThat(tb.getSpottedGuid()).isEqualTo("83858f68-ba77-4342-ad89-83aebcf37f86");
         assertThat(tb.getSpottedName()).isEqualTo("cachertimsi");
-*/
 
         final LogEntry lastLog = tb.getLogs().get(0);
         assertThat(lastLog.author).isEqualTo("cachertimsi");


### PR DESCRIPTION
## Description
- adapt tb location parsing to recent website changes (as agreed upon with HQ)
- re-enable tb location tests

## Test cases:
- tb 12345 (a tb currently in the hands of the owner)
- tb 12347 (a tb in the hands of a user other than owner)
- tb 12351 (a tb marked missing)
- tb TB6P14F (a tb currently in a cache)
- and one of my own tb which is currently in my own hand (so similar to first case, but owner being the user currently logged in)
