### PR TITLE
recognize WIG-links if both details.aspx and download.aspx are linked

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/apps/cache/WhereYouGoAppTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/apps/cache/WhereYouGoAppTest.java
@@ -12,7 +12,7 @@ public class WhereYouGoAppTest {
     public void testGetWhereIGoUrl() {
         final Geocache cache = new Geocache();
         cache.setDescription("<p style=\"max-width:670px;\"><a href=\"http://www.wherigo.com/cartridge/details.aspx?CGUID=c4577c31-09e9-44f0-ae48-83737e57adbd\"><img class=\"InsideTable\"");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=c4577c31-09e9-44f0-ae48-83737e57adbd");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo(WhereYouGoApp.URL_BASE + "c4577c31-09e9-44f0-ae48-83737e57adbd");
     }
 
     // from GC461KF (URL with "download.aspx")
@@ -20,7 +20,7 @@ public class WhereYouGoAppTest {
     public void testGetWhereIGoUrlDownload() {
         final Geocache cache = new Geocache();
         cache.setDescription("<a href=\"http://www.wherigo.com/cartridge/download.aspx?CGUID=ec53c2bc-98dc-4d5f-bf9b-0709931d53bc\">Download Cartridge</a><br>");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=ec53c2bc-98dc-4d5f-bf9b-0709931d53bc");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo(WhereYouGoApp.URL_BASE + "ec53c2bc-98dc-4d5f-bf9b-0709931d53bc");
     }
 
     @Test
@@ -35,7 +35,7 @@ public class WhereYouGoAppTest {
     public void testGetWherIGoURLHttps() {
         final Geocache cache = new Geocache();
         cache.setDescription("Da kannsch da die Cartridge oaladn:<br>\n<br>\n<a target=\"_blank\" href=\"https://www.wherigo.com/cartridge/details.aspx?CGUID=a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6\"><img src=\"https://imgproxy.geocaching.com/5e0c76c4b8cccbb11eecc36b322a9177d6820421?url=https%3A%2F%2Fwww.muggelfrei.at%2Fcaches%2Fi-heart-innsbruck%2Fcartridge.png\"></a><br>");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo(WhereYouGoApp.URL_BASE + "a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6");
     }
 
     // from GC7WDB4
@@ -43,7 +43,7 @@ public class WhereYouGoAppTest {
     public void testGetWhereIGoUrlSameURLTwice() {
         final Geocache cache = new Geocache();
         cache.setDescription("<p><strong><a href=\"http://www.wherigo.com/cartridge/details.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f\">http://www.wherigo.com/cartridge/download.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f</a></strong></p>");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo(WhereYouGoApp.URL_BASE + "bb9a7000-c59c-4822-9e10-d779c752345f");
     }
 
     // from GC7WDB4 (modified)

--- a/main/src/androidTest/java/cgeo/geocaching/apps/cache/WhereYouGoAppTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/apps/cache/WhereYouGoAppTest.java
@@ -12,7 +12,7 @@ public class WhereYouGoAppTest {
     public void testGetWhereIGoUrl() {
         final Geocache cache = new Geocache();
         cache.setDescription("<p style=\"max-width:670px;\"><a href=\"http://www.wherigo.com/cartridge/details.aspx?CGUID=c4577c31-09e9-44f0-ae48-83737e57adbd\"><img class=\"InsideTable\"");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("http://www.wherigo.com/cartridge/details.aspx?CGUID=c4577c31-09e9-44f0-ae48-83737e57adbd");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=c4577c31-09e9-44f0-ae48-83737e57adbd");
     }
 
     // from GC461KF (URL with "download.aspx")
@@ -20,7 +20,7 @@ public class WhereYouGoAppTest {
     public void testGetWhereIGoUrlDownload() {
         final Geocache cache = new Geocache();
         cache.setDescription("<a href=\"http://www.wherigo.com/cartridge/download.aspx?CGUID=ec53c2bc-98dc-4d5f-bf9b-0709931d53bc\">Download Cartridge</a><br>");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("http://www.wherigo.com/cartridge/download.aspx?CGUID=ec53c2bc-98dc-4d5f-bf9b-0709931d53bc");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=ec53c2bc-98dc-4d5f-bf9b-0709931d53bc");
     }
 
     @Test
@@ -35,15 +35,15 @@ public class WhereYouGoAppTest {
     public void testGetWherIGoURLHttps() {
         final Geocache cache = new Geocache();
         cache.setDescription("Da kannsch da die Cartridge oaladn:<br>\n<br>\n<a target=\"_blank\" href=\"https://www.wherigo.com/cartridge/details.aspx?CGUID=a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6\"><img src=\"https://imgproxy.geocaching.com/5e0c76c4b8cccbb11eecc36b322a9177d6820421?url=https%3A%2F%2Fwww.muggelfrei.at%2Fcaches%2Fi-heart-innsbruck%2Fcartridge.png\"></a><br>");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/details.aspx?CGUID=a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6");
     }
 
     // from GC7WDB4
     @Test
     public void testGetWhereIGoUrlSameURLTwice() {
         final Geocache cache = new Geocache();
-        cache.setDescription("<p><strong><a href=\"http://www.wherigo.com/cartridge/details.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f\">http://www.wherigo.com/cartridge/details.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f</a></strong></p>");
-        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("http://www.wherigo.com/cartridge/details.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f");
+        cache.setDescription("<p><strong><a href=\"http://www.wherigo.com/cartridge/details.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f\">http://www.wherigo.com/cartridge/download.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f</a></strong></p>");
+        assertThat(WhereYouGoApp.getWhereIGoUrl(cache)).isEqualTo("https://www.wherigo.com/cartridge/download.aspx?CGUID=bb9a7000-c59c-4822-9e10-d779c752345f");
     }
 
     // from GC7WDB4 (modified)

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.activity.INavigationSource;
 import cgeo.geocaching.activity.Progress;
 import cgeo.geocaching.activity.TabbedViewPagerActivity;
 import cgeo.geocaching.activity.TabbedViewPagerFragment;
+import cgeo.geocaching.apps.cache.WhereYouGoApp;
 import cgeo.geocaching.apps.cachelist.MapsMeCacheListApp;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
 import cgeo.geocaching.calendar.CalendarAdder;
@@ -1571,7 +1572,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         private void updateWhereYouGoBox(final CacheDetailActivity activity) {
-            final boolean isEnabled = cache.getType() == CacheType.WHERIGO && StringUtils.isNotEmpty(getWhereIGoUrl(cache));
+            final boolean isEnabled = new WhereYouGoApp().isEnabled(cache);
             binding.whereyougoBox.setVisibility(isEnabled ? View.VISIBLE : View.GONE);
             binding.whereyougoText.setText(isWhereYouGoInstalled() ? R.string.cache_whereyougo_start : R.string.cache_whereyougo_install);
             if (isEnabled) {

--- a/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class WhereYouGoApp extends AbstractGeneralApp {
     private static final Pattern PATTERN_CARTRIDGE = Pattern.compile("https?" + Pattern.quote("://www.wherigo.com/cartridge/") + "(details|download)" + Pattern.quote(".aspx?") + "[Cc][Gg][Uu][Ii][Dd]=([-0-9a-zA-Z]*)");
-    private static final String URL_BASE = "https://www.wherigo.com/cartridge/download.aspx?CGUID=";
+    protected static final String URL_BASE = "https://www.wherigo.com/cartridge/download.aspx?CGUID=";
 
     public WhereYouGoApp() {
         super(getString(R.string.cache_menu_whereyougo), "menion.android.whereyougo");

--- a/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class WhereYouGoApp extends AbstractGeneralApp {
     private static final Pattern PATTERN_CARTRIDGE = Pattern.compile("https?" + Pattern.quote("://www.wherigo.com/cartridge/") + "(details|download)" + Pattern.quote(".aspx?") + "[Cc][Gg][Uu][Ii][Dd]=([-0-9a-zA-Z]*)");
-    private static final String URL_BASE = "https://www.wherigo.com/cartridge/details.aspx?CGUID=";
+    private static final String URL_BASE = "https://www.wherigo.com/cartridge/download.aspx?CGUID=";
 
     public WhereYouGoApp() {
         super(getString(R.string.cache_menu_whereyougo), "menion.android.whereyougo");
@@ -47,7 +47,7 @@ public class WhereYouGoApp extends AbstractGeneralApp {
         final Matcher matcher = PATTERN_CARTRIDGE.matcher(cache.getShortDescription() + " " + cache.getDescription());
         final Set<String> cartridgeGuids = new HashSet<>();
         while (matcher.find()) {
-            cartridgeGuids.add(matcher.group(1));
+            cartridgeGuids.add(matcher.group(2));
         }
         if (cartridgeGuids.size() == 1) {
             return URL_BASE + cartridgeGuids.iterator().next();

--- a/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
@@ -20,7 +20,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
 public class WhereYouGoApp extends AbstractGeneralApp {
-    private static final Pattern PATTERN_CARTRIDGE = Pattern.compile("(https?" + Pattern.quote("://www.wherigo.com/cartridge/") + "(details|download)" + Pattern.quote(".aspx?") + "[Cc][Gg][Uu][Ii][Dd]=[-0-9a-zA-Z]*)");
+    private static final Pattern PATTERN_CARTRIDGE = Pattern.compile("https?" + Pattern.quote("://www.wherigo.com/cartridge/") + "(details|download)" + Pattern.quote(".aspx?") + "[Cc][Gg][Uu][Ii][Dd]=([-0-9a-zA-Z]*)");
+    private static final String URL_BASE = "https://www.wherigo.com/cartridge/details.aspx?CGUID=";
 
     public WhereYouGoApp() {
         super(getString(R.string.cache_menu_whereyougo), "menion.android.whereyougo");
@@ -44,12 +45,12 @@ public class WhereYouGoApp extends AbstractGeneralApp {
     @Nullable
     public static String getWhereIGoUrl(final Geocache cache) {
         final Matcher matcher = PATTERN_CARTRIDGE.matcher(cache.getShortDescription() + " " + cache.getDescription());
-        final Set<String> urls = new HashSet<>();
+        final Set<String> cartridgeGuids = new HashSet<>();
         while (matcher.find()) {
-            urls.add(matcher.group(1));
+            cartridgeGuids.add(matcher.group(1));
         }
-        if (urls.size() == 1) {
-            return urls.iterator().next();
+        if (cartridgeGuids.size() == 1) {
+            return URL_BASE + cartridgeGuids.iterator().next();
         }
         return null;
     }


### PR DESCRIPTION
currently the WIG-recognition fails if both download and details page are linked. Fix that by recognizing only the ID

fixes #13822