### PR TITLE
make relative the default for date filters

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/gui/DateRangeFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/DateRangeFilterViewHolder.java
@@ -73,12 +73,13 @@ public class DateRangeFilterViewHolder<F extends DateRangeGeocacheFilter> extend
 
         relativeSlider = new ItemRangeSlider<>(getActivity());
         relativeSlider.setScale(Arrays.asList(relativeValues), (i, v) -> relativeLabels[i], (i, v) -> relativeShortLabels[i]);
-        relativeSlider.setVisibility(View.GONE);
 
         llp = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         llp.setMargins(0, dpToPixel(0), 0, dpToPixel(5));
         ll.addView(relativeSlider, llp);
 
+        dateRangeSelector.setVisibility(View.GONE);
+        absoluteRelative.setCheckedButtonByIndex(1, true);
         return ll;
     }
 


### PR DESCRIPTION
Change the default type for date filters from absolute to realtive

![image](https://github.com/cgeo/cgeo/assets/1258173/6bafde77-9bc4-4068-902e-77a7d6cd2e11)

fixes #14366