### PR TITLE
merge waypoints on refresh from Okapi (fix #14100)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -782,7 +782,10 @@ final class OkapiClient {
             cache.setAttributes(parseAttributes((ArrayNode) response.path(CACHE_ATTRNAMES), (ArrayNode) response.get(CACHE_ATTR_ACODES)));
             //TODO: Store license per cache
             //cache.setLicense(response.getString("attribution_note"));
-            cache.setWaypoints(parseWaypoints((ArrayNode) response.path(CACHE_WPTS)), false);
+
+            final List<Waypoint> waypointsOfResponse = parseWaypoints((ArrayNode) response.path(CACHE_WPTS));
+            Waypoint.mergeWayPoints(waypointsOfResponse, cache.getWaypoints(), false);
+            cache.setWaypoints(waypointsOfResponse, false);
 
             cache.mergeInventory(parseTrackables((ArrayNode) response.path(CACHE_TRACKABLES)), EnumSet.of(TrackableBrand.GEOKRETY));
 

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -783,9 +783,7 @@ final class OkapiClient {
             //TODO: Store license per cache
             //cache.setLicense(response.getString("attribution_note"));
 
-            final List<Waypoint> waypointsOfResponse = parseWaypoints((ArrayNode) response.path(CACHE_WPTS));
-            Waypoint.mergeWayPoints(waypointsOfResponse, cache.getWaypoints(), false);
-            cache.setWaypoints(waypointsOfResponse, false);
+            cache.mergeWaypoints(parseWaypoints((ArrayNode) response.path(CACHE_WPTS)), true);
 
             cache.mergeInventory(parseTrackables((ArrayNode) response.path(CACHE_TRACKABLES)), EnumSet.of(TrackableBrand.GEOKRETY));
 

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -351,9 +351,7 @@ public class Geocache implements IWaypoint {
             myVote = other.myVote;
         }
 
-        final List<Waypoint> newPoints = new ArrayList<>(waypoints);
-        Waypoint.mergeWayPoints(newPoints, other.waypoints, false);
-        this.setWaypoints(newPoints, false);
+        mergeWaypoints(other.waypoints, false);
 
         if (spoilers == null) {
             spoilers = other.spoilers;
@@ -404,6 +402,16 @@ public class Geocache implements IWaypoint {
 
         this.eventTimesInMin.reset(); // will be recalculated if/when necessary
         return isEqualTo(other);
+    }
+
+    public void mergeWaypoints(final List<Waypoint> otherWaypoints, final boolean forceMerge) {
+        if (waypoints.isEmpty()) {
+            this.setWaypoints(otherWaypoints, false);
+        } else {
+            final List<Waypoint> newPoints = new ArrayList<>(waypoints);
+            Waypoint.mergeWayPoints(newPoints, otherWaypoints, forceMerge);
+            this.setWaypoints(newPoints, false);
+        }
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -350,13 +350,11 @@ public class Geocache implements IWaypoint {
         if (myVote == 0) {
             myVote = other.myVote;
         }
-        if (waypoints.isEmpty()) {
-            this.setWaypoints(other.waypoints, false);
-        } else {
-            final List<Waypoint> newPoints = new ArrayList<>(waypoints);
-            Waypoint.mergeWayPoints(newPoints, other.waypoints, false);
-            this.setWaypoints(newPoints, false);
-        }
+
+        final List<Waypoint> newPoints = new ArrayList<>(waypoints);
+        Waypoint.mergeWayPoints(newPoints, other.waypoints, false);
+        this.setWaypoints(newPoints, false);
+
         if (spoilers == null) {
             spoilers = other.spoilers;
         }

--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -136,6 +136,10 @@ public class Waypoint implements IWaypoint {
     }
 
     public static void mergeWayPoints(final List<Waypoint> newPoints, final List<Waypoint> oldPoints, final boolean forceMerge) {
+        if (oldPoints.isEmpty()) {
+            return;
+        }
+
         // Build a map of new waypoints for faster subsequent lookups
         final Map<String, Waypoint> newPrefixes = new HashMap<>(newPoints.size());
         for (final Waypoint waypoint : newPoints) {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
fixes deletion of user defined waypoints on update cache from OC with defined user-coordinates on website.
Waypoints are now getting merged instead of overwritten.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #14100

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
to discuss, if the coordinates from the user-coordinates on website should be overtaken in c:geo as modified cache-coordinates