### PR TITLE
targetSdk 33 for subprojects

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         minSdk 21
         //noinspection OldTargetApi
-        targetSdk 31
+        targetSdk 33
 
         // include only those language resources from libraries which we actively maintain ourselves in the translation project
         // not yet enough translations (~50%): "is","iw" (="he"),"zh"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -455,6 +455,9 @@ dependencies {
     // Support Library RecyclerView
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
 
+    // Support Library viewpager2 used for tabbed view
+    implementation "androidx.viewpager2:viewpager2:1.0.0"
+
     // Settings Library
     implementation 'androidx.preference:preference:1.2.1'
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -455,9 +455,6 @@ dependencies {
     // Support Library RecyclerView
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
 
-    // Support Library viewpager2 used for tabbed view
-    implementation "androidx.viewpager2:viewpager2:1.0.0"
-
     // Settings Library
     implementation 'androidx.preference:preference:1.2.1'
 

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         minSdk 21
         //noinspection OldTargetApi
-        targetSdk 31
+        targetSdk 33
     }
 
     sourceSets.main {

--- a/organicmaps-api/build.gradle
+++ b/organicmaps-api/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 33
 
         consumerProguardFiles "consumer-rules.pro"
     }


### PR DESCRIPTION
Set targetSdk 33 for all other projects to stay in line with `main`.

Follow up changes should not be necessary, imho.
