### PR TITLE
Document unknown settings types

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/SettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SettingsUtils.java
@@ -84,6 +84,7 @@ public class SettingsUtils {
         } else if (value instanceof Float) {
             return SettingsType.TYPE_FLOAT;
         }
+        Log.e("Unknown settings type: value=" + value + ", type=" + value.getClass().getCanonicalName());
         return SettingsType.TYPE_UNKNOWN;
     }
 


### PR DESCRIPTION
## Description
While working on sortable quicklaunchitems I stumbled upon unknown preference types (`Set<String>` in this case) neither being stored nor documented in settings backup. This is no longer a problem for quicklaunch items, as those are stored as string meanwhile, but let's at least document if we ever find an unknown type on creating a settings backup.