### PR TITLE
AGP 7.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'

--- a/build.gradle
+++ b/build.gradle
@@ -90,9 +90,12 @@ allprojects {
             resolutionStrategy {
                 componentSelection {
                     all { ComponentSelection selection ->
-                        if (['alpha', 'beta', 'rc', 'cr', 'm', 'pr'].any { qualifier -> selection.candidate.version.contains(qualifier)}) {
-                            selection.reject('Release candidate')
-                        }
+                        // deactivate this rule for now, as alpha software is needed as dependency for tests
+                        // from com.android.tools.utp:android-test-plugin-host-additional-test-output:30.3.1,
+                        // see https://github.com/cgeo/cgeo/pull/13634
+                        //if (['alpha', 'beta', 'rc', 'cr', 'm', 'pr'].any { qualifier -> selection.candidate.version.contains(qualifier)}) {
+                        //    selection.reject('Release candidate')
+                        //}
 
                         // see https://assertj.github.io/doc/#assertj-core-android
                         // AssertJ Core 3.x is compatible with Android API Level 26+, except for soft assertions and assumptions.

--- a/build.gradle
+++ b/build.gradle
@@ -113,10 +113,6 @@ allprojects {
                 }
                 // new versions of checkstyle use guava 27, which has troublesome dependencies: https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
                 force 'com.google.guava:guava:26.0-jre'
-
-                // force this version because of conflict to our resolutionStrategy from lint-gradle
-                // TODO check necessity after every gradle update (gradlew :main:lintBasicDebug)
-                force 'com.android.tools.build:aapt2-proto:4.2.2-7147631'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.3.1'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'

--- a/cgeo-contacts/AndroidManifest.xml
+++ b/cgeo-contacts/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cgeo.contacts"
     android:versionCode="202010113"
     android:versionName="2020.10.13" >
 

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.application'
 android {
     namespace 'cgeo.contacts'
 
-    compileSdkVersion 32
+    compileSdk 32
 
     // signing is handled via private.properties
     signingConfigs {
@@ -20,13 +20,13 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
         //noinspection OldTargetApi
-        targetSdkVersion 31
+        targetSdk 31
 
         // include only those language resources from libraries which we actively maintain ourselves in the translation project
         // not yet enough translations (~50%): "is","iw" (="he"),"zh"
-        resConfigs "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr","zh-rTW"
+        resourceConfigurations += [ 'en', 'ar', 'ca', 'ceb', 'cs', 'da', 'de', 'el', 'es', 'fi', 'fil', 'fr', 'hu', 'in', 'it', 'ja', 'ko', 'lt', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'tl', 'tr', 'zh-rTW' ]
     }
 
     sourceSets {

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -5,6 +5,8 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'cgeo.contacts'
+
     compileSdkVersion 32
 
     // signing is handled via private.properties

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -36,7 +36,7 @@ android {
         }
     }
 
-    lintOptions {
+    lint {
         // generally we accept lint errors when building
         abortOnError false
 

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="cgeo.geocaching"
     android:installLocation="auto">
 
     <uses-sdk tools:overrideLibrary="locus.api.android"/>

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -194,6 +194,9 @@ android {
         // we will take what is given by crowdin - For locale "fr": "many" is missing currently
         disable 'MissingQuantity'
 
+        // necessary as we changing locales at runtime (CgeoApplication.initApplicationLocale())
+        disable 'AppBundleLocaleChanges'
+
         // analyze all dependency modules in parallel and produce a single report
         // including issues from the app and all of its dependencies
         checkDependencies true

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -19,6 +19,8 @@ if (isContinuousIntegrationServer()) {
 }
 
 android {
+    namespace 'cgeo.geocaching'
+
     compileSdkVersion 32
 
     compileOptions {

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -21,7 +21,7 @@ if (isContinuousIntegrationServer()) {
 android {
     namespace 'cgeo.geocaching'
 
-    compileSdkVersion 32
+    compileSdk 32
 
     compileOptions {
         // use the diamond operator and some other goodies in Android
@@ -30,9 +30,9 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
         //noinspection OldTargetApi
-        targetSdkVersion 31
+        targetSdk 31
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 
@@ -53,12 +53,12 @@ android {
 
         // include only those language resources from libraries which we actively maintain ourselves in the translation project at https://crowdin.com/project/cgeo
         // not yet enough translations (~50%): "is","iw"(="he"),"lb"
-        def locales = [ "en","ar","ca","ceb","cs","da","de","el","es","fi","fil","fr","hu","in","it","ja","ko","lt","lv","nb","nl","pl","pt","ro","ru","sk","sl","sv","tl","tr","uk","zh","zh-rTW" ]
+        def locales = [ 'en', 'ar', 'ca', 'ceb', 'cs', 'da', 'de', 'el', 'es', 'fi', 'fil', 'fr', 'hu', 'in', 'it', 'ja', 'ko', 'lt', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'tl', 'tr', 'uk', 'zh', 'zh-rTW' ]
 
         // needed for in-app language selector
         buildConfigField "String[]", "TRANSLATION_ARRAY", "new String[]{\""+locales.join("\",\"")+"\"}"
 
-        resConfigs locales
+        resourceConfigurations += locales
     }
 
     // signing is handled via private.properties
@@ -200,39 +200,43 @@ android {
     }
 
     packagingOptions {
-        // you can double click an APK file in Android Studio 2.2+ to see what's in there
-        // license files of libs are not needed in our APK
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/dependencies'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/notice'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/license'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/license.txt'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/notice.txt'
-        exclude 'COPYING'
-        exclude 'COPYING.LESSER'
-        exclude '.readme'
-        // AndroidAnnotations
-        exclude 'androidannotations-api.properties'
-        // mapsforge
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.properties'
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.xml'
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map/pom.properties'
-        exclude 'META-INF/maven/org.mapsforge/mapsforge-map/pom.xml'
-        exclude 'COPYING.LESSER.v3'
-        exclude 'COPYING.v3'
-        // Play Services
-        exclude 'build-data.properties'
-        // rxjava
-        exclude 'META-INF/rxandroid.properties'
-        exclude 'META-INF/rxjava.properties'
+        resources {
+            excludes += [
+                    // you can double click an APK file in Android Studio 2.2+ to see what's in there
+                    // license files of libs are not needed in our APK
+                    'META-INF/DEPENDENCIES',
+                    'META-INF/dependencies',
+                    'META-INF/NOTICE',
+                    'META-INF/notice',
+                    'META-INF/LICENSE',
+                    'META-INF/license',
+                    'META-INF/LICENSE.txt',
+                    'META-INF/license.txt',
+                    'META-INF/NOTICE.txt',
+                    'META-INF/notice.txt',
+                    'COPYING',
+                    'COPYING.LESSER',
+                    '.readme',
+                    // AndroidAnnotations
+                    'androidannotations-api.properties',
+                    // mapsforge
+                    'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.properties',
+                    'META-INF/maven/org.mapsforge/mapsforge-map-reader/pom.xml',
+                    'META-INF/maven/org.mapsforge/mapsforge-map/pom.properties',
+                    'META-INF/maven/org.mapsforge/mapsforge-map/pom.xml',
+                    'COPYING.LESSER.v3',
+                    'COPYING.v3',
+                    // Play Services
+                    'build-data.properties',
+                    // rxjava
+                    'META-INF/rxandroid.properties',
+                    'META-INF/rxjava.properties'
+            ]
 
-        // vtm-themes
-        resources.pickFirsts.add("assets/symbols/**")
-        resources.pickFirsts.add("assets/patterns/**")
+            // vtm-themes
+            pickFirsts.add("assets/symbols/**")
+            pickFirsts.add("assets/patterns/**")
+        }
     }
 
     flavorDimensions "javaCompilerTime" // all flavours must be assigned a dimension

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -176,7 +176,7 @@ android {
         resultsDir = "$project.buildDir/build/test-results"
     }
 
-    lintOptions {
+    lint {
         // we do not accept lint errors when building
         abortOnError true
         // Warnings shall not fail build
@@ -189,6 +189,8 @@ android {
 
         // ExtraTranslation - old translation will be deleted by the next crowdin import
         disable 'ExtraTranslation'
+        // we will take what is given by crowdin - For locale "fr": "many" is missing currently
+        disable 'MissingQuantity'
 
         // analyze all dependency modules in parallel and produce a single report
         // including issues from the app and all of its dependencies

--- a/main/lint.xml
+++ b/main/lint.xml
@@ -26,6 +26,8 @@
     <issue id="MissingTranslation" severity="ignore" />
     <!-- old translation will be deleted by the next crowdin import -->
     <issue id="ExtraTranslation" severity="ignore" />
+    <!-- we will take what is given by crowdin - For locale "fr": "many" is missing currently -->
+    <issue id="MissingQuantity" severity="ignore" />
     <!-- treat non use of ellipsis character as error to avoid them on incoming translations -->
     <issue id="TypographyEllipsis" severity="error" />
 

--- a/mapswithme-api/AndroidManifest.xml
+++ b/mapswithme-api/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mapwithme.maps.api"
     android:versionCode="1"
     android:versionName="1.0" >
 

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.mapwithme.maps.api'
 
     compileSdkVersion 32
 

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -21,7 +21,7 @@ android {
         res.srcDirs = ['res']
     }
 
-    lintOptions {
+    lint {
         // generally we accept lint errors when building
         abortOnError false
 

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     namespace 'com.mapwithme.maps.api'
 
-    compileSdkVersion 32
+    compileSdk 32
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -11,9 +11,9 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
         //noinspection OldTargetApi
-        targetSdkVersion 31
+        targetSdk 31
     }
 
     sourceSets.main {

--- a/mapswithme-api/lint.xml
+++ b/mapswithme-api/lint.xml
@@ -27,8 +27,8 @@
     <issue id="DrawAllocation" severity="ignore" />
     <issue id="DuplicateActivity" severity="ignore" />
     <issue id="DuplicateDefinition" severity="ignore" />
-    <issue id="DuplicateIds" severity="ignore" />
-    <issue id="DuplicateIncludedIds" severity="ignore" />
+    <issue id="DuplicateIds" severity="error" />
+    <issue id="DuplicateIncludedIds" severity="error" />
     <issue id="DuplicateUsesFeature" severity="ignore" />
     <issue id="EnforceUTF8" severity="ignore" />
     <issue id="ExportedContentProvider" severity="ignore" />
@@ -153,7 +153,7 @@
     <issue id="TooManyViews" severity="ignore" />
     <issue id="TrulyRandom" severity="ignore" />
     <issue id="TypographyDashes" severity="ignore" />
-    <issue id="TypographyEllipsis" severity="ignore" />
+    <issue id="TypographyEllipsis" severity="error" />
     <issue id="TypographyFractions" severity="ignore" />
     <issue id="TypographyOther" severity="ignore" />
     <issue id="Typos" severity="ignore" />

--- a/tests/AndroidManifest.xml
+++ b/tests/AndroidManifest.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cgeo.geocaching.test"
     android:versionCode="1"
     android:versionName="1.0" >
-
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="31" />
 
     <uses-feature
         android:name="android.hardware.screen.portrait"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,0 +1,11 @@
+android {
+    namespace 'cgeo.geocaching.test'
+
+    compileSdkVersion 33
+
+    defaultConfig {
+        minSdkVersion 21
+        //noinspection OldTargetApi
+        targetSdkVersion 31
+    }
+}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,11 +1,11 @@
 android {
     namespace 'cgeo.geocaching.test'
 
-    compileSdkVersion 33
+    compileSdk 32
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
         //noinspection OldTargetApi
-        targetSdkVersion 31
+        targetSdk 31
     }
 }


### PR DESCRIPTION
Move AGP from 4.2.2 to 7.1.3, partially using the assistent. Renaming `lintOptions` to `lint` as required from AGP.

The lint tool results in
~~~
res\values-fr\strings.xml:347: Error: For locale "fr" (French) the following quantities should also be defined: many [MissingQuantity]
    <plurals name="caches_more_caches_next_x">
~~~
As `plurals` is not supported for `french` on crowdin we have to disable it.
