### PR TITLE
add a relative date filter looking into the future to filter events by date

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
@@ -313,7 +313,7 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
                 GeocacheFilterType.NAME, GeocacheFilterType.OWNER,
                 GeocacheFilterType.TYPE, GeocacheFilterType.SIZE,
                 GeocacheFilterType.DIFFICULTY, GeocacheFilterType.TERRAIN, GeocacheFilterType.DIFFICULTY_TERRAIN,
-                GeocacheFilterType.FAVORITES, GeocacheFilterType.STATUS, GeocacheFilterType.HIDDEN, GeocacheFilterType.LOG_ENTRY);
+                GeocacheFilterType.FAVORITES, GeocacheFilterType.STATUS, GeocacheFilterType.HIDDEN, GeocacheFilterType.EVENT_DATE, GeocacheFilterType.LOG_ENTRY);
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
@@ -212,6 +212,7 @@ public class GCMap {
                 search.setStatusEnabled(statusFilter.isExcludeDisabled() ? Boolean.TRUE : (statusFilter.isExcludeActive() ? FALSE : null));
                 break;
             case HIDDEN:
+            case EVENT_DATE:
                 final HiddenGeocacheFilter hiddenFilter = (HiddenGeocacheFilter) basicFilter;
                 search.setPlacementDate(hiddenFilter.getMinDate(), hiddenFilter.getMaxDate());
                 break;

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilterType.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilterType.java
@@ -26,6 +26,7 @@ public enum GeocacheFilterType {
     FAVORITES("favorites", R.string.cache_filter_favorites, R.string.cache_filtergroup_details, FavoritesGeocacheFilter::new),
     DISTANCE("distance", R.string.cache_filter_distance, R.string.cache_filtergroup_userspecific, DistanceGeocacheFilter::new),
     HIDDEN("hidden", R.string.cache_filter_hidden, R.string.cache_filtergroup_basic, HiddenGeocacheFilter::new),
+    EVENT_DATE("eventdate", R.string.cache_filter_eventdate, R.string.cache_filtergroup_basic, HiddenGeocacheFilter::new),
     LOGS_COUNT("logs_count", R.string.cache_filter_logs_count, R.string.cache_filtergroup_details, LogsCountGeocacheFilter::new),
     LAST_FOUND("last_found", R.string.cache_filter_last_found, R.string.cache_filtergroup_details, LastFoundGeocacheFilter::new),
     LOG_ENTRY("log_entry", R.string.cache_filter_log_entry, R.string.cache_filtergroup_details, LogEntryGeocacheFilter::new),

--- a/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -103,6 +103,12 @@ public class FilterViewHolderCreator {
                         LocalizationUtils.getStringArray(R.array.cache_filter_hidden_since_stored_values_label),
                         LocalizationUtils.getStringArray(R.array.cache_filter_hidden_since_stored_values_label_short));
                 break;
+            case EVENT_DATE:
+                result = new DateRangeFilterViewHolder<HiddenGeocacheFilter>(true,
+                        LocalizationUtils.getIntArray(R.array.cache_filter_event_date_stored_values_d),
+                        LocalizationUtils.getStringArray(R.array.cache_filter_event_date_stored_values_label),
+                        LocalizationUtils.getStringArray(R.array.cache_filter_event_date_stored_values_label_short));
+                break;
             case LAST_FOUND:
                 final int[] values = LocalizationUtils.getIntArray(R.array.cache_filter_hidden_since_stored_values_d);
                 result = new DateRangeFilterViewHolder<LastFoundGeocacheFilter>(true,

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -543,6 +543,7 @@
     <string name="cache_filter_favorites">Favorites</string>
     <string name="cache_filter_distance">Distance</string>
     <string name="cache_filter_hidden">Hidden Date</string>
+    <string name="cache_filter_eventdate">Event Date</string>
     <string name="cache_filter_logs_count">Logs Count</string>
     <string name="cache_filter_last_found">Last Found Date</string>
     <string name="cache_filter_log_entry">Log Entry</string>
@@ -710,6 +711,40 @@
         <item>1w</item>
         <item>3d</item>
         <item>&lt;3d</item>
+    </string-array>
+
+    <integer-array name="cache_filter_event_date_stored_values_d" translatable="false">
+        <item>-100000</item> <!-- past events -->
+        <item>0</item> <!-- today -->
+        <item>1</item> <!-- tomorrow -->
+        <item>2</item> <!-- 2 days from now -->
+        <item>3</item> <!-- 3 days from now -->
+        <item>7</item> <!-- 1 week from now -->
+        <item>14</item> <!-- 2 weeks from now -->
+        <item>30</item> <!-- 1 month from now -->
+        <item>500</item> <!-- forever in the future -->
+    </integer-array>
+    <string-array name="cache_filter_event_date_stored_values_label">
+        <item>past</item>
+        <item>today</item>
+        <item>tomorrow</item>
+        <item>2 days from now</item>
+        <item>3 days from now</item>
+        <item>1 week from now</item>
+        <item>2 weeks from now</item>
+        <item>1 month from now</item>
+        <item>all future</item>
+    </string-array>
+    <string-array name="cache_filter_event_date_stored_values_label_short">
+        <item>past</item>
+        <item>0d</item>
+        <item>1d</item>
+        <item>2d</item>
+        <item>3d</item>
+        <item>1w</item>
+        <item>2w</item>
+        <item>1m</item>
+        <item>&gt;1m</item>
     </string-array>
 
     <!-- about -->


### PR DESCRIPTION
adds a new "Event Date" filter which is actually just a "Hidden Date" filter but with relative range reaching into the future, not the past

![image](https://github.com/cgeo/cgeo/assets/1258173/f2b133c0-764b-406b-8785-25c0f8175672)

fixes #14330