### PR TITLE
fix #13805: remove old image gallery for trackables

### DIFF
--- a/main/src/main/java/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/main/java/cgeo/geocaching/TrackableActivity.java
@@ -442,7 +442,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
     @Override
     protected String getTitle(final long pageId) {
         if (pageId == Page.IMAGEGALLERY.id) {
-            String title = "*" + this.getString(Page.find(pageId).resId) + "*";
+            String title = this.getString(Page.find(pageId).resId);
             if (this.imageGallery != null) {
                 title += " (" + this.imageGallery.getImageCount() + ")";
             }
@@ -458,7 +458,7 @@ public class TrackableActivity extends TabbedViewPagerActivity implements Androi
             if (CollectionUtils.isNotEmpty(trackable.getLogs())) {
                 pages.add(Page.LOGS.id);
             }
-            if (CollectionUtils.isNotEmpty(trackable.getImages())) {
+            if (!Settings.enableFeatureNewImageGallery() && CollectionUtils.isNotEmpty(trackable.getImages())) {
                 pages.add(Page.IMAGES.id);
             }
             if (Settings.enableFeatureNewImageGallery()) {


### PR DESCRIPTION
fix #13805: remove old image gallery for trackables