### PR TITLE
New GCLogApi: make it work for nonmigrated users + restore log favorite capability

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -84,7 +84,7 @@ public final class ActivityMixin {
     }
 
     private static void showCgeoToast(final Context context, final String text, final int toastDuration) {
-        Log.v("[" + context.getClass().getName() + "].showToast(" + text + "){" + toastDuration + "}");
+        Log.d("[" + context.getClass().getName() + "].showToast(" + text + "){" + toastDuration + "}");
         try {
             final Toast toast = Toast.makeText(context, text, toastDuration);
             if (Build.VERSION.SDK_INT < 30) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
@@ -130,6 +130,7 @@ class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.L
     public void onLoadFinished(@NonNull final Loader<GCLoggingManager.Result> loader, final GCLoggingManager.Result result) {
         if (result == null) {
             hasLoaderError = true;
+            Log.w("GCLoggingManager loaderError: empty result");
         } else {
             if (result.trackables != null) {
                 trackables = result.trackables;
@@ -140,6 +141,9 @@ class GCLoggingManager extends AbstractLoggingManager implements LoaderManager.L
 
             possibleLogTypes = result.possibleLogTypes;
             hasLoaderError = possibleLogTypes.isEmpty();
+            if (possibleLogTypes.isEmpty()) {
+                Log.w("GCLoggingManager loaderError: empty log types");
+            }
 
             if (result.premFavcount != null) {
                 premFavcount = result.premFavcount;

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1952,7 +1952,13 @@ public final class GCParser {
 
         final String match = TextUtils.getMatch(page, GCConstants.PATTERN_TYPE4, null);
         if (match == null) {
-            return Collections.emptyList();
+            //September 2023:
+            // During migration time of gc.com to new log page there is still the old page returned for non-migrated members.
+            //--> call old parser in this case.
+            //-- > when migration is completed on gc.com side, replace with: return Collections.emptyList();
+            //see https://github.com/orgs/cgeo/discussions/77 for complete discussion
+            return parseTypes(page);
+            //return Collections.emptyList();
         }
         try {
             final AvailableLogTypeNew[] availableTypes = MAPPER.readValue("[" + match + "]", AvailableLogTypeNew[].class);

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -1381,8 +1381,6 @@ class GCWebAPI {
                                                      final String log, @NonNull final List<cgeo.geocaching.log.TrackableLog> trackables,
                                                      final boolean addToFavorites) {
 
-        //TODO: "addToFavorites" is ignored for now
-
         final String geocode = geocache.getGeocode();
         //1.) Call log page and get a valid CSRF Token
         final String csrfToken = getCsrfTokenFromUrl(WEBSITE_URL + "/live/geocache/" + geocode + "/log");
@@ -1402,6 +1400,7 @@ class GCWebAPI {
             tLog.trackableLogTypeId = t.action.gcApiId;
             return tLog;
         }).toArray(GCWebLogTrackable.class);
+        logEntry.usedFavoritePoint = addToFavorites; //not used by web page, but seems to work
 
         final GCWebLogEntry response = websiteReq().uri("/api/live/v1/logs/" + geocode + "/geocacheLog")
                 .method(HttpRequest.Method.POST)


### PR DESCRIPTION
New GCLogApi: make it work for nonmigrated users + restore log favorite capability

Builds on top of #14635 and adds:
* Ability to log for not-yet-migrated users
* Restore ability to add favorite point directly in log dialog 

Still open:
* Trackable Logging