### PR TITLE
migrate RouteSortActivity to Recyclerview

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -470,9 +470,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    // Drag n drop for listview
-    implementation 'asia.ivity.android:drag-sort-listview:1.0'
-
     // needed for chrome custom tabs
     implementation 'androidx.browser:browser:1.4.0'
 

--- a/main/res/layout/route_sort_item.xml
+++ b/main/res/layout/route_sort_item.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="horizontal"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:minHeight="40sp"
     android:paddingTop="3dp"
     android:paddingLeft="3dp"
@@ -43,23 +44,23 @@
         tools:text="detail info" />
 
     <Button
-        android:id="@+id/button_left"
+        android:id="@+id/delete"
         style="@style/button_icon"
-        android:layout_toLeftOf="@id/img_right"
         android:layout_centerInParent="true"
-        android:visibility="gone" />
+        android:layout_toLeftOf="@id/drag"
+        app:icon="@drawable/ic_menu_delete" />
 
     <ImageView
-        android:id="@+id/img_right"
+        android:id="@+id/drag"
         android:layout_width="@dimen/buttonSize_iconButton"
         android:layout_height="@dimen/buttonSize_iconButton"
-        android:layout_marginLeft="6dip"
-        android:layout_marginRight="6dip"
-        android:layout_marginTop="3dip"
-        android:layout_marginBottom="3dip"
-        android:padding="3dip"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="6dp"
+        android:layout_marginRight="6dp"
+        android:scaleType="centerInside"
         android:layout_alignParentRight="true"
-        android:layout_centerInParent="true"
-        android:visibility="gone" />
+        android:layout_gravity="left"
+        app:srcCompat="@drawable/ic_menu_reorder"
+        tools:src="@drawable/ic_menu_reorder"/>
 
 </RelativeLayout>

--- a/main/res/values/strings_not_translatable.xml
+++ b/main/res/values/strings_not_translatable.xml
@@ -158,7 +158,6 @@
     - [The Apache Commons Project](https://commons.apache.org/)\n
     - [Google Material Design Icons](https://material.io/tools/icons/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
     - [Community Material Design Icons](https://materialdesignicons.com/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
-    - [DragSortListView library by Carl Bauer](https://github.com/bauerca/drag-sort-listview/) ([Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html))\n
     - [Geocoding courtesy of MapQuest](https://www.mapquest.com/)\n
     - [Geocoding data from OpenStreetMap](https://www.openstreetmap.org/)\n
     - OpenStreetMap cartography (OSM:Mapnik) © OpenStreetMap contributors. Map tile data [licensed](http://www.openstreetmap.org/copyright/en) under Creative Commons 2.0 BY-SA.\n

--- a/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -44,6 +44,9 @@ public class RouteSortActivity extends AbstractActionBarActivity {
     private ArrayList<RouteItem> originalRouteItems;
     private RecyclerView listView;
 
+    private static final String SAVED_STATE_ROUTEITEMS = "cgeo.geocaching.saved_state_routeitems";
+
+
     protected static class RouteItemViewHolder extends AbstractRecyclerViewHolder {
         private final RouteSortItemBinding binding;
 
@@ -120,11 +123,23 @@ public class RouteSortActivity extends AbstractActionBarActivity {
         setTheme();
         setTitle(getString(R.string.map_sort_individual_route));
 
-        originalRouteItems = DataStore.loadIndividualRoute();
         listView = new RecyclerView(this, null);
+        setContentView(listView);
+
+        originalRouteItems = DataStore.loadIndividualRoute();
+
         routeItemAdapter = new RouteItemListAdapter(listView);
         routeItemAdapter.setItems(originalRouteItems);
-        setContentView(listView);
+
+        if (savedInstanceState != null) {
+            routeItemAdapter.setItems(savedInstanceState.getParcelableArrayList(SAVED_STATE_ROUTEITEMS));
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelableArrayList(SAVED_STATE_ROUTEITEMS, new ArrayList<>(routeItemAdapter.getItems()));
     }
 
     private void invertOrder() {

--- a/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -63,7 +63,7 @@ public class RouteSortActivity extends AbstractActionBarActivity {
                     .setSupportDragDrop(true));
         }
 
-        private void fillViewHolder(final RouteItemViewHolder holder, final RouteItem routeItem, final int position) {
+        private void fillViewHolder(final RouteItemViewHolder holder, final RouteItem routeItem) {
             final boolean cacheOrWaypointType = routeItem.getType() == RouteItem.RouteItemType.GEOCACHE || routeItem.getType() == RouteItem.RouteItemType.WAYPOINT;
             final IWaypoint data = cacheOrWaypointType ? routeItem.getType() == RouteItem.RouteItemType.GEOCACHE ? DataStore.loadCache(routeItem.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB) : DataStore.loadWaypoint(routeItem.getWaypointId()) : null;
 
@@ -113,7 +113,7 @@ public class RouteSortActivity extends AbstractActionBarActivity {
 
         @Override
         public void onBindViewHolder(@NonNull final RouteItemViewHolder holder, final int position) {
-            fillViewHolder(holder, getItem(position), position);
+            fillViewHolder(holder, getItem(position));
         }
     }
 

--- a/main/src/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/cgeo/geocaching/storage/DataStore.java
@@ -3294,7 +3294,7 @@ public class DataStore {
         }
     }
 
-    public static void saveIndividualRoute(final ArrayList<RouteItem> routeItems) {
+    public static void saveIndividualRoute(final List<RouteItem> routeItems) {
         init();
 
         database.beginTransaction();


### PR DESCRIPTION
- This change replaces the legacy DragSortListView library with RecyclerView using build-in AndroidX drag sort implementation (fix #9884)
- don't discard current sorting when turning screen
