### PR TITLE
UnifiedMap: Fix crash on VTM screen rotation (rel. to #13575)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -97,7 +97,9 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         };
         mMap.events.bind(mapUpdateListener);
 
-        onMapReadyTasks.run();
+        if (onMapReadyTasks != null) {
+            onMapReadyTasks.run();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes crash on screen rotation, as `onMapReadyTasks` are undefined of first call to `onViewCreated` (but only on subsequent calls).
