### PR TITLE
#13481 AL found state

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector.al;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCLogin;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.WaypointType;
@@ -201,6 +202,7 @@ final class ALApi {
         query.setTake(100);
         query.setRadiusInMeters(distanceInMeters);
         query.setRecentlyPublishedDays(daysSincePublish);
+        query.setCallingUserPublicGuid(GCLogin.getInstance().getPublicGuid());
         try {
             final Response response = apiPostRequest("SearchV4", headers, query, false).blockingGet();
             return importCachesFromJSON(response);
@@ -350,7 +352,7 @@ final class ALApi {
             cache.setRating(response.get("RatingsAverage").floatValue());
             cache.setArchived(response.get("IsArchived").asBoolean());
             cache.setHidden(parseDate(response.get("PublishedUtc").asText()));
-            // cache.setFound(parseCompletionStatus(response.get("CompletionStatus").asInt())); as soon as we're using active mode
+            cache.setFound(response.get("IsComplete").asBoolean());
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.CACHE));
             return cache;
         } catch (final NullPointerException e) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLogin.java
@@ -316,6 +316,15 @@ public class GCLogin extends AbstractLogin {
         }
     }
 
+    public String getPublicGuid() {
+        try {
+            final ServerParameters params = getServerParameters();
+            return params.userInfo.publicGuid;
+        } catch (final Exception e) {
+            return "UNKNOWN";
+        }
+    }
+
     /**
      * Ensure that the website is presented in the specified language.
      *


### PR DESCRIPTION
## Description
This is an attempt to finally get the "true found state" for Adventure Lab Caches. The `SearchV4` method, when called with the user's `publicGuid` is supposed to return that state.

My tests on the emulator showed that indeed the true found state is reported once the `publicGuid` is provided to the `SearchV4` API method.

Please note: When explicitly fetching a Lab Cache by its ID, we still use the method [/api/Adventures/{id}](https://labs-api.geocaching.com/swagger/ui/index#!/Adventures/Adventures_Get) which does **not** return the true found state, however once the lab is on the map, it got there as a result of using the SearchV4 API, which now provides that state and it seems that state is cached when subsequently loading the cache detailed view. Please also note that this method: [/api/Adventures/{id}](https://labs-api.geocaching.com/swagger/ui/index#!/Adventures/Adventures_Get) is now deprecated, so we might want to look for an appropriate replacement.

## Related issues
#13481


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->