### PR TITLE
UnifiedMap: Fix initial load of individual route (fix #14363)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -282,7 +282,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
         // FilterUtils.initializeFilterBar(this, this);
 
-        Routing.connect(ROUTING_SERVICE_KEY, () -> viewModel.individualRoute.notifyDataChanged(), this);
+        Routing.connect(ROUTING_SERVICE_KEY, () -> viewModel.reloadIndividualRoute(), this);
         viewModel.reloadIndividualRoute();
 
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());


### PR DESCRIPTION
## Description
On activity init BRouter is not yet ready and returns empty routes, which get converted to straight connections. 
The callback for Routing.connect() therefore needs to reload the route, not only refresh its display.

Whether we want to leave in the `viewModel.reloadIndividualRoute();` line after the `Routing.connect()` line is a matter of taste: Shall the uncalculated route be displayed already, or do we wait for a calculated route?