### PR TITLE
fix bookmark list import

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1798,7 +1798,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     private static void startActivityWithAttachment(@NonNull final Context context, @NonNull final GCList pocketQuery) {
         final Uri uri = pocketQuery.getUri();
         final Intent cachesIntent = new Intent(Intent.ACTION_VIEW, uri, context, CacheListActivity.class);
-        cachesIntent.setDataAndType(uri, "application/zip");
+        cachesIntent.setDataAndType(uri, pocketQuery.isBookmarkList() ? "application/xml" : "application/zip");
         cachesIntent.putExtra(Intents.EXTRA_NAME, pocketQuery.getName());
         context.startActivity(cachesIntent);
     }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListActivity.java
@@ -146,7 +146,7 @@ public abstract class AbstractListActivity extends AbstractActionBarActivity {
 
     public void returnResult(final GCList pocketQuery) {
         setResult(RESULT_OK, new Intent()
-                .setDataAndType(pocketQuery.getUri(), "application/zip"));
+                .setDataAndType(pocketQuery.getUri(), pocketQuery.isBookmarkList() ? "application/xml" : "application/zip"));
         finish();
     }
 


### PR DESCRIPTION
Bookmark lists are now downloaded as GPX instead of ZIP, breaking our list import. This is the fix for release