### PR TITLE
 UnifiedMap (GM): Clear layer in onPause (fix #13591) 

### DIFF
--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
@@ -32,6 +32,13 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
         historyObjs = new GoogleMapObjects(googleMap);
     }
 
+    protected void destroyLayer(final GoogleMap map) {
+        directionObjs.removeAll();
+        positionObjs.removeAll();
+        trackObjs.removeAll();
+        historyObjs.removeAll();
+    }
+
     public void setCurrentPositionAndHeading(final Location location, final float heading) {
         setCurrentPositionAndHeadingHelper(location, heading, (directionLine) -> {
             directionObjs.removeAll();

--- a/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
+++ b/main/src/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
@@ -229,6 +229,7 @@ public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements On
             }
             return positionLayer;
         } else {
+            ((GoogleMapsPositionLayer) positionLayer).destroyLayer(mMap);
             positionLayer = null;
         }
         return null;


### PR DESCRIPTION
## Description
Remove objects from positionLayer for GM in `onPause` (similar to what's done already for VTM)
