### PR TITLE
Fix failing searchByOwner test

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/CgeoApplicationTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/CgeoApplicationTest.java
@@ -257,7 +257,7 @@ public class CgeoApplicationTest {
             final SearchResult search = GCParser.searchByOwner(GCConnector.getInstance(), "Lineflyer");
             assertThat(search).isNotNull();
             assertThat(search.getGeocodes().size()).isGreaterThanOrEqualTo(20);
-            assertThat(search.getGeocodes()).contains("GC7J99X");
+            assertThat(search.getGeocodes()).contains("GC8TGJ6");
         });
     }
 


### PR DESCRIPTION
## Description
Tests are currently failing on CI due to paged search result no longer contains the cache being tested against on the first result page. Therefore select a cache further up in the result set.