### PR TITLE
Distinguish between default and extended config mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/PreferenceTextAlwaysShow.java
+++ b/main/src/main/java/cgeo/geocaching/settings/PreferenceTextAlwaysShow.java
@@ -1,0 +1,34 @@
+package cgeo.geocaching.settings;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
+
+/**
+ * Behaves exactly the same as Preference, only needed to have a separate class to compare against
+ */
+
+public class PreferenceTextAlwaysShow extends Preference {
+
+    public PreferenceTextAlwaysShow(final @NonNull Context context) {
+        this(context, null);
+    }
+
+    public PreferenceTextAlwaysShow(final @NonNull Context context, final @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public PreferenceTextAlwaysShow(final @NonNull Context context, final @Nullable AttributeSet attrs, final int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        holder.setDividerAllowedAbove(false);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2337,4 +2337,7 @@ public class Settings {
         return getBoolean(R.string.pref_mapActionbarAutohide, false);
     }
 
+    public static boolean extendedSettingsAreEnabled() {
+        return getBoolean(R.string.pref_extended_settings_enabled, false);
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -342,13 +342,6 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
 
     // search related extensions
 
-    public void rebuildSearchIndex() {
-        synchronized (searchIndex) {
-            searchIndex.clear();
-        }
-        buildSearchIndex();
-    }
-
     private void buildSearchIndex() {
         synchronized (searchIndex) {
             if (searchIndex.size() > 0) {
@@ -438,11 +431,12 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
 
         @Override
         protected Cursor query(@NonNull final String searchTerm) {
+            final boolean showExtended = Settings.extendedSettingsAreEnabled();
             final SettingsSearchSuggestionCursor resultCursor = new SettingsSearchSuggestionCursor();
             if (searchTerm.length() > 2) {
                 synchronized (searchdata) {
                     for (BasePreferenceFragment.PrefSearchDescriptor item : searchdata) {
-                        if (StringUtils.containsIgnoreCase(item.prefTitle, searchTerm) || StringUtils.containsIgnoreCase(item.prefSummary, searchTerm)) {
+                        if ((StringUtils.containsIgnoreCase(item.prefTitle, searchTerm) || StringUtils.containsIgnoreCase(item.prefSummary, searchTerm)) && (showExtended || item.isBasicSetting)) {
                             resultCursor.addItem(item.prefTitle, item.prefSummary, item.prefKey, item.prefCategoryIconRes);
                         }
                     }

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -342,6 +342,13 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
 
     // search related extensions
 
+    public void rebuildSearchIndex() {
+        synchronized (searchIndex) {
+            searchIndex.clear();
+        }
+        buildSearchIndex();
+    }
+
     private void buildSearchIndex() {
         synchronized (searchIndex) {
             if (searchIndex.size() > 0) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -127,6 +127,12 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
         }
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        checkExtendedSettingsVisibility(Settings.extendedSettingsAreEnabled() || this instanceof PreferencesFragment);
+    }
+
     /**
      * searches recursively in all elements of given prefGroup for first occurrence of s
      * returns found preference on success, null else
@@ -151,12 +157,14 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
 
     public void initPreferences(final @XmlRes int preferenceResource, final String rootKey) {
         setPreferencesFromResource(preferenceResource, rootKey);
+        checkExtendedSettingsVisibility(Settings.extendedSettingsAreEnabled() || this instanceof PreferencesFragment);
+    }
+
+    protected void checkExtendedSettingsVisibility(final boolean forceShowAll) {
         lazyInitPreferenceKeys();
-        if (!Settings.extendedSettingsAreEnabled()) {
-            final PreferenceScreen prefScreen = getPreferenceScreen();
-            if (prefScreen != null) {
-                hideExtendedSettings(prefScreen, false);
-            }
+        final PreferenceScreen prefScreen = getPreferenceScreen();
+        if (prefScreen != null) {
+            checkExtendedSettingsVisibilityHelper(prefScreen, forceShowAll);
         }
     }
 
@@ -168,7 +176,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
         }
     }
 
-    private int hideExtendedSettings(final PreferenceGroup start, final boolean forceShowAll) {
+    private int checkExtendedSettingsVisibilityHelper(final PreferenceGroup start, final boolean forceShowAll) {
         // if key of start group is included, all entries below will be included as well
         final boolean showAll = forceShowAll || ArrayUtils.contains(basicPreferences, start.getKey());
         // recursively test all items below
@@ -183,7 +191,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
                 pref.setVisible(false);
             }
             if (pref instanceof PreferenceGroup) {
-                visibleCount += hideExtendedSettings((PreferenceGroup) pref, showAll);
+                visibleCount += checkExtendedSettingsVisibilityHelper((PreferenceGroup) pref, showAll);
             }
         }
         if (visibleCount == 0) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -79,13 +79,15 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
         public CharSequence prefTitle;
         public CharSequence prefSummary;
         public int prefCategoryIconRes;
+        public boolean isBasicSetting;
 
-        PrefSearchDescriptor(final String baseKey, final String prefKey, final CharSequence prefTitle, final CharSequence prefSummary, @DrawableRes final int prefCategoryIconRes) {
+        PrefSearchDescriptor(final String baseKey, final String prefKey, final CharSequence prefTitle, final CharSequence prefSummary, @DrawableRes final int prefCategoryIconRes, final boolean isBasicSetting) {
             this.baseKey = baseKey;
             this.prefKey = prefKey;
             this.prefTitle = prefTitle;
             this.prefSummary = prefSummary;
             this.prefCategoryIconRes = prefCategoryIconRes;
+            this.isBasicSetting = isBasicSetting;
         }
     }
 
@@ -139,7 +141,6 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
      */
     private void doSearch(final String baseKey, final ArrayList<PrefSearchDescriptor> data, final PreferenceGroup start) {
         lazyInitPreferenceKeys();
-        final boolean showAll = Settings.extendedSettingsAreEnabled();
         final int prefCount = start.getPreferenceCount();
         for (int i = 0; i < prefCount; i++) {
             final Preference pref = start.getPreference(i);
@@ -149,9 +150,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
                     pref.setKey(baseKey + "-" + (nextKey++));
                 }
             }
-            if (showAll || ArrayUtils.contains(basicPreferences, pref.getKey()) || pref instanceof PreferenceTextAlwaysShow) {
-                data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary(), icon));
-            }
+            data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary(), icon, ArrayUtils.contains(basicPreferences, pref.getKey()) || pref instanceof PreferenceTextAlwaysShow));
             if (pref instanceof PreferenceGroup) {
                 doSearch(baseKey, data, (PreferenceGroup) pref);
             }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.PreferenceTextAlwaysShow;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Action2;
@@ -47,6 +48,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             // map sources
             R.string.pref_mapsource, R.string.pref_fakekey_info_offline_maps, R.string.pref_fakekey_start_downloader,
             R.string.pref_persistablefolder_offlinemaps,
+            R.string.pref_fakekey_info_offline_mapthemes,
             // map content & behavior
             R.string.pref_maptrail,
             R.string.pref_bigSmileysOnMap, R.string.pref_dtMarkerOnCacheIcon,
@@ -57,10 +59,10 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             // logging
             R.string.pref_signature, R.string.pref_sigautoinsert, R.string.preference_category_logging_logtemplates, R.string.pref_trackautovisit, R.string.pref_log_offline,
             // offline data
-            // @todo: disable whole section
+            // whole section disabled @todo: enable in extended config mode
             // routing / navigation
-            R.string.pref_fakekey_brouterDistanceThresholdTitle,
-            R.string.pref_defaultNavigationTool, R.string.pref_defaultNavigationTool2,
+            R.string.pref_fakekey_brouterDistanceThresholdTitle, R.string.pref_brouterDistanceThreshold,
+            R.string.pref_defaultNavigationTool, R.string.pref_defaultNavigationTool2, R.string.pref_fakekey_navigationMenu,
             // system
             R.string.pref_persistablefolder_basedir,
             R.string.pref_googleplayservices, R.string.pref_lowpowermode, R.string.pref_force_orientation_sensor, R.string.pref_extended_settings_enabled, R.string.pref_debug, R.string.pref_fakekey_generate_logcat, R.string.pref_fakekey_memory_dump, R.string.pref_fakekey_generate_infos_downloadmanager, R.string.pref_fakekey_view_settings,
@@ -174,7 +176,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
         final int prefCount = start.getPreferenceCount();
         for (int i = 0; i < prefCount; i++) {
             final Preference pref = start.getPreference(i);
-            if (showAll || ArrayUtils.contains(basicPreferences, pref.getKey())) {
+            if (showAll || ArrayUtils.contains(basicPreferences, pref.getKey()) || pref instanceof PreferenceTextAlwaysShow) {
                 pref.setVisible(true);
                 visibleCount++;
             } else if (!(pref instanceof PreferenceGroup)) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -38,7 +38,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             // services (all)
             R.string.preference_screen_services,
             // appearance
-            R.string.pref_theme_setting, R.string.pref_wallpaper,
+            R.string.pref_theme_setting,
             R.string.pref_selected_language, R.string.pref_units_imperial,
             R.string.pref_cacheListInfo,
             // cache details
@@ -48,24 +48,23 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             // map sources
             R.string.pref_mapsource, R.string.pref_fakekey_info_offline_maps, R.string.pref_fakekey_start_downloader,
             R.string.pref_persistablefolder_offlinemaps,
-            R.string.pref_fakekey_info_offline_mapthemes,
+            R.string.pref_fakekey_info_offline_mapthemes, R.string.pref_persistablefolder_offlinemapthemes,
             // map content & behavior
             R.string.pref_maptrail,
             R.string.pref_bigSmileysOnMap, R.string.pref_dtMarkerOnCacheIcon,
             R.string.pref_excludeWpOriginal, R.string.pref_excludeWpParking, R.string.pref_excludeWpVisited,
             R.string.pref_longTapOnMap,
             R.string.pref_mapRotation,
-            R.string.pref_proximityDistanceFar, R.string.pref_proximityDistanceNear, R.string.pref_proximityNotificationGeneral, R.string.pref_proximityNotificationSpecific, R.string.pref_proximityNotificationType,
             // logging
             R.string.pref_signature, R.string.pref_sigautoinsert, R.string.preference_category_logging_logtemplates, R.string.pref_trackautovisit, R.string.pref_log_offline,
             // offline data
-            // whole section disabled @todo: enable in extended config mode
+            // whole section disabled in basic mode
             // routing / navigation
             R.string.pref_fakekey_brouterDistanceThresholdTitle, R.string.pref_brouterDistanceThreshold,
             R.string.pref_defaultNavigationTool, R.string.pref_defaultNavigationTool2, R.string.pref_fakekey_navigationMenu,
             // system
             R.string.pref_persistablefolder_basedir,
-            R.string.pref_googleplayservices, R.string.pref_lowpowermode, R.string.pref_force_orientation_sensor, R.string.pref_extended_settings_enabled, R.string.pref_debug, R.string.pref_fakekey_generate_logcat, R.string.pref_fakekey_memory_dump, R.string.pref_fakekey_generate_infos_downloadmanager, R.string.pref_fakekey_view_settings,
+            R.string.pref_extended_settings_enabled, R.string.pref_debug, R.string.pref_fakekey_generate_logcat,
             // backup / restore
             R.string.pref_backup_logins, R.string.pref_fakekey_preference_startbackup, R.string.pref_fakekey_startrestore, R.string.pref_fakekey_startrestore_dirselect
     };

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -139,6 +139,8 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
      * (prefers preference entries over preference groups)
      */
     private void doSearch(final String baseKey, final ArrayList<PrefSearchDescriptor> data, final PreferenceGroup start) {
+        lazyInitPreferenceKeys();
+        final boolean showAll = Settings.extendedSettingsAreEnabled();
         final int prefCount = start.getPreferenceCount();
         for (int i = 0; i < prefCount; i++) {
             final Preference pref = start.getPreference(i);
@@ -148,7 +150,9 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
                     pref.setKey(baseKey + "-" + (nextKey++));
                 }
             }
-            data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary(), icon));
+            if (showAll || ArrayUtils.contains(basicPreferences, pref.getKey()) || pref instanceof PreferenceTextAlwaysShow) {
+                data.add(new PrefSearchDescriptor(baseKey, pref.getKey(), pref.getTitle(), pref.getSummary(), icon));
+            }
             if (pref instanceof PreferenceGroup) {
                 doSearch(baseKey, data, (PreferenceGroup) pref);
             }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -26,7 +26,7 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_appearence, rootKey);
+        initPreferences(R.xml.preferences_appearence, rootKey);
 
         final Preference themePref = findPreference(getString(R.string.pref_theme_setting));
         themePref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceBackupFragment.java
@@ -15,7 +15,7 @@ public class PreferenceBackupFragment extends BasePreferenceFragment {
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_backup, rootKey);
+        initPreferences(R.xml.preferences_backup, rootKey);
 
         final BackupUtils backupUtils = ((SettingsActivity) getActivity()).getBackupUtils();
 

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceCachedetailsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceCachedetailsFragment.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 public class PreferenceCachedetailsFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_cachedetails, rootKey);
+        initPreferences(R.xml.preferences_cachedetails, rootKey);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceLoggingFragment.java
@@ -17,7 +17,7 @@ public class PreferenceLoggingFragment extends BasePreferenceFragment {
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_logging, rootKey);
+        initPreferences(R.xml.preferences_logging, rootKey);
         logTemplatesCategory = findPreference(getString(R.string.preference_category_logging_logtemplates));
     }
 

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
@@ -17,7 +17,7 @@ public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_map_content_behavior, rootKey);
+        initPreferences(R.xml.preferences_map_content_behavior, rootKey);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -28,7 +28,7 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
 
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_map_sources, rootKey);
+        initPreferences(R.xml.preferences_map_sources, rootKey);
         prefMapSources = findPreference(getString(R.string.pref_mapsource));
 
         initMapSourcePreference();

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class PreferenceNavigationFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_navigation, rootKey);
+        initPreferences(R.xml.preferences_navigation, rootKey);
 
         initDefaultNavigationPreferences();
         initOfflineRoutingPreferences();

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceOfflinedataFragment.java
@@ -23,7 +23,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers;
 public class PreferenceOfflinedataFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_offlinedata, rootKey);
