### PR TITLE
agp 7.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'


### PR DESCRIPTION
Switch to AGP 7.4.2.

For release notes see https://developer.android.com/build/releases/past-releases/agp-7-4-0-release-notes.

This version is compatible with at least AS Electric Eel.
