### PR TITLE
rel to #14391: add polygon hole support for vtm and google

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -67,8 +67,6 @@ import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.ui.GeoItemSelectorUtils;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
-import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemTestLayer;
-import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeV6GeoItemLayer;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.ApplicationSettings;
@@ -170,8 +168,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     private GeoObjectLayer geoObjectLayer;
     private CachesBundle caches;
     private final MapHandlers mapHandlers = new MapHandlers(new TapHandler(this), new DisplayHandler(this), new ShowProgressHandler(this));
-
-    private final GeoItemTestLayer testItemLayer = new GeoItemTestLayer();
 
     private RenderThemeHelper renderThemeHelper = null; //must be initialized in onCreate();
 
@@ -802,9 +798,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         this.historyLayer = new HistoryLayer(trailHistory);
         this.mapView.getLayerManager().getLayers().add(this.historyLayer);
 
-        //Test Layer
-        testItemLayer.init(new MapsforgeV6GeoItemLayer(this.mapView.getLayerManager(), this.mapView.getMapViewProjection()));
-
         // RouteLayer
         this.routeLayer = new RouteLayer(realRouteDistance -> {
             if (null != this.distanceView) {
@@ -843,7 +836,7 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
         GeoitemLayer.resetColors();
 
         // TapHandler
-        this.tapHandlerLayer = new TapHandlerLayer(this.mapHandlers.getTapHandler(), this.testItemLayer, this);
+        this.tapHandlerLayer = new TapHandlerLayer(this.mapHandlers.getTapHandler(), this);
         this.mapView.getLayerManager().getLayers().add(this.tapHandlerLayer);
 
         // Caches bundle
@@ -904,10 +897,6 @@ public class NewMap extends AbstractBottomNavigationActivity implements Observer
     }
 
     private void terminateLayers() {
-
-        //test
-        testItemLayer.destroy();
-
 
         this.resumeDisposables.clear();
 

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
@@ -2,9 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6.layers;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
-import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.maps.mapsforge.v6.TapHandler;
-import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemTestLayer;
 
 import android.content.Context;
 
@@ -27,12 +25,10 @@ public class TapHandlerLayer extends Layer {
     private LatLong longTapLatLong;
     private Bitmap markerBitmap;
 
-    private final GeoItemTestLayer testItemLayer;
     private final WeakReference<Context> wrContext;
 
-    public TapHandlerLayer(final TapHandler tapHandler, final GeoItemTestLayer testItemLayer, final Context context) {
+    public TapHandlerLayer(final TapHandler tapHandler, final Context context) {
         this.tapHandler = tapHandler;
-        this.testItemLayer = testItemLayer;
         this.wrContext = new WeakReference<>(context);
     }
 
@@ -53,11 +49,6 @@ public class TapHandlerLayer extends Layer {
     public boolean onTap(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
 
         tapHandler.finished();
-
-        final Context ctx = wrContext.get();
-        if (testItemLayer != null && ctx != null) {
-            testItemLayer.handleTap(ctx, new Geopoint(tapLatLong.latitude, tapLatLong.longitude), false);
-        }
 
         return true;
     }

--- a/main/src/main/java/cgeo/geocaching/models/geoitem/GeoGroup.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/GeoGroup.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-/** Represents a drawable primitive GeoItem such as a point, polyline or polygon */
+/** Represents a group of drawable GeoItem such as a point, polyline, polygon or enclosed groups */
 public class GeoGroup implements GeoItem, Parcelable {
 
     //immutable

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -259,13 +259,11 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
 
         clickableItemsLayer = new GeoItemLayer<>("clickableItems");
         final GeoItemLayer<String> nonClickableItemsLayer = new GeoItemLayer<>("nonClickableItems");
-        final GeoItemLayer<String> testLayer = new GeoItemLayer<>("test");
 
         layers.add(clickableItemsLayer);
         layers.add(nonClickableItemsLayer);
-        layers.add(testLayer);
 
-        new GeoItemTestLayer().initforUnifiedMap(testLayer);
+        new GeoItemTestLayer().initforUnifiedMap(clickableItemsLayer);
 
         new PositionLayer(this, nonClickableItemsLayer);
         new PositionHistoryLayer(this, nonClickableItemsLayer);
@@ -726,6 +724,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
         final LinkedList<RouteItem> result = new LinkedList<>();
 
         for (String key : clickableItemsLayer.getTouched(Geopoint.forE6(latitudeE6, longitudeE6))) {
+
             final IWaypoint wp = viewModel.geoItems.getMap().get(key);
             if (wp != null) {
                 result.add(new RouteItem(wp));
@@ -738,7 +737,6 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
                 }
             }
         }
-
         Log.e("touched elements (" + result.size() + "): " + result);
 
         if (result.size() == 0) {
@@ -750,6 +748,7 @@ public class UnifiedMapActivity extends AbstractBottomNavigationActivity {
                         .show();
             } else {
                 mapFragment.adaptLayoutForActionbar(HideActionBarUtils.toggleActionBar(this));
+                GeoItemTestLayer.handleTapTest(clickableItemsLayer, this, Geopoint.forE6(latitudeE6, longitudeE6), isLongTap);
             }
         } else if (result.size() == 1) {
             handleTap(result.get(0), isLongTap, x, y);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemTestLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemTestLayer.java
@@ -70,8 +70,8 @@ public class GeoItemTestLayer {
         }
     }
 
-    public void handleTap(final Context ctx, final Geopoint tapped, final boolean isLongTap) {
-        if (!Settings.enableFeatureUnifiedGeoItemLayer()) {
+    public static void handleTapTest(final GeoItemLayer<String> testLayer, final Context ctx, final Geopoint tapped, final boolean isLongTap) {
+        if (!Settings.enableFeatureUnifiedGeoItemLayer() || testLayer == null) {
             return;
         }
 
@@ -111,39 +111,49 @@ public class GeoItemTestLayer {
             for (int y = 0; y <= 2; y++) {
                 final Geopoint point = center.project(90, x * 20).project(180, y * 20);
                 final GeoItem gi = testIconWithPoly(point, Color.GREEN, x * 0.5f, y * 0.5f, 0);
-                layer.put("testMarkerOffset-" + x + "-" + y, gi);
+                layer.put("test-MarkerOffset-" + x + "-" + y, gi);
             }
         }
 
-        layer.put("testMarkerOffsetRightTop", testIconWithPoly(center.project(90, 100), Color.GRAY, GeoIcon.Hotspot.UPPER_RIGHT_CORNER.xAnchor, GeoIcon.Hotspot.UPPER_RIGHT_CORNER.yAnchor, 0));
+        layer.put("test-MarkerOffsetRightTop", testIconWithPoly(center.project(90, 100), Color.GRAY, GeoIcon.Hotspot.UPPER_RIGHT_CORNER.xAnchor, GeoIcon.Hotspot.UPPER_RIGHT_CORNER.yAnchor, 0));
 
         final Geopoint circleCenter = center.project(90, 200);
         for (int a = 0; a < 360; a += 40) {
             final Geopoint point = circleCenter.project(a, 40);
             final GeoItem gi = testIconWithPoly(point, Color.RED, GeoIcon.Hotspot.CENTER.xAnchor, GeoIcon.Hotspot.CENTER.yAnchor, a);
-            layer.put("testMarkerAngle-" + a, gi);
+            layer.put("test-MarkerAngle-" + a, gi);
         }
 
         final Geopoint staticPolylineCenter = center.project(180, 50);
-        layer.put("staticPolyline", polygonAround(staticPolylineCenter, 50, Color.RED));
+        layer.put("test-staticPolyline", polygonAround(staticPolylineCenter, 50, Color.RED));
 
         final Geopoint staticCircle = staticPolylineCenter.project(90, 50);
-        layer.put("staticCircle", GeoPrimitive.createCircle(staticCircle, 40, GeoStyle.builder().setStrokeColor(Color.DKGRAY).setFillColor(Color.YELLOW).build()));
+        layer.put("test-staticCircle", GeoPrimitive.createCircle(staticCircle, 40, GeoStyle.builder().setStrokeColor(Color.DKGRAY).setFillColor(Color.YELLOW).build()));
 
         final Geopoint staticPolygon = staticCircle.project(90, 50);
-        layer.put("staticPolygon", GeoPrimitive.createPolygon(geoGridPoints(
+        layer.put("test-staticPolygon", GeoPrimitive.createPolygon(geoGridPoints(
                 staticPolygon, 10, 0, 0, 3, 0, 3, 1, 2, 1, 2, 2, 3, 2, 3, 3, 1, 3, 0, 2
         ), GeoStyle.builder().setStrokeColor(Color.YELLOW).setStrokeWidth(5f).setFillColor(Color.GREEN).build()));
 
+        final Geopoint staticPolWithHole = staticPolygon.project(90, 50);
+        final GeoPrimitive pol = GeoPrimitive.builder().setType(GeoItem.GeoType.POLYGON)
+                .setStyle(GeoStyle.builder().setStrokeColor(Color.YELLOW).setStrokeWidth(5f).setFillColor(Color.GREEN).build())
+                .addPoints(geoGridPoints(staticPolWithHole, 10, 0, 0, 7, 0, 7, 7, 0, 7))
+                .addHole(geoGridPoints(staticPolWithHole, 10, 1, 1, 1, 2, 2, 2, 2, 1))
+                .addHole(geoGridPoints(staticPolWithHole, 10, 4, 4, 4, 5, 5, 5, 5, 4))
+                .build();
+        layer.put("test-staticPolygonWithTwoHoles", pol);
 
         final Geopoint zLevelStuff = staticPolygon.project(180, 50);
         final GeoPrimitive one = GeoPrimitive.createPolygon(geoGridPoints(zLevelStuff, 10, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0), GeoStyle.builder().setStrokeColor(Color.BLUE).setStrokeWidth(5f).setFillColor(Color.GREEN).build());
         final GeoPrimitive two = GeoPrimitive.createPolygon(geoGridPoints(zLevelStuff.project(110, 8), 10, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0), GeoStyle.builder().setStrokeColor(Color.BLUE).setStrokeWidth(5f).setFillColor(Color.YELLOW).build());
         final GeoPrimitive three = GeoPrimitive.createPolygon(geoGridPoints(zLevelStuff.project(140, 6), 10, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0), GeoStyle.builder().setStrokeColor(Color.BLUE).setStrokeWidth(5f).setFillColor(Color.RED).build());
 
-        layer.put("zOne", one.buildUpon().setZLevel(0).build());
-        layer.put("zTwo", two.buildUpon().setZLevel(2).build());
-        layer.put("zThree", three.buildUpon().setZLevel(1).build());
+        layer.put("test-zOne", one.buildUpon().setZLevel(0).build());
+        layer.put("test-zTwo", two.buildUpon().setZLevel(2).build());
+        layer.put("test-zThree", three.buildUpon().setZLevel(1).build());
+
+
     }
 
     private static GeoGroup testIconWithPoly(final Geopoint point, final int polyColor, final float xAnchor, final float yAnchor, final float angle) {
@@ -195,12 +205,12 @@ public class GeoItemTestLayer {
         final GeoItem point = GeoPrimitive.createPoint(center.project(angle, distance), GeoStyle.builder().setStrokeColor(Color.GREEN).build());
         final GeoItem group = GeoGroup.builder().addItems(point, poly).build();
 
-        layer.put("testQuad", group);
+        layer.put("test-Quad", group);
 
         final GeoItem flowMarker = GeoPrimitive.createMarker(center.project(angle, distance * 0.8), GeoIcon.builder()
                 .setBitmap(createBitmap(R.drawable.type_event))
                 .setRotation(angle).build());
-        layer.put("testFlowMarker", flowMarker);
+        layer.put("test-FlowMarker", flowMarker);
 
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
@@ -17,6 +17,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.util.Pair;
 
 import java.util.Collection;
+import java.util.List;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.Projection;
@@ -99,12 +100,18 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
                         .zIndex(zLevel));
                 break;
             case POLYGON:
-                context = map.addPolygon(new PolygonOptions()
+                final PolygonOptions polygonOptions = new PolygonOptions()
                         .strokeWidth(strokeWidth)
                         .strokeColor(strokeColor)
                         .fillColor(fillColor)
                         .addAll(GP_CONVERTER.toList(item.getPoints()))
-                        .zIndex(zLevel));
+                        .zIndex(zLevel);
+                if (item.getHoles() != null) {
+                    for (List<Geopoint> hole : item.getHoles()) {
+                        polygonOptions.addHole(GP_CONVERTER.toList(hole));
+                    }
+                }
+                context = map.addPolygon(polygonOptions);
                 break;
             case POLYLINE:
             default:

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeV6GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeV6GeoItemLayer.java
@@ -29,6 +29,7 @@ import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.layer.GroupLayer;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.LayerManager;
 import org.mapsforge.map.layer.overlay.Circle;
@@ -94,7 +95,18 @@ public class MapsforgeV6GeoItemLayer extends Layer implements IProviderGeoItemLa
             default:
                 final Polygon po = new Polygon(fillPaint, strokePaint, AndroidGraphicFactory.INSTANCE);
                 po.addPoints(CollectionStream.of(item.getPoints()).map(MapsforgeV6GeoItemLayer::latLong).toList());
-                goLayer = po;
+                if (item.getHoles() == null) {
+                    goLayer = po;
+                } else {
+                    final GroupLayer group = new GroupLayer();
+                    group.layers.add(po);
+                    for (List<Geopoint> hole : item.getHoles()) {
+                        final Polyline plHole = new Polyline(strokePaint, AndroidGraphicFactory.INSTANCE);
+                        plHole.addPoints(CollectionStream.of(hole).map(MapsforgeV6GeoItemLayer::latLong).toList());
+                        group.layers.add(plHole);
+                    }
+                    goLayer = group;
+                }
                 break;
         }
         if (goLayer != null) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/TracksLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/TracksLayer.java
@@ -4,10 +4,10 @@ import cgeo.geocaching.maps.Tracks;
 import cgeo.geocaching.models.geoitem.GeoGroup;
 import cgeo.geocaching.models.geoitem.GeoPrimitive;
 import cgeo.geocaching.models.geoitem.GeoStyle;
-import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.unifiedmap.UnifiedMapViewModel;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemLayer;
-import cgeo.geocaching.utils.MapLineUtils;
+
+import android.graphics.Color;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
@@ -24,15 +24,24 @@ public class TracksLayer {
             if (track == null || track.getRoute().isHidden()) {
                 layer.remove(key);
             } else {
-                final GeoStyle lineStyle = GeoStyle.builder()
-                        .setStrokeColor(track.getTrackfile().getColor())
-                        .setStrokeWidth(MapLineUtils.getWidthFromRaw(track.getTrackfile().getWidth(), true))
-                        .build();
+
+                //Apply current chosen default color to all elements and display
+
+                final float widthFactor = 2f;
+                final float defaultWidth = track.getTrackfile().getWidth() / widthFactor;
+                final int defaultStrokeColor = track.getTrackfile().getColor();
+                final int defaultFillColor = Color.argb(128, Color.red(defaultStrokeColor), Color.green(defaultStrokeColor), Color.blue(defaultStrokeColor));
 
                 final GeoGroup.Builder geoGroup = GeoGroup.builder();
-                for (GeoPrimitive segment : track.getRoute().getGeoData()) {
-                    geoGroup.addItems(GeoPrimitive.createPolyline(segment.getPoints(), lineStyle).buildUpon().setZLevel(LayerHelper.ZINDEX_TRACK_ROUTE).build());
+                for (GeoPrimitive item : track.getRoute().getGeoData()) {
+                    final GeoStyle style = GeoStyle.builder()
+                        .setStrokeColor(GeoStyle.getStrokeColor(item.getStyle(), defaultStrokeColor))
+                        .setFillColor(GeoStyle.getFillColor(item.getStyle(), defaultFillColor))
+                        .setStrokeWidth(GeoStyle.getStrokeWidth(item.getStyle(), defaultWidth)).build();
+
+                    geoGroup.addItems(item.buildUpon().setStyle(style).build());
                 }
+
                 layer.put(key, geoGroup.build());
             }
         })));


### PR DESCRIPTION
rel to #14391: add polygon hole support for vtm and google.

Support for mapsforge is not added because mapsforge Polygon object don't naturally support holes. Holes are only supported in new unified map.

![image](https://github.com/cgeo/cgeo/assets/6909759/2d1ab4b7-a32e-4c86-964f-6f81ed74ac28)
