### PR TITLE
Add integrity check to tile downloader (fix #10416)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -100,6 +100,17 @@ public abstract class AbstractDownloader {
         return null;
     }
 
+    // do some integrity check after file download (and before copying it to final location)
+    // true = integrity ok (or untested), false = error (file will be deleted automatically)
+    protected boolean verifiedBeforeCopying(final String filename, final Uri result) {
+        return true;
+    }
+
+    // similar to verifiedBeforeCopying, but after having copied (and probably ZIP-extracted) the file
+    protected boolean verifiedAfterCopying(final String filename, final Uri result) {
+        return true;
+    }
+
     // default action to be started after having received and copied the downloaded file successfully
     protected void onSuccessfulReceive(final Uri result) {
         // default: nothing to do

--- a/main/src/main/java/cgeo/geocaching/downloader/BRouterTileDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/BRouterTileDownloader.java
@@ -3,11 +3,14 @@ package cgeo.geocaching.downloader;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.brouter.BRouterConstants;
+import cgeo.geocaching.brouter.mapaccess.PhysicalFile;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.network.Network;
+import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
 
 import android.net.Uri;
@@ -16,6 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
+import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,4 +89,12 @@ public class BRouterTileDownloader extends AbstractDownloader {
         return tiles;
     }
 
+    @Override
+    protected boolean verifiedBeforeCopying(final String filename, final Uri file) {
+        final String result = PhysicalFile.checkTileDataIntegrity(filename, (FileInputStream) ContentStorage.get().openForRead(file));
+        if (result != null) {
+            Log.e("Downloading routing tile '" + filename + "' failed: " + result);
+        }
+        return (result == null);
+    }
 }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2652,6 +2652,7 @@
     <string name="receivedownload_error_filenotfound_exception">File not found error while receiving file.</string>
     <string name="receivedownload_amount_copied">%s copied</string>
     <string name="receivedownload_cancelled">File transfer cancelled</string>
+    <string name="receivedownload_integritycheck_failed">Integrity check failed</string>
 
     <!-- Download map preference and menu entry -->
     <string name="downloadmap_title">Download offline map</string>


### PR DESCRIPTION
## Description
Extends download by integrity checks capabilities (after download, but before copying, and after copying).
`BRouterTileDownloader` hooks into the first one and does an integrity check before copying the file.

Second type of integrity check could be used by OSM offline map downloaders (but is not yet implemented for them).