### PR TITLE
Send2cgeo: force to  redownload the cache on importing via send2cgeo (fix #14110)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/network/Send2CgeoDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/network/Send2CgeoDownloader.java
@@ -48,7 +48,7 @@ public class Send2CgeoDownloader {
                     final String response = Network.getResponseData(responseFromWeb);
                     if (response != null && response.length() > 2) {
                         handler.sendMessage(handler.obtainMessage(DownloadProgress.MSG_LOADING, response));
-                        Geocache.storeCache(null, response, Collections.singleton(listId), false, null);
+                        Geocache.storeCache(null, response, Collections.singleton(listId), true, null);
                         handler.sendMessage(handler.obtainMessage(DownloadProgress.MSG_LOADED, response));
                         baseTime = System.currentTimeMillis();
                         worker.schedule(this);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
forces to redownload the cache, if send2cgeo imports a cache, that is already in the database

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #14110 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->