### PR TITLE
Add 'set as target' to map's long tap popup (fix #13539)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
@@ -123,7 +123,7 @@ public abstract class AbstractMap {
     public abstract void refreshMapData(boolean circlesSwitched);
 
     public boolean isTargetSet() {
-        return StringUtils.isNotBlank(targetGeocode) && null != lastNavTarget;
+        return /* StringUtils.isNotBlank(targetGeocode) && */ null != lastNavTarget;
     }
 
     @Nullable

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -823,7 +823,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     public void triggerLongTapContextMenu(final Point tapXY) {
         if (Settings.isLongTapOnMapActivated()) {
             MapUtils.createMapLongClickPopupMenu(activity, new Geopoint(overlayPositionAndScale.getLongTapLatLng().latitude, overlayPositionAndScale.getLongTapLatLng().longitude),
-                            tapXY.x, tapXY.y, individualRoute, overlayPositionAndScale, this::updateRouteTrackButtonVisibility, getCurrentTargetCache(), mapOptions)
+                            tapXY, individualRoute, overlayPositionAndScale, this::updateRouteTrackButtonVisibility, getCurrentTargetCache(), mapOptions, this::setTarget)
                     .setOnDismissListener(menu -> overlayPositionAndScale.resetLongTapLatLng())
                     .show();
         }

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -31,6 +31,7 @@ import cgeo.geocaching.ui.dialog.SimplePopupMenu;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.FilterUtils;
+import cgeo.geocaching.utils.functions.Action2;
 import static cgeo.geocaching.brouter.BRouterConstants.BROUTER_TILE_FILEEXTENSION;
 
 import android.app.Activity;
@@ -187,12 +188,12 @@ public class MapUtils {
     /**
      * @return the complete popup builder without dismiss listener specified
      */
-    public static SimplePopupMenu createMapLongClickPopupMenu(final Activity activity, final Geopoint longClickGeopoint, final int tapX, final int tapY, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Runnable updateRouteTrackButtonVisibility, final Geocache currentTargetCache, final MapOptions mapOptions) {
+    public static SimplePopupMenu createMapLongClickPopupMenu(final Activity activity, final Geopoint longClickGeopoint, final Point tapXY, final IndividualRoute individualRoute, final IndividualRoute.UpdateIndividualRoute routeUpdater, final Runnable updateRouteTrackButtonVisibility, final Geocache currentTargetCache, final MapOptions mapOptions, final Action2<Geopoint, String> setTarget) {
         final int offset = ResourcesCompat.getDrawable(activity.getResources(), R.drawable.map_pin, null).getIntrinsicHeight() / 2;
 
         return SimplePopupMenu.of(activity)
                 .setMenuContent(R.menu.map_longclick)
-                .setPosition(new Point(tapX, tapY - offset), (int) (offset * 1.25))
+                .setPosition(new Point(tapXY.x, tapXY.y - offset), (int) (offset * 1.25))
                 .setOnCreatePopupMenuListener(menu -> {
                     menu.findItem(R.id.menu_add_waypoint).setVisible(currentTargetCache != null);
                     menu.findItem(R.id.menu_add_to_route_start).setVisible(individualRoute.getNumPoints() > 0);
@@ -220,6 +221,10 @@ public class MapUtils {
                 .addItemClickListener(R.id.menu_add_to_route_start, item -> {
                     individualRoute.toggleItem(activity, new RouteItem(longClickGeopoint), routeUpdater, true);
                     updateRouteTrackButtonVisibility(updateRouteTrackButtonVisibility);
+                })
+                .addItemClickListener(R.id.menu_target, item -> {
+                    setTarget.call(longClickGeopoint, null);
+                    updateRouteTrackButtonVisibility.run();
                 })
                 .addItemClickListener(R.id.menu_navigate, item -> NavigationAppFactory.showNavigationMenu(activity, null, null, longClickGeopoint, false, true));
     }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1005,9 +1005,9 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     public void triggerLongTapContextMenu(final Point tapXY) {
         if (Settings.isLongTapOnMapActivated()) {
             MapUtils.createMapLongClickPopupMenu(this, new Geopoint(tapHandlerLayer.getLongTapLatLong().latitude, tapHandlerLayer.getLongTapLatLong().longitude),
-                            (int) tapXY.x, (int) tapXY.y, individualRoute, routeLayer,
+                            new android.graphics.Point((int) tapXY.x, (int) tapXY.y), individualRoute, routeLayer,
                             this::updateRouteTrackButtonVisibility,
-                            getCurrentTargetCache(), mapOptions)
+                            getCurrentTargetCache(), mapOptions, this::setTarget)
                     .setOnDismissListener(menu -> tapHandlerLayer.resetLongTapLatLong())
                     .show();
         }
@@ -1569,7 +1569,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     };
 
     private Boolean isTargetSet() {
-        return StringUtils.isNotBlank(targetGeocode) && null != lastNavTarget;
+        return /* StringUtils.isNotBlank(targetGeocode) && */ null != lastNavTarget;
     }
 
     private static class ResourceBitmapCacheMonitor {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -53,6 +53,7 @@ import static cgeo.geocaching.utils.DisplayUtils.SIZE_CACHE_MARKER_DP;
 
 import android.content.Intent;
 import android.content.res.Resources;
+import android.graphics.Point;
 import android.location.Location;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
@@ -763,7 +764,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
             if (isLongTap) {
                 final Geopoint gp = Geopoint.forE6(latitudeE6, longitudeE6);
                 viewModel.longTapCoords.setValue(gp);
-                MapUtils.createMapLongClickPopupMenu(this, gp, x, y, viewModel.individualRoute.getValue(), route -> viewModel.individualRoute.notifyDataChanged(), null, null, new MapOptions() /*todo: params are currently just placeholder*/)
+                MapUtils.createMapLongClickPopupMenu(this, gp, new Point(x, y), viewModel.individualRoute.getValue(), route -> viewModel.individualRoute.notifyDataChanged(), null, null, new MapOptions(), (geopoint, string) -> { } /*todo: params are currently just placeholder*/)
                         .setOnDismissListener(d -> viewModel.longTapCoords.setValue(null))
                         .show();
             } else {

--- a/main/src/main/res/menu/map_longclick.xml
+++ b/main/src/main/res/menu/map_longclick.xml
@@ -21,6 +21,10 @@
         android:title="@string/context_map_show_coords">
     </item>
     <item
+        android:id="@+id/menu_target"
+        android:title="@string/cache_menu_target">
+    </item>
+    <item
         android:id="@+id/menu_navigate"
         android:title="@string/cache_menu_navigate">
     </item>


### PR DESCRIPTION
## Description
Adds "set as target" option to map's long tap menu:

![image](https://github.com/cgeo/cgeo/assets/3754370/308fe55e-6556-4df7-b929-d3e540486fd5).![image](https://github.com/cgeo/cgeo/assets/3754370/21c0c924-782f-4274-988e-c460b0cc7364)
