### PR TITLE
Group UnifiedMap prefs in separate category (rel. to #13750)

### DIFF
--- a/main/res/values/preference_keys.xml
+++ b/main/res/values/preference_keys.xml
@@ -232,6 +232,7 @@
 
     <!-- category other -->
     <string translatable="false" name="pref_map_osm_multithreaded">map_osm_multithreaded</string>
+    <string translatable="false" name="pref_fakekey_unifiedmap">fakekey_unifiedmap</string>
     <string translatable="false" name="pref_useUnifiedMap">useUnifiedMap</string>
 
 

--- a/main/res/values/strings.xml
+++ b/main/res/values/strings.xml
@@ -1133,6 +1133,8 @@
     <string name="init_map_other">Other</string>
     <string name="init_map_osm_multithreaded">Multi-threaded (OSM)</string>
     <string name="init_summary_map_osm_multithreaded">Use multiple threads to render OpenStreetMap maps</string>
+    <string name="category_unifiedMap">Unified Map</string>
+    <string name="experimental">(experimental)</string>
     <string name="init_title_useUnifiedMap">Use unified map</string>
     <string name="init_summary_useUnifiedMap">Use new unified map instead of built-in Google Map / Mapsforge (OSM) maps (experimental / far from being complete / for testing only)</string>
     <string name="localstorage_migrate_title">Migration of local files</string>

--- a/main/res/xml/preferences_map.xml
+++ b/main/res/xml/preferences_map.xml
@@ -16,11 +16,6 @@
             android:summary="%s"
             android:title="@string/init_mapsource_select"
             app:iconSpaceReserved="false" />
-        <MultiSelectListPreference
-            android:key="@string/pref_tileprovider_hidden"
-            android:title="@string/settings_hide_tileproviders_title"
-            android:summary="@string/settings_hide_tileproviders_summary"
-            app:iconSpaceReserved="false" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/settings_title_offline_maps"
@@ -366,6 +361,24 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:key="@string/pref_fakekey_unifiedmap"
+        android:title="@string/category_unifiedMap"
+        android:summary="@string/experimental"
+        app:iconSpaceReserved="false">
+        <MultiSelectListPreference
+            android:key="@string/pref_tileprovider_hidden"
+            android:title="@string/settings_hide_tileproviders_title"
+            android:summary="@string/settings_hide_tileproviders_summary"
+            app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_useUnifiedMap"
+            android:summary="@string/init_summary_useUnifiedMap"
+            android:title="@string/init_title_useUnifiedMap"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/init_map_other"
         app:iconSpaceReserved="false">
         <CheckBoxPreference
@@ -373,12 +386,6 @@
             android:key="@string/pref_map_osm_multithreaded"
             android:summary="@string/init_summary_map_osm_multithreaded"
             android:title="@string/init_map_osm_multithreaded"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/pref_useUnifiedMap"
-            android:summary="@string/init_summary_useUnifiedMap"
-            android:title="@string/init_title_useUnifiedMap"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
+++ b/main/src/cgeo/geocaching/settings/fragments/PreferenceMapFragment.java
@@ -35,8 +35,12 @@ public class PreferenceMapFragment extends BasePreferenceFragment {
         initMapSourcePreference();
 
         final boolean showUnifiedMap = Settings.getBoolean(R.string.pref_showUnifiedMap, false);
+
+        final Preference catUnifiedMap = findPreference(getString(R.string.pref_fakekey_unifiedmap));
+        catUnifiedMap.setVisible(showUnifiedMap);
+
         final MultiSelectListPreference hideTileprovidersPref = findPreference(getString(R.string.pref_tileprovider_hidden));
-        hideTileprovidersPref.setVisible(showUnifiedMap);
+        // hideTileprovidersPref.setVisible(showUnifiedMap);
         if (showUnifiedMap) {
             // new unified map providers
             final HashMap<String, AbstractTileProvider> tileproviders = TileProviderFactory.getTileProviders();


### PR DESCRIPTION
## Description
Group the two settings related to `UnifiedMap` into a separate category to avoid misunderstandings as described in the related issue:

![image](https://user-images.githubusercontent.com/3754370/206303874-a3e7a3e6-3c98-4cf0-b650-2ed7d11c6d2c.png)

This category will only be visible when hidden pref key `showUnifiedMap` is set to true.