### PR TITLE
UnifiedMap: Restore combined OSM feature (fix #13594)

### DIFF
--- a/main/src/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeMultiOfflineTileProvider.java
+++ b/main/src/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeMultiOfflineTileProvider.java
@@ -24,7 +24,7 @@ import org.oscim.tiling.source.mapfile.MapFileTileSource;
 import org.oscim.tiling.source.mapfile.MapInfo;
 import org.oscim.tiling.source.mapfile.MultiMapFileTileSource;
 
-class MapsforgeMultiOfflineTileProvider extends AbstractMapsforgeTileProvider {
+class MapsforgeMultiOfflineTileProvider extends AbstractMapsforgeOfflineTileProvider {
 
     private final List<ImmutablePair<String, Uri>> maps;
 


### PR DESCRIPTION
## Description
Restores "Combined OSM map" capability

## Additional context
Displaying Hessen and NRW as separate maps, using "combined" feature:
![image](https://user-images.githubusercontent.com/3754370/199593493-aa20e57f-494b-416d-96ba-c718adbfc2cf.png)
