### PR TITLE
Make startscreen selectable (fix #14284)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/SplashActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SplashActivity.java
@@ -31,7 +31,7 @@ public class SplashActivity extends AppCompatActivity {
                 intent.putExtra(InstallWizardActivity.BUNDLE_MODE, firstInstall ? InstallWizardActivity.WizardMode.WIZARDMODE_DEFAULT.id : InstallWizardActivity.WizardMode.WIZARDMODE_MIGRATION.id);
             } else {
                 // otherwise regular startup
-                intent = new Intent(this, MainActivity.class);
+                intent = Settings.getStartscreenIntent(this);
                 intent.putExtras(getIntent());
             }
             cLog.add("fi");

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -22,6 +22,7 @@ import cgeo.geocaching.ui.GeoItemSelectorUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AndroidRxUtils;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -232,24 +233,24 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
         return onNavigationItemSelectedDefaultBehaviour(item);
     }
 
-    public boolean onNavigationItemSelectedDefaultBehaviour(final @NonNull MenuItem item) {
-        final int id = item.getItemId();
-        final Intent launchIntent;
-
+    public static Intent getBottomNavigationIntent(final Activity fromActivity, final int id) {
         if (id == MENU_MAP) {
-            launchIntent = DefaultMap.getLiveMapIntent(this);
+            return DefaultMap.getLiveMapIntent(fromActivity);
         } else if (id == MENU_LIST) {
-            launchIntent = CacheListActivity.getActivityOfflineIntent(this);
+            return CacheListActivity.getActivityOfflineIntent(fromActivity);
         } else if (id == MENU_SEARCH) {
-            launchIntent = new Intent(this, SearchActivity.class);
+            return new Intent(fromActivity, SearchActivity.class);
         } else if (id == MENU_NEARBY) {
-            launchIntent = CacheListActivity.getNearestIntent(this);
+            return CacheListActivity.getNearestIntent(fromActivity);
         } else if (id == MENU_HOME) {
-            launchIntent = new Intent(this, MainActivity.class);
+            return new Intent(fromActivity, MainActivity.class);
         } else {
             throw new IllegalStateException("unknown navigation item selected"); // should never happen
         }
+    }
 
+    public boolean onNavigationItemSelectedDefaultBehaviour(final @NonNull MenuItem item) {
+        final Intent launchIntent = getBottomNavigationIntent(this, item.getItemId());
         startActivity(launchIntent);
 
         // Clear activity stack if the user actively navigates via the bottom navigation

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.settings;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractBottomNavigationActivity;
 import cgeo.geocaching.apps.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.brouter.BRouterConstants;
 import cgeo.geocaching.connector.ConnectorFactory;
@@ -48,7 +49,9 @@ import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT_ID;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.res.Configuration;
@@ -1296,6 +1299,21 @@ public class Settings {
 
     public static boolean isLightSkin(final @NonNull Context context) {
         return !isDarkThemeActive(context, getAppTheme(context));
+    }
+
+    public static Intent getStartscreenIntent(final @NonNull Activity activity) {
+        final String startscreen = getString(R.string.pref_startscreen, activity.getString(R.string.pref_value_startscreen_home));
+        if (StringUtils.equals(startscreen, activity.getString(R.string.pref_value_startscreen_stored))) {
+            return AbstractBottomNavigationActivity.getBottomNavigationIntent(activity, AbstractBottomNavigationActivity.MENU_LIST);
+        } else if (StringUtils.equals(startscreen, activity.getString(R.string.pref_value_startscreen_map))) {
+            return AbstractBottomNavigationActivity.getBottomNavigationIntent(activity, AbstractBottomNavigationActivity.MENU_MAP);
+        } else if (StringUtils.equals(startscreen, activity.getString(R.string.pref_value_startscreen_search))) {
+            return AbstractBottomNavigationActivity.getBottomNavigationIntent(activity, AbstractBottomNavigationActivity.MENU_SEARCH);
+        } else if (StringUtils.equals(startscreen, activity.getString(R.string.pref_value_startscreen_nearby))) {
+            return AbstractBottomNavigationActivity.getBottomNavigationIntent(activity, AbstractBottomNavigationActivity.MENU_NEARBY);
+        } else {
+            return AbstractBottomNavigationActivity.getBottomNavigationIntent(activity, AbstractBottomNavigationActivity.MENU_HOME);
+        }
     }
 
     @NonNull

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -157,6 +157,7 @@
     <string translatable="false" name="pref_selected_language">selectedLanguage</string>
     <string translatable="false" name="pref_units_imperial">units</string>
     <string translatable="false" name="pref_quicklaunchitems">quicklaunchitems_sorted</string>
+    <string translatable="false" name="pref_startscreen">startscreen</string>
 
     <!-- category cache lists -->
     <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>
@@ -399,6 +400,20 @@
         <item>@string/pref_value_theme_system_default</item>
         <item>@string/pref_value_theme_light</item>
         <item>@string/pref_value_theme_dark</item>
+    </string-array>
+
+    <!-- appearance => start screen -->
+    <string translatable="false" name="pref_value_startscreen_home">HOME</string>
+    <string translatable="false" name="pref_value_startscreen_stored">STORED</string>
+    <string translatable="false" name="pref_value_startscreen_map">MAP</string>
+    <string translatable="false" name="pref_value_startscreen_search">SEARCH</string>
+    <string translatable="false" name="pref_value_startscreen_nearby">NEARBY</string>
+    <string-array name="pref_startscreen_values">
+        <item>@string/pref_value_startscreen_home</item>
+        <item>@string/pref_value_startscreen_stored</item>
+        <item>@string/pref_value_startscreen_map</item>
+        <item>@string/pref_value_startscreen_search</item>
+        <item>@string/pref_value_startscreen_nearby</item>
     </string-array>
 
     <string translatable="false" name="pref_mapShadingLinearity">mapShadingLinearity</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -992,6 +992,17 @@
         <item>Light</item>
         <item>Dark</item>
     </string-array>
+
+    <!-- app startscreen -->
+    <string name="settings_startscreen_title">Default screen</string>
+    <string-array name="settings_startscreen">
+        <item>@string/home_button</item>
+        <item>@string/stored_caches_button</item>
+        <item>@string/map_map</item>
+        <item>@string/advanced_search_button</item>
+        <item>@string/caches_nearby_button</item>
+    </string-array>
+
     <string name="init_wallpaper">Wallpaper</string>
     <string name="init_summary_wallpaper">Show device wallpaper as home screen background</string>
 

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -51,6 +51,14 @@
             android:title="@string/init_quicklaunchitems"
             android:summary="@string/init_summary_quicklaunchitems"
             app:iconSpaceReserved="false" />
+        <ListPreference
+            android:defaultValue="@string/pref_value_startscreen_home"
+            android:entries="@array/settings_startscreen"
+            android:entryValues="@array/pref_startscreen_values"
+            android:key="@string/pref_startscreen"
+            android:title="@string/settings_startscreen_title"
+            android:summary="%s"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
Let the user decide which page of bottom navigation they want to start with. Default is "HOME".

See settings => appearance => Default screen:

![image](https://github.com/cgeo/cgeo/assets/3754370/212d1d10-a2e9-48a2-932c-855c81b56fb8)
