### PR TITLE
Remove outdated 'show on map' menu entry (fix #14500)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -700,7 +700,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setVisible(menu, R.id.menu_select_next100, adapter.isSelectMode()); // same here
 
             setVisibleEnabled(menu, R.id.menu_cache_list_app_provider, listNavigationApps.size() > 1, !isEmpty);
-            setVisibleEnabled(menu, R.id.menu_cache_list_app, listNavigationApps.size() == 1, !isEmpty);
 
             // Manage Caches submenu
             setEnabled(menu, R.id.menu_refresh_stored, !isEmpty);
@@ -905,10 +904,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             invalidateOptionsMenuCompatible();
         } else if (menuItem == R.id.menu_show_attributes) {
             adapter.showAttributes();
-        } else if (menuItem == R.id.menu_cache_list_app) {
-            if (cacheToShow()) {
-                CacheListApps.getActiveApps().get(0).invoke(CacheListAppUtils.filterCoords(adapter.getList()), this, getFilteredSearch());
-            }
         } else if (menuItem == R.id.menu_make_list_unique) {
             new MakeListUniqueCommand(this, listId) {
 

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -40,12 +40,6 @@
         android:title="@string/caches_select_next100"
         app:showAsAction="ifRoom|withText"/>
     <item
-        android:id="@+id/menu_cache_list_app"
-        android:icon="@drawable/ic_menu_navigate"
-        android:title="@null"
-        android:visible="false"
-        app:showAsAction="ifRoom|withText"/>
-    <item
         android:id="@+id/menu_cache_list_app_provider"
         android:icon="@drawable/ic_menu_navigate"
         android:title="@string/caches_on_map"


### PR DESCRIPTION
## Description
Removes outdated unlabelled(!) "show on map" menu entry that only appeared when only one cache list navigation app is present. This did not happen for a long while, as "internal map" and "maps.me" have always been marked as being present, but with the removal of "maps.me is always marked as being installed", this menu entry got triggered again.
(See https://github.com/cgeo/cgeo/issues/14500#issuecomment-1676116938 for more info)