### PR TITLE
Add 'append all to route' for waypoints

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -741,6 +741,8 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 cache = DataStore.loadCache(InternalConnector.GEOCODE_HISTORY_CACHE, LoadFlags.LOAD_ALL_DB_ONLY);
                 notifyDataSetChanged();
             }));
+        } else if (menuItem == R.id.menu_add_to_route) {
+            AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> DataStore.appendToIndividualRoute(cache.getWaypoints()), () -> ActivityMixin.showShortToast(this, R.string.waypoints_appended_to_route));
         } else if (menuItem == R.id.menu_export_gpx) {
             new GpxExport().export(Collections.singletonList(cache), this, cache.getName());
         } else if (menuItem == R.id.menu_export_fieldnotes) {

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -26,6 +26,7 @@ import cgeo.geocaching.log.LogTypeTrackable;
 import cgeo.geocaching.log.OfflineLogEntry;
 import cgeo.geocaching.log.ReportProblemType;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.IWaypoint;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteItem;
@@ -3575,7 +3576,7 @@ public class DataStore {
         });
     }
 
-    public static void appendToIndividualRoute(@NonNull final Collection<Geocache> caches) {
+    public static void appendToIndividualRoute(@NonNull final Collection<? extends IWaypoint> items) {
         withAccessLock(() -> {
 
             init();
@@ -3589,8 +3590,8 @@ public class DataStore {
                 }
                 // append new items
                 final SQLiteStatement insertRouteItem = PreparedStatement.INSERT_ROUTEITEM.getStatement();
-                for (Geocache cache : caches) {
-                    insertRouteItemHelper(insertRouteItem, new RouteItem(cache), ++maxPrecedence);
+                for (IWaypoint item : items) {
+                    insertRouteItemHelper(insertRouteItem, new RouteItem(item), ++maxPrecedence);
                 }
                 database.setTransactionSuccessful();
             } catch (final Exception e) {

--- a/main/src/main/res/menu/cache_options.xml
+++ b/main/src/main/res/menu/cache_options.xml
@@ -131,6 +131,10 @@
                 android:title="@string/clear_goto_history_title"
                 android:visible="false">
             </item>
+            <item
+                android:id="@+id/menu_add_to_route"
+                android:title="@string/caches_append_to_route_all"
+                app:showAsAction="ifRoom|withText"/>
         </menu>
     </item>
     <item

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -459,6 +459,7 @@
     <string name="caches_append_to_route_selected">Append selected to individual route</string>
     <string name="caches_append_to_route_all">Append all to individual route</string>
     <string name="caches_appended_to_route">Caches appended to route</string>
+    <string name="waypoints_appended_to_route">Waypoints appended to route</string>
     <string name="caches_delete_events">Delete past events</string>
     <string name="caches_upload_bookmarklist">Add to bookmark list</string>
     <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>


### PR DESCRIPTION
## Description
We already have a "append all to route" for cache lists. This PR adds "append all to route" for waypoints, to be called from waypoint list. Useful for multis or lab adventures.