### PR TITLE
fix adding caches to GC lists / creating GC lists

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
@@ -62,7 +62,7 @@ public class BookmarkUtils {
         if (selection.getGuid().equals(NEW_LIST_GUID)) {
             SimpleDialog.ofContext(context).setTitle(R.string.search_bookmark_new).input(-1, null, null, null,
                     name -> AndroidRxUtils.networkScheduler.scheduleDirect(() -> {
-                        final String guid = GCParser.createBookmarkList(name);
+                        final String guid = GCParser.createBookmarkList(name, geocaches.get(0));
                         if (guid == null) {
                             ActivityMixin.showToast(context, context.getString(R.string.search_bookmark_create_new_failed));
                             return;

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -186,6 +186,7 @@ public final class GCConstants {
     static final Pattern PATTERN_VIEWSTATEFIELDCOUNT = Pattern.compile("id=\"__VIEWSTATEFIELDCOUNT\"[^(value)]+value=\"(\\d+)\"[^>]+>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
     static final Pattern PATTERN_VIEWSTATES = Pattern.compile("id=\"__VIEWSTATE(\\d*)\"[^(value)]+value=\"([^\"]+)\"[^>]+>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
     static final Pattern PATTERN_USERTOKEN = Pattern.compile("userToken\\s*=\\s*'([^']+)'");
+    static final Pattern PATTERN_REQUESTVERIFICATIONTOKEN = Pattern.compile("__RequestVerificationToken\" type=\"hidden\" value=\"([^\"]+)\"");
 
     /**
      * downloadable PQs

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -100,6 +100,8 @@ public final class GCParser {
     @NonNull
     private static final ImmutablePair<StatusCode, Geocache> UNKNOWN_PARSE_ERROR = ImmutablePair.of(StatusCode.UNKNOWN_ERROR, null);
 
+    private static String HEADER_VERIFICATION_TOKEN = "X-Verification-Token";
+
     private GCParser() {
         // Utility class
     }
@@ -1070,12 +1072,13 @@ public final class GCParser {
      */
     @Nullable
     @WorkerThread
-    public static String createBookmarkList(final String name) {
+    public static String createBookmarkList(final String name, final Geocache geocache) {
         final ObjectNode jo = new ObjectNode(JsonUtils.factory).put("name", name);
         jo.putObject("type").put("code", "bm");
 
         try {
-            final String result = Network.getResponseData(Network.postJsonRequest("https://www.geocaching.com/api/proxy/web/v1/lists", jo));
+            final Parameters headers = new Parameters(HEADER_VERIFICATION_TOKEN, getRequestVerificationToken(geocache));
+            final String result = Network.getResponseData(Network.postJsonRequest("https://www.geocaching.com/api/proxy/web/v1/lists", headers, jo));
 
             if (StringUtils.isBlank(result)) {
                 Log.e("GCParser.createBookmarkList: No response from server");
@@ -1115,7 +1118,8 @@ public final class GCParser {
         Log.d(arrayNode.toString());
 
         try {
-            Network.completeWithSuccess(Network.putJsonRequest("https://www.geocaching.com/api/proxy/web/v1/lists/" + listGuid + "/geocaches", arrayNode));
+            final Parameters headers = new Parameters(HEADER_VERIFICATION_TOKEN, getRequestVerificationToken(geocaches.get(0)));
+            Network.completeWithSuccess(Network.putJsonRequest("https://www.geocaching.com/api/proxy/web/v1/lists/" + listGuid + "/geocaches", headers, arrayNode));
             Log.i("GCParser.addCachesToBookmarkList - caches uploaded to GC.com bookmark list");
             return true;
         } catch (final Exception ignored) {
@@ -1400,6 +1404,14 @@ public final class GCParser {
 
     private static String parseUserToken(final String page) {
         return TextUtils.getMatch(page, GCConstants.PATTERN_USERTOKEN, "");
+    }
+
+    private static String getRequestVerificationToken(@NonNull final Geocache cache) {
+        return parseRequestVerificationToken(requestHtmlPage(cache.getGeocode(), null, "n"));
+    }
+
+    private static String parseRequestVerificationToken(final String page) {
+        return TextUtils.getMatch(page, GCConstants.PATTERN_REQUESTVERIFICATIONTOKEN, "");
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/network/Network.java
+++ b/main/src/main/java/cgeo/geocaching/network/Network.java
@@ -278,6 +278,22 @@ public final class Network {
     }
 
     /**
+     * PUT HTTP request with Json POST DATA
+     *
+     * @param uri  the URI to request
+     * @param headers    http headers
+     * @param json the json object to add to the POST request
+     * @return a single with the HTTP response, or an IOException
+     */
+    @NonNull
+    public static Single<Response> putJsonRequest(final String uri, final Parameters headers, final BaseJsonNode json) {
+        final Builder request = new Request.Builder().url(uri).put(RequestBody.create(MEDIA_TYPE_APPLICATION_JSON,
+                json.toString()));
+        addHeaders(request, headers, null);
+        return RxOkHttpUtils.request(OK_HTTP_CLIENT, request.build());
+    }
+
+    /**
      * Multipart POST HTTP request
      *
      * @param uri             the URI to request


### PR DESCRIPTION
the existing calls to https://www.geocaching.com/api/proxy/web/v1/lists now require a "X-Verification-Token" header, the value of which can be obtained from cache pages: input[name="__RequestVerificationToken"]

There's also a new API for managing lists - https://www.geocaching.com/plan/api/lists/ - but this PR doesn't switch to that as it's not required (yet?)