### PR TITLE
Put proximity info in notification title (fix #14673)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/main/java/cgeo/geocaching/location/ProximityNotification.java
@@ -132,7 +132,9 @@ public class ProximityNotification implements Parcelable {
         if (useTextNotifications) {
             final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, NotificationChannels.PROXIMITY_NOTIFICATION.name())
                     .setSmallIcon(near ? R.drawable.proximity_notification_near : R.drawable.proximity_notification_far)
-                    .setContentTitle(context.getString(R.string.notification_proximity_title))
+                    // deliberately set notification info to both title and content, as some devices
+                    // show title first (and content is cut off)
+                    .setContentTitle(notification)
                     .setContentText(notification)
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(notification))
                     .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2539,7 +2539,6 @@
     <string name="notification_channel_downloader_description">result notifications for downloads (e.g. offline maps)</string>
     <string name="notification_channel_cache_download_name">cache downloader</string>
     <string name="notification_channel_cache_download_description">result notifications for caches background downloads</string>
-    <string name="notification_proximity_title">c:geo proximity notification</string>
     <string name="notification_download_receiver_title">Importing download</string>
 
     <!-- individual routes -->


### PR DESCRIPTION
## Description
Put proximity info ("14 meters: GCxxxx Cache name") in both notification title and content, as some devices show title first (and cut off content).