### PR TITLE
fix several errors mentioned by prelaunch flight

### DIFF
--- a/main/res/layout/about_version_page.xml
+++ b/main/res/layout/about_version_page.xml
@@ -101,6 +101,7 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dip"
+            android:layout_marginHorizontal="40dp"
             android:baselineAligned="false"
             android:gravity="center_horizontal"
             android:orientation="horizontal" >
@@ -108,7 +109,6 @@
             <Button
                 android:id="@+id/donate"
                 style="@style/button_full"
-                android:layout_width="280dip"
                 android:lines="2"
                 android:text="@string/about_donation_more" />
         </LinearLayout>

--- a/main/res/layout/cache_filter_generic_string.xml
+++ b/main/res/layout/cache_filter_generic_string.xml
@@ -47,7 +47,8 @@
                 android:layout_height="18dp"
                 app:srcCompat="@drawable/settings_info"
                 android:layout_alignParentRight="true"
-                android:layout_centerVertical="true"/>
+                android:layout_centerVertical="true"
+                android:contentDescription="@string/tap_icon_more_info"/>
 
         </RelativeLayout>
     </LinearLayout>
@@ -57,11 +58,12 @@
         style="@style/textinput_autocompletetextview"
         android:layout_below="@+id/filter_options"
         android:layout_alignParentLeft="true"
-        android:layout_alignParentRight="true">
+        android:layout_alignParentRight="true"
+        android:hint="@string/cache_filter_stringfilter_searchtext_hint" android:labelFor="@id/generic_autocomplete_single">
 
         <AutoCompleteTextView
-            style="@style/textinput_embedded_singleline"
-            android:hint="@string/cache_filter_stringfilter_searchtext_hint" />
+            android:id="@+id/generic_autocomplete_single"
+            style="@style/textinput_embedded_singleline" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </RelativeLayout>

--- a/main/res/layout/cache_filter_generic_string.xml
+++ b/main/res/layout/cache_filter_generic_string.xml
@@ -39,7 +39,8 @@
                 android:text="@string/cache_filter_stringfilter_matchcase"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_centerVertical="true"/>
+                android:layout_centerVertical="true"
+                android:layout_toLeftOf="@id/item_info"/>
 
             <ImageView
                 android:id="@+id/item_info"

--- a/main/res/layout/checkbox_item.xml
+++ b/main/res/layout/checkbox_item.xml
@@ -34,7 +34,9 @@
             android:layout_marginLeft="6dp"
             android:layout_centerVertical="true"
 	        android:textSize="@dimen/textSize_detailsPrimary"
-            android:textColor="@color/colorText"/>
+            android:textColor="@color/colorText"
+            android:contentDescription="@string/tap_icon_more_info"
+            android:labelFor="@id/item_info"/>
         <ImageView
             android:id="@+id/item_info"
             android:layout_width="18dp"

--- a/main/res/layout/continuousrangeslider_view.xml
+++ b/main/res/layout/continuousrangeslider_view.xml
@@ -25,6 +25,7 @@
             android:valueTo="10.0"
             app:labelBehavior="floating"
             android:layout_weight="8"
+            android:hint="@string/use_slider_adjust_value"
             />
 
         <Space

--- a/main/res/layout/editwaypoint_activity.xml
+++ b/main/res/layout/editwaypoint_activity.xml
@@ -27,11 +27,13 @@
             android:orientation="vertical"
             android:importantForAutofill="noExcludeDescendants">
 
-            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/textinput_edittext_singleline"
+                android:hint="@string/waypoint_bearing"
+                android:labelFor="@id/bearing">
                 <EditText
                     android:id="@+id/bearing"
                     style="@style/textinput_embedded_singleline"
-                    android:hint="@string/waypoint_bearing"
                     android:inputType="numberDecimal|numberSigned"
                     android:enabled="false"/>
             </com.google.android.material.textfield.TextInputLayout>
