### PR TITLE
rel to #14514: redesign GUI for image edit

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -732,7 +732,7 @@
             android:windowSoftInputMode="stateHidden" >
         </activity>
         <activity
-            android:name=".ImageSelectActivity"
+            android:name=".ImageEditActivity"
             android:label="@string/log_image" >
         </activity>
 

--- a/main/src/main/java/cgeo/geocaching/ImageEditActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ImageEditActivity.java
@@ -1,12 +1,9 @@
 package cgeo.geocaching;
 
 import cgeo.geocaching.activity.AbstractActionBarActivity;
-import cgeo.geocaching.databinding.ImageselectActivityBinding;
-import cgeo.geocaching.enumerations.LoadFlags;
-import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.databinding.ImageeditActivityBinding;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.ImageActivityHelper;
 import cgeo.geocaching.ui.TextSpinner;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -17,7 +14,8 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.View;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,32 +23,29 @@ import androidx.annotation.Nullable;
 import java.util.Arrays;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 
-public class ImageSelectActivity extends AbstractActionBarActivity {
-    private ImageselectActivityBinding binding;
+public class ImageEditActivity extends AbstractActionBarActivity {
+    private ImageeditActivityBinding binding;
 
     private final TextSpinner<Integer> imageScale = new TextSpinner<>();
 
     private static final int RC_EDIT_IMAGE_EXTERNAL = 50;
 
     private static final String SAVED_STATE_IMAGE = "cgeo.geocaching.saved_state_image";
-    private static final String SAVED_STATE_ORIGINAL_IMAGE = "cgeo.geocaching.saved_state_original_image";
+    private static final String SAVED_STATE_ORIGINAL_IMAGE_URI = "cgeo.geocaching.saved_state_original_image_uri";
     private static final String SAVED_STATE_IMAGE_INDEX = "cgeo.geocaching.saved_state_image_index";
     private static final String SAVED_STATE_IMAGE_SCALE = "cgeo.geocaching.saved_state_image_scale";
     private static final String SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE = "cgeo.geocaching.saved_state_max_image_upload_size";
-    private static final String SAVED_STATE_IMAGE_CAPTION_MANDATORY = "cgeo.geocaching.saved_state_image_caption_mandatory";
     private static final String SAVED_STATE_GEOCODE = "cgeo.geocaching.saved_state_geocode";
     private static final String SAVED_STATE_IMAGEHELPER = "cgeo.geocaching.saved_state_imagehelper";
-
 
     private Uri originalImageUri;
     private Image image;
     private int imageIndex = -1;
     private long maxImageUploadSize;
-    private boolean imageCaptionMandatory;
+
     @Nullable private String geocode;
 
     private final ImageActivityHelper imageActivityHelper = new ImageActivityHelper(this, (rc, imgs, uk) -> {
@@ -63,12 +58,14 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setThemeAndContentView(R.layout.imageselect_activity);
-        binding = ImageselectActivityBinding.bind(findViewById(R.id.imageselect_activity_viewroot));
+        setThemeAndContentView(R.layout.imageedit_activity);
+        binding = ImageeditActivityBinding.bind(findViewById(R.id.imageselect_activity_viewroot));
 
         imageScale.setSpinner(findViewById(R.id.logImageScale))
                 .setValues(Arrays.asList(ArrayUtils.toObject(getResources().getIntArray(R.array.log_image_scale_values))))
                 .setChangeListener(Settings::setLogImageScale);
+
+        setTitle(getString(R.string.log_edit_image));
 
         // Get parameters from intent and basic cache information from database
         final Bundle extras = getIntent().getExtras();
@@ -77,31 +74,17 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
             originalImageUri = image == null ? null : image.uri;
             imageIndex = extras.getInt(Intents.EXTRA_INDEX, -1);
             maxImageUploadSize = extras.getLong(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE);
-            imageCaptionMandatory = extras.getBoolean(Intents.EXTRA_IMAGE_CAPTION_MANDATORY);
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
 
-            //try to find a good title from what we got
-            final String context = extras.getString(Intents.EXTRA_GEOCODE);
-            if (StringUtils.isBlank(context)) {
-                setTitle(getString(R.string.cache_image));
-            } else {
-                final Geocache cache = DataStore.loadCache(context, LoadFlags.LOAD_CACHE_OR_DB);
-                if (cache != null) {
-                    setCacheTitleBar(cache);
-                } else {
-                    setTitle(context + ": " + getString(R.string.cache_image));
-                }
-            }
         }
 
         // Restore previous state
         if (savedInstanceState != null) {
             image = savedInstanceState.getParcelable(SAVED_STATE_IMAGE);
-            originalImageUri = savedInstanceState.getParcelable(SAVED_STATE_ORIGINAL_IMAGE);
+            originalImageUri = savedInstanceState.getParcelable(SAVED_STATE_ORIGINAL_IMAGE_URI);
             imageIndex = savedInstanceState.getInt(SAVED_STATE_IMAGE_INDEX, -1);
             imageScale.set(savedInstanceState.getInt(SAVED_STATE_IMAGE_SCALE));
             maxImageUploadSize = savedInstanceState.getLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE);
-            imageCaptionMandatory = savedInstanceState.getBoolean(SAVED_STATE_IMAGE_CAPTION_MANDATORY);
             geocode = savedInstanceState.getString(SAVED_STATE_GEOCODE);
             imageActivityHelper.setState(savedInstanceState.getBundle(SAVED_STATE_IMAGEHELPER));
         }
@@ -130,12 +113,28 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
             Dialogs.moveCursorToEnd(binding.caption);
         }
 
-        binding.save.setOnClickListener(v -> saveImageInfo(true, false));
-        binding.cancel.setOnClickListener(v -> saveImageInfo(false, false));
-        binding.delete.setOnClickListener(v -> saveImageInfo(false, true));
-        binding.delete.setVisibility(imageIndex >= 0 ? View.VISIBLE : View.GONE);
-
         loadImagePreview();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.menu_ok_cancel, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        final int itemId = item.getItemId();
+        if (itemId == R.id.menu_item_cancel) {
+            finishEdit(false);
+        } else if (itemId == R.id.menu_item_save) {
+            finishEdit(true);
+        } else {
+            return super.onOptionsItemSelected(item);
+        }
+        return true;
+
     }
 
     @Override
