### PR TITLE
Switch OrganicMaps install check to intent resolution

### DIFF
--- a/organicmaps-api/src/main/AndroidManifest.xml
+++ b/organicmaps-api/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <!-- packages we want to see using the package manager need to be declared starting with targetSDK 30, and we need to use specific strings / cannot use @string/xxx notation -->
+        <package android:name="app.organicmaps" />
+        <package android:name="app.organicmaps.debug" />
+        <package android:name="app.organicmaps.beta" />
+    </queries>
+
 </manifest>

--- a/organicmaps-api/src/main/java/app/organicmaps/api/OrganicMapsApi.java
+++ b/organicmaps-api/src/main/java/app/organicmaps/api/OrganicMapsApi.java
@@ -1,17 +1,13 @@
 package app.organicmaps.api;
 
-/* added by c:geo project as temporary workaround until OrganicMaps API is completed */
-
 import android.app.Activity;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ActivityInfo;
 
 import java.util.ArrayList;
 
 public class OrganicMapsApi {
-
-    static final String PACKAGE_NAME = "app.organicmaps";
 
     private OrganicMapsApi() {
         // utility class
@@ -19,7 +15,7 @@ public class OrganicMapsApi {
 
     public static void showPointOnMap(final Activity activity, final double lat, final double lon, final String name) {
         final ArrayList<Point> points = new ArrayList<>(1);
-        points.add(new Point(lat, lon, name, String.valueOf(name.hashCode())));
+        points.add(new Point(lat, lon, name));
         showPointsOnMap(activity, name, points);
     }
 
@@ -33,9 +29,6 @@ public class OrganicMapsApi {
 
     public static void sendRequest(final Activity caller, final Intent intent) {
         if (isOrganicMapsInstalled(caller)) {
-            // Match activity for intent
-            final ActivityInfo aInfo = caller.getPackageManager().resolveActivity(intent, 0).activityInfo;
-            intent.setClassName(aInfo.packageName, aInfo.name);
             caller.startActivity(intent);
         } else {
             new DownloadDialog(caller).show();
@@ -43,11 +36,11 @@ public class OrganicMapsApi {
     }
 
     /**
-     * Detects if any version (Lite, Pro) of OrganicMaps is installed on the device
+     * Detects if any version of OrganicMaps is installed on the device
      */
     public static boolean isOrganicMapsInstalled(final Context context) {
-        final Intent i = context.getPackageManager().getLaunchIntentForPackage(PACKAGE_NAME);
-        return i != null;
+        final ComponentName c = new MapRequest().toIntent().resolveActivity(context.getPackageManager());
+        return c != null;
     }
 
 }


### PR DESCRIPTION
## Description
Switches OrganicMaps installation check to intent resolution so that we do not have to check for several different package names manually.