### PR TITLE
Sysinfo: Fix indentation for persisted doc uri

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
@@ -234,7 +234,7 @@ public final class SystemInformation {
     private static void appendPersistedDocumentUris(@NonNull final StringBuilder body) {
         body.append("\n- PersistedDocumentUris: #").append(PersistableUri.values().length);
         for (PersistableUri persDocUri : PersistableUri.values()) {
-            body.append("\n- ").append(persDocUri);
+            body.append("\n  - ").append(persDocUri);
         }
     }
 


### PR DESCRIPTION
## Description
Fix indentation for persisted doc uri in sysinfo