### PR TITLE
fix #13659: add trunc function to formula

### DIFF
--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1697,6 +1697,7 @@
     <string name="formula_function_tan">Tangent</string>
     <string name="formula_function_abs">Absolute Value</string>
     <string name="formula_function_round">Round</string>
+    <string name="formula_function_trunc">Trunc</string>
     <string name="formula_function_if">If</string>
     <string name="formula_function_length">String Length</string>
     <string name="formula_function_substring">Substring</string>

--- a/main/src/cgeo/geocaching/utils/formulas/FormulaFunction.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaFunction.java
@@ -31,8 +31,9 @@ public enum FormulaFunction {
     ABS("abs", FunctionGroup.SIMPLE_NUMERIC, R.string.formula_function_abs, "Absolute Value", null, 0,
             singleValueNumericFunction(Math::abs)),
     ROUND(new String[]{"round", "rd"}, FunctionGroup.SIMPLE_NUMERIC, R.string.formula_function_round, "Round", null, 0,
-            p -> Value.of(FormulaUtils.round(p.getAsDouble(0, -1), (int) p.getAsInt(1, 0)))),
-
+            p -> Value.of(FormulaUtils.round(p.getAsDouble(0, 0), (int) p.getAsInt(1, 0)))),
+    TRUNC(new String[]{"trunc", "tr", "floor", "fl"}, FunctionGroup.SIMPLE_NUMERIC, R.string.formula_function_trunc, "Trunc", null, 0,
+            p -> Value.of(FormulaUtils.trunc(p.getAsDouble(0, 0), (int) p.getAsInt(1, 0)))),
     IF("if", FunctionGroup.COMPLEX_NUMERIC, R.string.formula_function_if, "If", null, 0,
             minMaxParamFunction(2, -1, FormulaUtils::ifFunction)),
 

--- a/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -72,6 +72,14 @@ public class FormulaUtils {
         return Math.round(value * factor) / factor;
     }
 
+    public static double trunc(final double value, final int digits) {
+        if (digits <= 0) {
+            return Math.floor(value);
+        }
+        final double factor = Math.pow(10, digits);
+        return Math.floor(value * factor) / factor;
+    }
+
     public static String substring(final String value, final int start, final int length) {
         if (value == null || start >= value.length()) {
             return "";


### PR DESCRIPTION
fix #13659: add trunc function to formula

This PR adds the "trunc" function to c:geo, which truncs a comma-separated value (synonym: floor). It can resolve the issue in the discussion #13659 in yet another way.

![image](https://user-images.githubusercontent.com/6909759/202863137-d648cd1b-d6c4-4bb6-b1dc-2d32e4837fb0.png)

