### PR TITLE
synchronize empty waypoint description (fix #11762 )

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -111,9 +111,12 @@ public class Waypoint implements IWaypoint {
         if (coords == null) {
             coords = old.coords;
         }
-        if (StringUtils.isBlank(note)) {
+
+        // keep note only for user-defined waypoints
+        if (StringUtils.isBlank(note) && isUserDefined()) {
             note = old.note;
         }
+
         if (StringUtils.isBlank(userNote)) {
             userNote = old.userNote;
         }

--- a/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
@@ -153,6 +153,17 @@ public class WaypointTest {
     }
 
     @Test
+    public void testMergeNoteEmptyServerNote() {
+        final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        local.setNote("Old Note");
+        local.setUserNote("Local User Note");
+        final Waypoint server = new Waypoint("Stage 1", WaypointType.STAGE, false);
+        server.merge(local);
+        assertThat(server.getNote()).isEqualTo("");
+        assertThat(server.getUserNote()).isEqualTo("Local User Note");
+    }
+
+    @Test
     public void testGetDefaultWaypointName() {
         final Geocache cache = new Geocache();
         // all test cases check numbering across different waypoint types

--- a/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
@@ -72,7 +72,7 @@ public class WaypointTest {
 
         assertThat(server.getPrefix()).isEqualTo("S1");
         assertThat(server.getCoords()).isEqualTo(new Geopoint("N 45°49.739 E 9°45.038"));
-        assertThat(server.getNote()).isEqualTo("Note");
+        assertThat(server.getNote()).isEqualTo("");
         assertThat(server.getUserNote()).isEqualTo("User Note");
         assertThat(server.isVisited()).isTrue();
         assertThat(server.getId()).isEqualTo(4711);
@@ -153,13 +153,24 @@ public class WaypointTest {
     }
 
     @Test
-    public void testMergeNoteEmptyServerNote() {
+    public void testMergeNoteEmptyNoteServerWP() {
         final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, false);
         local.setNote("Old Note");
         local.setUserNote("Local User Note");
         final Waypoint server = new Waypoint("Stage 1", WaypointType.STAGE, false);
         server.merge(local);
         assertThat(server.getNote()).isEqualTo("");
+        assertThat(server.getUserNote()).isEqualTo("Local User Note");
+    }
+
+    @Test
+    public void testMergeNoteEmptyNoteUserWP() {
+        final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, true);
+        local.setNote("Old Note");
+        local.setUserNote("Local User Note");
+        final Waypoint server = new Waypoint("Stage 1", WaypointType.STAGE, true);
+        server.merge(local);
+        assertThat(server.getNote()).isEqualTo("Old Note");
         assertThat(server.getUserNote()).isEqualTo("Local User Note");
     }
 

--- a/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
@@ -129,6 +129,24 @@ public class WaypointTest {
     }
 
     @Test
+    public void testMergeStageWPWithLocalCoords() {
+        final Waypoint local = new Waypoint("STAGE", WaypointType.STAGE, false);
+        local.setCoords(new Geopoint("N 45°49.739 E 9°45.038"));
+        final Waypoint server = new Waypoint("STAGE", WaypointType.STAGE, false);
+        server.merge(local);
+        assertThat(server.getCoords()).isEqualTo(new Geopoint("N 45°49.739 E 9°45.038"));
+    }
+
+    @Test
+    public void testMergeStageWPWithServerCoords() {
+        final Waypoint local = new Waypoint("STAGE", WaypointType.STAGE, false);
+        final Waypoint server = new Waypoint("STAGE", WaypointType.STAGE, false);
+        server.setCoords(new Geopoint("N 45°49.739 E 9°45.038"));
+        server.merge(local);
+        assertThat(server.getCoords()).isEqualTo(new Geopoint("N 45°49.739 E 9°45.038"));
+    }
+
+    @Test
     public void testMergeNote() {
         final Waypoint local = new Waypoint("Stage 1", WaypointType.STAGE, false);
         local.setNote("Old Note");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
For server-side waypoints, always the original description / note will be taken, even if it's an empty one.

An empty description of a waypoint will be only overwritten for user-defined waypoints with an already existing description.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #11762

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->