### PR TITLE
fix adding caches to GC lists / creating GC lists

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
@@ -62,7 +62,7 @@ public class BookmarkUtils {
         if (selection.getGuid().equals(NEW_LIST_GUID)) {
             SimpleDialog.ofContext(context).setTitle(R.string.search_bookmark_new).input(-1, null, null, null,
                     name -> AndroidRxUtils.networkScheduler.scheduleDirect(() -> {
-                        final String guid = GCParser.createBookmarkList(name);
+                        final String guid = GCParser.createBookmarkList(name, geocaches.get(0));
                         if (guid == null) {
                             ActivityMixin.showToast(context, context.getString(R.string.search_bookmark_create_new_failed));
                             return;

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -186,6 +186,7 @@ public final class GCConstants {
     static final Pattern PATTERN_VIEWSTATEFIELDCOUNT = Pattern.compile("id=\"__VIEWSTATEFIELDCOUNT\"[^(value)]+value=\"(\\d+)\"[^>]+>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
     static final Pattern PATTERN_VIEWSTATES = Pattern.compile("id=\"__VIEWSTATE(\\d*)\"[^(value)]+value=\"([^\"]+)\"[^>]+>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
     static final Pattern PATTERN_USERTOKEN = Pattern.compile("userToken\\s*=\\s*'([^']+)'");
+    static final Pattern PATTERN_REQUESTVERIFICATIONTOKEN = Pattern.compile("__RequestVerificationToken\" type=\"hidden\" value=\"([^\"]+)\"");
 
     /**
      * downloadable PQs

--- a/main/src/main/java/cgeo/geocaching/network/Network.java
+++ b/main/src/main/java/cgeo/geocaching/network/Network.java
@@ -278,6 +278,22 @@ public final class Network {
     }
 
     /**
+     * PUT HTTP request with Json POST DATA
+     *
+     * @param uri  the URI to request
+     * @param headers    http headers
+     * @param json the json object to add to the POST request
+     * @return a single with the HTTP response, or an IOException
+     */
+    @NonNull
+    public static Single<Response> putJsonRequest(final String uri, final Parameters headers, final BaseJsonNode json) {
+        final Builder request = new Request.Builder().url(uri).put(RequestBody.create(MEDIA_TYPE_APPLICATION_JSON,
+                json.toString()));
+        addHeaders(request, headers, null);
+        return RxOkHttpUtils.request(OK_HTTP_CLIENT, request.build());
+    }
+
+    /**
      * Multipart POST HTTP request
      *
      * @param uri             the URI to request


### PR DESCRIPTION
the existing calls to https://www.geocaching.com/api/proxy/web/v1/lists now require a "X-Verification-Token" header, the value of which can be obtained from cache pages: input[name="__RequestVerificationToken"]

There's also a new API for managing lists - https://www.geocaching.com/plan/api/lists/ - but this PR doesn't switch to that as it's not required (yet?)


Targeted against release as this should be in the next bugfix