### PR TITLE
Mark startscreen config items names as non-translatable (fix #14337)

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -995,13 +995,6 @@
 
     <!-- app startscreen -->
     <string name="settings_startscreen_title">Default screen</string>
-    <string-array name="settings_startscreen">
-        <item>@string/home_button</item>
-        <item>@string/stored_caches_button</item>
-        <item>@string/map_map</item>
-        <item>@string/advanced_search_button</item>
-        <item>@string/caches_nearby_button</item>
-    </string-array>
 
     <string name="init_wallpaper">Wallpaper</string>
     <string name="init_summary_wallpaper">Show device wallpaper as home screen background</string>

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -200,6 +200,15 @@
     <string translatable="false" name="ellipsis">…</string>
     <string translatable="false" name="triple_dash_vertical">┆</string>
 
+    <!-- app startscreen config item names -->
+    <string-array translatable="false" name="settings_startscreen">
+        <item>@string/home_button</item>
+        <item>@string/stored_caches_button</item>
+        <item>@string/map_map</item>
+        <item>@string/advanced_search_button</item>
+        <item>@string/caches_nearby_button</item>
+    </string-array>
+
     <!-- websites and product names -->
     <string translatable="false" name="caches_map_locus">Locus</string>
     <string translatable="false" name="settings_title_gc">Geocaching.com</string>


### PR DESCRIPTION
## Description
Mark startscreen config items name references as non-translatable