### PR TITLE
Support back key to finish CheckableItemSelectActivity (fix #14086)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/CheckableItemSelectActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CheckableItemSelectActivity.java
@@ -139,7 +139,6 @@ public class CheckableItemSelectActivity extends AbstractActionBarActivity {
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             onBackPressed();
-            finish();
             return true;
         }
         return false;
@@ -154,5 +153,6 @@ public class CheckableItemSelectActivity extends AbstractActionBarActivity {
             }
         }
         Settings.setInfoItems(prefKey, selected);
+        finish();
     }
 }


### PR DESCRIPTION
## Description
Pressing back key will now not only store the results but also return to previous settings screen, same as arrow in the header does.
