### PR TITLE
Catch RxJava error before converting to LiveData

### DIFF
--- a/main/src/main/java/cgeo/geocaching/about/SystemInformationViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/about/SystemInformationViewModel.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.about;
 
+import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.SystemInformation;
 
 import android.app.Application;

--- a/main/src/main/java/cgeo/geocaching/about/SystemInformationViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/about/SystemInformationViewModel.java
@@ -23,7 +23,12 @@ public class SystemInformationViewModel extends AndroidViewModel {
         super(application);
 
         systemInformation = LiveDataReactiveStreams.fromPublisher(
-            Flowable.fromCallable(() -> SystemInformation.getSystemInformation(application)).subscribeOn(Schedulers.io())
+            Flowable.fromCallable(() -> SystemInformation.getSystemInformation(application))
+                    .subscribeOn(Schedulers.io())
+                    .onErrorReturn(throwable -> {
+                        Log.e("Could not load system information", throwable);
+                        return null;
+                    })
         );
     }
 


### PR DESCRIPTION


## Description
Catches RxJava error before converting it to LiveData, preventing a crash.

Instead, the error is logged and the result is set to `null` (pretty much same as not loaded in this case).


## Related issues
Prevents a crash documented in #13553.


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->