### PR TITLE
GPX-Parser: read name as geocode for unknown_connector (fix #13794)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/files/GPXParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/files/GPXParserTest.java
@@ -670,4 +670,20 @@ public class GPXParserTest  {
         final Geocache cache = caches.get(0);
         assertThat(cache.getSize()).isEqualTo(CacheSize.NANO);
     }
+
+    /**
+     * import 5 waypoints with duplicates and similar names:
+     * "268591", "268591", "268591 1", "268591 2", "268591-1"
+     * -> 4 waypoints should be imported
+     */
+    @Test
+    public void testIgnoreDuplicateCache() throws Exception {
+        final List<Geocache> caches = readGPX11(R.raw.no_connector_dupliactes);
+        assertThat(caches).hasSize(4);
+
+        assertThat(caches.stream().filter(cache -> cache.getGeocode().equals("268591")).count()).isEqualTo(1);
+        assertThat(caches.stream().filter(cache -> cache.getGeocode().equals("268591 1")).count()).isEqualTo(1);
+        assertThat(caches.stream().filter(cache -> cache.getGeocode().equals("268591 2")).count()).isEqualTo(1);
+        assertThat(caches.stream().filter(cache -> cache.getGeocode().equals("268591-1")).count()).isEqualTo(1);
+    }
 }

--- a/main/src/androidTest/res/raw/no_connector_dupliactes.gpx
+++ b/main/src/androidTest/res/raw/no_connector_dupliactes.gpx
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gpx
+ xmlns="http://www.topografix.com/GPX/1/1"
+ creator="OziExplorer Version 3956f - http://www.oziexplorer.com"
+ version="1.1"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+ <time>2022-12-25T09:03:59Z</time>
+ <bounds minlat="55.917333" minlon="92.275015" maxlat="56.021194" maxlon="92.978554"/>
+</metadata>
+<wpt lat="56.0051300" lon="92.8536300">
+ <time>2021-07-04T00:00:00.000Z</time>
+ <name>268591 1</name>
+</wpt>
+<wpt lat="56.0067300" lon="92.8726700">
+ <time>2021-07-04T00:00:00.000Z</time>
+ <name>268591 2</name>
+</wpt>
+<wpt lat="56.0051300" lon="92.8536300">
+ <time>2021-07-04T00:00:00.000Z</time>
+ <name>268591</name>
+</wpt>
+<wpt lat="56.0067300" lon="92.8726700">
+ <time>2021-07-04T00:00:00.000Z</time>
+ <name>268591</name>
+</wpt>
+<wpt lat="56.0067300" lon="92.8726700">
+ <time>2021-07-04T00:00:00.000Z</time>
+ <name>268591-1</name>
+</wpt>
+</gpx>

--- a/main/src/main/java/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXParser.java
@@ -932,8 +932,10 @@ abstract class GPXParser extends FileParser {
             // a geocode should not be part of a word
             if (geocode.length() == trimmed.length() || Character.isWhitespace(trimmed.charAt(geocode.length()))) {
                 final IConnector foundConnector = ConnectorFactory.getConnector(geocode);
-                if (!foundConnector.equals(ConnectorFactory.UNKNOWN_CONNECTOR) || useUnknownConnector) {
+                if (!foundConnector.equals(ConnectorFactory.UNKNOWN_CONNECTOR)) {
                     cache.setGeocode(geocode);
+                } else if (useUnknownConnector) {
+                    cache.setGeocode(trimmed);
                 }
             }
         }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
While reading / importing caches from a gpx-file, use the whole name as geocode for unknown_connector (unknown-connector supports any text as geocode)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #13794 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->