### PR TITLE
Update checkstyle version

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CheckStyle-IDEA" serialisationVersion="2">
-    <checkstyleVersion>10.3.2</checkstyleVersion>
+    <checkstyleVersion>10.3.4</checkstyleVersion>
     <scanScope>JavaOnlyWithTests</scanScope>
     <scanBeforeCheckin>true</scanBeforeCheckin>
     <option name="thirdPartyClasspath" />

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -662,7 +662,7 @@ checkstyle {
     // assign the checkstyle version explicitly here
     // and in AndroidStudio Settings (.idea/checkstyle-idea.xml)
     // and align it with codacy (https://github.com/codacy/codacy-checkstyle)
-    toolVersion = '8.44'
+    toolVersion = '10.3.4'
 
     configDirectory = rootProject.projectDir
     configFile = rootProject.file("checkstyle.xml")


### PR DESCRIPTION
fixes #13597

The checkstyle version number for gradle was not changed according to the AS version. With checkstyle 9.2.1 https://checkstyle.sourceforge.io/releasenotes.html#Release_9.2.1 there was a bugfix for "ParameterAssignment does not detect problem for Lambda parameters".

Also update to the current 10.3.x version aligned to codacy.
