### PR TITLE
Adjust BRouter test to changed data

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
@@ -172,8 +172,8 @@ public void testOpenAndroMaps() {
         // check one named entry
         final Download d = findByName(list, "E5_N50.rd5");
         assertThat(d).isNotNull();
-        final String sizeInfoString = d.getSizeInfo(); // 130.5 MB as of 2022-02-13
+        final String sizeInfoString = d.getSizeInfo(); // 154.8 MB as of 2023-06-05
         final float sizeInfoFloat = Float.parseFloat(sizeInfoString.substring(0, sizeInfoString.length() - 3));
-        assertThat(sizeInfoFloat).isBetween(120.0F, 150.0F);
+        assertThat(sizeInfoFloat).isBetween(120.0F, 170.0F);
     }
 }


### PR DESCRIPTION
## Description
File size of routing tile tested against has increased so much in size that test fails. PR adjust accepted size span.