### PR TITLE
Widen log description column in landscape mode (rel. to #14014)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -469,7 +469,7 @@
         </activity>
         <activity
             android:name=".CacheDetailActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="keyboardHidden|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="wikitudeapi.arcallback" />

--- a/main/src/main/res/layout/logs_item.xml
+++ b/main/src/main/res/layout/logs_item.xml
@@ -15,14 +15,14 @@
 
         <LinearLayout
             android:id="@+id/detail_box"
-            android:layout_width="102dip"
+            android:layout_width="@dimen/logItemLeftColumnOuterWidth"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_gravity="left|top"
             android:orientation="horizontal" >
 
             <LinearLayout
-                android:layout_width="100dip"
+                android:layout_width="@dimen/logItemLeftColumnInnerWidth"
                 android:layout_height="wrap_content"
                 android:layout_gravity="right|top"
                 android:orientation="vertical"

--- a/main/src/main/res/values-land/dimens.xml
+++ b/main/src/main/res/values-land/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- log item view -->
+    <dimen name="logItemLeftColumnOuterWidth">132dp</dimen>
+    <dimen name="logItemLeftColumnInnerWidth">130dp</dimen>
+
+</resources>

--- a/main/src/main/res/values/dimens.xml
+++ b/main/src/main/res/values/dimens.xml
@@ -14,6 +14,9 @@
     <!-- fastscroll extra padding -->
     <dimen name="paddingRight_fastscroll">5dp</dimen>
 
+    <!-- log item view -->
+    <dimen name="logItemLeftColumnOuterWidth">102dp</dimen>
+    <dimen name="logItemLeftColumnInnerWidth">100dp</dimen>
 
     <!-- font size dimensions ====================================== -->
 


### PR DESCRIPTION
## Description
Enlarge column width for log item description column in landscape mode as a simple mitigation for #14014

Not sure about possible side-effect of having to remove "orientation" from `AndroidManifest` for `CacheDetailActivity` to make the view recognize orientation change to recalculate the layout, so we should keep an eye on it in the nightlies.