@@ -42,11 +44,12 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                     style="@style/textinput_edittext_singleline"
-                    android:layout_toLeftOf="@id/distanceUnit">
+                    android:layout_toLeftOf="@id/distanceUnit"
+                    android:hint="@string/waypoint_distance"
+                    android:labelFor="@id/distance">
                     <EditText
                         android:id="@+id/distance"
                         style="@style/textinput_embedded_singleline"
-                        android:hint="@string/waypoint_distance"
                         android:inputType="numberDecimal"
                         android:enabled="false"/>
                 </com.google.android.material.textfield.TextInputLayout>
@@ -74,34 +77,30 @@
             tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/waypoint_name" android:id="@+id/name_layout">
+            android:hint="@string/waypoint_name" android:labelFor="@id/name" android:id="@+id/name_layout">
             <AutoCompleteTextView
                 android:id="@+id/name"
-                style="@style/textinput_embedded_singleline"
-                tools:ignore="LabelFor" />
+                style="@style/textinput_embedded_singleline" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/note_layout"
             style="@style/textinput_edittext"
-            android:hint="@string/waypoint_note">
+            android:hint="@string/waypoint_note" android:labelFor="@id/note">
             <EditText
                 android:id="@+id/note"
                 style="@style/textinput_embedded"
-
                 android:inputType="textMultiLine|textCapSentences"
-                android:minLines="5"
-                tools:ignore="LabelFor" />
+                android:minLines="5" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext"
-            android:hint="@string/waypoint_user_note">
+            android:hint="@string/waypoint_user_note" android:labelFor="@id/user_note">
             <EditText
                 android:id="@+id/user_note"
                 style="@style/textinput_embedded"
                 android:inputType="textMultiLine|textCapSentences"
-                android:minLines="5"
-                tools:ignore="LabelFor" />
+                android:minLines="5" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <CheckBox

--- a/main/res/layout/itemrangeslider_view.xml
+++ b/main/res/layout/itemrangeslider_view.xml
@@ -27,6 +27,7 @@
             android:stepSize="1"
             app:labelBehavior="floating"
             android:layout_weight="8"
+            android:hint="@string/use_slider_adjust_value"
             />
 
         <Space

--- a/main/res/layout/map_settings_button.xml
+++ b/main/res/layout/map_settings_button.xml
@@ -15,7 +15,8 @@
         <ImageButton
             android:id="@+id/map_settings_popup"
             android:src="@drawable/map_quick_settings"
-            style="@style/map_quicksettingsbutton" />
+            style="@style/map_quicksettingsbutton"
+            android:hint="@string/quick_settings"/>
     </LinearLayout>
     <LinearLayout
         android:id="@+id/container_individualroute"
@@ -27,6 +28,7 @@
         <ImageButton
             android:id="@+id/map_individualroute_popup"
             style="@style/map_quicksettingsbutton"
-            android:src="@drawable/map_quick_route" />
+            android:src="@drawable/map_quick_route"
+            android:hint="@string/routes_tracks_dialog_title"/>
     </LinearLayout>
 </RelativeLayout>

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -41,7 +41,8 @@
                 android:layout_marginLeft="0dp"
                 android:layout_marginRight="10dp"
                 android:layout_alignParentRight="true"
-                android:layout_centerVertical="true" />
+                android:layout_centerVertical="true"
+                android:hint="@string/tap_icon_more_info"/>
         </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >

--- a/main/res/layout/search_activity.xml
+++ b/main/res/layout/search_activity.xml
@@ -54,11 +54,11 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/geocode_input_layout"
-            style="@style/textinput_autocompletetextview">
+            style="@style/textinput_autocompletetextview"
+            android:hint="@string/search_geo" android:labelFor="@id/geocode">
             <AutoCompleteTextView
                 android:id="@+id/geocode"
                 style="@style/textinput_embedded_singleline_go"
-                android:hint="@string/search_geo"
                 android:inputType="textVisiblePassword"
                 android:text="GC"
                 tools:ignore="HardcodedText" />
