### PR TITLE
Hide map's action bar on demand

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -243,11 +243,29 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
         // Clear activity stack if the user actively navigates via the bottom navigation
         clearBackStack();
 
-        // avoid weired transitions
+        // avoid weird transitions
         ActivityMixin.overrideTransitionToFade(this);
         return true;
     }
 
+    /** prerequisite for toggleActionBar without moving content around; call it before setContentView() */
+    public void setStableLayout() {
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    }
+
+    public boolean toggleActionBar() {
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar == null) {
+            return false;
+        }
+        if (actionBar.isShowing()) {
+            actionBar.hide();
+            return false;
+        } else {
+            actionBar.show();
+            return true;
+        }
+    }
 
     private final class ConnectivityChangeReceiver extends BroadcastReceiver {
         private boolean isConnected = Network.isConnected();

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.CompassActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.WaypointPopup;
+import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.databinding.MapGoogleBinding;
@@ -89,7 +90,6 @@ import android.widget.ViewSwitcher.ViewFactory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -143,7 +143,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     // Those are initialized in onCreate() and will never be null afterwards
     private Resources res;
-    private AppCompatActivity activity;
+    private AbstractBottomNavigationActivity activity;
     private MapItemFactory mapItemFactory;
     private final LeastRecentlyUsedSet<Geocache> caches = new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount());
     private MapSource mapSource;
@@ -479,7 +479,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         // class init
         res = this.getResources();
-        activity = this.getActivity();
+        activity = (AbstractBottomNavigationActivity) this.getActivity();
 
         MapsforgeMapProvider.getInstance().updateOfflineMaps();
 
@@ -516,6 +516,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
 
         // adding the bottom navigation component is handled by {@link AbstractBottomNavigationActivity#setContentView}
+        activity.setStableLayout();
         activity.setContentView(MapGoogleBinding.inflate(activity.getLayoutInflater()).getRoot());
 
         // map settings popup

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.maps.google.v2;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
@@ -22,6 +23,7 @@ import cgeo.geocaching.maps.mapsforge.AbstractMapsforgeMapSource;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.maps.google.v2.GoogleMapUtils.isGoogleMapsAvailable;
 import static cgeo.geocaching.storage.extension.OneTimeDialogs.DialogType.MAP_AUTOROTATION_DISABLE;
@@ -215,7 +217,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         }
 
         getMapAsync(this);
-        gestureDetector = new GestureDetector(context, new GestureListener());
+        gestureDetector = new GestureDetector(context, new GestureListener((AbstractBottomNavigationActivity) context));
     }
 
 
@@ -395,6 +397,13 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
     }
 
     private class GestureListener extends SimpleOnGestureListener {
+
+        private final WeakReference<AbstractBottomNavigationActivity> activityRef;
+
+        GestureListener(final AbstractBottomNavigationActivity activity) {
+            super();
+            this.activityRef = new WeakReference<>(activity);
+        }
         @Override
         public boolean onDoubleTap(final MotionEvent e) {
             // no need to move to new location, google maps will do it for us
@@ -416,11 +425,22 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
                         final Point waypointPoint = googleMap.getProjection().toScreenLocation(new LatLng(closest.getCoord().getCoords().getLatitude(), closest.getCoord().getCoords().getLongitude()));
                         if (insideCachePointDrawable(p, waypointPoint, closest.getMarker(0).getDrawable())) {
                             onCacheTapListener.onCacheTap(closest.getCoord());
+                        } else {
+                            toggleActionBar();
                         }
+                    } else {
+                        toggleActionBar();
                     }
                 }
             }
             return false;
+        }
+
+        private void toggleActionBar() {
+            final AbstractBottomNavigationActivity activity = activityRef.get();
+            if (activity != null) {
+                FilterUtils.toggleActionBar(activity);
+            }
         }
 
         @Override

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -263,6 +263,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         ActivityMixin.setTheme(this);
 
         // adding the bottom navigation component is handled by {@link AbstractBottomNavigationActivity#setContentView}
+        setStableLayout();
         setContentView(MapMapsforgeV6Binding.inflate(getLayoutInflater()).getRoot());
 
         setTitle();
@@ -1297,6 +1298,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
     public void showSelection(@NonNull final List<GeoitemRef> items, final boolean longPressMode) {
         if (items.isEmpty()) {
+            FilterUtils.toggleActionBar(this);
             return;
         }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -33,6 +33,7 @@ import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.CompactIconModeUtils;
+import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.HistoryTrackUtils;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.Log;
@@ -794,7 +795,11 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         Log.e("touched elements (" + result.size() + "): " + result);
 
         if (result.size() == 0) {
-            // @todo: open context popup for coordinates
+            if (isLongTap) {
+                // @todo: open context popup for coordinates
+            } else {
+                FilterUtils.toggleActionBar(this);
+            }
         } else if (result.size() == 1) {
             handleTap(result.get(0), isLongTap);
         } else {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
@@ -45,6 +45,7 @@ public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements On
     @Override
     public void init(final UnifiedMapActivity activity, final int delayedZoomTo, final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         super.init(activity, delayedZoomTo, delayedCenterTo, onMapReadyTasks);
+        activity.setStableLayout();
         activity.setContentView(R.layout.unifiedmap_googlemaps);
         rootView = activity.findViewById(R.id.unifiedmap_gm);
         mMapView = activity.findViewById(R.id.mapViewGM);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
@@ -64,6 +64,7 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
     @Override
     public void init(final UnifiedMapActivity activity, final int delayedZoomTo, final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         super.init(activity, delayedZoomTo, delayedCenterTo, onMapReadyTasks);
+        activity.setStableLayout();
         activity.setContentView(R.layout.unifiedmap_mapsforgevtm);
         rootView = activity.findViewById(R.id.unifiedmap_vtm);
         mMapView = activity.findViewById(R.id.mapViewVTM);

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
 import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
@@ -82,6 +83,11 @@ public class FilterUtils {
         final View filterView = activity.findViewById(R.id.filter_bar);
         filterView.setOnClickListener(v -> filteredActivity.showFilterMenu());
         filterView.setOnLongClickListener(v -> filteredActivity.showSavedFilterList());
+    }
+
+    public static void toggleActionBar(@NonNull final AbstractBottomNavigationActivity activity) {
+        final boolean actionBarShown = activity.toggleActionBar();
+        activity.findViewById(R.id.actionBarSpacer).setVisibility(actionBarShown ? View.VISIBLE : View.GONE);
     }
 
     public static void initializeFilterMenu(@NonNull final Activity activity, @NonNull final FilteredActivity filteredActivity) {

--- a/main/src/main/res/layout/filter_sort_bar.xml
+++ b/main/src/main/res/layout/filter_sort_bar.xml
@@ -8,12 +8,18 @@
     android:id="@+id/filterbar"
     android:background="@color/colorBackgroundActionBar">
 
+    <Space
+        android:id="@+id/actionBarSpacer"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"/>
+
     <LinearLayout
         android:id="@+id/filter_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_toLeftOf="@id/sort_bar"
+        android:layout_below="@id/actionBarSpacer"
         android:orientation="horizontal"
         android:visibility="gone"
         tools:ignore="UseCompoundDrawables"


### PR DESCRIPTION
## Description
To gain more vertical space on the map (esp. in landscape mode) you can hide the action bar on demand by short-tapping on a free space of the map. Unhiding is done the same way.

For screenshots see https://github.com/cgeo/cgeo/issues/13315#issuecomment-1450862440.