### PR TITLE
Make image format error message clearer (rel. to #14038)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/ImageActivityHelper.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageActivityHelper.java
@@ -310,7 +310,7 @@ public class ImageActivityHelper {
 
         final String mimeType = context.getContentResolver().getType(imageUri);
         if (checkMimeType && (!("image/jpeg".equals(mimeType) || "image/png".equals(mimeType) || "image/gif".equals(mimeType)))) {
-            ActivityMixin.showToast(context, R.string.err_acquire_image_failed);
+            ActivityMixin.showToast(context, R.string.err_acquire_image_unsupported_format);
             return false;
         }
         return true;

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
     <string name="err_favorite_failed">Changing favorite status failed.</string>
     <string name="err_select_logimage_failed">Selecting an image for the log failed.</string>
     <string name="err_acquire_image_failed">Acquiring an image failed.</string>
+    <string name="err_acquire_image_unsupported_format">Image format needs to be one of JPEG/JPG, PNG or GIF</string>
     <string name="err_tb_display">c:geo can\'t display the trackable you want. Is it really a trackable?</string>
     <string name="err_tb_details_open">c:geo can\'t open trackable details.</string>
     <string name="err_tb_not_loggable">This trackable isn\'t loggable.</string>


### PR DESCRIPTION
## Description
Explain reason when acquiring log image fails due to format error
