### PR TITLE
agp 7.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'
@@ -23,7 +23,7 @@ plugins {
     id 'idea'
 
     // check for updates of gradle plugin dependencies
-    id 'com.github.ben-manes.versions' version '0.44.0'
+    id 'com.github.ben-manes.versions' version '0.45.0'
     id 'se.ascp.gradle.gradle-versions-filter' version "0.1.16"
 
     // use SpotBugs instead of FindBugs, see https://plugins.gradle.org/plugin/com.github.spotbugs


### PR DESCRIPTION
AGP 7.4.2 is in sync with AS 2022.1.1 Patch 2

For AS see https://developer.android.com/studio/releases?utm_source=android-studio#android-studio-electric-eel-|-2022.1.1-patch-2-february-2023 
For AGP see https://developer.android.com/studio/releases/gradle-plugin#android-gradle-plugin-7.4.2-february-2023

Both are bug fixes.
At `master` we are using already AGP 7.4.1, so this is only a bugfix for c:geo.

As suggested in https://github.com/cgeo/cgeo/pull/14037#issuecomment-1449992144 targeted to release.

The `versions`-Update is already in use at master.

replaces #14037