### PR TITLE
Catch null settings values on performing backup (fix #14218)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/SettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SettingsUtils.java
@@ -84,7 +84,7 @@ public class SettingsUtils {
         } else if (value instanceof Float) {
             return SettingsType.TYPE_FLOAT;
         }
-        Log.e("Unknown settings type: value=" + value + ", type=" + value.getClass().getCanonicalName());
+        Log.w("Unknown settings type: value=" + value + (value != null ? ", type=" + value.getClass().getCanonicalName() : ""));
         return SettingsType.TYPE_UNKNOWN;
     }
 


### PR DESCRIPTION
## Description
Catch `null` values while documenting unknown setting types when performing a settings' backup.
(Also lowers the message level to "warning" instead of "error".)