### PR TITLE
use compileSdkVersion 32

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     // signing is handled via private.properties
     signingConfigs {

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,7 +19,7 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     compileOptions {
         // use the diamond operator and some other goodies in Android

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
 
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
In this way we can update some google library which need this.

This will be done later on the dedicated PR
- androidx.annotation
- androidx.appcompat
- play-services-location
- play-services-maps

Unclear: com.google.android.material.
I got some strange errors. This needs a separate check.

Not able to update: androidx.core.
This needs compileSdkVersion 33.
