### PR TITLE
update button icons in image gallery

### DIFF
--- a/main/src/main/res/drawable/ic_menu_camera.xml
+++ b/main/src/main/res/drawable/ic_menu_camera.xml
@@ -6,6 +6,6 @@
     android:viewportHeight="24"
     android:tint="?android:textColorPrimary">
   <path
-      android:pathData="M3,4V1h2v3h3v2H5v3H3V6H0V4H3zM6,10V7h3V4h7l1.83,2H21c1.1,0 2,0.9 2,2v12c0,1.1 -0.9,2 -2,2H5c-1.1,0 -2,-0.9 -2,-2V10H6zM13,19c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5s-5,2.24 -5,5S10.24,19 13,19zM9.8,14c0,1.77 1.43,3.2 3.2,3.2s3.2,-1.43 3.2,-3.2s-1.43,-3.2 -3.2,-3.2S9.8,12.23 9.8,14z"
-      android:fillColor="#FF000000"/>
+      android:pathData="M3 4V1H5V4H8V6H5V9H3V6H0V4M6 10V7H9V4H16L17.8 6H21C22.1 6 23 6.9 23 8V20C23 21.1 22.1 22 21 22H5C3.9 22 3 21.1 3 20V10M13 19C17.45 19 19.69 13.62 16.54 10.46C13.39 7.31 8 9.55 8 14C8 16.76 10.24 19 13 19M9.8 14C9.8 16.85 13.25 18.28 15.26 16.26C17.28 14.25 15.85 10.8 13 10.8C11.24 10.8 9.8 12.24 9.8 14Z"
+      android:fillColor="@android:color/white"/>
 </vector>

--- a/main/src/main/res/drawable/ic_menu_file_add.xml
+++ b/main/src/main/res/drawable/ic_menu_file_add.xml
@@ -1,11 +1,11 @@
 <!-- taken from post_add / materialdesignicons-google -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
     android:tint="?android:textColorPrimary">
   <path
       android:fillColor="@android:color/white"
-      android:pathData="M32,18.45V21.45H16.05V18.45ZM32,24.8V27.8H16.05V24.8ZM32,31.15V34.15H16.05V31.15ZM37.6,6V10.4H42V13.4H37.6V17.8H34.6V13.4H30.2V10.4H34.6V6ZM28.7,6V9H9Q9,9 9,9Q9,9 9,9V39Q9,39 9,39Q9,39 9,39H39Q39,39 39,39Q39,39 39,39V19.3H42V39Q42,40.2 41.1,41.1Q40.2,42 39,42H9Q7.8,42 6.9,41.1Q6,40.2 6,39V9Q6,7.8 6.9,6.9Q7.8,6 9,6Z"/>
+      android:pathData="M14 2H6C4.89 2 4 2.89 4 4V20C4 21.11 4.89 22 6 22H13.81C13.28 21.09 13 20.05 13 19C13 18.67 13.03 18.33 13.08 18H6V16H13.81C14.27 15.2 14.91 14.5 15.68 14H6V12H18V13.08C18.33 13.03 18.67 13 19 13S19.67 13.03 20 13.08V8L14 2M13 9V3.5L18.5 9H13M18 15V18H15V20H18V23H20V20H23V18H20V15H18Z"/>
 </vector>

--- a/main/src/main/res/drawable/ic_menu_image_multi.xml
+++ b/main/src/main/res/drawable/ic_menu_image_multi.xml
@@ -6,6 +6,6 @@
     android:viewportHeight="24"
     android:tint="?android:textColorPrimary">
   <path
-      android:pathData="M19,7v2.99s-1.99,0.01 -2,0L17,7h-3s0.01,-1.99 0,-2h3L17,2h2v3h3v2h-3zM16,11L16,8h-3L13,5L5,5c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2v-8h-3zM5,19l3,-4 2,3 3,-4 4,5L5,19z"
-      android:fillColor="#FF000000"/>
+      android:pathData="M18 15V18H15V20H18V23H20V20H23V18H20V15H18M13.3 21H5C3.9 21 3 20.1 3 19V5C3 3.9 3.9 3 5 3H19C20.1 3 21 3.9 21 5V13.3C20.4 13.1 19.7 13 19 13C17.9 13 16.8 13.3 15.9 13.9L14.5 12L11 16.5L8.5 13.5L5 18H13.1C13 18.3 13 18.7 13 19C13 19.7 13.1 20.4 13.3 21Z"
+      android:fillColor="@android:color/white"/>
 </vector>


### PR DESCRIPTION
update buttons in image gallery to a) use current material design look, b) use filled (instead of outline) for "add file"

Old:
![image](https://github.com/cgeo/cgeo/assets/1258173/44f00903-a756-46ba-85f3-2bb2ecd84d0f)

New:
![image](https://github.com/cgeo/cgeo/assets/1258173/f6d62512-3cfa-4e22-9af4-c78f0275c618)
