### PR TITLE
Do not store route in bundle (rel. to #14109)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -138,7 +138,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     private static final String BUNDLE_MAP_STATE = "mapState";
     private static final String BUNDLE_LIVE_ENABLED = "liveEnabled";
     private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
-    private static final String BUNDLE_ROUTE = "route";
     private static final String BUNDLE_FILTERCONTEXT = "filterContext";
 
     // Those are initialized in onCreate() and will never be null afterwards
@@ -367,9 +366,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         if (proximityNotification != null) {
             outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
         }
-        if (individualRoute != null) {
-            outState.putParcelable(BUNDLE_ROUTE, individualRoute);
-        }
         if (mapOptions.filterContext != null) {
             outState.putParcelable(BUNDLE_FILTERCONTEXT, mapOptions.filterContext);
         }
@@ -501,12 +497,11 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             mapOptions.isLiveEnabled = savedInstanceState.getBoolean(BUNDLE_LIVE_ENABLED, false);
             mapOptions.filterContext = savedInstanceState.getParcelable(BUNDLE_FILTERCONTEXT);
             proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
-            individualRoute = savedInstanceState.getParcelable(BUNDLE_ROUTE);
         } else {
             currentSourceId = Settings.getMapSource().getNumericalId();
             proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
-            individualRoute = null;
         }
+        individualRoute = null;
         if (null != proximityNotification) {
             proximityNotification.setTextNotifications(activity);
         }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -196,7 +196,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
     private static final String BUNDLE_MAP_STATE = "mapState";
     private static final String BUNDLE_PROXIMITY_NOTIFICATION = "proximityNotification";
-    private static final String BUNDLE_ROUTE = "route";
     private static final String BUNDLE_FILTERCONTEXT = "filterContext";
 
     // Handler messages
@@ -246,7 +245,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             mapOptions.mapState = savedInstanceState.getParcelable(BUNDLE_MAP_STATE);
             mapOptions.filterContext = savedInstanceState.getParcelable(BUNDLE_FILTERCONTEXT);
             proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
-            individualRoute = savedInstanceState.getParcelable(BUNDLE_ROUTE);
             followMyLocation = mapOptions.mapState.followsMyLocation();
         } else {
             if (mapOptions.mapState != null) {
@@ -254,9 +252,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             } else {
                 followMyLocation = followMyLocation && mapOptions.mapMode == MapMode.LIVE;
             }
-            individualRoute = null;
             proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
         }
+        individualRoute = null;
         if (null != proximityNotification) {
             proximityNotification.setTextNotifications(this);
         }
@@ -947,9 +945,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         outState.putParcelable(BUNDLE_MAP_STATE, state);
         if (proximityNotification != null) {
             outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
-        }
-        if (individualRoute != null) {
-            outState.putParcelable(BUNDLE_ROUTE, individualRoute);
         }
         if (mapOptions.filterContext != null) {
             outState.putParcelable(BUNDLE_FILTERCONTEXT, mapOptions.filterContext);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -84,7 +84,6 @@ import org.oscim.core.GeoPoint;
 public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
     private static final String STATE_ROUTETRACKUTILS = "routetrackutils";
-    private static final String BUNDLE_ROUTE = "route";
     private static final String BUNDLE_OVERRIDEPOSITIONANDZOOM = "overridePositionAndZoom";
 
     private static final String ROUTING_SERVICE_KEY = "UnifiedMap";
@@ -221,7 +220,6 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
             }
             overridePositionAndZoom = savedInstanceState.getBoolean(BUNDLE_OVERRIDEPOSITIONANDZOOM, false);
 //            proximityNotification = savedInstanceState.getParcelable(BUNDLE_PROXIMITY_NOTIFICATION);
-            individualRoute = savedInstanceState.getParcelable(BUNDLE_ROUTE);
 //            followMyLocation = mapOptions.mapState.followsMyLocation();
         } else {
 //            if (mapOptions.mapState != null) {
@@ -229,9 +227,9 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 //            } else {
 //                followMyLocation = followMyLocation && mapOptions.mapMode == MapMode.LIVE;
 //            }
-            individualRoute = null;
 //            proximityNotification = Settings.isGeneralProximityNotificationActive() ? new ProximityNotification(true, false) : null;
         }
+        individualRoute = null;
         // make sure we have a defined mapType
         if (mapType == null || mapType.type == UnifiedMapType.UnifiedMapTypeType.UMTT_Undefined) {
             mapType = new UnifiedMapType();
@@ -883,9 +881,6 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 //        if (proximityNotification != null) {
 //            outState.putParcelable(BUNDLE_PROXIMITY_NOTIFICATION, proximityNotification);
 //        }
-        if (individualRoute != null) {
-            outState.putParcelable(BUNDLE_ROUTE, individualRoute);
-        }
         outState.putBoolean(BUNDLE_OVERRIDEPOSITIONANDZOOM, true);
     }
 


### PR DESCRIPTION
## Description
Do not store calculated route in map activity bundle to avoid "transaction too large" errors on bundling/unbundling. Will lead to route recalculation on activity recreation.