### PR TITLE
avoid mkdir 'error' message "File exists" on CI

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -639,7 +639,7 @@ tasks.register('copyDefaultPreferencesToAndroid') {
                 }
                 project.exec {
                     executable = project.android.getAdbExe().toString()
-                    args = ['shell', 'run-as', 'cgeo.geocaching', 'mkdir', '/data/data/cgeo.geocaching/shared_prefs/']
+                    args = ['shell', 'run-as', 'cgeo.geocaching', 'mkdir', '-p', '/data/data/cgeo.geocaching/shared_prefs/']
                 }
                 project.exec {
                     executable = project.android.getAdbExe().toString()


### PR DESCRIPTION
see eg. from CI:
~~~
22:08:37  emulator-5554 shell run-as cgeo.geocaching mkdir /data/data/cgeo.geocaching/shared_prefs/ ...
22:08:37  Process 'command '/opt/android-sdk-linux/platform-tools/adb'' finished with non-zero exit value 1mkdir: '/data/data/cgeo.geocaching/shared_prefs/': File exists
~~~
