### PR TITLE
Update GM to latest renderer (when available) ( #12023)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -412,7 +412,7 @@ dependencies {
 
     // Play Services
     implementation 'com.google.android.gms:play-services-location:19.0.1'
-    implementation 'com.google.android.gms:play-services-maps:17.0.1'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
     // somehow there is a transitive play service dependency which we don't want
     configurations.all*.exclude module: "play-services-measurement"
 

--- a/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
@@ -43,6 +43,7 @@ public abstract class AbstractMap {
     public String targetGeocode = null;
     public Geopoint lastNavTarget = null;
     public TargetView targetView;
+    protected volatile boolean latestRenderer = false; // GM specific
 
     protected AbstractMap(@NonNull final MapActivityImpl activity) {
         mapActivity = activity;
@@ -158,4 +159,7 @@ public abstract class AbstractMap {
 
     public abstract MapOptions getMapOptions();
 
+    public void setLatestRenderer(final boolean latestRenderer) {
+        this.latestRenderer = latestRenderer;
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -1615,7 +1615,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     }
 
     private CachesOverlayItemImpl getCacheItem(final Geocache cache, final boolean isDotMode) {
-        final CachesOverlayItemImpl item = mapItemFactory.getCachesOverlayItem(cache, cache.applyDistanceRule());
+        final CachesOverlayItemImpl item = mapItemFactory.getCachesOverlayItem(cache, cache.applyDistanceRule(), latestRenderer);
         if (isDotMode) {
             item.setMarker(MapMarkerUtils.getCacheDotMarker(getResources(), cache));
         } else {
@@ -1625,7 +1625,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     }
 
     private CachesOverlayItemImpl getWaypointItem(final Waypoint waypoint, final boolean isDotMode) {
-        final CachesOverlayItemImpl item = mapItemFactory.getCachesOverlayItem(waypoint, waypoint.applyDistanceRule());
+        final CachesOverlayItemImpl item = mapItemFactory.getCachesOverlayItem(waypoint, waypoint.applyDistanceRule(), latestRenderer);
         if (isDotMode) {
             item.setMarker(MapMarkerUtils.getWaypointDotMarker(getResources(), waypoint));
         } else {

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleCacheOverlayItem.java
@@ -16,10 +16,12 @@ public class GoogleCacheOverlayItem implements CachesOverlayItemImpl, MapObjectO
     private final boolean applyDistanceRule;
     private BitmapDescriptorCache bitmapDescriptorCache;
     private CacheMarker marker;
+    private final boolean setDraggable;
 
-    public GoogleCacheOverlayItem(final IWaypoint coordinate, final boolean applyDistanceRule) {
+    public GoogleCacheOverlayItem(final IWaypoint coordinate, final boolean applyDistanceRule, final boolean setDraggable) {
         this.coord = coordinate;
         this.applyDistanceRule = applyDistanceRule;
+        this.setDraggable = setDraggable;
     }
 
     @Override
@@ -61,7 +63,8 @@ public class GoogleCacheOverlayItem implements CachesOverlayItemImpl, MapObjectO
                 .icon(toBitmapDescriptor(this.marker))
                 .position(toLatLng(coord))
                 .anchor(0.5f, 1)
-                .zIndex((coord instanceof Geocache) ? GoogleCachesList.ZINDEX_GEOCACHE : GoogleCachesList.ZINDEX_WAYPOINT);
+                .zIndex((coord instanceof Geocache) ? GoogleCachesList.ZINDEX_GEOCACHE : GoogleCachesList.ZINDEX_WAYPOINT)
+                .draggable(setDraggable);
 
         if (showCircles && applyDistanceRule) {
             final CircleOptions circle = new CircleOptions()

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -100,16 +100,20 @@ public class GoogleMapActivity extends AbstractNavigationBarActivity implements 
 
     @Override
     public void onMapsSdkInitialized(final MapsInitializer.Renderer renderer) {
+        Log.e("onMapsSdkInitialized");
         switch (renderer) {
             case LATEST:
                 Log.d("GMv2: The latest version of the renderer is used.");
+                mapBase.setLatestRenderer(true);
                 break;
             case LEGACY:
                 Log.d("GMv2: The legacy version of the renderer is used.");
+                mapBase.setLatestRenderer(false);
                 break;
             default:
                 // to make Codacy happy...
                 Log.w("GMv2: Unknown renderer version used, neither LATEST nor LEGACY.");
+                mapBase.setLatestRenderer(false);
                 break;
         }
     }

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
+import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.Intents.ACTION_INVALIDATE_MAPLIST;
 import static cgeo.geocaching.filters.gui.GeocacheFilterActivity.EXTRA_FILTER_CONTEXT;
 import static cgeo.geocaching.maps.google.v2.GoogleMapUtils.isGoogleMapsAvailable;
@@ -40,6 +41,8 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 import org.apache.commons.lang3.StringUtils;
 
 // super calls are handled via mapBase (mapBase.onCreate, mapBase.onSaveInstanceState, ...)
@@ -47,7 +50,7 @@ import org.apache.commons.lang3.StringUtils;
 //       Either merge GoogleMapActivity with CGeoMap
 //       or generify our map handling so that we only have one map activity at all to avoid code duplication
 @SuppressLint("MissingSuperCall")
-public class GoogleMapActivity extends AbstractNavigationBarActivity implements MapActivityImpl, FilteredActivity {
+public class GoogleMapActivity extends AbstractNavigationBarActivity implements MapActivityImpl, FilteredActivity, OnMapsSdkInitializedCallback {
 
     private static final String STATE_ROUTETRACKUTILS = "routetrackutils";
 
@@ -81,6 +84,7 @@ public class GoogleMapActivity extends AbstractNavigationBarActivity implements 
 
     @Override
     public void onCreate(final Bundle icicle) {
+        MapsInitializer.initialize(getApplicationContext(), MapsInitializer.Renderer.LATEST, this);
         mapBase.onCreate(icicle);
         routeTrackUtils = new RouteTrackUtils(this, icicle == null ? null : icicle.getBundle(STATE_ROUTETRACKUTILS), mapBase::centerOnPosition,
                 mapBase::clearIndividualRoute, mapBase::reloadIndividualRoute, mapBase::setTrack, mapBase::isTargetSet);
@@ -92,6 +96,22 @@ public class GoogleMapActivity extends AbstractNavigationBarActivity implements 
                 invalidateOptionsMenu();
             }
         });
+    }
+
+    @Override
+    public void onMapsSdkInitialized(final MapsInitializer.Renderer renderer) {
+        switch (renderer) {
+            case LATEST:
+                Log.d("GMv2: The latest version of the renderer is used.");
+                break;
+            case LEGACY:
+                Log.d("GMv2: The legacy version of the renderer is used.");
+                break;
+            default:
+                // to make Codacy happy...
+                Log.w("GMv2: Unknown renderer version used, neither LATEST nor LEGACY.");
+                break;
+        }
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapItemFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapItemFactory.java
@@ -16,8 +16,8 @@ public class GoogleMapItemFactory implements MapItemFactory {
     }
 
     @Override
-    public CachesOverlayItemImpl getCachesOverlayItem(final IWaypoint coordinate, final boolean applyDistanceRule) {
-        final GoogleCacheOverlayItem item = new GoogleCacheOverlayItem(coordinate, applyDistanceRule);
+    public CachesOverlayItemImpl getCachesOverlayItem(final IWaypoint coordinate, final boolean applyDistanceRule, final boolean setDraggable) {
+        final GoogleCacheOverlayItem item = new GoogleCacheOverlayItem(coordinate, applyDistanceRule, setDraggable);
         item.setBitmapDescriptorCache(bitmapDescriptorCache);
         return item;
     }

--- a/main/src/main/java/cgeo/geocaching/maps/interfaces/MapItemFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/interfaces/MapItemFactory.java
@@ -7,6 +7,6 @@ public interface MapItemFactory {
 
     GeoPointImpl getGeoPointBase(Geopoint coords);
 
-    CachesOverlayItemImpl getCachesOverlayItem(IWaypoint iWaypoint, boolean applyDistanceRule);
+    CachesOverlayItemImpl getCachesOverlayItem(IWaypoint iWaypoint, boolean applyDistanceRule, boolean setDraggable);
 
 }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapItemFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapItemFactory.java
@@ -17,7 +17,7 @@ public class MapsforgeMapItemFactory implements MapItemFactory {
     }
 
     @Override
-    public CachesOverlayItemImpl getCachesOverlayItem(final IWaypoint coordinate, final boolean applyDistanceRule) {
+    public CachesOverlayItemImpl getCachesOverlayItem(final IWaypoint coordinate, final boolean applyDistanceRule, final boolean setDraggable) {
         return null;
         // @todo
         // return new MapsforgeCacheOverlayItem(coordinate, applyDistanceRule);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractGoogleTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractGoogleTileProvider.java
@@ -3,12 +3,15 @@ package cgeo.geocaching.unifiedmap.tileproviders;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.unifiedmap.AbstractMapFragment;
 import cgeo.geocaching.unifiedmap.googlemaps.GoogleMapsFragment;
+import cgeo.geocaching.utils.Log;
 
 import androidx.annotation.StringRes;
 
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
 
-public class AbstractGoogleTileProvider extends AbstractTileProvider {
+public class AbstractGoogleTileProvider extends AbstractTileProvider implements OnMapsSdkInitializedCallback {
 
     final int mapType;
 
@@ -26,7 +29,23 @@ public class AbstractGoogleTileProvider extends AbstractTileProvider {
 
     @Override
     public AbstractMapFragment createMapFragment() {
+        MapsInitializer.initialize(CgeoApplication.getInstance(), MapsInitializer.Renderer.LATEST, this);
         return new GoogleMapsFragment();
     }
 
+    @Override
+    public void onMapsSdkInitialized(final MapsInitializer.Renderer renderer) {
+        switch (renderer) {
+            case LATEST:
+                Log.d("GMv2: The latest version of the renderer is used.");
+                break;
+            case LEGACY:
+                Log.d("GMv2: The legacy version of the renderer is used.");
+                break;
+            default:
+                // to make Codacy happy...
+                Log.w("GMv2: Unknown renderer version used, neither LATEST nor LEGACY.");
+                break;
+        }
+    }
 }


### PR DESCRIPTION
## Description
- Updates Google Maps rendering engine
- comes with a mitigation for long-tap function to avoid #14534

TODO: needs to toggle `draggable` property on cache markers depending on renderer type, therefore setting draft state for now