### PR TITLE
UnifiedMap: Remove indiv. route items on long tap only (fix #14213)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
@@ -56,7 +56,7 @@ public class TapHandlerLayer extends Layer {
 
         final Context ctx = wrContext.get();
         if (testItemLayer != null && ctx != null) {
-            testItemLayer.handleTap(ctx, new Geopoint(tapLatLong.latitude, tapLatLong.longitude));
+            testItemLayer.handleTap(ctx, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), false);
         }
 
         return true;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -768,7 +768,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
     public void onTap(final int latitudeE6, final int longitudeE6, final int x, final int y, final boolean isLongTap) {
         for (ILayer layer : layers) {
-            if (layer.handleTap(this, Geopoint.forE6(latitudeE6, longitudeE6))) {
+            if (layer.handleTap(this, Geopoint.forE6(latitudeE6, longitudeE6), isLongTap)) {
                 return;
             }
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemTestLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemTestLayer.java
@@ -62,7 +62,7 @@ public class GeoItemTestLayer implements ILayer {
     }
 
     @Override
-    public boolean handleTap(final Context ctx, final Geopoint tapped) {
+    public boolean handleTap(final Context ctx, final Geopoint tapped, final boolean isLongTap) {
         if (!Settings.enableFeatureUnifiedGeoItemLayer()) {
             return false;
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/ILayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/ILayer.java
@@ -9,7 +9,7 @@ public interface ILayer {
 
     void destroy();
 
-    default boolean handleTap(Context context, Geopoint tapped) {
+    default boolean handleTap(Context context, Geopoint tapped, final boolean isLongTap) {
         return false;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/IndividualRouteLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/IndividualRouteLayer.java
@@ -81,11 +81,11 @@ public class IndividualRouteLayer implements ILayer {
     }
 
     @Override
-    public boolean handleTap(final Context context, final Geopoint tapped) {
+    public boolean handleTap(final Context context, final Geopoint tapped, final boolean isLongTap) {
         final Set<String> items = geoItemLayer.getTouched(tapped);
         if (items.size() <= 2) { // route line + coords marker
             for (String item : items) {
-                if (!KEY_INDIVIDUAL_ROUTE.equals(item)) {
+                if (isLongTap && !KEY_INDIVIDUAL_ROUTE.equals(item)) {
                     viewModel.toggleRouteItem(context, new RouteItem(geoItemLayer.get(item).getCenter()));
                     return true;
                 }


### PR DESCRIPTION
## Description
For Unified Map: Extends `ILayer.onTap` to distinguish between taps and long taps and remove route items on long taps only.
