### PR TITLE
Provide selction dialog for editing boolean settings

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.databinding.ViewSettingsAddBinding;
 import cgeo.geocaching.ui.FastScrollListener;
+import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.ApplicationSettings;
@@ -31,6 +32,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -231,35 +233,46 @@ public class ViewSettingsActivity extends AbstractActivity {
 
     private void editItem(final int position) {
         final KeyValue keyValue = filteredItems.get(position);
-        final String key = keyValue.key;
-        final SettingsUtils.SettingsType type = keyValue.type;
-
-        int inputType = 0;
-        switch (type) {
-            case TYPE_INTEGER:
-            case TYPE_LONG:
-                inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_SIGNED;
-                break;
-            case TYPE_FLOAT:
-                inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_DECIMAL;
-                break;
-            default:
-                inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL;
-                break;
-        }
-        Dialogs.input(this, String.format(getString(R.string.edit_setting), key), keyValue.value, null, inputType, 1, 1, newValue -> {
-            final SharedPreferences.Editor editor = prefs.edit();
-            try {
-                SettingsUtils.putValue(editor, type, key, newValue);
-                editor.apply();
-                debugAdapter.remove(keyValue);
-                debugAdapter.insert(new KeyValue(key, newValue, type), position);
-            } catch (XmlPullParserException e) {
-                showToast(R.string.edit_setting_error_unknown_type);
-            } catch (NumberFormatException e) {
-                showToast(String.format(getString(R.string.edit_setting_error_invalid_data), newValue));
+        if (keyValue.type == SettingsUtils.SettingsType.TYPE_BOOLEAN) {
+            final ArrayList<Boolean> items = new ArrayList<>(Arrays.asList(false, true));
+            SimpleDialog.of(this).setTitle(TextParam.text(keyValue.key)).selectSingle(
+                    items,
+                    (l, pos) -> TextParam.text(items.get(pos) ? "true" : "false"),
+                    StringUtils.equals(keyValue.value, "true") ? 1 : 0,
+                    SimpleDialog.SingleChoiceMode.SHOW_RADIO_AND_OK,
+                    (l, pos) -> editItemHelper(position, keyValue, String.valueOf(items.get(pos))),
+                    (l, pos) -> { } /* do nothing on cancel */
+                    );
+        } else {
+            int inputType = 0;
+            switch (keyValue.type) {
+                case TYPE_INTEGER:
+                case TYPE_LONG:
+                    inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_SIGNED;
+                    break;
+                case TYPE_FLOAT:
+                    inputType = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL | InputType.TYPE_NUMBER_FLAG_DECIMAL;
+                    break;
+                default:
+                    inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_NORMAL;
+                    break;
             }
-        });
+            Dialogs.input(this, String.format(getString(R.string.edit_setting), keyValue.key), keyValue.value, null, inputType, 1, 1, newValue -> editItemHelper(position, keyValue, newValue));
+        }
+    }
+
+    private void editItemHelper(final int position, final KeyValue keyValue, final String newValue) {
+        final SharedPreferences.Editor editor = prefs.edit();
+        try {
+            SettingsUtils.putValue(editor, keyValue.type, keyValue.key, newValue);
+            editor.apply();
+            debugAdapter.remove(keyValue);
+            debugAdapter.insert(new KeyValue(keyValue.key, newValue, keyValue.type), position);
+        } catch (XmlPullParserException e) {
+            showToast(R.string.edit_setting_error_unknown_type);
+        } catch (NumberFormatException e) {
+            showToast(String.format(getString(R.string.edit_setting_error_invalid_data), newValue));
+        }
     }
 
     private void addItem() {


### PR DESCRIPTION
## Description
Currently editing any setting requires you to enter a string for its value. This is ok for most settings' types, but pretty cumbersome for type boolean. This PR provides a selection box for type boolean settings:

|old|new|
|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/1c961f98-c1e2-4322-b453-24777f9189dc)|![image](https://github.com/cgeo/cgeo/assets/3754370/1f2c2f4a-3596-47ab-b05c-df083d19fade)|
