### PR TITLE
fix #13994: make coordinate parsing regex fit for android regex implementation

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/utils/InstrumentedFormulaUtilsTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/utils/InstrumentedFormulaUtilsTest.java
@@ -1,4 +1,6 @@
-package cgeo.geocaching.utils.formulas;
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.utils.formulas.FormulaUtils;
 
 import android.util.Pair;
 
@@ -8,79 +10,9 @@ import java.util.List;
 import org.junit.Test;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-public class FormulaUtilsTest {
-
-    @Test
-    public void substring() {
-        assertThat(FormulaUtils.substring("test", 1, 2)).isEqualTo("es");
-        assertThat(FormulaUtils.substring(null, 1, 2)).isEqualTo("");
-        assertThat(FormulaUtils.substring("t", 1, 2)).isEqualTo("");
-        assertThat(FormulaUtils.substring("te", 1, 2)).isEqualTo("e");
-    }
-
-    @Test
-    public void checksum() {
-        assertThat(FormulaUtils.checksum(255, false)).isEqualTo(12);
-        assertThat(FormulaUtils.checksum(255, true)).isEqualTo(3);
-        assertThat(FormulaUtils.checksum(-255, false)).isEqualTo(12);
-        assertThat(FormulaUtils.checksum(0, false)).isEqualTo(0);
-    }
-
-    @Test
-    public void letterValue() {
-        assertThat(FormulaUtils.letterValue("abc")).isEqualTo(6);
-        assertThat(FormulaUtils.letterValue("ABC")).isEqualTo(6);
-        assertThat(FormulaUtils.letterValue("")).isEqualTo(0);
-        assertThat(FormulaUtils.letterValue("1234")).isEqualTo(10);
-        assertThat(FormulaUtils.letterValue("äöüß")).isEqualTo(27 + 28 + 29 + 30);
-        assertThat(FormulaUtils.letterValue("ÄÖÜß")).isEqualTo(27 + 28 + 29 + 30);
-        assertThat(FormulaUtils.letterValue("--")).isEqualTo(0);
-        assertThat(FormulaUtils.letterValue("Ç")).isEqualTo(3);
-        assertThat(FormulaUtils.letterValue("eêéè")).isEqualTo(20);
-        assertThat(FormulaUtils.letterValue("^ee^ä")).isEqualTo(37);
-    }
-
-    @Test
-    public void rot() {
-        assertThat(FormulaUtils.rot("abc", 1)).isEqualTo("bcd");
-        assertThat(FormulaUtils.rot("abc", 0)).isEqualTo("abc");
-        assertThat(FormulaUtils.rot("abc", -25)).isEqualTo("bcd");
-        assertThat(FormulaUtils.rot("ab1c2", 1)).isEqualTo("bc1d2");
-    }
-
-    @Test
-    public void ifFunction() {
-        assertThat(FormulaUtils.ifFunction(new ValueList())).isEqualTo(Value.of(0));
-        assertThat(FormulaUtils.ifFunction(new ValueList().add(Value.of(""), Value.of("a"), Value.of("b")))).isEqualTo(Value.of("b"));
-        assertThat(FormulaUtils.ifFunction(new ValueList().add(Value.of("true"), Value.of("a"), Value.of("b")))).isEqualTo(Value.of("a"));
-        assertThat(FormulaUtils.ifFunction(new ValueList().add(Value.of(""), Value.of("a")))).isEqualTo(Value.of(0));
-        assertThat(FormulaUtils.ifFunction(new ValueList().add(Value.of(0), Value.of("a"), Value.of(1), Value.of("b"), Value.of("c")))).isEqualTo(Value.of("b"));
-    }
-
-
-    @Test
-    public void roman() {
-        //I=1, V=5, X=10, L=50, C=100, D=500, M=1000
-        assertThat(FormulaUtils.roman("")).isEqualTo(0);
-        assertThat(FormulaUtils.roman("I")).isEqualTo(1);
-        assertThat(FormulaUtils.roman("V")).isEqualTo(5);
-        assertThat(FormulaUtils.roman("VIII")).isEqualTo(8);
-        assertThat(FormulaUtils.roman("VII I")).isEqualTo(8);
-        assertThat(FormulaUtils.roman("VI IV")).isEqualTo(10);
-        assertThat(FormulaUtils.roman("IV")).isEqualTo(4);
-        assertThat(FormulaUtils.roman("MDCLXVI")).isEqualTo(1666);
-        assertThat(FormulaUtils.roman("mmmDDDcccLLLxxxVVViii")).isEqualTo(1666 * 3);
-        assertThat(FormulaUtils.roman("MCD")).isEqualTo(1400);
-    }
-
-    @Test
-    public void vanity() {
-        assertThat(FormulaUtils.vanity("")).isEqualTo(0);
-        assertThat(FormulaUtils.vanity("A")).isEqualTo(2);
-        assertThat(FormulaUtils.vanity("AD")).isEqualTo(23);
-        assertThat(FormulaUtils.vanity("ABCDEF")).isEqualTo(222333);
-        assertThat(FormulaUtils.vanity("ghijkl")).isEqualTo(444555);
-    }
+//Android uses different RegEx implementation than Java JRE.
+//-> so we repeat critical tests in instrumented mode to ensure Android works correct
+public class InstrumentedFormulaUtilsTest {
 
     @Test
     public void scanForFormulas() {

--- a/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class FormulaUtils {
 
-    private static final String F_OPS = "+/!^:*x-";
+    private static final String F_OPS = "\\+/!\\^:\\*x-";
     private static final String F_FORMULA = "((\\h*\\(\\h*)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7})(((\\h*[()\\[\\]]\\h*)*(\\h*[" + F_OPS + "]\\h*)+)(\\h*[()]\\h*)*([a-zA-Z][a-zA-Z0-9]{0,2}|[0-9]{1,10}|[0-9]{1,3}\\.[0-9]{1,7}))+(\\h*\\)\\h*)*)";
 
     private static final Pattern FORMULA_SCAN_PATTERN = Pattern.compile("[^a-zA-Z0-9(]" + F_FORMULA + "[^a-zA-Z0-9)]");
@@ -36,8 +36,8 @@ public class FormulaUtils {
     };
 
 
-    private static final String COORDINATE_SCAN_DIGIT_NONLETTER = "[0-9°'\".,\\s()\\[\\]" + F_OPS + "]";
-    private static final String COORDINATE_SCAN_DIGIT_PATTERN = "(([a-zA-Z]{0,3})?" + COORDINATE_SCAN_DIGIT_NONLETTER + ")+";
+    private static final String COORDINATE_SCAN_DIGIT_NONLETTER = "[0-9\\s°'\".,()\\[\\]" + F_OPS + "]";
+    private static final String COORDINATE_SCAN_DIGIT_PATTERN = "([a-zA-Z]{0,3}" + COORDINATE_SCAN_DIGIT_NONLETTER + ")+";
     private static final Pattern COORDINATE_SCAN_PATTERN = Pattern.compile(
             "(?<lat>[nNsS](\\h*[0-9]|\\h+[A-Za-z])" + COORDINATE_SCAN_DIGIT_PATTERN + ")\\s*([a-zA-Z,()-]{2,}\\s+){0,3}(?<lon>[eEwWoO](\\h*[0-9]|\\h+[A-Za-z])" + COORDINATE_SCAN_DIGIT_PATTERN + ")"
     );
@@ -201,7 +201,7 @@ public class FormulaUtils {
         int start = 0;
         while (m.find(start)) {
             final String lat = m.group(1); // group("lat") needs SDk level >= 26
-            final String lon = m.group(6); // group("lon") needs SDk level >= 26
+            final String lon = m.group(5); // group("lon") needs SDk level >= 26
             final String latProcessed = processFoundDegree(lat);
             final String lonProcessed = processFoundDegree(lon);
             final String key = pairToKey(latProcessed, lonProcessed);


### PR DESCRIPTION
fix #13994: make coordinate parsing regex fit for android regex implementation