### PR TITLE
save only non-empty-log-text to be used as "repeat last log" (rel #14371)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -469,7 +469,9 @@ public class LogCacheActivity extends AbstractLoggingActivity {
                 AndroidRxUtils.computationScheduler.scheduleDirect(() -> {
                     try (ContextLogger ccLog = new ContextLogger("LogCacheActivity.saveLog.doInBackground(gc=%s)", cache.getGeocode())) {
                         cache.logOffline(LogCacheActivity.this, logEntry);
-                        Settings.setLastCacheLog(logEntry.log);
+                        if (!logEntry.log.isEmpty()) {
+                            Settings.setLastCacheLog(logEntry.log);
+                        }
                         ccLog.add("log=%s", logEntry.log);
                         imageListFragment.adjustImagePersistentState();
                     }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Currently even an empty log text is saved for future use and therefor overrides the last "useful" log-text

This PR saves only non-empty-log-text for using it in "repeat last log".
Saving an empty log is still possible.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #14371 ("Insert last log" discarded when adding image first)

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->