### PR TITLE
Add last logs smiley row to configurable info items ( #14084)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/enumerations/CacheListInfoItem.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/CacheListInfoItem.java
@@ -21,7 +21,8 @@ public class CacheListInfoItem extends InfoItem {
         SIZE(5, R.string.cacheListInfoItem_Size),
         JASMER(7, R.string.cacheListInfoItem_Jasmer),
         EVENTDATE(8, R.string.cacheListInfoItem_EventDate),
-        LISTS(6, R.string.cacheListInfoItem_Lists);
+        LISTS(6, R.string.cacheListInfoItem_Lists),
+        RECENT_LOGS(9, R.string.cache_latest_logs);
 
         public final int id;
         @StringRes public final int info;
@@ -40,7 +41,8 @@ public class CacheListInfoItem extends InfoItem {
         new CacheListInfoItem(VALUES.SIZE.id, R.string.cacheListInfoItem_Size),
         new CacheListInfoItem(VALUES.JASMER.id, R.string.cacheListInfoItem_Jasmer),
         new CacheListInfoItem((VALUES.EVENTDATE.id), R.string.cacheListInfoItem_EventDate),
-        new CacheListInfoItem(VALUES.LISTS.id, R.string.cacheListInfoItem_Lists)
+        new CacheListInfoItem(VALUES.LISTS.id, R.string.cacheListInfoItem_Lists),
+        new CacheListInfoItem(VALUES.RECENT_LOGS.id, R.string.cache_latest_logs)
     ));
 
     CacheListInfoItem(final int id, final @StringRes int titleResId) {

--- a/main/src/main/java/cgeo/geocaching/enumerations/CacheListInfoItem.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/CacheListInfoItem.java
@@ -22,7 +22,13 @@ public class CacheListInfoItem extends InfoItem {
         JASMER(7, R.string.cacheListInfoItem_Jasmer),
         EVENTDATE(8, R.string.cacheListInfoItem_EventDate),
         LISTS(6, R.string.cacheListInfoItem_Lists),
-        RECENT_LOGS(9, R.string.cache_latest_logs);
+        RECENT_LOGS(9, R.string.cache_latest_logs),
+
+        // insert additional items before those
+        NEWLINE1(101, R.string.newline),
+        NEWLINE2(102, R.string.newline),
+        NEWLINE3(103, R.string.newline),
+        NEWLINE4(104, R.string.newline);
 
         public final int id;
         @StringRes public final int info;
@@ -42,7 +48,13 @@ public class CacheListInfoItem extends InfoItem {
         new CacheListInfoItem(VALUES.JASMER.id, R.string.cacheListInfoItem_Jasmer),
         new CacheListInfoItem((VALUES.EVENTDATE.id), R.string.cacheListInfoItem_EventDate),
         new CacheListInfoItem(VALUES.LISTS.id, R.string.cacheListInfoItem_Lists),
-        new CacheListInfoItem(VALUES.RECENT_LOGS.id, R.string.cache_latest_logs)
+        new CacheListInfoItem(VALUES.RECENT_LOGS.id, R.string.cache_latest_logs),
+
+        // insert additional items before those
+        new CacheListInfoItem(VALUES.NEWLINE1.id, R.string.newline),
+        new CacheListInfoItem(VALUES.NEWLINE2.id, R.string.newline),
+        new CacheListInfoItem(VALUES.NEWLINE3.id, R.string.newline),
+        new CacheListInfoItem(VALUES.NEWLINE4.id, R.string.newline)
     ));
 
     CacheListInfoItem(final int id, final @StringRes int titleResId) {

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1992,15 +1992,13 @@ public class Settings {
                 result.add(CacheListInfoItem.VALUES.SIZE.id);
                 result.add(CacheListInfoItem.VALUES.EVENTDATE.id);
                 result.add(CacheListInfoItem.VALUES.MEMBERSTATE.id);
-                putString(prefKey, StringUtils.join(result, ","));
-                Log.i("migrated infoline1: " + result);
-            } else if (defaultSource == 3) {
                 // migrate showListsInCacheList setting
                 if (getBoolean(R.string.old_pref_showListsInCacheList, false)) {
+                    result.add(CacheListInfoItem.VALUES.NEWLINE1.id);
                     result.add(CacheListInfoItem.VALUES.LISTS.id);
                 }
                 putString(prefKey, StringUtils.join(result, ","));
-                Log.i("migrated infoline2: " + result);
+                Log.i("migrated infoline: " + result);
             }
         } else {
             for (String s : pref.split(",")) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -59,11 +59,8 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
             QuickLaunchItem.startActivity(getActivity(), R.string.init_quicklaunchitems, R.string.pref_quicklaunchitems);
         });
 
-        setPrefClick(this, R.string.pref_cacheListInfo1, () -> {
-            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo1, R.string.pref_cacheListInfo1, 2);
-        });
-        setPrefClick(this, R.string.pref_cacheListInfo2, () -> {
-            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo2, R.string.pref_cacheListInfo2, 3);
+        setPrefClick(this, R.string.pref_cacheListInfo, () -> {
+            CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo1, R.string.pref_cacheListInfo, 2);
         });
 
     }

