### PR TITLE
restrict WRITE_EXTERNAL_STORAGE request to maxSDK 28

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.NFC" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <!-- <uses-permission android:name="android.permission.READ_CONTACTS" /> Activate when SDKmin=23, see #13777 -->
 
     <uses-feature

--- a/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
@@ -40,7 +40,7 @@ public class InstallWizardActivity extends AppCompatActivity {
     private static final String BUNDLE_CSAH = "csah";
     private static final String BUNDLE_BACKUPUTILS = "backuputils";
 
-    private static final boolean DO_LEGACY_WRITE_STORAGE = android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.Q; // <= SDK29
+    private static final boolean DO_LEGACY_WRITE_STORAGE = android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q; // < SDK29
 
     public enum WizardMode {
         WIZARDMODE_DEFAULT(0),


### PR DESCRIPTION
## Description
Restricts requesting WRITE_EXTERNAL_STORAGE to SDK 28 or less

tested successfully against API 29 in emulator

see discussion in #13997