### PR TITLE
Replace connector-specific string in general message (fix #14377)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1002,7 +1002,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         if (!Network.isConnected()) {
-            showToast(getString(R.string.err_server));
+            showToast(getString(R.string.err_server_general));
             return;
         }
 

--- a/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
@@ -240,7 +240,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
             }
 
             if (!Network.isConnected()) {
-                showToast(getString(R.string.err_server));
+                showToast(getString(R.string.err_server_general));
                 return;
             }
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLogin.java
@@ -176,7 +176,7 @@ public class GCLogin extends AbstractLogin {
 
             if (StringUtils.isBlank(tryLoggedInData)) {
                 logLastLoginError("Failed to retrieve login page (1st)");
-                return StatusCode.CONNECTION_FAILED; // no login page
+                return StatusCode.CONNECTION_FAILED_GC; // no login page
             }
 
             if (getLoginStatus(tryLoggedInData)) {
@@ -229,7 +229,7 @@ public class GCLogin extends AbstractLogin {
             return status.statusCode;
         } catch (final Exception ignored) {
             logLastLoginError("communication error");
-            return StatusCode.CONNECTION_FAILED;
+            return StatusCode.CONNECTION_FAILED_GC;
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -909,13 +909,13 @@ public final class GCParser {
 
         if (StringUtils.isBlank(page)) {
             Log.e("GCParser.searchByNextPage: No data from server");
-            return new SearchResult(con, StatusCode.CONNECTION_FAILED);
+            return new SearchResult(con, StatusCode.CONNECTION_FAILED_GC);
         }
 
         final SearchResult searchResult = parseSearch(con, url, page, context.getInt(GCConnector.SEARCH_CONTEXT_TOOK_TOTAL, 0));
         if (searchResult == null || CollectionUtils.isEmpty(searchResult.getGeocodes())) {
             Log.w("GCParser.searchByNextPage: No cache parsed");
-            return new SearchResult(con, StatusCode.CONNECTION_FAILED);
+            return new SearchResult(con, StatusCode.CONNECTION_FAILED_GC);
         }
 
         // search results don't need to be filtered so load GCVote ratings here

--- a/main/src/main/java/cgeo/geocaching/enumerations/StatusCode.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/StatusCode.java
@@ -13,7 +13,7 @@ public enum StatusCode {
     LOG_SAVED(R.string.info_log_saved),
     LOGIN_PARSE_ERROR(R.string.err_parse),
     LOGIN_CAPTCHA_ERROR(R.string.err_captcha),
-    CONNECTION_FAILED(R.string.err_server),
+    CONNECTION_FAILED_GC(R.string.err_server_gc),
     CONNECTION_FAILED_EC(R.string.err_server_ec),
     CONNECTION_FAILED_LC(R.string.err_server_lc),
     CONNECTION_FAILED_SU(R.string.err_server_su),

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -216,7 +216,8 @@
     <string name="err_none">OK</string>
     <string name="err_parse">Failed Login page parsing</string>
     <string name="err_captcha">The service requires a Captcha. Please open the geocaching.com website with your browser and solve the Captcha shown while logging in there. Then try again to login with c:geo.</string>
-    <string name="err_server">Unable to contact Geocaching.com. The website may be down or your internet connection not working.</string>
+    <string name="err_server_general">Unable to contact geocaching server. The website may be down or your internet connection not working.</string>
+    <string name="err_server_gc">Unable to contact Geocaching.com. The website may be down or your internet connection not working.</string>
     <string name="err_server_ec">Unable to contact Extremcaching.com. The website may be down or your internet connection not working.</string>
     <string name="err_server_lc">Unable to contact labs.geocaching.com. The website may be down or your internet connection not working.</string>
     <string name="err_server_su">Unable to contact Geocaching.su. The website may be down or your internet connection not working.</string>


### PR DESCRIPTION
## Description
Use GC-specific error message in GC connector-related files only, and remove GC-specific text in general contexts.