### PR TITLE
New GCLog API: Basic Cache logging + images + trackable status

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
@@ -191,6 +191,9 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
     @NonNull
     @Override
     public String getCacheCreateNewLogUrl(@NonNull final Geocache cache) {
+        if (Settings.enableFeatureNewGCLogApi()) {
+            return GC_BASE_URL + "live/geocache/" + cache.getGeocode() + "/log";
+        }
         return GC_BASE_URL + "play/geocache/" + cache.getGeocode() + "/log";
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -68,6 +68,7 @@ public final class GCConstants {
     static final Pattern PATTERN_FAVORITECOUNT = Pattern.compile("<span class=\"favorite-value\">\\D*([0-9]+?)\\D*</span>");
     static final Pattern PATTERN_COUNTLOGS = Pattern.compile("<span id=\"ctl00_ContentBody_lblFindCounts\"><ul(.+?)</ul></span>");
     static final Pattern PATTERN_WATCHLIST_COUNT = Pattern.compile("data-watchcount=\"(\\d+)\"");
+    static final Pattern PATTERN_CSRF_TOKEN = Pattern.compile("\"csrfToken\":\"([^\"]+)\"");
 
     /**
      * Two groups !
@@ -181,6 +182,7 @@ public final class GCConstants {
     static final Pattern PATTERN_TYPE2 = Pattern.compile("<option( selected=\"selected\")? value=\"(\\d+)\">[^<]+</option>", Pattern.CASE_INSENSITIVE);
     // new logpage logtype pattern:         logSettings.logTypes.push({"Value":46,"Description":"Owner maintenance","IsRealtimeOnly":false});
     static final Pattern PATTERN_TYPE3 = Pattern.compile("logSettings.logTypes.push\\(([^;]*)\\);");
+    static final Pattern PATTERN_TYPE4 = Pattern.compile("\"logTypes\":\\[([^]]+)]");
     static final Pattern PATTERN_MAINTENANCE = Pattern.compile("<span id=\"ctl00_ContentBody_LogBookPanel1_lbConfirm\"[^>]*>([^<]*<font[^>]*>)?([^<]+)(</font>[^<]*)?</span>", Pattern.CASE_INSENSITIVE);
     static final Pattern PATTERN_OK2 = Pattern.compile("<div id=[\"|']ctl00_ContentBody_LogBookPanel1_ViewLogPanel[\"|'] class=", Pattern.CASE_INSENSITIVE);
     static final Pattern PATTERN_VIEWSTATEFIELDCOUNT = Pattern.compile("id=\"__VIEWSTATEFIELDCOUNT\"[^(value)]+value=\"(\\d+)\"[^>]+>", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
@@ -94,7 +94,8 @@ class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.L
                     Log.w("GCLoggingManager.onLoadFinished: getTrackableInventory", e);
                 }
 
-                final List<LogType> possibleLogTypes = GCParser.parseTypes(page);
+                final List<LogType> possibleLogTypes = Settings.enableFeatureNewGCLogApi() ?
+                        GCParser.parseTypesNew(page) : GCParser.parseTypes(page);
 
                 // TODO: also parse ProblemLogTypes: logSettings.problemLogTypes.push(45);
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.network.HttpRequest;
 import cgeo.geocaching.network.HttpResponse;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.Log;
@@ -42,7 +43,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.reactivex.rxjava3.core.Single;
@@ -69,6 +72,7 @@ class GCWebAPI {
     //<input name="__RequestVerificationToken" type="hidden" value="(token-value)" />
     private static final Pattern PATTERN_REQUEST_VERIFICATION_TOKEN = Pattern.compile("name=\"__RequestVerificationToken\"\\s+type=\"hidden\"\\s+value=\"([^\"]+)\"");
 
+    private static final String HTML_HEADER_CSRF_TOKEN = "CSRF-Token";
 
     /**
      * maximum number of elements to retrieve with one call
@@ -530,13 +534,13 @@ class GCWebAPI {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class TrackableInventoryEntry {
         @JsonProperty("referenceCode")
-        String referenceCode;
+        String referenceCode; // The public one, starting with "TB"
         @JsonProperty("name")
         String name;
         @JsonProperty("iconUrl")
         String iconUrl;
         @JsonProperty("trackingNumber")
-        String trackingNumber;
+        String trackingNumber; // The secret one
     }
 
     private static Single<Authorization> getAuthorization() {
@@ -1036,6 +1040,10 @@ class GCWebAPI {
                 + "; date: " + date + ", log: " + logInfo
                 + "; trackables: " + trackables.size());
 
+        if (Settings.enableFeatureNewGCLogApi()) {
+            return postLogNew(geocache, logType, date, log, trackables, addToFavorites);
+        }
+
         try {
             // coordinates are only used for LogType.UPDATE_COORDINATES, which c:geo doesn't support at the moment
             final double latitude = 0.0;
@@ -1211,6 +1219,10 @@ class GCWebAPI {
     @NonNull
     static ImmutablePair<StatusCode, String> postLogImage(final String geocode, final String logId, final Image image) {
 
+        if (Settings.enableFeatureNewGCLogApi()) {
+            return postLogImageNew(geocode, logId, image);
+        }
+
         // 0) open log page to get a Request Token
         final String html = httpReq().uri(WEBSITE_URL + "/play/geocache/" + geocode + "/log").request().blockingGet().getBodyString();
         if (html == null) {
@@ -1280,12 +1292,204 @@ class GCWebAPI {
         return result;
     }
 
+    //Format Request:
+    // {
+    //   'images': [], // an array of image GUIDs  (String)
+    //   'logDate': logdate, // timestamp, e.g. "2023-09-08T22:31:54.004Z"
+    //   'logText': logtext, //string (logtext)
+    //   'logType': logtype, //integer
+    //   'trackables': [], //array of object. Example: [{"trackableCode":"TBxyz","trackableLogTypeId":75}]
+    //   'updatedCoordinates': null, //unknown, most likely only used for Owner log
+    //   'usedFavoritePoint': false //boolean. Not yet verified
+    //  }
+    //
+    //Format Reply:
+    // {"guid":"xyz","logReferenceCode":"GLxyz","dateTimeCreatedUtc":"2023-09-17T14:03:26","dateTimeLastUpdatedUtc":"2023-09-17T14:03:26","logDate":"2023-09-08T12:00:00","logType":4,"images":[],"trackables":[],"cannotDelete":false,"usedFavoritePoint":false}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class GCWebLogTrackable {
+        //Log Creation Fields
+        @JsonProperty("trackableCode")
+        String trackableCode; // e.g. "TBxyz"
+        @JsonProperty("trackableLogTypeId")
+        Integer trackableLogTypeId;
+    }
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class GCWebLogEntry extends HttpResponse {
+        //Log Creation Fields
+        @JsonProperty("images")
+        String[] images; //image GUIDs
+        @JsonProperty("logDate")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        Date logDate;
+        @JsonProperty("logText")
+        String logText;
+        @JsonProperty("logType")
+        Integer logType;
+        @JsonProperty("trackables")
+        GCWebLogTrackable[] trackables;
+
+        //Field used in return
+        @JsonProperty("guid")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String guid;
+        @JsonProperty("logReferenceCode")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String logReferenceCode;
+        @JsonProperty("dateTimeCreatedUtc")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        Date dateTimeCreatedUtc;
+        @JsonProperty("dateTimeLastUpdatedUtc")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        Date dateTimeLastUpdatedUtc;
+        @JsonProperty("cannotDelete")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Boolean cannotDelete;
+        @JsonProperty("usedFavoritePoint")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Boolean usedFavoritePoint;
+
+    }
+
+    // Response for GC Log Image create/update request:
+    // {
+    //    "guid": "c7xyz-xyz-xyz-xyz-xyz",
+    //    "url": "https://img.geocaching.com/c7xyz-xyz-xyz-xyz-xyz.jpg",
+    //    "thumbnailUrl": "https://img.geocaching.com/large/c7xyz-xyz-xyz-xyz-xyz.jpg",
+    //    "success": true
+    //}
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class GCWebLogImageResponse extends HttpResponse {
+        @JsonProperty("guid")
+        String guid;
+        @JsonProperty("url")
+        String url;
+        @JsonProperty("thumbnailUrl")
+        String thumbnailUrl;
+        @JsonProperty("success")
+        Boolean success;
+
+    }
+
+    //New Log API
+    @NonNull
+    @WorkerThread
+    public static ImmutablePair<StatusCode, String> postLogNew (final Geocache geocache,
+                                                     final LogType logType, final Date date,
+                                                     final String log, @NonNull final List<cgeo.geocaching.log.TrackableLog> trackables,
+                                                     final boolean addToFavorites) {
+
+        //TODO: "addToFavorites" is ignored for now
+
+        final String geocode = geocache.getGeocode();
+        //1.) Call log page and get a valid CSRF Token
+        final String csrfToken = getCsrfTokenFromUrl(WEBSITE_URL + "/live/geocache/" + geocode + "/log");
+        if (csrfToken == null) {
+            return generateLogError(false, "Lost Post: unable to find a CSRF Token in Log Page");
+        }
+
+        //2,) Fill Log Entry object and post it
+        final GCWebLogEntry logEntry = new GCWebLogEntry();
+        logEntry.images = new String[0];
+        logEntry.logDate = date;
+        logEntry.logType = logType.id;
+        logEntry.logText = log;
+        logEntry.trackables = CollectionStream.of(trackables).map(t -> {
+            final GCWebLogTrackable tLog = new GCWebLogTrackable();
+            tLog.trackableCode = t.geocode;
+            tLog.trackableLogTypeId = t.action.gcApiId;
+            return tLog;
+        }).toArray(GCWebLogTrackable.class);
+
+        final GCWebLogEntry response = websiteReq().uri("/api/live/v1/logs/" + geocode + "/geocacheLog")
+                .method(HttpRequest.Method.POST)
+                .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
+                .bodyJson(logEntry)
+                .requestJson(GCWebLogEntry.class).blockingGet();
+
+        if (response.logReferenceCode == null) {
+            return generateLogError(false, "Problem pasting log, response is: " + response);
+        }
+
+        return new ImmutablePair<>(StatusCode.NO_ERROR, response.logReferenceCode);
+    }
+
+    @WorkerThread
+    @NonNull
+    static ImmutablePair<StatusCode, String> postLogImageNew(final String geocode, final String logId, final Image image) {
+        //1) Get CSRF Token from "Edit Log" page. URL is https://www.geocaching.com/live/log/GLxyz
+        final String csrfToken = getCsrfTokenFromUrl(WEBSITE_URL + "/live/log/" + logId);
+        if (csrfToken == null) {
+            return generateLogError(true, "Problem getting CSRF-Token");
+        }
+
+        //2) Create a new "image" attached to the log, uploading only image data
+        //   (Do not yet upload name + description, for some reason this results in a server timeout)
+        // via POST to https://www.geocaching.com/api/live/v1/logs/GLxyz/images with image payload
+        final GCWebLogImageResponse imgResponse = websiteReq().uri("/api/live/v1/logs/" + logId + "/images")
+                .method(HttpRequest.Method.POST)
+                .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
+                .bodyForm(null, "image", "image/jpeg", image.getFile())
+                .requestJson(GCWebLogImageResponse.class).blockingGet();
+        if (imgResponse.guid == null || imgResponse.url == null) {
+            return generateLogError(true, "Problem posting log, response is: " + imgResponse);
+        }
+
+        //3) Post the image name + description via PUT
+        // URL like: https://www.geocaching.com/api/live/v1/images/GLxyz/c7xyz-xyz-xyz-xyz-xyz/replace (PUT)
+        final Parameters params = new Parameters();
+        if (!StringUtils.isBlank(image.getTitle())) {
+            params.put("name", image.getTitle());
+        }
+        if (!StringUtils.isBlank(image.getDescription())) {
+            params.put("description", image.getDescription());
+        }
+
+        if (!params.isEmpty()) {
+            //We can reuse same CSRF-Token in this second request
+            final GCWebLogImageResponse putImgResponse = websiteReq().uri("/api/live/v1/images/" + logId + "/" + imgResponse.guid + "/replace")
+                    .method(HttpRequest.Method.PUT)
+                    .headers(HTML_HEADER_CSRF_TOKEN, csrfToken)
+                    //.bodyForm(params, "image", "image/jpeg", image.getFile())
+                    .bodyForm(params, null, null, null)
+                    .requestJson(GCWebLogImageResponse.class).blockingGet();
+            if (putImgResponse.url == null) {
+                return generateLogError(true, "Problem putting image: " + putImgResponse);
+            }
+        }
+
+        return new ImmutablePair<>(StatusCode.NO_ERROR, imgResponse.url);
+    }
+
+    private static ImmutablePair<StatusCode, String> generateLogError(final boolean image, final String errorMsg) {
+        Log.w((image ? "LOG IMAGE ERROR:" : "LOG ERROR:") + errorMsg);
+        return new ImmutablePair<>(image ? StatusCode.LOGIMAGE_POST_ERROR : StatusCode.LOG_POST_ERROR, "");
+    }
+
+    private static String getCsrfTokenFromUrl(final String url) {
+        final String html =
+                httpReq().uri(url).request().blockingGet().getBodyString();
+        final String csrfToken = TextUtils.getMatch(html, GCConstants.PATTERN_CSRF_TOKEN, null);
+        if (csrfToken == null) {
+            Log.w("Lost Post: unable to find a CSRF Token in Log Page '" + url + "'");
+            return null;
+        }
+        return csrfToken;
+    }
+
     private static HttpRequest httpReq() {
         return new HttpRequest().requestPreparer(reqBuilder -> getCachedAuthorization().map(a -> {
             reqBuilder.addHeader("Authorization", a.getAuthorizationField());
             return reqBuilder;
         }));
     }
+
+    private static HttpRequest websiteReq() {
+        return httpReq().uriBase(WEBSITE_URL);
+    }
+
 
     private static HttpRequest apiReq() {
         return httpReq().uriBase(API_URL);

--- a/main/src/main/java/cgeo/geocaching/log/TrackableLog.java
+++ b/main/src/main/java/cgeo/geocaching/log/TrackableLog.java
@@ -7,8 +7,8 @@ import org.apache.commons.lang3.StringUtils;
 public final class TrackableLog {
     public final int ctl;
     public final int id;
-    public final String geocode;
-    public final String trackCode;
+    public final String geocode; // The public one, e.g. starting with "TB" for gc.com trackables
+    public final String trackCode; // The secret one
     public final String name;
     public final TrackableBrand brand;
     public LogTypeTrackable action = LogTypeTrackable.DO_NOTHING; // base.logTrackablesAction - no action

--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
  */
 public class HttpRequest {
 
-    public enum Method { GET, POST, PATCH }
+    public enum Method { GET, POST, PATCH, PUT }
 
     private static final ObjectMapper JSON_MAPPER = JsonUtils.mapper;
 
@@ -138,18 +138,11 @@ public class HttpRequest {
             return mappedResponse;
         });
 
-        //error logging
-        return result.onErrorResumeNext(t -> {
-            Log.w(LOGPRAEFIX + "ERR: Exception on calling " + getFinalUri() + "/" + method, t);
-            return Single.error(t);
-        });
+        return result;
     }
 
     private Single<Response> executeRequest(final Request.Builder reqBuilder) {
         final Request req = reqBuilder.build();
-        if (Log.isDebug()) {
-            Log.d(LOGPRAEFIX + req.method() + ": " + req.url());
-        }
         return RxOkHttpUtils.request(Network.OK_HTTP_CLIENT, req);
     }
 
@@ -178,6 +171,9 @@ public class HttpRequest {
                 break;
             case PATCH:
                 builder.patch(rbs.get());
+                break;
+            case PUT:
+                builder.put(rbs.get());
                 break;
             case GET:
             default:
@@ -247,6 +243,7 @@ public class HttpRequest {
     public HttpRequest bodyJson(final Object jsonObject) {
         try {
             final String jsonString = JSON_MAPPER.writeValueAsString(jsonObject);
+            Log.d("HTTP-JSON: attempt to send: " + jsonString);
             this.requestBodySupplier = () -> RequestBody.create(jsonString, MEDIA_TYPE_APPLICATION_JSON);
             return this;
         } catch (JsonProcessingException jpe) {

--- a/main/src/main/java/cgeo/geocaching/network/HttpResponse.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpResponse.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.network;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 
+import androidx.annotation.NonNull;
+
 import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -69,6 +71,10 @@ public class HttpResponse {
         }
     }
 
+    public int getStatusCode() {
+        return response == null ? -1 : response.code();
+    }
+
 
     public Response getResponse() {
         return response;
@@ -95,6 +101,12 @@ public class HttpResponse {
             }
         }
         return null;
+    }
+
+    @Override
+    @NonNull
+    public String toString() {
+        return this.getClass().getName() + ", status=" + getStatusCode() + ", isSuccessful=" + isSuccessful() + ", response = " + response + ", body = " + getBodyString();
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/network/Network.java
+++ b/main/src/main/java/cgeo/geocaching/network/Network.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.network;
 
 import cgeo.geocaching.BuildConfig;
 import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
@@ -45,6 +46,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.functions.Function;
 import okhttp3.ConnectionSpec;
 import okhttp3.FormBody;
+import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -399,7 +401,7 @@ public final class Network {
             final Request request = chain.request();
             final String reqLogStr = request.method() + " " + hidePassword(request.url().toString());
 
-            Log.d(reqLogStr);
+            Log.d("HTTP-REQ:" + reqLogStr + ", headers=[" + headerToString(request.headers()) + "]");
 
             final long before = System.currentTimeMillis();
             try {
@@ -407,15 +409,30 @@ public final class Network {
                 final String protocol = " (" + response.protocol() + ')';
                 final String redirect = request.url().equals(response.request().url()) ? "" : " (=> " + response.request().url() + ")";
                 if (response.isSuccessful()) {
-                    Log.d(response.code() + formatTimeSpan(before) + reqLogStr + protocol + redirect);
+                    Log.d("HTTP-RESP:" + response.code() + formatTimeSpan(before) + reqLogStr + protocol + redirect + ", headers=[" + headerToString(response.headers()) + "]");
                 } else {
-                    Log.d(response.code() + " [" + response.message() + "]" + formatTimeSpan(before) + reqLogStr + protocol);
+                    Log.d("HTTP-RESP:" + response.code() + " [" + response.message() + "]" + formatTimeSpan(before) + reqLogStr + protocol + ", headers=[" + headerToString(response.headers()) + "]");
                 }
                 return response;
             } catch (final IOException e) {
-                Log.w("Failure" + formatTimeSpan(before) + reqLogStr + " (" + e + ")");
+                Log.w("HTTP-ERROR:" +  formatTimeSpan(before) + reqLogStr + " (" + e + ")", e);
                 throw e;
             }
+        }
+
+        private static String headerToString(final Headers headers) {
+            if (headers == null) {
+                return "";
+            }
+            return CollectionStream.of(headers.names()).map(n -> n + ":" + prepareHeaderValueForLog(n, headers.get(n))).toJoinedString(";");
+        }
+
+        private static String prepareHeaderValueForLog(final String key, final String value) {
+            if (StringUtils.isBlank(value) || value.length() < 10) {
+                return value;
+            }
+            final boolean shorten = value.length() > 150 || key.contains("uthorization") || key.contains("assword");
+            return shorten ? value.substring(0, 10) + "#" + value.length() + "#" + value.substring(value.length() - 3) : value;
         }
 
         private static String hidePassword(final String message) {

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -697,6 +697,9 @@ public class Settings {
         return getBoolean(R.string.pref_alc_advanced, false);
     }
 
+    public static boolean enableFeatureNewGCLogApi() {
+        return getBoolean(R.string.pref_feature_new_gc_log_api, false);
+    }
     public static boolean enableFeatureUnifiedGeoItemLayer() {
         return getBoolean(R.string.pref_feature_unified_geoitem_layer, false);
     }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -508,6 +508,7 @@
     <string translatable="false" name="pref_pass_vote">pass-vote</string>
     <string translatable="false" name="pref_webDeviceCode">webDeviceCode</string>
     <string translatable="false" name="pref_feature_unified_geoitem_layer">feature_unified_geoitem_layer</string>
+    <string translatable="false" name="pref_feature_new_gc_log_api">feature_new_gc_log_api</string>
 
     <!-- additional map settings -->
     <string translatable="false" name="pref_showUnifiedMap">showUnifiedMap</string>

--- a/main/src/test/java/cgeo/geocaching/utils/TextUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/TextUtilsTest.java
@@ -6,6 +6,7 @@ import android.text.SpannableString;
 import android.util.Pair;
 
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
@@ -266,6 +267,16 @@ public class TextUtilsTest {
 
         assertThat(TextUtils.containsHtml("Special char &; doesn't exist")).isFalse();
 
+    }
+
+    @Test
+    public void pattern() {
+        final String text = "abc\"logTypes\":[{\"value\":2},{\"value\":3},{\"value\":4},{\"value\":45},{\"value\":7}]def";
+        final Pattern p = Pattern.compile("\"logTypes\":\\[([^]]+)]");
+        final Matcher m = p.matcher(text);
+        assertThat(m.find()).isTrue();
+        assertThat(m.group(1)).isEqualTo("{\"value\":2},{\"value\":3},{\"value\":4},{\"value\":45},{\"value\":7}");
+        //"logTypes":[{"value":2},{"value":3},{"value":4},{"value":45},{"value":7}]
     }
 
 }


### PR DESCRIPTION
First implementation for new GC.com Log API.

To activate usage of new API by c:geo, a new hidden boolean setting `feature_new_gc_log_api` must be added and set to value `true`. 

With this activated the following should work via new logging API:
* Simple logging of geocaches, e.g. log date, type, text
* Adding of images to a log (including name + description)
* Automatic trackable status setting to "visited"/"dropped" according to setting in c:geo

The following will NOT work for the new setting:
* "add to favorites" setting in log will be ignored (-> as of now it is not clear whether this can be handled by new API)
* Logging of Trackables seems to be using the new API too on website, but was not yet touched in c:geo

The implementation is to be considered a first try. Alpha testing is heavily needed, preferably with Log leve set to debug for easy analysis in case of problems.

Reference to internal discussion: https://github.com/orgs/cgeo/discussions/77 
