### PR TITLE
Show permission update info on API33+ w/o notification permission

### DIFF
--- a/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
@@ -440,6 +440,10 @@ public class InstallWizardActivity extends AppCompatActivity {
         return PermissionContext.NOTIFICATIONS.hasAllPermissions();
     }
 
+    public static boolean needsNotificationsPermission() {
+        return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !hasNotificationsPermission();
+    }
+
     // -------------------------------------------------------------------
     // Android SAF-based permissions related methods
 

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.BuildConfig;
 import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.CacheListActivity;
 import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.InstallWizardActivity;
 import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SearchActivity;
@@ -24,6 +25,7 @@ import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.GeoItemSelectorUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
@@ -515,6 +517,12 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
 
             // check for finished, but unreceived downloads
             DownloaderUtils.checkPendingDownloads(this);
+
+            // check for notifications permission on migration (API 33+ only)
+            if (InstallWizardActivity.needsNotificationsPermission()) {
+                Dialogs.basicOneTimeMessage(this, OneTimeDialogs.DialogType.NOTIFICATION_PERMISSION, () -> startActivity(new Intent(this, InstallWizardActivity.class)));
+            }
+
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -28,7 +28,8 @@ public class OneTimeDialogs extends DataStore.DBExtension {
         MAP_THEME_FIX_SLOWNESS(R.string.onetime_mapthemefixslow_title, R.string.onetime_mapthemefixslow_message, DefaultBehavior.SHOW_ALWAYS, R.string.faq_url_settings_themes),
         MAP_AUTOROTATION_DISABLE(R.string.map_gm_autorotation, R.string.map_gm_autorotation_disable, DefaultBehavior.SHOW_ALWAYS, 0),
         MAP_LIVE_DISABLED(R.string.map_live_disabled, R.string.map_live_disabled_hint, DefaultBehavior.SHOW_ALWAYS, 0),
-        ROUTE_OPTIMIZATION(R.string.route_optimization, R.string.route_optimization_info, DefaultBehavior.SHOW_ALWAYS, 0);
+        ROUTE_OPTIMIZATION(R.string.route_optimization, R.string.route_optimization_info, DefaultBehavior.SHOW_ALWAYS, 0),
+        NOTIFICATION_PERMISSION(R.string.changed_permissions_title, R.string.changed_permissions_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0);
 
         public final Integer messageTitle;
         public final Integer messageText;

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2583,6 +2583,10 @@
     <string name="running_route_optimizations">Running route optimizations</string>
     <string name="route_optimization_finished">Route optimization finished</string>
 
+    <!-- changed permissions one time message -->
+    <string name="changed_permissions_title">Changed permissions</string>
+    <string name="changed_permissions_info">Android has introduced a new permission required by c:geo. Run the c:geo configuration wizard to check this permission and get more detailed info. You can either run the wizard now or run it later using the menu entry for it on c:geo home screen.\n\nDo you want to run the configuration wizard now?</string>
+
     <!-- individual track -->
     <string name="map_load_track">Load track/route from GPX</string>
     <string name="load_track_error">Error loading track/route</string>


### PR DESCRIPTION
## Description
Shows a OneTimeDialog informing about required POST_NOTIFICATIONS permission and optionally starts configuration wizard.
Happens on API33+ systems only, and only if notification permission is missing.