### PR TITLE
fix #13936: select text only if selection bounds are met to prevent indexoutofboundsexception

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -2458,9 +2458,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
         @Override
         public boolean onMenuItemClick(final MenuItem menuItem) {
+            if (selectedTextView == null || selectedTextView.getText() == null) {
+                return false;
+            }
+            final CharSequence text = selectedTextView.getText();
             final int startSelection = selectedTextView.getSelectionStart();
             final int endSelection = selectedTextView.getSelectionEnd();
-            clickedItemText = selectedTextView.getText().subSequence(startSelection, endSelection);
+            clickedItemText = startSelection >= 0 && endSelection >= startSelection && endSelection <= text.length() ?
+                    text.subSequence(startSelection, endSelection) : text;
             return onClipboardItemSelected(mActionMode, menuItem, clickedItemText, cache);
         }
     }


### PR DESCRIPTION
fix #13936: select text only if selection bounds are met to prevent indexoutofboundsexception