### PR TITLE
Fix missing routing symbol after 'append to route' (fix #13850)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -585,7 +585,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             individualRoute = new IndividualRoute(this::setNavigationTargetFromIndividualRoute);
         }
         individualRoute.toggleItem(this.mapView.getContext(), new RouteItem(item), overlayPositionAndScale);
-        mapActivity.getRouteTrackUtils().updateRouteTrackButtonVisibility(activity.findViewById(R.id.container_individualroute), individualRoute, mapActivity.getTracks());
+        updateRouteTrackButtonVisibility();
         overlayPositionAndScale.repaintRequired();
     }
 
@@ -804,7 +804,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     public void triggerLongTapContextMenu(final Point tapXY) {
         if (Settings.isLongTapOnMapActivated()) {
             MapUtils.createMapLongClickPopupMenu(activity, new Geopoint(overlayPositionAndScale.getLongTapLatLng().latitude, overlayPositionAndScale.getLongTapLatLng().longitude),
-                            tapXY.x, tapXY.y, individualRoute, overlayPositionAndScale, getCurrentTargetCache(), mapOptions)
+                            tapXY.x, tapXY.y, individualRoute, overlayPositionAndScale, this::updateRouteTrackButtonVisibility, getCurrentTargetCache(), mapOptions)
                     .setOnDismissListener(menu -> overlayPositionAndScale.resetLongTapLatLng())
                     .show();
         }
@@ -854,7 +854,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     public void setTrack(final String key, final IGeoDataProvider route) {
         mapActivity.getTracks().setRoute(key, route);
         resumeTrack(key, null == route);
-        mapActivity.getRouteTrackUtils().updateRouteTrackButtonVisibility(activity.findViewById(R.id.container_individualroute), individualRoute, mapActivity.getTracks());
+        updateRouteTrackButtonVisibility();
     }
 
     @Override
@@ -868,7 +868,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     public void reloadIndividualRoute() {
         individualRoute.reloadRoute((route) -> {
             overlayPositionAndScale.updateIndividualRoute(route);
-            mapActivity.getRouteTrackUtils().updateRouteTrackButtonVisibility(activity.findViewById(R.id.container_individualroute), individualRoute, mapActivity.getTracks());
+            updateRouteTrackButtonVisibility();
             mapView.repaintRequired(overlayPositionAndScale instanceof GeneralOverlay ? ((GeneralOverlay) overlayPositionAndScale) : null);
         });
     }
@@ -884,9 +884,13 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     public void clearIndividualRoute() {
         individualRoute.clearRoute((route) -> {
             overlayPositionAndScale.repaintRequired();
-            mapActivity.getRouteTrackUtils().updateRouteTrackButtonVisibility(activity.findViewById(R.id.container_individualroute), individualRoute, mapActivity.getTracks());
+            updateRouteTrackButtonVisibility();
             ActivityMixin.showToast(activity, res.getString(R.string.map_individual_route_cleared));
         });
+    }
+
+    private void updateRouteTrackButtonVisibility() {
+        mapActivity.getRouteTrackUtils().updateRouteTrackButtonVisibility(activity.findViewById(R.id.container_individualroute), individualRoute, mapActivity.getTracks());
     }
 
     private void setMapRotation(final MenuItem item, final int rotation) {

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -183,7 +183,7 @@ public class MapUtils {
     /**
      * @return the complete popup builder without dismiss listener specified
      */
-    public static SimplePopupMenu createMapLongClickPopupMenu(final Activity activity, final Geopoint longClickGeopoint, final int tapX, final int tapY, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Geocache currentTargetCache, final MapOptions mapOptions) {
+    public static SimplePopupMenu createMapLongClickPopupMenu(final Activity activity, final Geopoint longClickGeopoint, final int tapX, final int tapY, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Runnable updateRouteTrackButtonVisibility, final Geocache currentTargetCache, final MapOptions mapOptions) {
         final int offset = ResourcesCompat.getDrawable(activity.getResources(), R.drawable.map_pin, null).getIntrinsicHeight() / 2;
 
         return SimplePopupMenu.of(activity)
@@ -209,8 +209,14 @@ public class MapUtils {
                     textview.set(dialog.findViewById(android.R.id.message));
                     new CoordinatesFormatSwitcher().setView(textview.get()).setCoordinate(longClickGeopoint);
                 })
-                .addItemClickListener(R.id.menu_add_to_route, item -> individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, false))
-                .addItemClickListener(R.id.menu_add_to_route_start, item -> individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, true))
+                .addItemClickListener(R.id.menu_add_to_route, item -> {
+                    individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, false);
+                    updateRouteTrackButtonVisibility.run();
+                })
+                .addItemClickListener(R.id.menu_add_to_route_start, item -> {
+                    individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, true);
+                    updateRouteTrackButtonVisibility.run();
+                })
                 .addItemClickListener(R.id.menu_navigate, item -> NavigationAppFactory.showNavigationMenu(activity, null, null, longClickGeopoint, false, true));
     }
 }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -556,7 +556,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         individualRoute.clearRoute(routeLayer);
         individualRoute.clearRoute((route) -> {
             routeLayer.updateIndividualRoute(route);
-            routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
+            updateRouteTrackButtonVisibility();
         });
         distanceView.showRouteDistance();
         showToast(res.getString(R.string.map_individual_route_cleared));
@@ -974,6 +974,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
             MapUtils.createMapLongClickPopupMenu(this, new Geopoint(tapHandlerLayer.getLongTapLatLong().latitude, tapHandlerLayer.getLongTapLatLong().longitude),
                             (int) tapXY.x, (int) tapXY.y, individualRoute, routeLayer,
+                            this::updateRouteTrackButtonVisibility,
                             getCurrentTargetCache(), mapOptions)
                     .setOnDismissListener(menu -> tapHandlerLayer.resetLongTapLatLong())
                     .show();
@@ -1385,7 +1386,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         }
         individualRoute.toggleItem(this, new RouteItem(item), routeLayer);
         distanceView.showRouteDistance();
-        routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
+        updateRouteTrackButtonVisibility();
     }
 
     @Nullable
@@ -1470,7 +1471,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     private void setTrack(final String key, final IGeoDataProvider route) {
         tracks.setRoute(key, route);
         resumeTrack(key, null == route);
-        routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
+        updateRouteTrackButtonVisibility();
     }
 
     private void reloadIndividualRoute() {
@@ -1480,12 +1481,16 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     private void reloadIndividualRouteFollowUp(final Route route) {
         if (null != routeLayer) {
             routeLayer.updateIndividualRoute(route);
-            routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
+            updateRouteTrackButtonVisibility();
         } else {
             // try again in 0.25 seconds
             new Handler(Looper.getMainLooper()).postDelayed(() -> reloadIndividualRouteFollowUp(route), 250);
         }
     }
+
+    private void updateRouteTrackButtonVisibility() {
+        routeTrackUtils.updateRouteTrackButtonVisibility(findViewById(R.id.container_individualroute), individualRoute, tracks);
+    };
 
     private Boolean isTargetSet() {
         return StringUtils.isNotBlank(targetGeocode) && null != lastNavTarget;


### PR DESCRIPTION
## Description
On creating a new route by using long-tap, "Append to route", no routing quick settings icon was displayed on map. This PR fixes this.