### PR TITLE
Remove the temporary string in strings.xml

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- fixes -->
-
-    <!-- This entry shall solve a bug with material.io Date picker, see https://github.com/material-components/material-components-android/issues/1346 -->
-    <string name="mtrl_picker_confirm" tools:override="true">OK</string>
-
     <!-- basics -->
     <string name="cache">Cache</string>
     <string name="detail">Details</string>


### PR DESCRIPTION
Remove the temporary string in strings.xml, as the error is solved in the meantime, the issue https://github.com/material-components/material-components-android/issues/1346 is fixed.
