### PR TITLE
Prevent NPE on setting list name memento (fix #13841)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -495,7 +495,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 listNameMemento.rememberTerm(extras.getString(Intents.EXTRA_NAME));
             } else {
                 final String data = ContentStorage.get().getName(getIntent().getData());
-                listNameMemento.rememberTerm(StringUtils.endsWith(data.toLowerCase(Locale.ROOT), ".gpx") ? StringUtils.substring(data, 0, -4) : data);
+                listNameMemento.rememberTerm(StringUtils.isNotBlank(data) && StringUtils.endsWith(data.toLowerCase(Locale.ROOT), ".gpx") ? StringUtils.substring(data, 0, -4) : data);
             }
             importGpxAttachement();
         }


### PR DESCRIPTION
## Description
Prevents NPE on GPX file import when trying to infer a default for list name