### PR TITLE
rel to #14375: radical approach to move database operations to splash activity

### DIFF
--- a/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
@@ -67,7 +67,6 @@ public class InstallWizardActivity extends AppCompatActivity {
     private WizardStep step = WizardStep.WIZARD_START;
     private boolean forceSkipButton = false;
     private ContentStorageActivityHelper contentStorageActivityHelper = null;
-    private BackupUtils backupUtils;
 
     private static final int REQUEST_CODE_WIZARD_GC = 0x7167;
 
@@ -99,7 +98,6 @@ public class InstallWizardActivity extends AppCompatActivity {
         supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
         setTheme(R.style.NoActionbarTheme);
 
-        backupUtils = new BackupUtils(this, savedInstanceState == null ? null : savedInstanceState.getBundle(BUNDLE_BACKUPUTILS));
         if (savedInstanceState != null) {
             step = WizardStep.values()[savedInstanceState.getInt(BUNDLE_STEP)];
             mode = WizardMode.values()[savedInstanceState.getInt(BUNDLE_MODE)];
@@ -236,9 +234,9 @@ public class InstallWizardActivity extends AppCompatActivity {
                     setButtonToDone();
                     DataStore.resetNewlyCreatedDatabase();
                     if (BackupUtils.hasBackup(BackupUtils.newestBackupFolder(false))) {
-                        backupUtils.restore(BackupUtils.newestBackupFolder(false));
+                        BackupUtils.startAction(this, BackupUtils.StartupAction.RESTORE);
                     } else {
-                        backupUtils.selectBackupDirIntent();
+                        BackupUtils.startAction(this, BackupUtils.StartupAction.RESTORE_OTHER_FOLDER);
                     }
                 }, button3Info, R.string.wizard_advanced_restore_info);
                 break;
@@ -528,7 +526,6 @@ public class InstallWizardActivity extends AppCompatActivity {
         savedInstanceState.putInt(BUNDLE_MODE, mode.id);
         savedInstanceState.putInt(BUNDLE_STEP, step.ordinal());
         savedInstanceState.putBundle(BUNDLE_CSAH, contentStorageActivityHelper.getState());
-        savedInstanceState.putBundle(BUNDLE_BACKUPUTILS, backupUtils.getState());
     }
 
     @Override
@@ -549,6 +546,5 @@ public class InstallWizardActivity extends AppCompatActivity {
         if ((contentStorageActivityHelper == null || !contentStorageActivityHelper.onActivityResult(requestCode, resultCode, data))) {
             return;
         }
-        backupUtils.onActivityResult(requestCode, resultCode, data);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -84,7 +84,6 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
     private static final Object initializedMutex = new Object();
     private static boolean initialized = false;
     private static boolean restoreMessageShown = false;
-    private BackupUtils backupUtils = null;
 
 
     private ActivityNavigationbarBinding binding = null;
@@ -187,7 +186,6 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        backupUtils = new BackupUtils(this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
     }
 
     @Override
@@ -437,13 +435,11 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
     @Override
     protected void onSaveInstanceState(@NonNull final Bundle savedInstanceState) {
         super.onSaveInstanceState(savedInstanceState);
-        savedInstanceState.putBundle(STATE_BACKUPUTILS, backupUtils.getState());
     }
 
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);  // call super to make lint happy
-        backupUtils.onActivityResult(requestCode, resultCode, intent);
     }
 
     protected void runInitAndMaintenance() {
@@ -490,12 +486,6 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
             RenderThemeHelper.resynchronizeOrDeleteMapThemeFolder();
             cLog.add("rth");
 
-            // automated backup check
-            if (Settings.automaticBackupDue()) {
-                new BackupUtils(this, null).backup(() -> Settings.setAutomaticBackupLastCheck(false), true);
-            }
-            cLog.add("ab");
-
             // check for finished, but unreceived downloads
             DownloaderUtils.checkPendingDownloads(this);
         }
@@ -511,7 +501,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
                     .setPositiveButton(getString(android.R.string.ok), (dialog, id) -> {
                         dialog.dismiss();
                         DataStore.resetNewlyCreatedDatabase();
-                        backupUtils.restore(BackupUtils.newestBackupFolder(false));
+                        BackupUtils.startAction(this, BackupUtils.StartupAction.RESTORE);
                     })
                     .setNegativeButton(getString(android.R.string.cancel), (dialog, id) -> {
                         dialog.cancel();

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -45,6 +45,7 @@ import cgeo.geocaching.ui.AvatarUtils;
 import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
+import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.maps.MapProviderFactory.MAP_LANGUAGE_DEFAULT_ID;
@@ -2023,6 +2024,21 @@ public class Settings {
 
     public static int allowedBackupsNumber() {
         return getInt(R.string.pref_backup_backup_history_length, getKeyInt(R.integer.backup_history_length_default));
+    }
+
+    public static BackupUtils.StartupAction getStartupAction() {
+        final int startupActionInt = getInt(R.string.pref_startup_action, -1);
+        Log.iForce("get StartupAction returns: " + startupActionInt);
+        if (startupActionInt < 0 || startupActionInt >= BackupUtils.StartupAction.values().length) {
+            return null;
+        }
+        return BackupUtils.StartupAction.values()[startupActionInt];
+    }
+
+    public static void setStartupAction(final BackupUtils.StartupAction action) {
+        final int startupAction = action == null ? -1 : action.ordinal();
+        Log.iForce("set StartupAction to: " + startupAction);
+        putInt(R.string.pref_startup_action, startupAction);
     }
 
     public static boolean automaticBackupDue() {

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -28,7 +28,6 @@ import cgeo.geocaching.storage.ContentStorageActivityHelper;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.storage.PersistableUri;
 import cgeo.geocaching.utils.ApplicationSettings;
-import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 
@@ -83,10 +82,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     public static final int RESTART_NEEDED = 2;
 
     public static final String STATE_CSAH = "csah";
-    public static final String STATE_CSAH_PN = "csahpn";
-    public static final String STATE_BACKUPUTILS = "backuputils";
 
-    private BackupUtils backupUtils = null;
     private ContentStorageActivityHelper contentStorageHelper = null;
 
     private CharSequence title;
@@ -99,8 +95,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     protected void onCreate(final Bundle savedInstanceState) {
         ApplicationSettings.setLocale(this);
         super.onCreate(savedInstanceState);
-
-        backupUtils = new BackupUtils(SettingsActivity.this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));
 
         this.contentStorageHelper = new ContentStorageActivityHelper(this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_CSAH))
                 .addSelectActionCallback(ContentStorageActivityHelper.SelectAction.SELECT_FOLDER_PERSISTED, PersistableFolder.class, folder -> {
@@ -137,10 +131,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         AndroidBeam.disable(this);
 
         setResult(NO_RESTART_NEEDED);
-    }
-
-    public BackupUtils getBackupUtils() {
-        return backupUtils;
     }
 
     public void askShowWallpaperPermission() {
@@ -253,7 +243,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
     public void onSaveInstanceState(@NonNull final Bundle savedInstanceState) {
         super.onSaveInstanceState(savedInstanceState);
         savedInstanceState.putBundle(STATE_CSAH, contentStorageHelper.getState());
-        savedInstanceState.putBundle(STATE_BACKUPUTILS, backupUtils.getState());
 
         // Save current activity title so we can set it again after a configuration change
         savedInstanceState.putCharSequence(TITLE_TAG, title);
@@ -313,9 +302,6 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
         super.onActivityResult(requestCode, resultCode, data);
 
         if (contentStorageHelper.onActivityResult(requestCode, resultCode, data)) {
-            return;
-        }
-        if (backupUtils.onActivityResult(requestCode, resultCode, data)) {
             return;
         }
     }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.BackupSeekbarPreference;
-import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.BackupUtils;
 
@@ -11,26 +10,23 @@ import android.os.Bundle;
 import androidx.preference.CheckBoxPreference;
 
 public class PreferenceBackupFragment extends BasePreferenceFragment {
-    public static final String STATE_BACKUPUTILS = "backuputils";
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences_backup, rootKey);
 
-        final BackupUtils backupUtils = ((SettingsActivity) getActivity()).getBackupUtils();
-
         findPreference(getString(R.string.pref_fakekey_preference_startbackup)).setOnPreferenceClickListener(preference -> {
-            backupUtils.backup(this::updateSummary, false);
+            BackupUtils.startAction(this.getActivity(), BackupUtils.StartupAction.BACKUP);
             return true;
         });
 
         findPreference(getString(R.string.pref_fakekey_startrestore)).setOnPreferenceClickListener(preference -> {
-            backupUtils.restore(BackupUtils.newestBackupFolder(false));
+            BackupUtils.startAction(this.getActivity(), BackupUtils.StartupAction.RESTORE);
             return true;
         });
 
         findPreference(getString(R.string.pref_fakekey_startrestore_dirselect)).setOnPreferenceClickListener(preference -> {
-            backupUtils.selectBackupDirIntent();
+            BackupUtils.startAction(this.getActivity(), BackupUtils.StartupAction.RESTORE_OTHER_FOLDER);
             return true;
         });
 
@@ -46,10 +42,9 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
         updateSummary();
 
         findPreference(getString(R.string.pref_backup_backup_history_length)).setOnPreferenceChangeListener((preference, value) -> {
-            backupUtils.deleteBackupHistoryDialog((BackupSeekbarPreference) preference, (int) value, false);
+            BackupUtils.deleteBackupHistoryDialog(getActivity(), (BackupSeekbarPreference) preference, (int) value, false);
             return true;
         });
-
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.SettingsUtils;
 
@@ -48,9 +49,8 @@ public class PreferenceOfflinedataFragment extends BasePreferenceFragment {
         final Preference isDbOnSdCard = findPreference(getString(R.string.pref_dbonsdcard));
         isDbOnSdCard.setPersistent(false);
         isDbOnSdCard.setOnPreferenceClickListener(preference -> {
-            final boolean oldValue = Settings.isDbOnSDCard();
-            DataStore.moveDatabase(getActivity());
-            return oldValue != Settings.isDbOnSDCard();
+            BackupUtils.startAction(getActivity(), BackupUtils.StartupAction.MOVE_DATABASE);
+            return true;
         });
 
         final Preference dataDirPreference = findPreference(getString(R.string.pref_fakekey_dataDir));

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -564,6 +564,7 @@
     <string translatable="false" name="pref_hideVisitedWaypoints">hideVisitedWaypoints</string>
     <string translatable="false" name="pref_cache_filter_config">cache_filter_config</string>
     <string translatable="false" name="pref_cache_sort_config">cache_sort_config</string>
+    <string translatable="false" name="pref_startup_action">startup_action</string>
     <string translatable="false" name="pref_automaticBackupLastCheck">automaticBackupLastCheck</string>
     <string translatable="false" name="pref_dbCleanupLastCheck">dbCleanupLastCheck</string>
     <string translatable="false" name="pref_dbReindexLastCheck">dbReindexLastCheck</string>


### PR DESCRIPTION
rel to #14375: radical approach to move database operations to splash activity

This PR moves all operations in need of a closed DB towards SplashActivity /BackupUtils and allows them only on c:geo startup. This is a rather radical change. Actions are: 
* Auto-Backup
* manual backup
* restore from latest folder
* restore from chosen folder
* moving data from internal to sd card or back

If merged, then all buttons in settings related to such action will only set a flag internally and trigger the following dialog:
![image](https://github.com/cgeo/cgeo/assets/6909759/0ee663da-5aef-4273-9ea9-88994b7c713b)

Then, on next startup, the following dialog will appear:
![image](https://github.com/cgeo/cgeo/assets/6909759/d783c9bc-9d64-4591-a8e2-171ffc134061)

Only here, using this dialog, can the actions actually being executed.

Note that dialogs and GUI are far from finished. Also this change is rather radical and thus should be discussed in the team. For those reasons I mark the PR as draft/WIP
