### PR TITLE
WIP Move backup/restore to BackupActivity

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -111,6 +111,10 @@
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
         </activity>
         <activity
+            android:name=".backup.BackupActivity"
+            android:theme="@style/cgeo"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/cgeo"

--- a/main/src/main/java/cgeo/geocaching/SplashActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SplashActivity.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching;
 
+import cgeo.geocaching.backup.BackupActivity;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorageActivityHelper;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
@@ -8,6 +9,7 @@ import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.TextUtils;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_NONE;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -29,6 +31,9 @@ public class SplashActivity extends AppCompatActivity {
                 // new install, base folder missing or folder migration needed => run installation wizard
                 intent = new Intent(this, InstallWizardActivity.class);
                 intent.putExtra(InstallWizardActivity.BUNDLE_MODE, firstInstall ? InstallWizardActivity.WizardMode.WIZARDMODE_DEFAULT.id : InstallWizardActivity.WizardMode.WIZARDMODE_MIGRATION.id);
+            } else if (Settings.getEDBARequested() != EDBA_NONE) {
+                // if any pending backup requests are found: start backup
+                intent = new Intent(this, BackupActivity.class);
             } else {
                 // otherwise regular startup
                 intent = Settings.getStartscreenIntent(this);

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -36,6 +36,7 @@ import cgeo.geocaching.utils.Version;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NEARBY;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NONE;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_PLACEHOLDER;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_BACKUP_AUTO;
 
 import android.app.Activity;
 import android.content.BroadcastReceiver;
@@ -492,7 +493,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
 
             // automated backup check
             if (Settings.automaticBackupDue()) {
-                new BackupUtils(this, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true);
+                Settings.setEDBARequested(EDBA_BACKUP_AUTO);
             }
             cLog.add("ab");
 

--- a/main/src/main/java/cgeo/geocaching/backup/BackupActivity.java
+++ b/main/src/main/java/cgeo/geocaching/backup/BackupActivity.java
@@ -1,0 +1,116 @@
+package cgeo.geocaching.backup;
+
+import cgeo.geocaching.databinding.InstallWizardBinding;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.BackupUtils;
+import cgeo.geocaching.utils.ContextLogger;
+import cgeo.geocaching.utils.Log;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_NONE;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class BackupActivity extends AppCompatActivity {
+
+    public static final String STATE_BACKUPUTILS = "backuputils";
+    public static final String STATE_EDBA = "EDBA_requested";
+
+    private BackupUtils backupUtils = null;
+    private Settings.EXCLUSIVEDBACTION requestedEDBA = EDBA_NONE;
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        final InstallWizardBinding binding = InstallWizardBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        requestedEDBA = savedInstanceState != null ? Settings.EXCLUSIVEDBACTION.values()[savedInstanceState.getInt(STATE_EDBA)] : Settings.getEDBARequested();
+        Settings.setEDBARequested(EDBA_NONE);
+
+        if (requestedEDBA == EDBA_NONE) {
+            finish();
+        }
+
+        try (ContextLogger cLog = new ContextLogger(Log.LogLevel.DEBUG, "BackupActivity.onCreate")) {
+            backupUtils = new BackupUtils(this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
+            binding.wizardPrev.setVisibility(View.GONE);
+            binding.wizardSkip.setVisibility(View.GONE);
+
+            binding.wizardNext.setVisibility(View.VISIBLE);
+            binding.wizardNext.setText("Cancel");
+            binding.wizardNext.setEnabled(true);
+            binding.wizardNext.setOnClickListener(v -> {
+                // prepare restart of c:geo
+                final Intent intent = Settings.getStartscreenIntent(this);
+                intent.putExtras(getIntent());
+                startActivity(intent);
+                cLog.add("fin");
+                finish();
+            });
+
+            switch (requestedEDBA) {
+                case EDBA_BACKUP_AUTO: {
+                    binding.wizardTitle.setText("Automatic backup");
+                    backupUtils.backup(() -> {
+                        cLog.add("abackup");
+                        Settings.setAutomaticBackupLastCheck(false);
+                    }, true);
+                    break;
+                }
+                case EDBA_BACKUP_MANUAL: {
+                    binding.wizardTitle.setText("Manual backup");
+                    backupUtils.backup(() -> {
+                        cLog.add("mbackup");
+                    }, false);
+                    break;
+                }
+                case EDBA_RESTORE_NEWEST: {
+                    binding.wizardTitle.setText("Restore");
+                    backupUtils.restore(BackupUtils.newestBackupFolder(false));
+                    cLog.add("restoreN");
+                    break;
+                }
+                case EDBA_RESTORE_SELECT: {
+                    binding.wizardTitle.setText("Restore");
+                    backupUtils.selectBackupDirIntent();
+                    cLog.add("restoreS");
+                    break;
+                }
+                /*
+                case EDBA_SETSIZE: {
+                    // @todo: set max allowed number of backups; delete superfluous backups
+                    break;
+                }
+                case EDBA_DBMOVE: {
+                    // @todo: move database
+                    break;
+                }
+                */
+                default: {
+                    throw new IllegalStateException("unknown value for requested EDBA");
+                }
+            }
+            binding.wizardText.setText("Tap button to continue to c:geo");
+            binding.wizardNext.setText("Continue");
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+        savedInstanceState.putBundle(STATE_BACKUPUTILS, backupUtils.getState());
+        savedInstanceState.putInt(STATE_EDBA, requestedEDBA.ordinal());
+    }
+
+    @Override
+    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        backupUtils.onActivityResult(requestCode, resultCode, data);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -48,6 +48,7 @@ import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT_ID;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_NONE;
 
 import android.app.Activity;
 import android.content.Context;
@@ -107,6 +108,8 @@ public class Settings {
     public static final int CUSTOMBNITEM_PLACEHOLDER = -2;
     public static final int CUSTOMBNITEM_NONE = -1;
     public static final int CUSTOMBNITEM_NEARBY = 0;
+
+    public enum EXCLUSIVEDBACTION { EDBA_NONE, EDBA_BACKUP_AUTO, EDBA_BACKUP_MANUAL, EDBA_RESTORE_NEWEST, EDBA_RESTORE_SELECT, EDBA_SETSIZE, EDBA_DBMOVE }
 
     public static final int HOURS_TO_SECONDS = 60 * 60;
     public static final int DAYS_TO_SECONDS = 24 * HOURS_TO_SECONDS;
@@ -574,6 +577,16 @@ public class Settings {
         final SharedPreferences.Editor edit = sharedPrefs.edit();
         edit.putInt(getKey(prefKeyId), value);
         edit.apply();
+    }
+
+    /** same as putInt(), but immediately stores values (blocking) */
+    private static void putIntSync(final int prefKeyId, final int value) {
+        if (sharedPrefs == null) {
+            return;
+        }
+        final SharedPreferences.Editor edit = sharedPrefs.edit();
+        edit.putInt(getKey(prefKeyId), value);
+        edit.commit();
     }
 
     private static void putLong(final int prefKeyId, final long value) {
@@ -2044,6 +2057,16 @@ public class Settings {
 
     public static void setAutomaticBackupLastCheck(final boolean delay) {
         putLong(R.string.pref_automaticBackupLastCheck, calculateNewTimestamp(delay, getAutomaticBackupInterval() * 24));
+    }
+
+    public static EXCLUSIVEDBACTION getEDBARequested() {
+        Log.e("getEDBARequested: " + getInt(R.string.pref_EDBARequested, EDBA_NONE.ordinal()));
+        return EXCLUSIVEDBACTION.values()[getInt(R.string.pref_EDBARequested, EDBA_NONE.ordinal())];
+    }
+
+    public static void setEDBARequested(final EXCLUSIVEDBACTION action) {
+        Log.e("setEDBARequested(" + action + "): " + action.ordinal());
+        putIntSync(R.string.pref_EDBARequested, action.ordinal());
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -28,7 +28,6 @@ import cgeo.geocaching.storage.ContentStorageActivityHelper;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.utils.ApplicationSettings;
-import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 
@@ -84,9 +83,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 
     public static final String STATE_CSAH = "csah";
     public static final String STATE_CSAH_PN = "csahpn";
-    public static final String STATE_BACKUPUTILS = "backuputils";
 
-    private BackupUtils backupUtils = null;
     private ContentStorageActivityHelper contentStorageHelper = null;
 
     private CharSequence title;
@@ -99,8 +96,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     protected void onCreate(final Bundle savedInstanceState) {
         ApplicationSettings.setLocale(this);
         super.onCreate(savedInstanceState);
-
-        backupUtils = new BackupUtils(SettingsActivity.this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
 
         this.contentStorageHelper = new ContentStorageActivityHelper(this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_CSAH))
                 .addSelectActionCallback(ContentStorageActivityHelper.SelectAction.SELECT_FOLDER_PERSISTED, PersistableFolder.class, folder -> {
@@ -137,10 +132,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         AndroidBeam.disable(this);
 
         setResult(NO_RESTART_NEEDED);
-    }
-
-    public BackupUtils getBackupUtils() {
-        return backupUtils;
     }
 
     public void askShowWallpaperPermission() {
@@ -253,7 +244,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     public void onSaveInstanceState(@NonNull final Bundle savedInstanceState) {
         super.onSaveInstanceState(savedInstanceState);
         savedInstanceState.putBundle(STATE_CSAH, contentStorageHelper.getState());
-        savedInstanceState.putBundle(STATE_BACKUPUTILS, backupUtils.getState());
 
         // Save current activity title so we can set it again after a configuration change
         savedInstanceState.putCharSequence(TITLE_TAG, title);
@@ -313,9 +303,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         super.onActivityResult(requestCode, resultCode, data);
 
         if (contentStorageHelper.onActivityResult(requestCode, resultCode, data)) {
-            return;
-        }
-        if (backupUtils.onActivityResult(requestCode, resultCode, data)) {
             return;
         }
     }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -1,36 +1,33 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.settings.BackupSeekbarPreference;
-import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.BackupUtils;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_BACKUP_MANUAL;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_RESTORE_NEWEST;
+import static cgeo.geocaching.settings.Settings.EXCLUSIVEDBACTION.EDBA_RESTORE_SELECT;
 
 import android.os.Bundle;
 
 import androidx.preference.CheckBoxPreference;
 
 public class PreferenceBackupFragment extends BasePreferenceFragment {
-    public static final String STATE_BACKUPUTILS = "backuputils";
-
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_backup, rootKey);
 
-        final BackupUtils backupUtils = ((SettingsActivity) getActivity()).getBackupUtils();
-
         findPreference(getString(R.string.pref_fakekey_preference_startbackup)).setOnPreferenceClickListener(preference -> {
-            backupUtils.backup(this::updateSummary, false);
+            BackupUtils.restartForBackupRestore(getActivity(), EDBA_BACKUP_MANUAL);
             return true;
         });
 
         findPreference(getString(R.string.pref_fakekey_startrestore)).setOnPreferenceClickListener(preference -> {
-            backupUtils.restore(BackupUtils.newestBackupFolder(false));
+            BackupUtils.restartForBackupRestore(getActivity(), EDBA_RESTORE_NEWEST);
             return true;
         });
 
         findPreference(getString(R.string.pref_fakekey_startrestore_dirselect)).setOnPreferenceClickListener(preference -> {
-            backupUtils.selectBackupDirIntent();
+            BackupUtils.restartForBackupRestore(getActivity(), EDBA_RESTORE_SELECT);
             return true;
         });
 
@@ -45,10 +42,12 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
 
         updateSummary();
 
+        /* @todo
         findPreference(getString(R.string.pref_backup_backup_history_length)).setOnPreferenceChangeListener((preference, value) -> {
             backupUtils.deleteBackupHistoryDialog((BackupSeekbarPreference) preference, (int) value, false);
             return true;
         });
+        */
 
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import static cgeo.geocaching.utils.ProcessUtils.restartApplication;
 import static cgeo.geocaching.utils.SettingsUtils.SettingsType.TYPE_STRING;
 import static cgeo.geocaching.utils.SettingsUtils.SettingsType.TYPE_UNKNOWN;
 
@@ -757,6 +758,13 @@ public class BackupUtils {
             return null;
         }
         return subfolder;
+    }
+
+    public static void restartForBackupRestore(final Activity activity, final Settings.EXCLUSIVEDBACTION action) {
+        SimpleDialog.of(activity).setTitle(TextParam.text("Restart required")).setMessage(TextParam.text("c:geo needs to be restarted to perform this action")).confirm((x, y) -> {
+            Settings.setEDBARequested(action);
+            restartApplication(activity);
+        });
     }
 
 }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -536,6 +536,10 @@
     <string translatable="false" name="pref_next_unique_notification_id">next_unique_notification_id</string>
     <string translatable="false" name="pref_changelog_last_checksum">changelog_last_checksum</string>
 
+    <!-- handling backups (used internally) -->
+    <string translatable="false" name="pref_automaticBackupLastCheck">automaticBackupLastCheck</string>
+    <string translatable="false" name="pref_EDBARequested">EDBARequested</string>
+
     <!-- other preferences, used internally -->
     <string translatable="false" name="pref_dataDir">pref_dataDir</string>
     <string translatable="false" name="pref_logTemplates">logTemplates</string>
@@ -558,7 +562,6 @@
     <string translatable="false" name="pref_hideVisitedWaypoints">hideVisitedWaypoints</string>
     <string translatable="false" name="pref_cache_filter_config">cache_filter_config</string>
     <string translatable="false" name="pref_cache_sort_config">cache_sort_config</string>
-    <string translatable="false" name="pref_automaticBackupLastCheck">automaticBackupLastCheck</string>
     <string translatable="false" name="pref_dbCleanupLastCheck">dbCleanupLastCheck</string>
     <string translatable="false" name="pref_dbReindexLastCheck">dbReindexLastCheck</string>
     <string translatable="false" name="pref_pendingDownloadsLastCheck">pendingDownloadsLastCheck</string>


### PR DESCRIPTION
## Description
- Requesting a backup (either manually or automatically) or a restore just sets an internal flag in settings and informs the user about necessary restart.
- `SplashActivity` checks for this flag and calls `BackupActivity` if the flag is set, otherwise calls regular start activity

## Related issues
See discussion in #14375

## Additional context
This is a draft version still unfinished and having some UX issues, posting it here to get some early feedback.

## Notes to myself
- "Continue" button should only be accessible when cancelling current action, or when current action has finished. Requires an extension for restore actions, as it does not use a callback yet.
- ~On requesting a backup/restore, ask user before restarting c:geo (or at least give some user feedback instead of just a blank screen)~ _(implemented)_
- actions missing yet: changing number of backups; moving database
