### PR TITLE
Enable coreLibraryDesugaring to provide access to modern java APIs on old API levels

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -294,7 +294,7 @@ android {
 
 dependencies {
     // desugaring of Java 8 APIs
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -24,7 +24,10 @@ android {
 
 
     compileOptions {
-        // use the diamond operator and some other goodies in Android
+        // https://developer.android.com/studio/write/java8-support
+        // enable Java 8 APIs like Streams on older Android versions
+        coreLibraryDesugaringEnabled true
+        // use the diamond operator, lambdas and some other Java 8 language features in Android
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -290,6 +293,9 @@ android {
 }
 
 dependencies {
+    // desugaring of Java 8 APIs
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+
     // Apache Commons
     implementation 'org.apache.commons:commons-collections4:4.4'
 


### PR DESCRIPTION
> `coreLibraryDesugaringEnabled` is a feature in Android's build system that enables developers to use modern language features and APIs on older Android versions. Some benefits of using this feature include the ability to write more expressive, modular, and maintainable code, as well as leveraging the latest language features available in Java. However, there are also potential downsides to using `coreLibraryDesugaringEnabled`, including performance overhead, increased APK size, compatibility issues, and debugging issues. Developers should consider these pros and cons before deciding to use this feature in their Android projects.

___

Some cool Java features like `Streams` are only natively supported starting with API 24 while we are still targeting API 21. However, google provides a desugaring compatibility library which we could use. However, we need to weigh the potential benefits against the potential drawbacks and consider whether it is the right choice for us.

More details:
https://developer.android.com/studio/write/java8-support