### PR TITLE
declare vtm natives as runtimeonly to solve android studio issues

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -376,10 +376,10 @@ dependencies {
     implementation "org.locationtech.jts:jts-core:1.16.1"
 
     implementation "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion"
-    implementation "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-armeabi-v7a"
-    implementation "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-arm64-v8a"
-    implementation "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-x86"
-    implementation "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-x86_64"
+    runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-armeabi-v7a"
+    runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-arm64-v8a"
+    runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-x86"
+    runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-x86_64"
 
     implementation "$mapsforgeVTMSource:vtm-http:$mapsforgeVTMVersion"
 


### PR DESCRIPTION
Declare vtm natives as runtimeonly, trying to solve android studio issues

I started to experience issues with my local Android Studio similar to what @moving-bits had describes some weeks ago (one by one classes started to "disappear" from the knowledge of Android Studio, were marked red etc).

I had the impression that this is caused by VTM native libraries being part of compile path. Removing them from this path resolved the issue for me. This is what this PR is doing (->moving it to "runtimeOnly"). VTM seems to work with this change, at least in the emulator.

@moving-bits does this also solve your problems? If yes, maybe we should merge it?