### PR TITLE
Provide 'Append to individual route' to cache list options

### DIFF
--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -75,6 +75,10 @@
                 android:title="@string/caches_remove_all"
                 app:showAsAction="ifRoom|withText"/>
             <item
+                android:id="@+id/menu_add_to_route"
+                android:title="@string/caches_append_to_route_all"
+                app:showAsAction="ifRoom|withText"/>
+            <item
                 android:id="@+id/menu_delete_events"
                 android:title="@string/caches_delete_events"
                 android:enabled="false"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -435,6 +435,9 @@
     <string name="caches_remove_selected">Remove selected from list</string>
     <string name="caches_remove_all_completely">Delete all from device</string>
     <string name="caches_remove_selected_completely">Delete selected from device</string>
+    <string name="caches_append_to_route_selected">Append selected to individual route</string>
+    <string name="caches_append_to_route_all">Append all to individual route</string>
+    <string name="caches_appended_to_route">Caches appended to route</string>
     <string name="caches_delete_events">Delete past events</string>
     <string name="caches_upload_bookmarklist">Add to bookmark list</string>
     <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>


### PR DESCRIPTION
## Description
Adds "Append to individual route" to cache lists' "Manage caches" menu.

I've decided to not call route optimization automatically - it's a different task, and as you can see the optimization's results only on map anyway, let's keep that function to be called from there.
