### PR TITLE
Fix default max for ProximitySeekbar (fix #14394)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/ProximityPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/ProximityPreference.java
@@ -33,7 +33,6 @@ public class ProximityPreference extends SeekbarPreference {
     @Override
     protected void init() {
         minProgress = 1;
-        maxProgress = valueToProgressHelper(Settings.getKeyInt(R.integer.proximitynotification_distance_max));
     }
 
     @Override

--- a/main/src/main/res/values/numbers.xml
+++ b/main/src/main/res/values/numbers.xml
@@ -9,7 +9,7 @@
 
     <!-- seekbar preference default & max values -->
     <integer name="brouter_threshold_default">10</integer>
-    <integer name="brouter_threshold_max">120</integer>
+    <integer name="brouter_threshold_max">1000</integer>
     <integer name="brouter_updateinterval_default">30</integer>
     <integer name="brouter_updateinterval_max">366</integer>
     <integer name="map_updateinterval_default">30</integer>


### PR DESCRIPTION
## Description
- fix wrong initialization of ProximitySeekbar's max progress value
- raise max value for routing threshold from 120 to ~250~ 1000 km