### PR TITLE
Show elevation info for current position on map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -37,6 +37,7 @@ import cgeo.geocaching.maps.interfaces.OnCacheTapListener;
 import cgeo.geocaching.maps.interfaces.OnMapDragListener;
 import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.maps.mapsforge.v6.NewMap;
+import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IWaypoint;
@@ -1097,6 +1098,11 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
 
                             if (map.proximityNotification != null) {
                                 map.proximityNotification.checkDistance(map.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
+                            }
+
+                            if (Settings.showElevation()) {
+                                final float elevation = Routing.getElevation(new Geopoint(currentLocation));
+                                map.overlayPositionAndScale.setElevation(elevation, currentLocation.hasAltitude() ? (float) currentLocation.getAltitude() : Routing.NO_ELEVATION_AVAILABLE);
                             }
                         } else if (needsRepaintForHeading) {
                             final float mapBearing = map.mapView.getBearing();

--- a/main/src/main/java/cgeo/geocaching/maps/DistanceDrawer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DistanceDrawer.java
@@ -30,6 +30,10 @@ public class DistanceDrawer {
         }
     }
 
+    public void setElevation(final float elevationFromRouting, final float elevationFromGNSS) {
+        mapDistanceDrawer.drawElevation(elevationFromRouting, elevationFromGNSS);
+    }
+
     public Geopoint getDestinationCoords() {
         return destinationCoords;
     }

