### PR TITLE
Adapt Mapsforge test to new Portugal map size (fix #13889)

### DIFF
--- a/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/tests/src-android/cgeo/geocaching/downloader/DownloaderTest.java
@@ -67,7 +67,7 @@ public class DownloaderTest extends AbstractResourceInstrumentationTestCase {
         assertThat(d).isNotNull();
         final String sizeInfoString = d.getSizeInfo(); // 220M
         final int sizeInfoInt = Integer.parseInt(sizeInfoString.substring(0, sizeInfoString.length() - 1));
-        assertThat(sizeInfoInt).isBetween(200, 250);
+        assertThat(sizeInfoInt).isBetween(275, 350);
     }
 
     public static void testOpenAndroMaps() {


### PR DESCRIPTION
## Description
Portugal map size has exceeded the limits set by our test for Mapsforge data, so adapt the test's limits