### PR TITLE
fix #13935: contentstoragehelper, use correct copychoice parameter instead of nullable runningintentdata

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/ContentStorageActivityHelper.java
+++ b/main/src/main/java/cgeo/geocaching/storage/ContentStorageActivityHelper.java
@@ -467,7 +467,7 @@ public class ContentStorageActivityHelper {
                     .create()
                     .show();
         } else {
-            continuePersistableFolderSelectionCopyMove(folder, targetUri, runningIntentData.copyChoice == CopyChoice.ASK_IF_DIFFERENT ? CopyChoice.DO_NOTHING : runningIntentData.copyChoice, action);
+            continuePersistableFolderSelectionCopyMove(folder, targetUri, copyChoice == CopyChoice.ASK_IF_DIFFERENT ? CopyChoice.DO_NOTHING : copyChoice, action);
         }
     }
 


### PR DESCRIPTION
fix #13935: contentstoragehelper, use correct copychoice parameter instead of nullable runningintentdata