### PR TITLE
Refresh caches in route (fix #13382)

### DIFF
--- a/main/src/main/res/layout/routes_tracks_item.xml
+++ b/main/src/main/res/layout/routes_tracks_item.xml
@@ -17,10 +17,20 @@
         android:id="@+id/item_edit"
         style="@style/button_icon"
         android:layout_centerVertical="true"
-        android:layout_toLeftOf="@id/item_visibility"
+        android:layout_toLeftOf="@id/item_refresh"
         android:background="?android:attr/selectableItemBackgroundBorderless"
         android:src="@drawable/ic_menu_edit"
         android:tooltipText="@string/map_sort_individual_route"
+        android:visibility="gone" />
+
+    <ImageButton
+        android:id="@+id/item_refresh"
+        style="@style/button_icon"
+        android:layout_centerVertical="true"
+        android:layout_toLeftOf="@id/item_visibility"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_menu_refresh"
+        android:tooltipText="@string/map_refresh_individual_route"
         android:visibility="gone" />
 
     <ImageButton

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2486,6 +2486,7 @@
     <string name="individual_route_error_toggling_waypoint">error toggling waypoint</string>
     <string name="individual_route_error_single_waypoint_mode">Not available in single waypoint mode</string>
     <string name="map_sort_individual_route">Sort individual route</string>
+    <string name="map_refresh_individual_route">Refresh</string>
     <string name="map_export_individual_route">Export individual route</string>
     <string name="map_load_individual_route">Load individual route</string>
     <string name="map_load_individual_route_confirm">Overwrite existing route?</string>


### PR DESCRIPTION
## Description
Adds a "refresh" button for individual route to route/track menu which triggers a forced reload of the route's caches in the background.
