### PR TITLE
NewMap: Add long-tap context menu for caches/waypoints (rel. to #13176)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -585,6 +585,17 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         overlayPositionAndScale.repaintRequired();
     }
 
+    public void handleCacheWaypointLongTap(final IWaypoint item, final int tapX, final int tapY) {
+        final RouteItem routeItem = new RouteItem(item);
+        if (MapUtils.isPartOfRoute(routeItem, individualRoute)) {
+            MapUtils.createCacheWaypointLongClickPopupMenu(activity, routeItem, tapX, tapY, individualRoute, overlayPositionAndScale, this::updateRouteTrackButtonVisibility)
+//                    .setOnDismissListener(menu -> tapHandlerLayer.resetLongTapLatLong())
+                    .show();
+        } else {
+            toggleRouteItem(item);
+        }
+    }
+
     public void toggleRouteItem(final Geopoint geopoint) {
         if (individualRoute == null) {
             individualRoute = new IndividualRoute(this::setNavigationTargetFromIndividualRoute);

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -18,6 +18,7 @@ import cgeo.geocaching.models.Download;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IndividualRoute;
 import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.RouteSegment;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
@@ -48,9 +49,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class MapUtils {
 
@@ -211,16 +215,82 @@ public class MapUtils {
                 })
                 .addItemClickListener(R.id.menu_add_to_route, item -> {
                     individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, false);
-                    if (updateRouteTrackButtonVisibility != null) {
-                        updateRouteTrackButtonVisibility.run();
-                    }
+                    updateRouteTrackButtonVisibility(updateRouteTrackButtonVisibility);
                 })
                 .addItemClickListener(R.id.menu_add_to_route_start, item -> {
                     individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, true);
-                    if (updateRouteTrackButtonVisibility != null) {
-                        updateRouteTrackButtonVisibility.run();
-                    }
+                    updateRouteTrackButtonVisibility(updateRouteTrackButtonVisibility);
                 })
                 .addItemClickListener(R.id.menu_navigate, item -> NavigationAppFactory.showNavigationMenu(activity, null, null, longClickGeopoint, false, true));
     }
