### PR TITLE
Update Mapsforge & VTM to v0.19.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -355,16 +355,16 @@ dependencies {
     implementation "com.asamm:locus-api-android:0.9.32"
 
     // Mapsforge official version
-    //String mapsforgeSource = 'org.mapsforge'
-    //String mapsforgeVersion = '0.18.0'
+    String mapsforgeSource = 'org.mapsforge'
+    String mapsforgeVersion = '0.19.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     //String mapsforgeSource = 'com.github.mapsforge.mapsforge'
     //String mapsforgeVersion = 'fbc75a4' // master as of 18.07.22
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
-    String mapsforgeSource = 'com.github.cgeo.mapsforge'
-    String mapsforgeVersion = 'fbc75a4' // fix for #12210
+    // String mapsforgeSource = 'com.github.cgeo.mapsforge'
+    // String mapsforgeVersion = 'fbc75a4' // fix for #12210
 
     implementation "$mapsforgeSource:mapsforge-core:$mapsforgeVersion"
     implementation "$mapsforgeSource:mapsforge-map:$mapsforgeVersion"
@@ -374,7 +374,7 @@ dependencies {
 
     // Mapsforge VTM implementation
     String mapsforgeVTMSource = 'org.mapsforge'
-    String mapsforgeVTMVersion = '0.18.0'
+    String mapsforgeVTMVersion = '0.19.0'
 
     implementation "$mapsforgeVTMSource:vtm:$mapsforgeVTMVersion"
     implementation "$mapsforgeVTMSource:vtm-themes:$mapsforgeVTMVersion"
@@ -479,7 +479,7 @@ dependencies {
     //implementation 'io.github.igreenwood.loupe:extensions:1.0.1' //as of now not needed
 
     //TooLargeTool is used for logging transaction sizes and thus helpng find transactionTooLargeExceptions
-    //See https://github.com/guardian/toolargetool 
+    //See https://github.com/guardian/toolargetool
     implementation 'com.gu.android:toolargetool:0.3.0'
 }
 


### PR DESCRIPTION
## Description
Updates both Mapsforge and VTM to v0.19
(Removes usage of specific commit id of Mapsforge to support hillshading on SAF, as this is part of v0.19 meanwhile)