### PR TITLE
reenable gc.com basic member settings (fix #13724)

### DIFF
--- a/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/res/xml/preferences_services_geocaching_com.xml
@@ -27,19 +27,23 @@
             app:summary="@string/auth_unconnected"
             app:iconSpaceReserved="false" />
 
-        <PreferenceScreen
-            android:dependency="@string/pref_connectorGCActive"
-            android:key="@string/preference_screen_basicmembers"
-            android:title="@string/settings_title_basicmembers"
-            app:iconSpaceReserved="false">
-            <CheckBoxPreference
-                android:defaultValue="true"
-                android:key="@string/pref_loaddirectionimg"
-                android:summary="@string/init_summary_loaddirectionimg"
-                android:title="@string/init_loaddirectionimg"
-                app:iconSpaceReserved="false" />
-        </PreferenceScreen>
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:dependency="@string/pref_connectorGCActive"
+        android:key="@string/preference_screen_basicmembers"
+        android:title="@string/settings_title_basicmembers"
+        app:iconSpaceReserved="false">
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/pref_loaddirectionimg"
+            android:summary="@string/init_summary_loaddirectionimg"
+            android:title="@string/init_loaddirectionimg"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
 
     <PreferenceCategory
         android:title="@string/settings_information"

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComFragment.java
@@ -60,7 +60,7 @@ public class PreferenceServiceGeocachingComFragment extends PreferenceFragmentCo
 
     void initBasicMemberPreferences() {
         findPreference(getString((R.string.preference_screen_basicmembers)))
-                .setEnabled(!Settings.isGCPremiumMember());
+                .setVisible(!Settings.isGCPremiumMember());
         findPreference(getString((R.string.pref_loaddirectionimg)))
                 .setEnabled(!Settings.isGCPremiumMember());
     }


### PR DESCRIPTION
## Description
gc.com preference was still using a nested `PreferenceScreen` which is not supported by AndroidX preferences. Switching this into a `PreferenceCategory` resolved the problem.
The new category will be displayed for basic members only, and only if gc.com service is activated.

![image](https://user-images.githubusercontent.com/3754370/204057722-f9e24f69-3b27-4d09-8953-142ef06ce23f.png)
