### PR TITLE
Replace progress dialogs with inline views in cache listing

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -162,8 +162,6 @@ import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
 
-import com.google.android.material.button.MaterialButton;
-
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -180,6 +178,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.android.material.button.MaterialButton;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.functions.Function;
@@ -1381,7 +1380,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     if (ProgressBarDisposableHandler.isInProgress(activity) || activity.progress.isShowing()) {
-                        activity.showToast(activity.res.getString(R.string.err_watchlist_still_managing));
+                        activity.showToast(activity.res.getString(R.string.err_detail_still_working));
                         return;
                     }
                     handler.showProgress(button);
@@ -2826,8 +2825,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         @Override
         public void handleRegularMessage(final Message msg) {
             if (msg.what != UPDATE_LOAD_PROGRESS_DETAIL) {
-                button.setIcon(originalIcon);
-                dismissProgress(R.string.cache_progress_done_store);
+                dismissProgress();
                 notifyDataSetChanged(activityRef);
             }
         }
@@ -2841,10 +2839,11 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
         @Override
         public void handleRegularMessage(final Message msg) {
+            final CacheDetailActivity cacheDetailActivity = (CacheDetailActivity) activityRef.get();
             if (msg.what == UPDATE_SHOW_STATUS_TOAST && msg.obj instanceof String) {
                 showToast((String) msg.obj);
             } else if (msg.what != UPDATE_LOAD_PROGRESS_DETAIL) {
-                dismissProgress(R.string.cache_progress_done_refresh);
+                dismissProgress(cacheDetailActivity.getString(R.string.cache_progress_done_refresh, cacheDetailActivity.geocode));
                 notifyDataSetChanged(activityRef);
             }
         }

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -755,7 +755,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         } else if (menuItem == R.id.menu_tts_toggle) {
             SpeechService.toggleService(this, cache.getCoords());
         } else if (menuItem == R.id.menu_set_cache_icon) {
-            EmojiUtils.selectEmojiPopup(this, cache.getAssignedEmoji(), cache, newCacheIcon -> setCacheIcon(newCacheIcon));
+            EmojiUtils.selectEmojiPopup(this, cache.getAssignedEmoji(), cache, this::setCacheIcon);
         } else if (LoggingUI.onMenuItemSelected(item, this, cache, null)) {
             refreshOnResume = true;
         } else {

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1108,7 +1108,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
         CheckboxHandler(final DetailsViewCreator creator, final CacheDetailActivity activity) {
             super(activity);
-
             creatorRef = new WeakReference<>(creator);
             activityWeakReference = new WeakReference<>(activity);
         }
@@ -1376,7 +1375,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 handler = new CheckboxHandler(DetailsViewCreator.this, activity);
             }
 