+
+    private static void updateRouteTrackButtonVisibility(final Runnable updateRouteTrackButtonVisibility) {
+        if (updateRouteTrackButtonVisibility != null) {
+            updateRouteTrackButtonVisibility.run();
+        }
+    }
+
+    public static boolean isPartOfRoute(final RouteItem routeItem, final IndividualRoute individualRoute) {
+        final RouteSegment[] segments = (individualRoute != null ? individualRoute.getSegments() : null);
+        if (segments == null || segments.length == 0) {
+            return false;
+        }
+        final String routeItemIdentifier = routeItem.getIdentifier();
+        for (RouteSegment segment : segments) {
+            if (StringUtils.equals(routeItemIdentifier, segment.getItem().getIdentifier())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("PMD.NPathComplexity") // split up would not help readability
+    public static SimplePopupMenu createCacheWaypointLongClickPopupMenu(final Activity activity, final RouteItem routeItem, final int tapX, final int tapY, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Runnable updateRouteTrackButtonVisibility) {
+        final RouteSegment[] segments = (individualRoute != null ? individualRoute.getSegments() : null);
+        final boolean routeIsNotEmpty = segments != null && segments.length > 0;
+        final int baseId = (segments != null ? segments.length : 0) + 100;
+
+        boolean isEnd = false;
+        final SimplePopupMenu menu = SimplePopupMenu.of(activity).setPosition(new Point(tapX, tapY), 0);
+        if (routeIsNotEmpty) {
+            final String routeItemIdentifier = routeItem.getIdentifier();
+            final boolean isStart = StringUtils.equals(routeItemIdentifier, segments[0].getItem().getIdentifier());
+            if (isStart) {
+                addMenuHelper(activity, menu, 0, activity.getString(R.string.context_map_remove_from_route_start), individualRoute, routeUpdater, updateRouteTrackButtonVisibility);
+            }
+            for (int i = 1; i < segments.length - 1; i++) {
+                if (StringUtils.equals(routeItemIdentifier, segments[i].getItem().getIdentifier())) {
+                    addMenuHelper(activity, menu, i, String.format(Locale.getDefault(), activity.getString(R.string.context_map_remove_from_route_pos), i), individualRoute, routeUpdater, updateRouteTrackButtonVisibility);
+                }
+            }
+            isEnd = (segments.length > 1) && StringUtils.equals(routeItemIdentifier, segments[segments.length - 1].getItem().getIdentifier());
+            if (isEnd) {
+                addMenuHelper(activity, menu, segments.length - 1, activity.getString(R.string.context_map_remove_from_route_end), individualRoute, routeUpdater, updateRouteTrackButtonVisibility);
+            }
+            if (!isStart) {
+                addMenuHelper(activity, menu, baseId, activity.getString(R.string.context_map_add_to_route_start), routeItem, true, individualRoute, routeUpdater, updateRouteTrackButtonVisibility);
+            }
+        }
+        if (!isEnd) {
+            addMenuHelper(activity, menu, baseId + 1, activity.getString(R.string.context_map_add_to_route), routeItem, false, individualRoute, routeUpdater, updateRouteTrackButtonVisibility);
+        }
+        return menu;
+    }
+
+    private static void addMenuHelper(final Activity activity, final SimplePopupMenu menu, final int uniqueId, final CharSequence title, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Runnable updateRouteTrackButtonVisibility) {
+        menu.addMenuItem(uniqueId, title);
+        menu.addItemClickListener(uniqueId, item -> {
+            individualRoute.removeItem(activity, uniqueId, routeUpdater);
+            updateRouteTrackButtonVisibility(updateRouteTrackButtonVisibility);
+        });
+    }
+
+    private static void addMenuHelper(final Activity activity, final SimplePopupMenu menu, final int uniqueId, final CharSequence title, final RouteItem routeItem, final boolean addToRouteStart, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Runnable updateRouteTrackButtonVisibility) {
+        menu.addMenuItem(uniqueId, title);
+        menu.addItemClickListener(uniqueId, item -> {
+            individualRoute.addItem(activity, routeItem, routeUpdater, addToRouteStart);
+            updateRouteTrackButtonVisibility(updateRouteTrackButtonVisibility);
+        });
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -145,7 +145,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
                     final Point waypointPoint = googleMap.getProjection().toScreenLocation(new LatLng(closest.getCoord().getCoords().getLatitude(), closest.getCoord().getCoords().getLongitude()));
                     if (insideCachePointDrawable(tappedPoint, waypointPoint, closest.getMarker(0).getDrawable())) {
                         hitWaypoint = true;
-                        ((CGeoMap) onCacheTapListener).toggleRouteItem(closest.getCoord());
+                        ((CGeoMap) onCacheTapListener).handleCacheWaypointLongTap(closest.getCoord(), waypointPoint.x, waypointPoint.y);
                     }
                 }
                 if (!hitWaypoint && null != positionAndHistoryRef) {

--- a/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
@@ -47,6 +47,14 @@ public class IndividualRoute extends Route implements Parcelable {
     }
 
     public void toggleItem(final Context context, final RouteItem item, final UpdateIndividualRoute routeUpdater, final boolean addToRouteStart) {
+        addOrToggleItem(context, item, routeUpdater, false, addToRouteStart);
+    }
+
+    public void addItem(final Context context, final RouteItem item, final UpdateIndividualRoute routeUpdater, final boolean addToRouteStart) {
+        addOrToggleItem(context, item, routeUpdater, true, addToRouteStart);
+    }
+
+    private void addOrToggleItem(final Context context, final RouteItem item, final UpdateIndividualRoute routeUpdater, final boolean forceAdd, final boolean addToRouteStart) {
         if (loadingRoute) {
             Log.d("[RouteTrackDebug] Individual route: Cannot toggle item, route still loading");
             return;
@@ -57,11 +65,18 @@ public class IndividualRoute extends Route implements Parcelable {
             return;
         }
 
-        final ToggleItemState result = toggleItemInternal(item, addToRouteStart);
+        final ToggleItemState result = toggleItemInternal(item, forceAdd, addToRouteStart);
         if (result == ToggleItemState.REMOVED) {
             Log.d("[RouteTrackDebug] Individual route: Removed first element from route (" + item.getIdentifier() + ")");
         }
         Toast.makeText(context, result == ToggleItemState.ADDED ? R.string.individual_route_added : result == ToggleItemState.REMOVED ? R.string.individual_route_removed : R.string.individual_route_error_toggling_waypoint, Toast.LENGTH_SHORT).show();
+        updateRoute(routeUpdater);
+        saveRoute();
+    }
+
+    public void removeItem(final Context context, final int pos, final UpdateIndividualRoute routeUpdater) {
+        final ToggleItemState result = removeItem(pos);
+        Toast.makeText(context, result == ToggleItemState.REMOVED ? R.string.individual_route_removed : R.string.individual_route_error_toggling_waypoint, Toast.LENGTH_SHORT).show();
         updateRoute(routeUpdater);
         saveRoute();
     }
@@ -111,7 +126,7 @@ public class IndividualRoute extends Route implements Parcelable {
         final ArrayList<RouteItem> routeItems = DataStore.loadIndividualRoute();
         for (int i = 0; i < routeItems.size(); i++) {
             Log.d("[RouteTrackDebug] Individual route: Add item #" + i + " (" + routeItems.get(i).getIdentifier() + ")");
-            toggleItemInternal(routeItems.get(i), false);
+            toggleItemInternal(routeItems.get(i), true, false);
         }
         Log.d("[RouteTrackDebug] Individual route: Finished loading from database");
         loadingRoute = false;
@@ -138,11 +153,11 @@ public class IndividualRoute extends Route implements Parcelable {
      * @param item item to be added or removed
      * @return ToggleItemState
      */
-    private ToggleItemState toggleItemInternal(final RouteItem item, final boolean addToRouteStart) {
+    private ToggleItemState toggleItemInternal(final RouteItem item, final boolean forceAdd, final boolean addToRouteStart) {
         if (segments == null) {
             segments = new ArrayList<>();
         }
-        final int pos = pos(item);
+        final int pos = (forceAdd ? -1 : pos(item));
         if (pos == -1) {
             final RouteSegment segment = new RouteSegment(item, null, true);
             if (segment.hasPoint()) {
@@ -160,14 +175,21 @@ public class IndividualRoute extends Route implements Parcelable {
                 return ToggleItemState.ERROR_NO_POINT;
             }
         } else {
-            distance -= segments.get(pos).getDistance();
-            segments.remove(pos);
-            calculateNavigationRoute(pos);
-            if (pos < segments.size()) {
-                calculateNavigationRoute(pos + 1);
-            }
-            return ToggleItemState.REMOVED;
+            return removeItem(pos);
         }
+    }
+
+    private ToggleItemState removeItem(final int pos) {
+        if (pos < 0 || pos >= segments.size()) {
+            return ToggleItemState.ERROR_NO_POINT;
+        }
+        distance -= segments.get(pos).getDistance();
+        segments.remove(pos);
+        calculateNavigationRoute(pos);
+        if (pos < segments.size()) {
+            calculateNavigationRoute(pos + 1);
+        }
+        return ToggleItemState.REMOVED;
     }
 
     private int pos(final RouteItem item) {

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimplePopupMenu.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimplePopupMenu.java
@@ -12,14 +12,18 @@ import android.view.ViewGroup;
 import androidx.annotation.IdRes;
 import androidx.annotation.MenuRes;
 import androidx.appcompat.widget.PopupMenu;
+import androidx.core.util.Pair;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class SimplePopupMenu {
     private final Context context;
 
     private final Map<Integer, OnItemClickListener> itemListeners = new HashMap<>();
+    private final List<Pair<Integer, CharSequence>> additionalMenuItems = new ArrayList<>();
 
     private Activity activity;
     private Point point;
@@ -63,6 +67,11 @@ public class SimplePopupMenu {
         return this;
     }
 
+    public SimplePopupMenu addMenuItem(final int uniqueId, final CharSequence title) {
+        this.additionalMenuItems.add(new Pair<>(uniqueId, title));
+        return this;
+    }
+
     public SimplePopupMenu setMenuContent(final @MenuRes int menuRes) {
         this.menuRes = menuRes;
         return this;
@@ -83,6 +92,7 @@ public class SimplePopupMenu {
         return this;
     }
 
+    @SuppressWarnings("PMD.NPathComplexity") // split up would not help readability
     public void show() {
         final ViewGroup root = activity.getWindow().getDecorView().findViewById(android.R.id.content);
 
@@ -110,6 +120,9 @@ public class SimplePopupMenu {
             onCreateListener.onCreatePopupMenu(popupMenu.getMenu());
         }
 
+        for (Pair<Integer, CharSequence> item : additionalMenuItems) {
+            popupMenu.getMenu().add(Menu.NONE, item.first, Menu.NONE, item.second);
+        }
 
         popupMenu.setOnDismissListener(menu -> {
             if (view == null) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -802,7 +802,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
                 HideActionBarUtils.toggleActionBar(this);
             }
         } else if (result.size() == 1) {
-            handleTap(result.get(0), isLongTap);
+            handleTap(result.get(0), isLongTap, x, y);
         } else {
             try {
                 final ArrayList<RouteItem> sorted = new ArrayList<>(result);
@@ -821,7 +821,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
                     .setTitle(res.getString(R.string.map_select_multiple_items))
                     .setAdapter(adapter, (dialog1, which) -> {
                         if (which >= 0 && which < sorted.size()) {
-                            handleTap(sorted.get(which), isLongTap);
+                            handleTap(sorted.get(which), isLongTap, x, y);
                         }
                     })
                     .create();
@@ -834,11 +834,17 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
     }
 
-    private void handleTap(final RouteItem item, final boolean isLongTap) {
+    private void handleTap(final RouteItem item, final boolean isLongTap, final int tapX, final int tapY) {
         if (isLongTap) {
             // toggle route item
             if (Settings.isLongTapOnMapActivated()) {
-                viewModel.toggleRouteItem(this, item);
+                if (MapUtils.isPartOfRoute(item, viewModel.getIndividualRoute().getValue())) {
+                    MapUtils.createCacheWaypointLongClickPopupMenu(this, item, tapX, tapY, viewModel.getIndividualRoute().getValue(), viewModel, null)
+//                            .setOnDismissListener(menu -> tapHandlerLayer.resetLongTapLatLong())
+                            .show();
+                } else {
+                    viewModel.toggleRouteItem(this, item);
+                }
             }
         } else {
             // open popup for element

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -18,7 +18,7 @@ import androidx.core.util.Pair;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
-public class UnifiedMapViewModel extends ViewModel {
+public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.UpdateIndividualRoute {
 
     // ViewModels will survive config changes, no savedInstanceState is needed
     // Don't hold an activity references inside the ViewModel!
@@ -78,6 +78,11 @@ public class UnifiedMapViewModel extends ViewModel {
 
     public void clearIndividualRoute() {
         individualRoute.getValue().clearRoute(route -> individualRoute.notifyDataChanged());
+    }
+
+    @Override
+    public void updateIndividualRoute(final IndividualRoute route) {
+        individualRoute.notifyDataChanged();
     }
 
     public void toggleRouteItem(final Context context, final RouteItem item) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1596,6 +1596,10 @@
 
     <string name="context_map_add_to_route">Append to route</string>
     <string name="context_map_add_to_route_start">Prepend to route</string>
+    <string name="context_map_remove_from_route">Remove from route</string>
+    <string name="context_map_remove_from_route_start">Remove from start</string>
+    <string name="context_map_remove_from_route_pos">Remove from position %d</string>
+    <string name="context_map_remove_from_route_end">Remove from end</string>
     <string name="context_map_show_coords">Show coordinates</string>
 
     <string name="create_internal_cache">Create user-defined cache</string>


### PR DESCRIPTION
## Description
Adds a "long tap" context menu for caches/waypoints on map, providing (up to) the following items:
- append to route
- prepend to route
- remove from route
- remove from route end
- remove from route start

This allows to add a cache/waypoint multiple times to a route, specifically as both start and end point to create a round-trip.
Long tap on a cache/waypoint will now always trigger this context menu, no longer auto-toggle route item (as discussed in related issue among others.)

Implemented for `NewMap` only currently, to gather some feedback.

|Screenshot 1|Screenshot 2|
|---|---|
|![image](https://user-images.githubusercontent.com/3754370/233858783-c16f82cd-a738-443f-bcb3-afcbf6d1f050.png)|![image](https://user-images.githubusercontent.com/3754370/233858791-ef9d1910-67fe-4f6e-b7a4-77cf11a944dd.png)|

Screenshot 1: Cache is not yet part of the route, so allow to append or prepend to route.
Screenshot 2: Cache is part of the route (at the end), so allow prepend or remove.
