### PR TITLE
Show only available routing options (fix #14721)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -110,18 +110,21 @@ public class MapSettingsUtils {
         }
 
         // routing profile legend for user-defined entries
-        final StringBuilder sb = new StringBuilder();
-        final String temp1 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER1), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
-        if (StringUtils.isNotBlank(temp1)) {
-            sb.append("1: ").append(temp1);
-        }
-        final String temp2 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER2), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
-        if (StringUtils.isNotBlank(temp2)) {
-            sb.append(StringUtils.isNotBlank(sb) ? " - " : "").append("2: ").append(temp2);
-        }
-        if (StringUtils.isNotBlank(sb)) {
-            dialogView.routingProfileinfo.setVisibility(View.VISIBLE);
-            dialogView.routingProfileinfo.setText("(" + sb + ")");
+        final boolean useInternalRouting = Settings.useInternalRouting();
+        if (useInternalRouting) {
+            final StringBuilder sb = new StringBuilder();
+            final String temp1 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER1), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
+            if (StringUtils.isNotBlank(temp1)) {
+                sb.append("1: ").append(temp1);
+            }
+            final String temp2 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER2), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
+            if (StringUtils.isNotBlank(temp2)) {
+                sb.append(StringUtils.isNotBlank(sb) ? " - " : "").append("2: ").append(temp2);
+            }
+            if (StringUtils.isNotBlank(sb)) {
+                dialogView.routingProfileinfo.setVisibility(View.VISIBLE);
+                dialogView.routingProfileinfo.setText("(" + sb + ")");
+            }
         }
 
         if (showAutotargetIndividualRoute || showPNMastertoggle) {
@@ -166,6 +169,8 @@ public class MapSettingsUtils {
 
         compactIconWrapper.init();
         routingChoiceWrapper.init();
+        routingChoiceWrapper.getByResId(R.id.routing_user1).button.setVisibility(useInternalRouting ? View.VISIBLE : View.GONE);
+        routingChoiceWrapper.getByResId(R.id.routing_user2).button.setVisibility(useInternalRouting ? View.VISIBLE : View.GONE);
 
         if (!Routing.isAvailable()) {
             configureRoutingButtons(false, routingChoiceWrapper);

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -135,10 +135,8 @@ public class PreferenceNavigationFragment extends BasePreferenceFragment {
 
     private void updateRoutingPrefs(final boolean useInternalRouting) {
         final boolean anyRoutingAvailable = useInternalRouting || ProcessUtils.isInstalled(getString(R.string.package_brouter));
+        findPreference(getString(R.string.pref_fakekey_brouterDistanceThresholdTitle)).setEnabled(anyRoutingAvailable);
         findPreference(getString(R.string.pref_brouterDistanceThreshold)).setEnabled(anyRoutingAvailable);
         findPreference(getString(R.string.pref_brouterShowBothDistances)).setEnabled(anyRoutingAvailable);
-        findPreference(getString(R.string.pref_brouterProfileWalk)).setEnabled(useInternalRouting);
-        findPreference(getString(R.string.pref_brouterProfileBike)).setEnabled(useInternalRouting);
-        findPreference(getString(R.string.pref_brouterProfileCar)).setEnabled(useInternalRouting);
     }
 }

--- a/main/src/main/res/xml/preferences_navigation.xml
+++ b/main/src/main/res/xml/preferences_navigation.xml
@@ -70,27 +70,32 @@
             android:dialogTitle="@string/init_brouterProfileWalk"
             android:key="@string/pref_brouterProfileWalk"
             android:title="@string/init_brouterProfileWalk"
+            android:dependency="@string/pref_useInternalRouting"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:dialogTitle="@string/init_brouterProfileBike"
             android:key="@string/pref_brouterProfileBike"
             android:title="@string/init_brouterProfileBike"
+            android:dependency="@string/pref_useInternalRouting"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:defaultValue="car-eco.brf"
             android:dialogTitle="@string/init_brouterProfileCar"
             android:key="@string/pref_brouterProfileCar"
             android:title="@string/init_brouterProfileCar"
+            android:dependency="@string/pref_useInternalRouting"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:dialogTitle="@string/init_brouterProfileUser"
             android:key="@string/pref_brouterProfileUser1"
             android:title="@string/init_brouterProfileUser"
+            android:dependency="@string/pref_useInternalRouting"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:dialogTitle="@string/init_brouterProfileUser"
             android:key="@string/pref_brouterProfileUser2"
             android:title="@string/init_brouterProfileUser"
+            android:dependency="@string/pref_useInternalRouting"
             app:iconSpaceReserved="false" />
 
         <CheckBoxPreference


### PR DESCRIPTION
## Description
- Hide pref title "Max. distance for routing calculation" if no routing option is available
- Hide routing profile options if not using internal routing
- Hide user1/2 options in map quick settings and their label if not using internal routing
