### PR TITLE
Navigate up when using back key

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
@@ -30,7 +30,7 @@ public class DownloaderTest {
     private static int count(final List<Download> list, final boolean isDir) {
         int i = 0;
         for (Download d : list) {
-            if (d.getIsDir() == isDir) {
+            if (d.isDir() == isDir) {
                 i++;
             }
         }
@@ -55,7 +55,7 @@ public class DownloaderTest {
         assertThat(list.size()).isBetween(53, 57);
 
         // first entry has to be the "up" entry
-        assertThat(list.get(0).getIsDir()).isTrue();
+        assertThat(list.get(0).isDir()).isTrue();
 
         // number of dirs found
         assertThat(count(list, true)).isEqualTo(5);
@@ -79,7 +79,7 @@ public void testOpenAndroMaps() {
         assertThat(list.size()).isBetween(55, 65);
 
         // first entry has to be the "up" entry
-        assertThat(list.get(0).getIsDir()).isTrue();
+        assertThat(list.get(0).isDir()).isTrue();
 
         // number of dirs found
         assertThat(count(list, true)).isEqualTo(1);

--- a/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -28,7 +28,6 @@ public abstract class AbstractDownloader {
     public final String projectUrl;
     public final String likeItUrl;
     public final PersistableFolder targetFolder;
-    public static final String oneDirUp = CgeoApplication.getInstance().getString(R.string.downloadmap_onedirup);
     public String forceExtension = "";
     public boolean useCompanionFiles = true; // store source info (uri etc.) in companion files (true) or use date/timestamp and identical uri only (false)?
     @DrawableRes public int iconRes = R.drawable.ic_menu_save;
@@ -69,7 +68,7 @@ public abstract class AbstractDownloader {
                 final String oneUp = uri.toString();
                 final int endOfPreviousSegment = oneUp.lastIndexOf("/", oneUp.length() - 2); // skip trailing "/"
                 if (endOfPreviousSegment > -1) {
-                    final Download offlineMap = new Download(oneDirUp, Uri.parse(oneUp.substring(0, endOfPreviousSegment + 1)), true, "", "", offlineMapType, ICONRES_FOLDER);
+                    final Download offlineMap = new Download(Uri.parse(oneUp.substring(0, endOfPreviousSegment + 1)), offlineMapType);
                     list.add(offlineMap);
                 }
             }

--- a/main/src/main/java/cgeo/geocaching/downloader/DownloadSelectorActivity.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloadSelectorActivity.java
@@ -20,6 +20,7 @@ import android.database.Cursor;
 import android.database.CursorIndexOutOfBoundsException;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -83,9 +84,9 @@ public class DownloadSelectorActivity extends AbstractActionBarActivity {
             final Download offlineMap = activity.getQueries().get(position);
             holder.binding.label.setText(offlineMap.getName());
             holder.binding.progressHorizontal.setVisibility(View.GONE);
-            if (offlineMap.getIsDir()) {
+            if (offlineMap.isDir()) {
                 holder.binding.info.setText(R.string.downloadmap_directory);
-                holder.binding.action.setImageResource(R.drawable.downloader_folder);
+                holder.binding.action.setImageResource(offlineMap.isBackDir() ? R.drawable.downloader_folder_back : R.drawable.downloader_folder);
                 holder.binding.getRoot().setOnClickListener(v -> new DownloadSelectorMapListTask(activity, offlineMap.getUri(), offlineMap.getName(), current, lastCompanionType, lastCompanionList, activity::setLastCompanions, activity::onMapListTaskPostExecuteInternal).execute());
             } else {
                 final int typeResId = offlineMap.getType().getTypeNameResId();
@@ -221,6 +222,27 @@ public class DownloadSelectorActivity extends AbstractActionBarActivity {
                 ShareUtils.openUrl(this, current.projectUrl);
             }
         });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onBackPressed() {
+        // navigate one level back instead of leaving the activity if possible
+        for (Download offlineMap : maps) {
+            if (offlineMap.isBackDir()) {
+                new DownloadSelectorMapListTask(this, offlineMap.getUri(), offlineMap.getName(), current, lastCompanionType, lastCompanionList, this::setLastCompanions, this::onMapListTaskPostExecuteInternal).execute();
+                return;
+            }
+        }
+        super.onBackPressed();
     }
 
     private void changeSource(final int position) {

--- a/main/src/main/java/cgeo/geocaching/models/Download.java
+++ b/main/src/main/java/cgeo/geocaching/models/Download.java
@@ -33,6 +33,7 @@ public class Download {
     private final String name;
     private final Uri uri;
     private final boolean isDir;
+    private final boolean isBackDir; // virtual folder type for back navigation
     private final long dateInfo;
     private final String sizeInfo;
     private String addInfo;
@@ -44,6 +45,7 @@ public class Download {
         this.name = CompanionFileUtils.getDisplayName(name);
         this.uri = uri;
         this.isDir = isDir;
+        this.isBackDir = false;
         this.sizeInfo = sizeInfo;
         this.addInfo = "";
         this.dateInfo = CalendarUtils.parseYearMonthDay(dateISO);
@@ -57,11 +59,24 @@ public class Download {
         this.name = CompanionFileUtils.getDisplayName(pendingDownload.getFilename());
         this.uri = Uri.parse(pendingDownload.getRemoteUrl());
         this.isDir = false;
+        this.isBackDir = false;
         this.sizeInfo = "";
         this.addInfo = "";
         this.dateInfo = pendingDownload.getDate();
         this.type = desc == null ? DownloadType.DOWNLOADTYPE_ALL_MAPRELATED : desc.type;
         this.iconRes = R.drawable.ic_menu_file;
+    }
+
+    public Download(final Uri navigateUpUri, final DownloadType type) {
+        this.name = CgeoApplication.getInstance().getString(R.string.downloadmap_onedirup);
+        this.uri = navigateUpUri;
+        this.isDir = true;
+        this.isBackDir = true;
+        this.sizeInfo = "";
+        this.addInfo = "";
+        this.dateInfo = 0;
+        this.type = type;
+        this.iconRes = 0;
     }
 
     public String getName() {
@@ -72,8 +87,12 @@ public class Download {
         return uri;
     }
 
-    public boolean getIsDir() {
+    public boolean isDir() {
         return isDir;
+    }
+
+    public boolean isBackDir() {
+        return isBackDir;
     }
 
     public String getDateInfoAsString() {

--- a/main/src/main/res/drawable/downloader_folder_back.xml
+++ b/main/src/main/res/drawable/downloader_folder_back.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20,6h-8l-2,-2H4C2.9,4 2,4.9 2,6v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V8C22,6.9 21.1,6 20,6zM20,18H4V6h5.17l2,2H20V18zM13.41,15.59L12,17l-4,-4l4,-4l1.41,1.41L11.83,12H16v2h-4.17L13.41,15.59z"/>
+</vector>


### PR DESCRIPTION
Navigate up when using back key and show different icon for "(one level up)" folder.

From time to time, I was struggling with the fact that back key finishes the download activity instead of navigating up. This annoyed my every time so much that I finally fixed this thing.

As I introduced a special `isBackDir` flag anyway, I also gave it a new dedicated icon on the fly:

![grafik](https://github.com/cgeo/cgeo/assets/64581222/09d331dc-9d38-4ff6-beda-9e233dcd7239)
