### PR TITLE
Add filtering to SimpleDialog.selectMultiple (rel. to 14602)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -479,7 +479,7 @@ public class ViewUtils {
         return new BitmapDrawable(APP_RESOURCES, bitmap);
     }
 
-    public static TextWatcher createSimpleWatcher(final Consumer<Editable> callback) {
+    public static TextWatcher createSimpleWatcher(@NonNull final Consumer<Editable> callback) {
         return new TextWatcher() {
             @Override
             public void beforeTextChanged(final CharSequence s, final int start, final int count, final int after) {

--- a/main/src/main/res/layout/simpledialog_filtered_selection.xml
+++ b/main/src/main/res/layout/simpledialog_filtered_selection.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.textfield.TextInputLayout android:id="@+id/filterContainer" style="@style/textinput_edittext_singleline">
+        <EditText
+            android:id="@+id/filter"
+            style="@style/textinput_embedded_singleline"
+            android:inputType="text"
+            android:hint="@string/search_filter" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <ListView
+        android:id="@+id/selection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:divider="@null" />
+</LinearLayout>


### PR DESCRIPTION
## Description
Adds a filter box to `SimpleDialog.selectMultiple()`:

![image](https://github.com/cgeo/cgeo/assets/3754370/0667f793-e68a-474d-ab72-90cd7089e1f4).![image](https://github.com/cgeo/cgeo/assets/3754370/9c774815-7d49-49e3-8c30-e4edefbabf78)

- Filter will only be displayed when there are 10 entries or more initially.
- Entry for "Select all" reflects the number of visible elements and only gets applied to visible elements.
- Entry for "Select all" will not be filtered out.
- Filtered-out but still checked elements are part of the result.
- Uses a custom layout for the `AlertDialog` to be able to inject the filter box. Therefore requires a custom adapter as well (as it's already done in `SimpleDialog.selectSingle()`).
- Checkbox state of "Select all" can become invalid currently when used in combination with filtering.
- Tested only with "Select lists for cache" for now.

Setting draft state for now due to the last two items.

@eddiemuc 
Can you cross-check if I haven't broken some of the use-cases for `SimpleDialog.selectMultiple()`? Thanks.