### PR TITLE
Regrant Uri permissions on restore

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
@@ -127,23 +127,23 @@ public class BackupUtils {
                                 regrantAccessFolders.remove(0);
                                 triggerNextRegrantStep(null, null);
                             });
-/* reactivate this if there will ever be PersistableUri again stored in our preferences
         } else if (!regrantAccessUris.isEmpty()) {
-            final Uri uriToBeRestored = Uri.parse(regrantAccessUris.get(0).right);
-            final String temp = uriToBeRestored.getPath();
-            final String displayName = temp.substring(temp.lastIndexOf('/') + 1);
+            for (ImmutableTriple<PersistableUri, String, String> data : regrantAccessUris) {
+                final Uri uriToBeRestored = Uri.parse(data.right);
+                final String temp = uriToBeRestored.getPath();
+                final String displayName = temp.substring(temp.lastIndexOf('/') + 1);
 
-            SimpleDialog.of(activityContext)
-                .setTitle(R.string.init_backup_settings_restore)
-                .setMessage(R.string.settings_file_changed, activityContext.getString(regrantAccessUris.get(0).left.getNameKeyId()), displayName, activityContext.getString(android.R.string.cancel), activityContext.getString(android.R.string.ok))
-                .confirm((d, v) -> {
-                    fileSelector.restorePersistableUri(PersistableUri.TRACK, uriToBeRestored);
-                },
-                (d2, v2) -> {
-                    regrantAccessUris.remove(0);
-                    triggerNextRegrantStep(null, null);
-                });
-*/
+                SimpleDialog.of(activityContext)
+                    .setTitle(R.string.init_backup_settings_restore)
+                    .setMessage(R.string.settings_file_changed, activityContext.getString(data.left.getNameKeyId()), displayName, activityContext.getString(android.R.string.cancel), activityContext.getString(android.R.string.ok))
+                    .confirm((d, v) -> {
+                        fileSelector.restorePersistableUri(data.left, uriToBeRestored);
+                    },
+                    (d2, v2) -> {
+                        regrantAccessUris.remove(0);
+                        triggerNextRegrantStep(null, null);
+                    });
+            }
         } else {
             finishRestoreInternal(activityContext, regrantAccessRestartNeeded, regrantAccessResultString);
         }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1090,6 +1090,7 @@
     <string name="settings_readingerror">Error reading settings</string>
     <string name="settings_restart">c:geo needs to be restarted now to bring loaded settings into effect</string>
     <string name="settings_folder_changed">Folder \"%1$s\" will be changed to \"%2$s\" during restoration.\n\nTap \"%4$s\" to proceed. In that case you will be asked to regrant c:geo access to that folder.\n\nTap \"%3$s\" to keep the current folder setting instead.</string>
+    <string name="settings_file_changed">\"%1$s\" will be changed to \"%2$s\" during restoration.\n\nTap \"%4$s\" to proceed. In that case you will be asked to regrant c:geo access to that file.\n\nTap \"%3$s\" to keep the current setting instead.</string>
 
     <string name="settings_info_offline_maps_title">Info on Offline Maps</string>
     <string name="settings_info_offline_maps">c:geo supports maps for offline use. You can obtain maps from different providers or even create your own maps (from OSM data). First you have to select the folder in which offline maps are to be stored.</string>


### PR DESCRIPTION
## Description
When restoring a backup which includes persisted URI, the user needs to regrant access to those files.

We had this for persisted track file and removed functionality when we switched to supporting multiple track files with a different storage method. Now we have persisted URI for proximity notification audio files and need to re-enable this mechanism.