### PR TITLE
don't draw waypoints without note at cache coords

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -1405,7 +1405,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 final boolean forceCompactIconMode = CompactIconModeUtils.forceCompactIconMode(cachesCnt);
                 if (mapOptions.mapMode == MapMode.SINGLE || cachesCnt < Settings.getWayPointsThreshold()) {
                     for (final Waypoint waypoint : waypointsToDisplay) {
-                        if (waypoint != null && waypoint.getCoords() != null && waypoint.getCoords().isValid()) {
+                        if (waypoint != null && waypoint.getCoords() != null && waypoint.getCoords().isValid() && !(waypoint.getCoords() == waypoint.getParentGeocache().getCoords() && waypoint.getNote().isEmpty())) {
                             itemsToDisplay.add(getWaypointItem(waypoint, forceCompactIconMode));
                         }
                     }


### PR DESCRIPTION
fixes #14649 (Waypoint icon shown behind cache icon) by not drawing the waypoint icon on map if waypoint coords are the same as cache coords.
I added a special case if the waypoint has a note - this would e.g. be a multi stage with description - if the user has set the cache coords to stage coords.