### PR TITLE
Add Google Terrain tileprovider to UnifiedMap (rel. to #14043)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/GoogleTerrainSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/GoogleTerrainSource.java
@@ -1,0 +1,13 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.R;
+
+import com.google.android.gms.maps.GoogleMap;
+
+class GoogleTerrainSource extends AbstractGoogleTileProvider {
+
+    GoogleTerrainSource() {
+        super(GoogleMap.MAP_TYPE_TERRAIN, R.string.map_source_google_terrain);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -138,6 +138,7 @@ public class TileProviderFactory {
         if (isGoogleMapsInstalled()) {
             registerTileProvider(new GoogleMapSource());
             registerTileProvider(new GoogleSatelliteSource());
+            registerTileProvider(new GoogleTerrainSource());
         }
 
         // OSM online tile providers

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1179,6 +1179,7 @@
     <!-- map sources -->
     <string name="map_source_google_map">Google: Map</string>
     <string name="map_source_google_satellite">Google: Satellite</string>
+    <string name="map_source_google_terrain">Google: Terrain</string>
     <string name="map_source_osm_offline">Offline</string>
     <string name="map_source_osm_offline_combined">Combined (Offline)</string>
     <string name="map_source_attribution_dialog_title">Map Attributions</string>


### PR DESCRIPTION
## Description
Adds Google Terrain maps as tileprovider for UnifiedMap

![image](https://user-images.githubusercontent.com/3754370/222896181-ab6563cf-2188-45ea-83fc-3cfe05e1f441.png)
