### PR TITLE
fix #14521: ensure minimum image size for display

### DIFF
--- a/main/src/main/java/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/main/java/cgeo/geocaching/network/HtmlImage.java
@@ -224,7 +224,7 @@ public class HtmlImage implements Html.ImageGetter {
         if (FileUtils.isFileUrl(url)) {
             return Observable.defer(() -> {
                 final ImmutableTriple<Bitmap, Metadata, Boolean> data = loadCachedImage(FileUtils.urlToFile(url), true);
-                return data != null && data.left != null ? Observable.just(ImmutablePair.of(ImageUtils.scaleBitmapToFitDisplay(data.left), data.middle)) :
+                return data != null && data.left != null ? Observable.just(ImmutablePair.of(ImageUtils.scaleBitmapToDisplay(data.left), data.middle)) :
                         Observable.just(IMAGE_ERROR_DATA);
             }).subscribeOn(AndroidRxUtils.computationScheduler);
         }
@@ -235,7 +235,7 @@ public class HtmlImage implements Html.ImageGetter {
                 delayForTest();
 
                 final ImmutableTriple<Bitmap, Metadata, Boolean> data = loadCachedImage(uri, true, -1);
-                return data != null && data.left != null ? Observable.just(ImmutablePair.of(ImageUtils.scaleBitmapToFitDisplay(data.left), data.middle)) :
+                return data != null && data.left != null ? Observable.just(ImmutablePair.of(ImageUtils.scaleBitmapToDisplay(data.left), data.middle)) :
                         Observable.just(IMAGE_ERROR_DATA);
             }).subscribeOn(AndroidRxUtils.computationScheduler);
         }
@@ -319,7 +319,7 @@ public class HtmlImage implements Html.ImageGetter {
 
     protected ImmutableTriple<BitmapDrawable, Metadata, Boolean> scaleImage(final ImmutableTriple<Bitmap, Metadata, Boolean> loadResult) {
         final Bitmap bitmap = loadResult.left;
-        return ImmutableTriple.of(bitmap != null ? ImageUtils.scaleBitmapToFitDisplay(bitmap) : null, loadResult.middle, loadResult.right);
+        return ImmutableTriple.of(bitmap != null ? ImageUtils.scaleBitmapToDisplay(bitmap) : null, loadResult.middle, loadResult.right);
     }
 
     public Completable waitForEndCompletable(@Nullable final DisposableHandler handler) {

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -80,6 +80,10 @@ public class ViewUtils {
         return (int) (dp * (APP_RESOURCES == null ? 20f : APP_RESOURCES.getDisplayMetrics().density));
     }
 
+    public static int spToPixel(final float sp) {
+        return (int) (sp * (APP_RESOURCES == null ? 20f : APP_RESOURCES.getDisplayMetrics().scaledDensity));
+    }
+
     public static int pixelToDp(final float px) {
         return (int) (px / (APP_RESOURCES == null ? 20f : APP_RESOURCES.getDisplayMetrics().density));
     }


### PR DESCRIPTION
fix #14521: ensure minimum image size for display

Fix is to apply a minimum size onto all images displayed in listing. Currently hardcoded at 20dp (width + height). Looks now like this:

![image](https://github.com/cgeo/cgeo/assets/6909759/b4f722bf-b34b-4e0e-9308-47f54e93f1ed)
