### PR TITLE
Fix cache popup navigation menu font size

### DIFF
--- a/main/src/main/java/cgeo/geocaching/apps/navi/NavigationAppFactory.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/NavigationAppFactory.java
@@ -200,7 +200,7 @@ public final class NavigationAppFactory {
          * Using an ArrayAdapter with list of NavigationAppsEnum items avoids
          * handling between mapping list positions allows us to do dynamic filtering of the list based on use case.
          */
-        final ArrayAdapter<NavigationAppsEnum> adapter = new ArrayAdapter<>(activity, android.R.layout.select_dialog_item, items);
+        final ArrayAdapter<NavigationAppsEnum> adapter = new ArrayAdapter<>(activity, R.layout.select_dialog_item, items);
 
         final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
         builder.setTitle(R.string.cache_menu_navigate);

--- a/main/src/main/res/layout/select_dialog_item.xml
+++ b/main/src/main/res/layout/select_dialog_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:textColor="?android:attr/textColorAlertDialogListItem"
+    android:gravity="center_vertical"
+    android:paddingStart="14dip"
+    android:paddingEnd="15dip"
+    android:ellipsize="marquee"
+    android:textSize="@dimen/textSize_detailsPrimary"
+    />


### PR DESCRIPTION
## Description
Fixes font size and line spacing of cache/waypoint popup's navigation menu

|Cache details|Cache popup before|Cache popup after|
|---|---|---|
|![image](https://user-images.githubusercontent.com/3754370/216838066-eb51f4bf-9863-41ac-81df-3275b8b4957d.png)|![image](https://user-images.githubusercontent.com/3754370/216838068-cb5b9d85-bd86-4631-a063-946912ad509d.png)|![image](https://user-images.githubusercontent.com/3754370/216838075-345f0a88-1494-42d3-bc11-e14f03f7ae1b.png)|
