### PR TITLE
Add 'refresh and keep list' to cache download options (fix #14190)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -82,8 +82,10 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
                 .setTitle(R.string.caches_store_background_title)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
                     final int id = radioGroup.getCheckedRadioButtonId();
-                    if (id == R.id.radio_button_refresh) {
+                    if (id == R.id.radio_button_refresh_and_add) {
                         askForListsIfNecessaryAndDownload(context, geocodes, true, false, onStartCallback);
+                    } else if (id == R.id.radio_button_refresh_and_keep) {
+                        downloadCachesInternal(context, geocodes, null, true, onStartCallback);
                     } else if (id == R.id.radio_button_add_to_list) {
                         askForListsIfNecessaryAndDownload(context, geocodes, false, false, onStartCallback);
                     } else {

--- a/main/src/main/res/layout/dialog_background_download_config.xml
+++ b/main/src/main/res/layout/dialog_background_download_config.xml
@@ -28,9 +28,14 @@
             android:layout_height="match_parent"
             android:text="@string/caches_store_background_option_add_to_list"/>
         <RadioButton
-            android:id="@+id/radio_button_refresh"
+            android:id="@+id/radio_button_refresh_and_add"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:text="@string/caches_store_background_option_refresh"/>
+            android:text="@string/caches_store_background_option_refresh_and_add"/>
+        <RadioButton
+            android:id="@+id/radio_button_refresh_and_keep"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="@string/caches_store_background_option_refresh_and_keep"/>
     </RadioGroup>
 </LinearLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -392,7 +392,8 @@
     <string name="caches_store_background_already_stored">Some caches are already stored. What should happen with them?</string>
     <string name="caches_store_background_option_nothing">Do nothing</string>
     <string name="caches_store_background_option_add_to_list">Add to list</string>
-    <string name="caches_store_background_option_refresh">Refresh and add to list</string>
+    <string name="caches_store_background_option_refresh_and_add">Refresh and add to list</string>
+    <string name="caches_store_background_option_refresh_and_keep">Refresh and keep list</string>
     <string name="caches_store_background_result_failed" tools:ignore="PluralsCandidate">Download failed, %1$d/%2$d caches were downloaded</string>
     <string name="caches_store_background_result_canceled" tools:ignore="PluralsCandidate">Download canceled, %1$d/%2$d caches were downloaded</string>
     <plurals name="caches_store_background_result">

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -393,7 +393,7 @@
     <string name="caches_store_background_option_nothing">Do nothing</string>
     <string name="caches_store_background_option_add_to_list">Add to list</string>
     <string name="caches_store_background_option_refresh_and_add">Refresh and add to list</string>
-    <string name="caches_store_background_option_refresh_and_keep">Refresh and keep list</string>
+    <string name="caches_store_background_option_refresh_and_keep">Refresh and keep current list assignments</string>
     <string name="caches_store_background_result_failed" tools:ignore="PluralsCandidate">Download failed, %1$d/%2$d caches were downloaded</string>
     <string name="caches_store_background_result_canceled" tools:ignore="PluralsCandidate">Download canceled, %1$d/%2$d caches were downloaded</string>
     <plurals name="caches_store_background_result">


### PR DESCRIPTION
## Description
Add a "refresh caches, but keep their assigned lists" option to cache download options available in map and "show as list":

![image](https://user-images.githubusercontent.com/3754370/234109746-165513c6-e425-4f38-ae18-33646880da90.png).![image](https://user-images.githubusercontent.com/3754370/234109780-07b946d8-4f99-47e4-b51d-72389c934f6b.png)
