### PR TITLE
Hide elements of bottom navigation

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -196,6 +196,7 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
     @Override
     protected void onResume() {
         super.onResume();
+        showHideBottomNavItems();
         updateSelectedBottomNavItemId();
         startLoginIssueHandler();
         registerReceiver(connectivityChangeReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
@@ -217,6 +218,13 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
 
         // avoid weired transitions
         ActivityMixin.overrideTransitionToFade(this);
+    }
+
+    /** show or hide elements of bottom navigation at user's request (default: show all) */
+    private void showHideBottomNavItems() {
+        // add the other elements as well, but first make sure, that they are all available as home screen shortcuts,
+        // otherwise you will lock yourself out from reaching settings etc. if you disable home screen
+        ((NavigationBarView) binding.activityBottomNavigation).getMenu().findItem(MENU_NEARBY).setVisible(!Settings.getBoolean(R.string.pref_hidebn_nearby, false));
     }
 
     public void updateSelectedBottomNavItemId() {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -535,6 +535,9 @@
     <string translatable="false" name="pref_mapWpScale">mapWpScale</string>
     <string translatable="false" name="pref_mapScaleOnly">mapScaleOnly</string>
 
+    <!-- hide parts of bottom navigation -->
+    <string translatable="false" name="pref_hidebn_nearby">hidebn_nearby</string>
+
     <!-- pq/bookmark list: show downloadable/new only -->
     <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
     <string translatable="false" name="pref_bookmarklistsShowNewOnly">bookmarklistsShowNewOnly</string>


### PR DESCRIPTION
## Description
Small preview to demonstrate how hiding certain elements of bottom navigation could be implemented (as has been requested in the past for at least "home screen" and "nearby search").

The actual bottom navigation items are still available and reachable, just no longer being displayed in bottom navigation.
If you have a c:geo shortcut to eg "nearby", you can still call this from your mobile's home screen. But you won't see it in bottom navigation (and cannot accidentally hit the "nearby" search entry).

Currently, it's implemented for "nearby" only:

![image](https://github.com/cgeo/cgeo/assets/3754370/8ea32ef4-0c52-44f8-b509-a6e4e431bb86)

Before we also implement this for the other elements as well, we should make sure, that all elements are available as c:geo shortcuts, otherwise hiding the home screen would effectively lock you out from changing settings.