### PR TITLE
add a "Save and upload" button in Edit Personal Note dialog

### DIFF
--- a/main/src/main/res/menu/menu_ok_cancel.xml
+++ b/main/src/main/res/menu/menu_ok_cancel.xml
@@ -28,6 +28,14 @@
         tools:ignore="AlwaysShowAction">
     </item>
     <item
+        android:id="@+id/menu_item_save_and_upload"
+        android:icon="@drawable/ic_menu_upload"
+        android:title="@string/cache_personal_note_save_and_upload"
+        android:visible="false"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction">
+    </item>
+    <item
         android:id="@+id/menu_item_cancel"
         android:icon="@drawable/ic_menu_cancel"
         android:title="@string/cancel"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1416,6 +1416,7 @@
     <string name="cache_personal_note_upload_done">Personal note uploaded</string>
     <string name="cache_personal_note_upload_error">Error uploading personal note</string>
     <string name="cache_personal_note_upload_cancelled">Personal note upload cancelled</string>
+    <string name="cache_personal_note_save_and_upload">Save and upload</string>
     <string name="cache_personal_note_vars_out_of_sync">Variables in notes are out of sync (%d)</string>
     <string name="cache_personal_note_vars_out_of_sync_dialog_title">Sync variables</string>
     <string name="cache_personal_note_vars_out_of_sync_title">Check variables whose value should be overwritten from notes</string>


### PR DESCRIPTION
in Edit Personal Note dialog add a third button to perform a "save and upload" (if the connector supports it) instead of saving, then clicking the "upload" button in Description view

![image](https://github.com/cgeo/cgeo/assets/1258173/b174132a-1401-4fb8-ae59-f8e0bb9c5ddc)
