### PR TITLE
Support scaling of non-square drawables (rel. to #14612)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/ScalableDrawable.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ScalableDrawable.java
@@ -22,8 +22,9 @@ public class ScalableDrawable extends Drawable {
 
     public ScalableDrawable(final Drawable drawable, final float factor) {
         this(drawable);
-        final int size = (int) (drawable.getIntrinsicWidth() * factor);
-        setBounds(0, 0, size, size);
+        final int width = (int) (drawable.getIntrinsicWidth() * factor);
+        final int height = (int) (drawable.getIntrinsicHeight() * factor);
+        setBounds(0, 0, width, height);
     }
 
     @Override


### PR DESCRIPTION
## Description
`ScalableDrawable` assumed drawables to be squares and failed correct scaling on non-squares, which this PR fixes.