### PR TITLE
fix #13763: prevent numberformatex on parsing degree formulas with multiple dots

### DIFF
--- a/main/src/cgeo/geocaching/utils/formulas/DegreeFormula.java
+++ b/main/src/cgeo/geocaching/utils/formulas/DegreeFormula.java
@@ -346,11 +346,16 @@ public class DegreeFormula {
         if (hasDigits) {
             final String digits = v.getAsString();
             final Pair<CharSequence, Boolean> digitsAfter = padDigits(vAfter.getAsString(), precision);
-            final double result = Double.parseDouble(digits + "." + digitsAfter.first);
-            if (checker.test(result)) {
-                add(css, digits, ".", digitsAfter.first);
-                return new Pair<>(result, digitsAfter.second);
-            } else {
+            try {
+                final double result = Double.parseDouble(digits + "." + digitsAfter.first);
+                if (checker.test(result)) {
+                    add(css, digits, ".", digitsAfter.first);
+                    return new Pair<>(result, digitsAfter.second);
+                } else {
+                    addError(css, digits, ".", digitsAfter.first);
+                    return new Pair<>(null, digitsAfter.second);
+                }
+            } catch (NumberFormatException nfe) {
                 addError(css, digits, ".", digitsAfter.first);
                 return new Pair<>(null, digitsAfter.second);
             }

--- a/tests/src/cgeo/geocaching/utils/formulas/DegreeFormulaTest.java
+++ b/tests/src/cgeo/geocaching/utils/formulas/DegreeFormulaTest.java
@@ -92,7 +92,10 @@ public class DegreeFormulaTest {
 
     @Test
     public void parseNonparseable() {
+        //tests both stability for non-parseable formulats (-> no exceptions allowed!) and correct error text
         assertThat(DegreeFormula.compile("E 053° 33.06(4**A)'", true).evaluateToString(null)).isEqualTo("E053°33.06(4**A)'?");
+        assertThat(DegreeFormula.compile("E 053 33.06A", true).evaluateToString(v -> Value.of("."))).isEqualTo("E053°33.06.'");
+
     }
 
     @Test


### PR DESCRIPTION
fix #13763: prevent numberformatex on parsing degree formulas with multiple dots