### PR TITLE
Allow selecting, copying etc. of image description (EXIF info) (fix #14415)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ImageViewActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ImageViewActivity.java
@@ -404,11 +404,7 @@ public class ImageViewActivity extends AbstractActionBarActivity {
 
                 final String comment = MetadataUtils.getComment(p.second);
                 if (!StringUtils.isBlank(comment)) {
-                    String commentInView = comment;
-                    if (comment.length() > 300) {
-                        commentInView = comment.substring(0, 280) + "...(" + comment.length() + " chars)";
-                    }
-                    imageInfosNew.add(Html.fromHtml("<b>" + LocalizationUtils.getString(R.string.imageview_metadata_comment) + ":</b> <i>" + commentInView + "</i>"));
+                    imageInfosNew.add(Html.fromHtml("<b>" + LocalizationUtils.getString(R.string.imageview_metadata_comment) + ":</b> <i>" + comment + "</i>"));
                 }
 
                 binding.imageviewInformationText.setText(TextUtils.join(imageInfosNew, d -> d, "\n"));

--- a/main/src/main/res/layout/imageview_image.xml
+++ b/main/src/main/res/layout/imageview_image.xml
@@ -92,7 +92,10 @@
                 style="@style/text_default"
                 android:layout_toLeftOf="@+id/imageview_information_icon_less"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:textIsSelectable="true"
+                android:focusable="true"
+                android:maxLines="7"/>
             <ImageView android:id="@+id/imageview_information_icon_less"
                 android:layout_alignParentRight="true"
                 android:layout_alignParentTop="true"


### PR DESCRIPTION
## Description
Enable selection context menu on image (EXIF) description for copying of text, translation etc.
Text limitation to 380 chars is removed (to be able to see/copy the complete description, which is helpful for some mysteries), but `TextView` size is limited to 7 lines to keep maximum size similar to today.

Additional info:
Enabling the selection context menu requires the `TextView` to enable "isSelectable" and "isFocusable" attributes. Tapping on image description will therefore no longer show/hide the image description. The other two ways for hiding/unhiding the description (tapping on the image or tapping the small arrow beside image description) are still available, though.