### PR TITLE
Remove actionBarSpacer in CacheListActivity (fix #14065)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -480,7 +480,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         initAdapter();
 
-        FilterUtils.initializeFilterBar(this, this);
+        FilterUtils.initializeFilterBar(this, this, false);
         updateFilterBar();
 
         if (type.canSwitch) {

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -568,7 +568,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         mapView.onMapReady(() -> initializeMap(trailHistory));
 
-        FilterUtils.initializeFilterBar(activity, mapActivity);
+        FilterUtils.initializeFilterBar(activity, mapActivity, true);
         MapUtils.updateFilterBar(activity, mapOptions.filterContext);
 
         AndroidBeam.disable(activity);

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -346,7 +346,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             postZoomToViewport(new Viewport(Settings.getMapCenter().getCoords(), 0, 0));
         }
 
-        FilterUtils.initializeFilterBar(this, this);
+        FilterUtils.initializeFilterBar(this, this, true);
         MapUtils.updateFilterBar(this, mapOptions.filterContext);
 
         Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true), this);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -238,6 +238,12 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         }
         changeMapSource(Settings.getTileProvider());
 
+        // temporary workaround to show spacer; will be replaced by
+        // FilterUtils.initializeFilterBar(this, this, true);
+        // as soon as filtering gets integrated into UnifiedMapActivity
+        FilterUtils.toggleActionBar(this);
+        FilterUtils.toggleActionBar(this);
+
         Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true), this);
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -79,10 +79,11 @@ public class FilterUtils {
     /**
      * filterView must exist
      */
-    public static void initializeFilterBar(@NonNull final Activity activity, @NonNull final FilteredActivity filteredActivity) {
+    public static void initializeFilterBar(@NonNull final Activity activity, @NonNull final FilteredActivity filteredActivity, final boolean showSpacer) {
         final View filterView = activity.findViewById(R.id.filter_bar);
         filterView.setOnClickListener(v -> filteredActivity.showFilterMenu());
         filterView.setOnLongClickListener(v -> filteredActivity.showSavedFilterList());
+        activity.findViewById(R.id.actionBarSpacer).setVisibility(showSpacer ? View.VISIBLE : View.GONE);
     }
 
     public static void toggleActionBar(@NonNull final AbstractBottomNavigationActivity activity) {

--- a/main/src/main/res/layout/filter_sort_bar.xml
+++ b/main/src/main/res/layout/filter_sort_bar.xml
@@ -11,7 +11,8 @@
     <Space
         android:id="@+id/actionBarSpacer"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"/>
+        android:layout_height="?attr/actionBarSize"
+        android:visibility="gone"/>
 
     <LinearLayout
         android:id="@+id/filter_bar"


### PR DESCRIPTION
## Description
In contrast to map activities `CacheListActivity` should not use the extra spacer above the filter bar.