-            public void doExecute(final int titleId, final int messageId, final Action1<ProgressButtonDisposableHandler> action) {
+            public void doExecute(final Action1<ProgressButtonDisposableHandler> action) {
                 final CacheDetailActivity activity = (CacheDetailActivity) getActivity();
                 if (activity != null) {
                     if (ProgressBarDisposableHandler.isInProgress(activity) || activity.progress.isShowing()) {
@@ -1397,9 +1396,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             @Override
             public void onClick(final View arg0) {
                 button = (MaterialButton) arg0;
-                doExecute(R.string.cache_dialog_watchlist_add_title,
-                        R.string.cache_dialog_watchlist_add_message,
-                        handler -> DetailsViewCreator.this.watchListAdd(handler));
+                doExecute(handler -> DetailsViewCreator.this.watchListAdd(handler));
             }
         }
 
@@ -1410,9 +1407,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             @Override
             public void onClick(final View arg0) {
                 button = (MaterialButton) arg0;
-                doExecute(R.string.cache_dialog_watchlist_remove_title,
-                        R.string.cache_dialog_watchlist_remove_message,
-                        handler -> DetailsViewCreator.this.watchListRemove(handler));
+                doExecute(handler -> DetailsViewCreator.this.watchListRemove(handler));
             }
         }
 
@@ -1422,7 +1417,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private void watchListAdd(final ProgressButtonDisposableHandler handler) {
             final WatchListCapability connector = (WatchListCapability) ConnectorFactory.getConnector(cache);
             if (connector.addToWatchlist(cache)) {
-                handler.obtainMessage(MESSAGE_SUCCEEDED).sendToTarget();
+                handler.sendTextMessage(MESSAGE_SUCCEEDED, R.string.cachedetails_progress_watch);
             } else {
                 handler.sendTextMessage(MESSAGE_FAILED, R.string.err_watchlist_failed);
             }
@@ -1434,7 +1429,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private void watchListRemove(final ProgressButtonDisposableHandler handler) {
             final WatchListCapability connector = (WatchListCapability) ConnectorFactory.getConnector(cache);
             if (connector.removeFromWatchlist(cache)) {
-                handler.obtainMessage(MESSAGE_SUCCEEDED).sendToTarget();
+                handler.sendTextMessage(MESSAGE_SUCCEEDED, R.string.cachedetails_progress_unwatch);
             } else {
                 handler.sendTextMessage(MESSAGE_FAILED, R.string.err_watchlist_failed);
             }
@@ -1446,7 +1441,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private void favoriteAdd(final ProgressButtonDisposableHandler handler) {
             final IFavoriteCapability connector = (IFavoriteCapability) ConnectorFactory.getConnector(cache);
             if (connector.addToFavorites(cache)) {
-                handler.obtainMessage(MESSAGE_SUCCEEDED).sendToTarget();
+                handler.sendTextMessage(MESSAGE_SUCCEEDED, R.string.cachedetails_progress_favorite);
             } else {
                 handler.sendTextMessage(MESSAGE_FAILED, R.string.err_favorite_failed);
             }
@@ -1458,7 +1453,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private void favoriteRemove(final ProgressButtonDisposableHandler handler) {
             final IFavoriteCapability connector = (IFavoriteCapability) ConnectorFactory.getConnector(cache);
             if (connector.removeFromFavorites(cache)) {
-                handler.obtainMessage(MESSAGE_SUCCEEDED).sendToTarget();
+                handler.sendTextMessage(MESSAGE_SUCCEEDED, R.string.cachedetails_progress_unfavorite);
             } else {
                 handler.sendTextMessage(MESSAGE_FAILED, R.string.err_favorite_failed);
             }
@@ -1471,9 +1466,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             @Override
             public void onClick(final View arg0) {
                 button = (MaterialButton) arg0;
-                doExecute(R.string.cache_dialog_favorite_add_title,
-                        R.string.cache_dialog_favorite_add_message,
-                        handler -> DetailsViewCreator.this.favoriteAdd(handler));
+                doExecute(handler -> DetailsViewCreator.this.favoriteAdd(handler));
             }
         }
 
@@ -1484,9 +1477,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             @Override
             public void onClick(final View arg0) {
                 button = (MaterialButton) arg0;
-                doExecute(R.string.cache_dialog_favorite_remove_title,
-                        R.string.cache_dialog_favorite_remove_message,
-                        handler -> DetailsViewCreator.this.favoriteRemove(handler));
+                doExecute(handler -> DetailsViewCreator.this.favoriteRemove(handler));
             }
         }
 
@@ -2825,7 +2816,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         @Override
         public void handleRegularMessage(final Message msg) {
             if (msg.what != UPDATE_LOAD_PROGRESS_DETAIL) {
-                dismissProgress();
+                super.handleRegularMessage(msg);
                 notifyDataSetChanged(activityRef);
             }
         }
@@ -2843,7 +2834,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (msg.what == UPDATE_SHOW_STATUS_TOAST && msg.obj instanceof String) {
                 showToast((String) msg.obj);
             } else if (msg.what != UPDATE_LOAD_PROGRESS_DETAIL) {
-                dismissProgress(cacheDetailActivity.getString(R.string.cache_progress_done_refresh, cacheDetailActivity.geocode));
+                dismissProgress(cacheDetailActivity.getString(R.string.cachedetails_progress_refresh, cacheDetailActivity.geocode));
                 notifyDataSetChanged(activityRef);
             }
         }
@@ -2891,8 +2882,8 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     }
 
     private void uploadPersonalNote() {
-        final ProgressBarDisposableHandler myHandler = new ProgressBarDisposableHandler(this);
-        myHandler.showProgress();
+        final ProgressButtonDisposableHandler myHandler = new ProgressButtonDisposableHandler(this);
+        myHandler.showProgress(findViewById(R.id.upload_personalnote));
 
         myHandler.add(AndroidRxUtils.networkScheduler.scheduleDirect(() -> {
             final PersonalNoteCapability connector = (PersonalNoteCapability) ConnectorFactory.getConnector(cache);

--- a/main/src/main/java/cgeo/geocaching/utils/DisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/DisposableHandler.java
@@ -47,7 +47,7 @@ public abstract class DisposableHandler extends Handler implements Disposable {
     }
 
     @Override
-    public final void handleMessage(final Message message) {
+    public void handleMessage(final Message message) {
         if (message.obj instanceof CancelHolder) {
             final CancelHolder holder = (CancelHolder) message.obj;
             if (holder.kind == CancelHolder.CANCEL && !isDisposed()) {

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressBarDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressBarDisposableHandler.java
@@ -1,64 +1,14 @@
 package cgeo.geocaching.utils;
 
-import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
 
-import android.content.res.Resources;
-import android.os.Bundle;
-import android.os.Message;
 import android.view.View;
 
-import androidx.annotation.StringRes;
-
-import java.lang.ref.WeakReference;
-
-public class ProgressBarDisposableHandler extends DisposableHandler {
-    public static final String MESSAGE_TEXT = "message_text";
-    private static final int DISPOSE_WITH_MESSAGE = -738434;
-    protected final WeakReference<AbstractActivity> activityRef;
+public class ProgressBarDisposableHandler extends SimpleDisposableHandler {
 
     public ProgressBarDisposableHandler(final AbstractActivity activity) {
-        this.activityRef = new WeakReference<>(activity);
-    }
-
-    @Override
-    protected void handleRegularMessage(final Message msg) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null && msg.getData() != null && msg.getData().getString(MESSAGE_TEXT) != null) {
-            activity.showToast(msg.getData().getString(MESSAGE_TEXT));
-        }
-        dismissProgress();
-        if (msg.what == DISPOSE_WITH_MESSAGE) {
-            dispose();
-        }
-    }
-
-    @Override
-    protected void handleDispose() {
-        dismissProgress();
-    }
-
-    protected final void showToast(@StringRes final int resId) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            final Resources res = activity.getResources();
-            activity.showToast(res.getText(resId).toString());
-        }
-    }
-
-    protected final void showToast(final String msg) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            activity.showToast(msg);
-        }
-    }
-
-    protected final void showShortToast(final String msg) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            activity.showShortToast(msg);
-        }
+        super(activity, null);
     }
 
     public final void showProgress() {
@@ -71,20 +21,21 @@ public class ProgressBarDisposableHandler extends DisposableHandler {
         }
     }
 
+    @Override
     protected final void dismissProgress() {
         dismissProgress(null);
     }
 
-    protected final void dismissProgress(@StringRes final Integer resId) {
+    protected final void dismissProgress(final String text) {
         final AbstractActivity activity = activityRef.get();
         if (activity != null) {
             final View progressBar = activity.findViewById(R.id.progressBar);
             if (progressBar != null) {
                 progressBar.setVisibility(View.GONE);
             }
-        }
-        if (resId != null) {
-            showShortToast(activity.getString(resId));
+            if (text != null) {
+                activity.showShortToast(text);
+            }
         }
     }
 
@@ -97,24 +48,4 @@ public class ProgressBarDisposableHandler extends DisposableHandler {
         }
         return false;
     }
-
-    protected final void finishActivity() {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            activity.finish();
-        }
-
-    }
-
-    public void sendTextMessage(final int what, @StringRes final int resId) {
-        final CacheDetailActivity activity = (CacheDetailActivity) activityRef.get();
-        if (activity != null) {
-            final Message msg = obtainMessage(what);
-            final Bundle bundle = new Bundle();
-            bundle.putString(MESSAGE_TEXT, activity.getString(resId));
-            msg.setData(bundle);
-            msg.sendToTarget();
-        }
-    }
-
 }

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressBarDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressBarDisposableHandler.java
@@ -1,0 +1,120 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.CacheDetailActivity;
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActivity;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.os.Message;
+import android.view.View;
+
+import androidx.annotation.StringRes;
+
+import java.lang.ref.WeakReference;
+
+public class ProgressBarDisposableHandler extends DisposableHandler {
+    public static final String MESSAGE_TEXT = "message_text";
+    private static final int DISPOSE_WITH_MESSAGE = -738434;
+    protected final WeakReference<AbstractActivity> activityRef;
+
+    public ProgressBarDisposableHandler(final AbstractActivity activity) {
+        this.activityRef = new WeakReference<>(activity);
+    }
+
+    @Override
+    protected void handleRegularMessage(final Message msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null && msg.getData() != null && msg.getData().getString(MESSAGE_TEXT) != null) {
+            activity.showToast(msg.getData().getString(MESSAGE_TEXT));
+        }
+        dismissProgress();
+        if (msg.what == DISPOSE_WITH_MESSAGE) {
+            dispose();
+        }
+    }
+
+    @Override
+    protected void handleDispose() {
+        dismissProgress();
+    }
+
+    protected final void showToast(@StringRes final int resId) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            final Resources res = activity.getResources();
+            activity.showToast(res.getText(resId).toString());
+        }
+    }
+
+    protected final void showToast(final String msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            activity.showToast(msg);
+        }
+    }
+
+    protected final void showShortToast(final String msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            activity.showShortToast(msg);
+        }
+    }
+
+    public final void showProgress() {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            final View progressBar = activity.findViewById(R.id.progressBar);
+            if (progressBar != null) {
+                progressBar.setVisibility(View.VISIBLE);
+            }
+        }
+    }
+
+    protected final void dismissProgress() {
+        dismissProgress(null);
+    }
+
+    protected final void dismissProgress(@StringRes final Integer resId) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            final View progressBar = activity.findViewById(R.id.progressBar);
+            if (progressBar != null) {
+                progressBar.setVisibility(View.INVISIBLE);
+            }
+        }
+        if (resId != null) {
+            showShortToast(activity.getString(resId));
+        }
+    }
+
+    public static boolean isInProgress(final AbstractActivity activity) {
+        if (activity != null) {
+            final View progressBar = activity.findViewById(R.id.progressBar);
+            if (progressBar != null) {
+                return progressBar.getVisibility() == View.VISIBLE;
+            }
+        }
+        return false;
+    }
+
+    protected final void finishActivity() {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            activity.finish();
+        }
+
+    }
+
+    public void sendTextMessage(final int what, @StringRes final int resId) {
+        final CacheDetailActivity activity = (CacheDetailActivity) activityRef.get();
+        if (activity != null) {
+            final Message msg = obtainMessage(what);
+            final Bundle bundle = new Bundle();
+            bundle.putString(MESSAGE_TEXT, activity.getString(resId));
+            msg.setData(bundle);
+            msg.sendToTarget();
+        }
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressBarDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressBarDisposableHandler.java
@@ -80,7 +80,7 @@ public class ProgressBarDisposableHandler extends DisposableHandler {
         if (activity != null) {
             final View progressBar = activity.findViewById(R.id.progressBar);
             if (progressBar != null) {
-                progressBar.setVisibility(View.INVISIBLE);
+                progressBar.setVisibility(View.GONE);
             }
         }
         if (resId != null) {

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
@@ -10,15 +10,14 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Message;
-import android.view.View;
 
 import androidx.annotation.StringRes;
+
+import java.lang.ref.WeakReference;
 
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
 import com.google.android.material.progressindicator.IndeterminateDrawable;
-
-import java.lang.ref.WeakReference;
 
 public class ProgressButtonDisposableHandler extends DisposableHandler {
     public static final String MESSAGE_TEXT = "message_text";
@@ -110,8 +109,8 @@ public class ProgressButtonDisposableHandler extends DisposableHandler {
     }
 
     private static IndeterminateDrawable getCircularProgressIndicatorDrawable(final Context context) {
-        CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_ExtraSmall);
-        spec.indicatorSize = ViewUtils.dpToPixel(28);
+        final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_ExtraSmall);
+        spec.indicatorSize = ViewUtils.dpToPixel(context.getResources().getDimension(R.dimen.buttonSize_iconButton) / context.getResources().getDisplayMetrics().density / 1.5f);
         return IndeterminateDrawable.createCircularDrawable(context, spec);
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
@@ -1,72 +1,22 @@
 package cgeo.geocaching.utils;
 
-import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.ui.ViewUtils;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.os.Message;
-
-import androidx.annotation.StringRes;
-
-import java.lang.ref.WeakReference;
 
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
 import com.google.android.material.progressindicator.IndeterminateDrawable;
 
-public class ProgressButtonDisposableHandler extends DisposableHandler {
-    public static final String MESSAGE_TEXT = "message_text";
-    private static final int DISPOSE_WITH_MESSAGE = -738434;
-    protected final WeakReference<AbstractActivity> activityRef;
+public class ProgressButtonDisposableHandler extends SimpleDisposableHandler {
     public MaterialButton button;
     public Drawable originalIcon;
 
     public ProgressButtonDisposableHandler(final AbstractActivity activity) {
-        this.activityRef = new WeakReference<>(activity);
-    }
-
-    @Override
-    protected void handleRegularMessage(final Message msg) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null && msg.getData() != null && msg.getData().getString(MESSAGE_TEXT) != null) {
-            activity.showToast(msg.getData().getString(MESSAGE_TEXT));
-        }
-        dismissProgress();
-        if (msg.what == DISPOSE_WITH_MESSAGE) {
-            dispose();
-        }
-    }
-
-    @Override
-    protected void handleDispose() {
-        dismissProgress();
-    }
-
-    protected final void showToast(@StringRes final int resId) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            final Resources res = activity.getResources();
-            activity.showToast(res.getText(resId).toString());
-        }
-    }
-
-    protected final void showToast(final String msg) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            activity.showToast(msg);
-        }
-    }
-
-    protected final void showShortToast(final String msg) {
-        final AbstractActivity activity = activityRef.get();
-        if (activity != null) {
-            activity.showShortToast(msg);
-        }
+        super(activity, null);
     }
 
     public void showProgress(final MaterialButton button) {
@@ -78,38 +28,17 @@ public class ProgressButtonDisposableHandler extends DisposableHandler {
         }
     }
 
