### PR TITLE
fix #13586: ImageGallery: fix flickering and self-scrolling

### DIFF
--- a/main/res/layout/image_gallery_category.xml
+++ b/main/res/layout/image_gallery_category.xml
@@ -51,13 +51,4 @@
 
     </RelativeLayout>
 
-    <androidx.gridlayout.widget.GridLayout
-        android:id="@+id/image_gallery_list"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-
-    <android.widget.Space
-        android:layout_width="match_parent"
-        android:layout_height="10dp"/>
-
 </LinearLayout>

--- a/main/res/layout/image_gallery_image.xml
+++ b/main/res/layout/image_gallery_image.xml
@@ -7,12 +7,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
-    <!--
-       General note wrt this layout: width/height sizes (150dp/160dp) will be changed in code
-       according to concrete screen size and layout
-    -->
-
-
     <!-- following LinearLayout is needed so image is centered inside column of gridlayout -->
     <LinearLayout
         android:id="@+id/image_complete"

--- a/main/res/layout/imagegallery_view.xml
+++ b/main/res/layout/imagegallery_view.xml
@@ -22,7 +22,7 @@
         android:nestedScrollingEnabled="true"
         android:orientation="vertical"
         android:padding="4dip"
-        android:scrollbars="none"
+        android:scrollbars="vertical"
         tools:listitem="@layout/image_gallery_image">
 
     </androidx.recyclerview.widget.RecyclerView>

--- a/main/src/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/cgeo/geocaching/CacheDetailActivity.java
@@ -230,7 +230,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     protected ImagesList imagesList;
 
     private ImageGalleryView imageGallery;
-    private int imageGalleryPos = 0;
+    private int imageGalleryPos = -1;
 
     private final CompositeDisposable createDisposables = new CompositeDisposable();
     /**
@@ -2348,10 +2348,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 return;
             }
             binding.getRoot().setVisibility(View.VISIBLE);
-
-            binding.experimental.setOnClickListener(v -> {
-                binding.imageGallery.scrollTo(binding.imageGallery.getImageCount() - 1);
-            });
 
             if (activity.imageGallery == null) {
                 final ImageGalleryView imageGallery = binding.getRoot().findViewById(R.id.image_gallery);


### PR DESCRIPTION
fix #13586: ImageGallery: fix flickering and self-scrolling

The key fix is the replacement of `scrollToPosition` with `scrollToPositionWithOffset`. I am not exactly sure why the `WithOffset `doesn't have the strange side effects of the simple `scrollToPosition`, but I am glad it works...

The other changes are fine-tuning and cleaning up some mess I found on the way