### PR TITLE
Add pseudo logScaling and stepSize to SeekbarPreference implementation 

### DIFF
--- a/main/res/values/attrs.xml
+++ b/main/res/values/attrs.xml
@@ -25,8 +25,10 @@
     <declare-styleable name="SeekbarPreference">
         <attr name="min" format="integer" />
         <attr name="max" format="integer" />
+        <attr name="stepSize" format="integer" />
         <attr name="label" format="string" />
         <attr name="hasDecimals" format="boolean" />
+        <attr name="logScaling" format="boolean" />
     </declare-styleable>
 
     <!-- custom attributes for ProximityPreference -->

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -45,6 +45,7 @@
             android:key="@string/pref_mapAutoDownloadsInterval"
             android:defaultValue="@integer/map_updateinterval_default"
             app:max="@integer/map_updateinterval_max"
+            app:logScaling="true"
             app:iconSpaceReserved="false" />
 
         <Preference
@@ -125,6 +126,7 @@
             android:defaultValue="@integer/waypoint_threshold_default"
             app:min="0"
             app:max="@integer/waypoint_threshold_max"
+            app:logScaling="true"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
@@ -168,6 +170,8 @@
             android:defaultValue="@integer/historytrack_length_default"
             app:min="100"
             app:max="@integer/historytrack_length_max"
+            app:stepSize="100"
+            app:logScaling="true"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"

--- a/main/res/xml/preferences_offlinedata.xml
+++ b/main/res/xml/preferences_offlinedata.xml
@@ -34,6 +34,8 @@
         android:defaultValue="@integer/list_load_limit_default"
         app:min="0"
         app:max="@integer/list_load_limit_max"
+        app:stepSize="100"
+        app:logScaling="true"
         app:iconSpaceReserved="false" />
 
     <PreferenceCategory


### PR DESCRIPTION
Add pseudo logScaling to our custom SeekbarPreference implementation and use it for sliders with large ranges

Add stepSize to our custom SeekbarPreference implementation and use it where exact values doesn't make much sense

e.g. suggested in https://github.com/cgeo/cgeo/issues/11191#issuecomment-882013224