### PR TITLE
Display GC member state on home screen (rel. to #13796)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.capability.IAvatar;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.BookmarkListActivity;
+import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.PocketQueryListActivity;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.databinding.MainActivityBinding;
@@ -170,6 +171,9 @@ public class MainActivity extends AbstractBottomNavigationActivity {
                                         return new Pair<>(userFoundCount, userNameText);
                                     },
                                     p -> {
+                                        if (conn instanceof GCConnector) {
+                                            connectorStatus.setText(connInfo.append(Formatter.SEPARATOR).append(CgeoApplication.getInstance().getString(Settings.isGCPremiumMember() ? R.string.gc_premium : R.string.gc_basic)));
+                                        }
                                         final TextView userName = connectorInfo.findViewById(R.id.item_title);
                                         final TextView userFounds = connectorInfo.findViewById(R.id.item_info);
                                         userName.setText(p.second);

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -328,6 +328,9 @@
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>
     <string name="switched_to_mf">Default map switched to Mapsforge map provider. Restart your map now.</string>
 
+    <string name="gc_premium">Premium</string>
+    <string name="gc_basic">Basic</string>
+
     <!-- location service -->
     <string name="loc_last">Last known</string>
     <string name="loc_net">Network</string>


### PR DESCRIPTION
## Description
Displays either "(Basic)" or "(Premium)" after connector status info on home screen (for GCConnector only):

![image](https://user-images.githubusercontent.com/3754370/212561939-92615011-9419-4b11-bc96-f7509bcdbffe.png)

Not sure if we should make those strings translatable or not. How does GC handle this?