### PR TITLE
Include routing elevation conf file in DefaultFiles (fix #14572)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/brouter/util/DefaultFilesUtils.java
+++ b/main/src/main/java/cgeo/geocaching/brouter/util/DefaultFilesUtils.java
@@ -24,6 +24,7 @@ public class DefaultFilesUtils {
         MOPED(R.raw.routing_moped, "moped.brf"),
         SHORTEST(R.raw.routing_shortest, "shortest.brf"),
         TREKKING(R.raw.routing_trekking, "trekking.brf"),
+        DUMMY(R.raw.routing_dummy, "dummy.brf"),
         LOOKUPS(R.raw.routing_lookups, "lookups.dat");
 
         @RawRes


### PR DESCRIPTION
## Description
Fixes `UnusedResource` error, also first step for testing whether new "elevation only" mode can be useful for c:geo