### PR TITLE
don't show file copy dialog on clean install

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/main/java/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -431,7 +431,7 @@ public class ContentStorageActivityHelper {
         if (askUserForCopyMove) {
             folderInfoBeforeRaw = FolderUtils.get().getFolderInfo(before, -1);
             //suppress asking user to copy/move if source has 0 files
-            if (folderInfoBeforeRaw.fileCount == 0 && folderInfoBeforeRaw.resultIsIncomplete) {
+            if (folderInfoBeforeRaw.fileCount == 0 && !folderInfoBeforeRaw.resultIsIncomplete) {
                 askUserForCopyMove = false;
             }
         }


### PR DESCRIPTION
don't show file copy dialog on clean install (fix #11846)