### PR TITLE
use AndroidX SplashScreen compat lib (fix #13640)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -95,7 +95,7 @@
 
         <activity
             android:name=".SplashActivity"
-            android:theme="@style/SplashScreenTheme"
+            android:theme="@style/Theme.App.Starting"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -439,6 +439,9 @@ dependencies {
     // Settings Library
     implementation 'androidx.preference:preference:1.2.0'
 
+    // Support Library for consistent splash screens
+    implementation 'androidx.core:core-splashscreen:1.0.0'
+
     // Support Annotations. use same version for the main app and the test app
     def annotationVersion = '1.4.0'
     implementation "androidx.annotation:annotation:$annotationVersion"

--- a/main/res/values/themes.xml
+++ b/main/res/values/themes.xml
@@ -109,10 +109,15 @@
 
     <!-- theme for splash screen -->
 
-    <style name="SplashScreenTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="android:statusBarColor">@color/just_black</item>
-        <item name="android:windowBackground">@drawable/splashscreen_background</item>
-        <item name="android:windowActivityTransitions">false</item>
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <!-- Set the splash screen background, animated icon, and animation duration. -->
+        <item name="windowSplashScreenBackground">@color/colorBackground</item>
+        <!-- Use windowSplashScreenAnimatedIcon to add either a drawable or an animated drawable. One of these is required. -->
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splashscreen_background</item>
+        <!-- Required for animated icons -->
+        <item name="windowSplashScreenAnimationDuration">200</item>
+        <!-- Set the theme of the Activity that directly follows your splash screen. -->
+        <item name="postSplashScreenTheme">@style/cgeo</item>
     </style>
 
     <!-- theme for installation wizard activity -->

--- a/main/src/cgeo/geocaching/SplashActivity.java
+++ b/main/src/cgeo/geocaching/SplashActivity.java
@@ -13,12 +13,16 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.splashscreen.SplashScreen;
 
 public class SplashActivity extends AppCompatActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         try (ContextLogger cLog = new ContextLogger(Log.LogLevel.DEBUG, "SplashActivity.onCreate")) {
+            // Handle the splash screen transition
+            SplashScreen.installSplashScreen(this);
+
             // don't call the super implementation with the layout argument, as that would set the wrong theme
             super.onCreate(savedInstanceState);
 


### PR DESCRIPTION
## Description
Instead of directly calling our `SplashActivity` with home-grewn theme, use AndroidX SplashScreen compatibility lib with according theme
