### PR TITLE
enable Lab-button also for bonus caches with link to lab

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -170,6 +170,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
@@ -1615,15 +1617,17 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         private void updateALCBox(final CacheDetailActivity activity) {
-            final boolean isEnabled = cache.getType() == CacheType.ADVLAB && StringUtils.isNotEmpty(cache.getUrl());
+            final boolean isLabListing = cache.getType() == CacheType.ADVLAB && StringUtils.isNotEmpty(cache.getUrl());
+            final boolean isEnabled = isLabListing || (cache.getType() == CacheType.MYSTERY && findAdvLabUrl(cache) != null);
             final Intent alc = ProcessUtils.getLaunchIntent(getString(R.string.package_alc));
             binding.alcBox.setVisibility(isEnabled ? View.VISIBLE : View.GONE);
-            binding.alcText.setText(alc != null ? R.string.cache_alc_start : R.string.cache_alc_install);
+            binding.alcText.setText(alc != null ? (isLabListing ? R.string.cache_alc_start : R.string.cache_alc_related_start) : R.string.cache_alc_install);
             if (isEnabled) {
+                final String advLabUrl = isLabListing ? cache.getUrl() : findAdvLabUrl(cache);
                 binding.sendToAlc.setOnClickListener(v -> {
                     // re-check installation state, might have changed since creating the view
                     if (alc != null) {
-                        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(cache.getUrl()));
+                        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(advLabUrl));
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         activity.startActivity(intent);
                     } else {
@@ -1631,6 +1635,24 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                     }
                 });
             }
+        }
+
+        @Nullable
+        /**
+         * Find links to Adventure Labs in Listing of a cache. Returns URL if exactly 1 link target is found, else null.
+         * 3 types of URLs possible: https://adventurelab.page.link/Cw3L, https://labs.geocaching.com/goto/Theater, https://labs.geocaching.com/goto/a4b45b7b-fa76-4387-a54f-045875ffee0c
+         */
+        private static String findAdvLabUrl(final Geocache cache) {
+            final Pattern patternAdvLabUrl = Pattern.compile("(https?://labs.geocaching.com/goto/[a-zA-Z0-9-_]{1,36}|https?://adventurelab.page.link/[a-zA-Z0-9]{4})");
+            final Matcher matcher = patternAdvLabUrl.matcher(cache.getShortDescription() + " " + cache.getDescription());
+            final Set<String> urls = new HashSet<>();
+            while (matcher.find()) {
+                urls.add(matcher.group(1));
+            }
+            if (urls.size() == 1) {
+                return urls.iterator().next();
+            }
+            return null;
         }
     }
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1576,6 +1576,7 @@
     <string name="cache_chirpwolf_start">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can open Chirp Wolf.</string>
     <string name="cache_chirpwolf_install">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can install Chirp Wolf.</string>
     <string name="cache_alc_start">Open Adventure Lab to start playing this adventure</string>
+    <string name="cache_alc_related_start">Open Adventure Lab to start playing related adventure</string>
     <string name="cache_alc_install">Install Adventure Lab player to play this adventure</string>
 
     <string name="context_share_as_text">Share text</string>


### PR DESCRIPTION
When a Mystery (unknown) cache includes a link to an Adventure Lab cache assume that it's a Bonus for that Adventure Lab and allow starting the Adventure Lab from Details tab - just like for ALCs opened in c:geo

fixes #13832