--- a/main/src/main/java/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
@@ -2,12 +2,13 @@ package cgeo.geocaching.maps;
 
 /*
  * Standard view is: (at the top of the map view)
- * target           distances1
- *     supersize    distances2
+ * target      distances1
+ * supersize
+ *             distances2
  *
  * - target is only used when in target navigation (opened via cache/waypoint popup)
  * - distances1/distances2 placeholder will be filled with straight distance, routed distance,
- *   individual route length (depending on settings and current data)
+ *   individual route length and elevation info (depending on settings and current data)
  * - By tapping on any of the distance fields either straight or routed distance can be supersized.
  *   It gets removed from the distance view containers and displayed in a larger font:
  * - Tapping on the supersized window toggles between real distance supersized, straight distance
@@ -42,6 +43,7 @@ public class MapDistanceDrawerCommons {
     private String realDistanceInfo = "";
     private String distanceInfo = "";
     private String routingInfo = "";
+    private String elevationInfo = "";
 
     public MapDistanceDrawerCommons(final View root) {
         distances1 = root.findViewById(R.id.distances1);
@@ -67,6 +69,11 @@ public class MapDistanceDrawerCommons {
         updateDistanceViews();
     }
 
+    public void drawElevation(final float elevationFromRouting, final float elevationFromGNSS) {
+        elevationInfo = UnifiedTargetAndDistancesHandler.buildElevationInfo(elevationFromRouting, elevationFromGNSS);
+        updateDistanceViews();
+    }
+
     public void drawRouteDistance(final float routeDistance) {
         this.routeDistance = routeDistance;
         drawDistance(showBothDistances, distance, realDistance);
@@ -80,7 +87,7 @@ public class MapDistanceDrawerCommons {
 
     private void updateDistanceViews() {
         // glue code to UnifiedMap
-        UnifiedTargetAndDistancesHandler.updateDistanceViews(distanceInfo, realDistanceInfo, routingInfo, distances1, distances2, distanceSupersizeView, targetView);
+        UnifiedTargetAndDistancesHandler.updateDistanceViews(distanceInfo, realDistanceInfo, routingInfo, elevationInfo, distances1, distances2, distanceSupersizeView, targetView);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -462,6 +462,12 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
         }
     }
 
+    public void setElevation(final float elevationFromRouting, final float elevationFromGNSS) {
+        if (distanceDrawer != null) {
+            this.distanceDrawer.setElevation(elevationFromRouting, elevationFromGNSS);
+        }
+    }
+
     public Geopoint getDestinationCoords() {
         if (distanceDrawer != null) {
             return distanceDrawer.getDestinationCoords();

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -150,6 +150,11 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
         }
     }
 
+    @Override
+    public void setElevation(final float elevationFromRouting, final float elevationFromGNSS) {
+        mapView.setElevation(elevationFromRouting, elevationFromGNSS);
+    }
+
     public void updateMapRotation() {
         this.mapRotation = Settings.getMapRotation();
         final GoogleMap map = mapRef.get();

--- a/main/src/main/java/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/interfaces/PositionAndHistory.java
@@ -16,6 +16,8 @@ public interface PositionAndHistory extends IndividualRoute.UpdateIndividualRout
 
     Location getCoordinates();
 
+    void setElevation(float elevationFromRouting, float elevationFromGNSS);
+
     void setHeading(float bearingNow);
 
     float getHeading();

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/DistanceView.java
@@ -29,6 +29,10 @@ public class DistanceView {
         }
     }
 
+    public void setElevation(final float elevationFromRouting, final float elevationFromGNSS) {
+        mapDistanceDrawer.drawElevation(elevationFromRouting, elevationFromGNSS);
+    }
+
     public void setRealDistance(final float realDistance) {
         this.realDistance = realDistance;
     }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -1259,6 +1259,11 @@ public class NewMap extends AbstractNavigationBarActivity implements Observer, F
                                 map.proximityNotification.checkDistance(map.caches.getClosestDistanceInM(new Geopoint(currentLocation.getLatitude(), currentLocation.getLongitude())));
                                 timeLastDistanceCheck = System.currentTimeMillis();
                             }
+
+                            if (Settings.showElevation()) {
+                                final float elevation = Routing.getElevation(new Geopoint(currentLocation));
+                                map.distanceView.setElevation(elevation, currentLocation.hasAltitude() ? (float) currentLocation.getAltitude() : Routing.NO_ELEVATION_AVAILABLE);
+                            }
                         }
                     }
                 } catch (final RuntimeException e) {

--- a/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps.routing;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.brouter.core.RoutingEngine;
 import cgeo.geocaching.downloader.DownloadConfirmationActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.settings.Settings;
@@ -32,6 +33,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 public final class Routing {
+    public static final float NO_ELEVATION_AVAILABLE = Float.NaN; // check with Float.isNaN(...)
+
     private static final double UPDATE_MIN_DISTANCE_KILOMETERS = 0.005;
     private static final double MIN_ROUTING_DISTANCE_KILOMETERS = 0.04;
     private static final int UPDATE_MIN_DELAY_SECONDS = 3;
@@ -176,6 +179,48 @@ public final class Routing {
         lastDirectionUpdatePoint = start;
         timeLastUpdate = timeNow;
         return ensureTrack(lastRoutingPoints, start, destination);
+    }
+
+    public static float getElevation(final Geopoint current) {
+        if (routingServiceConnection == null) {
+            return NO_ELEVATION_AVAILABLE;
+        }
+        final Bundle params = new Bundle();
+        params.putInt("engineMode", RoutingEngine.BROUTER_ENGINEMODE_GETELEV);
+        params.putDoubleArray("lats", new double[]{current.getLatitude(), current.getLatitude()});
+        params.putDoubleArray("lons", new double[]{current.getLongitude(), current.getLongitude()});
+        params.putString("v", RoutingMode.STRAIGHT.parameterValue);
+        final String gpx = routingServiceConnection.getTrackFromParams(params);
+
+        // parse result
+        final boolean[] inElevationElement = new boolean[1];
+        final float[] result = new float[1];
+        result[0] = NO_ELEVATION_AVAILABLE;
+        try {
+            Xml.parse(gpx, new DefaultHandler() {
+                @Override
+                public void startElement(final String uri, final String localName, final String qName, final Attributes atts) throws SAXException {
+                    if (qName.equalsIgnoreCase("ele")) {
+                        inElevationElement[0] = true;
+                    }
+                }
+
+                @Override
+                public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+                    inElevationElement[0] = false;
+                }
+
+                @Override
+                public void characters(final char[] ch, final int start, final int length) throws SAXException {
+                    if (inElevationElement[0]) {
+                        result[0] = Float.parseFloat(String.valueOf(ch));
+                    }
+                }
+            });
+        } catch (SAXException ignore) {
+            return NO_ELEVATION_AVAILABLE;
+        }
+        return result[0];
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1421,6 +1421,10 @@ public class Settings {
         return getBoolean(R.string.pref_bigSmileysOnMap, false);
     }
 
+    public static boolean showElevation() {
+        return getBoolean(R.string.pref_showElevation, false);
+    }
+
     /**
      * Proximity notification settings
      */

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -178,6 +178,14 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity {
                         if (needsRepaintForDistanceOrAccuracy || needsRepaintForHeading) {
                             mapActivity.viewModel.setCurrentPositionAndHeading(currentLocation, currentHeading);
                             // @todo: check if proximity notification needs an update
+
+                            if (Settings.showElevation()) {
+                                float elevation = Routing.getElevation(new Geopoint(currentLocation));
+                                if (Float.isNaN(elevation) && currentLocation.hasAltitude()) {
+                                    elevation = (float) currentLocation.getAltitude();
+                                }
+                                mapActivity.viewModel.elevation.setValue(elevation);
+                            }
                         }
                     }
                 } catch (final RuntimeException e) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -39,6 +39,7 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
     public final HashMapLiveData<String, IWaypoint> geoItems = new HashMapLiveData<>();
     public final MutableLiveData<Geopoint> longTapCoords = new MutableLiveData<>();
     public final MutableLiveData<Geopoint> coordsIndicator = new MutableLiveData<>(); // null if coords indicator should be hidden
