### PR TITLE
Limit fav ratio to 100% on cache details page (fix #14543)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1529,7 +1529,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
                 final int findsCount = cache.getFindsCount();
                 if (findsCount > 0) {
-                    favoriteLine.valueView.setText(activity.res.getString(R.string.favorite_count_percent, favCount, (float) (favCount * 100) / findsCount));
+                    favoriteLine.valueView.setText(activity.res.getString(R.string.favorite_count_percent, favCount, Math.min((float) (favCount * 100) / findsCount, 100.0f)));
                 } else {
                     favoriteLine.valueView.setText(activity.res.getString(R.string.favorite_count, favCount));
                 }


### PR DESCRIPTION
## Description
Limits fav ratio on cache details page to a maximum of 100%

![image](https://github.com/cgeo/cgeo/assets/3754370/7dd2aa35-f85a-4722-9cf1-14d1ade98851)