@@ -143,16 +142,15 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
         super.onSaveInstanceState(outState);
         syncEditTexts();
         outState.putParcelable(SAVED_STATE_IMAGE, image);
-        outState.putParcelable(SAVED_STATE_ORIGINAL_IMAGE, originalImageUri);
+        outState.putParcelable(SAVED_STATE_ORIGINAL_IMAGE_URI, originalImageUri);
         outState.putInt(SAVED_STATE_IMAGE_INDEX, imageIndex);
         outState.putInt(SAVED_STATE_IMAGE_SCALE, imageScale.get());
         outState.putLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
-        outState.putBoolean(SAVED_STATE_IMAGE_CAPTION_MANDATORY, imageCaptionMandatory);
         outState.putString(SAVED_STATE_GEOCODE, geocode);
         outState.putBundle(SAVED_STATE_IMAGEHELPER, imageActivityHelper.getState());
     }
 
-    public void saveImageInfo(final boolean saveInfo, final boolean deleteImage) {
+    public void finishEdit(final boolean saveInfo) {
         if (saveInfo) {
 
             final Intent intent = new Intent();
@@ -161,14 +159,6 @@ public class ImageSelectActivity extends AbstractActionBarActivity {
             intent.putExtra(Intents.EXTRA_INDEX, imageIndex);
             //"originalImageUri" is now obsolete. But we never delete originalImage (in case log gets not stored)
             setResult(RESULT_OK, intent);
-            finish();
-        } else if (deleteImage) {
-            final Intent intent = new Intent();
-            intent.putExtra(Intents.EXTRA_DELETE_FLAG, true);
-            intent.putExtra(Intents.EXTRA_INDEX, imageIndex);
-            setResult(RESULT_OK, intent);
-            deleteImageFromDeviceIfNotOriginal();
-            //original image is now obsolete. BUt we never delete original Image (in case log gets not stored)
             finish();
         } else {
             deleteImageFromDeviceIfNotOriginal();

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -26,10 +26,8 @@ public class Intents {
     public static final String EXTRA_INDEX = PREFIX + "index";
     public static final String EXTRA_CLASS = PREFIX + "class";
     public static final String EXTRA_FIELD = PREFIX + "field";
-    public static final String EXTRA_DELETE_FLAG = PREFIX + "deleteflag";
     public static final String EXTRA_IMAGES = PREFIX + "images";
     public static final String EXTRA_MAX_IMAGE_UPLOAD_SIZE = PREFIX + "max-image-upload-size";
-    public static final String EXTRA_IMAGE_CAPTION_MANDATORY = PREFIX + "image-caption-mandatory";
     public static final String EXTRA_ID = PREFIX + "id";
     public static final String EXTRA_KEYWORD = PREFIX + "keyword";
     public static final String EXTRA_KEYWORD_SEARCH = PREFIX + "keyword_search";

--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -503,8 +503,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
             } else {
                 Toast.makeText(this, R.string.cache_empty_log, Toast.LENGTH_LONG).show();
             }
-        } else if (itemId == R.id.menu_image) {
-            imageListFragment.startAddImageDialog();
         } else if (itemId == R.id.save) {
             finish(SaveMode.FORCE);
         } else if (itemId == R.id.clear) {
@@ -594,7 +592,6 @@ public class LogCacheActivity extends AbstractLoggingActivity {
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);
-        menu.findItem(R.id.menu_image).setVisible(cache.supportsLogImages());
         menu.findItem(R.id.save).setVisible(true);
         menu.findItem(R.id.clear).setVisible(true);
         menu.findItem(R.id.menu_sort_trackables_by).setVisible(true);

--- a/main/src/main/java/cgeo/geocaching/ui/ImageActivityHelper.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageActivityHelper.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.ImageUtils;
+import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Action3;
 
 import android.app.Activity;
@@ -267,12 +268,20 @@ public class ImageActivityHelper {
      * Helper function to load and scale an image asynchronously into a view
      */
     public static void displayImageAsync(final Image image, final ImageView imageView) {
+        displayImageAsync(image, imageView, null);
+    }
+
+    public static void displayImageAsync(final Image image, final ImageView imageView, final Action1<ImageView> resetAction) {
+
         if (image.isEmpty()) {
             return;
         }
         imageView.setVisibility(View.INVISIBLE);
         AndroidRxUtils.andThenOnUi(AndroidRxUtils.computationScheduler, () -> ImageUtils.readAndScaleImageToFitDisplay(image.getUri()), bitmap -> {
             imageView.setImageBitmap(bitmap);
+            if (resetAction != null) {
+                resetAction.call(imageView);
+            }
             imageView.setVisibility(View.VISIBLE);
         });
     }

--- a/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
@@ -1,6 +1,6 @@
 package cgeo.geocaching.ui;
 
-import cgeo.geocaching.ImageSelectActivity;
+import cgeo.geocaching.ImageEditActivity;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
@@ -105,11 +105,8 @@ public class ImageListFragment extends Fragment {
             if (resultCode == RESULT_OK) {
                 final int imageIndex = data.getIntExtra(Intents.EXTRA_INDEX, -1);
                 final boolean indexIsValid = imageIndex >= 0 && imageIndex < imageList.getItemCount();
-                final boolean deleteFlag = data.getBooleanExtra(Intents.EXTRA_DELETE_FLAG, false);
                 final Image image = data.getParcelableExtra(Intents.EXTRA_IMAGE);
-                if (deleteFlag && indexIsValid) {
-                    imageList.removeItem(imageIndex);
-                } else if (image != null && indexIsValid) {
+                if (image != null && indexIsValid) {
                     imageList.updateItem(image, imageIndex);
                 } else if (image != null) {
                     imageList.addItem(image);
@@ -292,14 +289,13 @@ public class ImageListFragment extends Fragment {
      * internally start the detail image edit dialog
      */
     private void addOrEditImage(final int imageIndex) {
-        final Intent selectImageIntent = new Intent(this.getActivity(), ImageSelectActivity.class);
+        final Intent selectImageIntent = new Intent(this.getActivity(), ImageEditActivity.class);
         if (imageIndex >= 0 && imageIndex < imageList.getItemCount()) {
             selectImageIntent.putExtra(Intents.EXTRA_IMAGE, imageList.getItem(imageIndex));
         }
         selectImageIntent.putExtra(Intents.EXTRA_INDEX, imageIndex);
         selectImageIntent.putExtra(Intents.EXTRA_GEOCODE, geocode);
         selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
-        selectImageIntent.putExtra(Intents.EXTRA_IMAGE_CAPTION_MANDATORY, captionMandatory);
 
         getActivity().startActivityForResult(selectImageIntent, SELECT_IMAGE);
     }

--- a/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
@@ -279,13 +279,6 @@ public class ImageListFragment extends Fragment {
     }
 
     /**
-     * trigger the start of the detailed "add image" dialog
-     */
-    public void startAddImageDialog() {
-        addOrEditImage(-1);
-    }
-
-    /**
      * internally start the detail image edit dialog
      */
     private void addOrEditImage(final int imageIndex) {

--- a/main/src/main/res/layout/imageedit_activity.xml
+++ b/main/src/main/res/layout/imageedit_activity.xml
@@ -17,38 +17,26 @@
 
         <ImageView
             android:id="@+id/image_preview"
-            android:scaleType="centerInside"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:scaleType="fitCenter"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
             android:layout_marginBottom="5dip"
             android:layout_marginTop="5dip"
-            android:background="#000000"
+            android:layout_gravity="center_horizontal"
+            android:background="@android:color/transparent"
             android:padding="1dp"
             android:visibility="gone"
             tools:visibility="visible"/>
 
         <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-
-            <Button
-                android:id="@+id/image_stored"
-                style="@style/button_icon"
-                android:layout_gravity="left"
-                app:icon="@drawable/ic_menu_image" />
-
-            <Button
-                android:id="@+id/image_camera"
-                style="@style/button_icon"
-                android:layout_gravity="left"
-                android:layout_toRightOf="@+id/image_stored"
-                app:icon="@drawable/ic_menu_camera" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal">
 
             <Button
                 android:id="@+id/image_rotate"
                 style="@style/button_icon"
                 android:layout_gravity="left"
-                android:layout_toRightOf="@+id/image_camera"
                 android:layout_marginLeft="50dp"
                 app:icon="@drawable/ic_menu_rotate_right" />
 
@@ -74,6 +62,7 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:prompt="@string/log_image_scale"
+            android:paddingVertical="10dp"
             tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout

--- a/main/src/main/res/layout/imageedit_activity.xml
+++ b/main/src/main/res/layout/imageedit_activity.xml
@@ -8,47 +8,24 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:padding="4dip"
-    tools:context=".ImageSelectActivity">
+    tools:context=".ImageEditActivity">
 
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical" >
 
-        <RelativeLayout style="@style/separator_horizontal_layout" >
-            <View style="@style/separator_horizontal_heading" />
-            <TextView
-                style="@style/separator_horizontal_heading_text"
-                android:text="@string/log_image" />
-        </RelativeLayout>
-
-        <LinearLayout
-            android:layout_width="fill_parent"
+        <ImageView
+            android:id="@+id/image_preview"
+            android:scaleType="centerInside"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal" >
-
-            <Button
-                android:id="@+id/delete"
-                style="@style/button_full"
-                android:layout_width="0dip"
-                android:layout_weight="1"
-                android:text="@string/log_image_delete" />
-
-            <Button
-                android:id="@+id/cancel"
-                style="@style/button_full"
-                android:layout_width="0dip"
-                android:layout_weight="1"
-                android:text="@string/cancel" />
-
-            <Button
-                android:id="@+id/save"
-                style="@style/button_full"
-                android:layout_width="0dip"
-                android:layout_weight="1"
-                android:text="@string/ok" />
-
-        </LinearLayout>
+            android:layout_marginBottom="5dip"
+            android:layout_marginTop="5dip"
+            android:background="#000000"
+            android:padding="1dp"
+            android:visibility="gone"
+            tools:visibility="visible"/>
 
         <RelativeLayout
             android:layout_width="fill_parent"
@@ -92,17 +69,12 @@
 
         </RelativeLayout>
 
-        <ImageView
-            android:id="@+id/image_preview"
-            android:scaleType="centerInside"
-            android:layout_width="match_parent"
+        <Spinner
+            android:id="@+id/logImageScale"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="5dip"
-            android:layout_marginTop="5dip"
-            android:background="#000000"
-            android:padding="1dp"
-            android:visibility="gone"
-            tools:visibility="visible"/>
+            android:prompt="@string/log_image_scale"
+            tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout
             style="@style/textinput_edittext_singleline"
@@ -133,13 +105,6 @@
                 android:maxLength="250"
                 android:minLines="5" />
         </com.google.android.material.textfield.TextInputLayout>
-
-        <Spinner
-            android:id="@+id/logImageScale"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:prompt="@string/log_image_scale"
-            tools:listitem="@android:layout/simple_spinner_item" />
 
     </LinearLayout>
 

--- a/main/src/main/res/menu/abstract_logging_activity.xml
+++ b/main/src/main/res/menu/abstract_logging_activity.xml
@@ -16,13 +16,6 @@
         <menu /> <!-- filled dynamically -->
     </item>
     <item
-        android:id="@+id/menu_image"
-        android:icon="@drawable/ic_menu_attachment"
-        android:title="@string/log_image_attach"
-        android:visible="false"
-        app:showAsAction="ifRoom|withText">
-    </item>
-    <item
         android:id="@+id/menu_smileys"
         android:icon="@drawable/ic_menu_emoticons"
         android:title="@string/log_smilies"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -176,10 +176,8 @@
     <string name="log_smilies">Smilies</string>
     <string name="log_image">Image</string>
     <string name="log_images">Images</string>
+    <string name="log_edit_image">Edit Image</string>
     <string name="log_image_attach">Attach Image</string>
-    <string name="log_image_stored">Existing</string>
-    <string name="log_image_camera">New</string>
-    <string name="log_image_delete">Delete</string>
     <string name="log_image_caption">Caption</string>
     <string name="log_image_description">Description</string>
     <string name="log_image_scale">Scaling</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -176,8 +176,7 @@
     <string name="log_smilies">Smilies</string>
     <string name="log_image">Image</string>
     <string name="log_images">Images</string>
-    <string name="log_edit_image">Edit Image</string>
-    <string name="log_image_attach">Attach Image</string>
+    <string name="log_edit_image">Edit image</string>
     <string name="log_image_caption">Caption</string>
     <string name="log_image_description">Description</string>
     <string name="log_image_scale">Scaling</string>


### PR DESCRIPTION
rel to #14514: redesign GUI for image edit

Following the layout discussed in the issue, when merging this PR layout will look like this:
* "delete" was removed completely, "ok/cancel" was moved into action bar using symbols
* title was changed from cache title to constant "edit image"
* order of input elements was changed to the order suggested in issue

![image](https://github.com/cgeo/cgeo/assets/6909759/afc823f3-8c1c-4cd6-ad45-0efbc247bff6)

