### PR TITLE
Write visited flag to personal note (fix #14428)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -173,7 +173,7 @@ public class Waypoint implements IWaypoint {
      */
     public boolean isUserModified() {
         return
-                isUserDefined() ||
+                isUserDefined() || isVisited() ||
                         (isOriginalCoordsEmpty() && (getCoords() != null || getCalcStateConfig() != null)) ||
                         StringUtils.isNotBlank(getUserNote());
     }
@@ -393,6 +393,11 @@ public class Waypoint implements IWaypoint {
             this.setUserNote(parsedWaypoint.getUserNote());
             changed = true;
         }
+
+        if (parsedWaypoint.isVisited()) {
+            setVisited(true);
+        }
+
         return changed;
     }
 

--- a/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
@@ -197,6 +197,46 @@ public class CacheArtefactParserTest {
     }
 
     @Test
+    public void testCreateParseableVisitedWaypointTextAndParseIt() {
+        final Waypoint wp = new Waypoint("name", WaypointType.FINAL, true);
+        final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
+        wp.setCoords(gp);
+        wp.setVisited(true);
+        wp.setPrefix("PR");
+        wp.setUserNote("user note with {v} visited text");
+        assertThat(CacheArtefactParser.getParseableText(wp)).isEqualTo(
+                "@name (F) {v} " + toParseableWpString(gp) + " " +
+                        "\"user note with {v} visited text\"");
+
+        final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
+        final Collection<Waypoint> parsedWaypoints = cacheArtefactParser.parse(CacheArtefactParser.getParseableText(wp)).getWaypoints();
+        assertThat(parsedWaypoints).hasSize(1);
+        final Waypoint newWp = parsedWaypoints.iterator().next();
+        assertWaypoint(newWp, wp);
+        assertThat(newWp.isVisited()).isTrue();
+    }
+
+    @Test
+    public void testCreateParseableWaypointVisitedTextAndParseIt() {
+        final Waypoint wp = new Waypoint("name", WaypointType.FINAL, true);
+        final Geopoint gp = new Geopoint("N 45°49.739 E 9°45.038");
+        wp.setCoords(gp);
+        wp.setPrefix("PR");
+        wp.setUserNote("user note with {v} visited text");
+        assertThat(CacheArtefactParser.getParseableText(wp)).isEqualTo(
+                "@name (F) " + toParseableWpString(gp) + " " +
+                        "\"user note with {v} visited text\"");
+
+        final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
+        final Collection<Waypoint> parsedWaypoints = cacheArtefactParser.parse(CacheArtefactParser.getParseableText(wp)).getWaypoints();
+        assertThat(parsedWaypoints).hasSize(1);
+        final Waypoint newWp = parsedWaypoints.iterator().next();
+        assertWaypoint(newWp, wp);
+        assertThat(newWp.isVisited()).isFalse();
+
+    }
+
+    @Test
     public void testCreateParseableWaypointTextWithoutCoordinateAndParseIt() {
         final Waypoint wp = new Waypoint("name", WaypointType.FINAL, false);
         wp.setCoords(null);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Exports the visited-flag as {v} into the personal note, if waypoint is visited.
syntax: @Name (F) **{v}** Coordinates "note"

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #14428

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
writes {v} to indicated, that the waypoint is visited. If flag is not set, but existing waypoint is visited, the merged waypoint will be visited.