### PR TITLE
Fix link to full changelog

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/activity/AboutActivityTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/activity/AboutActivityTest.java
@@ -30,6 +30,6 @@ public class AboutActivityTest {
     public void displayChangeLog() {
         CgeoTestUtils.executeForActivity(AboutActivity.class,
                 intent -> intent.putExtra(AboutActivity.EXTRA_ABOUT_STARTPAGE, AboutActivity.Page.CHANGELOG.id),
-                scenario -> onView(withId(R.id.changelog_github)).check(matches(withText(LocalizationUtils.getString(R.string.changelog_github)))));
+                scenario -> onView(withId(R.id.changelog_github)).check(matches(withText(LocalizationUtils.getString(R.string.about_changelog_full)))));
     }
 }

--- a/main/src/main/java/cgeo/geocaching/AboutActivity.java
+++ b/main/src/main/java/cgeo/geocaching/AboutActivity.java
@@ -243,7 +243,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
                 markwon.setMarkdown(binding.changelogMaster, "## " + getString(R.string.about_changelog_nightly_build) + "\n\n" + changelogBase);
                 markwon.setMarkdown(binding.changelogRelease, changelogBugfix);
             }
-            binding.changelogGithub.setOnClickListener(v -> ShareUtils.openUrl(activity, "https://github.com/cgeo/cgeo/blob/master/main/res/raw/changelog_full.md"));
+            binding.changelogGithub.setOnClickListener(v -> ShareUtils.openUrl(activity, getString(R.string.changelog_full)));
         }
     }
 

--- a/main/src/main/res/layout/about_changes_page.xml
+++ b/main/src/main/res/layout/about_changes_page.xml
@@ -24,7 +24,7 @@
         <Button
             android:id="@+id/changelog_github"
             style="@style/button_full"
-            android:text="@string/changelog_github" />
+            android:text="@string/about_changelog_full" />
     </LinearLayout>
 
 </ScrollView>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -737,7 +737,7 @@
     <string name="about_system_write_logcat_success">Logfile \"%1$s\" written to folder \"%2$s\"</string>
     <string name="about_system_write_logcat_error">Error writing logfile</string>
     <string name="about_system_write_infos_downloadmanager">View downloads</string>
-    <string name="changelog_github">List of all changes</string>
+    <string name="about_changelog_full">List of all changes</string>
     <string name="about_nutshellmanual">Online manual</string>
 
     <string name="about_contributors_carnerodetails">as the father of c:geo</string>

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -195,6 +195,7 @@
     <string translatable="false" name="github_link"><a href="">github.com/cgeo/cgeo/issues</a></string>
     <string translatable="false" name="faq_link_full">https://faq.cgeo.org</string>
     <string translatable="false" name="manual_link_full">https://manual.cgeo.org</string>
+    <string translatable="false" name="changelog_full">https://github.com/cgeo/cgeo/blob/master/main/src/main/res/raw/changelog_full.md</string>
 
     <string translatable="false" name="ellipsis">…</string>
     <string translatable="false" name="triple_dash_vertical">┆</string>


### PR DESCRIPTION
## Description
- Fix link to "full changelog" in about:changelog (was still pointing to old folder structure)
- Extract Uri to `strings_not_translatable.xml`
- give label string var a more meaningful name
