### PR TITLE
lint: try to fix QueryPermissionsNeeded

### DIFF
--- a/main/src/cgeo/geocaching/utils/ProcessUtils.java
+++ b/main/src/cgeo/geocaching/utils/ProcessUtils.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
@@ -57,7 +58,12 @@ public final class ProcessUtils {
 
     /**
      * This will find installed applications even without launch intent (e.g. the streetview plugin).
+     *
+     * Be aware:
+     * Starting with Android 11 getInstalledPackages() will only return packages declared in AndroidManifest.xml
+     * (Add a lint exception, as we have cross-checked our current usages for this method)
      */
+    @SuppressLint("QueryPermissionsNeeded")
     private static boolean hasPackageInstalled(@NonNull final String packageName) {
         final List<PackageInfo> packs = CgeoApplication.getInstance().getPackageManager().getInstalledPackages(0);
         for (final PackageInfo packageInfo : packs) {


### PR DESCRIPTION
## Description
fix unnecessary lint warning `QueryPermissionsNeeded` as discussed in https://github.com/cgeo/cgeo/issues/13639#issuecomment-1312778980
