### PR TITLE
Fix compass status view alignment in landscape mode (fix #14203)

### DIFF
--- a/main/src/main/res/layout-land/compass_activity.xml
+++ b/main/src/main/res/layout-land/compass_activity.xml
@@ -136,7 +136,8 @@
         <cgeo.geocaching.ui.LocationStatusView
             android:id="@+id/location_status"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true" />
 
         <RelativeLayout
             android:id="@+id/status"


### PR DESCRIPTION
## Description
Align compass status view to parent's bottom in landscape mode to avoid overlapping texts

![image](https://user-images.githubusercontent.com/3754370/233839848-9889dbcf-e981-481f-831d-cbb92c05fa08.png)
