### PR TITLE
fix #14000: ImageUtils can't handle URL, needs path

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ImageViewActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ImageViewActivity.java
@@ -375,7 +375,7 @@ public class ImageViewActivity extends AbstractActionBarActivity {
             imageCache.loadImage(currentImage.getUrl(), p -> {
 
                 binding.imageFull.setImageDrawable(p.first);
-                binding.imageFull.setRotation(ImageUtils.getImageRotationDegrees(currentImage.getUri()));
+                binding.imageFull.setRotation(ImageUtils.getImageRotationDegrees(Uri.parse(currentImage.getPath())));
                 binding.imageProgressBar.setVisibility(View.GONE);
 
                 final int bmHeight = p.first == null || p.first.getBitmap() == null ? -1 : p.first.getBitmap().getHeight();

--- a/main/src/main/java/cgeo/geocaching/ui/ImageGalleryView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageGalleryView.java
@@ -33,6 +33,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
@@ -217,7 +218,7 @@ public class ImageGalleryView extends LinearLayout {
                 }
 
                 binding.imageImage.setImageDrawable(p.first);
-                binding.imageImage.setRotation(ImageUtils.getImageRotationDegrees(currentEntry.image.getUri()));
+                binding.imageImage.setRotation(ImageUtils.getImageRotationDegrees(Uri.parse(currentEntry.image.getPath())));
                 binding.imageImage.setVisibility(View.VISIBLE);
 
                 final Geopoint gp = MetadataUtils.getFirstGeopoint(p.second);


### PR DESCRIPTION
fixes #14000

Regression caused by:
aa85c0551cb190a8675d370982a1c6a556e348ab (fix #13984: handle image orientation correctly)

I've replaced
currentImage.getUri()
with
Uri.parse(currentImage.getPath()))
and all seems good now afaict.

