### PR TITLE
Display info on home screen for unread messages

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -563,7 +563,7 @@ public class Settings {
         putString(prefKeyId, StringUtils.join(elements, SEPARATOR_CHAR));
     }
 
-    protected static void putBoolean(final int prefKeyId, final boolean value) {
+    public static void putBoolean(final int prefKeyId, final boolean value) {
         if (sharedPrefs == null) {
             return;
         }

--- a/main/src/main/res/layout/main_activity.xml
+++ b/main/src/main/res/layout/main_activity.xml
@@ -41,6 +41,14 @@
             android:layout_marginBottom="8dp"
             android:visibility="gone" />
 
+        <include
+            android:id="@+id/mcupdate"
+            layout="@layout/mainactivity_action_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone" />
+
     </LinearLayout>
 
     <RelativeLayout

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -572,6 +572,7 @@
     <string translatable="false" name="pref_dbCleanupLastCheck">dbCleanupLastCheck</string>
     <string translatable="false" name="pref_dbReindexLastCheck">dbReindexLastCheck</string>
     <string translatable="false" name="pref_pendingDownloadsLastCheck">pendingDownloadsLastCheck</string>
+    <string translatable="false" name="pref_pollMessageCenter">pollMessageCenter</string>
 
     <string translatable="false" name="pref_caches_history">caches_history</string>
     <string translatable="false" name="pref_phone_model_and_sdk">phone_model_and_sdk</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3177,4 +3177,15 @@
     <string name="smiley_disapprove">Disapproved</string>
     <string name="smiley_question">Question</string>
 
+    <!-- message center notifications -->
+    <string name="mcpolling_title">Message Center</string>
+    <string name="mcpolling_summary">Check message center for incoming messages in regular intervals</string>
+    <plurals name="mcupdate">
+        <item quantity="zero">%d unread messages in message center</item>
+        <item quantity="one">%d unread message in message center</item>
+        <item quantity="two">%d unread messages in message center</item>
+        <item quantity="few">%d unread messages in message center</item>
+        <item quantity="many">%d unread messages in message center</item>
+        <item quantity="other">%d unread messages in message center</item>
+    </plurals>
 </resources>

--- a/main/src/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/src/main/res/xml/preferences_services_geocaching_com.xml
@@ -27,6 +27,14 @@
             app:summary="@string/auth_unconnected"
             app:iconSpaceReserved="false" />
 
+        <CheckBoxPreference
+            android:dependency="@string/pref_connectorGCActive"
+            android:key="@string/pref_pollMessageCenter"
+            android:title="@string/mcpolling_title"
+            android:summary="@string/mcpolling_summary"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
Optionally polls message center for unread messages and displays a notification on home screen if so.

![image](https://github.com/cgeo/cgeo/assets/3754370/9ca60aa7-6f40-486f-aa08-f6e8197f2dfc)

Notification handling is the same as for other update infos:
- notification text + blue badge on home screen bottom navigation icon
- a short tap opens the message center in the browser
- a long top closes the notification without opening the message center

This functionality can be activated in settings => services => geocaching.com, default is "off".