--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -212,20 +212,19 @@ public final class Formatter {
         final SpannableStringBuilder sb = new SpannableStringBuilder();
 
         final ArrayList<SpannableString> infos = new ArrayList<>();
-        addConfiguredInfoItems(cache, Settings.getInfoItems(R.string.pref_cacheListInfo1, 2), storedLists, excludeList, infos);
+        addConfiguredInfoItems(cache, Settings.getInfoItems(R.string.pref_cacheListInfo, 2), storedLists, excludeList, infos);
+        boolean newlineRequested = false;
         for (SpannableString s : infos) {
             if (s.length() > 0) {
-                sb.append(sb.length() > 0 ? SEPARATOR : "").append(s);
-            }
-        }
+                if (StringUtils.equals(s, "\n")) {
+                    if (sb.length() > 0) {
+                        newlineRequested = true;
+                    }
+                } else {
+                    sb.append(sb.length() > 0 ? newlineRequested ? "\n" : SEPARATOR : "").append(s);
+                    newlineRequested = false;
+                }
 
-        infos.clear();
-        addConfiguredInfoItems(cache, Settings.getInfoItems(R.string.pref_cacheListInfo2, 3), storedLists, excludeList, infos);
-        boolean needsNewline = (sb.length() > 0);
-        for (SpannableString s : infos) {
-            if (s.length() > 0) {
-                sb.append(sb.length() > 0 ? needsNewline ? "\n" : SEPARATOR : "").append(s);
-                needsNewline = false;
             }
         }
         return sb;
@@ -279,6 +278,10 @@ public final class Formatter {
                     }
                     infos.add(new SpannableString(s.subSequence(0, count)));
                 }
+
+            // newline items should be last in list
+            } else if (item == CacheListInfoItem.VALUES.NEWLINE1.id || item == CacheListInfoItem.VALUES.NEWLINE2.id || item == CacheListInfoItem.VALUES.NEWLINE3.id || item == CacheListInfoItem.VALUES.NEWLINE4.id) {
+                infos.add(new SpannableString("\n"));
             }
         }
     }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -160,8 +160,7 @@
 
     <!-- category cache lists -->
     <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
-    <string translatable="false" name="pref_cacheListInfo1">cacheListInfo1</string>
-    <string translatable="false" name="pref_cacheListInfo2">cacheListInfo2</string>
+    <string translatable="false" name="pref_cacheListInfo">cacheListInfo</string>
 
     <!-- ============================================================================================================================================================================== -->
     <!-- keys for cachedetails screen -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -963,8 +963,7 @@
     <string name="init_summary_choose_list">Ask which list to store caches in</string>
     <string name="init_list_initial_load_limit">List Load limit</string>
     <string name="init_summary_list_initial_load_limit">Maximum number of caches to load from database initially when displaying stored lists. Choose 0 for \'unlimited\'</string>
-    <string name="init_title_cacheListInfo1">Configure list info lines (Line 1)</string>
-    <string name="init_title_cacheListInfo2">Configure list info lines (Line 2)</string>
+    <string name="init_title_cacheListInfo1">Configure list info lines</string>
     <string name="init_summary_cacheListInfo">Select the additional information to be shown for each cache in cache lists</string>
     <string name="init_livelist">Show Direction</string>
     <string name="init_summary_livelist">Show an arrow with compass direction for caches in a list</string>
@@ -980,6 +979,7 @@
     <string name="cacheListInfoItem_Lists">Other lists</string>
     <string name="cacheListInfoItem_Jasmer">Jasmer</string>
     <string name="cacheListInfoItem_EventDate">Event date</string>
+    <string name="newline">Newline</string>
 
     <string name="active_elements">Active Elements</string>
     <string name="disabled_elements">Disabled Elements</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -71,13 +71,8 @@
             app:logScaling="true"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_cacheListInfo1"
+            android:key="@string/pref_cacheListInfo"
             android:title="@string/init_title_cacheListInfo1"
-            android:summary="@string/init_summary_cacheListInfo"
-            app:iconSpaceReserved="false" />
-        <Preference
-            android:key="@string/pref_cacheListInfo2"
-            android:title="@string/init_title_cacheListInfo2"
             android:summary="@string/init_summary_cacheListInfo"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>


### PR DESCRIPTION
## Description
- Supports "last logs smiley row" in configurable info items (can be in a separate row or "flowing" in text)
- Reduces configurable info items to one setting (instead of two)
- Supports "newline" items, so that user can determine number of lines on their own
