### PR TITLE
DT marker: differentiate between missing and not supported

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
@@ -292,6 +292,11 @@ public abstract class AbstractConnector implements IConnector {
     }
 
     @Override
+    public boolean supportsDifficultyTerrain() {
+        return true;
+    }
+
+    @Override
     public int getMaxTerrain() {
         return 5;
     }

--- a/main/src/main/java/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/IConnector.java
@@ -257,6 +257,12 @@ public interface IConnector {
     String getWaypointPrefix(String name);
 
     /**
+     * Get info whether connector supports D/T ratings
+     */
+    @NonNull
+    boolean supportsDifficultyTerrain();
+
+    /**
      * Get the maximum value for Terrain
      */
     int getMaxTerrain();

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
@@ -110,6 +110,11 @@ public class ALConnector extends AbstractConnector implements ISearchByGeocode, 
     }
 
     @Override
+    public boolean supportsDifficultyTerrain() {
+        return false;
+    }
+
+    @Override
     public SearchResult searchByGeocode(@Nullable final String geocode, @Nullable final String guid, final DisposableHandler handler) {
         if (geocode == null) {
             return null;

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -165,6 +165,11 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     @Override
+    public boolean supportsDifficultyTerrain() {
+        return false;
+    }
+
+    @Override
     public SearchResult searchByGeocode(@Nullable final String geocode, @Nullable final String guid, final DisposableHandler handler) {
 
         DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_loadpage);

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -686,7 +686,7 @@ public class Geocache implements IWaypoint {
     }
 
     public float getDifficulty() {
-        return difficulty;
+        return getConnector().supportsDifficultyTerrain() ? difficulty : -1;
     }
 
     @Override
@@ -717,7 +717,7 @@ public class Geocache implements IWaypoint {
     }
 
     public float getTerrain() {
-        return terrain;
+        return getConnector().supportsDifficultyTerrain() ? terrain : -1;
     }
 
     public boolean isArchived() {

--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -697,13 +697,24 @@ public final class MapMarkerUtils {
         }
     }
 
-    @SuppressWarnings("DiscouragedApi")
+    /**
+     * Create a LayerDrawable showing the caches difficulty and terrain rating. If the connector doesn't support D/T show a "-" instead, if the info is missing (not loaded) a "?"
+     * @param res           Resources bundle
+     * @param difficulty    Difficulty rating
+     * @param terrain       Terrain rating
+     * @return              LayerDrawable composed of round background and foreground showing the ratings
+     */
     private static LayerDrawable createDTRatingMarker(final Resources res, final float difficulty, final float terrain) {
         final Drawable background = DrawableCompat.wrap(ResourcesCompat.getDrawable(res, R.drawable.marker_rating_bg, null));
         final InsetsBuilder insetsBuilder = new InsetsBuilder(res, background.getIntrinsicWidth(), background.getIntrinsicHeight());
         insetsBuilder.withInset(new InsetBuilder(background));
+        int layers = 4;
 
-        if (difficulty < 0.5 && terrain < 0.5) {
+        if (difficulty == -1 && terrain == -1) {
+            layers = 2;
+            insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_rating_notsupported));
+        } else if (difficulty == 0 && terrain == 0) {
+            layers = 2;
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_rating_notavailable));
         } else {
             final String packageName = CgeoApplication.getInstance().getPackageName();
@@ -713,9 +724,10 @@ public final class MapMarkerUtils {
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_rating_fg));
         }
 
-        return buildLayerDrawable(insetsBuilder, 4, 0);
+        return buildLayerDrawable(insetsBuilder, layers, 0);
     }
 
+    @SuppressWarnings("DiscouragedApi")
     private static Drawable getDTRatingMarkerSection(final Resources res, final String packageName, final String ratingLetter, final float rating) {
         // ensure that rating is an integer between 0 and 50 in steps of 5
         final int r = Math.max(0, Math.min(Math.round(rating * 2) * 5, 50));

--- a/main/src/main/res/drawable/marker_rating_notsupported.xml
+++ b/main/src/main/res/drawable/marker_rating_notsupported.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="13dp"
+    android:viewportWidth="13"
+    android:viewportHeight="13">
+  <path
+      android:pathData="m6.5,6.5m-6.125,0a6.125,6.125 0,1 1,12.25 0,6.125 6.125,0 1,1 -12.25,0"
+      android:strokeWidth=".75"
+      android:strokeColor="@color/cacheMarker_border"/>
+  <path
+      android:pathData="M4,6h5v1h-5z"
+      android:strokeWidth="0"
+      android:fillColor="@color/cacheMarker_border"/>
+</vector>


### PR DESCRIPTION
fixes #14343

for D/T cache marker differentiate between "not supported by connector" -> "-" and "information missing" -> "?"

Afaik AL is the only connector not supporting DT, so this change effects only those as of right now

![image](https://github.com/cgeo/cgeo/assets/1258173/305df3ad-fb2e-4c7c-8e38-c9539b59bd8a)
