### PR TITLE
Move cache list config to appearance screens (rel. to #14073)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.settings.fragments;
 import cgeo.geocaching.BuildConfig;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.CacheListInfoItem;
 import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
@@ -56,6 +57,13 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
 
         setPrefClick(this, R.string.pref_quicklaunchitems, () -> {
             QuickLaunchItem.startActivity(getActivity(), R.string.init_quicklaunchitems, R.string.pref_quicklaunchitems);
+        });
+
+        setPrefClick(this, R.string.pref_cacheListInfo1, () -> {
+            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo1, R.string.pref_cacheListInfo1, 2);
+        });
+        setPrefClick(this, R.string.pref_cacheListInfo2, () -> {
+            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo2, R.string.pref_cacheListInfo2, 3);
         });
 
     }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.enumerations.CacheListInfoItem;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.storage.DataStore;
@@ -10,7 +9,6 @@ import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.SettingsUtils;
-import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
 import android.app.Activity;
 import android.app.ProgressDialog;
@@ -26,13 +24,6 @@ public class PreferenceOfflinedataFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_offlinedata, rootKey);
-
-        setPrefClick(this, R.string.pref_cacheListInfo1, () -> {
-            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo1, R.string.pref_cacheListInfo1, 2);
-        });
-        setPrefClick(this, R.string.pref_cacheListInfo2, () -> {
-            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo2, R.string.pref_cacheListInfo2, 3);
-        });
 
         findPreference(getString(R.string.pref_fakekey_preference_maintenance_directories)).setOnPreferenceClickListener(preference -> {
             // disable the button, as the cleanup runs in background and should not be invoked a second time

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -158,6 +158,10 @@
     <string translatable="false" name="pref_units_imperial">units</string>
     <string translatable="false" name="pref_quicklaunchitems">quicklaunchitems_sorted</string>
 
+    <!-- category cache lists -->
+    <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
+    <string translatable="false" name="pref_cacheListInfo1">cacheListInfo1</string>
+    <string translatable="false" name="pref_cacheListInfo2">cacheListInfo2</string>
 
     <!-- ============================================================================================================================================================================== -->
     <!-- keys for cachedetails screen -->
@@ -261,9 +265,6 @@
     <!-- ============================================================================================================================================================================== -->
     <string translatable="false" name="pref_logimages">logimages</string>
     <string translatable="false" name="pref_choose_list">choose_list</string>
-    <string translatable="false" name="pref_cacheListInfo1">cacheListInfo1</string>
-    <string translatable="false" name="pref_cacheListInfo2">cacheListInfo2</string>
-    <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
 
     <!-- category gpx -->
     <string translatable="false" name="pref_persistablefolder_gpx">persistablefolder_gpx</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -951,6 +951,7 @@
     <string name="init_summary_save_log_img">Save Images from Logs</string>
     <string name="init_units">Use Imperial Units</string>
     <string name="init_summary_units">Use Imperial Units instead of Metric Units</string>
+    <string name="init_cachelists">Cache Lists</string>
     <string name="init_log_offline">Offline Logging</string>
     <string name="init_summary_log_offline">Enable Offline Logging (Won\'t show online log screen when logging, won\'t upload logs)</string>
     <string name="init_choose_list">Ask for List</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -47,4 +47,33 @@
         android:title="@string/init_quicklaunchitems"
         android:summary="@string/init_summary_quicklaunchitems"
         app:iconSpaceReserved="false" />
+
+    <PreferenceCategory
+        android:title="@string/init_cachelists"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:title="@string/init_list_initial_load_limit"
+            android:summary="@string/init_summary_list_initial_load_limit"
+            app:allowDividerBelow="false"
+            app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_list_initial_load_limit"
+            android:defaultValue="@integer/list_load_limit_default"
+            app:min="0"
+            app:max="@integer/list_load_limit_max"
+            app:minValueDescription="@string/init_settings_description_unlimited"
+            app:stepSize="100"
+            app:logScaling="true"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="@string/pref_cacheListInfo1"
+            android:title="@string/init_title_cacheListInfo1"
+            android:summary="@string/init_summary_cacheListInfo"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="@string/pref_cacheListInfo2"
+            android:title="@string/init_title_cacheListInfo2"
+            android:summary="@string/init_summary_cacheListInfo"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/main/src/main/res/xml/preferences_offlinedata.xml
+++ b/main/src/main/res/xml/preferences_offlinedata.xml
@@ -17,32 +17,6 @@
         android:summary="@string/init_summary_choose_list"
         android:title="@string/init_choose_list"
         app:iconSpaceReserved="false" />
-    <Preference
-        android:title="@string/init_list_initial_load_limit"
-        android:summary="@string/init_summary_list_initial_load_limit"
-        app:allowDividerBelow="false"
-        app:iconSpaceReserved="false"/>
-    <cgeo.geocaching.settings.SeekbarPreference
-        android:key="@string/pref_list_initial_load_limit"
-        android:defaultValue="@integer/list_load_limit_default"
-        app:min="0"
-        app:max="@integer/list_load_limit_max"
-        app:minValueDescription="@string/init_settings_description_unlimited"
-        app:stepSize="100"
-        app:logScaling="true"
-        app:iconSpaceReserved="false" />
-
-    <Preference
-        android:key="@string/pref_cacheListInfo1"
-        android:title="@string/init_title_cacheListInfo1"
-        android:summary="@string/init_summary_cacheListInfo"
-        app:iconSpaceReserved="false" />
-    <Preference
-        android:key="@string/pref_cacheListInfo2"
-        android:title="@string/init_title_cacheListInfo2"
-        android:summary="@string/init_summary_cacheListInfo"
-        app:iconSpaceReserved="false" />
-
     <PreferenceCategory
         android:title="@string/settings_title_gpx"
         app:iconSpaceReserved="false">


### PR DESCRIPTION
## Description
Move the following settings from "Offline data" to "Appearance" settings into a new category "Cache Lists":
- List load limit
- Config info item line 1
- Config info item line 2
