### PR TITLE
UnifiedMap VTM: support built-in theme variants

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1621,6 +1621,15 @@ public class Settings {
         return getString(R.string.pref_renderthemefile, "");
     }
 
+    public static boolean isDefaultMapRenderTheme() {
+        return StringUtils.isBlank(getSelectedMapRenderTheme());
+    }
+
+    /** to be called by {@link cgeo.geocaching.unifiedmap.mapsforgevtm.VtmThemes} solely! */
+    public static String getVtmDefaultVariantName() {
+        return getString(R.string.pref_vtm_default, "");
+    }
+
     /**
      * Shall SOLELY be used by {@link cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper}!
      */

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
@@ -176,7 +176,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
 
     private void applyDefaultTheme(final Map map, final AbstractTileProvider tileProvider) {
         if (tileProvider.supportsThemes()) {
-            mTheme = map.setTheme(VtmThemes.OSMARENDER);
+            mTheme = map.setTheme(VtmThemes.getDefaultVariant());
         }
         applyScales(Settings.RENDERTHEMESCALE_DEFAULTKEY);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
@@ -62,6 +62,10 @@ public class MapsforgeThemeSettingsFragment extends PreferenceFragmentCompat {
             themeStylePrefKey = Settings.RENDERTHEMESCALE_DEFAULTKEY;
         }
 
+        if (Settings.isDefaultMapRenderTheme()) {
+            this.renderthemeMenu.addPreference(VtmThemes.getPreference(activity));
+        }
+
         //scale preferences for theme
         addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.MAP),
                 R.string.maptheme_scale_map_title, R.string.maptheme_scale_map_summary);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/VtmThemes.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/VtmThemes.java
@@ -22,8 +22,16 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+
+import android.content.Context;
+
+import androidx.preference.ListPreference;
+
 import java.io.InputStream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.oscim.backend.AssetAdapter;
 import org.oscim.theme.IRenderTheme.ThemeException;
 import org.oscim.theme.ThemeFile;
@@ -87,5 +95,39 @@ public enum VtmThemes implements ThemeFile {
     @Override
     public void setResourceProvider(final XmlThemeResourceProvider resourceProvider) {
         // intentionally left empty
+    }
+
+    /** returns ListPreference to select one of the built-in themes from */
+    public static ListPreference getPreference(final Context context) {
+        final ListPreference themeVariants = new ListPreference(context);
+        themeVariants.setTitle(R.string.vtm_theme_variant);
+        themeVariants.setSummary(getDefaultVariant().name());
+        themeVariants.setKey(context.getString(R.string.pref_vtm_default));
+        final CharSequence[] variants = new CharSequence[VtmThemes.values().length];
+        int i = 0;
+        for (VtmThemes vtmTheme : VtmThemes.values()) {
+            variants[i] = vtmTheme.name();
+            i++;
+        }
+        themeVariants.setEntries(variants);
+        themeVariants.setEntryValues(variants);
+        themeVariants.setOnPreferenceChangeListener((preference, newValue) -> {
+            themeVariants.setSummary(newValue.toString());
+            return true;
+        });
+        themeVariants.setDefaultValue(VtmThemes.OSMARENDER.name());
+        themeVariants.setIconSpaceReserved(false);
+        return themeVariants;
+    }
+
+    /** returns currently selected theme or default theme, if none configured */
+    public static VtmThemes getDefaultVariant() {
+        final String vtmDefaultVariantName = Settings.getVtmDefaultVariantName();
+        for (VtmThemes vtmTheme : VtmThemes.values()) {
+            if (StringUtils.equals(vtmTheme.name(), vtmDefaultVariantName)) {
+                return vtmTheme;
+            }
+        }
+        return OSMARENDER; // for compatibility reasons return this instead of DEFAULT
     }
 }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -493,6 +493,7 @@
     <string translatable="false" name="pref_autotarget_individualroute">autotarget_individualroute</string>
     <string translatable="false" name="pref_mapAutoDownloadsLastCheck">mapAutoDownloadsLastCheck</string>
     <string translatable="false" name="pref_renderthemefile">renderthemefile</string>
+    <string translatable="false" name="pref_vtm_default">vtm_default</string>
     <string translatable="false" name="pref_map_routing">map_routing</string>
     <string translatable="false" name="pref_theme_menu">theme_menu</string>
     <string translatable="false" name="pref_google_map_theme">google_map_theme</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2638,6 +2638,7 @@
     <string name="maptheme_scale_text_summary">Additionally scales text labels in map; 100% = no extra scaling</string>
     <string name="maptheme_scale_symbol_title">Symbol Scale factor</string>
     <string name="maptheme_scale_symbol_summary">Additionally scales symbol sizes in map; 100% = no extra scaling</string>
+    <string name="vtm_theme_variant">Theme Variant</string>
 
     <!-- history track -->
     <string name="map_clear_trailhistory">Clear history track</string>


### PR DESCRIPTION
## Description
Supports selecting one of the built-in VTM theme variants:

|OSMARENDER|DEFAULT|NEWTRON|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3754370/215326692-97e575d5-83a0-43d5-8ad5-bbf4c3930953.png)|![image](https://user-images.githubusercontent.com/3754370/215326716-09219752-8453-4ab1-87ae-7e857980c9b9.png)|![image](https://user-images.githubusercontent.com/3754370/215326730-d78d21a7-b458-4657-8f16-9c336d371f69.png)|

Although VTM uses a new DEFAULT theme, c:geo users are more accustomed to the OSMARENDER variant, so this is what c:geo will keep using as predefined theme variant.

Switching a variant is done using theme options.
