### PR TITLE
hide the whole "unified map" preferences category if not enabled instead of only 1 setting

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -71,7 +71,7 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         initPublicFolders(this, activity.getCsah());
 
         // display checkbox pref for unified map, if showUnifiedMap is enabled
-        final Preference p = findPreference(activity.getString(R.string.pref_useUnifiedMap));
+        final Preference p = findPreference(activity.getString(R.string.pref_fakekey_unifiedmap));
         if (p != null) {
             p.setVisible(Settings.getBoolean(R.string.pref_showUnifiedMap, false));
         }


### PR DESCRIPTION
PreferenceCategory pref_fakekey_unifiedmap has 2 entries but only one of them was hidden depending on R.string.pref_showUnifiedMap