### PR TITLE
Fix text size in selectSingle dialogs (rel. to #14602)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -638,7 +638,7 @@ public class SimpleDialog {
     @NotNull
     private ListAdapter createListAdapterSingle(@NotNull final List<TextParam> items, final SingleChoiceMode showMode, final Func1<Integer, Integer> groupMapper) {
 
-        final LayoutInflater inflater = LayoutInflater.from(getContext());
+        final LayoutInflater inflater = LayoutInflater.from(new ContextThemeWrapper(getContext(), R.style.text_default)); // fixes text size
 
         return new ArrayAdapter<TextParam>(
                 getContext(),


### PR DESCRIPTION
## Description
Sets text size in dialogs based on `SimpleDialog.selectSingle()` to our default text size, as we have done for `selectMulti()` already (but does not change item spacing).