### PR TITLE
Add OpenTopoMap as map provider for Mapsforge and VTM (fix #9470)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -61,6 +61,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         registerMapSource(new OsmMapSource(this, resources.getString(R.string.map_source_osm_mapnik)));
         registerMapSource(new OsmdeMapSource(this, resources.getString(R.string.map_source_osm_osmde)));
         registerMapSource(new CyclosmMapSource(this, resources.getString(R.string.map_source_osm_cyclosm)));
+        registerMapSource(new OpenTopoMapSource(this, resources.getString(R.string.map_source_osm_opentopomap)));
 
         //get notified if Offline Maps directory changes
         PersistableFolder.OFFLINE_MAPS.registerChangeListener(this, pf -> updateOfflineMaps());
@@ -171,6 +172,19 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         @Override
         public ImmutablePair<String, Boolean> calculateMapAttribution(final Context ctx) {
             return new ImmutablePair<>(ctx.getString(R.string.map_attribution_cyclosm_html), false);
+        }
+
+    }
+
+    public static final class OpenTopoMapSource extends AbstractMapsforgeMapSource {
+
+        public OpenTopoMapSource(final MapProvider mapProvider, final String name) {
+            super(mapProvider, name, TileSourceOpenTopoMap.INSTANCE);
+        }
+
+        @Override
+        public ImmutablePair<String, Boolean> calculateMapAttribution(final Context ctx) {
+            return new ImmutablePair<>(ctx.getString(R.string.map_attribution_opentopomap_html), false);
         }
 
     }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/TileSourceOpenTopoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/TileSourceOpenTopoMap.java
@@ -1,0 +1,52 @@
+package cgeo.geocaching.maps.mapsforge;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
+
+public class TileSourceOpenTopoMap extends AbstractTileSource {
+    /**
+     * A tile source which fetches tiles from OpenTopoMap.org.
+     * License is CC-BY-SA
+     * https://opentopomap.org/about
+     */
+    public static final TileSourceOpenTopoMap INSTANCE = new TileSourceOpenTopoMap(new String[]{"a.tile.opentopomap.org", "b.tile.opentopomap.org", "c.tile.opentopomap.org"}, 443);
+    private static final int PARALLEL_REQUESTS_LIMIT = 8;
+    private static final String PROTOCOL = "https";
+    private static final int ZOOM_LEVEL_MAX = 18;
+    private static final int ZOOM_LEVEL_MIN = 0;
+
+    public TileSourceOpenTopoMap(final String[] hostNames, final int port) {
+        super(hostNames, port);
+        /* Default TTL: 8279 seconds (the TTL currently set by the OSM server). */
+        defaultTimeToLive = 8279000;
+    }
+
+    @Override
+    public int getParallelRequestsLimit() {
+        return PARALLEL_REQUESTS_LIMIT;
+    }
+
+    @Override
+    public URL getTileUrl(final Tile tile) throws MalformedURLException {
+        return new URL(PROTOCOL, getHostName(), this.port, "/" + tile.zoomLevel + '/' + tile.tileX + '/' + tile.tileY + ".png");
+    }
+
+    @Override
+    public byte getZoomLevelMax() {
+        return ZOOM_LEVEL_MAX;
+    }
+
+    @Override
+    public byte getZoomLevelMin() {
+        return ZOOM_LEVEL_MIN;
+    }
+
+    @Override
+    public boolean hasAlpha() {
+        return false;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapSource.java
@@ -1,0 +1,12 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import android.net.Uri;
+
+import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
+
+class OpenTopoMapSource extends AbstractMapsforgeOnlineTileProvider {
+    OpenTopoMapSource() {
+        super("OpenTopoMap", Uri.parse("https://c.tile.opentopomap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -141,6 +141,7 @@ public class TileProviderFactory {
         registerTileProvider(new OsmOrgSource());
         registerTileProvider(new OsmDeSource());
         registerTileProvider(new CyclosmSource());
+        registerTileProvider(new OpenTopoMapSource());
 
         // OSM offline tile providers
         final List<ImmutablePair<String, Uri>> offlineMaps =

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -43,6 +43,7 @@
     <string translatable="false" name="map_source_osm_mapnik">OpenStreetMap.org</string>
     <string translatable="false" name="map_source_osm_osmde">OpenStreetMap.de</string>
     <string translatable="false" name="map_source_osm_cyclosm">CyclOSM</string>
+    <string translatable="false" name="map_source_osm_opentopomap">OpenTopoMap</string>
 
     <!-- edit waypoint -->
     <string translatable="false" name="waypoint_latitude_null">N/S --° --.---</string>
@@ -58,6 +59,7 @@
     <string translatable="false" name="map_attribution_openstreetmap_html"><![CDATA[<a href="https://www.openstreetmap.org/copyright">© OpenStreetMap contributors</a>]]></string>
     <string translatable="false" name="map_attribution_openstreetmapde_html"><![CDATA[© <a href="https://openstreetmap.de/">OpenStreetMap DE</a>, map data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>]]></string>
     <string translatable="false" name="map_attribution_cyclosm_html"><![CDATA[© <a href="https://www.cyclosm.org/">CyclOSM</a>, map data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>]]></string>
+    <string translatable="false" name="map_attribution_opentopomap_html"><![CDATA[© <a href="https://www.opentopomap.org/">OpenTopoMap</a> (CC-BY-SA), map data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, SRTM]]></string>
 
     <!-- links to manual pages -->
     <string translatable="false" name="manual_url_settings_offline_maps">https://manual.cgeo.org/en/offlinemaps</string>
@@ -162,7 +164,7 @@
     - [Geocoding courtesy of MapQuest](https://www.mapquest.com/)\n
     - [Geocoding data from OpenStreetMap](https://www.openstreetmap.org/)\n
     - OpenStreetMap cartography (OSM:Mapnik) © OpenStreetMap contributors. Map tile data [licensed](https://www.openstreetmap.org/copyright/en) under Creative Commons 2.0 BY-SA.\n
-    - More maps based on OpenStreetMap cartography: © [openstreetmap.de](https://www.openstreetmap.de/) and © [cyclosm.org](https://www.cyclosm.org/).\n
+    - More maps based on OpenStreetMap cartography: © [openstreetmap.de](https://www.openstreetmap.de/), © [cyclosm.org](https://www.cyclosm.org/) and  © [opentopomap.org](https://www.opentopomap.org/).\n
     - Map Downloader supports maps from [Mapsforge](https://github.com/mapsforge), [OpenAndroMaps](https://www.openandromaps.org), [Freizeitkarte](https://www.freizeitkarte-osm.de/) and [Hylly](https://kartat.hylly.org/).\n
     - Routing © 2019 BRouter contributors ([MIT license](https://github.com/abrensch/brouter/blob/master/LICENSE))\n
 	</string>


### PR DESCRIPTION
## Description
Adds OpenTopoMap as map provider for both `NewMap` and `UnifiedMap`, including attribution etc.