### PR TITLE
fix #13434: DataStore.updateCacheCount: pass exceptions correctly to emitter

### DIFF
--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -792,8 +792,12 @@ public class DataStore {
     }
 
     private static final Single<Integer> allCachesCountObservable = Single.create((SingleOnSubscribe<Integer>) emitter -> {
-        if (isInitialized()) {
-            emitter.onSuccess(getAllCachesCount());
+        try {
+            if (isInitialized()) {
+                emitter.onSuccess(getAllCachesCount());
+            }
+        } catch (RuntimeException re) {
+            emitter.onError(re);
         }
     }).timeout(500, TimeUnit.MILLISECONDS).retry(10).subscribeOn(Schedulers.io());
 


### PR DESCRIPTION
fix #13434: DataStore.updateCacheCount: pass exceptions correctly to emitter

This is a best-try to handle the observed problem. I assume that the exception is simply not passed the right way towards the subscriber (where it is handled in a good way, by logging it), this PR tries to fix that.

I would appreciate a review from someone with more knowledge about RxJava than I have. 

I also assume that the error happens in situations where the database is no longer available, which can happen either at app closing or during backup. Any support tickets which might be linked to this?