### PR TITLE
rel #13603: correct filter display string for minimum / maximum values

### DIFF
--- a/main/src/cgeo/geocaching/filters/core/NumberRangeFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/NumberRangeFilter.java
@@ -99,12 +99,6 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
                 max = v;
             }
         }
-
-        if (isEqualValue(min, max)) {
-            foundMinUnlimited = false;
-            foundMaxUnlimited = false;
-        }
-
         setMinMaxRange(foundMinUnlimited ? null : min, foundMaxUnlimited ? null : max);
     }
 

--- a/main/src/cgeo/geocaching/filters/core/NumberRangeFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/NumberRangeFilter.java
@@ -99,6 +99,12 @@ public class NumberRangeFilter<T extends Number & Comparable<T>> {
                 max = v;
             }
         }
+
+        if (isEqualValue(min, max)) {
+            foundMinUnlimited = false;
+            foundMaxUnlimited = false;
+        }
+
         setMinMaxRange(foundMinUnlimited ? null : min, foundMaxUnlimited ? null : max);
     }
 

--- a/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
@@ -63,14 +63,9 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
     public <V extends Number & Comparable<V>> void setMinMaxRange(@NonNull final V leftValue, @NonNull final V rightValue,
                                                                   @NonNull final V minValue, @NonNull final V maxValue,
                                                                   @NonNull final Func1<V, T> valueConverter) {
-        boolean foundMinUnlimited = leftValue.compareTo(minValue) <= 0;
-        boolean foundMaxUnlimited = rightValue.compareTo(maxValue) >= 0;
-        if ((leftValue.equals(rightValue))
-                || (leftValue.compareTo(maxValue) >= 0)
-                || (rightValue.compareTo(minValue) <= 0)) {
-            foundMinUnlimited = false;
-            foundMaxUnlimited = false;
-        }
+        final boolean foundMinUnlimited = leftValue.compareTo(minValue) < 0; // leftValue < minValue
+        final boolean foundMaxUnlimited = rightValue.compareTo(maxValue) > 0; // rightValue > maxValue
+
         setMinMaxRange(foundMinUnlimited ? null : valueConverter.call(leftValue),
                 foundMaxUnlimited ? null : valueConverter.call(rightValue));
     }

