### PR TITLE
Remove outdated specific theming for settings

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -273,7 +273,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/settings_titlebar"
             android:parentActivityName="cgeo.geocaching.MainActivity"
-            android:theme="@style/settings"
+            android:theme="@style/cgeo"
             android:exported="false">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettings.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettings.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.maps.mapsforge.v6;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.settings.Settings;
 
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -22,7 +21,6 @@ public class RenderThemeSettings extends AppCompatActivity {
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
-        setTheme(Settings.isLightSkin(this) ? R.style.settings_light : R.style.settings);
         super.onCreate(savedInstanceState);
 
         ActivityMixin.setDisplayHomeAsUpEnabled(this, true);

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -93,7 +93,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         ApplicationSettings.setLocale(this);
-        setTheme(Settings.isLightSkin(this) ? R.style.settings_light : R.style.settings);
         super.onCreate(savedInstanceState);
 
         backupUtils = new BackupUtils(SettingsActivity.this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettings.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettings.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.settings.Settings;
 
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -22,7 +21,6 @@ public class MapsforgeThemeSettings extends AppCompatActivity {
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
-        setTheme(Settings.isLightSkin(this) ? R.style.settings_light : R.style.settings);
         super.onCreate(savedInstanceState);
 
         ActivityMixin.setDisplayHomeAsUpEnabled(this, true);

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -68,45 +68,6 @@
         <item name="android:windowIsFloating">true</item>
     </style>
 
-    <!-- theme for settings (temporary workaround, needed only as long as SettingsActivity is not derived from AppCompatActivity) -->
-
-    <style name="settings" parent="cgeo">
-        <item name="android:textColor">@color/settings_primary_selector_night</item>
-        <item name="android:textColorSecondary">@color/settings_secondary_selector_night</item>
-        <item name="android:colorBackground">@color/settings_colorBackgroundDark</item>
-        <item name="android:dialogTheme">@style/settings.DialogTheme</item>
-        <item name="android:alertDialogTheme">@style/settings.DialogTheme</item>
-    </style>
-
-    <style name="settings.light" parent="cgeo">
-        <item name="android:textColor">@color/settings_primary_selector_light</item>
-        <item name="android:textColorSecondary">@color/settings_secondary_selector_light</item>
-        <item name="android:colorBackground">@color/settings_colorBackgroundLight</item>
-        <item name="android:dialogTheme">@style/settings.DialogTheme.light</item>
-        <item name="android:alertDialogTheme">@style/settings.DialogTheme.light</item>
-    </style>
-
-    <style name="settings.DialogTheme" parent="@style/Theme.AppCompat.Dialog.Alert">
-        <item name="android:textColor">@color/settings_primary_selector_night</item>
-        <item name="android:colorAccent">@color/colorAccent</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="colorOnSurface">@color/colorAccent</item>
-        <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
-        <item name="android:background">@color/settings_colorBackgroundDark</item>
-    </style>
-
-    <style name="settings.DialogTheme.light" parent="@style/Theme.AppCompat.Light.Dialog.Alert">
-        <item name="android:textColor">@color/settings_primary_selector_light</item>
-        <item name="android:colorAccent">@color/colorAccent</item>
-        <item name="colorAccent">@color/colorAccent</item>
-        <item name="colorOnSurface">@color/colorAccent</item>
-        <item name="android:buttonBarButtonStyle">@style/settings.buttons</item>
-    </style>
-
-    <style name="settings.buttons" parent="@style/button">
-        <item name="android:textColor">@color/colorAccent</item>
-    </style>
-
     <!-- theme for splash screen -->
 
     <style name="SplashScreenTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">


### PR DESCRIPTION
## Description
Since `SettingsActivity` is derived from `AppCompatActivity` meanwhile, specific theming instructions for settings are no longer needed, so let's remove them.
