### PR TITLE
Add message center quicklaunch item

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.connector.capability.IAvatar;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.BookmarkListActivity;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCConstants;
 import cgeo.geocaching.connector.gc.GCLogin;
 import cgeo.geocaching.connector.gc.PocketQueryListActivity;
 import cgeo.geocaching.connector.internal.InternalConnector;
@@ -318,7 +319,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
                                 displayActionItem(R.id.mcupdate, res.getQuantityString(R.plurals.mcupdate, count, count), (actionRequested) -> {
                                     updateHomeBadge(-1);
                                     if (actionRequested) {
-                                        ShareUtils.openUrl(this, "https://www.geocaching.com/account/messagecenter");
+                                        ShareUtils.openUrl(this, GCConstants.URL_MESSAGECENTER);
                                     }
                                 });
                             });
@@ -398,6 +399,8 @@ public class MainActivity extends AbstractBottomNavigationActivity {
             startActivityForResult(new Intent(this, SettingsActivity.class), Intents.SETTINGS_ACTIVITY_REQUEST_CODE);
         } else if (which == QuickLaunchItem.VALUES.BACKUPRESTORE.id) {
             SettingsActivity.openForScreen(R.string.preference_screen_backup, this);
+        } else if (which == QuickLaunchItem.VALUES.MESSAGECENTER.id) {
+            ShareUtils.openUrl(this, GCConstants.URL_MESSAGECENTER);
         } else if (which == QuickLaunchItem.VALUES.MANUAL.id) {
             ShareUtils.openUrl(this, getString(R.string.manual_link_full));
         } else if (which == QuickLaunchItem.VALUES.FAQ.id) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -219,6 +219,9 @@ public final class GCConstants {
     // Pages with such title seem to be returned with a 200 code instead of 404
     static final String STRING_404_FILE_NOT_FOUND = "<title>404 - File Not Found</title>";
 
+    // URL to message center
+    public static final String URL_MESSAGECENTER = "https://www.geocaching.com/account/messagecenter";
+
     /**
      * Number of logs to retrieve from GC.com
      */

--- a/main/src/main/java/cgeo/geocaching/enumerations/QuickLaunchItem.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/QuickLaunchItem.java
@@ -22,6 +22,7 @@ public class QuickLaunchItem extends InfoItem {
         SETTINGS(4),
         VIEWSETTINGS(8),
         BACKUPRESTORE(5),
+        MESSAGECENTER(10),
         MANUAL(6),
         FAQ(7);
 
@@ -39,6 +40,7 @@ public class QuickLaunchItem extends InfoItem {
         new QuickLaunchItem(VALUES.SETTINGS, R.string.menu_settings, R.drawable.settings_nut, false),
         new QuickLaunchItem(VALUES.VIEWSETTINGS, R.string.view_settings, R.drawable.settings_eye, false),
         new QuickLaunchItem(VALUES.BACKUPRESTORE, R.string.menu_backup, R.drawable.settings_backup, false),
+        new QuickLaunchItem(VALUES.MESSAGECENTER, R.string.mcpolling_title, R.drawable.ic_menu_email, false),
         new QuickLaunchItem(VALUES.MANUAL, R.string.about_nutshellmanual, R.drawable.ic_menu_info_details, false),
         new QuickLaunchItem(VALUES.FAQ, R.string.faq_title, R.drawable.ic_menu_hint, false)
     ));


### PR DESCRIPTION
## Description
As discussed in our last team meeting: Make message center available on home screen even when unread messages notification is disabled.

This PR adds a quicklaunch item which the user can activate. Tapping on it opens message center in the browser.

![image](https://github.com/cgeo/cgeo/assets/3754370/5be728b3-88f3-4dc9-ace2-e68b0b29073f)
