### PR TITLE
Set targetSDK to 33

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -32,7 +32,7 @@ android {
     defaultConfig {
         minSdk 21
         //noinspection OldTargetApi
-        targetSdk 31
+        targetSdk 33
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)
 


### PR DESCRIPTION
## Description
Set `targetSDK` to 33 on `release` branch to be able to do releases from `release` again.
(Preparational step for a new beta release from `release`.)