### PR TITLE
Add missing navigation menu XML entry for OrganicMaps (fix #14466)

### DIFF
--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -346,7 +346,7 @@
     <string translatable="false" name="pref_navigation_menu_where_you_go">navigationWhereYouGo</string>
     <string translatable="false" name="pref_navigation_menu_pebble">navigationPebble</string>
     <string translatable="false" name="pref_navigation_menu_mapswithme">navigationMapsWithMe</string>
-    <string translatable="false" name="pref_navigation_menu_organicmaps">navigation_menu_organicmaps</string>
+    <string translatable="false" name="pref_navigation_menu_organicmaps">navigationOrganicMaps</string>
     <string translatable="false" name="pref_navigation_menu_cruiser">navigationCruiser</string>
 
 

--- a/main/src/main/res/xml/preferences_navigation_navigation.xml
+++ b/main/src/main/res/xml/preferences_navigation_navigation.xml
@@ -128,6 +128,12 @@
     <CheckBoxPreference
         android:defaultValue="true"
         android:enabled="false"
+        android:key="@string/pref_navigation_menu_organicmaps"
+        android:title="@string/caches_menu_organicmaps"
+        app:iconSpaceReserved="false" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:enabled="false"
         android:key="@string/pref_navigation_menu_cruiser"
         android:title="@string/cache_menu_cruiser"
         app:iconSpaceReserved="false" />


### PR DESCRIPTION
## Description
Add missing XML configuration for OrganicMaps entry in navigation menu definition

Also aligns preference key value for OrganicMaps to the other navigation preference keys