### PR TITLE
Display hint in compass in textfield (fix #14108)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CompassActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CompassActivity.java
@@ -65,7 +65,7 @@ public class CompassActivity extends AbstractActionBarActivity {
     private CompassActivityBinding binding;
 
     private final PermissionAction<Void> askLocationPermissionAction = PermissionAction.register(this, PermissionContext.LOCATION, b -> {
-        binding.locationStatus.updatePermissions();
+        binding.hint.locationStatus.updatePermissions();
     });
 
 
@@ -129,7 +129,7 @@ public class CompassActivity extends AbstractActionBarActivity {
         // make sure we can control the TTS volume
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
-        binding.locationStatus.setPermissionRequestCallback(() -> {
+        binding.hint.locationStatus.setPermissionRequestCallback(() -> {
             askLocationPermissionAction.launch();
         });
     }
@@ -235,7 +235,16 @@ public class CompassActivity extends AbstractActionBarActivity {
         } else if (id == R.id.menu_tts_toggle) {
             SpeechService.toggleService(this, dstCoords);
         } else if (id == R.id.menu_hint) {
-            cache.showHintToast(this);
+            if (binding.hint.offlineHintText.getVisibility() == View.VISIBLE) {
+                binding.hint.offlineHintSeparator1.setVisibility(View.GONE);
+                binding.hint.offlineHintSeparator2.setVisibility(View.GONE);
+                binding.hint.offlineHintText.setVisibility(View.GONE);
+            } else {
+                binding.hint.offlineHintSeparator1.setVisibility(View.VISIBLE);
+                binding.hint.offlineHintSeparator2.setVisibility(View.VISIBLE);
+                binding.hint.offlineHintText.setVisibility(View.VISIBLE);
+                binding.hint.offlineHintText.setText(cache.getHint());
+            }
         } else if (LoggingUI.onMenuItemSelected(item, this, cache, null)) {
             return true; // to satisfy static code analysis
         } else {
@@ -301,11 +310,11 @@ public class CompassActivity extends AbstractActionBarActivity {
     private final Consumer<Status> gpsStatusHandler = new Consumer<Status>() {
         @Override
         public void accept(final Status gpsStatus) {
-            if (binding == null || binding.locationStatus == null) {
+            if (binding == null || binding.hint.locationStatus == null) {
                 //activity is not initialized yet, ignore update
                 return;
             }
-            binding.locationStatus.updateSatelliteStatus(gpsStatus);
+            binding.hint.locationStatus.updateSatelliteStatus(gpsStatus);
         }
     };
 
@@ -313,12 +322,12 @@ public class CompassActivity extends AbstractActionBarActivity {
     private final GeoDirHandler geoDirHandler = new GeoDirHandler() {
         @Override
         public void updateGeoDirData(@NonNull final GeoData geo, final DirectionData dir) {
-            if (binding == null || binding.locationStatus == null) {
+            if (binding == null || binding.hint.locationStatus == null) {
                 //activity is not initialized yet, ignore update
                 return;
             }
             try {
-                binding.locationStatus.updateGeoData(geo);
+                binding.hint.locationStatus.updateGeoData(geo);
 
                 updateDistanceInfo(geo);
 

--- a/main/src/main/res/layout-land/compass_activity.xml
+++ b/main/src/main/res/layout-land/compass_activity.xml
@@ -133,11 +133,7 @@
             android:text="@null"
             android:textSize="@dimen/textSize_compassTargeting" />
 
-        <cgeo.geocaching.ui.LocationStatusView
-            android:id="@+id/location_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true" />
+        <include layout="@layout/compass_hint_and_status" android:id="@+id/hint" />
 
         <RelativeLayout
             android:id="@+id/status"

--- a/main/src/main/res/layout/compass_activity.xml
+++ b/main/src/main/res/layout/compass_activity.xml
@@ -118,26 +118,13 @@
         </RelativeLayout>
     </LinearLayout>
 
-    <LinearLayout
-        android:id="@+id/info2"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginLeft="6dip"
-        android:layout_marginRight="6dip"
-        android:orientation="vertical" >
-
-        <cgeo.geocaching.ui.LocationStatusView
-            android:id="@+id/location_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
-    </LinearLayout>
+    <include layout="@layout/compass_hint_and_status" android:id="@+id/hint" />
 
     <view
         android:id="@+id/rose"
         android:layout_width="fill_parent"
         android:layout_height="295dip"
-        android:layout_above="@id/info2"
+        android:layout_above="@id/location_status"
         android:layout_below="@id/info1"
         android:layout_centerInParent="true"
         android:layout_gravity="center_horizontal"
@@ -150,6 +137,7 @@
         android:keepScreenOn="true"
         android:minHeight="289dip"
         android:minWidth="289dip"
-        android:padding="4dip" />
+        android:padding="4dip"
+        tools:ignore="NotSibling" />
 
 </RelativeLayout>

--- a/main/src/main/res/layout/compass_hint_and_status.xml
+++ b/main/src/main/res/layout/compass_hint_and_status.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical">
+
+    <RelativeLayout
+        android:id="@+id/offline_hint_separator1"
+        android:layout_above="@id/offline_hint_text"
+        style="@style/separator_horizontal_layout"
+        android:visibility="gone" >
+            <View style="@style/separator_horizontal" />
+    </RelativeLayout>
+    <TextView
+        android:id="@+id/offline_hint_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/offline_hint_separator2"
+        android:layout_marginLeft="6dip"
+        android:layout_marginRight="6dip"
+        android:paddingRight="3dip"
+        android:textIsSelectable="false"
+        android:textSize="@dimen/textSize_detailsSecondary"
+        android:visibility="gone"
+        tools:text="hint"
+        android:textColor="@color/colorText"/>
+    <RelativeLayout
+        android:id="@+id/offline_hint_separator2"
+        android:layout_above="@id/location_status"
+        style="@style/separator_horizontal_layout"
+        android:visibility="gone" >
+            <View style="@style/separator_horizontal" />
+    </RelativeLayout>
+
+    <cgeo.geocaching.ui.LocationStatusView
+        android:id="@+id/location_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginLeft="6dip"
+        android:layout_marginRight="6dip"/>
+
+</RelativeLayout>


### PR DESCRIPTION
## Description
Display hint in compass views in a text field instead of as a toast:

![image](https://user-images.githubusercontent.com/3754370/236671351-a85aeca6-1699-4abc-b5c1-9b278ccf1fdb.png)![image](https://user-images.githubusercontent.com/3754370/236671361-1030ad87-f56c-4fd5-b159-fb4d3709964e.png)

(Hint can be toggled using the hint button in action bar, default is hint off)