### PR TITLE
Support for user-selected audio for proximity notifications

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/main/java/cgeo/geocaching/location/ProximityNotification.java
@@ -3,12 +3,16 @@ package cgeo.geocaching.location;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.speech.TextFactory;
+import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.ui.notifications.NotificationChannels;
 import cgeo.geocaching.ui.notifications.Notifications;
+import cgeo.geocaching.utils.Log;
 
 import android.content.Context;
 import android.media.AudioManager;
+import android.media.MediaPlayer;
 import android.media.ToneGenerator;
+import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Parcel;
@@ -219,16 +223,29 @@ public class ProximityNotification implements Parcelable {
             lastTone = tone;
 
             if (useToneNotifications) {
-                final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_MUSIC, ToneGenerator.MAX_VOLUME);
-                toneG.startTone(tone);
-                final Handler handler = new Handler(Looper.getMainLooper());
-                if (tone == TONE_NEAR) {
-                    handler.postDelayed(() -> {
-                        toneG.startTone(TONE_NEAR);
+                final Uri audiofile = tone == TONE_NEAR ? PersistableUri.PROXIMITY_NOTIFICATION_CLOSE.getUri() : PersistableUri.PROXIMITY_NOTIFICATION_FAR.getUri();
+                if (audiofile == null) {
+                    final ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_MUSIC, ToneGenerator.MAX_VOLUME);
+                    toneG.startTone(tone);
+                    final Handler handler = new Handler(Looper.getMainLooper());
+                    if (tone == TONE_NEAR) {
+                        handler.postDelayed(() -> {
+                            toneG.startTone(TONE_NEAR);
+                            handler.postDelayed(toneG::release, 350);
+                        }, 350);
+                    } else {
                         handler.postDelayed(toneG::release, 350);
-                    }, 350);
+                    }
                 } else {
-                    handler.postDelayed(toneG::release, 350);
+                    final MediaPlayer mp = new MediaPlayer();
+                    try {
+                        mp.setDataSource(context, audiofile);
+                        mp.setVolume(1f, 1f);
+                        mp.prepare();
+                        mp.start();
+                    } catch (Exception e) {
+                        Log.e("print tone: " + e);
+                    }
                 }
             }
         }

