### PR TITLE
Remove divider lines above ColorpickerPreference (fix #14126)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/ColorpickerPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/ColorpickerPreference.java
@@ -58,6 +58,7 @@ public class ColorpickerPreference extends Preference {
     @Override
     public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
+        holder.setDividerAllowedAbove(false);
 
         originalColor = getPersistedInt(defaultColor);
         originalWidth = getSharedPreferences().getInt(lineWidthPreferenceKey, defaultWidth);


### PR DESCRIPTION
## Description
Removes the divider lines above ColorpickerPreferences (but allows them below to cater category separator lines)

![image](https://user-images.githubusercontent.com/3754370/227714884-3683531a-3287-46e8-8024-d23ae87d02db.png)