+    @Override
     protected final void dismissProgress() {
-        dismissProgress(null);
-    }
-
-    protected final void dismissProgress(@StringRes final Integer resId) {
         if (button != null && originalIcon != null) {
             button.setIcon(originalIcon);
             button.setEnabled(true);
         }
-        if (resId != null) {
-            final AbstractActivity activity = activityRef.get();
-            if (activity != null) {
-                showShortToast(activity.getString(resId));
-            }
-        } else {
-            showShortToast("done");
-        }
     }
 
-    public void sendTextMessage(final int what, @StringRes final int resId) {
-        final CacheDetailActivity activity = (CacheDetailActivity) activityRef.get();
-        if (activity != null) {
-            final Message msg = obtainMessage(what);
-            final Bundle bundle = new Bundle();
-            bundle.putString(MESSAGE_TEXT, activity.getString(resId));
-            msg.setData(bundle);
-            msg.sendToTarget();
-        }
-    }
-
-    private static IndeterminateDrawable getCircularProgressIndicatorDrawable(final Context context) {
-        final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_ExtraSmall);
+    private static IndeterminateDrawable<CircularProgressIndicatorSpec> getCircularProgressIndicatorDrawable(final Context context) {
+        //final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_ExtraSmall);
+        final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null);
         spec.indicatorSize = ViewUtils.dpToPixel(context.getResources().getDimension(R.dimen.buttonSize_iconButton) / context.getResources().getDisplayMetrics().density / 1.5f);
         return IndeterminateDrawable.createCircularDrawable(context, spec);
     }

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
@@ -1,0 +1,118 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.CacheDetailActivity;
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActivity;
+import cgeo.geocaching.ui.ViewUtils;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.os.Message;
+import android.view.View;
+
+import androidx.annotation.StringRes;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
+import com.google.android.material.progressindicator.IndeterminateDrawable;
+
+import java.lang.ref.WeakReference;
+
+public class ProgressButtonDisposableHandler extends DisposableHandler {
+    public static final String MESSAGE_TEXT = "message_text";
+    private static final int DISPOSE_WITH_MESSAGE = -738434;
+    protected final WeakReference<AbstractActivity> activityRef;
+    public MaterialButton button;
+    public Drawable originalIcon;
+
+    public ProgressButtonDisposableHandler(final AbstractActivity activity) {
+        this.activityRef = new WeakReference<>(activity);
+    }
+
+    @Override
+    protected void handleRegularMessage(final Message msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null && msg.getData() != null && msg.getData().getString(MESSAGE_TEXT) != null) {
+            activity.showToast(msg.getData().getString(MESSAGE_TEXT));
+        }
+        dismissProgress();
+        if (msg.what == DISPOSE_WITH_MESSAGE) {
+            dispose();
+        }
+    }
+
+    @Override
+    protected void handleDispose() {
+        dismissProgress();
+    }
+
+    protected final void showToast(@StringRes final int resId) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            final Resources res = activity.getResources();
+            activity.showToast(res.getText(resId).toString());
+        }
+    }
+
+    protected final void showToast(final String msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            activity.showToast(msg);
+        }
+    }
+
+    protected final void showShortToast(final String msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null) {
+            activity.showShortToast(msg);
+        }
+    }
+
+    public void showProgress(final MaterialButton button) {
+        if (button != null) {
+            this.button = button;
+            originalIcon = button.getIcon();
+            button.setIcon(getCircularProgressIndicatorDrawable(activityRef.get()));
+            button.setEnabled(false);
+        }
+    }
+
+    protected final void dismissProgress() {
+        dismissProgress(null);
+    }
+
+    protected final void dismissProgress(@StringRes final Integer resId) {
+        if (button != null && originalIcon != null) {
+            button.setIcon(originalIcon);
+            button.setEnabled(true);
+        }
+        if (resId != null) {
+            final AbstractActivity activity = activityRef.get();
+            if (activity != null) {
+                showShortToast(activity.getString(resId));
+            }
+        } else {
+            showShortToast("done");
+        }
+    }
+
+    public void sendTextMessage(final int what, @StringRes final int resId) {
+        final CacheDetailActivity activity = (CacheDetailActivity) activityRef.get();
+        if (activity != null) {
+            final Message msg = obtainMessage(what);
+            final Bundle bundle = new Bundle();
+            bundle.putString(MESSAGE_TEXT, activity.getString(resId));
+            msg.setData(bundle);
+            msg.sendToTarget();
+        }
+    }
+
+    private static IndeterminateDrawable getCircularProgressIndicatorDrawable(final Context context) {
+        CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_ExtraSmall);
+        spec.indicatorSize = ViewUtils.dpToPixel(28);
+        return IndeterminateDrawable.createCircularDrawable(context, spec);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProgressButtonDisposableHandler.java
@@ -6,17 +6,32 @@ import cgeo.geocaching.ui.ViewUtils;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.os.Message;
 
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
 import com.google.android.material.progressindicator.IndeterminateDrawable;
 
 public class ProgressButtonDisposableHandler extends SimpleDisposableHandler {
+    private static final int MESSAGE_SUCCEEDED = 1;
     public MaterialButton button;
     public Drawable originalIcon;
 
     public ProgressButtonDisposableHandler(final AbstractActivity activity) {
         super(activity, null);
+    }
+
+    @Override
+    protected void handleRegularMessage(final Message msg) {
+        final AbstractActivity activity = activityRef.get();
+        if (activity != null && msg.getData() != null && msg.getData().getString(MESSAGE_TEXT) != null) {
+            if (msg.what == MESSAGE_SUCCEEDED) {
+                activity.showShortToast(msg.getData().getString(MESSAGE_TEXT));
+            } else {
+                activity.showToast(msg.getData().getString(MESSAGE_TEXT));
+            }
+        }
+        dismissProgress();
     }
 
     public void showProgress(final MaterialButton button) {
@@ -37,9 +52,8 @@ public class ProgressButtonDisposableHandler extends SimpleDisposableHandler {
     }
 
     private static IndeterminateDrawable<CircularProgressIndicatorSpec> getCircularProgressIndicatorDrawable(final Context context) {
-        //final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_ExtraSmall);
-        final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null);
-        spec.indicatorSize = ViewUtils.dpToPixel(context.getResources().getDimension(R.dimen.buttonSize_iconButton) / context.getResources().getDisplayMetrics().density / 1.5f);
+        final CircularProgressIndicatorSpec spec = new CircularProgressIndicatorSpec(context, null, 0, com.google.android.material.R.style.Widget_MaterialComponents_CircularProgressIndicator_Small);
+        spec.indicatorSize = ViewUtils.dpToPixel(context.getResources().getDimension(R.dimen.buttonSize_iconButton) / context.getResources().getDisplayMetrics().density / 1.8f);
         return IndeterminateDrawable.createCircularDrawable(context, spec);
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/SimpleDisposableHandler.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SimpleDisposableHandler.java
@@ -35,14 +35,6 @@ public class SimpleDisposableHandler extends DisposableHandler {
         }
     }
 
-    public Message cancelMessage(final String text) {
-        final Message msg = obtainMessage(DISPOSE_WITH_MESSAGE);
-        final Bundle bundle = new Bundle();
-        bundle.putString(MESSAGE_TEXT, text);
-        msg.setData(bundle);
-        return msg;
-    }
-
     @Override
     protected void handleDispose() {
         dismissProgress();
@@ -63,7 +55,7 @@ public class SimpleDisposableHandler extends DisposableHandler {
         }
     }
 
-    protected final void dismissProgress() {
+    protected void dismissProgress() {
         final Progress progressDialog = progressDialogRef.get();
         if (progressDialog != null) {
             progressDialog.dismiss();
@@ -83,15 +75,6 @@ public class SimpleDisposableHandler extends DisposableHandler {
             activity.finish();
         }
 
-    }
-
-    protected void updateStatusMsg(@StringRes final int resId, final String msg) {
-        final CacheDetailActivity activity = (CacheDetailActivity) activityRef.get();
-        if (activity != null) {
-            setProgressMessage(activity.getString(resId)
-                    + "\n\n"
-                    + msg);
-        }
     }
 
     public void sendTextMessage(final int what, @StringRes final int resId) {

--- a/main/src/main/res/layout/cachedetail_details_page.xml
+++ b/main/src/main/res/layout/cachedetail_details_page.xml
@@ -100,7 +100,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true" >
 
-                    <com.google.android.material.button.MaterialButton
+                    <Button
                         android:id="@+id/offline_refresh"
                         style="@style/button_icon"
                         app:icon="@drawable/ic_menu_refresh"
@@ -188,15 +188,14 @@
                     tools:text="The cache may or may not be on your watch list."
                     android:textIsSelectable="false" />
 
-                <com.google.android.material.button.MaterialButton
+                <Button
                     android:id="@+id/add_to_watchlist"
                     style="@style/button_icon"
                     android:layout_alignParentRight="true"
-                    android:visibility="gone"
                     app:icon="@drawable/ic_menu_watch"
-                    tools:visibility="visible" />
+                    android:visibility="gone" />
 
-                <com.google.android.material.button.MaterialButton
+                <Button
                     android:id="@+id/remove_from_watchlist"
                     style="@style/button_icon"
                     android:layout_alignParentRight="true"
@@ -374,8 +373,7 @@
                     style="@style/button_icon"
                     android:layout_alignParentRight="true"
                     app:icon="@drawable/ic_menu_favorite"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
+                    android:visibility="gone" />
 
                 <Button
                     android:id="@+id/remove_from_favpoint"

--- a/main/src/main/res/layout/cachedetail_details_page.xml
+++ b/main/src/main/res/layout/cachedetail_details_page.xml
@@ -100,7 +100,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true" >
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/offline_refresh"
                         style="@style/button_icon"
                         app:icon="@drawable/ic_menu_refresh"
@@ -188,7 +188,7 @@
                     tools:text="The cache may or may not be on your watch list."
                     android:textIsSelectable="false" />
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/add_to_watchlist"
                     style="@style/button_icon"
                     android:layout_alignParentRight="true"
@@ -196,7 +196,7 @@
                     app:icon="@drawable/ic_menu_watch"
                     tools:visibility="visible" />
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/remove_from_watchlist"
                     style="@style/button_icon"
                     android:layout_alignParentRight="true"

--- a/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
+++ b/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
@@ -1,47 +1,54 @@
-<LinearLayout
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     tools:context=".activity.TabbedViewPagerActivity">
 
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/progressBar"
         android:indeterminate="true"
-        android:visibility="invisible"
+        android:visibility="gone"
+        android:layout_alignParentTop="true"
         android:layout_width="match_parent"
         android:layout_height="4dp" />
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipe_refresh"
-        android:layout_width="match_parent"
-        android:layout_marginTop="-4dp"
-        android:layout_height="0dp"
-        android:layout_weight="1">
+    <LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_alignParentTop="true"
+    android:orientation="vertical">
 
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/viewpager"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1" />
+            android:layout_weight="1">
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/viewpager"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
 
-    <View style="@style/separator_horizontal" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tab_layout"
-        app:tabTextColor="@color/colorTextActionBar"
-        app:tabSelectedTextColor="@color/colorAccent"
-        app:tabIndicatorColor="@color/colorAccent"
-        app:tabPaddingStart="18sp"
-        app:tabPaddingEnd="18sp"
-        app:tabMode="scrollable"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="@dimen/textSize_detailsPrimary"
-        android:background="@color/colorBackgroundActionBar" />
+        <View style="@style/separator_horizontal" />
 
-</LinearLayout>
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            app:tabTextColor="@color/colorTextActionBar"
+            app:tabSelectedTextColor="@color/colorAccent"
+            app:tabIndicatorColor="@color/colorAccent"
+            app:tabPaddingStart="18sp"
+            app:tabPaddingEnd="18sp"
+            app:tabMode="scrollable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/textSize_detailsPrimary"
+            android:background="@color/colorBackgroundActionBar" />
+
+    </LinearLayout>
+</RelativeLayout>

--- a/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
+++ b/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
@@ -12,11 +12,12 @@
         android:indeterminate="true"
         android:visibility="invisible"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="4dp" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
+        android:layout_marginTop="-4dp"
         android:layout_height="0dp"
         android:layout_weight="1">
 

--- a/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
+++ b/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
@@ -7,6 +7,13 @@
     android:orientation="vertical"
     tools:context=".activity.TabbedViewPagerActivity">
 
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progressBar"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"

--- a/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
+++ b/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
@@ -16,10 +16,10 @@
         android:layout_height="4dp" />
 
     <LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_alignParentTop="true"
-    android:orientation="vertical">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignParentTop="true"
+        android:orientation="vertical">
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipe_refresh"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -242,7 +242,6 @@
     <string name="err_detail_no_spoiler">c:geo found no spoiler images for this cache.</string>
     <string name="err_detail_still_working">Still working on another task.</string>
     <string name="err_detail_premium_log_found">This cache is only available to premium members of geocaching.com. Therefore, the cache information cannot be displayed.\n\nHowever, if you have already found this cache, you can log it here.</string>
-    <string name="err_watchlist_still_managing">Still managing your watchlist.</string>
     <string name="err_watchlist_failed">Changing your watchlist failed.</string>
     <string name="err_application_no">c:geo can\'t find any suitable application.</string>
     <string name="err_auth_initialize">c:geo failed to initialize authorization process.</string>
@@ -1619,8 +1618,7 @@
     <string name="cache_recently_viewed_empty">No recently viewed caches</string>
     <string name="cache_clear_recently_viewed">clear</string>
 
-    <string name="cache_progress_done_refresh">Cache details refreshed</string>
-    <string name="cache_progress_done_store">Cache stored</string>
+    <string name="cache_progress_done_refresh">%s refreshed</string>
 
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1619,6 +1619,8 @@
     <string name="cache_recently_viewed_empty">No recently viewed caches</string>
     <string name="cache_clear_recently_viewed">clear</string>
 
+    <string name="cache_progress_done_refresh">Cache details refreshed</string>
+    <string name="cache_progress_done_store">Cache stored</string>
 
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1618,7 +1618,12 @@
     <string name="cache_recently_viewed_empty">No recently viewed caches</string>
     <string name="cache_clear_recently_viewed">clear</string>
 
-    <string name="cache_progress_done_refresh">%s refreshed</string>
+    <string name="cachedetails_progress_refresh">%s refreshed</string>
+    <string name="cachedetails_progress_watch">Added to watchlist</string>
+    <string name="cachedetails_progress_unwatch">Removed from watchlist</string>
+    <string name="cachedetails_progress_favorite">Added to favorites</string>
+    <string name="cachedetails_progress_unfavorite">Removed to favorites</string>
+    <string name="cachedetails_progress_upload_note">Personal note uploaded</string>
 
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>


### PR DESCRIPTION
Replace most dialogs when performing network actions from CacheDetails view with progress bar. Only one not replaced is the initial cache loading.
fixes #14358
fixes #14355
see these issues for more reasoning

PR also includes #14356 due to some rewrites, will rebase once that one is merged