### PR TITLE
fix #13682: prevent npe on imagegallery camery select when intent is null

### DIFF
--- a/main/src/cgeo/geocaching/ui/ImageGalleryView.java
+++ b/main/src/cgeo/geocaching/ui/ImageGalleryView.java
@@ -505,7 +505,7 @@ public class ImageGalleryView extends LinearLayout {
     /** Important: include this in your activity's "onActivityReenter" method.
      * Needed e.g. for correct back transition when returning from detail view (e.g. scrolling to image gallery position) */
     public static int onActivityReenter(final Activity activity, final ImageGalleryView imageGallery, final Intent data) {
-        final int pos = data.getExtras() == null ? -1 : data.getExtras().getInt(ImageViewActivity.EXTRA_IMAGEVIEW_POS, -1);
+        final int pos = data == null || data.getExtras() == null ? -1 : data.getExtras().getInt(ImageViewActivity.EXTRA_IMAGEVIEW_POS, -1);
         if (pos >= 0) {
             activity.postponeEnterTransition();
             if (imageGallery != null) {


### PR DESCRIPTION
fix #13682: prevent npe on imagegallery camery select when intent is null