### PR TITLE
add proguard rule for slf4j

### DIFF
--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -140,3 +140,6 @@
 
 # keep Emma code coverage during debug builds, and ignore related warnings
 -dontwarn com.vladium.**
+
+# transitive needed using R8 (minifyEnabled)
+-dontwarn org.slf4j.impl.StaticLoggerBinder


### PR DESCRIPTION
as found in the nightlies:
~~~
00:33:35  > Task :main:minifyBasicNightlyWithR8
00:34:29  WARNING:Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /srv/jenkins/jobs/cgeo nightly/workspace/main/build/outputs/mapping/basicNightly/missing_rules.txt. 00:34:29
00:34:29  WARNING:R8: Missing class org.slf4j.impl.StaticLoggerBinder (referenced from: void org.slf4j.LoggerFactory.bind() and 3 other contexts) 
~~~

This is not shown with `buildType.name == 'debug'`.