@@ -95,11 +95,11 @@
                 android:text="@string/search_address" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+            android:hint="@string/search_address" android:labelFor="@id/address">
             <AutoCompleteTextView
                 android:id="@+id/address"
-                style="@style/textinput_embedded_singleline_go"
-                android:hint="@string/search_address" />
+                style="@style/textinput_embedded_singleline_go" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -115,11 +115,11 @@
                 android:text="@string/search_kw" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+            android:hint="@string/search_kw_prefill" android:labelFor="@id/keyword">
             <AutoCompleteTextView
                 android:id="@+id/keyword"
-                style="@style/textinput_embedded_singleline_go"
-                android:hint="@string/search_kw_prefill" />
+                style="@style/textinput_embedded_singleline_go" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -135,11 +135,11 @@
                 android:text="@string/search_hbu" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+            android:hint="@string/search_hbu_prefill" android:labelFor="@id/owner">
             <AutoCompleteTextView
                 android:id="@+id/owner"
-                style="@style/textinput_embedded_singleline_go"
-                android:hint="@string/search_hbu_prefill" />
+                style="@style/textinput_embedded_singleline_go" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -155,11 +155,11 @@
                 android:text="@string/search_finder" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+            android:hint="@string/search_finder_prefill" android:labelFor="@id/finder">
             <AutoCompleteTextView
                 android:id="@+id/finder"
-                style="@style/textinput_embedded_singleline_go"
-                android:hint="@string/search_finder_prefill" />
+                style="@style/textinput_embedded_singleline_go" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <Button
@@ -176,11 +176,11 @@
                 android:text="@string/search_tb" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview">
+        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+            android:hint="@string/search_tb_hint" android:labelFor="@id/trackable">
             <AutoCompleteTextView
                 android:id="@+id/trackable"
                 style="@style/textinput_embedded_singleline_go"
-                android:hint="@string/search_tb_hint"
                 android:inputType="textVisiblePassword" />
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/main/res/layout/waypoint_item.xml
+++ b/main/res/layout/waypoint_item.xml
@@ -125,6 +125,7 @@
                 android:textColor="@color/colorText_listsPrimary"
                 android:visibility="gone"
                 tools:visiblity="visible"
+                android:hint="@string/waypoint_note"
                 tools:text="Note"/>
 
             <TextView
@@ -137,6 +138,7 @@
                 android:textColor="@color/colorText_listsPrimary"
                 android:visibility="gone"
                 tools:visiblity="visible"
+                android:hint="@string/waypoint_user_note"
                 tools:text="User Note"/>
         </LinearLayout>
 
@@ -150,7 +152,8 @@
             android:focusable="true"
             android:longClickable="true"
             android:scaleType="centerInside"
-            android:src="@drawable/ic_menu_compass" />
+            android:src="@drawable/ic_menu_compass"
+            android:hint="@string/init_default_navigation_tool"/>
     </LinearLayout>
 
     <View

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -317,6 +317,7 @@
     <string name="more_information">More information</string>
     <string name="undo">Undo</string>
     <string name="dont_show_again">Don\'t show again</string>
+    <string name="tap_icon_more_info">Tap on icon for more info</string>
 
     <string name="warn_gm_not_available">Google Maps not available.</string>
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -318,6 +318,7 @@
     <string name="undo">Undo</string>
     <string name="dont_show_again">Don\'t show again</string>
     <string name="tap_icon_more_info">Tap on icon for more info</string>
+    <string name="use_slider_adjust_value">Use slider to adjust value</string>
 
     <string name="warn_gm_not_available">Google Maps not available.</string>
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>


### PR DESCRIPTION
## Description
Before releasing a new version, Play Store does a prelaunch flight on several (virtual) devices, analyzing the resulting user experience. For c:geo there are quite a few results regarding accessibility (eg: missing labels) and other categories (eg: overlapping items, depending on translation). This PR intends to fix a couple of them.
