### PR TITLE
Add support for 'Voluntary MF5' OAM theme (fix #13866)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
@@ -100,13 +100,13 @@ public void testOpenAndroMaps() {
         final List<Download> list = getList(MapDownloaderOpenAndroMapsThemes.getInstance(), CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_updatecheckurl));
 
         // number of themes
-        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.size()).isEqualTo(2);
 
         // number of dirs found
         assertThat(count(list, true)).isEqualTo(0);
 
         // number of non-dirs found
-        assertThat(count(list, false)).isEqualTo(1);
+        assertThat(count(list, false)).isEqualTo(2);
 
         // check one named entry
         final Download d = findByName(list, "Elevate");

--- a/main/src/main/java/cgeo/geocaching/downloader/AbstractMapDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/AbstractMapDownloader.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.utils.FileUtils;
 
 import android.net.Uri;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import java.util.List;
@@ -29,8 +30,20 @@ abstract class AbstractMapDownloader extends AbstractDownloader {
         MapsforgeMapProvider.getInstance().updateOfflineMaps(result);
     }
 
-    // check if any of the given file exists in the given path
-    // if none exists: return descriptor for it
+    /**
+     * Check if any of the given files already exists in the given path
+     *
+     * @param filenames
+     *      Array of filenames to check for
+     * @param baseUrl
+     *      Base URL for the first filename
+     * @param offlineMapType
+     *      Descriptor type to return
+     * @return
+     *      Returns null, if any of the given files found.
+     *      Returns a download descriptor for the first entry (so baseUrl must be valid for that entry)
+     */
+    @Nullable
     public DownloaderUtils.DownloadDescriptor getExtrafile(final String[] filenames, final String baseUrl, final Download.DownloadType offlineMapType) {
         final List<ContentStorage.FileInformation> dirContent = ContentStorage.get().list(PersistableFolder.OFFLINE_MAP_THEMES);
         for (ContentStorage.FileInformation fi : dirContent) {

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -19,7 +19,7 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     private static final Pattern PATTERN_MAP = Pattern.compile("<a href=\"([A-Za-z0-9_-]+\\.zip)\">([A-Za-z0-9_-]+)\\.zip<\\/a>[ ]*([0-9]{2}-[A-Za-z]{3}-[0-9]{4}) [0-9]{2}:[0-9]{2}[ ]*([0-9]+)"); // 1:file name, 2:display name, 3:date DD-MMM-YYYY, 4:size (bytes)
     private static final Pattern PATTERN_DIR = Pattern.compile("<a href=\"([A-Z-a-z0-9]+\\/)\">([A-Za-z0-9]+)\\/<\\/a>");  // 1:file name, 2:display name
     private static final Pattern PATTERN_UP = Pattern.compile("<a href=\"(\\.\\.\\/)\">(\\.\\.)\\/<\\/a>"); // 1:relative dir, 2:..
-    private static final String[] THEME_FILES = {"Elevate.zip"};
+    private static final String[] THEME_FILES = {"Elevate.zip", MapDownloaderOpenAndroMapsThemes.FILENAME_VOLUNTARY};
     private static final MapDownloaderOpenAndroMaps INSTANCE = new MapDownloaderOpenAndroMaps();
 
     private MapDownloaderOpenAndroMaps() {

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsThemes.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.downloader;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Download;
+import cgeo.geocaching.network.Network;
+import cgeo.geocaching.network.Parameters;
 import cgeo.geocaching.utils.MatcherWrapper;
 
 import android.net.Uri;
@@ -10,12 +12,20 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Pattern;
+
+import okhttp3.Response;
+import org.apache.commons.lang3.StringUtils;
 
 public class MapDownloaderOpenAndroMapsThemes extends AbstractThemeDownloader {
 
-    private static final Pattern PATTERN_LAST_UPDATED_DATE = Pattern.compile("<a href=\"https:\\/\\/www\\.openandromaps\\.org\\/wp-content\\/users\\/tobias\\/version\\.txt\">[0-9]\\.[0-9](\\.[0-9])?<\\/a><\\/strong>, ([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{2}) ");
+    protected static final String FILENAME_VOLUNTARY = "Voluntary MF5.zip";
+    private static final Pattern PATTERN_LAST_UPDATED_DATE_ELEVATE = Pattern.compile("<a href=\"https:\\/\\/www\\.openandromaps\\.org\\/wp-content\\/users\\/tobias\\/version\\.txt\">[0-9]\\.[0-9](\\.[0-9])?<\\/a><\\/strong>, ([0-9]{1,2})\\.([0-9]{1,2})\\.([0-9]{2}) ");
+    private static final Pattern PATTERN_LAST_UPDATED_DATE_VOLUNTARY = Pattern.compile(FILENAME_VOLUNTARY + "<\\/a>\\s*([0-9]{1,2})-([A-Za-z]{3})-([0-9]{4})");
     private static final MapDownloaderOpenAndroMapsThemes INSTANCE = new MapDownloaderOpenAndroMapsThemes();
 
     private MapDownloaderOpenAndroMapsThemes() {
@@ -28,20 +38,52 @@ public class MapDownloaderOpenAndroMapsThemes extends AbstractThemeDownloader {
         if (file != null) {
             list.add(file);
         }
+
+        // small hack to support a second theme from a different location
+        final String urlVoluntary = CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_voluntary_downloadurl);
+        String pageVoluntary = null;
+        try {
+            final Response response = Network.getRequest(urlVoluntary, new Parameters()).blockingGet();
+            pageVoluntary = Network.getResponseData(response, true);
+        } catch (final Exception ignore) {
+            // ignore
+        }
+        if (StringUtils.isNotBlank(pageVoluntary)) {
+            final Download fileVoluntary = checkUpdateFor(pageVoluntary, urlVoluntary, FILENAME_VOLUNTARY);
+            if (fileVoluntary != null) {
+                list.add(fileVoluntary);
+            }
+        }
     }
 
     @Nullable
     @Override
     protected Download checkUpdateFor(final @NonNull String page, final String remoteUrl, final String remoteFilename) {
-        final MatcherWrapper matchDate = new MatcherWrapper(PATTERN_LAST_UPDATED_DATE, page);
+        // check for elevate
+        final MatcherWrapper matchDate = new MatcherWrapper(PATTERN_LAST_UPDATED_DATE_ELEVATE, page);
         if (matchDate.find()) {
             final String date = "20" + matchDate.group(4) + "-" + matchDate.group(3) + "-" + matchDate.group(2);
             return new Download("Elevate", Uri.parse(CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_downloadurl) + "Elevate.zip"), false, date, "", offlineMapType, iconRes);
         }
+        // check for voluntary
+        final MatcherWrapper matchDateVoluntary = new MatcherWrapper(PATTERN_LAST_UPDATED_DATE_VOLUNTARY, page);
+        if (matchDateVoluntary.find()) {
+            String date = matchDateVoluntary.group(3) + "-" + matchDateVoluntary.group(2) + "-" + matchDateVoluntary.group(1);
+            try {
+                // convert date returned by server into ISO format
+                final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MMM-dd", Locale.GERMANY);
+                date = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Objects.requireNonNull(formatter.parse(date)));
+            } catch (Exception ignore) {
+                // ignore
+            }
+            return new Download("Voluntary", Uri.parse(CgeoApplication.getInstance().getString(R.string.mapserver_openandromaps_themes_voluntary_downloadurl) + FILENAME_VOLUNTARY), false, date, "", offlineMapType, iconRes);
+        }
+        // neither found
         return null;
     }
 
     // elevate uses different servers for update check and download, need to map here
+    // no mapping needed for voluntary theme
     @Override
     protected String getUpdatePageUrl(final String downloadPageUrl) {
         final String compare = downloadPageUrl.endsWith("/") ? downloadPageUrl : downloadPageUrl + "/";

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -278,6 +278,7 @@
     <string translatable="false" name="mapserver_openandromaps_themes_name">OpenAndroMaps Theme</string>
     <string translatable="false" name="mapserver_openandromaps_themes_downloadurl">https://www.openandromaps.org/wp-content/users/tobias/</string>
     <string translatable="false" name="mapserver_openandromaps_themes_updatecheckurl">https://www.openandromaps.org/kartenlegende/elevation-hike-theme</string>
+    <string translatable="false" name="mapserver_openandromaps_themes_voluntary_downloadurl">https://ftp.gwdg.de/pub/misc/openstreetmap/openandromaps/themes/voluntary/downloads/</string>
 
     <string translatable="false" name="mapserver_freizeitkarte_name">Freizeitkarte</string>
     <string translatable="false" name="mapserver_freizeitkarte_downloadurl">http://repository.freizeitkarte-osm.de/repository_freizeitkarte_android.xml</string>


### PR DESCRIPTION
## Description
Add support for "Voluntary MF5" theme for OAM maps:
- offer theme when downloading maps from OAM
- check for theme updates
- don't download Elevate theme automatically, if Voluntary is already present
- adapt tests for OAM themes
