### PR TITLE
fix #13652: prevent re-inserting empty vars into variable list on scanning pcn

### DIFF
--- a/main/src/cgeo/geocaching/models/Geocache.java
+++ b/main/src/cgeo/geocaching/models/Geocache.java
@@ -1769,7 +1769,7 @@ public class Geocache implements IWaypoint {
                 changed |= addOrMergeInfoToExistingWaypoint(updateDb, namePrefix, parsedWaypoint);
             }
             for (Map.Entry<String, String> var : waypointParser.getParsedVariables().entrySet()) {
-                if (getVariables().isBlank(var.getKey())) {
+                if (getVariables().isWorthAddingWithoutLoss(var.getKey(), var.getValue())) {
                     getVariables().addVariable(var.getKey(), var.getValue());
                 }
                 getVariables().saveState();

--- a/main/src/cgeo/geocaching/utils/formulas/VariableList.java
+++ b/main/src/cgeo/geocaching/utils/formulas/VariableList.java
@@ -56,9 +56,10 @@ public class VariableList {
         return variablesSet.containsKey(var);
     }
 
-    public boolean isBlank(final String var) {
+    /** Returns true if the given 'newValue' for the given variable 'var' can/should be added without overriding existing info in list */
+    public boolean isWorthAddingWithoutLoss(final String var, final String newValue) {
         final VariableMap.VariableState state = getState(var);
-        return state == null || StringUtils.isBlank(state.getFormulaString());
+        return state == null || (StringUtils.isBlank(state.getFormulaString()) && !StringUtils.isBlank(newValue));
     }
 
     @Nullable


### PR DESCRIPTION
fix #13652: prevent re-inserting empty vars into variable list on scanning pcn