### PR TITLE
rel to #14109: add transaction size logging in debug mode, restructure logging

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -477,6 +477,10 @@ dependencies {
     // Loupe for ImageGallery and zoomable ImageViews
     implementation 'io.github.igreenwood.loupe:loupe:1.2.2'
     //implementation 'io.github.igreenwood.loupe:extensions:1.0.1' //as of now not needed
+
+    //TooLargeTool is used for logging transaction sizes and thus helpng find transactionTooLargeExceptions
+    //See https://github.com/guardian/toolargetool 
+    implementation 'com.gu.android:toolargetool:0.3.0'
 }
 
 // un-mocking of Android classes that don't depend on the Android device, but are portable Java only, like SparseArray

--- a/main/src/main/java/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/main/java/cgeo/geocaching/CgeoApplication.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.ui.notifications.NotificationChannels;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.OOMDumpingUncaughtExceptionHandler;
+import cgeo.geocaching.utils.TransactionSizeLogger;
 
 import android.annotation.SuppressLint;
 import android.app.Application;
@@ -51,6 +52,8 @@ public class CgeoApplication extends Application {
         Log.iForce("---------------- CGeoApplication: startup -------------");
         try (ContextLogger ignore = new ContextLogger(true, "CGeoApplication.onCreate")) {
             super.onCreate();
+
+            TransactionSizeLogger.get().setRequested();
 
             OOMDumpingUncaughtExceptionHandler.installUncaughtExceptionHandler();
 

--- a/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
@@ -100,6 +100,7 @@ public final class SystemInformation {
                 .append("\n- System date format: ").append(Formatter.getShortDateFormat())
                 .append("\n- Time zone: ").append(CalendarUtils.getUserTimeZoneString())
                 .append("\n- Debug mode active: ").append(Settings.isDebug() ? "yes" : "no")
+                .append("\n- Log Settings: ").append(Log.getLogSettingsForDisplay())
                 .append("\n- Last backup: ").append(BackupUtils.hasBackup(BackupUtils.newestBackupFolder()) ? BackupUtils.getNewestBackupDateTime() : "never")
                 .append("\n- Routing mode: ").append(LocalizationUtils.getEnglishString(context, Settings.getRoutingMode().infoResId))
                 .append("\n- Live map mode: ").append(Settings.isLiveMap())

--- a/main/src/main/java/cgeo/geocaching/utils/TransactionSizeLogger.java
+++ b/main/src/main/java/cgeo/geocaching/utils/TransactionSizeLogger.java
@@ -1,0 +1,121 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.CgeoApplication;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.gu.toolargetool.Formatter;
+import com.gu.toolargetool.Logger;
+import com.gu.toolargetool.SizeTree;
+import com.gu.toolargetool.TooLargeTool;
+import com.gu.toolargetool.TooLargeToolKt;
+
+public class TransactionSizeLogger {
+
+    private static final TransactionSizeLogger INSTANCE = new TransactionSizeLogger();
+
+    private final AtomicBoolean enabled = new AtomicBoolean(false);
+    private final AtomicBoolean enabledRequested = new AtomicBoolean(false);
+
+    private static final Formatter TOOLARGE_FORMATTER = new Formatter() {
+        @NonNull
+        @Override
+        public String format(@NonNull final Activity activity, @NonNull final Bundle bundle) {
+            return activity.getClass().getSimpleName() + ".onSaveInstanceState: " + bundleToString(bundle);
+        }
+
+        @NonNull
+        @Override
+        public String format(@NonNull final FragmentManager fragmentManager, @NonNull final Fragment fragment, @NonNull final Bundle bundle) {
+            String message = fragment.getClass().getSimpleName() + ".onSaveInstanceState: " + bundleToString(bundle);
+            final Bundle fragmentArguments = fragment.getArguments();
+            if (fragmentArguments != null) {
+                message += " [fragment arguments = " + bundleToString(fragmentArguments) + "]";
+            }
+
+            return message;
+        }
+    };
+
+    private static final Logger TOOLARGE_LOGGER = new Logger() {
+        @Override
+        public void log(@NonNull final String s) {
+            Log.d("[TransactionSize]" + s);
+        }
+
+        @Override
+        public void logException(@NonNull final Exception e) {
+            Log.d("[TransactionSize] Exception", e);
+        }
+    };
+
+    private TransactionSizeLogger() {
+        //no instance
+    }
+
+    public static TransactionSizeLogger get() {
+        return INSTANCE;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        enabledRequested.set(enabled);
+        setRequested();
+    }
+
+    public void setRequested() {
+        if (enabled.get() != enabledRequested.get()) {
+            if (enabledRequested.get()) {
+                tryEnable();
+            } else {
+                tryDisable();
+            }
+        }
+    }
+
+    private void tryEnable() {
+        final Application app = CgeoApplication.getInstance();
+        if (app == null || enabled.get()) {
+            return;
+        }
+        TooLargeTool.startLogging(app, TOOLARGE_FORMATTER, TOOLARGE_LOGGER);
+        enabled.set(true);
+    }
+
+    private void tryDisable() {
+        final Application app = CgeoApplication.getInstance();
+        if (app == null || !enabled.get()) {
+            return;
+        }
+        TooLargeTool.stopLogging(app);
+    }
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    private static String bundleToString(final Bundle bundle) {
+        final SizeTree st = TooLargeToolKt.sizeTreeFromBundle(bundle);
+
+        final StringBuilder sb = new StringBuilder(st.getKey() + "/" + cgeo.geocaching.utils.Formatter.formatBytes(st.getTotalSize()) + "/" + st.getSubTrees().size() + "keys (");
+        boolean first = true;
+        Collections.sort(st.getSubTrees(), (l1, l2) -> Integer.compare(l2.getTotalSize(), l1.getTotalSize()));
+        for (SizeTree child : st.getSubTrees()) {
+            if (!first) {
+                sb.append(";");
+            }
+            first = false;
+            sb.append(child.getKey()).append("=").append(cgeo.geocaching.utils.Formatter.formatBytes(child.getTotalSize()));
+        }
+        return sb.append(")").toString();
+    }
+
+}


### PR DESCRIPTION
rel to #14109: add transaction size logging in debug mode, restructure logging

This PR adds transaction size logging to c:geo using the library TooLargeTool, see https://github.com/guardian/toolargetool. This is meant for analyzation of #14109. Transaction Size Logging is activated in debug mode 

This PR also adds a "log settings" information into system information

**This PR also removes the logging behaviour of ending c:geo in debug mode whenever an error is logged!** I never understood this "feature", because it effectively restraints people from running c:geo in debug mode. It is exactly those error situations that we are usually interested in, and it is of no use if c:geo ends when they happen...
