### PR TITLE
Remove PreferenceCategory from settings main screen

### DIFF
--- a/main/src/main/res/xml/preferences.xml
+++ b/main/src/main/res/xml/preferences.xml
@@ -8,82 +8,79 @@
         android:key="@string/pref_extended_settings_enabled"
         android:summary="@string/init_summary_extended_settings"
         android:title="@string/init_title_extended_settings"
-        app:iconSpaceReserved="false" />
+        app:iconSpaceReserved="false"
+        app:allowDividerBelow="true"/>
 
-    <PreferenceCategory
-        android:title="@string/settings_settings"
-        app:iconSpaceReserved="false">
+    <!-- Services -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceServicesFragment"
+        app:icon="@drawable/settings_cloud"
+        app:summary="@string/settings_summary_services"
+        app:title="@string/settings_title_services"
+        app:allowDividerAbove="true"/>
 
-        <!-- Services -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceServicesFragment"
-            app:icon="@drawable/settings_cloud"
-            app:summary="@string/settings_summary_services"
-            app:title="@string/settings_title_services" />
+    <!-- Appearance -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceAppearanceFragment"
+        app:icon="@drawable/settings_eye"
+        app:summary="@string/settings_summary_appearance"
+        app:title="@string/settings_title_appearance" />
 
-        <!-- Appearance -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceAppearanceFragment"
-            app:icon="@drawable/settings_eye"
-            app:summary="@string/settings_summary_appearance"
-            app:title="@string/settings_title_appearance" />
+    <!-- Cache Details -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceCachedetailsFragment"
+        app:icon="@drawable/settings_details"
+        app:summary="@string/settings_summary_cachedetails"
+        app:title="@string/settings_title_cachedetails" />
 
-        <!-- Cache Details -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceCachedetailsFragment"
-            app:icon="@drawable/settings_details"
-            app:summary="@string/settings_summary_cachedetails"
-            app:title="@string/settings_title_cachedetails" />
+    <!-- Map Sources -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceMapSourcesFragment"
+        app:icon="@drawable/settings_map"
+        app:summary="@string/settings_summary_map_sources"
+        app:title="@string/settings_title_map_sources" />
 
-        <!-- Map Sources -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceMapSourcesFragment"
-            app:icon="@drawable/settings_map"
-            app:summary="@string/settings_summary_map_sources"
-            app:title="@string/settings_title_map_sources" />
+    <!-- Map Content / Behavior -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceMapContentBehaviorFragment"
+        app:icon="@drawable/settings_map_content"
+        app:summary="@string/settings_summary_map_content_behavior"
+        app:title="@string/settings_title_map_content_behavior" />
 
-        <!-- Map Content / Behavior -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceMapContentBehaviorFragment"
-            app:icon="@drawable/settings_map_content"
-            app:summary="@string/settings_summary_map_content_behavior"
-            app:title="@string/settings_title_map_content_behavior" />
+    <!-- Logging -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceLoggingFragment"
+        app:icon="@drawable/settings_pen"
+        app:summary="@string/settings_summary_logging"
+        app:title="@string/settings_title_logging" />
 
-        <!-- Logging -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceLoggingFragment"
-            app:icon="@drawable/settings_pen"
-            app:summary="@string/settings_summary_logging"
-            app:title="@string/settings_title_logging" />
+    <!-- Offline data -->
+    <Preference
+        android:key="@string/preference_menu_offlinedata"
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceOfflinedataFragment"
+        app:icon="@drawable/settings_sdcard"
+        app:summary="@string/settings_summary_offlinedata"
+        app:title="@string/settings_title_offlinedata" />
 
-        <!-- Offline data -->
-        <Preference
-            android:key="@string/preference_menu_offlinedata"
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceOfflinedataFragment"
-            app:icon="@drawable/settings_sdcard"
-            app:summary="@string/settings_summary_offlinedata"
-            app:title="@string/settings_title_offlinedata" />
+    <!-- Navigation -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceNavigationFragment"
+        app:icon="@drawable/settings_arrow"
+        app:summary="@string/settings_summary_navigation"
+        app:title="@string/settings_title_navigation" />
 
-        <!-- Navigation -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceNavigationFragment"
-            app:icon="@drawable/settings_arrow"
-            app:summary="@string/settings_summary_navigation"
-            app:title="@string/settings_title_navigation" />
+    <!-- System -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceSystemFragment"
+        app:icon="@drawable/settings_nut"
+        app:summary="@string/settings_summary_system"
+        app:title="@string/settings_title_system" />
 
-        <!-- System -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceSystemFragment"
-            app:icon="@drawable/settings_nut"
-            app:summary="@string/settings_summary_system"
-            app:title="@string/settings_title_system" />
+    <!-- Backup -->
+    <Preference
+        app:fragment="cgeo.geocaching.settings.fragments.PreferenceBackupFragment"
+        app:icon="@drawable/settings_backup"
+        app:summary="@string/settings_summary_backup"
+        app:title="@string/settings_title_backup" />
 
-        <!-- Backup -->
-        <Preference
-            app:fragment="cgeo.geocaching.settings.fragments.PreferenceBackupFragment"
-            app:icon="@drawable/settings_backup"
-            app:summary="@string/settings_summary_backup"
-            app:title="@string/settings_title_backup" />
-
-    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Description
Removes the PreferenceCategory ("heading") from settings' main screen, just draws the divider between "extended settings" switch and other settings. For screenshot see https://github.com/cgeo/cgeo/pull/14606#issuecomment-1721705749