### PR TITLE
Add route calculation for prepending points (fix #13849)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
@@ -148,10 +148,13 @@ public class IndividualRoute extends Route implements Parcelable {
             if (segment.hasPoint()) {
                 if (addToRouteStart) {
                     segments.add(0, segment);
+                    if (segments.size() > 1) {
+                        calculateNavigationRoute(1);
+                    }
                 } else {
                     segments.add(segment);
+                    calculateNavigationRoute(segments.size() - 1);
                 }
-                calculateNavigationRoute(segments.size() - 1);
                 return ToggleItemState.ADDED;
             } else {
                 return ToggleItemState.ERROR_NO_POINT;


### PR DESCRIPTION
## Description
Until now only the last segment got recalculated on adding a segment. This PR adapts this behavior if new segment got prepended.