### PR TITLE
Avoid race conditions on reordering route (fix #14135)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
@@ -67,7 +67,7 @@ public class IndividualRoute extends Route implements Parcelable {
     }
 
     public void reloadRoute(final UpdateIndividualRoute updateRoute) {
-        clearRouteInternal(updateRoute, false);
+        clearRouteInternal(null, false);
         AndroidRxUtils.andThenOnUi(Schedulers.io(), this::loadRouteInternal, () -> updateRoute(updateRoute));
     }
 


### PR DESCRIPTION
## Description
Update route on screen only after having fully reloaded it, to avoid race conditions as shown in related issue