### PR TITLE
Use icons for distance and elevation info (fix #14744)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapDistanceDrawerCommons.java
@@ -25,10 +25,9 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-public class MapDistanceDrawerCommons {
-    private static final String STRAIGHT_LINE_SYMBOL = Character.toString((char) 0x007C);
-    private static final String WAVY_LINE_SYMBOL = Character.toString((char) 0x2307);
+import androidx.core.util.Pair;
 
+public class MapDistanceDrawerCommons {
     private final LinearLayout distances1;
     private final LinearLayout distances2;
     private final TextView distanceSupersizeView;
@@ -40,10 +39,11 @@ public class MapDistanceDrawerCommons {
     private float realDistance = 0.0f;
     private float routeDistance = 0.0f;
 
-    private String realDistanceInfo = "";
-    private String distanceInfo = "";
-    private String routingInfo = "";
-    private String elevationInfo = "";
+    private final Pair<Integer, String> emptyInfo = new Pair<>(0, "");
+    private Pair<Integer, String> realDistanceInfo = emptyInfo;
+    private Pair<Integer, String> distanceInfo = emptyInfo;
+    private Pair<Integer, String> routingInfo = emptyInfo;
+    private Pair<Integer, String> elevationInfo = emptyInfo;
 
     public MapDistanceDrawerCommons(final View root) {
         distances1 = root.findViewById(R.id.distances1);
@@ -64,9 +64,10 @@ public class MapDistanceDrawerCommons {
         final boolean showRealDistance = realDistance > 0.0f && distance != realDistance && !routingModeStraight;
         bothViewsNeeded = showBothDistances && showRealDistance;
 
-        realDistanceInfo = showRealDistance ? (showBothDistances ? WAVY_LINE_SYMBOL + " " : "") + Units.getDistanceFromKilometers(realDistance) : "";
-        distanceInfo = (showBothDistances || routingModeStraight) && distance > 0.0f ? (showBothDistances ? STRAIGHT_LINE_SYMBOL + " " : "") + Units.getDistanceFromKilometers(distance) : "";
-        routingInfo = routeDistance > 0.0f ? Units.getDistanceFromKilometers(routeDistance) : "";
+        realDistanceInfo = showRealDistance ? new Pair<>(Settings.getRoutingMode().drawableId, Units.getDistanceFromKilometers(realDistance)) : emptyInfo;
+        distanceInfo = (showBothDistances || routingModeStraight) && distance > 0.0f ? new Pair<>(RoutingMode.STRAIGHT.drawableId, Units.getDistanceFromKilometers(distance)) : emptyInfo;
+        routingInfo = routeDistance > 0.0f ? new Pair<>(R.drawable.map_quick_route, Units.getDistanceFromKilometers(routeDistance)) : emptyInfo;
+
         updateDistanceViews();
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/routing/RoutingMode.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/RoutingMode.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.maps.routing;
 
 import cgeo.geocaching.R;
 
+import androidx.annotation.DrawableRes;
+import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 
@@ -9,23 +11,25 @@ import androidx.annotation.StringRes;
  * Mapping of routing modes and {@link BRouterServiceConnection} implementation dependent parameter values.
  */
 public enum RoutingMode {
-    OFF("off", R.string.switch_off, R.id.routing_off),
-    STRAIGHT("straight", R.string.routingmode_straight, R.id.routing_straight),
-    WALK("foot", R.string.routingmode_walk, R.id.routing_walk),
-    BIKE("bicycle", R.string.routingmode_bike, R.id.routing_bike),
-    CAR("motorcar", R.string.routingmode_car, R.id.routing_car),
-    USER1("user1", R.string.routingmode_user1, R.id.routing_user1),
-    USER2("user2", R.string.routingmode_user2, R.id.routing_user2);
+    OFF("off", R.string.switch_off, R.id.routing_off, R.drawable.routing_off),
+    STRAIGHT("straight", R.string.routingmode_straight, R.id.routing_straight, R.drawable.routing_straight),
+    WALK("foot", R.string.routingmode_walk, R.id.routing_walk, R.drawable.routing_walk),
+    BIKE("bicycle", R.string.routingmode_bike, R.id.routing_bike, R.drawable.routing_bike),
+    CAR("motorcar", R.string.routingmode_car, R.id.routing_car, R.drawable.routing_car),
+    USER1("user1", R.string.routingmode_user1, R.id.routing_user1, R.drawable.number_one),
+    USER2("user2", R.string.routingmode_user2, R.id.routing_user2, R.drawable.number_two);
 
     @NonNull
     public final String parameterValue;
     public final int infoResId;
-    public final int buttonResId;
+    @IdRes public final int buttonResId;
+    @DrawableRes public final int drawableId;
 
-    RoutingMode(@NonNull final String parameterValue, @StringRes final int infoResId, final int buttonResId) {
+    RoutingMode(@NonNull final String parameterValue, @StringRes final int infoResId, final int buttonResId, @DrawableRes final int drawableId) {
         this.parameterValue = parameterValue;
         this.infoResId = infoResId;
         this.buttonResId = buttonResId;
+        this.drawableId = drawableId;
     }
 
     public static RoutingMode fromString(@NonNull final String input) {

--- a/main/src/main/java/cgeo/geocaching/ui/TextParam.java
+++ b/main/src/main/java/cgeo/geocaching/ui/TextParam.java
@@ -11,6 +11,7 @@ import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -45,6 +46,7 @@ public class TextParam {
 
     private ImageParam image;
     private int imageSizeInDp = -1;
+    @ColorInt private int imageTintColor = 1;
 
 
     /**
@@ -118,6 +120,14 @@ public class TextParam {
         return this;
     }
 
+    /**
+     * set tint color for compound image
+     */
+    public TextParam setImageTint(@ColorInt final int imageTintColor) {
+        this.imageTintColor = imageTintColor;
+        return this;
+    }
+
     private TextParam(@StringRes final int textId, final CharSequence text, final TextParam[] concatTexts, final Object... params) {
         this.textId = textId;
         this.text = text;
@@ -138,7 +148,7 @@ public class TextParam {
      * Applies the current settings of this TextParam to a textview.
      * Parameter forceNoMovement allows to force not setting a movement method even if other params suggest. This is important
      * if TextParam is used in a context where resulting TextView needs to remain clickable by itself
-     * * Sets text returned by {@link #getText(Co ntext)}
+     * * Sets text returned by {@link #getText(Context)}
      * * Calls {@link #adjust(TextView, boolean)} on the textview
      */
     public void applyTo(@Nullable final TextView view, final boolean forceNoMovement) {
@@ -227,6 +237,13 @@ public class TextParam {
                 view.setCompoundDrawables(imageDrawable, null, null, null);
             }
 
+            // set image tint (if given)
+            if (imageTintColor != 1) {
+                final Drawable[] d = view.getCompoundDrawables();
+                if (d.length > 0) {
+                    d[0].setTint(imageTintColor);
+                }
+            }
             //Add margin between image and text (support various screen densities)
             view.setCompoundDrawablePadding(ViewUtils.dpToPixel(10));
         }

--- a/main/src/main/res/drawable/elevation.xml
+++ b/main/src/main/res/drawable/elevation.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M82,840L340,480L542,480L840,132L840,840L82,840ZM152,607L88,561L260,320L462,320L650,101L710,153L498,400L300,400L152,607ZM238,760L760,760L760,348L578,560L380,560L238,760ZM760,760L760,760L760,760L760,760L760,760L760,760Z"/>
+</vector>


### PR DESCRIPTION
## Description
Replaces Unicode characters by icons for distance and elevation symbols in map view.
Uses selected routing type-specific icons instead of generic "wavy line" symbol, if applicable.

![image](https://github.com/cgeo/cgeo/assets/3754370/a904a66e-f761-4b6e-90c1-f57740bb5939)
