### PR TITLE
GMv2: Remove individual route from map on deletion (fix #14535)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -907,6 +907,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
     @Override
     public void clearIndividualRoute() {
+        individualRoute.clearRoute(overlayPositionAndScale);
         individualRoute.clearRoute((route) -> {
             overlayPositionAndScale.repaintRequired();
             updateRouteTrackButtonVisibility();


### PR DESCRIPTION
## Description
Removes individual route from GMv2 map display on deleting the route