### PR TITLE
Correctly detect archived caches in search results (fix #13619)

### DIFF
--- a/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -918,6 +918,7 @@ class GCWebAPI {
 
                 c.setFavoritePoints(r.favoritePoints);
                 c.setDisabled(r.cacheStatus == 1);
+                c.setArchived(r.cacheStatus == 2);
                 if (r.owner != null) {
                     c.setOwnerDisplayName(r.owner.username);
                     c.setOwnerUserId(r.owner.username);


### PR DESCRIPTION
Correctly detect archived caches in search results. 
Though, I'm still wondering why this didn't come up before...?