### PR TITLE
Avoid NPE in PositionLayer.draw (fix #14295)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
@@ -78,7 +78,7 @@ public class PositionLayer extends Layer {
             rotateArrow();
         }
         final Bitmap localArrow = arrow;
-        if (localArrow != null) {
+        if (localArrow != null && !localArrow.isDestroyed()) {
             final int left = centerX - widthArrowHalf;
             final int top = centerY - heightArrowHalf;
             final int right = left + localArrow.getWidth();
@@ -90,7 +90,7 @@ public class PositionLayer extends Layer {
             }
             canvas.drawBitmap(localArrow, left, top);
         } else {
-            Log.d("PositionLayer.draw: localArrow=null, arrowNative=" + arrowNative);
+            Log.d("PositionLayer.draw: localArrow=null or destroyed, arrowNative=" + arrowNative);
         }
     }
 


### PR DESCRIPTION
## Description
Mapsforge's AndroidBitmap can be non-null, but the referenced bitmap being destroyed already, still leading to an NPE as mentioned in the referenced issue.
This PR adds a check for `isDestroyed()`.