### PR TITLE
load PQ preview from map instead of legacy search results (#14290)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1826,7 +1826,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, cacheListType);
         cachesIntent.putExtra(Intents.EXTRA_NAME, pocketQuery.getName());
-        cachesIntent.putExtra(Intents.EXTRA_POCKET_GUID, pocketQuery.getGuid());
+        cachesIntent.putExtra(Intents.EXTRA_POCKET_GUID, pocketQuery.getShortGuid());
+        cachesIntent.putExtra(Intents.EXTRA_POCKET_HASH, pocketQuery.getPqHash());
         context.startActivity(cachesIntent);
     }
 
@@ -1945,10 +1946,11 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                     loader = new NullGeocacheListLoader(this, search);
                     break;
                 case POCKET:
-                    final String guid = extras.getString(Intents.EXTRA_POCKET_GUID);
+                    final String shortGuid = extras.getString(Intents.EXTRA_POCKET_GUID);
+                    final String pqHash = extras.getString(Intents.EXTRA_POCKET_HASH);
                     title = listNameMemento.rememberTerm(extras.getString(Intents.EXTRA_NAME));
                     markerId = EmojiUtils.NO_EMOJI;
-                    loader = new PocketGeocacheListLoader(this, guid);
+                    loader = new PocketGeocacheListLoader(this, shortGuid, pqHash);
                     break;
                 default:
                     //can never happen, makes Codacy happy

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -59,6 +59,7 @@ public class Intents {
     public static final String EXTRA_USERNAME = PREFIX + "username";
     public static final String EXTRA_WAYPOINT_ID = PREFIX + "waypoint_id";
     public static final String EXTRA_POCKET_GUID = PREFIX + "pocket_guid";
+    public static final String EXTRA_POCKET_HASH = PREFIX + "pocket_hash";
 
     private static final String PREFIX_ACTION = "cgeo.geocaching.intent.action.";
     public static final String ACTION_GEOCACHE = PREFIX_ACTION + "GEOCACHE";

--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
@@ -34,7 +34,7 @@ public class BookmarkUtils {
         final List<GCList> lists = new ArrayList<>();
 
         // add "<create new list>" PseudoList
-        lists.add(0, new GCList(NEW_LIST_GUID, PseudoList.NEW_LIST.getTitleAndCount(), 0, false, 0, 0, false));
+        lists.add(0, new GCList(NEW_LIST_GUID, PseudoList.NEW_LIST.getTitleAndCount(), 0, false, 0, 0, false, null, null));
 
         AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> {
 

--- a/main/src/main/java/cgeo/geocaching/loaders/PocketGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/PocketGeocacheListLoader.java
@@ -8,18 +8,20 @@ import cgeo.geocaching.settings.Settings;
 import android.app.Activity;
 
 public class PocketGeocacheListLoader extends AbstractSearchLoader {
-    private final String guid;
+    private final String shortGuid;
+    private final String pqHash;
 
-    public PocketGeocacheListLoader(final Activity activity, final String guid) {
+    public PocketGeocacheListLoader(final Activity activity, final String shortGuid, final String pqHash) {
         super(activity);
-        this.guid = guid;
+        this.shortGuid = shortGuid;
+        this.pqHash = pqHash;
     }
 
     @Override
     public SearchResult runSearch() {
 
         if (Settings.isGCConnectorActive()) {
-            return GCParser.searchByPocketQuery(GCConnector.getInstance(), guid);
+            return GCParser.searchByPocketQuery(GCConnector.getInstance(), shortGuid, pqHash);
         }
 
         return new SearchResult();

--- a/main/src/main/java/cgeo/geocaching/models/GCList.java
+++ b/main/src/main/java/cgeo/geocaching/models/GCList.java
@@ -5,6 +5,10 @@ import android.net.Uri;
 public final class GCList {
 
     private final String guid;
+
+    private String shortGuid;
+
+    private String pqHash;
     private final int caches;
     private final String name;
     private final boolean downloadable;
@@ -12,7 +16,7 @@ public final class GCList {
     private final int daysRemaining;
     private final boolean bookmarkList;
 
-    public GCList(final String guid, final String name, final int caches, final boolean downloadable, final long lastGenerationTime, final int daysRemaining, final boolean bookmarkList) {
+    public GCList(final String guid, final String name, final int caches, final boolean downloadable, final long lastGenerationTime, final int daysRemaining, final boolean bookmarkList, final String shortGuid, final String pqHash) {
         this.guid = guid;
         this.name = name;
         this.caches = caches;
@@ -20,6 +24,8 @@ public final class GCList {
         this.lastGenerationTime = lastGenerationTime;
         this.daysRemaining = daysRemaining;
         this.bookmarkList = bookmarkList;
+        this.shortGuid = shortGuid;
+        this.pqHash = pqHash;
     }
 
     public boolean isDownloadable() {
@@ -52,6 +58,22 @@ public final class GCList {
 
     public Uri getUri() {
         return isBookmarkList() ? Uri.parse("https://www.geocaching.com/plan/api/gpx/list/" + guid) : Uri.parse("https://www.geocaching.com/pocket/downloadpq.ashx?g=" + guid + "&src=web");
+    }
+
+    public String getShortGuid() {
+        return shortGuid;
+    }
+
+    public String getPqHash() {
+        return pqHash;
+    }
+
+    public void setShortGuid(final String shortGuid) {
+        this.shortGuid = shortGuid;
+    }
+
+    public void setPqHash(final String pqHash) {
+        this.pqHash = pqHash;
     }
 
 }


### PR DESCRIPTION
For previewing PQs we're currently using https://www.geocaching.com/seek/nearest.aspx?pq= which is one of those old pages with lots of HTML, also limited to 20 results/page.
There's also a "preview on map" option, loading to https://www.geocaching.com/map/default.aspx?pq= which loads the actual data as geojson from https://tiles01.geocaching.com/map.pq?pq=..&st=..
This is a "nice" data format (json) and seems to deliver up to 1000 items.

Cache information that can be obtained this way:
- name
- geocode
- type
- archived
- disabled
- coordinates
- found
- userModifiedCoordinates

Missing info compared to old search page:
- d/t rating
- placed date
- size
- owner name
- favorite count

I think the advantage of getting more than 20 caches more than makes up the "loss" in information about these caches, especially as that info can easily be retrieved by storing the caches.