### PR TITLE
fix #14202: make calls to Linkify.addLinks safe and catch RuntimeExceptions

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -79,6 +79,7 @@ import cgeo.geocaching.ui.IndexOutOfBoundsAvoidingTextView;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.TrackableListAdapter;
 import cgeo.geocaching.ui.UserClickListener;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.WeakReferenceHandler;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.EditNoteDialog;
@@ -3001,7 +3002,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         if (StringUtils.isNotBlank(personalNote)) {
             personalNoteView.setVisibility(View.VISIBLE);
             separator.setVisibility(View.VISIBLE);
-            Linkify.addLinks(personalNoteView, Linkify.MAP_ADDRESSES | Linkify.WEB_URLS);
+            ViewUtils.safeAddLinks(personalNoteView, Linkify.MAP_ADDRESSES | Linkify.WEB_URLS);
         } else {
             personalNoteView.setVisibility(View.GONE);
             separator.setVisibility(View.GONE);

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1637,7 +1637,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         CharSequence message = HtmlCompat.fromHtml(attribution, HtmlCompat.FROM_HTML_MODE_LEGACY);
         if (linkify) {
             final SpannableString s = new SpannableString(message);
-            Linkify.addLinks(s, Linkify.ALL);
+            ViewUtils.safeAddLinks(s, Linkify.ALL);
             message = s;
         }
 

--- a/main/src/main/java/cgeo/geocaching/ui/TextParam.java
+++ b/main/src/main/java/cgeo/geocaching/ui/TextParam.java
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -195,7 +194,7 @@ public class TextParam {
         //linkify
         if (this.linkifyMask != 0) {
             final SpannableString linkifyString = SpannableString.valueOf(text);
-            Linkify.addLinks(linkifyString, this.linkifyMask);
+            ViewUtils.safeAddLinks(linkifyString, this.linkifyMask);
             text = linkifyString;
         }
 

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.databinding.CheckboxItemBinding;
 import cgeo.geocaching.databinding.DialogEdittextBinding;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Func1;
 import cgeo.geocaching.utils.functions.Func2;
@@ -25,6 +26,7 @@ import android.text.Selection;
 import android.text.Spannable;
 import android.text.TextWatcher;
 import android.text.method.ScrollingMovementMethod;
+import android.text.util.Linkify;
 import android.util.Pair;
 import android.view.ContextThemeWrapper;
 import android.view.Gravity;
@@ -48,6 +50,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.text.util.LinkifyCompat;
 import androidx.core.util.Consumer;
 import androidx.core.util.Predicate;
 
@@ -541,6 +544,26 @@ public class ViewUtils {
     public static void applyToView(@Nullable final View view, final Action1<View> applyMethod) {
         if (view != null) {
             applyMethod.call(view);
+        }
+    }
+
+    /** safe Linkify.addLinks version, prevents crash on older Android versions, see #14202 */
+    public static boolean safeAddLinks(@NonNull final TextView textView, @LinkifyCompat.LinkifyMask final int mask) {
+        try {
+            return Linkify.addLinks(textView, mask);
+        } catch (RuntimeException re) {
+            Log.d("Caught Error on Linkify.addLinks", re);
+            return false;
+        }
+    }
+
+    /** safe Linkify.addLinks version, prevents crash on older Android versions, see #14202 */
+    public static boolean safeAddLinks(@NonNull final Spannable sp, @LinkifyCompat.LinkifyMask final int mask) {
+        try {
+            return Linkify.addLinks(sp, mask);
+        } catch (RuntimeException re) {
+            Log.d("Caught Error on Linkify.addLinks", re);
+            return false;
         }
     }
 }


### PR DESCRIPTION
fix #14202: make calls to Linkify.addLinks safe and catch RuntimeExceptions