+        initPreferences(R.xml.preferences_offlinedata, rootKey);
 
         findPreference(getString(R.string.pref_fakekey_preference_maintenance_directories)).setOnPreferenceClickListener(preference -> {
             // disable the button, as the cleanup runs in background and should not be invoked a second time

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceServicesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceServicesFragment.java
@@ -9,7 +9,7 @@ import android.os.Bundle;
 public class PreferenceServicesFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_services, rootKey);
+        initPreferences(R.xml.preferences_services, rootKey);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.downloader.DownloaderUtils;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.settings.ViewSettingsActivity;
 import cgeo.geocaching.utils.BranchDetectionHelper;
@@ -28,7 +27,6 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
 
         setPrefClick(this, R.string.pref_fakekey_memory_dump, () -> DebugUtils.createMemoryDump(activity));
         setPrefClick(this, R.string.pref_fakekey_generate_logcat, () -> DebugUtils.createLogcat(activity));
-        setPrefClick(this, R.string.pref_fakekey_generate_infos_downloadmanager, () -> DownloaderUtils.dumpDownloadmanagerInfos(activity));
         setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
 
         findPreference(getString(R.string.pref_persistablefolder_testdir)).setVisible(BranchDetectionHelper.isDeveloperBuild());

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -16,7 +16,7 @@ import android.os.Bundle;
 public class PreferenceSystemFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
-        setPreferencesFromResource(R.xml.preferences_system, rootKey);
+        initPreferences(R.xml.preferences_system, rootKey);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -33,6 +33,11 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
 
         findPreference(getString(R.string.pref_persistablefolder_testdir)).setVisible(BranchDetectionHelper.isDeveloperBuild());
 
+        findPreference(getString(R.string.pref_extended_settings_enabled)).setOnPreferenceChangeListener((pref, newValue) -> {
+            checkExtendedSettingsVisibility((boolean) newValue);
+            return true;
+        });
+
         findPreference(getString(R.string.pref_debug)).setOnPreferenceChangeListener((pref, newValue) -> {
             Log.setDebug((Boolean) newValue);
             return true;

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -35,6 +35,7 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
 
         findPreference(getString(R.string.pref_extended_settings_enabled)).setOnPreferenceChangeListener((pref, newValue) -> {
             checkExtendedSettingsVisibility((boolean) newValue);
+            ((SettingsActivity) getActivity()).rebuildSearchIndex();
             return true;
         });
 

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -33,7 +33,6 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
 
         findPreference(getString(R.string.pref_extended_settings_enabled)).setOnPreferenceChangeListener((pref, newValue) -> {
             checkExtendedSettingsVisibility((boolean) newValue);
-            ((SettingsActivity) getActivity()).rebuildSearchIndex();
             return true;
         });
 

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferencesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferencesFragment.java
@@ -1,12 +1,28 @@
 package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 
 import android.os.Bundle;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
 
 public class PreferencesFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
         setPreferencesFromResource(R.xml.preferences, rootKey);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        final PreferenceScreen prefScreen = getPreferenceScreen();
+        if (prefScreen != null) {
+            final Preference pref = prefScreen.findPreference(getString(R.string.preference_menu_offlinedata));
+            if (pref != null) {
+                pref.setEnabled(Settings.extendedSettingsAreEnabled());
+            }
+        }
     }
 }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -319,6 +319,7 @@
     <!-- categories default navigation / secondary navigation -->
     <string translatable="false" name="pref_defaultNavigationTool">defaultNavigationTool</string>
     <string translatable="false" name="pref_defaultNavigationTool2">defaultNavigationTool2</string>
+    <string translatable="false" name="pref_fakekey_navigationMenu">fakekey_preference_navigationMenu</string>
 
 
     <!-- ============================================================================================================================================================================== -->
@@ -367,7 +368,7 @@
     <!-- category orientation sensor -->
     <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
 
-    <!-- category power user -->
+    <!-- category extended settings -->
     <string translatable="false" name="pref_extended_settings_enabled">extended_settings_enabled</string>
 
     <!-- category debug -->

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -367,6 +367,9 @@
     <!-- category orientation sensor -->
     <string translatable="false" name="pref_force_orientation_sensor">forceOrientationSensort</string>
 
+    <!-- category power user -->
+    <string translatable="false" name="pref_extended_settings_enabled">extended_settings_enabled</string>
+
     <!-- category debug -->
     <string translatable="false" name="pref_debug">debug</string>
     <string translatable="false" name="pref_fakekey_generate_logcat">fakekey_generate_logcat</string>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -280,6 +280,7 @@
 
     <!-- ============================================================================================================================================================================== -->
     <!-- keys for offlinedata screen -->
+    <string translatable="false" name="preference_menu_offlinedata">preference_menu_offlinedata</string>
     <string translatable="false" name="preference_screen_offlinedata">preference_screen_offlinedata</string>
     <!-- ============================================================================================================================================================================== -->
     <string translatable="false" name="pref_logimages">logimages</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1197,6 +1197,8 @@
     <string name="init_force_orientation_sensor_title">Orientation sensor</string>
     <string name="init_force_orientation_sensor_note">On some devices, the regular rotation vector sensor behaves erratically, giving the wrong direction. In this case, an alternate sensor (the orientation sensor) may provide better results.</string>
     <string name="init_force_orientation_sensor">Force use of orientation sensor</string>
+    <string name="init_title_extended_settings">Extended settings</string>
+    <string name="init_summary_extended_settings">Show settings for the more experienced user</string>
     <string name="init_create_memory_dump">Create memory dump</string>
     <string name="init_memory_dump">Memory dump</string>
     <string name="init_memory_dumped">Memory dumped to %s</string>

--- a/main/src/main/res/xml/preferences.xml
+++ b/main/src/main/res/xml/preferences.xml
@@ -47,6 +47,7 @@
 
     <!-- Offline data -->
     <Preference
+        android:key="@string/preference_menu_offlinedata"
         app:fragment="cgeo.geocaching.settings.fragments.PreferenceOfflinedataFragment"
         app:icon="@drawable/settings_sdcard"
         app:summary="@string/settings_summary_offlinedata"

--- a/main/src/main/res/xml/preferences.xml
+++ b/main/src/main/res/xml/preferences.xml
@@ -50,7 +50,8 @@
         app:fragment="cgeo.geocaching.settings.fragments.PreferenceOfflinedataFragment"
         app:icon="@drawable/settings_sdcard"
         app:summary="@string/settings_summary_offlinedata"
-        app:title="@string/settings_title_offlinedata" />
+        app:title="@string/settings_title_offlinedata"
+        android:enabled="false"/>
 
     <!-- Navigation -->
     <Preference

--- a/main/src/main/res/xml/preferences_backup.xml
+++ b/main/src/main/res/xml/preferences_backup.xml
@@ -9,7 +9,7 @@
     <PreferenceCategory
         android:title="@string/init_backup_title"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/init_backup_summary" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_backup_summary" app:iconSpaceReserved="false" />
 
         <Preference
             android:title="@string/init_backup_history_length_title"

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -59,22 +59,6 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="@string/pref_excludeWpOriginal"
-            android:summary="@string/init_summary_hidewp_original"
-            android:title="@string/init_hidewp"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/pref_excludeWpParking"
-            android:summary="@string/init_summary_hidewp_parking"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/pref_excludeWpVisited"
-            android:summary="@string/init_summary_hidewp_visited"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
             android:key="@string/pref_zoomincludingwaypoints"
             android:summary="@string/init_zoomincludingwaypoints_description"
             android:title="@string/init_zoomincludingwaypoints"
@@ -95,14 +79,6 @@
             android:key="@string/pref_showRouteMenu"
             android:summary="@string/init_summary_show_routing_menu"
             android:title="@string/init_show_routing_menu"
-            app:iconSpaceReserved="false" />
-        <ListPreference
-            android:defaultValue="@string/pref_maprotation_manual"
-            android:entries="@array/maprotation"
-            android:entryValues="@array/maprotationValues"
-            android:key="@string/pref_mapRotation"
-            android:summary="%s"
-            android:title="@string/settings_title_map_rotation"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"

--- a/main/src/main/res/xml/preferences_navigation.xml
+++ b/main/src/main/res/xml/preferences_navigation.xml
@@ -9,7 +9,7 @@
     <PreferenceCategory
         android:title="@string/settings_title_offline_routing"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/settings_summary_offline_routing" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/settings_summary_offline_routing" app:iconSpaceReserved="false" />
 
         <Preference
             android:key="@string/pref_fakekey_brouterDistanceThresholdTitle"
@@ -88,7 +88,7 @@
     <PreferenceCategory
         android:title="@string/init_default_navigation_tool"
         app:iconSpaceReserved="false">
-        <Preference
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow
             app:summary="@string/init_default_navigation_tool_description"
             app:iconSpaceReserved="false" />
         <ListPreference
@@ -103,7 +103,7 @@
     <PreferenceCategory
         android:title="@string/init_secondary_navigation_tool"
         app:iconSpaceReserved="false">
-        <Preference
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow
             app:summary="@string/init_default_navigation_tool_2_description"
             app:iconSpaceReserved="false" />
         <ListPreference
@@ -118,12 +118,13 @@
     <PreferenceCategory
         android:title="@string/settings_title_navigation_menu"
         app:iconSpaceReserved="false">
-        <Preference
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow
             app:summary="@string/init_navigation_menu_description"
             app:iconSpaceReserved="false" />
 
         <!-- Navigation Navigation -->
         <Preference
+            android:key="@string/pref_fakekey_navigationMenu"
             app:fragment="cgeo.geocaching.settings.fragments.PreferenceNavigationNavigationFragment"
             app:title="@string/settings_title_navigation_menu"
             app:iconSpaceReserved="false" />

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -22,7 +22,7 @@
     <PreferenceCategory
         android:title="@string/init_location"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/init_location_note" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_location_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/pref_googleplayservices"
@@ -33,7 +33,7 @@
     <PreferenceCategory
         android:title="@string/init_low_power"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/init_low_power_note" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_low_power_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_lowpowermode"
@@ -44,7 +44,7 @@
     <PreferenceCategory
         android:title="@string/init_force_orientation_sensor_title"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/init_force_orientation_sensor_note" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_force_orientation_sensor_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_force_orientation_sensor"
@@ -55,7 +55,7 @@
     <PreferenceCategory
         android:title="@string/init_title_extended_settings"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/init_summary_extended_settings" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_summary_extended_settings" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_extended_settings_enabled"
@@ -66,7 +66,7 @@
     <PreferenceCategory
         android:title="@string/init_debug_title"
         app:iconSpaceReserved="false">
-        <Preference android:summary="@string/init_debug_note" app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_debug_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_debug"

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -83,11 +83,6 @@
             android:title="@string/init_create_memory_dump"
             app:iconSpaceReserved="false" />
         <Preference
-            android:key="@string/pref_fakekey_generate_infos_downloadmanager"
-            android:layout="@layout/preference_button"
-            android:title="@string/about_system_write_infos_downloadmanager"
-            app:iconSpaceReserved="false" />
-        <Preference
             android:key="@string/pref_fakekey_view_settings"
             android:layout="@layout/preference_button"
             android:title="@string/view_settings"

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -53,6 +53,17 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/init_title_extended_settings"
+        app:iconSpaceReserved="false">
+        <Preference android:summary="@string/init_summary_extended_settings" app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_extended_settings_enabled"
+            android:title="@string/init_title_extended_settings"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/init_debug_title"
         app:iconSpaceReserved="false">
         <Preference android:summary="@string/init_debug_note" app:iconSpaceReserved="false" />

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -22,7 +22,7 @@
     <PreferenceCategory
         android:title="@string/init_location"
         app:iconSpaceReserved="false">
-        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_location_note" app:iconSpaceReserved="false" />
+        <Preference android:summary="@string/init_location_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/pref_googleplayservices"
@@ -33,7 +33,7 @@
     <PreferenceCategory
         android:title="@string/init_low_power"
         app:iconSpaceReserved="false">
-        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_low_power_note" app:iconSpaceReserved="false" />
+        <Preference android:summary="@string/init_low_power_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_lowpowermode"
@@ -44,7 +44,7 @@
     <PreferenceCategory
         android:title="@string/init_force_orientation_sensor_title"
         app:iconSpaceReserved="false">
-        <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_force_orientation_sensor_note" app:iconSpaceReserved="false" />
+        <Preference android:summary="@string/init_force_orientation_sensor_note" app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_force_orientation_sensor"


### PR DESCRIPTION
## Description
Show fewer settings in default config mode, as proposed in [internal discussion](https://github.com/orgs/cgeo/discussions/78).
To toggle extended settings, see switch "extended settings" in system's config.

![image](https://github.com/cgeo/cgeo/assets/3754370/1f678c32-6989-419d-843a-d74379f66d67).![image](https://github.com/cgeo/cgeo/assets/3754370/492a42fa-b442-452e-9e51-56153ac6fa07)

Some things are not yet working fully:
- ~some descriptive texts are missing yet~
- ~"Offline settings" cannot be reached currently~
- ~toggling basic/extended settings requires restart of current settings screen~
- ~search index has not been tested with yet~
- toggling basic/extended settings closes system settings
