### PR TITLE
Add option to import public bookmark lists (fix #13566)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -723,6 +723,23 @@
 
         </activity>
         <activity
+            android:name="cgeo.geocaching.connector.gc.ImportBookmarkLinks"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="geocaching.com" />
+                <data android:host="www.geocaching.com" />
+                <data android:pathPrefix="/plan/lists/" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".CompassActivity"
             android:configChanges="orientation|screenSize"
             android:label="@string/compass_title" >

--- a/main/src/main/java/cgeo/geocaching/connector/gc/ImportBookmarkLinks.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/ImportBookmarkLinks.java
@@ -1,0 +1,44 @@
+package cgeo.geocaching.connector.gc;
+
+import cgeo.geocaching.CacheListActivity;
+import cgeo.geocaching.Intents;
+import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MatcherWrapper;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.regex.Pattern;
+
+public class ImportBookmarkLinks extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(final @Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final Intent intent = getIntent();
+        if (intent == null) {
+            finish();
+            return;
+        }
+        final String url = intent.getDataString();
+        // check url
+        final Pattern p = Pattern.compile("http[s]:\\/\\/(www\\.)?geocaching\\.com\\/plan\\/lists\\/([A-Z0-9]+)(\\?)");
+        final MatcherWrapper matcher = new MatcherWrapper(p, url);
+        while (matcher.find()) {
+            // list id given?
+            if (matcher.groupCount() >= 2) {
+                final Uri uri = Uri.parse("https://www.geocaching.com/plan/api/gpx/list/" + matcher.group(2));
+                Log.i("starting import of bookmark list with id=" + matcher.group(2));
+                final Intent cachesIntent = new Intent(Intent.ACTION_VIEW, uri, this, CacheListActivity.class);
+                cachesIntent.setDataAndType(uri, "application/zip");
+                cachesIntent.putExtra(Intents.EXTRA_NAME, matcher.group(2));
+                startActivity(cachesIntent);
+            }
+        }
+        finish();
+    }
+}


### PR DESCRIPTION
## Description
Tapping on a link to a public/shared gc bookmark lists will now trigger GPX import for this list.
(On Android 12+ app settings might need to be adjusted to open the link in c:geo, see https://www.cgeo.org/faq#android12)