--- a/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
@@ -65,7 +65,7 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
                                                                   @NonNull final Func1<V, T> valueConverter) {
         boolean foundMinUnlimited = leftValue.compareTo(minValue) <= 0;
         boolean foundMaxUnlimited = rightValue.compareTo(maxValue) >= 0;
-        if ((leftValue == rightValue)
+        if ((leftValue.equals(rightValue))
                 || (leftValue.compareTo(maxValue) >= 0)
                 || (rightValue.compareTo(minValue) <= 0)) {
             foundMinUnlimited = false;

--- a/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
+++ b/main/src/cgeo/geocaching/filters/core/NumberRangeGeocacheFilter.java
@@ -5,8 +5,9 @@ import cgeo.geocaching.storage.SqlBuilder;
 import cgeo.geocaching.utils.expressions.ExpressionConfig;
 import cgeo.geocaching.utils.functions.Func1;
 
-import java.util.Collection;
+import androidx.annotation.NonNull;
 
+import java.util.Collection;
 
 public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>> extends BaseGeocacheFilter {
 
@@ -58,6 +59,22 @@ public abstract class NumberRangeGeocacheFilter<T extends Number & Comparable<T>
     public void setMinMaxRange(final T min, final T max) {
         numberRangeFilter.setMinMaxRange(min, max);
     }
+
+    public <V extends Number & Comparable<V>> void setMinMaxRange(@NonNull final V leftValue, @NonNull final V rightValue,
+                                                                  @NonNull final V minValue, @NonNull final V maxValue,
+                                                                  @NonNull final Func1<V, T> valueConverter) {
+        boolean foundMinUnlimited = leftValue.compareTo(minValue) <= 0;
+        boolean foundMaxUnlimited = rightValue.compareTo(maxValue) >= 0;
+        if ((leftValue == rightValue)
+                || (leftValue.compareTo(maxValue) >= 0)
+                || (rightValue.compareTo(minValue) <= 0)) {
+            foundMinUnlimited = false;
+            foundMaxUnlimited = false;
+        }
+        setMinMaxRange(foundMinUnlimited ? null : valueConverter.call(leftValue),
+                foundMaxUnlimited ? null : valueConverter.call(rightValue));
+    }
+
 
     public T getMaxRangeValue() {
         return numberRangeFilter.getMaxRangeValue();

--- a/main/src/cgeo/geocaching/filters/core/UserDisplayableStringUtils.java
+++ b/main/src/cgeo/geocaching/filters/core/UserDisplayableStringUtils.java
@@ -4,7 +4,10 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 
-final class UserDisplayableStringUtils {
+public final class UserDisplayableStringUtils {
+
+    public static final char[] LESS_THAN_OR_EQUAL_TO = Character.toChars(0x2264);
+    public static final char[] GREATER_THAN_OR_EQUAL_TO = Character.toChars(0x2265);
 
     private UserDisplayableStringUtils() {
         // Do not instantiate
@@ -21,10 +24,10 @@ final class UserDisplayableStringUtils {
                 sb.append(minValue).append("-").append(maxValue);
             }
         } else if (StringUtils.isNotEmpty(minValue)) {
-            sb.append(">").append(minValue);
+            sb.append(GREATER_THAN_OR_EQUAL_TO).append(minValue);
         } else {
             // maxValueSet
-            sb.append("<").append(maxValue);
+            sb.append(LESS_THAN_OR_EQUAL_TO).append(maxValue);
         }
         return sb.toString();
     }

--- a/main/src/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
@@ -77,10 +77,7 @@ public class DistanceFilterViewHolder extends BaseFilterViewHolder<DistanceGeoca
         filter.setUseCurrentPosition(useCurrentPosition.isChecked());
         filter.setCoordinate(GeopointParser.parse(coordinate.getText().toString(), null));
         final ImmutablePair<Float, Float> range = slider.getRange();
-        filter.setMinMaxRange(
-                range.left < 0 ? null : (float) Math.round(range.left * conversion),
-                range.right > maxDistance ? null : (float) Math.round(range.right * conversion));
+        filter.setMinMaxRange(range.left, range.right , 0f, (float) maxDistance, value -> (float) Math.round(value * conversion));
         return filter;
     }
-
 }

--- a/main/src/cgeo/geocaching/filters/gui/FavoritesFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/FavoritesFilterViewHolder.java
@@ -88,9 +88,7 @@ public class FavoritesFilterViewHolder extends BaseFilterViewHolder<FavoritesGeo
         final FavoritesGeocacheFilter filter = createFilter();
         filter.setPercentage(percentage.getCheckedButtonIndex() == 1);
         final ImmutablePair<Float, Float> range = slider.getRange();
-        filter.setMinMaxRange(
-                range.left < 0 ? null : Math.round(range.left * granularity) / granularity,
-                range.right > maxValue ? null : Math.round(range.right * granularity) / granularity);
+        filter.setMinMaxRange(range.left, range.right , 0f, maxValue, value -> Math.round(value * granularity) / granularity);
         return filter;
     }
 

--- a/main/src/cgeo/geocaching/filters/gui/LogsCountFilterViewHolder.java
+++ b/main/src/cgeo/geocaching/filters/gui/LogsCountFilterViewHolder.java
@@ -75,9 +75,8 @@ public class LogsCountFilterViewHolder extends BaseFilterViewHolder<LogsCountGeo
     public LogsCountGeocacheFilter createFilterFromView() {
         final LogsCountGeocacheFilter filter = createFilter();
         final ImmutablePair<Float, Float> range = slider.getRange();
-        filter.setMinMaxRange(
-                range.left < 0 ? null : Math.round(range.left),
-                range.right > 1000 ? null : Math.round(range.right));
+        filter.setMinMaxRange(range.left, range.right , 0f, 1000f, value -> Math.round(value));
+
         filter.setLogType(selectSpinner.get() == UNKNOWN ? null : selectSpinner.get());
         return filter;
     }

--- a/tests/src-android/cgeo/geocaching/filters/UserDisplayableStringTest.java
+++ b/tests/src-android/cgeo/geocaching/filters/UserDisplayableStringTest.java
@@ -159,9 +159,9 @@ public class UserDisplayableStringTest {
                                                     final T minValue, final T maxValue,
                                                     final String minValueOutput, final String maxValueOutput) {
         testSingleUserDisplayStringForRange(filter, filterSetter, null, null, null);
-        testSingleUserDisplayStringForRange(filter, filterSetter, minValue, null, UserDisplayableStringUtils.GREATER_THAN_OR_EQUAL_TO + minValueOutput);
+        testSingleUserDisplayStringForRange(filter, filterSetter, minValue, null, new String(UserDisplayableStringUtils.GREATER_THAN_OR_EQUAL_TO) + minValueOutput);
         testSingleUserDisplayStringForRange(filter, filterSetter, minValue, maxValue, minValueOutput + "-" + maxValueOutput);
-        testSingleUserDisplayStringForRange(filter, filterSetter, null, maxValue, UserDisplayableStringUtils.LESS_THAN_OR_EQUAL_TO + maxValueOutput);
+        testSingleUserDisplayStringForRange(filter, filterSetter, null, maxValue, new String(UserDisplayableStringUtils.LESS_THAN_OR_EQUAL_TO) + maxValueOutput);
         testSingleUserDisplayStringForRange(filter, filterSetter, maxValue, maxValue, maxValueOutput);
     }
 }

--- a/tests/src-android/cgeo/geocaching/filters/UserDisplayableStringTest.java
+++ b/tests/src-android/cgeo/geocaching/filters/UserDisplayableStringTest.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.filters.core.NotGeocacheFilter;
 import cgeo.geocaching.filters.core.OrGeocacheFilter;
 import cgeo.geocaching.filters.core.StatusGeocacheFilter;
 import cgeo.geocaching.filters.core.TypeGeocacheFilter;
+import cgeo.geocaching.filters.core.UserDisplayableStringUtils;
 import cgeo.geocaching.utils.functions.Action2;
 
 import java.text.ParseException;
@@ -158,9 +159,9 @@ public class UserDisplayableStringTest {
                                                     final T minValue, final T maxValue,
                                                     final String minValueOutput, final String maxValueOutput) {
         testSingleUserDisplayStringForRange(filter, filterSetter, null, null, null);
-        testSingleUserDisplayStringForRange(filter, filterSetter, minValue, null, ">" + minValueOutput);
+        testSingleUserDisplayStringForRange(filter, filterSetter, minValue, null, UserDisplayableStringUtils.GREATER_THAN_OR_EQUAL_TO + minValueOutput);
         testSingleUserDisplayStringForRange(filter, filterSetter, minValue, maxValue, minValueOutput + "-" + maxValueOutput);
-        testSingleUserDisplayStringForRange(filter, filterSetter, null, maxValue, "<" + maxValueOutput);
+        testSingleUserDisplayStringForRange(filter, filterSetter, null, maxValue, UserDisplayableStringUtils.LESS_THAN_OR_EQUAL_TO + maxValueOutput);
         testSingleUserDisplayStringForRange(filter, filterSetter, maxValue, maxValue, maxValueOutput);
     }
 }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
adapt filter display string: 
* use "less/greater than or equal to" instead of "less/greater than"
* use "equal" if range is limited to min or max value

"Favorites: < 2.0" => "Favorites: ≤ 2.0"
"Favorites: < 0.0" => "Favorites: ≤ 0.0" (not really correct, but otherwise the logic in the filter has to be changed)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #13603 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->