### PR TITLE
Move quick settings buttons to the left in landscape (rel. to #13315)

### DIFF
--- a/main/src/main/res/layout-land/map_settings_button.xml
+++ b/main/src/main/res/layout-land/map_settings_button.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingRight="5dp"
+    android:layout_centerVertical="true">
+
+    <LinearLayout
+        android:id="@+id/container_settings"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true">
+        <ImageButton
+            android:id="@+id/map_settings_popup"
+            android:src="@drawable/map_quick_settings"
+            style="@style/map_quicksettingsbutton"
+            android:hint="@string/quick_settings"/>
+    </LinearLayout>
+    <LinearLayout
+        android:id="@+id/container_individualroute"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/container_settings"
+        android:layout_marginTop="6dp"
+        android:visibility="visible">
+        <ImageButton
+            android:id="@+id/map_individualroute_popup"
+            style="@style/map_quicksettingsbutton"
+            android:src="@drawable/map_quick_route"
+            android:hint="@string/routes_tracks_dialog_title"/>
+    </LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
## Description
To gain more visible vertical map space, move quick settings buttons to the left in landscape mode.

(See #13315 for discussion. I decided to put them to the left instead of to the right to not interfere with zoom controls and (maximized) distance info.)