### PR TITLE
Preserve target geocode on mapsource change (rel. to #12225)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapOptions.java
@@ -110,7 +110,7 @@ public class MapOptions {
         intent.putExtra(Intents.EXTRA_LIVE_ENABLED, isLiveEnabled);
         intent.putExtra(Intents.EXTRA_STORED_ENABLED, isStoredEnabled);
         intent.putExtra(Intents.EXTRA_SEARCH, searchResult);
-        intent.putExtra(Intents.EXTRA_GEOCODE, geocode);
+        intent.putExtra(Intents.EXTRA_GEOCODE, mapState != null && StringUtils.isNotBlank(mapState.getTargetGeocode()) ? mapState.getTargetGeocode() : geocode);
         intent.putExtra(Intents.EXTRA_COORDS, coords);
         intent.putExtra(Intents.EXTRA_WPTTYPE, waypointType);
         intent.putExtra(Intents.EXTRA_MAPSTATE, mapState);


### PR DESCRIPTION
## Description
This PR aims to mitigate the issue described in #12225, losing navigation geocode on mapsource change.
Should be thoroughly tested for any unwanted side-effects, therefore targeting this to `master` only.