### PR TITLE
Support target selector for more navi apps (fix #13540)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/apps/navi/AbstractPointNavigationApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/AbstractPointNavigationApp.java
@@ -1,20 +1,31 @@
 package cgeo.geocaching.apps.navi;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.apps.AbstractApp;
+import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.IWaypoint;
 import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.ui.GeoItemSelectorUtils;
+import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.content.Context;
 import android.content.Intent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+
 /**
  * navigation app for simple point navigation (no differentiation between cache/waypoint/point)
  */
-abstract class AbstractPointNavigationApp extends AbstractApp implements CacheNavigationApp, WaypointNavigationApp, GeopointNavigationApp {
+abstract class AbstractPointNavigationApp extends AbstractApp implements CacheNavigationApp, CacheSelectorNavigationApp, WaypointNavigationApp, GeopointNavigationApp {
 
     protected AbstractPointNavigationApp(@NonNull final String name, @Nullable final String intent) {
         super(name, intent);
@@ -25,10 +36,46 @@ abstract class AbstractPointNavigationApp extends AbstractApp implements CacheNa
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // asserted by caller
         navigate(context, coords);
+    }
+
+    @Override
+    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+        final ArrayList<IWaypoint> targets = new ArrayList<>();
+        targets.add(cache);
+        for (final Waypoint waypoint : cache.getWaypoints()) {
+            if ((waypoint.getWaypointType() == WaypointType.PARKING || waypoint.getWaypointType() == WaypointType.FINAL) && !cache.getCoords().equals(waypoint.getCoords())) {
+                targets.add(waypoint);
+            }
+        }
+        if (targets.size() < 2) {
+            navigateWithoutSelector(context, cache);
+        } else {
+            // show a selection of all parking places and the cache itself, when using the navigation for driving
+            final Context themeContext = Dialogs.newContextThemeWrapper(context);
+            final ListAdapter adapter = new ArrayAdapter<IWaypoint>(themeContext, R.layout.cacheslist_item_select, targets) {
+                @Override
+                public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
+                    return GeoItemSelectorUtils.createIWaypointItemView(context, getItem(position),
+                            GeoItemSelectorUtils.getOrCreateView(context, convertView, parent));
+                }
+            };
+
+            Dialogs.newBuilder(context)
+                    .setTitle(R.string.cache_menu_navigation_drive_select_target)
+                    .setAdapter(adapter, (dialog, which) -> {
+                        final IWaypoint target = targets.get(which);
+                        if (target instanceof Geocache) {
+                            navigateWithoutSelector(context, (Geocache) target);
+                        }
+                        if (target instanceof Waypoint) {
+                            navigate(context, (Waypoint) target);
+                        }
+                    }).show();
+        }
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/apps/navi/AbstractRadarApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/AbstractRadarApp.java
@@ -33,7 +33,7 @@ abstract class AbstractRadarApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         final Intent intent = createIntent(cache.getCoords());
         addIntentExtras(intent, cache);
         context.startActivity(intent);

--- a/main/src/main/java/cgeo/geocaching/apps/navi/CacheSelectorNavigationApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/CacheSelectorNavigationApp.java
@@ -1,0 +1,16 @@
+package cgeo.geocaching.apps.navi;
+
+import cgeo.geocaching.models.Geocache;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+public interface CacheSelectorNavigationApp extends CacheNavigationApp {
+
+    /*
+     * same as navigate(...), but will display a selector if cache has more than one waypoint
+     */
+    void navigateWithoutSelector(@NonNull Context context, @NonNull Geocache cache);
+
+}

--- a/main/src/main/java/cgeo/geocaching/apps/navi/CompassApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/CompassApp.java
@@ -32,7 +32,7 @@ class CompassApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         CompassActivity.startActivityCache(context, cache);
     }
 

--- a/main/src/main/java/cgeo/geocaching/apps/navi/CruiserNavigationApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/CruiserNavigationApp.java
@@ -29,7 +29,7 @@ public class CruiserNavigationApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // asserted by caller
         navigate(context, coords, cache.getName());

--- a/main/src/main/java/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
@@ -1,27 +1,15 @@
 package cgeo.geocaching.apps.navi;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
-import cgeo.geocaching.models.Geocache;
-import cgeo.geocaching.models.IWaypoint;
-import cgeo.geocaching.models.Waypoint;
-import cgeo.geocaching.ui.GeoItemSelectorUtils;
-import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.Log;
 
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.ListAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
-
-import java.util.ArrayList;
 
 abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
 
@@ -64,48 +52,6 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
     static class GoogleNavigationDrivingApp extends GoogleNavigationApp {
         GoogleNavigationDrivingApp() {
             super(R.string.cache_menu_navigation_drive, "d");
-        }
-
-        @Override
-        public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
-            final ArrayList<IWaypoint> targets = new ArrayList<>();
-            targets.add(cache);
-            for (final Waypoint waypoint : cache.getWaypoints()) {
-                if ((waypoint.getWaypointType() == WaypointType.PARKING || waypoint.getWaypointType() == WaypointType.FINAL) && !cache.getCoords().equals(waypoint.getCoords())) {
-                    targets.add(waypoint);
-                }
-            }
-            if (targets.size() > 1) {
-                selectDriveTarget(context, targets);
-            } else {
-                super.navigate(context, cache);
-            }
-        }
-
-        /**
-         * show a selection of all parking places and the cache itself, when using the navigation for driving
-         */
-        private void selectDriveTarget(final Context context, final ArrayList<IWaypoint> targets) {
-            final Context themeContext = Dialogs.newContextThemeWrapper(context);
-            final ListAdapter adapter = new ArrayAdapter<IWaypoint>(themeContext, R.layout.cacheslist_item_select, targets) {
-                @Override
-                public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
-                    return GeoItemSelectorUtils.createIWaypointItemView(context, getItem(position),
-                            GeoItemSelectorUtils.getOrCreateView(context, convertView, parent));
-                }
-            };
-
-            Dialogs.newBuilder(context)
-                    .setTitle(R.string.cache_menu_navigation_drive_select_target)
-                    .setAdapter(adapter, (dialog, which) -> {
-                        final IWaypoint target = targets.get(which);
-                        if (target instanceof Geocache) {
-                            GoogleNavigationDrivingApp.super.navigate(context, (Geocache) target);
-                        }
-                        if (target instanceof Waypoint) {
-                            navigate(context, (Waypoint) target);
-                        }
-                    }).show();
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/apps/navi/InternalMap.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/InternalMap.java
@@ -42,7 +42,7 @@ class InternalMap extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         DefaultMap.startActivityGeoCode(context, cls != null ? cls : Settings.getMapProvider().getMapClass(), cache.getGeocode());
     }
 

