### PR TITLE
Fix skipping some user-created waypoints on GPX import (fix #13972)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXParser.java
@@ -316,7 +316,17 @@ abstract class GPXParser extends FileParser {
                         }
                         waypoint.setId(-1);
                         waypoint.setGeocode(parentCacheCode);
-                        waypoint.setPrefix(cacheForWaypoint.getWaypointPrefix(cache.getName()));
+                        String cacheName = cache.getName();
+                        if (wptUserDefined) {
+                            // try to deduct original prefix from wpt name
+                            if (StringUtils.endsWithIgnoreCase(cacheName, parentCacheCode.substring(2))) {
+                                cacheName = cacheName.substring(0, cacheName.length() - parentCacheCode.length() + 2);
+                            }
+                            if (StringUtils.startsWithIgnoreCase(cacheName, Waypoint.PREFIX_OWN + "-")) {
+                                cacheName = cacheName.substring(4);
+                            }
+                        }
+                        waypoint.setPrefix(cacheForWaypoint.getWaypointPrefix(cacheName));
                         waypoint.setLookup("---");
                         // there is no lookup code in gpx file
 


### PR DESCRIPTION
## Description
Fixes skipping all but one user-created waypoints on GPX import (for GPX files having been created as GPX export by c:geo).
