### PR TITLE
Extend settings description for custom menu item (fix #14473)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -118,7 +118,7 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
     }
 
     private void setCustomBNItemSummary(final ListPreference customBNitem, final String newValue) {
-        customBNitem.setSummary(newValue);
+        customBNitem.setSummary(String.format(getString(R.string.init_custombnitem_description), newValue));
     }
 
     private void setLanguageSummary(final ListPreference languagePref, final String newValue) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1032,7 +1032,8 @@
     <string name="init_summary_livelist">Show an arrow with compass direction for caches in a list</string>
     <string name="init_quicklaunchitems">Quick launch buttons</string>
     <string name="init_summary_quicklaunchitems">Select one or more items as quick launch buttons on home screen</string>
-    <string name="init_custombnitem">Custom Menu Entry</string>
+    <string name="init_custombnitem">Custom Menu Item</string>
+    <string name="init_custombnitem_description">Rightmost bottom navigation menu item:\n%s</string>
     <string name="init_custombnitem_default">Nearby search (default)</string>
     <string name="init_custombnitem_none">(none)</string>
     <string name="init_custombnitem_empty_placeholder">(empty placeholder)</string>


### PR DESCRIPTION
## Description
- rename item to "Custom Menu Item" (instead of Custom Menu Entry)
- display a explanatory description (in addition to current value)

![image](https://github.com/cgeo/cgeo/assets/3754370/3688550c-3732-4da2-ba2a-8cfc769df382)
