### PR TITLE
Remove remainders from scanner integration (rel. to #11530)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -471,9 +471,6 @@ dependencies {
     // needed for chrome custom tabs
     implementation 'androidx.browser:browser:1.4.0'
 
-    // Zxing barcode reader integration
-    implementation 'com.google.zxing:android-integration:3.3.0'
-
     // MarkDown view
     implementation 'io.noties.markwon:core:4.6.2'
 

--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -90,8 +90,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.android.material.button.MaterialButton;
-import com.google.zxing.integration.android.IntentIntegrator;
-import com.google.zxing.integration.android.IntentResult;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
@@ -583,23 +581,14 @@ public class MainActivity extends AbstractNavigationBarActivity {
             if (resultCode == SettingsActivity.RESTART_NEEDED) {
                 ProcessUtils.restartApplication(this);
             }
-        } else {
-            final IntentResult scanResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, intent);
-            if (scanResult != null) {
-                final String scan = scanResult.getContents();
-                if (StringUtils.isBlank(scan)) {
-                    return;
+        } else if (requestCode == Intents.SEARCH_REQUEST_CODE) {
+            // SearchActivity activity returned without making a search
+            if (resultCode == RESULT_CANCELED) {
+                String query = intent.getStringExtra(SearchManager.QUERY);
+                if (query == null) {
+                    query = "";
                 }
-                SearchActivity.startActivityScan(scan, this);
-            } else if (requestCode == Intents.SEARCH_REQUEST_CODE) {
-                // SearchActivity activity returned without making a search
-                if (resultCode == RESULT_CANCELED) {
-                    String query = intent.getStringExtra(SearchManager.QUERY);
-                    if (query == null) {
-                        query = "";
-                    }
-                    SimpleDialog.of(this).setMessage(TextParam.text(res.getString(R.string.unknown_scan) + "\n\n" + query)).show();
-                }
+                SimpleDialog.of(this).setMessage(TextParam.text(res.getString(R.string.unknown_scan) + "\n\n" + query)).show();
             }
         }
     }

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -524,12 +524,4 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
         return super.onOptionsItemSelected(item);
     }
 
-    public static void startActivityScan(final String scan, final Activity fromActivity) {
-        final Intent searchIntent = new Intent(fromActivity, SearchActivity.class);
-        searchIntent.setAction(Intent.ACTION_SEARCH).
-                putExtra(SearchManager.QUERY, scan).
-                putExtra(Intents.EXTRA_KEYWORD_SEARCH, false);
-        fromActivity.startActivityForResult(searchIntent, Intents.SEARCH_REQUEST_CODE);
-    }
-
 }


### PR DESCRIPTION
## Description
We have some code and library remainders from our former scanner app integration. Without starting a scan there's no need for checking for an `ActivityResult` :-) and the integration lib can be removed as well.

Not sure, though, whether the `requestCode == Intents.SEARCH_REQUEST_CODE` code block is still required. Does not seem to be directly related to the scanner integration, but I cannot find a call to it from within c:geo either. I left the code part in for now, to be on the safe side.