### PR TITLE
Mark past events by italics (fix #14523)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
@@ -18,16 +18,15 @@ import cgeo.geocaching.sorting.GeocacheSortContext;
 import cgeo.geocaching.sorting.GlobalGPSDistanceComparator;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.AngleUtils;
-import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
+import cgeo.geocaching.utils.TextUtils;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Paint;
 import android.view.GestureDetector;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -39,7 +38,6 @@ import android.widget.SectionIndexer;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
 import androidx.core.text.HtmlCompat;
 
 import java.lang.ref.WeakReference;
@@ -441,19 +439,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
         compasses.add(holder.binding.direction);
         holder.binding.direction.setTargetCoords(cache.getCoords());
-
-        if (cache.isDisabled() || cache.isArchived() || CalendarUtils.isPastEvent(cache)) { // strike
-            holder.binding.text.setPaintFlags(holder.binding.text.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
-        } else {
-            holder.binding.text.setPaintFlags(holder.binding.text.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
-        }
-        if (cache.isArchived()) { // red color
-            holder.binding.text.setTextColor(ContextCompat.getColor(getContext(), R.color.archived_cache_color));
-        } else {
-            holder.binding.text.setTextColor(ContextCompat.getColor(getContext(), R.color.colorText));
-        }
-
-        holder.binding.text.setText(cache.getName(), TextView.BufferType.NORMAL);
+        holder.binding.text.setText(TextUtils.coloredCacheText(getContext(), cache, cache.getName()), TextView.BufferType.SPANNABLE);
         holder.cacheListType = cacheListType;
         updateViewHolder(holder, cache, res);
 

--- a/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
@@ -11,19 +11,17 @@ import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.MapMarkerUtils;
+import cgeo.geocaching.utils.TextUtils;
 
 import android.content.Context;
-import android.graphics.Paint;
 import android.text.Html;
+import android.text.SpannableString;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-
-import androidx.core.content.ContextCompat;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -36,8 +34,7 @@ public class GeoItemSelectorUtils {
     public static View createGeocacheItemView(final Context context, final Geocache cache, final View view) {
 
         final TextView tv = (TextView) view.findViewById(R.id.text);
-        setTitleTextStyle(context, tv, cache);
-        tv.setText(cache.getName());
+        tv.setText(TextUtils.coloredCacheText(context, cache, cache.getName()));
 
         tv.setCompoundDrawablesRelativeWithIntrinsicBounds(MapMarkerUtils.getCacheMarker(context.getResources(), cache, CacheListType.MAP, Settings.getIconScaleEverywhere()).getDrawable(), null, null, null);
 
@@ -57,16 +54,16 @@ public class GeoItemSelectorUtils {
 
     public static View createWaypointItemView(final Context context, final Waypoint waypoint, final View view) {
 
+        final Geocache parentCache = waypoint.getParentGeocache();
+
         final TextView tv = (TextView) view.findViewById(R.id.text);
-        tv.setText(waypoint.getName());
+        tv.setText(parentCache != null ? TextUtils.coloredCacheText(context, parentCache, waypoint.getName()) : waypoint.getName());
 
         tv.setCompoundDrawablesRelativeWithIntrinsicBounds(MapMarkerUtils.getWaypointMarker(context.getResources(), waypoint, false, Settings.getIconScaleEverywhere()).getDrawable(), null, null, null);
 
         final StringBuilder text = new StringBuilder(waypoint.getShortGeocode());
-        final Geocache parentCache = waypoint.getParentGeocache();
 
         if (parentCache != null) {
-            setTitleTextStyle(context, tv, parentCache);
             text.append(Formatter.SEPARATOR).append(parentCache.getName());
         }
 
@@ -147,21 +144,8 @@ public class GeoItemSelectorUtils {
 
     public static View getOrCreateView(final Context context, final View convertView, final ViewGroup parent) {
         final View view = convertView == null ? LayoutInflater.from(context).inflate(R.layout.cacheslist_item_select, parent, false) : convertView;
-        setTitleTextStyle(context, view.findViewById(R.id.text), null); // reset title style
+        ((TextView) view.findViewById(R.id.text)).setText(new SpannableString(""));
         return view;
-    }
-
-    private static void setTitleTextStyle(final Context context, final TextView tv, final Geocache cache) {
-        if (cache != null && (cache.isDisabled() || cache.isArchived() || CalendarUtils.isPastEvent(cache))) { // strike
-            tv.setPaintFlags(tv.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
-        } else {
-            tv.setPaintFlags(tv.getPaintFlags() & ~Paint.STRIKE_THRU_TEXT_FLAG);
-        }
-        if (cache != null && cache.isArchived()) { // red color
-            tv.setTextColor(ContextCompat.getColor(context, R.color.archived_cache_color));
-        } else {
-            tv.setTextColor(ContextCompat.getColor(context, R.color.colorText));
-        }
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
@@ -5,11 +5,13 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.utils.functions.Func1;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StrikethroughSpan;
+import android.text.style.StyleSpan;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -295,6 +297,9 @@ public final class TextUtils {
 
     public static SpannableString coloredCacheText(final Context context, @NonNull final Geocache cache, @NonNull final String text) {
         final SpannableString span = new SpannableString(text);
+        if (CalendarUtils.isPastEvent(cache)) { // italics
+            span.setSpan(new StyleSpan(Typeface.ITALIC), 0, span.length(), 0);
+        }
         if (cache.isDisabled() || cache.isArchived()) { // strike
             span.setSpan(new StrikethroughSpan(), 0, span.toString().length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }


### PR DESCRIPTION
## Description
- Mark past events by italics
- Refactoring: Use `TextUtils.coloredCacheText` in more places instead of individually composing attributes
