### PR TITLE
optimize lint configuration

### DIFF
--- a/main/lint.xml
+++ b/main/lint.xml
@@ -22,6 +22,11 @@
 
     <issue id="IconDensities" severity="ignore" />
 
+    <issue id="IconDuplicates" severity="ignore">
+        <!-- planned duplicate -->
+        <ignore path="src/main/res/drawable-xhdpi/attribute_kids*.png" />
+    </issue>
+
     <!-- unfinished localizations are okay since we always have English as fallback -->
     <issue id="MissingTranslation" severity="ignore" />
     <!-- old translation will be deleted by the next crowdin import -->

--- a/main/lint.xml
+++ b/main/lint.xml
@@ -56,9 +56,6 @@
         <!-- changelog files are referenced depending of release phase -->
         <ignore path="src/main/res/raw/changelog_*.md" />
 
-        <!-- part of the internal brouter -->
-        <ignore path="src/main/res/raw/routing_dummy.brf" />
-
         <!-- translations no longer used -->
         <ignore path="src/main/res/values-*/strings.xml" />
 

--- a/main/lint.xml
+++ b/main/lint.xml
@@ -48,38 +48,24 @@
 
     <!-- resources loaded by dynamic name lookup -->
     <issue id="UnusedResources">
-        <!-- used for notification system -->
-        <ignore path="res/drawable-xhdpi/attribute_maintenance.png" />
+        <!-- changelog files are referenced depending of release phase -->
+        <ignore path="src/main/res/raw/changelog_*.md" />
+
+        <!-- part of the internal brouter -->
+        <ignore path="src/main/res/raw/routing_dummy.brf" />
 
         <!-- translations no longer used -->
-        <ignore path="res/values-*/strings.xml" />
+        <ignore path="src/main/res/values-*/strings.xml" />
+
+        <!-- used for notification system -->
+        <ignore path="src/main/res/drawable-xhdpi/attribute_maintenance.png" />
 
         <!-- cache rating markers (drawables and color values used by the drawables) -->
-        <ignore path="res/drawable/marker_rating_d_0.xml" />
-        <ignore path="res/drawable/marker_rating_d_5.xml" />
-        <ignore path="res/drawable/marker_rating_d_10.xml" />
-        <ignore path="res/drawable/marker_rating_d_15.xml" />
-        <ignore path="res/drawable/marker_rating_d_20.xml" />
-        <ignore path="res/drawable/marker_rating_d_25.xml" />
-        <ignore path="res/drawable/marker_rating_d_30.xml" />
-        <ignore path="res/drawable/marker_rating_d_35.xml" />
-        <ignore path="res/drawable/marker_rating_d_40.xml" />
-        <ignore path="res/drawable/marker_rating_d_45.xml" />
-        <ignore path="res/drawable/marker_rating_d_50.xml" />
-        <ignore path="res/drawable/marker_rating_t_0.xml" />
-        <ignore path="res/drawable/marker_rating_t_5.xml" />
-        <ignore path="res/drawable/marker_rating_t_10.xml" />
-        <ignore path="res/drawable/marker_rating_t_15.xml" />
-        <ignore path="res/drawable/marker_rating_t_20.xml" />
-        <ignore path="res/drawable/marker_rating_t_25.xml" />
-        <ignore path="res/drawable/marker_rating_t_30.xml" />
-        <ignore path="res/drawable/marker_rating_t_35.xml" />
-        <ignore path="res/drawable/marker_rating_t_40.xml" />
-        <ignore path="res/drawable/marker_rating_t_45.xml" />
-        <ignore path="res/drawable/marker_rating_t_50.xml" />
+        <ignore path="src/main/res/drawable/marker_rating_*.xml" />
         <ignore regexp="R\.color\.marker_rating_[0-5]{1,2}" />
+
         <!-- defined in build.gradle android.buildTypes.manifestPlaceholders -->
-        <ignore path="res/*/ic_launcher_*round.xml" />
+        <ignore path="src/main/res/*/ic_launcher_*round.xml" />
     </issue>
 
     <issue id="MissingDefaultResource" severity="informational"/>


### PR DESCRIPTION
- change paths to changed c:geo "main" structure
- add ignore filter for changelog files
- compact filter for rating files
- add an IconDuplicates ignore entry

@moving-bits Adding the routing_dummy.brf file to c:geo source was intentional, wasn't it?
@ztNFny Using the same attributes_kids* file was  intentional, wasn't it?