### PR TITLE
Hide offline data settings in basic config mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferencesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferencesFragment.java
@@ -30,7 +30,7 @@ public class PreferencesFragment extends BasePreferenceFragment {
         if (prefScreen != null) {
             final Preference pref = prefScreen.findPreference(getString(R.string.preference_menu_offlinedata));
             if (pref != null) {
-                pref.setEnabled(value);
+                pref.setVisible(value);
             }
         }
     }

--- a/main/src/main/res/xml/preferences.xml
+++ b/main/src/main/res/xml/preferences.xml
@@ -62,8 +62,7 @@
             app:fragment="cgeo.geocaching.settings.fragments.PreferenceOfflinedataFragment"
             app:icon="@drawable/settings_sdcard"
             app:summary="@string/settings_summary_offlinedata"
-            app:title="@string/settings_title_offlinedata"
-            android:enabled="false"/>
+            app:title="@string/settings_title_offlinedata" />
 
         <!-- Navigation -->
         <Preference


### PR DESCRIPTION
## Description
Hide offline data settings in basic config mode instead of only disabling them (to be consistent with other extended settings)