### PR TITLE
Fix calculated vars line spacing (fix #13616)

### DIFF
--- a/main/res/layout/variable_list_item_minimalistic.xml
+++ b/main/res/layout/variable_list_item_minimalistic.xml
@@ -17,9 +17,9 @@
         android:layout_height="wrap_content"
         android:layout_width="@dimen/equation_name_width"
         android:gravity="right"
-        android:hint="@string/variables_varname_dialog_title"
+        android:hint=""
         android:textSize="22dp"
-        />
+        /><!-- hint intentionally left empty to keep layout intact, see #13616 -->
 
     <TextView
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Description
Remove the hint for variable name in calculated waypoint view, which (due to its length) lead to additional line spacing.