### PR TITLE
Ignore updates to the apache 'commons-text' package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,18 @@ updates:
     # no limit :)
     open-pull-requests-limit: 30
     ignore:
-      # Ignore some updates to the apache 'commons-io' package
+      # Ignore updates to the apache 'commons-io' package
       # commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
       - dependency-name: "commons-io:commons-io"
-      # Ignore some updates to the apache 'commons-io' package
+      # Ignore updates to the apache 'commons-io' package
       # commons-compress 1.21 uses (more) java.nio.file.Path - which is first contained in Android API26
       - dependency-name: "org.apache.commons:commons-compress"
-      # Ignore some updates to the apache 'commons-lang3' package
+      # Ignore updates to the apache 'commons-lang3' package
       # commons-lang3 3.12.0 uses StringJoiner which is first contained in Android API24
       - dependency-name: "org.apache.commons:commons-lang3"
+      # Ignore updates to the apache 'commons-text' package
+      # commons-text 1.10.0 uses commons-lang3 3.12.0 and commons-io 2.11.0, wait for updating both
+      - dependency-name: "org.apache.commons:commons-text"
       # Ignore some updates to the 'assertj' package
       # Ignore only new versions for >= 3.x
       - dependency-name: "org.assertj:assertj-core"

--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -57,6 +57,7 @@ android {
 dependencies {
     // Apache Commons
     // commons-lang3 3.12.0 uses StringJoiner which is first contained in API24. See https://github.com/cgeo/cgeo/issues/12577
+    //noinspection GradleDependency
     implementation 'org.apache.commons:commons-lang3:3.11'
     // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26
     // could be replaced by Storage Access Framework

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -302,6 +302,9 @@ dependencies {
     // See https://github.com/cgeo/cgeo/issues/12577
     //noinspection GradleDependency
     implementation 'org.apache.commons:commons-lang3:3.11'
+
+    // commons-text 1.10.0 uses commons-lang3 3.12.0 and commons-io 2.11.0, wait for updating both
+    //noinspection GradleDependency
     implementation 'org.apache.commons:commons-text:1.9'
 
     // commons-io 2.6 uses java.nio.file.Path - which is first contained in Android API26


### PR DESCRIPTION
... because of transitive dependency to other `commons-xxx` packages.

