### PR TITLE
Temporarily disable OSM multithreading for testing purposes

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1024,7 +1024,9 @@ public class Settings {
     }
 
     public static int getMapOsmThreads() {
-        return hasOSMMultiThreading() ? Math.max(1, getInt(R.string.pref_map_osm_threads, Math.min(Runtime.getRuntime().availableProcessors() + 1, 4))) : 1;
+        // @todo temporarily disabled, see https://github.com/orgs/cgeo/discussions/73
+        return 1;
+        // return hasOSMMultiThreading() ? Math.max(1, getInt(R.string.pref_map_osm_threads, Math.min(Runtime.getRuntime().availableProcessors() + 1, 4))) : 1;
     }
 
     public static int getCompactIconMode() {

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -133,8 +133,12 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_map_osm_multithreaded"
-            android:summary="@string/init_summary_map_osm_multithreaded"
+
+            android:summary="(temporarily disabled for testing purposes)"
+            android:enabled="false"
+            
             android:title="@string/init_map_osm_multithreaded"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
+    <!-- android:summary="@string/init_summary_map_osm_multithreaded" -->
 </PreferenceScreen>


### PR DESCRIPTION
## Description
see https://github.com/orgs/cgeo/discussions/73

(Will trigger some "unused string", "unused method" and "hardcoded string" lint messages, which should be ignored for the time being.)