### PR TITLE
Use fragment backstack on navigateUp in settings (fix #14552)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -141,6 +141,14 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
         setResult(NO_RESTART_NEEDED);
     }
 
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home && getSupportFragmentManager().popBackStackImmediate()) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
     public BackupUtils getBackupUtils() {
         return backupUtils;
     }


### PR DESCRIPTION
## Description
Use fragment backstack when navigating up in `SettingsActivity` and fall back to default `navigateUp` behavior, if no fragment left on backstack