### PR TITLE
Use short geocode for waypoints in RouteSort activity

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -84,7 +84,7 @@ public class RouteSortActivity extends AbstractActionBarActivity {
                     case WAYPOINT:
                         assert data instanceof Waypoint;
                         final Geocache cache = DataStore.loadCache(data.getGeocode(), LoadFlags.LOAD_CACHE_OR_DB);
-                        holder.binding.detail.setText(data.getGeocode() + (cache != null ? Formatter.SEPARATOR + cache.getName() : ""));
+                        holder.binding.detail.setText(((Waypoint) data).getShortGeocode() + (cache != null ? Formatter.SEPARATOR + cache.getName() : ""));
                         holder.binding.title.setCompoundDrawablesWithIntrinsicBounds(MapMarkerUtils.getWaypointMarker(res, (Waypoint) data, false, Settings.getIconScaleEverywhere()).getDrawable(), null, null, null);
                         break;
                     case COORDS:


### PR DESCRIPTION
## Description
Displaying waypoints along a route should use short geocodes, same as caches already do. Especially important if you make stages of lab adventures part of your route.