### PR TITLE
Make last bottom navigation item customizable

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -30,7 +30,6 @@ import cgeo.geocaching.sensors.GnssStatusProvider.Status;
 import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
-import cgeo.geocaching.settings.ViewSettingsActivity;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.extension.FoundNumCounter;
 import cgeo.geocaching.storage.extension.PendingDownload;
@@ -360,7 +359,7 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         for (int i : quicklaunchitems) {
             final QuickLaunchItem item = (QuickLaunchItem) QuickLaunchItem.getById(i, QuickLaunchItem.ITEMS);
             if (item != null && (!item.gcPremiumOnly || Settings.isGCPremiumMember())) {
-                addButton(item.iconRes, lp, () -> launchQuickLaunchItem(item.getId()), getString(item.getTitleResId()));
+                addButton(item.iconRes, lp, () -> QuickLaunchItem.launchQuickLaunchItem(this, item.getId()), getString(item.getTitleResId()));
             }
         }
 
@@ -379,37 +378,6 @@ public class MainActivity extends AbstractBottomNavigationActivity {
         TooltipCompat.setTooltipText(b, tooltip);
         binding.quicklaunchitems.addView(b);
         binding.quicklaunchitems.setVisibility(View.VISIBLE);
-    }
-
-    private void launchQuickLaunchItem(final int which) {
-        if (which == QuickLaunchItem.VALUES.GOTO.id) {
-            InternalConnector.assertHistoryCacheExists(this);
-            CacheDetailActivity.startActivity(this, InternalConnector.GEOCODE_HISTORY_CACHE, true);
-        } else if (which == QuickLaunchItem.VALUES.POCKETQUERY.id) {
-            if (Settings.isGCPremiumMember()) {
-                startActivity(new Intent(this, PocketQueryListActivity.class));
-            }
-        } else if (which == QuickLaunchItem.VALUES.BOOKMARKLIST.id) {
-            if (Settings.isGCPremiumMember()) {
-                startActivity(new Intent(this, BookmarkListActivity.class));
-            }
-        } else if (which == QuickLaunchItem.VALUES.RECENTLY_VIEWED.id) {
-            CacheListActivity.startActivityLastViewed(this, new SearchResult(DataStore.getLastOpenedCaches()));
-        } else if (which == QuickLaunchItem.VALUES.SETTINGS.id) {
-            startActivityForResult(new Intent(this, SettingsActivity.class), Intents.SETTINGS_ACTIVITY_REQUEST_CODE);
-        } else if (which == QuickLaunchItem.VALUES.BACKUPRESTORE.id) {
-            SettingsActivity.openForScreen(R.string.preference_screen_backup, this);
-        } else if (which == QuickLaunchItem.VALUES.MESSAGECENTER.id) {
-            ShareUtils.openUrl(this, GCConstants.URL_MESSAGECENTER);
-        } else if (which == QuickLaunchItem.VALUES.MANUAL.id) {
-            ShareUtils.openUrl(this, getString(R.string.manual_link_full));
-        } else if (which == QuickLaunchItem.VALUES.FAQ.id) {
-            ShareUtils.openUrl(this, getString(R.string.faq_link_full));
-        } else if (which == QuickLaunchItem.VALUES.VIEWSETTINGS.id) {
-            startActivity(new Intent(this, ViewSettingsActivity.class));
-        } else {
-            throw new IllegalStateException("MainActivity: unknown QuickLaunchItem");
-        }
     }
 
     private void init() {

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractBottomNavigationActivity.java
@@ -33,8 +33,9 @@ import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.Version;
-import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_EMPTY;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NEARBY;
+import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NONE;
+import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_PLACEHOLDER;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
@@ -249,15 +250,19 @@ public abstract class AbstractBottomNavigationActivity extends AbstractActionBar
 
     private void setCustomBNitem() {
         final MenuItem menu = ((BottomNavigationView) binding.activityBottomNavigation).getMenu().findItem(MENU_NEARBY);
+        menu.setVisible(true);
+        menu.setEnabled(true);
         final int item = Settings.getCustomBNitem();
-        if (item == CUSTOMBNITEM_EMPTY) {
-            menu.setVisible(false);
-        } else if (item == CUSTOMBNITEM_NEARBY) {
-            menu.setVisible(true);
+        if (item == CUSTOMBNITEM_NEARBY) {
             menu.setIcon(R.drawable.ic_menu_nearby);
             menu.setTitle(R.string.caches_nearby_button);
+        } else if (item == CUSTOMBNITEM_NONE) {
+            menu.setVisible(false);
+        } else if (item == CUSTOMBNITEM_PLACEHOLDER) {
+            menu.setEnabled(false);
+            menu.setIcon(R.drawable.ic_empty_placeholder);
+            menu.setTitle("");
         } else {
-            menu.setVisible(true);
             final QuickLaunchItem iitem = (QuickLaunchItem) QuickLaunchItem.getById(item, QuickLaunchItem.ITEMS);
             menu.setIcon(iitem.iconRes);
             menu.setTitle(iitem.getTitleResId());

--- a/main/src/main/java/cgeo/geocaching/enumerations/QuickLaunchItem.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/QuickLaunchItem.java
@@ -1,9 +1,23 @@
 package cgeo.geocaching.enumerations;
 
+import cgeo.geocaching.CacheDetailActivity;
+import cgeo.geocaching.CacheListActivity;
+import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
+import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.gc.BookmarkListActivity;
+import cgeo.geocaching.connector.gc.GCConstants;
+import cgeo.geocaching.connector.gc.PocketQueryListActivity;
+import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.models.InfoItem;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.settings.SettingsActivity;
+import cgeo.geocaching.settings.ViewSettingsActivity;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.ShareUtils;
 
 import android.app.Activity;
+import android.content.Intent;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
@@ -57,4 +71,36 @@ public class QuickLaunchItem extends InfoItem {
     public static void startActivity(final Activity caller, final @StringRes int title, @StringRes final int prefKey) {
         InfoItem.startActivity(caller, QuickLaunchItem.class.getCanonicalName(), "ITEMS", title, prefKey, 1);
     }
+
+    public static void launchQuickLaunchItem(final Activity activity, final int which) {
+        if (which == QuickLaunchItem.VALUES.GOTO.id) {
+            InternalConnector.assertHistoryCacheExists(activity);
+            CacheDetailActivity.startActivity(activity, InternalConnector.GEOCODE_HISTORY_CACHE, true);
+        } else if (which == QuickLaunchItem.VALUES.POCKETQUERY.id) {
+            if (Settings.isGCPremiumMember()) {
+                activity.startActivity(new Intent(activity, PocketQueryListActivity.class));
+            }
+        } else if (which == QuickLaunchItem.VALUES.BOOKMARKLIST.id) {
+            if (Settings.isGCPremiumMember()) {
+                activity.startActivity(new Intent(activity, BookmarkListActivity.class));
+            }
+        } else if (which == QuickLaunchItem.VALUES.RECENTLY_VIEWED.id) {
+            CacheListActivity.startActivityLastViewed(activity, new SearchResult(DataStore.getLastOpenedCaches()));
+        } else if (which == QuickLaunchItem.VALUES.SETTINGS.id) {
+            activity.startActivityForResult(new Intent(activity, SettingsActivity.class), Intents.SETTINGS_ACTIVITY_REQUEST_CODE);
+        } else if (which == QuickLaunchItem.VALUES.BACKUPRESTORE.id) {
+            SettingsActivity.openForScreen(R.string.preference_screen_backup, activity);
+        } else if (which == QuickLaunchItem.VALUES.MESSAGECENTER.id) {
+            ShareUtils.openUrl(activity, GCConstants.URL_MESSAGECENTER);
+        } else if (which == QuickLaunchItem.VALUES.MANUAL.id) {
+            ShareUtils.openUrl(activity, activity.getString(R.string.manual_link_full));
+        } else if (which == QuickLaunchItem.VALUES.FAQ.id) {
+            ShareUtils.openUrl(activity, activity.getString(R.string.faq_link_full));
+        } else if (which == QuickLaunchItem.VALUES.VIEWSETTINGS.id) {
+            activity.startActivity(new Intent(activity, ViewSettingsActivity.class));
+        } else {
+            throw new IllegalStateException("MainActivity: unknown QuickLaunchItem");
+        }
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -30,6 +30,7 @@ import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
 import cgeo.geocaching.models.Download;
+import cgeo.geocaching.models.InfoItem;
 import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.playservices.GooglePlayServices;
 import cgeo.geocaching.sensors.DirectionData;
@@ -103,6 +104,9 @@ public class Settings {
     public static final int COMPACTICON_OFF = 0;
     public static final int COMPACTICON_ON = 1;
     public static final int COMPACTICON_AUTO = 2;
+
+    public static final int CUSTOMBNITEM_EMPTY = -1;
+    public static final int CUSTOMBNITEM_NEARBY = 0;
 
     public static final int HOURS_TO_SECONDS = 60 * 60;
     public static final int DAYS_TO_SECONDS = 24 * HOURS_TO_SECONDS;
@@ -2052,6 +2056,19 @@ public class Settings {
             s.append(i);
         }
         putString(prefKey, s.toString());
+    }
+
+    public static int getCustomBNitem() {
+        final int item = Integer.parseInt(getString(R.string.pref_custombnitem, "0"));
+        if (item == CUSTOMBNITEM_EMPTY || item == CUSTOMBNITEM_NEARBY) {
+            return item;
+        }
+        // valid QuickLaunchItem entry?
+        final InfoItem temp = QuickLaunchItem.getById(item, QuickLaunchItem.ITEMS);
+        if (temp == null) {
+            return CUSTOMBNITEM_NEARBY;
+        }
+        return temp.getId();
     }
 
     public static void setRoutingMode(@NonNull final RoutingMode mode) {

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -105,7 +105,8 @@ public class Settings {
     public static final int COMPACTICON_ON = 1;
     public static final int COMPACTICON_AUTO = 2;
 
-    public static final int CUSTOMBNITEM_EMPTY = -1;
+    public static final int CUSTOMBNITEM_PLACEHOLDER = -2;
+    public static final int CUSTOMBNITEM_NONE = -1;
     public static final int CUSTOMBNITEM_NEARBY = 0;
 
     public static final int HOURS_TO_SECONDS = 60 * 60;
@@ -2060,7 +2061,7 @@ public class Settings {
 
     public static int getCustomBNitem() {
         final int item = Integer.parseInt(getString(R.string.pref_custombnitem, "0"));
-        if (item == CUSTOMBNITEM_EMPTY || item == CUSTOMBNITEM_NEARBY) {
+        if (item == CUSTOMBNITEM_NEARBY || item == CUSTOMBNITEM_NONE || item == CUSTOMBNITEM_PLACEHOLDER) {
             return item;
         }
         // valid QuickLaunchItem entry?

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -5,8 +5,11 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheListInfoItem;
 import cgeo.geocaching.enumerations.QuickLaunchItem;
+import cgeo.geocaching.models.InfoItem;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
+import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_EMPTY;
+import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NEARBY;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
 import android.os.Bundle;
@@ -63,6 +66,7 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
             CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo1, R.string.pref_cacheListInfo, 2);
         });
 
+        configCustomBNitemPreference();
     }
 
     @Override
@@ -76,6 +80,33 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
             }
         });
 
+    }
+
+    private void configCustomBNitemPreference() {
+        final ListPreference customBNitem = findPreference(getString(R.string.pref_custombnitem));
+        final String[] cbniEntries = new String[QuickLaunchItem.ITEMS.size() + 2];
+        final String[] cbniValues = new String[QuickLaunchItem.ITEMS.size() + 2];
+        cbniEntries[0] = "(empty)";
+        cbniValues[0] = String.valueOf(CUSTOMBNITEM_EMPTY);
+        cbniEntries[1] = "Nearby search";
+        cbniValues[1] = String.valueOf(CUSTOMBNITEM_NEARBY);
+        int i = 1;
+        for (InfoItem item : QuickLaunchItem.ITEMS) {
+            i++;
+            cbniEntries[i] = getString(item.getTitleResId());
+            cbniValues[i] = String.valueOf(item.getId());
+        }
+        customBNitem.setEntries(cbniEntries);
+        customBNitem.setEntryValues(cbniValues);
+        setCustomBNItemSummary(customBNitem, cbniEntries[customBNitem.findIndexOfValue(String.valueOf(Settings.getCustomBNitem()))]);
+        customBNitem.setOnPreferenceChangeListener((preference, newValue) -> {
+            setCustomBNItemSummary(customBNitem, cbniEntries[customBNitem.findIndexOfValue(newValue.toString())]);
+            return true;
+        });
+    }
+
+    private void setCustomBNItemSummary(final ListPreference customBNitem, final String newValue) {
+        customBNitem.setSummary(newValue);
     }
 
     private void setLanguageSummary(final ListPreference languagePref, final String newValue) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -86,16 +86,11 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
         final ListPreference customBNitem = findPreference(getString(R.string.pref_custombnitem));
         final String[] cbniEntries = new String[QuickLaunchItem.ITEMS.size() + 2];
         final String[] cbniValues = new String[QuickLaunchItem.ITEMS.size() + 2];
-        cbniEntries[0] = "(empty)";
-        cbniValues[0] = String.valueOf(CUSTOMBNITEM_EMPTY);
-        cbniEntries[1] = "Nearby search";
-        cbniValues[1] = String.valueOf(CUSTOMBNITEM_NEARBY);
-        int i = 1;
+        int i = addCustomBNSelectionItem(0, getString(R.string.init_custombnitem_default), String.valueOf(CUSTOMBNITEM_NEARBY), cbniEntries, cbniValues);
         for (InfoItem item : QuickLaunchItem.ITEMS) {
-            i++;
-            cbniEntries[i] = getString(item.getTitleResId());
-            cbniValues[i] = String.valueOf(item.getId());
+            i = addCustomBNSelectionItem(i, getString(item.getTitleResId()), String.valueOf(item.getId()), cbniEntries, cbniValues);
         }
+        addCustomBNSelectionItem(i, "(empty)", String.valueOf(CUSTOMBNITEM_EMPTY), cbniEntries, cbniValues);
         customBNitem.setEntries(cbniEntries);
         customBNitem.setEntryValues(cbniValues);
         setCustomBNItemSummary(customBNitem, cbniEntries[customBNitem.findIndexOfValue(String.valueOf(Settings.getCustomBNitem()))]);
@@ -103,6 +98,12 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
             setCustomBNItemSummary(customBNitem, cbniEntries[customBNitem.findIndexOfValue(newValue.toString())]);
             return true;
         });
+    }
+
+    private int addCustomBNSelectionItem(final int nextFreeItem, final String entry, final String value, final String[] cbniEntries, final String[] cbniValues) {
+        cbniEntries[nextFreeItem] = entry;
+        cbniValues[nextFreeItem] = value;
+        return nextFreeItem + 1;
     }
 
     private void setCustomBNItemSummary(final ListPreference customBNitem, final String newValue) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -8,8 +8,9 @@ import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.models.InfoItem;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
