### PR TITLE
show message on sending empty log (fix #13476)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -513,10 +513,15 @@ public class LogCacheActivity extends AbstractLoggingActivity {
         Log.v("LogCacheActivity.onOptionsItemSelected(" + item.getItemId() + "/" + item.getTitle() + ")");
         final int itemId = item.getItemId();
         if (itemId == R.id.menu_send) {
-            if (TextUtils.getNormalizedStringLength(binding.log.getText().toString()) <= LOG_MAX_LENGTH) {
-                sendLogAndConfirm();
+            final int logLength = TextUtils.getNormalizedStringLength(binding.log.getText().toString());
+            if (logLength > 0) {
+                if (logLength <= LOG_MAX_LENGTH) {
+                    sendLogAndConfirm();
+                } else {
+                    Toast.makeText(this, R.string.cache_log_too_long, Toast.LENGTH_LONG).show();
+                }
             } else {
-                Toast.makeText(this, R.string.cache_log_too_long, Toast.LENGTH_LONG).show();
+                Toast.makeText(this, R.string.cache_empty_log, Toast.LENGTH_LONG).show();
             }
         } else if (itemId == R.id.menu_image) {
             imageListFragment.startAddImageDialog();

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1491,6 +1491,7 @@
     <string name="cache_menu_open_with">Open with…</string>
     <string name="cache_menu_visit">Log Visit</string>
     <string name="cache_log_too_long">c:geo couldn\'t submit your log cause it is too long. But thanks for trying to write such an extensive log ;-)</string>
+    <string name="cache_empty_log">c:geo couldn\'t submit your log cause it is empty.</string>
     <string name="cache_menu_visit_offline">Quick offline log</string>
     <string name="cache_menu_spoilers">Spoiler images</string>
     <string name="cache_menu_around">Caches around</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
1. check length before posting log and show toast, if log is empty ("c:geo couldn\'t submit your log cause it is empty. Please be so kind and leave some nice words to the owner.")
2. show reason for failing posting log
3. check empty log on sending post request and set logResult accordingly



## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #13476

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
to discuss - if 2) and 3) is sufficient or if 1) is the better implementation