### PR TITLE
Keep old mapsize when 'tap to hide actionbar' is disabled

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -83,6 +83,7 @@ import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.FilterUtils;
+import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.ShareUtils;
@@ -459,7 +460,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         }
 
         setTitle(title);
-        setContentView(R.layout.cacheslist_activity);
+        HideActionBarUtils.setContentView(this, R.layout.cacheslist_activity, false);
 
         // Check whether we're recreating a previously destroyed instance
         if (savedInstanceState != null) {
@@ -480,7 +481,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         initAdapter();
 
-        FilterUtils.initializeFilterBar(this, this, false);
+        FilterUtils.initializeFilterBar(this, this);
         updateFilterBar();
 
         if (type.canSwitch) {

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -260,25 +260,6 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
         return true;
     }
 
-    /** prerequisite for toggleActionBar without moving content around; call it before setContentView() */
-    public void setStableLayout() {
-        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
-    }
-
-    public boolean toggleActionBar() {
-        final ActionBar actionBar = getSupportActionBar();
-        if (actionBar == null) {
-            return false;
-        }
-        if (actionBar.isShowing()) {
-            actionBar.hide();
-            return false;
-        } else {
-            actionBar.show();
-            return true;
-        }
-    }
-
     private final class ConnectivityChangeReceiver extends BroadcastReceiver {
         private boolean isConnected = Network.isConnected();
 

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -62,6 +62,7 @@ import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.HistoryTrackUtils;
 import cgeo.geocaching.utils.LeastRecentlyUsedSet;
 import cgeo.geocaching.utils.Log;
@@ -511,8 +512,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
 
         // adding the bottom navigation component is handled by {@link AbstractBottomNavigationActivity#setContentView}
-        activity.setStableLayout();
-        activity.setContentView(MapGoogleBinding.inflate(activity.getLayoutInflater()).getRoot());
+        HideActionBarUtils.setContentView(activity, MapGoogleBinding.inflate(activity.getLayoutInflater()).getRoot(), true);
 
         // map settings popup
         activity.findViewById(R.id.map_settings_popup).setOnClickListener(v ->
@@ -563,7 +563,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
         mapView.onMapReady(() -> initializeMap(trailHistory));
 
-        FilterUtils.initializeFilterBar(activity, mapActivity, true);
+        FilterUtils.initializeFilterBar(activity, mapActivity);
         MapUtils.updateFilterBar(activity, mapOptions.filterContext);
 
         AndroidBeam.disable(activity);

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -25,7 +25,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
-import cgeo.geocaching.utils.FilterUtils;
+import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.maps.google.v2.GoogleMapUtils.isGoogleMapsAvailable;
 import static cgeo.geocaching.storage.extension.OneTimeDialogs.DialogType.MAP_AUTOROTATION_DISABLE;
@@ -125,7 +125,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         googleMap.setOnCameraIdleListener(this::recognizePositionChange);
         googleMap.setOnMapClickListener(latLng -> {
             if (activityRef.get() != null) {
-                adaptLayoutForActionbar(FilterUtils.toggleActionBar(activityRef.get()));
+                adaptLayoutForActionbar(HideActionBarUtils.toggleActionBar(activityRef.get()));
             }
         });
         googleMap.setOnMarkerClickListener(marker -> {

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -74,6 +74,7 @@ import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.CompactIconModeUtils;
 import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.HistoryTrackUtils;
 import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.Log;
@@ -265,8 +266,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         ActivityMixin.setTheme(this);
 
         // adding the bottom navigation component is handled by {@link AbstractBottomNavigationActivity#setContentView}
-        setStableLayout();
-        setContentView(MapMapsforgeV6Binding.inflate(getLayoutInflater()).getRoot());
+        HideActionBarUtils.setContentView(this, MapMapsforgeV6Binding.inflate(getLayoutInflater()).getRoot(), true);
 
         setTitle();
         this.mapAttribution = findViewById(R.id.map_attribution);
@@ -344,7 +344,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
             postZoomToViewport(new Viewport(Settings.getMapCenter().getCoords(), 0, 0));
         }
 
-        FilterUtils.initializeFilterBar(this, this, true);
+        FilterUtils.initializeFilterBar(this, this);
         MapUtils.updateFilterBar(this, mapOptions.filterContext);
 
         Routing.connect(ROUTING_SERVICE_KEY, () -> resumeRoute(true), this);
@@ -1305,7 +1305,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
 
     public void showSelection(@NonNull final List<GeoitemRef> items, final boolean longPressMode) {
         if (items.isEmpty() && !longPressMode) {
-            FilterUtils.toggleActionBar(this);
+            HideActionBarUtils.toggleActionBar(this);
         }
         if (items.isEmpty()) {
             return;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -38,7 +38,7 @@ import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.CompactIconModeUtils;
-import cgeo.geocaching.utils.FilterUtils;
+import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.HistoryTrackUtils;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.Log;
@@ -264,10 +264,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
         changeMapSource(Settings.getTileProvider());
 
-        // temporary workaround to show spacer; will be replaced by
-        // FilterUtils.initializeFilterBar(this, this, true);
-        // as soon as filtering gets integrated into UnifiedMapActivity
-        FilterUtils.showActionBarSpacer(this);
+        // FilterUtils.initializeFilterBar(this, this);
 
         Routing.connect(ROUTING_SERVICE_KEY, () -> viewModel.getIndividualRoute().notifyDataChanged(), this);
         viewModel.reloadIndividualRoute();
@@ -802,7 +799,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
                         .setOnDismissListener(d -> viewModel.getLongTapCoords().setValue(null))
                         .show();
             } else {
-                FilterUtils.toggleActionBar(this);
+                HideActionBarUtils.toggleActionBar(this);
             }
         } else if (result.size() == 1) {
             handleTap(result.get(0), isLongTap);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsView.java
@@ -16,6 +16,7 @@ import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractGoogleTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
+import cgeo.geocaching.utils.HideActionBarUtils;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 
 import android.app.Activity;
@@ -47,8 +48,7 @@ public class GoogleMapsView extends AbstractUnifiedMapView<LatLng> implements On
     @Override
     public void init(final UnifiedMapActivity activity, final int delayedZoomTo, final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         super.init(activity, delayedZoomTo, delayedCenterTo, onMapReadyTasks);
-        activity.setStableLayout();
-        activity.setContentView(R.layout.unifiedmap_googlemaps);
+        HideActionBarUtils.setContentView(activity, R.layout.unifiedmap_googlemaps, true);
         rootView = activity.findViewById(R.id.unifiedmap_gm);
         mMapView = activity.findViewById(R.id.mapViewGM);
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmView.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeVtmGeoItemLayer;
 import cgeo.geocaching.unifiedmap.mapsforgevtm.legend.RenderThemeLegend;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
+import cgeo.geocaching.utils.HideActionBarUtils;
 
 import android.app.Activity;
 import android.view.MenuItem;
@@ -66,8 +67,7 @@ public class MapsforgeVtmView extends AbstractUnifiedMapView<GeoPoint> {
     @Override
     public void init(final UnifiedMapActivity activity, final int delayedZoomTo, final Geopoint delayedCenterTo, final Runnable onMapReadyTasks) {
         super.init(activity, delayedZoomTo, delayedCenterTo, onMapReadyTasks);
-        activity.setStableLayout();
-        activity.setContentView(R.layout.unifiedmap_mapsforgevtm);
+        HideActionBarUtils.setContentView(activity, R.layout.unifiedmap_mapsforgevtm, true);
         rootView = activity.findViewById(R.id.unifiedmap_vtm);
         mMapView = activity.findViewById(R.id.mapViewVTM);
         super.mMapView = mMapView;

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -1,15 +1,12 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
 import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.models.Geocache;
-import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.TextParam;
-import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 
 import android.app.Activity;
@@ -81,29 +78,10 @@ public class FilterUtils {
     /**
      * filterView must exist
      */
-    public static void initializeFilterBar(@NonNull final Activity activity, @NonNull final FilteredActivity filteredActivity, final boolean showSpacer) {
+    public static void initializeFilterBar(@NonNull final Activity activity, @NonNull final FilteredActivity filteredActivity) {
         final View filterView = activity.findViewById(R.id.filter_bar);
         filterView.setOnClickListener(v -> filteredActivity.showFilterMenu());
         filterView.setOnLongClickListener(v -> filteredActivity.showSavedFilterList());
-        activity.findViewById(R.id.actionBarSpacer).setVisibility(showSpacer ? View.VISIBLE : View.GONE);
-    }
-
-    /** temporary helper until UnifiedMap uses initializeFilterBar */
-    @Deprecated
-    public static void showActionBarSpacer(@NonNull final Activity activity) {
-        activity.findViewById(R.id.actionBarSpacer).setVisibility(View.VISIBLE);
-    }
-
-    public static boolean toggleActionBar(@NonNull final AbstractBottomNavigationActivity activity) {
-        if (!Settings.getMapActionbarAutohide()) {
-            return true;
-        }
-        final boolean actionBarShowing = activity.toggleActionBar();
-        final View spacer = activity.findViewById(R.id.actionBarSpacer);
-        ViewUtils.applyToView(activity.findViewById(R.id.filterbar), view -> view.animate().translationY(actionBarShowing ? 0 : -spacer.getHeight()).start());
-        ViewUtils.applyToView(activity.findViewById(R.id.distanceinfo), view -> view.animate().translationY(actionBarShowing ? 0 : -spacer.getHeight()).start());
-        ViewUtils.applyToView(activity.findViewById(R.id.map_progressbar), view -> view.animate().translationY(actionBarShowing ? 0 : -spacer.getHeight()).start());
-        return actionBarShowing;
     }
 
     public static void initializeFilterMenu(@NonNull final Activity activity, @NonNull final FilteredActivity filteredActivity) {

--- a/main/src/main/java/cgeo/geocaching/utils/HideActionBarUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/HideActionBarUtils.java
@@ -1,0 +1,73 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.ViewUtils;
+
+import android.app.Activity;
+import android.view.View;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+
+public class HideActionBarUtils {
+
+    private HideActionBarUtils() {
+        // utility class
+    }
+
+    /** use this instead of AbstractBootmNavigationActivity.setContentView for being able to use a action bar toogle */
+    public static void setContentView(@NonNull final AbstractBottomNavigationActivity activity, final View contentView, final boolean showSpacer) {
+        setStableLayout(activity, showSpacer);
+        activity.setContentView(contentView);
+        showActionBarSpacer(activity, showSpacer);
+    }
+
+    /** use this instead of AbstractBootmNavigationActivity.setContentView for being able to use a action bar toogle */
+    public static void setContentView(@NonNull final AbstractBottomNavigationActivity activity, @LayoutRes final int layoutResID, final boolean showSpacer) {
+        setStableLayout(activity, showSpacer);
+        activity.setContentView(layoutResID);
+        showActionBarSpacer(activity, showSpacer);
+    }
+
+    public static boolean toggleActionBar(@NonNull final AbstractBottomNavigationActivity activity) {
+        if (!Settings.getMapActionbarAutohide()) {
+            return true;
+        }
+        final boolean actionBarShowing = toggleActionBarHelper(activity);
+        final View spacer = activity.findViewById(R.id.actionBarSpacer);
+        ViewUtils.applyToView(activity.findViewById(R.id.filterbar), view -> view.animate().translationY(actionBarShowing ? 0 : -spacer.getHeight()).start());
+        ViewUtils.applyToView(activity.findViewById(R.id.distanceinfo), view -> view.animate().translationY(actionBarShowing ? 0 : -spacer.getHeight()).start());
+        ViewUtils.applyToView(activity.findViewById(R.id.map_progressbar), view -> view.animate().translationY(actionBarShowing ? 0 : -spacer.getHeight()).start());
+        return actionBarShowing;
+    }
+
+    private static boolean toggleActionBarHelper(@NonNull final AbstractBottomNavigationActivity activity) {
+        final ActionBar actionBar = activity.getSupportActionBar();
+        if (actionBar == null) {
+            return false;
+        }
+        if (actionBar.isShowing()) {
+            actionBar.hide();
+            return false;
+        } else {
+            actionBar.show();
+            return true;
+        }
+    }
+
+    private static void showActionBarSpacer(@NonNull final Activity activity, final boolean showSpacer) {
+        if (Settings.getMapActionbarAutohide()) {
+            activity.findViewById(R.id.actionBarSpacer).setVisibility(showSpacer ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private static void setStableLayout(@NonNull final AbstractBottomNavigationActivity activity, final boolean showSpacer) {
+        if (showSpacer && Settings.getMapActionbarAutohide()) {
+            activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+        }
+    }
+
+}

--- a/main/src/main/res/layout-h390dp-land/activity_bottom_navigation.xml
+++ b/main/src/main/res/layout-h390dp-land/activity_bottom_navigation.xml
@@ -24,6 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentStart="true"
+        android:layout_below="@id/actionBarSpacer"
         app:labelVisibilityMode="labeled"
         app:menu="@menu/bottom_navigation_menu" />
 </cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>

--- a/main/src/main/res/layout-land/activity_bottom_navigation.xml
+++ b/main/src/main/res/layout-land/activity_bottom_navigation.xml
@@ -25,6 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentStart="true"
+        android:layout_below="@id/actionBarSpacer"
         app:labelVisibilityMode="unlabeled"
         app:menu="@menu/bottom_navigation_menu" />
 </cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>


### PR DESCRIPTION
## Description
Implements the approach proposed in https://github.com/cgeo/cgeo/issues/14161#issuecomment-1508089543:
Do not move the map view beneath the action bar, when "hide on tap" is disabled.

Additionally extracts the map hiding methods into their on class (instead of being buried in `FilterUtils`) and uncouples it from `FilterUtils.initializeFilterBar()`.