### PR TITLE
Enable up navigation in service authorization screens

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/OAuthAuthorizationActivity.java
@@ -129,6 +129,7 @@ public abstract class OAuthAuthorizationActivity extends AbstractActivity {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setTheme();
+        setUpNavigationEnabled(true);
         binding = AuthorizationActivityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 

--- a/main/src/main/java/cgeo/geocaching/activity/TokenAuthorizationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/TokenAuthorizationActivity.java
@@ -88,6 +88,7 @@ public abstract class TokenAuthorizationActivity extends AbstractActivity {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setTheme();
+        setUpNavigationEnabled(true);
         binding = AuthorizationTokenActivityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 

--- a/main/src/main/java/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/AbstractCredentialsAuthorizationActivity.java
@@ -40,6 +40,7 @@ public abstract class AbstractCredentialsAuthorizationActivity extends AbstractA
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setTheme();
+        setUpNavigationEnabled(true);
         binding = AuthorizationCredentialsActivityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 


### PR DESCRIPTION
## Description
Currently our authorization screens for geocaching service do not support the up icon in action bar, you have tap the back key.
This PR fixes it for all services based on token, OAuth or credentials authorization.

![image](https://user-images.githubusercontent.com/3754370/222966670-a300a269-8fb7-4287-a7e3-2937c3cb2804.png)

