### PR TITLE
Fix dialog formatting issues for multi select (rel. to #14602)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -34,6 +34,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.core.util.Consumer;
 
 import java.util.ArrayList;
@@ -467,7 +468,7 @@ public class SimpleDialog {
             @Override
             public View getView(final int position, final @Nullable View convertView, final @NonNull ViewGroup parent) {
                 final int originalPos = getItem(position);
-                final View v = convertView != null ? convertView : LayoutInflater.from(getContext()).inflate(R.layout.select_dialog_multichoice_material, parent, false);
+                final View v = convertView != null ? convertView : LayoutInflater.from(new ContextThemeWrapper(getContext(), R.style.checkboxStyleNoParent)).inflate(R.layout.select_dialog_multichoice_material, parent, false);
                 final CheckedTextView tv = v.findViewById(android.R.id.text1);
                 tv.setText(itemTexts[originalPos]);
                 tv.setChecked(itemSelects[originalPos]);

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -37,6 +37,7 @@
         <item name="android:minHeight">@dimen/radioButtonCheckboxPreferredItemHeight</item>
         <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
         <item name="android:textColor">@color/colorText</item>
+        <item name="listPreferredItemHeightSmall">@dimen/radioButtonCheckboxPreferredItemHeight</item>
     </style>
 
     <style name="checkbox_full">
@@ -222,7 +223,7 @@
     </style>
 
     <!-- Chips -->
-    
+
     <style name="chip_choice" parent="@style/Widget.MaterialComponents.Chip.Filter">
         <item name="chipBackgroundColor">@color/chip_background_selector</item>
         <item name="android:textColor">@color/chip_textcolor_selector</item>

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -12,6 +12,7 @@
         <item name="checkboxStyle">@style/checkboxStyle</item>
         <item name="radioButtonStyle">@style/radioButtonStyle</item>
         <item name="materialAlertDialogTheme">@style/materialAlertDialogTheme</item>
+        <item name="android:textAppearanceMedium">@style/text_default</item>
         <item name="android:spinnerStyle">@style/spinnerStyle</item>
 
         <!-- set Material theme colors -->


### PR DESCRIPTION
## Description
Fix font size of new multi selection dialog. Item spacing is a bit too dense compared to the old dialog, so setting WIP for now.