### PR TITLE
Fix #13679: Call MapQuestGeocoder lazily

### DIFF
--- a/main/src/main/java/cgeo/geocaching/address/AddressListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/address/AddressListActivity.java
@@ -45,7 +45,7 @@ public class AddressListActivity extends AbstractActionBarActivity implements Ad
 
     private void lookupAddressInBackground(final String keyword, final AddressListAdapter adapter, final ProgressDialog waitDialog) {
         final Observable<Address> geocoderObservable = new AndroidGeocoder(this).getFromLocationName(keyword)
-                .onErrorResumeWith(MapQuestGeocoder.getFromLocationName(keyword));
+                .onErrorResumeNext(throwable -> MapQuestGeocoder.getFromLocationName(keyword));
         AndroidRxUtils.bindActivity(this, geocoderObservable.toList()).subscribe(foundAddresses -> {
             waitDialog.dismiss();
             addresses.addAll(foundAddresses);


### PR DESCRIPTION
Instead of passing the MapQuestGeocoder fallback value directly, we now provide a function that is only called in case of an error.