### PR TITLE
Import GPX track files with missing namespace id (fix #13852)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -53,6 +53,7 @@ public class GPXTrackOrRouteImporter {
 
     private static Route doInBackground(final Uri uri) {
         try {
+            // default: import properly formatted routes or tracks
             Route route = parse(new GPXTrackParser("http://www.topografix.com/GPX/1/1", "1.1"), uri);
             if (null == route) {
                 route = parse(new GPXRouteParser("http://www.topografix.com/GPX/1/1", "1.1"), uri);
@@ -63,11 +64,16 @@ public class GPXTrackOrRouteImporter {
             if (null == route) {
                 route = parse(new GPXRouteParser("http://www.topografix.com/GPX/1/0", "1.0"), uri);
             }
+            // import waypoints as tracks
             if (null == route) {
                 route = parse(new GPXWptAsTrackParser("http://www.topografix.com/GPX/1/1", "1.1"), uri);
             }
             if (null == route) {
                 route = parse(new GPXWptAsTrackParser("http://www.topografix.com/GPX/1/0", "1.0"), uri);
+            }
+            // as last resort ignore missing namespace identifier
+            if (null == route) {
+                route = parse(new GPXTrackParser("", "1.0"), uri);
             }
             if (null != route) {
                 route.calculateNavigationRoute();


### PR DESCRIPTION
## Description
Import GPX track files without proper namespace identifier as version 1.0 track files (fallback solution).