### PR TITLE
TB namespace conflict workaround for disabled GK connector (rel. to #13097)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/ConnectorFactoryTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/ConnectorFactoryTest.java
@@ -108,6 +108,7 @@ public class ConnectorFactoryTest {
 
     @Test
     public void testGetTrackableFromURL() throws Exception {
+        ConnectorFactory.updateTBConnectorsList(true); // make sure GK connector is included
         assertThat(ConnectorFactory.getTrackableFromURL("https://www.geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
         assertThat(ConnectorFactory.getTrackableFromURL("https://www.geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");
         assertThat(ConnectorFactory.getTrackableFromURL("https://geokrety.org/konkret.php?id=30970")).isEqualTo("GK78FA");

--- a/main/src/androidTest/java/cgeo/geocaching/connector/trackable/GeokretyConnectorTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/trackable/GeokretyConnectorTest.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.connector.trackable;
 
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.models.Trackable;
 import cgeo.geocaching.test.CgeoTestUtils;
 import cgeo.geocaching.test.R;
@@ -17,6 +18,7 @@ public class GeokretyConnectorTest  {
 
     @Test
     public void testCanHandleTrackable() {
+        ConnectorFactory.updateTBConnectorsList(true); // make sure GK connector is included
         assertThat(getConnector().canHandleTrackable("GK82A2")).isTrue();
         assertThat(getConnector().canHandleTrackable("TB1234")).isFalse();
         assertThat(getConnector().canHandleTrackable("UNKNOWN")).isFalse();

--- a/main/src/androidTest/java/cgeo/geocaching/models/TrackableTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/models/TrackableTest.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.models;
 
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
@@ -42,6 +43,7 @@ public class TrackableTest  {
 
     @Test
     public void testGeokretUrl() {
+        ConnectorFactory.updateTBConnectorsList(true); // make sure GK connector is included
         final Trackable geokret = createTrackable("GK82A2");
         assertThat(geokret.getUrl()).isEqualTo("https://geokrety.org/konkret.php?id=33442");
     }

--- a/main/src/main/java/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/main/java/cgeo/geocaching/connector/ConnectorFactory.java
@@ -88,11 +88,11 @@ public final class ConnectorFactory {
     @NonNull public static final UnknownTrackableConnector UNKNOWN_TRACKABLE_CONNECTOR = new UnknownTrackableConnector();
 
     @NonNull
-    private static final Collection<TrackableConnector> TRACKABLE_CONNECTORS = getTbConnectors();
+    private static Collection<TrackableConnector> trackableConnectors = getTbConnectors(false);
 
-    private static Collection<TrackableConnector> getTbConnectors() {
+    private static Collection<TrackableConnector> getTbConnectors(final boolean forceAllConnectors) {
         final List<TrackableConnector> connectors = new ArrayList<>();
-        if (Settings.isGeokretyConnectorActive()) {
+        if (forceAllConnectors || Settings.isGeokretyConnectorActive()) {
             connectors.add(new GeokretyConnector());
         }
         // travel bugs second to last, as their secret codes overlap with other connectors
@@ -100,6 +100,11 @@ public final class ConnectorFactory {
         // unknown trackable connector must be last
         connectors.add(UNKNOWN_TRACKABLE_CONNECTOR);
         return Collections.unmodifiableCollection(connectors);
+    }
+
+    /* being used in tests only */
+    public static void updateTBConnectorsList(final boolean forceAllConnectors) {
+        trackableConnectors = getTbConnectors(forceAllConnectors);
     }
 
     @NonNull
@@ -209,7 +214,7 @@ public final class ConnectorFactory {
     }
 
     public static boolean anyTrackableConnectorActive() {
-        for (final TrackableConnector conn : TRACKABLE_CONNECTORS) {
+        for (final TrackableConnector conn : trackableConnectors) {
             if (conn.isActive()) {
                 return true;
             }
@@ -271,7 +276,7 @@ public final class ConnectorFactory {
 
     @NonNull
     public static TrackableConnector getTrackableConnector(final String geocode, final TrackableBrand brand) {
-        for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
+        for (final TrackableConnector connector : trackableConnectors) {
             if (connector.canHandleTrackable(geocode, brand)) {
                 return connector;
             }
@@ -286,7 +291,7 @@ public final class ConnectorFactory {
      */
     public static List<TrackableConnector> getGenericTrackablesConnectors() {
         final List<TrackableConnector> trackableConnectors = new ArrayList<>();
-        for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
+        for (final TrackableConnector connector : ConnectorFactory.trackableConnectors) {
             if (connector.isActive()) {
                 trackableConnectors.add(connector);
             }
@@ -398,7 +403,7 @@ public final class ConnectorFactory {
 
     @NonNull
     public static Collection<TrackableConnector> getTrackableConnectors() {
-        return TRACKABLE_CONNECTORS;
+        return trackableConnectors;
     }
 
     /**
@@ -411,7 +416,7 @@ public final class ConnectorFactory {
         if (url == null) {
             return null;
         }
-        for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
+        for (final TrackableConnector connector : trackableConnectors) {
             final String geocode = connector.getTrackableCodeFromUrl(url);
             if (StringUtils.isNotBlank(geocode)) {
                 return geocode;
@@ -430,7 +435,7 @@ public final class ConnectorFactory {
         if (url == null) {
             return TrackableTrackingCode.EMPTY;
         }
-        for (final TrackableConnector connector : TRACKABLE_CONNECTORS) {
+        for (final TrackableConnector connector : trackableConnectors) {
             final String trackableCode = connector.getTrackableTrackingCodeFromUrl(url);
             if (StringUtils.isNotBlank(trackableCode)) {
                 return new TrackableTrackingCode(trackableCode, connector.getBrand());

--- a/main/src/main/java/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/main/java/cgeo/geocaching/connector/ConnectorFactory.java
@@ -88,11 +88,19 @@ public final class ConnectorFactory {
     @NonNull public static final UnknownTrackableConnector UNKNOWN_TRACKABLE_CONNECTOR = new UnknownTrackableConnector();
 
     @NonNull
-    private static final Collection<TrackableConnector> TRACKABLE_CONNECTORS = Collections.unmodifiableCollection(Arrays.<TrackableConnector>asList(
-            new GeokretyConnector(),
-            TravelBugConnector.getInstance(), // travel bugs last, as their secret codes overlap with other connectors
-            UNKNOWN_TRACKABLE_CONNECTOR // must be last
-    ));
+    private static final Collection<TrackableConnector> TRACKABLE_CONNECTORS = getTbConnectors();
+
+    private static Collection<TrackableConnector> getTbConnectors() {
+        final List<TrackableConnector> connectors = new ArrayList<>();
+        if (Settings.isGeokretyConnectorActive()) {
+            connectors.add(new GeokretyConnector());
+        }
+        // travel bugs second to last, as their secret codes overlap with other connectors
+        connectors.add(TravelBugConnector.getInstance());
+        // unknown trackable connector must be last
+        connectors.add(UNKNOWN_TRACKABLE_CONNECTOR);
+        return Collections.unmodifiableCollection(connectors);
+    }
 
     @NonNull
     private static final Collection<ISearchByViewPort> searchByViewPortConns = getMatchingConnectors(ISearchByViewPort.class);


### PR DESCRIPTION
## Description
Workaround for TB namespace conflicts for TB starting with "GK":
Leave out GeoKrety TB connector of list of TB connectors, if GeoKrety connector is not activated. In this case no GeoKrety TB will be searched for online.
Be aware, though, that Geokrety TB already stored locally in the database will still be retrieved by the TB search.