### PR TITLE
Remove maps.me auto-download + add install check (fix #14474)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/apps/cachelist/MapsMeCacheListApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/cachelist/MapsMeCacheListApp.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.apps.cachelist;
 
 import cgeo.geocaching.CacheDetailActivity;
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.apps.AbstractApp;
@@ -40,8 +41,7 @@ public class MapsMeCacheListApp extends AbstractApp implements CacheListApp {
 
     @Override
     public boolean isInstalled() {
-        // API can handle installing on the fly
-        return true;
+        return MapsWithMeApi.isMapsWithMeInstalled(CgeoApplication.getInstance());
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/apps/navi/MapsMeApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/MapsMeApp.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.apps.navi;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
@@ -72,8 +73,7 @@ class MapsMeApp extends AbstractPointNavigationApp {
 
     @Override
     public boolean isInstalled() {
-        // the library can handle the app not being installed
-        return true;
+        return MapsWithMeApi.isMapsWithMeInstalled(CgeoApplication.getInstance());
     }
 
     private static Activity getActivity(final Context context) {

--- a/mapswithme-api/src/com/mapswithme/maps/api/MapsWithMeApi.java
+++ b/mapswithme-api/src/com/mapswithme/maps/api/MapsWithMeApi.java
@@ -23,7 +23,6 @@
 package com.mapswithme.maps.api;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -60,26 +59,12 @@ public final class MapsWithMeApi {
   }
 
   public static void sendRequest(final Activity caller, final MwmRequest request) {
-    final Intent mwmIntent = request.toIntent(caller);
-
     if (isMapsWithMeInstalled(caller)) {
+      final Intent mwmIntent = request.toIntent(caller);
       // Match activity for intent
       final ActivityInfo aInfo = caller.getPackageManager().resolveActivity(mwmIntent, 0).activityInfo;
       mwmIntent.setClassName(aInfo.packageName, aInfo.name);
       caller.startActivity(mwmIntent);
-    } else {
-        // replace misleading/outdated maps.me dialog with c:geo warning message, see #13209
-        new AlertDialog.Builder(caller)
-            .setTitle("maps.me not found")
-            .setMessage("This may be due to maps.me not being installed or maps.me being installed in a version > 12.0, which is no longer compatible to their integration API.\n\nSee our FAQ for details.")
-            .setNeutralButton("Open FAQ", (dialog, which) -> {
-                final Intent viewIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://faq.cgeo.org#13209"));
-                caller.startActivity(viewIntent);
-                })
-            .setPositiveButton(android.R.string.ok, ((dialog, which) -> { }))
-            .show();
-        // original code was:
-        // (new DownloadMapsWithMeDialog(caller)).show();
     }
   }
 


### PR DESCRIPTION
## Description
- Add maps.me installation check, greying out navi menu entries when not installed
- Removes maps.me auto-download dialog (silently fails in that case)
- maps.me installed check is based on intent resolving, so no specification of package names needed for that
