### PR TITLE
Bump okhttpVersion from 4.10.0 to 4.11.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -405,7 +405,7 @@ dependencies {
     // Metadata Extractor, EXIF location extraction from images
     implementation 'com.drewnoakes:metadata-extractor:2.18.0'
 
-    String okhttpVersion = '4.10.0'
+    String okhttpVersion = '4.11.0'
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     // For local unit tests
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -94,13 +94,6 @@
 # Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
 -dontwarn org.codehaus.mojo.animal_sniffer.*
 -dontwarn okhttp3.OkHttpClient$Builder
-# OkHttp platform used only on JVM and when Conscrypt dependency is available.
--dontnote okhttp3.internal.platform.**
-# R8 missing, probaly fixed in next OkHttp release,
-# see https://github.com/square/okhttp/pull/6792
--dontwarn org.bouncycastle.jsse.**
--dontwarn org.conscrypt.*
--dontwarn org.openjsse.**
 
 # Play Services -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
replaces  #14224

As result of the update, we can now remove the proguard configuration for okhttp. This entries are now part of okhttp, see https://github.com/square/okhttp/commit/cf088f852e41bc61b02cea9859a1cd3763aff778 .
