### PR TITLE
Set targetSDK to 33

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -32,7 +32,7 @@ android {
     defaultConfig {
         minSdk 21
         //noinspection OldTargetApi
-        targetSdk 31
+        targetSdk 33
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 


### PR DESCRIPTION
## Description
As per Play Store requirements set `targetSDK` to 33. (Apps not supporting `targetSDK` 33 will be blocked from updating on Play Store starting end of August, see #14499.)