### PR TITLE
Fix hard-coded color in EmojiSelector (fix #14311)

### DIFF
--- a/main/src/main/res/layout/emojiselector_item.xml
+++ b/main/src/main/res/layout/emojiselector_item.xml
@@ -13,7 +13,7 @@
         android:layout_height="match_parent"
         android:layout_centerVertical="true"
         android:layout_centerHorizontal="true"
-        android:textColor="#ffffffff"
+        android:textColor="@color/colorText"
         android:gravity="center"/>
     <ImageView
         android:id="@+id/info_drawable"


### PR DESCRIPTION
## Description
Replace hard-coded "white" color in EmojiSelector with parametrized `colorText` to allow for color-adjustment of some style-aware emojis