### PR TITLE
Add UI for icon scaling options (rel. to #14388)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/SeekbarPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SeekbarPreference.java
@@ -227,6 +227,7 @@ public class SeekbarPreference extends Preference {
         // get views
         final SeekBar seekBar = (SeekBar) holder.findViewById(R.id.preference_seekbar);
         valueView = (TextView) holder.findViewById(R.id.preference_seekbar_value_view);
+        holder.setDividerAllowedAbove(false);
 
         // init seekbar
         seekBar.setMax(maxProgress);
@@ -280,4 +281,12 @@ public class SeekbarPreference extends Preference {
             });
         });
     }
+
+    /** apply mapping to change notifications */
+    @Override
+    public boolean callChangeListener(final Object newValue) {
+        final OnPreferenceChangeListener opcl = getOnPreferenceChangeListener();
+        return opcl == null || opcl.onPreferenceChange(this, progressToValue((int) newValue));
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -499,7 +499,7 @@ public class Settings {
         return Arrays.asList(StringUtils.split(getString(prefKeyId, defaultValue), SEPARATOR_CHAR));
     }
 
-    private static int getInt(final int prefKeyId, final int defaultValue) {
+    public static int getInt(final int prefKeyId, final int defaultValue) {
         return getIntDirect(getKey(prefKeyId), defaultValue);
     }
 
@@ -569,11 +569,15 @@ public class Settings {
     }
 
     private static void putInt(final int prefKeyId, final int value) {
+        putIntDirect(getKey(prefKeyId), value);
+    }
+
+    public static void putIntDirect(final String prefKey, final int value) {
         if (sharedPrefs == null) {
             return;
         }
         final SharedPreferences.Editor edit = sharedPrefs.edit();
-        edit.putInt(getKey(prefKeyId), value);
+        edit.putInt(prefKey, value);
         edit.apply();
     }
 

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.models.InfoItem;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
+import cgeo.geocaching.utils.MapMarkerUtils;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NEARBY;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NONE;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_PLACEHOLDER;
@@ -66,6 +67,14 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
         setPrefClick(this, R.string.pref_cacheListInfo, () -> {
             CacheListInfoItem.startActivity(getActivity(), R.string.init_title_cacheListInfo1, R.string.pref_cacheListInfo, 2);
         });
+
+        final Preference.OnPreferenceChangeListener pScaling = (preference, newValue) -> {
+            Settings.putIntDirect(preference.getKey(), (int) newValue);
+            MapMarkerUtils.resetAllCaches();
+            return true;
+        };
+        findPreference(getString(R.string.pref_mapCacheScaling)).setOnPreferenceChangeListener(pScaling);
+        findPreference(getString(R.string.pref_mapWpScaling)).setOnPreferenceChangeListener(pScaling);
 
         configCustomBNitemPreference();
     }

--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -50,13 +50,38 @@ public final class MapMarkerUtils {
     private static final Map<Integer, Integer> list2marker = new TreeMap<>();
     private static Boolean listsRead = false;
 
+    // the following vars depend on cache/wp scaling factor and need to be part of resetCache()
     private static final SparseArray<CacheMarker> overlaysCache = new SparseArray<>();
     private static final Map<String, EmojiUtils.EmojiPaint> emojiPaintMap = new HashMap<>();
-    private static final float scalingFactorCacheIcons = Settings.getLong(R.string.pref_mapCacheScale, 100) / 100.0f;
-    private static final float scalingFactorWpIcons = Settings.getLong(R.string.pref_mapWpScale, 100) / 100.0f;
+    private static float scalingFactorCacheIcons;
+    private static float scalingFactorWpIcons;
+
+    static {
+        resetAllCaches();
+    }
 
     private MapMarkerUtils() {
         // Do not instantiate
+    }
+
+    /**
+     * clear all caches and reset scaling-related variables
+     */
+    public static synchronized void resetAllCaches() {
+        overlaysCache.clear();
+        emojiPaintMap.clear();
+        scalingFactorCacheIcons = Settings.getInt(R.string.pref_mapCacheScaling, 100) / 100.0f;
+        scalingFactorWpIcons = Settings.getInt(R.string.pref_mapWpScaling, 100) / 100.0f;
+        Log.e("reset scaling factors to " + scalingFactorCacheIcons + " / " + scalingFactorWpIcons);
+    }
+
+    /**
+     * Clear the cache of drawable items.
+     */
+    public static void clearCachedItems() {
+        synchronized (overlaysCache) {
+            overlaysCache.clear();
+        }
     }
 
     /**
@@ -559,15 +584,6 @@ public final class MapMarkerUtils {
         final int offsetRightBottom = diffWidth - offsetLeftTop;
         layerDrawable.setLayerInset(0, -offsetLeftTop, -offsetLeftTop, -offsetRightBottom, -offsetRightBottom);
         return layerDrawable;
-    }
-
-    /**
-     * Clear the cache of drawable items.
-     */
-    public static void clearCachedItems() {
-        synchronized (overlaysCache) {
-            overlaysCache.clear();
-        }
     }
 
     public static LayerDrawable buildLayerDrawable(final InsetsBuilder insetsBuilder, final int layersInitialCapacity, final int insetsInitialCapacity) {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -532,8 +532,8 @@
     <string translatable="false" name="pref_theme_menu">theme_menu</string>
     <string translatable="false" name="pref_google_map_theme">google_map_theme</string>
     <string translatable="false" name="pref_mapSemitransVisitedWp">mapSemitransVisitedWp</string>
-    <string translatable="false" name="pref_mapCacheScale">mapCacheScale</string>
-    <string translatable="false" name="pref_mapWpScale">mapWpScale</string>
+    <string translatable="false" name="pref_mapCacheScaling">mapCacheScaling</string>
+    <string translatable="false" name="pref_mapWpScaling">mapWpScaling</string>
     <string translatable="false" name="pref_mapScaleOnly">mapScaleOnly</string>
 
     <!-- pq/bookmark list: show downloadable/new only -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1195,6 +1195,11 @@
     <string name="init_mapShadingLinearity_description">Small values accentuate contrast in steep slopes but hide changes in flats, large values make it more linear</string>
     <string name="init_mapShadingScale_title">Shading Opacity</string>
     <string name="init_mapShadingScale_description">Opacity of the shading layer, from invisible to higher values intensifying shading but may produce artifacts</string>
+    <string name="init_iconsizes">Icon Sizes</string>
+    <string name="init_mapCacheScaling_title">Cache icon scaling</string>
+    <string name="init_mapCacheScaling_description">Scaling factor for cache icons (in %)</string>
+    <string name="init_mapWpScaling_title">Waypoint icon scaling</string>
+    <string name="init_mapWpScaling_description">Scaling factor for waypoint icons (in %)</string>
     <string name="init_maintenance">Maintenance</string>
     <string name="init_maintenance_directories_note">c:geo stores images and other files related to a cache in a dedicated folder. In some cases (e.g. when importing/exporting the database) this folder may contain obsolete files that can be deleted here.</string>
     <string name="init_maintenance_directories">Delete orphaned files</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -91,6 +91,31 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/init_iconsizes"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:title="@string/init_mapCacheScaling_title"
+            android:summary="@string/init_mapCacheScaling_description"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_mapCacheScaling"
+            android:defaultValue="100"
+            app:min="50"
+            app:max="200"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:title="@string/init_mapWpScaling_title"
+            android:summary="@string/init_mapWpScaling_description"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_mapWpScaling"
+            android:defaultValue="100"
+            app:min="50"
+            app:max="200"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/init_maplines_title"
         app:iconSpaceReserved="false">
 


### PR DESCRIPTION
## Description
Adds settings' UI for icon scaling options as discussed in https://github.com/cgeo/cgeo/pull/14388#issuecomment-1622076437

![image](https://github.com/cgeo/cgeo/assets/3754370/25799cd1-8a33-49a8-bf56-66ade16d39d0)

Two caveats:
- I needed to rename the preference key, as seekbar preferences require an `int` preference, but for some reason I had created the scaling factors as `long` values. This will reset icon scaling factors once on upgrade.
- ~Currently a restart of c:geo is required to bring changed settings into effect.~

~I've tried resetting the marker cache + updating the scaling factor variables in `MapMarkerUtils` on changing the scaling settings' values, but on opening the map the next time within the same session, no markers got drawn and the map crashed eventually, without any useful info in Logcat. Any ideas?~