### PR TITLE
Revert "Bump commons-compress from 1.20 to 1.22"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       # Ignore some updates to the apache 'commons-io' package
       # commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
       - dependency-name: "commons-io:commons-io"
+      # Ignore some updates to the apache 'commons-io' package
+      # commons-compress 1.21 uses java.nio.file.Path - which is first contained in Android API26
+      - dependency-name: "commons-compress:commons-compress"
       # Ignore some updates to the apache 'commons-lang3' package
       # commons-lang3 3.12.0 uses StringJoiner which is first contained in Android API24
       - dependency-name: "org.apache.commons:commons-lang3"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -301,7 +301,12 @@ dependencies {
 
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
-    implementation 'org.apache.commons:commons-compress:1.22'
+
+    // commons.compress 1.21+ relies on java.nio which is only supported on API26+
+    // See https://github.com/cgeo/cgeo/issues/13730 / 13731
+    //noinspection GradleDependency
+    implementation 'org.apache.commons:commons-compress:1.20'
+
     // commons-lang3 3.12.0 uses StringJoiner which is first contained in Android API24
     // See https://github.com/cgeo/cgeo/issues/12577
     //noinspection GradleDependency


### PR DESCRIPTION
## Description
The crashes described in #13730/#13731 point to java.nio not supported. Dependency on this got introduced by an update of apache.commons.compress - which this PR therefore reverts.