### PR TITLE
Streamline permissions info in system information

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
@@ -296,7 +296,7 @@ public final class SystemInformation {
     }
 
     private static void appendPermission(final Context context, final StringBuilder body, final String permission) {
-        body.append("\n- ").append(permission).append(":: ").append(ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED ? "granted" : "DENIED");
+        body.append("\n- ").append(StringUtils.remove(permission, "android.permission.")).append(": ").append(ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED ? "granted" : "DENIED");
     }
 
     private static void appendPermissions(final Context context, final StringBuilder body) {


### PR DESCRIPTION
## Description
Streamline permission info block in system information
- remove common prefix "android.permission." from permission info
- remove doubled ":"

|before|after|
|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/425d010c-1636-4945-af7b-082785b6e1ba)|![image](https://github.com/cgeo/cgeo/assets/3754370/ed5d4996-3576-42bc-b93b-71df37ab9141)|