-import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_EMPTY;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NEARBY;
+import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NONE;
+import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_PLACEHOLDER;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
 import android.os.Bundle;
@@ -84,13 +85,14 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
 
     private void configCustomBNitemPreference() {
         final ListPreference customBNitem = findPreference(getString(R.string.pref_custombnitem));
-        final String[] cbniEntries = new String[QuickLaunchItem.ITEMS.size() + 2];
-        final String[] cbniValues = new String[QuickLaunchItem.ITEMS.size() + 2];
+        final String[] cbniEntries = new String[QuickLaunchItem.ITEMS.size() + 3];
+        final String[] cbniValues = new String[QuickLaunchItem.ITEMS.size() + 3];
         int i = addCustomBNSelectionItem(0, getString(R.string.init_custombnitem_default), String.valueOf(CUSTOMBNITEM_NEARBY), cbniEntries, cbniValues);
         for (InfoItem item : QuickLaunchItem.ITEMS) {
             i = addCustomBNSelectionItem(i, getString(item.getTitleResId()), String.valueOf(item.getId()), cbniEntries, cbniValues);
         }
-        addCustomBNSelectionItem(i, "(empty)", String.valueOf(CUSTOMBNITEM_EMPTY), cbniEntries, cbniValues);
+        i = addCustomBNSelectionItem(i, getString(R.string.init_custombnitem_none), String.valueOf(CUSTOMBNITEM_NONE), cbniEntries, cbniValues);
+        addCustomBNSelectionItem(i, getString(R.string.init_custombnitem_empty_placeholder), String.valueOf(CUSTOMBNITEM_PLACEHOLDER), cbniEntries, cbniValues);
         customBNitem.setEntries(cbniEntries);
         customBNitem.setEntryValues(cbniValues);
         setCustomBNItemSummary(customBNitem, cbniEntries[customBNitem.findIndexOfValue(String.valueOf(Settings.getCustomBNitem()))]);

--- a/main/src/main/res/drawable/ic_empty_placeholder.xml
+++ b/main/src/main/res/drawable/ic_empty_placeholder.xml
@@ -1,0 +1,11 @@
+<!-- empty placeholder, just taking up space -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:tint="?android:textColorPrimary">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19.74,18.33"/>
+</vector>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -158,6 +158,7 @@
     <string translatable="false" name="pref_units_imperial">units</string>
     <string translatable="false" name="pref_quicklaunchitems">quicklaunchitems_sorted</string>
     <string translatable="false" name="pref_startscreen">startscreen</string>
+    <string translatable="false" name="pref_custombnitem">custombnitem</string>
 
     <!-- category cache lists -->
     <string translatable="false" name="pref_list_initial_load_limit">list_initial_load_limit</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1006,6 +1006,8 @@
     <string name="init_summary_quicklaunchitems">Select one or more items as quick launch buttons on home screen</string>
     <string name="init_custombnitem">Custom Menu Entry</string>
     <string name="init_custombnitem_default">Nearby search (default)</string>
+    <string name="init_custombnitem_none">(none)</string>
+    <string name="init_custombnitem_empty_placeholder">(empty placeholder)</string>
 
     <!-- names for CacheListInfoItem -->
     <string name="cacheListInfoItem_Geocode">Geocode</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1004,6 +1004,7 @@
     <string name="init_summary_livelist">Show an arrow with compass direction for caches in a list</string>
     <string name="init_quicklaunchitems">Quick launch buttons</string>
     <string name="init_summary_quicklaunchitems">Select one or more items as quick launch buttons on home screen</string>
+    <string name="init_custombnitem">Custom Menu Entry</string>
 
     <!-- names for CacheListInfoItem -->
     <string name="cacheListInfoItem_Geocode">Geocode</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1005,6 +1005,7 @@
     <string name="init_quicklaunchitems">Quick launch buttons</string>
     <string name="init_summary_quicklaunchitems">Select one or more items as quick launch buttons on home screen</string>
     <string name="init_custombnitem">Custom Menu Entry</string>
+    <string name="init_custombnitem_default">Nearby search (default)</string>
 
     <!-- names for CacheListInfoItem -->
     <string name="cacheListInfoItem_Geocode">Geocode</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -59,6 +59,11 @@
             android:title="@string/settings_startscreen_title"
             android:summary="%s"
             app:iconSpaceReserved="false" />
+        <ListPreference
+            android:defaultValue="0"
+            android:key="@string/pref_custombnitem"
+            android:title="@string/init_custombnitem"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
Makes the last bottom navigation item customizable:
- default (= nearby search)
- empty
- any of the quick launch items (same as on home screen)

Configuration is in settings => appearance => Custom Menu Entry

This is an alternative to #14405.

Example: Last item replaced by "pocket queries":
![image](https://github.com/cgeo/cgeo/assets/3754370/bf72ebde-165b-4359-b05c-e65478dafeeb)

Configuration dialog: (updated)
![image](https://github.com/cgeo/cgeo/assets/3754370/259525a9-be3e-4995-b069-7f668bb507c8)
