### PR TITLE
Assign prefix on adding waypoints (rel. to #14053)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
@@ -729,13 +729,15 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
 
     public static void startActivityAddWaypoint(final Context context, final Geocache cache) {
         final Intent intent = new Intent(context, EditWaypointActivity.class)
-                .putExtra(Intents.EXTRA_GEOCODE, cache.getGeocode());
+                .putExtra(Intents.EXTRA_GEOCODE, cache.getGeocode())
+                .putExtra(Intents.EXTRA_WAYPOINT_ID, Waypoint.NEW_ID);
         context.startActivity(intent);
     }
 
     public static void startActivityAddWaypoint(final Context context, final Geocache cache, final Geopoint initialCoords) {
         final Intent intent = new Intent(context, EditWaypointActivity.class)
                 .putExtra(Intents.EXTRA_GEOCODE, cache.getGeocode())
+                .putExtra(Intents.EXTRA_WAYPOINT_ID, Waypoint.NEW_ID)
                 .putExtra(Intents.EXTRA_COORDS, initialCoords);
         context.startActivity(intent);
     }

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -1629,7 +1629,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             return;
         }
 
-        if (coordType == CoordinatesType.WAYPOINT && waypoint.getId() >= 0) {
+        if (coordType == CoordinatesType.WAYPOINT && !((Waypoint) waypoint).isNewWaypoint()) {
             CGeoMap.markCacheAsDirty(waypoint.getGeocode());
             WaypointPopup.startActivityAllowTarget(getActivity(), waypoint.getId(), waypoint.getGeocode());
         }

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -1535,7 +1535,7 @@ public class Geocache implements IWaypoint {
     public boolean addOrChangeWaypoint(final Waypoint waypoint, final boolean saveToDatabase) {
         waypoint.setGeocode(geocode);
 
-        if (waypoint.getId() < 0) { // this is a new waypoint
+        if (waypoint.isNewWaypoint()) {
             if (StringUtils.isBlank(waypoint.getPrefix())) {
                 assignUniquePrefix(waypoint);
             }
@@ -1664,7 +1664,7 @@ public class Geocache implements IWaypoint {
         if (waypoint == null) {
             return false;
         }
-        if (waypoint.getId() < 0) {
+        if (waypoint.isNewWaypoint()) {
             return false;
         }
         if (waypoint.getWaypointType() != WaypointType.ORIGINAL || waypoint.belongsToUserDefinedCache()) {

--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -38,7 +38,9 @@ public class Waypoint implements IWaypoint {
     private static final String WP_PREFIX_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     private static final int ORDER_UNDEFINED = -2;
 
-    private int id = -1;
+    public static final int NEW_ID = -1;
+
+    private int id = NEW_ID;
     private String geocode = "geocode";
     private Geocache parentCache = null;
     private WaypointType waypointType = WaypointType.WAYPOINT;
@@ -95,7 +97,7 @@ public class Waypoint implements IWaypoint {
     public Waypoint(final Waypoint other) {
         merge(other);
         this.waypointType = other.waypointType;
-        id = -1;
+        id = NEW_ID;
     }
 
     public void merge(final Waypoint old) {
@@ -202,6 +204,10 @@ public class Waypoint implements IWaypoint {
     @Override
     public int getId() {
         return id;
+    }
+
+    public boolean isNewWaypoint() {
+        return id == NEW_ID;
     }
 
     public void setId(final int id) {

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2393,7 +2393,7 @@ public class DataStore {
             for (final Waypoint waypoint : waypoints) {
                 final ContentValues values = createWaypointValues(geocode, waypoint);
 
-                if (waypoint.getId() < 0) {
+                if (waypoint.isNewWaypoint()) {
                     final long rowId = database.insert(dbTableWaypoints, null, values);
                     waypoint.setId((int) rowId);
                 } else {


### PR DESCRIPTION
## Description
Make `EditWaypointActivity` assign new waypoints a (generated) prefix.

## Detailed info
- Editing a waypoint will already assign a prefix if none exists and waypoint is detected as new.
- This will fail, though, for adding new waypoints, as they are currently not being recognized as new.
- This is due to the following code in `onCreate` (`waypointId = extras.getInt(Intents.EXTRA_WAYPOINT_ID);`), which assigns "0", if the value for waypoint id is missing in the intent. "0" is regarded a valid waypoint id, though, therefore this (newly to be created) waypoint will not be regarded as new, therefore the prefix check skipped.

Solution: Add the "new waypoint" marker (= -1) to calling intent on adding a new waypoint.