### PR TITLE
Add c:geo version info to logfile (fix #14530)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/main/java/cgeo/geocaching/CgeoApplication.java
@@ -50,6 +50,7 @@ public class CgeoApplication extends Application {
     @Override
     public void onCreate() {
         Log.iForce("---------------- CGeoApplication: startup -------------");
+        Log.e("c:geo version " + BuildConfig.VERSION_NAME);
         try (ContextLogger ignore = new ContextLogger(true, "CGeoApplication.onCreate")) {
             super.onCreate();
 


### PR DESCRIPTION
## Description
Add c:geo version info to logfile (fix #14530)
(Using `Log.e()` to make sure it's included in a logfile and not filtered out by log level)