--- a/main/src/main/java/cgeo/geocaching/settings/ButtonPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/ButtonPreference.java
@@ -1,0 +1,79 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+/**
+ * ButtonPreference:
+ * Regular preference, displaying a button in the widget area.
+ *
+ * Buttons defaults to "add" symbol, but can be set via app:src="res-id" in preferences xml file.
+ *
+ * Use setCallback() to define a callback function for the widget's button.
+ * Use hideButton() to hide or show the widget's button.
+ */
+
+public class ButtonPreference extends Preference {
+
+    final @DrawableRes int srcId;
+    Runnable callback = null;
+    boolean buttonHidden = false;
+    ImageView button = null;
+
+    public ButtonPreference(final Context context) {
+        this(context, null);
+    }
+
+    public ButtonPreference(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.dialogPreferenceStyle);
+    }
+
+    public ButtonPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        setWidgetLayoutResource(R.layout.preference_button_widget);
+
+        // get additional params, if given
+        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ButtonPreference, defStyle, 0);
+        try {
+            srcId = a.getResourceId(R.styleable.ButtonPreference_src, R.drawable.ic_menu_add);
+        } finally {
+            a.recycle();
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        holder.setDividerAllowedAbove(false);
+        button = (ImageView) holder.findViewById(R.id.widget_action);
+        hideButton(buttonHidden);
+        button.setOnClickListener(v -> {
+            if (!buttonHidden) {
+                hideButton(true);
+                if (callback != null) {
+                    callback.run();
+                }
+            }
+        });
+    }
+
+    public void hideButton(final boolean hide) {
+        buttonHidden = hide;
+        if (button != null) {
+            button.setBackgroundResource(hide ? 0 : srcId);
+        }
+    }
+
+    public void setCallback(final Runnable callback) {
+        this.callback = callback;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -486,7 +486,7 @@ public class Settings {
         return CgeoApplication.getInstance() == null ? -1 : CgeoApplication.getInstance().getResources().getInteger(prefKeyId);
     }
 
-    protected static String getString(final int prefKeyId, final String defaultValue) {
+    public static String getString(final int prefKeyId, final String defaultValue) {
         return getStringDirect(getKey(prefKeyId), defaultValue);
     }
 
@@ -546,7 +546,7 @@ public class Settings {
         return sharedPrefs == null ? defaultValue : sharedPrefs.getFloat(getKey(prefKeyId), defaultValue);
     }
 
-    protected static void putString(final int prefKeyId, final String value) {
+    public static void putString(final int prefKeyId, final String value) {
         putStringDirect(getKey(prefKeyId), value);
     }
 
@@ -2172,8 +2172,6 @@ public class Settings {
             return new String[]{"mapDirectory"};
         } else if (keyId == R.string.pref_persistablefolder_gpx) {
             return new String[]{"gpxExportDir", "gpxImportDir"};
-        } else if (keyId == R.string.pref_persistableuri_track) {
-            return new String[]{"pref_trackfile"};
         } else if (keyId == R.string.pref_persistablefolder_offlinemapthemes) {
             return new String[]{"renderthemepath"};
         } else {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
@@ -1,10 +1,17 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.ButtonPreference;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.utils.MapMarkerUtils;
 
+import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.annotation.StringRes;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment {
 
@@ -20,6 +27,8 @@ public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment
         assert activity != null;
         activity.setTitle(R.string.settings_title_map_content_behavior);
 
+        updateNotificationAudioInfo();
+
         // Clear icon cache when modifying settings that influence icon appearance
         findPreference(getString(R.string.pref_dtMarkerOnCacheIcon)).setOnPreferenceChangeListener((preference, newValue) -> {
             MapMarkerUtils.clearCachedItems();
@@ -30,4 +39,34 @@ public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment
             return true;
         });
     }
+
+    public void updateNotificationAudioInfo() {
+        setButton(true);
+        setButton(false);
+    }
+
+    private void setButton(final boolean first) {
+        final @StringRes int keyId = first ? R.string.pref_persistableuri_proximity_notification_far : R.string.pref_persistableuri_proximity_notification_close;
+        final ButtonPreference bp = findPreference(getString(keyId));
+        final String current = Settings.getString(keyId, "");
+
+        bp.setSummary(StringUtils.isNotBlank(current) ? Uri.parse(current).getLastPathSegment() : getString(R.string.proximitynotification_internal));
+        if (StringUtils.isNotBlank(current)) {
+            bp.hideButton(false);
+            bp.setCallback(() -> {
+                Settings.putString(keyId, "");
+                bp.setSummary(R.string.proximitynotification_internal);
+                bp.hideButton(true);
+            });
+        } else {
+            bp.setCallback(null);
+            bp.hideButton(true);
+        }
+        bp.setOnPreferenceClickListener(preference -> {
+            ((SettingsActivity) getActivity()).startProximityNotificationSelector(first);
+            return false;
+        });
+    }
+
 }
+

--- a/main/src/main/java/cgeo/geocaching/storage/PersistableUri.java
+++ b/main/src/main/java/cgeo/geocaching/storage/PersistableUri.java
@@ -13,7 +13,8 @@ import androidx.annotation.StringRes;
  */
 public enum PersistableUri {
 
-    UNUSED_TRACK(R.string.pref_persistableuri_track, R.string.persistableuri_track, null);
+    PROXIMITY_NOTIFICATION_FAR(R.string.pref_persistableuri_proximity_notification_far, R.string.persistableuri_proximitynotification_audiofile_far, null),
+    PROXIMITY_NOTIFICATION_CLOSE(R.string.pref_persistableuri_proximity_notification_close, R.string.persistableuri_proximitynotification_audiofile_close, null);
 
     @StringRes
     private final int prefKeyId;

--- a/main/src/main/res/layout/preference_button_widget.xml
+++ b/main/src/main/res/layout/preference_button_widget.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_action"
+    android:layout_width="32dp"
+    android:layout_height="32dp"
+    android:layout_gravity="center"
+    android:scaleType="fitXY" />

--- a/main/src/main/res/values/attrs.xml
+++ b/main/src/main/res/values/attrs.xml
@@ -15,6 +15,11 @@
     <attr name="urlButton" format="string" />
     <attr name="connector" format="string" />
 
+    <!-- attributes for ButtonPreference -->
+    <declare-styleable name="ButtonPreference">
+        <attr name="src" format="integer" />
+    </declare-styleable>
+
     <!-- attributes for ColorpickerPreference -->
     <declare-styleable name="ColorpickerPreference">
         <attr name="showOpaquenessSlider" format="boolean" />

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -443,7 +443,8 @@
     <string translatable="false" name="pref_persistablefolder_fieldnotes">persistablefolder_fieldnotes</string>
     <string translatable="false" name="pref_persistablefolder_spoilerimages">persistablefolder_spoilerimages</string>
     <string translatable="false" name="pref_persistablefolder_routingbase">persistablefolder_routingbase</string>
-    <string translatable="false" name="pref_persistableuri_track">persistableuri_track</string>
+    <string translatable="false" name="pref_persistableuri_proximity_notification_far">persistableuri_proximity_notification_far</string>
+    <string translatable="false" name="pref_persistableuri_proximity_notification_close">persistableuri_proximity_notification_close</string>
 
     <!-- services => authentification (grouped by service) -->
     <string translatable="false" name="pref_username">username</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1293,7 +1293,9 @@
     <string name="persistablefolder_routingbase">Routing</string>
     <string name="persistablefolder_routingtiles">Routing data</string>
 
-    <string name="persistableuri_track">Trackfile</string>
+    <string name="persistableuri_proximitynotification_audiofile_far">Audio file (far)</string>
+    <string name="persistableuri_proximitynotification_audiofile_close">Audio file (close)</string>
+    <string name="proximitynotification_internal">(internal)</string>
 
     <!-- FolderUtils: async processing -->
     <string name="folder_process_status_done">%1$s/%2$s, %3$s/%4$s done</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -152,5 +152,15 @@
             android:summary="%s"
             android:title="@string/init_proximity_notification_type"
             app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.ButtonPreference
+            android:key="@string/pref_persistableuri_proximity_notification_far"
+            android:title="@string/persistableuri_proximitynotification_audiofile_far"
+            app:src="@drawable/ic_menu_delete"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.ButtonPreference
+            android:key="@string/pref_persistableuri_proximity_notification_close"
+            android:title="@string/persistableuri_proximitynotification_audiofile_close"
+            app:src="@drawable/ic_menu_delete"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Description
Extension to proximity notifications to let users select their own audio files for proximity notification.
Uses SAF file picker to select one or two audio files. Resetting to built-in tone is possible by pressing the "delete" icon beside the file selection.