### PR TITLE
don't draw waypoints without note at cache coords

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -1407,9 +1407,14 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
                 final boolean forceCompactIconMode = CompactIconModeUtils.forceCompactIconMode(cachesCnt);
                 if (mapOptions.mapMode == MapMode.SINGLE || cachesCnt < Settings.getWayPointsThreshold()) {
                     for (final Waypoint waypoint : waypointsToDisplay) {
-                        if (waypoint != null && waypoint.getCoords() != null && waypoint.getCoords().isValid() && !(waypoint.getCoords() == waypoint.getParentGeocache().getCoords() && waypoint.getNote().isEmpty())) {
-                            itemsToDisplay.add(getWaypointItem(waypoint, forceCompactIconMode));
+                        if (waypoint == null || waypoint.getCoords() == null || !waypoint.getCoords().isValid()) {
+                            continue;
                         }
+                        final Geocache cache = waypoint.getParentGeocache();
+                        if (waypoint.getNote().isEmpty() && cache != null && cache.getCoords() != null && cache.getCoords().isValid() && waypoint.getCoords().equals(cache.getCoords())) {
+                            continue;
+                        }
+                        itemsToDisplay.add(getWaypointItem(waypoint, forceCompactIconMode));
                     }
                 }
                 for (final Geocache cache : cachesToDisplay) {

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/WaypointsOverlay.java
@@ -57,6 +57,10 @@ public class WaypointsOverlay extends AbstractCachesOverlay {
             if (waypoint == null || waypoint.getCoords() == null || !waypoint.getCoords().isValid()) {
                 continue;
             }
+            final Geocache cache = waypoint.getParentGeocache();
+            if (waypoint.getNote().isEmpty() && cache != null && cache.getCoords() != null && cache.getCoords().isValid() && waypoint.getCoords().equals(cache.getCoords())) {
+                continue;
+            }
             if (removeCodes.contains(waypoint.getFullGpxId())) {
                 removeCodes.remove(waypoint.getFullGpxId());
             } else {


### PR DESCRIPTION
Better fix for https://github.com/cgeo/cgeo/issues/14649 (Waypoint icon shown behind cache icon) by not drawing the waypoint icon on map if waypoint coords are the same as cache coords.

Old fix covered only Google Maps, this also avoids some corner cases.

UnifiedMap doesn't support drawing Waypoints yet but a similar implementation will be required there when it does.