--- a/main/src/main/java/cgeo/geocaching/apps/navi/MapsMeApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/MapsMeApp.java
@@ -29,7 +29,7 @@ class MapsMeApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         final List<Waypoint> waypoints = cache.getWaypoints();
         if (waypoints.isEmpty()) {
             navigate(context, cache.getCoords(), cache.getName());

--- a/main/src/main/java/cgeo/geocaching/apps/navi/OruxMapsApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/OruxMapsApp.java
@@ -43,7 +43,7 @@ abstract class OruxMapsApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // guaranteed by caller
         navigate(context, coords, cache.getName());

--- a/main/src/main/java/cgeo/geocaching/apps/navi/OsmAndApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/OsmAndApp.java
@@ -35,7 +35,7 @@ public class OsmAndApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         final Geopoint coords = cache.getCoords();
         assert coords != null; // guaranteed by super class
         navigate(context, coords, cache.getName());

--- a/main/src/main/java/cgeo/geocaching/apps/navi/OtherMapsApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/OtherMapsApp.java
@@ -53,7 +53,7 @@ abstract class OtherMapsApp extends AbstractPointNavigationApp {
     }
 
     @Override
-    public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
+    public void navigateWithoutSelector(@NonNull final Context context, @NonNull final Geocache cache) {
         navigate(context, cache.getCoords(), cache.getName());
     }
 


### PR DESCRIPTION
## Description
Google Maps (Driving) navigation app supports selection of target waypoint for a cache, if multiple waypoints exist.

This PR extends this feature to all navi apps derived from `AbstractPointNavigationApp`:
- AbstractRadarApp (inherited by RadarApp, PebbleApp)
- CompassApp
- CruiserNavigationApp
- GoogleNavigationApp (all variants)
- InternalMap
- OruxMapsApp
- OsmAndApp
- OtherMapsApp (all variants)
