### PR TITLE
rel to #14109: log content and size of individual route on saving

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -71,6 +71,7 @@ import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeV6GeoItemLayer;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.ApplicationSettings;
+import cgeo.geocaching.utils.BundleUtils;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.Formatter;
@@ -949,6 +950,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
         }
         if (individualRoute != null) {
+            if (Log.isEnabled(Log.LogLevel.DEBUG)) {
+                Log.d("NewMap: storing IndividualRoute: " + individualRoute + " (size:" + BundleUtils.getParcelSize(individualRoute) + ")");
+            }
             outState.putParcelable(BUNDLE_ROUTE, individualRoute);
         }
         if (mapOptions.filterContext != null) {

--- a/main/src/main/java/cgeo/geocaching/models/Route.java
+++ b/main/src/main/java/cgeo/geocaching/models/Route.java
@@ -11,6 +11,8 @@ import cgeo.geocaching.models.geoitem.IGeoItemSupplier;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -221,5 +223,19 @@ public class Route implements IGeoItemSupplier, Parcelable {
         dest.writeInt(routeable ? 1 : 0);
         dest.writeFloat(distance);
         dest.writeInt(isHidden ? 1 : 0);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        final int segmentCount = segments == null ? -1 : segments.size();
+        int pointCount = 0;
+        if (segments != null) {
+            for (RouteSegment s : segments) {
+                pointCount += s == null ? 0 : s.getSize();
+            }
+        }
+        return "[" + getClass().getSimpleName() + "]name=" + name + ",routable=" + routeable + ",distance=" + distance + ",isHidden=" + isHidden +
+                ",#segments=" + segmentCount + ",#points=" + pointCount;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/models/RouteSegment.java
+++ b/main/src/main/java/cgeo/geocaching/models/RouteSegment.java
@@ -52,7 +52,7 @@ public class RouteSegment implements Parcelable {
     }
 
     public int getSize() {
-        return points.size();
+        return points == null ? 0 : points.size();
     }
 
     public Geopoint getPoint() {

--- a/main/src/main/java/cgeo/geocaching/utils/BundleUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/BundleUtils.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.utils;
 
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
 
@@ -17,5 +19,18 @@ public class BundleUtils {
             return res;
         }
         return defaultValue;
+    }
+
+    public static int getParcelSize(final Parcelable parcelable) {
+        if (parcelable == null) {
+            return 0;
+        }
+        final Parcel p = Parcel.obtain();
+        try {
+            parcelable.writeToParcel(p, 0);
+            return p.dataSize();
+        } finally {
+            p.recycle();
+        }
     }
 }


### PR DESCRIPTION
rel to #14109: log content and size of individual route on saving

This PR logs (on debug level) infos about content and size of `IndividualRoute` before it is saved into transaction when leaving NewMap (Mapsforge V6). This is to further analyze #14109 because this object seems to become very large (around 2MB)