### PR TITLE
NewMap: Give waypoints unique id (rel. to #13675, #14053)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
@@ -280,6 +280,12 @@ public abstract class AbstractConnector implements IConnector {
 
     @Override
     @NonNull
+    public String getFullWaypointGpxId(@NonNull final String prefix, @NonNull final String geocode) {
+        return geocode + getWaypointGpxId(prefix, geocode);
+    }
+
+    @Override
+    @NonNull
     public String getWaypointPrefix(final String name) {
         // Default: just return the name
         return name;

--- a/main/src/main/java/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/IConnector.java
@@ -246,6 +246,10 @@ public interface IConnector {
     @NonNull
     String getWaypointGpxId(@NonNull String prefix, @NonNull String geocode);
 
+    /** similar to getWaypointGpxId, but includes geocode to be distinct across different caches */
+    @NonNull
+    String getFullWaypointGpxId(@NonNull String prefix, @NonNull String geocode);
+
     /**
      * Get the 'prefix' (key) for a waypoint from the 'name' in the GPX file
      */

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -207,7 +207,7 @@ public abstract class AbstractCachesOverlay {
     }
 
     protected final boolean addItem(final Waypoint waypoint, final boolean isDotMode) {
-        final GeoEntry entry = new GeoEntry(waypoint.getGpxId(), overlayId);
+        final GeoEntry entry = new GeoEntry(waypoint.getFullGpxId(), overlayId);
         final GeoitemLayer waypointItem = getWaypointItem(waypoint, this.mapHandlers.getTapHandler(), isDotMode);
         if (waypointItem != null && geoEntries.add(entry)) {
             layerList.add(waypointItem);

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -57,11 +57,11 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
             if (waypoint == null || waypoint.getCoords() == null || !waypoint.getCoords().isValid()) {
                 continue;
             }
-            if (removeCodes.contains(waypoint.getGpxId())) {
-                removeCodes.remove(waypoint.getGpxId());
+            if (removeCodes.contains(waypoint.getFullGpxId())) {
+                removeCodes.remove(waypoint.getFullGpxId());
             } else {
                 if (addItem(waypoint, forceCompactIconMode)) {
-                    newCodes.add(waypoint.getGpxId());
+                    newCodes.add(waypoint.getFullGpxId());
                 }
             }
         }
@@ -80,7 +80,7 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
         for (final Geocache cache : baseCaches) {
             final List<Waypoint> wl = cache.getWaypoints();
             for (final Waypoint w : wl) {
-                invalidWpCodes.add(w.getGpxId());
+                invalidWpCodes.add(w.getFullGpxId());
             }
         }
         invalidate(invalidWpCodes);

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -2309,6 +2309,11 @@ public class Geocache implements IWaypoint {
     }
 
     @NonNull
+    public String getFullWaypointGpxId(@NonNull final String prefix) {
+        return getConnector().getFullWaypointGpxId(prefix, geocode);
+    }
+
+    @NonNull
     public String getWaypointPrefix(final String name) {
         return getConnector().getWaypointPrefix(name);
     }

--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -342,6 +342,20 @@ public class Waypoint implements IWaypoint {
         return gpxId;
     }
 
+    /** similar to getGpxId, but includes geocode to be unique across different caches */
+    public String getFullGpxId() {
+        String gpxId = geocode + prefix;
+
+        if (StringUtils.isNotBlank(geocode)) {
+            final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+            if (cache != null) {
+                gpxId = cache.getFullWaypointGpxId(prefix);
+            }
+        }
+
+        return gpxId;
+    }
+
     public boolean mergeFromParsedText(final Waypoint parsedWaypoint, final String parsePraefix) {
         boolean changed = false;
 
@@ -393,7 +407,7 @@ public class Waypoint implements IWaypoint {
     }
 
     public GeoitemRef getGeoitemRef() {
-        return new GeoitemRef(getGpxId(), getCoordType(), getGeocode(), getId(), getName(), getWaypointType().markerId);
+        return new GeoitemRef(getFullGpxId(), getCoordType(), getGeocode(), getId(), getName(), getWaypointType().markerId);
     }
 
     public String getUserNote() {


### PR DESCRIPTION
## Description
Assign waypoints a unique id (`geocode` + `getGpxId()`) to avoid waypoints having the same prefix being removed in NewMap's waypoints layer handling. See https://github.com/cgeo/cgeo/issues/14053#issuecomment-1530188394 for details.

Attempts to fix issue #13675 (and the rest of #14053 and #12999)