### PR TITLE
rel to #13793: refactor google maps drawing object handling

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
@@ -72,9 +72,9 @@ public class GoogleCacheOverlayItem implements CachesOverlayItemImpl, MapObjectO
                     .radius(GoogleCachesList.CIRCLE_RADIUS)
                     .zIndex(GoogleCachesList.ZINDEX_CIRCLE);
 
-            return new MapObjectOptions[]{MapObjectOptions.from(marker), MapObjectOptions.from(circle)};
+            return new MapObjectOptions[]{MapObjectOptions.marker(marker), MapObjectOptions.circle(circle)};
         } else {
-            return new MapObjectOptions[]{MapObjectOptions.from(marker)};
+            return new MapObjectOptions[]{MapObjectOptions.marker(marker)};
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleCachesList.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleCachesList.java
@@ -46,15 +46,15 @@ public class GoogleCachesList {
         }
         if (this.options == null) {
             this.options = options;
-            mapObjects.requestAdd(this.options);
+            mapObjects.add(this.options);
         } else {
             final Collection<MapObjectOptions> toRemove = diff(this.options, options);
             final Collection<MapObjectOptions> toAdd = toRemove.size() == this.options.size() ? options : diff(options, this.options);
 //            Log.i("From original " + this.options.size()  + " items will be " + toAdd.size() + " added and " + toRemove.size() + " removed to match new count " + options.size());
             this.options = options;
 
-            mapObjects.requestRemove(toRemove);
-            mapObjects.requestAdd(toAdd);
+            mapObjects.remove(toRemove);
+            mapObjects.add(toAdd);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapObjects.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapObjects.java
@@ -1,59 +1,23 @@
 package cgeo.geocaching.maps.google.v2;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.CircleOptions;
-import com.google.android.gms.maps.model.MarkerOptions;
-import com.google.android.gms.maps.model.PolygonOptions;
-import com.google.android.gms.maps.model.PolylineOptions;
 
 /**
- * class to wrap GoogleMapObjectsQueue, able to draw individually map objects and to remove all previously
- * drawn
+ * class to wrap GoogleMapObjectsQueue
  */
 public class GoogleMapObjects {
 
     private final GoogleMapObjectsQueue queue;
-    /**
-     * list of object options to be drawn to google map
-     */
-    private final Collection<MapObjectOptions> objects = new ArrayList<>();
 
     public GoogleMapObjects(final GoogleMap googleMap) {
         queue = new GoogleMapObjectsQueue(googleMap);
     }
 
-    protected void addOptions(final Object options) {
-        synchronized (objects) {
-            final MapObjectOptions opts = MapObjectOptions.from(options);
-            objects.add(opts);
-            queue.requestAdd(opts);
-        }
+    public void add(final MapObjectOptions opt) {
+        queue.add(opt);
     }
-
-    public void addMarker(final MarkerOptions opts) {
-        addOptions(opts);
-    }
-
-    public void addCircle(final CircleOptions opts) {
-        addOptions(opts);
-    }
-
-    public void addPolyline(final PolylineOptions opts) {
-        addOptions(opts);
-    }
-
-    public void addPolygon(final PolygonOptions opts) {
-        addOptions(opts);
-    }
-
 
     public void removeAll() {
-        synchronized (objects) {
-            queue.requestRemove(objects);
-            objects.clear();
-        }
+        queue.removeAll();
     }
 }

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapObjectsQueue.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapObjectsQueue.java
@@ -1,150 +1,270 @@
 package cgeo.geocaching.maps.google.v2;
 
+import cgeo.geocaching.utils.Log;
+
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Pair;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.Circle;
-import com.google.android.gms.maps.model.CircleOptions;
-import com.google.android.gms.maps.model.Marker;
-import com.google.android.gms.maps.model.Polygon;
-import com.google.android.gms.maps.model.Polyline;
 
+/**
+ * Represents and manages a group of drawable objects (such as markers, circles, polylines and polygons) on a concrete Google Map instance.
+ *
+ * This class provides methods to add and remove drawable objects to this map. It manages under the hood
+ * and asynchronous process to perform those add/removals in the background and with minimal impact on the Android GUI thread.
+ *
+ * This class works with instances of {@link MapObjectOptions} to encapsulate individual drawable objects. It relies heavily on
+ * equals() and hashCode() methods of this class.
+ */
 public class GoogleMapObjectsQueue {
 
+    /** magic number of milliseconds. maximum allowed time of adding or removing items to googlemap on UI thread */
+    protected static final long TIME_MAX = 40;
 
+    private static final String LOG_PREFIX = GoogleMapObjectsQueue.class.getSimpleName() + ": ";
+
+    //Google map with which this Group is associated
     private final GoogleMap googleMap;
+    private final ICommandExecutor commandExecutor;
 
+    //Runner instance which performs updates on google map asynchronous
+    private final RepaintRunner repaintRunner = new RepaintRunner();
     private boolean repaintRequested = false;
 
-    private final ConcurrentLinkedQueue<MapObjectOptions> requestedToAdd = new ConcurrentLinkedQueue<>();
-    private final ConcurrentLinkedQueue<MapObjectOptions> requestedToRemove = new ConcurrentLinkedQueue<>();
+    //Storage for currently drawn objects as well as requested actions.
+    //Implementation note: every access to these objects must be done under lock and leave them in a consistent state!
 
-    private final RepaintRunner repaintRunner = new RepaintRunner();
-
+    //Currently drawn/visible objects. Value Map is the Google Object representation (needed when removal is requested later)
+    private final Map<MapObjectOptions, Object> drawnObjects = new HashMap<>();
+    //All drawable objects which are currently requested to be added to map
+    private final Set<MapObjectOptions> requestedToAdd = new HashSet<>();
+    //All drawable objects which are currently requested to be removed from map
+    private final Set<MapObjectOptions> requestedToRemove = new HashSet<>();
+    //Current command queue. Contains not-yet-processed add/remove commands as Pair (options, flag), where flag=true means ADD and flag=false means REMOVE
+    // Commands may be outdated at time of processing e.g. if same object was requested to be added and removed in this order
+    // and those commands were not processed yet. In such a case, commands must be skipped at processing time
+    // according to content of requestedToAdd/requestedToRemove
+    private final Queue<Pair<MapObjectOptions, Boolean>> commandProcessQueue = new LinkedList<>();
+    // LOCK to acquire before any access to any of the above members to ensure correct concurrent behaviour
     private final Lock lock = new ReentrantLock();
 
+    //Executor of commands. This abstraction is used to inject another executor for unit testing
+    protected interface ICommandExecutor {
+        Object addToMap(GoogleMap map, MapObjectOptions obj);
+        void removeFromMap(Object mapObject);
+        void runOnUIThread(Runnable runnable);
+        boolean continueCommandExecution(long startTime, int queueLength);
+    }
+
+    private static final ICommandExecutor PROD_EXECUTOR = new ICommandExecutor() {
+        @Override
+        public Object addToMap(final GoogleMap map, final MapObjectOptions obj) {
+            return obj.addToGoogleMap(map);
+        }
+
+        @Override
+        public void removeFromMap(final Object mapObject) {
+            MapObjectOptions.removeFromGoogleMap(mapObject);
+        }
+
+        @Override
+        public void runOnUIThread(final Runnable runnable) {
+            // inspired by http://stackoverflow.com/questions/12850143/android-basics-running-code-in-the-ui-thread/25250494#25250494
+            // modifications of google map must be run on main (UI) thread
+            new Handler(Looper.getMainLooper()).post(runnable);
+        }
+
+        @Override
+        public boolean continueCommandExecution(final long startTime, final int queueLength) {
+            return System.currentTimeMillis() - startTime < TIME_MAX;
+        }
+    };
 
     public GoogleMapObjectsQueue(final GoogleMap googleMap) {
+        this(googleMap, PROD_EXECUTOR);
+    }
+
+    /** For usage in Unit-tests only! */
+    protected GoogleMapObjectsQueue(final GoogleMap googleMap, final ICommandExecutor commandExecutor) {
         this.googleMap = googleMap;
+        this.commandExecutor = commandExecutor;
     }
 
-    public void requestAdd(final Collection<? extends MapObjectOptions> toAdd) {
-        requestedToAdd.addAll(toAdd);
-        requestRepaint();
+    /** adds drawable objects to this MapObjectGroup */
+    public void add(final Collection<? extends MapObjectOptions> toAdd) {
+        requestChange(() -> {
+            for (MapObjectOptions opt : toAdd) {
+                addSingle(opt);
+            }
+        });
     }
 
-    public void requestAdd(final MapObjectOptions toAdd) {
-        requestedToAdd.add(toAdd);
-        requestRepaint();
+    /** adds drawable object to this MapObjectGroup */
+    public void add(final MapObjectOptions toAdd) {
+        add(Collections.singleton(toAdd));
     }
 
-    public void requestRemove(final Collection<? extends MapObjectOptions> toRemove) {
-        requestedToRemove.addAll(toRemove);
-        requestRepaint();
+    /** removes drawable objects to this MapObjectGroup */
+    public void remove(final Collection<? extends MapObjectOptions> toRemove) {
+        requestChange(() -> {
+            for (MapObjectOptions opt : toRemove) {
+                removeSingle(opt);
+            }
+        });
     }
 
-    void requestRepaint() {
+    /** removes ALL drawable objects from this MapObjectGroup */
+    public void removeAll() {
+        requestChange(() -> {
+            //clear all existing requests to add/remove
+            requestedToAdd.clear();
+            requestedToRemove.clear();
+            commandProcessQueue.clear();
+            //refill pipeline with requests to remove everything which is drawn
+            requestedToRemove.addAll(drawnObjects.keySet());
+            for (MapObjectOptions o : requestedToRemove) {
+                commandProcessQueue.add(new Pair<>(o, false));
+            }
+        });
+    }
+
+
+    /**
+     * replaces drawable objects in this group completely with given objects
+     *
+     * Same effect could be reached by calling removeAll() followed by add(newObjects),
+     * but performance is better when calling replace() method instead
+     */
+    public void replace(final Collection<? extends MapObjectOptions> newObjects) {
+        requestChange(() -> {
+            //calculate what to add/remove to currently drawn set to reach toReplace state finally
+            final Set<MapObjectOptions> toAdd = new HashSet<>(newObjects);
+            toAdd.removeAll(drawnObjects.keySet());
+            final Set<MapObjectOptions> toRemove = new HashSet<>(drawnObjects.keySet());
+            toRemove.removeAll(newObjects);
+            //clear all existing requests to add/remove
+            requestedToAdd.clear();
+            requestedToRemove.clear();
+            commandProcessQueue.clear();
+            //refill pipeline with requests to add/remove
+            requestedToAdd.addAll(toAdd);
+            requestedToRemove.addAll(toRemove);
+            for (MapObjectOptions o : toRemove) {
+                commandProcessQueue.add(new Pair<>(o, false));
+            }
+            for (MapObjectOptions o : toAdd) {
+                commandProcessQueue.add(new Pair<>(o, true));
+            }
+        });
+    }
+
+    //CALL ONLY WITH ACQUIRED LOCK!
+    private void addSingle(final MapObjectOptions options) {
+        //make sure that any pending removal requests for this object are removed
+        requestedToRemove.remove(options);
+
+        //we need to add only if object is not already drawn
+        if (!drawnObjects.containsKey(options) && requestedToAdd.add(options)) {
+            //only if there was no add request yet we need to add a command to processqueue
+            commandProcessQueue.add(new Pair<>(options, true));
+        }
+    }
+
+    //CALL ONLY WITH ACQUIRED LOCK!
+    private void removeSingle(final MapObjectOptions options) {
+        //makke sure that any pending add requests for this object are removed
+        requestedToAdd.remove(options);
+
+        //we need to delete only if object currently exists
+        if (drawnObjects.containsKey(options) && requestedToRemove.add(options)) {
+            //only if there was no remove request yet we need to add a command to processqueue
+            commandProcessQueue.add(new Pair<>(options, false));
+        }
+    }
+
+    private void requestChange(final Runnable changeAction) {
         lock.lock();
-        if (!repaintRequested) {
-            repaintRequested = true;
-            runOnUIThread(repaintRunner);
-        }
-        lock.unlock();
-    }
-
-    public void runOnUIThread(final Runnable runnable) {
-        // inspired by http://stackoverflow.com/questions/12850143/android-basics-running-code-in-the-ui-thread/25250494#25250494
-        // modifications of google map must be run on main (UI) thread
-        new Handler(Looper.getMainLooper()).post(runnable);
-    }
-
-
-    private static void removeDrawnObject(final Object obj) {
-        if (obj == null) {
-            return; // failsafe
-        }
-        if (obj instanceof Marker) {
-            ((Marker) obj).remove();
-        } else if (obj instanceof Circle) {
-            ((Circle) obj).remove();
-        } else if (obj instanceof Polyline) {
-            ((Polyline) obj).remove();
-        } else if (obj instanceof Polygon) {
-            ((Polygon) obj).remove();
-        } else {
-            throw new IllegalStateException();
+        try {
+            changeAction.run();
+            if (!repaintRequested) {
+                repaintRequested = true;
+                commandExecutor.runOnUIThread(repaintRunner);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
     private class RepaintRunner implements Runnable {
 
-        /**
-         * magic number of milliseconds. maximum allowed time of adding or removing items to googlemap
-         */
-        protected static final long TIME_MAX = 40;
-
-        private final Map<MapObjectOptions, Object> drawObjects = new HashMap<>();
-        private final Map<Object, MapObjectOptions> drawnBy = new HashMap<>();
-
-        private boolean removeRequested() {
+        //CALL ONLY WITH ACQUIRED LOCK!!!
+        private boolean processQueue() {
             final long time = System.currentTimeMillis();
-            MapObjectOptions options;
-            while ((options = requestedToRemove.poll()) != null) {
-                final Object obj = drawObjects.get(options);
-                if (obj != null) {
-                    removeDrawnObject(obj);
-                    drawnBy.remove(obj);
+            Pair<MapObjectOptions, Boolean> request;
+            while ((request = commandProcessQueue.poll()) != null) {
+                if (request.second) {
+                    //ADD request
+                    processAddCommand(request.first);
                 } else {
-                    // could not remove, is it enqueued to be draw?
-                    if (requestedToAdd.contains(options)) {
-                        // if yes, it is not anymore
-                        requestedToAdd.remove(options);
-                    }
+                    //REMOVE request
+                    processRemoveCommand(request.first);
                 }
-                if (System.currentTimeMillis() - time >= TIME_MAX) {
-                    // removing and adding markers are time costly operations and we don't want to block UI thread
-                    runOnUIThread(this);
+                if (!commandExecutor.continueCommandExecution(time, commandProcessQueue.size())) {
+                    // removing and adding objects to Google Maps are time costly operations and we don't want to block UI thread
+                    commandExecutor.runOnUIThread(this);
                     return false;
                 }
             }
             return true;
+        }
+
+        //CALL ONLY WITH ACQUIRED LOCK!!!
+        private void processRemoveCommand(final MapObjectOptions options) {
+            final boolean stillValid = requestedToRemove.remove(options);
+            //if stillValid = false, then the process command was outdated by later changes to requestedToRemove -> in this case ignore it
+            if (stillValid) {
+                final Object obj = drawnObjects.remove(options);
+                if (obj != null) {
+                    commandExecutor.removeFromMap(obj);
+                } else {
+                    // could not remove, is it enqueued to be draw?
+                    Log.e(LOG_PREFIX + "requesting non-existing object for removal -> must be programming bug!");
+                }
+            }
+        }
+        //CALL ONLY WITH ACQUIRED LOCK!!!
+        private void processAddCommand(final MapObjectOptions options) {
+            final boolean stillValid = requestedToAdd.remove(options);
+            //if stillValid = false, then the process command was outdated by later changes to requestedToRemove -> in this case ignore it
+            if (stillValid) {
+                final Object drawn = commandExecutor.addToMap(googleMap, options);
+                drawnObjects.put(options, drawn);
+            }
         }
 
         @Override
         public void run() {
             lock.lock();
-            if (repaintRequested && removeRequested() && addRequested()) {
-                // repaint successful, set flag to false
-                repaintRequested = false;
-            }
-            lock.unlock();
-        }
-
-        private boolean addRequested() {
-            final long time = System.currentTimeMillis();
-            MapObjectOptions options;
-            while ((options = requestedToAdd.poll()) != null) {
-                // avoid redrawing exactly the same accuracy circle, as sometimes consecutive identical circles remain on the map
-                if (!(options.options instanceof CircleOptions) || ((CircleOptions) options.options).getZIndex() != GooglePositionAndHistory.ZINDEX_POSITION_ACCURACY_CIRCLE || !drawObjects.containsKey(options)) {
-                    final Object drawn = options.addToGoogleMap(googleMap);
-                    drawnBy.put(drawn, options);
-                    drawObjects.put(options, drawn);
+            try {
+                if (repaintRequested && processQueue()) {
+                    // repaint successful, set flag to false
+                    repaintRequested = false;
                 }
-                if (System.currentTimeMillis() - time >= TIME_MAX) {
-                    // removing and adding markers are time costly operations and we dont want to block UI thread
-                    runOnUIThread(this);
-                    return false;
-                }
+            } finally {
+                lock.unlock();
             }
-            return true;
         }
 
     }

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -18,6 +18,9 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapLineUtils;
+import static cgeo.geocaching.maps.google.v2.MapObjectOptions.circle;
+import static cgeo.geocaching.maps.google.v2.MapObjectOptions.marker;
+import static cgeo.geocaching.maps.google.v2.MapObjectOptions.polyline;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 
@@ -293,22 +296,22 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
         final LatLng latLng = new LatLng(coordinates.getLatitude(), coordinates.getLongitude());
 
         // accuracy circle
-        positionObjs.addCircle(new CircleOptions()
+        positionObjs.add(circle(new CircleOptions()
                 .center(latLng)
                 .strokeColor(MapLineUtils.getAccuracyCircleColor())
                 .strokeWidth(3)
                 .fillColor(MapLineUtils.getAccuracyCircleFillColor())
                 .radius(coordinates.getAccuracy())
-                .zIndex(ZINDEX_POSITION_ACCURACY_CIRCLE)
+                .zIndex(ZINDEX_POSITION_ACCURACY_CIRCLE))
         );
 
-        positionObjs.addMarker(new MarkerOptions()
+        positionObjs.add(marker(new MarkerOptions()
                 .icon(BitmapDescriptorCache.toBitmapDescriptor(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.my_location_chevron, null)))
                 .position(latLng)
                 .rotation(heading)
                 .anchor(0.5f, 0.5f)
                 .flat(true)
-                .zIndex(ZINDEX_POSITION)
+                .zIndex(ZINDEX_POSITION))
         );
 
         final Geopoint destCoords = mapView.getDestinationCoords();
@@ -316,7 +319,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
             final Geopoint currentCoords = new Geopoint(coordinates);
             if (Settings.isMapDirection()) {
                 // draw direction line
-                positionObjs.addPolyline(getDirectionPolyline(currentCoords, destCoords));
+                positionObjs.add(polyline(getDirectionPolyline(currentCoords, destCoords)));
             } else if (null != postRealDistance) {
                 postRealDistance.postRealDistance(destCoords.distanceTo(currentCoords));
             }
@@ -357,11 +360,11 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
                     }
                     if (points.size() > 1) {
                         // history line
-                        historyObjs.addPolyline(new PolylineOptions()
+                        historyObjs.add(polyline(new PolylineOptions()
                                 .addAll(points)
                                 .color(MapLineUtils.getTrailColor())
                                 .width(MapLineUtils.getHistoryLineWidth(false))
-                                .zIndex(ZINDEX_HISTORY)
+                                .zIndex(ZINDEX_HISTORY))
                         );
                     }
                 }
@@ -386,7 +389,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
                 .add(new LatLng(viewport.getLatitudeMax(), viewport.getLongitudeMin()))
                 .add(new LatLng(viewport.getLatitudeMin(), viewport.getLongitudeMin()));
 
-        positionObjs.addPolyline(options);
+        positionObjs.add(polyline(options));
         lastViewport = viewport;
     }
 
@@ -396,11 +399,11 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
         final CachedRoute individualRoute = cache.get(KEY_INDIVIDUAL_ROUTE);
         if (individualRoute != null && !individualRoute.isHidden && individualRoute.track != null && individualRoute.track.size() > 0) {
             for (List<LatLng> segment : individualRoute.track) {
-                routeObjs.addPolyline(new PolylineOptions()
+                routeObjs.add(polyline(new PolylineOptions()
                         .addAll(segment)
                         .color(MapLineUtils.getRouteColor())
                         .width(MapLineUtils.getRouteLineWidth(false))
-                        .zIndex(ZINDEX_ROUTE)
+                        .zIndex(ZINDEX_ROUTE))
                 );
             }
         }
@@ -411,11 +414,11 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
                 // route hidden, no route or route too short?
                 if (c != individualRoute && !c.isHidden && c.track != null && c.track.size() > 0) {
                     for (List<LatLng> segment : c.track) {
-                        trackObjs.addPolyline(new PolylineOptions()
+                        trackObjs.add(polyline(new PolylineOptions()
                                 .addAll(segment)
                                 .color(MapLineUtils.getTrackColor())
                                 .width(MapLineUtils.getTrackLineWidth(false))
-                                .zIndex(ZINDEX_TRACK)
+                                .zIndex(ZINDEX_TRACK))
                         );
                     }
                 }
@@ -426,11 +429,11 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
     private synchronized void drawLongTapMarker() {
         longTapObjs.removeAll();
         if (longTapLatLng != null) {
-            positionObjs.addMarker(new MarkerOptions()
+            positionObjs.add(marker(new MarkerOptions()
                     .icon(BitmapDescriptorCache.toBitmapDescriptor(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.map_pin, null)))
                     .position(longTapLatLng)
                     .anchor(0.5f, 1f)
-                    .zIndex(ZINDEX_POSITION)
+                    .zIndex(ZINDEX_POSITION))
             );
         }
     }

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/MapObjectOptions.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/MapObjectOptions.java
@@ -3,14 +3,24 @@ package cgeo.geocaching.maps.google.v2;
 import java.util.Objects;
 
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.CircleOptions;
+import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.PolygonOptions;
+import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
- * simple wrapper of googlemaps *Options, implements equals() and hashCode()
+ * This class wraps instances of GoogleMaps diverse *Options classes for different drawable objects
+ * such as Markers, Circles, Polylines and Polygons.
+ *
+ * This class implements equals() and hashCode() for these Option classes.
+ *
+ * CAREFUL: instances of this class assume the *Option objects to remain immutable once they are wrapped!
+ * (e.g. it caches once calculated hashCode!)
  */
 public class MapObjectOptions {
 
@@ -24,12 +34,66 @@ public class MapObjectOptions {
      */
     int hashCode = 0;
 
-    public MapObjectOptions(final Object options) {
+    private MapObjectOptions(final Object options) {
         checkInstance(options);
         this.options = options;
     }
 
-    protected static void checkInstance(final Object options) {
+    public static MapObjectOptions marker(final MarkerOptions marker) {
+        return from(marker);
+    }
+
+    public static MapObjectOptions circle(final CircleOptions circle) {
+        return from(circle);
+    }
+
+    public static MapObjectOptions polyline(final PolylineOptions polyline) {
+        return from(polyline);
+    }
+
+    public static MapObjectOptions polygon(final PolygonOptions polygon) {
+        return from(polygon);
+    }
+
+    /** adds the drawable object wrapped by this instance to given google map and returns the google map object */
+    public Object addToGoogleMap(final GoogleMap googleMap) {
+        if (options instanceof MarkerOptions) {
+            return googleMap.addMarker((MarkerOptions) options);
+        } else if (options instanceof CircleOptions) {
+            return googleMap.addCircle((CircleOptions) options);
+        } else if (options instanceof PolylineOptions) {
+            return googleMap.addPolyline((PolylineOptions) options);
+        } else if (options instanceof PolygonOptions) {
+            return googleMap.addPolygon((PolygonOptions) options);
+        } else {
+            throw new IllegalStateException("Invalid options type, check should be performed constructor, this should not happpen");
+        }
+    }
+
+    /** removes the given google map object from its associated map */
+    public static void removeFromGoogleMap(final Object googleObject) {
+        if (googleObject == null) {
+            return; // failsafe
+        }
+        if (googleObject instanceof Marker) {
+            ((Marker) googleObject).remove();
+        } else if (googleObject instanceof Circle) {
+            ((Circle) googleObject).remove();
+        } else if (googleObject instanceof Polyline) {
+            ((Polyline) googleObject).remove();
+        } else if (googleObject instanceof Polygon) {
+            ((Polygon) googleObject).remove();
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    /** Returns the original Google Options object encapsulated by this wrapper */
+    public Object getOptions() {
+        return options;
+    }
+
+    private static void checkInstance(final Object options) {
         if (options == null) {
             throw new IllegalArgumentException("Options cannot be null");
         }
@@ -43,14 +107,16 @@ public class MapObjectOptions {
         }
     }
 
-    public static MapObjectOptions from(final Object opts) {
+
+
+    private static MapObjectOptions from(final Object opts) {
         if (opts instanceof MapObjectOptions) {
             return (MapObjectOptions) opts;
         }
         return new MapObjectOptions(opts);
     }
 
-    protected static boolean equalsOptions(final Object opts1, final Object opts2) {
+    private static boolean equalsOptions(final Object opts1, final Object opts2) {
         if (opts1.getClass() != opts2.getClass()) {
             return false;
         }
@@ -67,11 +133,11 @@ public class MapObjectOptions {
         }
     }
 
-    protected static boolean objEquals(final Object a, final Object b) {
+    private static boolean objEquals(final Object a, final Object b) {
         return Objects.equals(a, b);
     }
 
-    protected static boolean equals(final MarkerOptions a, final MarkerOptions b) {
+    private static boolean equals(final MarkerOptions a, final MarkerOptions b) {
         return a.getAlpha() == b.getAlpha() &&
                 a.getAnchorU() == b.getAnchorU() &&
                 a.getAnchorV() == b.getAnchorV() &&
@@ -88,7 +154,7 @@ public class MapObjectOptions {
                 a.isVisible() == b.isVisible();
     }
 
-    protected static boolean equals(final CircleOptions a, final CircleOptions b) {
+    private static boolean equals(final CircleOptions a, final CircleOptions b) {
         return a.getZIndex() == b.getZIndex() &&
                 objEquals(a.getCenter(), b.getCenter()) &&
                 a.getFillColor() == b.getFillColor() &&
@@ -99,7 +165,7 @@ public class MapObjectOptions {
                 a.isClickable() == b.isClickable();
     }
 
-    protected static boolean equals(final PolylineOptions a, final PolylineOptions b) {
+    private static boolean equals(final PolylineOptions a, final PolylineOptions b) {
         return a.getZIndex() == b.getZIndex() &&
                 a.getColor() == b.getColor() &&
                 objEquals(a.getPoints(), b.getPoints()) &&
@@ -109,7 +175,7 @@ public class MapObjectOptions {
                 a.isGeodesic() == b.isGeodesic();
     }
 
-    protected static boolean equals(final PolygonOptions a, final PolygonOptions b) {
+    private static boolean equals(final PolygonOptions a, final PolygonOptions b) {
         return a.getZIndex() == b.getZIndex() &&
                 a.getStrokeColor() == b.getStrokeColor() &&
                 a.getFillColor() == b.getFillColor() &&
@@ -207,21 +273,4 @@ public class MapObjectOptions {
                 .toHashCode();
     }
 
-    public Object addToGoogleMap(final GoogleMap googleMap) {
-        if (options instanceof MarkerOptions) {
-            return googleMap.addMarker((MarkerOptions) options);
-        } else if (options instanceof CircleOptions) {
-            return googleMap.addCircle((CircleOptions) options);
-        } else if (options instanceof PolylineOptions) {
-            return googleMap.addPolyline((PolylineOptions) options);
-        } else if (options instanceof PolygonOptions) {
-            return googleMap.addPolygon((PolygonOptions) options);
-        } else {
-            throw new IllegalStateException("Invalid options type, check should be performed constructor, this should not happpen");
-        }
-    }
-
-    public Object getOptions() {
-        return options;
-    }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsPositionLayer.java
@@ -8,6 +8,9 @@ import cgeo.geocaching.models.Route;
 import cgeo.geocaching.unifiedmap.AbstractPositionLayer;
 import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.utils.MapLineUtils;
+import static cgeo.geocaching.maps.google.v2.MapObjectOptions.circle;
+import static cgeo.geocaching.maps.google.v2.MapObjectOptions.marker;
+import static cgeo.geocaching.maps.google.v2.MapObjectOptions.polyline;
 import static cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory.MAP_GOOGLE;
 
 import android.location.Location;
@@ -50,12 +53,12 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
     public void setCurrentPositionAndHeading(final Location location, final float heading) {
         setCurrentPositionAndHeadingHelper(location, heading, (directionLine) -> {
             directionObjs.removeAll();
-            directionObjs.addPolyline(new PolylineOptions()
+            directionObjs.add(polyline(new PolylineOptions()
                     .addAll(directionLine)
                     .color(MapLineUtils.getDirectionColor())
                     .width(MapLineUtils.getDirectionLineWidth(true))
                     .zIndex(LayerHelper.ZINDEX_DIRECTION_LINE)
-            );
+            ));
         }, MAP_GOOGLE);
     }
 
@@ -88,24 +91,24 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
         // accuracy circle
         final float accuracy = currentLocation.getAccuracy();
         if (accuracy > 0.001f) {
-            positionObjs.addCircle(new CircleOptions()
+            positionObjs.add(circle(new CircleOptions()
                     .center(latLng)
                     .strokeColor(MapLineUtils.getAccuracyCircleColor())
                     .strokeWidth(3)
                     .fillColor(MapLineUtils.getAccuracyCircleFillColor())
                     .radius(accuracy)
                     .zIndex(LayerHelper.ZINDEX_POSITION_ACCURACY_CIRCLE)
-            );
+            ));
         }
 
         // position and heading arrow
-        positionObjs.addMarker(new MarkerOptions()
+        positionObjs.add(marker(new MarkerOptions()
                 .icon(BitmapDescriptorFactory.fromBitmap(positionAndHeadingArrow))
                 .position(latLng)
                 .rotation(currentHeading)
                 .anchor(0.5f, 0.5f)
                 .flat(true)
-                .zIndex(LayerHelper.ZINDEX_POSITION)
+                .zIndex(LayerHelper.ZINDEX_POSITION))
         );
 
     }
@@ -113,22 +116,22 @@ class GoogleMapsPositionLayer extends AbstractPositionLayer<LatLng> {
     @Override
     protected void repaintHistory() {
         historyObjs.removeAll();
-        repaintHistoryHelper((points) -> historyObjs.addPolyline(new PolylineOptions()
+        repaintHistoryHelper((points) -> historyObjs.add(polyline(new PolylineOptions()
                 .addAll(points)
                 .color(MapLineUtils.getTrailColor())
                 .width(MapLineUtils.getHistoryLineWidth(true))
-                .zIndex(LayerHelper.ZINDEX_HISTORY)
+                .zIndex(LayerHelper.ZINDEX_HISTORY))
         ));
     }
 
     @Override
     protected void repaintRouteAndTracks() {
         trackObjs.removeAll();
-        repaintRouteAndTracksHelper((segment, isTrack) -> trackObjs.addPolyline(new PolylineOptions()
+        repaintRouteAndTracksHelper((segment, isTrack) -> trackObjs.add(polyline(new PolylineOptions()
                 .addAll(segment)
                 .color(isTrack ? MapLineUtils.getTrackColor() : MapLineUtils.getRouteColor())
                 .width(isTrack ? MapLineUtils.getTrackLineWidth(true) : MapLineUtils.getRouteLineWidth(true))
-                .zIndex(LayerHelper.ZINDEX_TRACK_ROUTE)
+                .zIndex(LayerHelper.ZINDEX_TRACK_ROUTE))
         ));
     }
 

--- a/main/src/test/java/cgeo/geocaching/maps/google/v2/GoogleMapObjectGroupTest.java
+++ b/main/src/test/java/cgeo/geocaching/maps/google/v2/GoogleMapObjectGroupTest.java
@@ -1,0 +1,177 @@
+package cgeo.geocaching.maps.google.v2;
+
+import cgeo.geocaching.utils.functions.Action1;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.CircleOptions;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.PolylineOptions;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class GoogleMapObjectGroupTest {
+
+    private static final MapObjectOptions CIRCLE_1_2 = MapObjectOptions.circle(new CircleOptions().center(new LatLng(1, 2)));
+    private static final MapObjectOptions POLYLINE_1_2_3_4 = MapObjectOptions.polyline(new PolylineOptions().add(new LatLng(1, 2), new LatLng(3, 4)));
+
+    private static class TestExecutor implements GoogleMapObjectsQueue.ICommandExecutor {
+
+        private final Set<MapObjectOptions> onMap = new HashSet<>();
+        private final List<ImmutablePair<MapObjectOptions, Boolean>> actionsOnMap = new ArrayList<>();
+
+        public Set<MapObjectOptions> getMapObjects() {
+            return onMap;
+        }
+
+        public List<ImmutablePair<MapObjectOptions, Boolean>> getActions() {
+            return actionsOnMap;
+        }
+
+        @Override
+        public Object addToMap(final GoogleMap map, final MapObjectOptions obj) {
+            if (onMap.contains(obj)) {
+                throw new IllegalStateException("add: Object shouldn't be on map already!");
+            }
+            onMap.add(obj);
+            actionsOnMap.add(new ImmutablePair<>(obj, true));
+            return obj;
+        }
+
+        @Override
+        public void removeFromMap(final Object obj) {
+            final MapObjectOptions mapObject = (MapObjectOptions) obj;
+            if (!onMap.contains(mapObject)) {
+                throw new IllegalStateException("remove: Object should be on map already!");
+            }
+            onMap.remove(mapObject);
+            actionsOnMap.add(new ImmutablePair<>(mapObject, false));
+        }
+
+        @Override
+        public void runOnUIThread(final Runnable runnable) {
+            runnable.run();
+        }
+
+        public boolean continueCommandExecution(final long startTime, final int queueLength) {
+            return true;
+        }
+    }
+
+    @Test
+    public void simpleAdd() {
+        assertMapGroupBehaviour(group -> {
+            group.add(CIRCLE_1_2);
+            group.add(POLYLINE_1_2_3_4);
+        }, Arrays.asList(
+            POLYLINE_1_2_3_4, CIRCLE_1_2
+        ), Arrays.asList(
+            addAction(CIRCLE_1_2),
+            addAction(POLYLINE_1_2_3_4)
+        ));
+    }
+
+    @Test
+    public void simpleRemove() {
+        assertMapGroupBehaviour(group -> {
+            group.add(CIRCLE_1_2);
+            group.remove(Collections.singleton(CIRCLE_1_2));
+        }, Collections.emptyList(), Arrays.asList(
+                addAction(CIRCLE_1_2),
+                removeAction(CIRCLE_1_2)
+        ));
+    }
+
+    @Test
+    public void ignoreInvalidRequests() {
+        assertMapGroupBehaviour(group -> {
+            group.remove(Collections.singleton(CIRCLE_1_2));
+            group.add(POLYLINE_1_2_3_4);
+        }, Collections.singleton(POLYLINE_1_2_3_4), Collections.singletonList(
+                addAction(POLYLINE_1_2_3_4)
+        ));
+    }
+
+    @Test
+    public void ignoreDuplicateAdds() {
+        assertMapGroupBehaviour(group -> {
+            group.add(POLYLINE_1_2_3_4);
+            group.add(POLYLINE_1_2_3_4);
+        }, Collections.singleton(POLYLINE_1_2_3_4), Collections.singletonList(
+                addAction(POLYLINE_1_2_3_4)
+        ));
+    }
+
+    @Test
+    public void simpleRemoveAll() {
+        assertMapGroupBehaviour(group -> {
+            group.add(POLYLINE_1_2_3_4);
+            group.removeAll();
+            group.add(POLYLINE_1_2_3_4);
+        }, Collections.singleton(POLYLINE_1_2_3_4), Arrays.asList(
+                addAction(POLYLINE_1_2_3_4),
+                removeAction(POLYLINE_1_2_3_4),
+                addAction(POLYLINE_1_2_3_4)
+                ));
+    }
+
+    @Test
+    public void replaceIdentical() {
+        assertMapGroupBehaviour(group -> {
+            group.add(POLYLINE_1_2_3_4);
+            group.replace(Collections.singleton(POLYLINE_1_2_3_4));
+        }, Collections.singleton(POLYLINE_1_2_3_4), Collections.singletonList(
+                addAction(POLYLINE_1_2_3_4)
+        ));
+    }
+
+    @Test
+    public void replaceNew() {
+        assertMapGroupBehaviour(group -> {
+            group.add(POLYLINE_1_2_3_4);
+            group.replace(Collections.singleton(CIRCLE_1_2));
+        }, Collections.singleton(CIRCLE_1_2), Arrays.asList(
+                addAction(POLYLINE_1_2_3_4),
+                removeAction(POLYLINE_1_2_3_4),
+                addAction(CIRCLE_1_2)
+        ));
+    }
+
+    @Test
+    public void replaceMixed() {
+        assertMapGroupBehaviour(group -> {
+            group.add(POLYLINE_1_2_3_4);
+            group.add(CIRCLE_1_2);
+            group.replace(Collections.singleton(CIRCLE_1_2));
+        }, Collections.singleton(CIRCLE_1_2), Arrays.asList(
+                addAction(POLYLINE_1_2_3_4),
+                addAction(CIRCLE_1_2),
+                removeAction(POLYLINE_1_2_3_4)
+        ));
+    }
+
+    private static ImmutablePair<MapObjectOptions, Boolean> addAction(final MapObjectOptions obj) {
+        return new ImmutablePair<>(obj, true);
+    }
+
+    private static ImmutablePair<MapObjectOptions, Boolean> removeAction(final MapObjectOptions obj) {
+        return new ImmutablePair<>(obj, false);
+    }
+
+
+    private static void assertMapGroupBehaviour(final Action1<GoogleMapObjectsQueue> mapAction, final Collection<MapObjectOptions> expectedContent, final List<ImmutablePair<MapObjectOptions, Boolean>> expectedActions) {
+        final TestExecutor te = new TestExecutor();
+        final GoogleMapObjectsQueue group = new GoogleMapObjectsQueue(null, te);
+        mapAction.call(group);
+        assertThat(te.getMapObjects()).hasSameElementsAs(expectedContent);
+        assertThat(te.getActions()).isEqualTo(expectedActions);
+    }
+}


### PR DESCRIPTION
rel to #13793: refactor google maps drawing object handling

This PR reworks almost completely the way in which c:geo renders drwaings onto Google Map. Intention is to fix previous bugs and performance problems due to incorrect concurrency handling in the asynchronous google object drawer:
* use a **single** command queue for add/remove commands (instead of two different ones) to avoid problems when add/remove is used for same objects repeatedly (which unfortunately happens often in current implementation)
* optimize number of objects removed + drawn anew by making difference checks already on add/remove commands
* allow more effective replacement of objects
* document code
* add unit testing