### PR TITLE
force correct overflow button color (fix #14162)

### DIFF
--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -85,6 +85,7 @@
 
     <style name="actionBarActionOverflow" parent="Widget.AppCompat.ActionButton.Overflow">
         <item name="android:src">@drawable/three_dot_vertical</item>
+        <item name="tint">@color/colorTextActionBar</item>
     </style>
 
     <style name="tool_bar" parent="actionBarStyle">


### PR DESCRIPTION
Hopefully fix #14162 by explicitly setting correct overflow button color