### PR TITLE
Add two user-defined routing profiles (fix #14700)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.maps;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.brouter.BRouterConstants;
 import cgeo.geocaching.databinding.MapSettingsDialogBinding;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.filters.core.GeocacheFilter;
@@ -17,6 +18,7 @@ import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.view.LayoutInflater;
@@ -38,6 +40,7 @@ import java.util.Objects;
 import static java.lang.Boolean.TRUE;
 
 import com.google.android.material.button.MaterialButtonToggleGroup;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class MapSettingsUtils {
@@ -51,6 +54,7 @@ public class MapSettingsUtils {
     }
 
     // splitting up that method would not help improve readability
+    @SuppressLint("SetTextI18n")
     @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
     public static void showSettingsPopup(final Activity activity, @Nullable final IndividualRoute route, @NonNull final Action1<Boolean> onMapSettingsPopupFinished, @NonNull final Action1<RoutingMode> setRoutingValue, @NonNull final Action1<Integer> setCompactIconValue, final Runnable configureProximityNotifications, final GeocacheFilterContext filterContext) {
         isShowCircles = Settings.isShowCircles();
@@ -103,6 +107,21 @@ public class MapSettingsUtils {
         final ToggleButtonWrapper<RoutingMode> routingChoiceWrapper = new ToggleButtonWrapper<>(Routing.isAvailable() || Settings.getRoutingMode() == RoutingMode.OFF ? Settings.getRoutingMode() : RoutingMode.STRAIGHT, setRoutingValue, dialogView.routingTooglegroup);
         for (RoutingMode mode : RoutingMode.values()) {
             routingChoiceWrapper.add(new ButtonChoiceModel<>(mode.buttonResId, mode, activity.getString(mode.infoResId)));
+        }
+
+        // routing profile legend for user-defined entries
+        final StringBuilder sb = new StringBuilder();
+        final String temp1 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER1), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
+        if (StringUtils.isNotBlank(temp1)) {
+            sb.append("1: ").append(temp1);
+        }
+        final String temp2 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER2), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
+        if (StringUtils.isNotBlank(temp2)) {
+            sb.append(StringUtils.isNotBlank(sb) ? " - " : "").append("2: ").append(temp2);
+        }
+        if (StringUtils.isNotBlank(sb)) {
+            dialogView.routingProfileinfo.setVisibility(View.VISIBLE);
+            dialogView.routingProfileinfo.setText("(" + sb + ")");
         }
 
         if (showAutotargetIndividualRoute || showPNMastertoggle) {

--- a/main/src/main/java/cgeo/geocaching/maps/routing/RoutingMode.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/RoutingMode.java
@@ -13,7 +13,9 @@ public enum RoutingMode {
     STRAIGHT("straight", R.string.routingmode_straight, R.id.routing_straight),
     WALK("foot", R.string.routingmode_walk, R.id.routing_walk),
     BIKE("bicycle", R.string.routingmode_bike, R.id.routing_bike),
-    CAR("motorcar", R.string.routingmode_car, R.id.routing_car);
+    CAR("motorcar", R.string.routingmode_car, R.id.routing_car),
+    USER1("user1", R.string.routingmode_user1, R.id.routing_user1),
+    USER2("user2", R.string.routingmode_user2, R.id.routing_user2);
 
     @NonNull
     public final String parameterValue;

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1388,6 +1388,10 @@ public class Settings {
             return getString(R.string.pref_brouterProfileBike, BRouterConstants.BROUTER_PROFILE_BIKE_DEFAULT);
         } else if (mode.equals(RoutingMode.WALK)) {
             return getString(R.string.pref_brouterProfileWalk, BRouterConstants.BROUTER_PROFILE_WALK_DEFAULT);
+        } else if (mode.equals(RoutingMode.USER1)) {
+            return getString(R.string.pref_brouterProfileUser1, null);
+        } else if (mode.equals(RoutingMode.USER2)) {
+            return getString(R.string.pref_brouterProfileUser2, null);
         } else {
             return null;
         }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -109,6 +109,8 @@ public class PreferenceNavigationFragment extends BasePreferenceFragment {
         updateRoutingProfilePref(R.string.pref_brouterProfileWalk, RoutingMode.WALK, entries, values);
         updateRoutingProfilePref(R.string.pref_brouterProfileBike, RoutingMode.BIKE, entries, values);
         updateRoutingProfilePref(R.string.pref_brouterProfileCar, RoutingMode.CAR, entries, values);
+        updateRoutingProfilePref(R.string.pref_brouterProfileUser1, RoutingMode.USER1, entries, values);
+        updateRoutingProfilePref(R.string.pref_brouterProfileUser2, RoutingMode.USER2, entries, values);
     }
 
     private void updateRoutingProfilePref(@StringRes final int prefId, final RoutingMode mode, final CharSequence[] entries, final CharSequence[] values) {

--- a/main/src/main/res/drawable/number_one.xml
+++ b/main/src/main/res/drawable/number_one.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="96"
+    android:viewportHeight="96"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m 43 76 l 0 -43.8 l -9.2 6.6 l -4.6 -7 l 16.4 -11.8 l 6.4 0 l 0 56 l -9 0 z"/>
+</vector>

--- a/main/src/main/res/drawable/number_two.xml
+++ b/main/src/main/res/drawable/number_two.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m 284 760 l 0 -84 l 200 -204 q 33 -35 46.5 -58.5 q 13.5 -23.5 13.5 -53.5 q 0 -29 -22.5 -52.5 q -22.5 -23.5 -67.5 -23.5 q -36 0 -59.5 20 q -23.5 20 -32.5 52 l -80 -32 q 14 -45 58 -84.5 q 44 -39.5 116 -39.5 q 83 0 129.5 47.5 q 46.5 47.5 46.5 112.5 q 0 45 -21 82 q -21 37 -65 82 l -146 152 l 2 4 l 238 0 l 0 80 l -356 0 z"/>
+</vector>

--- a/main/src/main/res/layout/map_settings_dialog.xml
+++ b/main/src/main/res/layout/map_settings_dialog.xml
@@ -104,6 +104,16 @@
                 android:id="@+id/routing_car"
                 style="@style/button_icon_accent"
                 app:icon="@drawable/routing_car" />
+
+            <Button
+                android:id="@+id/routing_user1"
+                style="@style/button_icon_accent"
+                app:icon="@drawable/number_one" />
+
+            <Button
+                android:id="@+id/routing_user2"
+                style="@style/button_icon_accent"
+                app:icon="@drawable/number_two" />
         </com.google.android.material.button.MaterialButtonToggleGroup>
 
         <ImageView
@@ -113,6 +123,14 @@
             android:src="@drawable/ic_info_blue"
             android:layout_alignParentRight="true"
             android:layout_alignBottom="@id/routing_tooglegroup"
+            android:visibility="gone"/>
+
+        <TextView
+            android:id="@+id/routing_profileinfo"
+            style="@style/text_default"
+            android:textSize="@dimen/textSize_detailsSecondary"
+            android:text="@string/map_routing"
+            android:layout_below="@id/routing_tooglegroup"
             android:visibility="gone"/>
     </RelativeLayout>
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -317,6 +317,8 @@
     <string translatable="false" name="pref_brouterProfileWalk">brouterProfileWalk</string>
     <string translatable="false" name="pref_brouterProfileBike">brouterProfileBike</string>
     <string translatable="false" name="pref_brouterProfileCar">brouterProfileCar</string>
+    <string translatable="false" name="pref_brouterProfileUser1">brouterProfileUser1</string>
+    <string translatable="false" name="pref_brouterProfileUser2">brouterProfileUser2</string>
     <string translatable="false" name="pref_removeFromRouteOnLog">removeFromRouteOnLog</string>
 
     <!-- categories default navigation / secondary navigation -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -994,6 +994,7 @@
     <string name="init_brouterProfileWalk">\"Walk\" profile</string>
     <string name="init_brouterProfileBike">\"Bike\" profile</string>
     <string name="init_brouterProfileCar">\"Car\" profile</string>
+    <string name="init_brouterProfileUser">User-defined profile</string>
     <string name="init_removeFromRouteOnLog">Remove from route on log</string>
     <string name="init_summary_removeFromRouteOnLog">On sending or storing a log remove the cache from current route.</string>
     <string name="brouter_recalculating">Recalculating route in background…</string>
@@ -2650,6 +2651,8 @@
     <string name="routingmode_walk">Walk</string>
     <string name="routingmode_bike">Bike</string>
     <string name="routingmode_car">Car</string>
+    <string name="routingmode_user1">User 1</string>
+    <string name="routingmode_user2">User 2</string>
 
     <!-- view settings -->
     <string name="view_settings">View settings</string>

--- a/main/src/main/res/xml/preferences_navigation.xml
+++ b/main/src/main/res/xml/preferences_navigation.xml
@@ -82,6 +82,16 @@
             android:key="@string/pref_brouterProfileCar"
             android:title="@string/init_brouterProfileCar"
             app:iconSpaceReserved="false" />
+        <ListPreference
+            android:dialogTitle="@string/init_brouterProfileUser"
+            android:key="@string/pref_brouterProfileUser1"
+            android:title="@string/init_brouterProfileUser"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:dialogTitle="@string/init_brouterProfileUser"
+            android:key="@string/pref_brouterProfileUser2"
+            android:title="@string/init_brouterProfileUser"
+            app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
             android:defaultValue="false"


### PR DESCRIPTION
## Description
Adds two user-defined routing profile for easier toggling between multiple user-selected routing profiles. See discussion in #14700.

![image](https://github.com/cgeo/cgeo/assets/3754370/7eec1571-65db-446e-87fe-9d645a358078)

Names of selected user-defined profiles will be shown below toggle button row.