### PR TITLE
Disable GCVote for all users (+ per default) (rel. to #13599)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -121,7 +121,7 @@
 
     <!-- settings for gcvote.com screen -->
     <string translatable="false" name="preference_screen_gcvote">preference_screen_gcvote</string>
-    <string translatable="false" name="pref_ratingwanted">ratingwanted</string>
+    <string translatable="false" name="pref_ratingwanted">useGCVote</string>
     <string translatable="false" name="pref_fakekey_gcvote_authorization">fakekey_gcvote_authorization</string>
     <string translatable="false" name="pref_fakekey_gcvote_website">fakekey_gcvote_website</string>
 

--- a/main/res/xml/preferences_services_gcvote_com.xml
+++ b/main/res/xml/preferences_services_gcvote_com.xml
@@ -9,7 +9,7 @@
         android:title="@string/settings_settings"
         app:iconSpaceReserved="false" >
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="@string/pref_ratingwanted"
             android:summary="@string/init_summary_ratingwanted"
             android:title="@string/init_ratingwanted"

--- a/main/src/cgeo/geocaching/settings/Settings.java
+++ b/main/src/cgeo/geocaching/settings/Settings.java
@@ -901,7 +901,7 @@ public class Settings {
     }
 
     public static boolean isRatingWanted() {
-        return getBoolean(R.string.pref_ratingwanted, true);
+        return getBoolean(R.string.pref_ratingwanted, false);
     }
 
     public static boolean isGeokretyConnectorActive() {


### PR DESCRIPTION
## Description
- disable GCVote for all new users by default
- disable GCVote for all existing users (by renaming the preference key), users can manually re-enable it