+    public final MutableLiveData<Float> elevation = new MutableLiveData<>();
 
     /**
      * LiveData wrapping the PositionHistory object or null if PositionHistory should be hidden

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/NavigationTargetLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/NavigationTargetLayer.java
@@ -70,6 +70,8 @@ public class NavigationTargetLayer {
         });
 
         viewModel.individualRoute.observe(activity, individualRoute -> mapDistanceDrawer.drawRouteDistance(individualRoute.getDistance()));
+
+        viewModel.elevation.observe(activity, elevation -> mapDistanceDrawer.drawElevation(elevation));
     }
 
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -236,6 +236,7 @@
     <string translatable="false" name="pref_maptrail_length">maptrail_length</string>
     <string translatable="false" name="pref_bigSmileysOnMap">pref_bigSmileysOnMap</string>
     <string translatable="false" name="pref_dtMarkerOnCacheIcon">pref_dtMarkerOnCacheIcon</string>
+    <string translatable="false" name="pref_showElevation">showElevation</string>
 
     <!-- category waypoints -->
     <string translatable="false" name="pref_showwaypointsthreshold">waypointsthreshold</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1002,6 +1002,8 @@
     <string name="init_summary_bigSmileysOnMap">If enabled, symbols like the \'found smiley\' or the \'corrected coordinates\' marker will be shown enlarged on the map instead of the cache type icon.</string>
     <string name="init_dtMarkerOnCacheIcon">D/T rating on cache icons</string>
     <string name="init_summary_dtMarkerOnCacheIcon">Show an marker for the Difficulty (left) and Terrain (right) ratings on cache markers in upper-right corner ("stored" marker is moved to middle).</string>
+    <string name="init_showElevation">Show Elevation</string>
+    <string name="init_summary_showElevation">Show elevation info for current position, taken from routing data or GNSS (if available)</string>
     <string name="init_global_wp_extraction_disable">Disable waypoint extraction</string>
     <string name="init_summary_global_wp_extraction_disable">Globally disable waypoint extraction from personal cache notes. It can still be enabled for individual caches by deactivating the checkbox below the personal cache note.</string>
     <string name="init_prevent_cache_note_merge">Overwrite Personal Cache Note</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -40,6 +40,12 @@
             android:summary="@string/init_summary_dtMarkerOnCacheIcon"
             android:title="@string/init_dtMarkerOnCacheIcon"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_showElevation"
+            android:title="@string/init_showElevation"
+            android:summary="@string/init_summary_showElevation"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
Show elevation info for current position on map (if activated in settings, default=false).
BRouter routing tiles provide LIDAR-based elevation info, so it's taken from that, if available. Otherwise looks for available GNSS altitude info (if available).

Elevation info is displayed top-right, below distance infos (if applicable):
![image](https://github.com/cgeo/cgeo/assets/3754370/528b751f-7af3-4509-a016-b91545ce2a2e)
