### PR TITLE
UnifiedMap: Prevent crash on adding wpt to route

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgePositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgePositionLayer.java
@@ -149,6 +149,9 @@ class MapsforgePositionLayer extends AbstractPositionLayer<GeoPoint> {
     protected void repaintRouteAndTracks() {
         trackLayer.clear();
         repaintRouteAndTracksHelper((segment, isTrack) -> {
+            if (segment.size() < 2) {
+                return; // no line can be drawn from a single point
+            }
             final LineDrawable path = new LineDrawable(segment, isTrack ? trackStyle : routeStyle);
             trackLayer.add(path);
         });


### PR DESCRIPTION
## Description
Prevents crash of UnifiedMap on adding a waypoint to an empty route.

## Additional context
VTM `LineDrawable` crashes on adding if it consists of only a single point