### PR TITLE
UnifiedMap: Try to fix line widths

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapLineUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapLineUtils.java
@@ -89,7 +89,7 @@ public class MapLineUtils {
     // helper methods
 
     public static float getWidthFromRaw(final int rawValue, final boolean unifiedMap) {
-        return (rawValue / (unifiedMap ? 4.0f : 2.0f) + 1.0f) * DisplayUtils.getDisplayDensity();
+        return (rawValue / 2.0f) * (unifiedMap ? 1.0f : DisplayUtils.getDisplayDensity());
     }
 
     private static float getWidth(final int prefKeyId, final int defaultValueKeyId, final boolean unifiedMap) {


### PR DESCRIPTION
## Description
Currently map line widths on UnifiedMap VTM are way too heavy. It looks to me like the manual adjustment to display density is no longer needed since the recent changes to VTM map layers. This PR adjusts `MapLineUtils` accordingly.

|NewMap|VTM before|VTM after|
|---|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/70c624c7-6ade-4507-a8b4-997e2bfed8ec)|![image](https://github.com/cgeo/cgeo/assets/3754370/b3dcdd11-abed-4d67-8ea5-a46d99addec2)|![image](https://github.com/cgeo/cgeo/assets/3754370/52fbc93b-b681-4fdf-862a-2303bb04c76d)|

|CGeoMap|Google Map Unified|
|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/0634ca2b-aa42-4d8c-967f-df444df56902)|![image](https://github.com/cgeo/cgeo/assets/3754370/416fd3be-d6d7-4574-b25c-e5c8f63f39f4)|

(taken on a different device, though, compared to Mapsforge/VTM screenshots)
