### PR TITLE
re-enable item click listener on unified map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.CoordinatesType;
 import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.maps.mapsforge.v6.caches.GeoitemRef;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IWaypoint;
@@ -131,14 +132,15 @@ public class GeoItemSelectorUtils {
             }
         }
 
-        // Fallback - neither a cache nor waypoint. should never happen...
+        // Fallback - coords only points
+
         final TextView tv = view.findViewById(R.id.text);
-        tv.setText(routeItem.getIdentifier());
+        tv.setText(R.string.route_item_point);
 
         final TextView infoView = view.findViewById(R.id.info);
-        infoView.setText(routeItem.getGeocode());
+        infoView.setText(routeItem.getPoint().format(GeopointFormatter.Format.LAT_LON_DECMINUTE));
 
-        // tv.setCompoundDrawablesWithIntrinsicBounds(routeItem.getMarkerId(), 0, 0, 0);
+         tv.setCompoundDrawablesWithIntrinsicBounds(R.drawable.marker_routepoint_large, 0, 0, 0);
         return view;
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.maps.RouteTrackUtils;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.LocationDataProvider;
@@ -818,7 +819,16 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
                 }
             }
 
-            // todo waypoints
+            if (key.startsWith(UnifiedMapViewModel.WAYPOINT_KEY_PREFIX)) {
+                final String fullGpxId = key.substring(UnifiedMapViewModel.WAYPOINT_KEY_PREFIX.length());
+
+                for (Waypoint waypoint : viewModel.waypoints.getValue()) {
+                    if (fullGpxId.equals(waypoint.getFullGpxId())) {
+                        result.add(new RouteItem(waypoint));
+                        break;
+                    }
+                }
+            }
 
         }
         Log.e("touched elements (" + result.size() + "): " + result);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -798,18 +798,28 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
 
         for (String key : clickableItemsLayer.getTouched(Geopoint.forE6(latitudeE6, longitudeE6))) {
 
-            //todo make caches/WPs clickable
-            /*final IWaypoint wp = viewModel.geoItems.getMap().get(key);
-            if (wp != null) {
-                result.add(new RouteItem(wp));
-            } else if (isLongTap) {
+            if (key.startsWith(UnifiedMapViewModel.CACHE_KEY_PREFIX)) {
+                final String geocode = key.substring(UnifiedMapViewModel.CACHE_KEY_PREFIX.length());
+
+                final Geocache temp = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+                if (temp != null && temp.getCoords() != null) {
+                    result.add(new RouteItem(temp));
+                }
+            }
+
+            if (key.startsWith(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX)) {
+                final String identifier = key.substring(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX.length());
+
                 for (RouteItem item : viewModel.individualRoute.getValue().getRouteItems()) {
-                    if (key.equals(item.getIdentifier())) {
+                    if (identifier.equals(item.getIdentifier())) {
                         result.add(item);
                         break;
                     }
                 }
-            }*/
+            }
+
+            // todo waypoints
+
         }
         Log.e("touched elements (" + result.size() + "): " + result);
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -808,7 +808,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
                 }
             }
 
-            if (key.startsWith(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX)) {
+            if (key.startsWith(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX) && isLongTap) { // only consider when tap was a longTap
                 final String identifier = key.substring(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX.length());
 
                 for (RouteItem item : viewModel.individualRoute.getValue().getRouteItems()) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -24,6 +24,10 @@ import androidx.lifecycle.ViewModel;
 public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.UpdateIndividualRoute {
     public static final int MAX_CACHES = 500;
 
+    public static final String CACHE_KEY_PREFIX = "CACHE_";
+    public static final String WAYPOINT_KEY_PREFIX = "WP_";
+    public static final String COORDSPOINT_KEY_PREFIX = "COORDS_";
+
     // ViewModels will survive config changes, no savedInstanceState is needed
     // Don't hold an activity references inside the ViewModel!
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.maps.Tracks;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.IndividualRoute;
 import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.models.geoitem.IGeoItemSupplier;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
@@ -20,6 +21,8 @@ import android.location.Location;
 import androidx.core.util.Pair;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+
+import java.util.HashSet;
 
 public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.UpdateIndividualRoute {
     public static final int MAX_CACHES = 500;
@@ -43,6 +46,7 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
     public final MutableLiveData<Target> target = new MutableLiveData<>();
 
     public final ConstantLiveData<LeastRecentlyUsedSet<Geocache>> caches = new ConstantLiveData<>(new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount()));
+    public final ConstantLiveData<HashSet<Waypoint>> waypoints = new ConstantLiveData<>(new HashSet<>());
 
     public final MutableLiveData<Geopoint> longTapCoords = new MutableLiveData<>();
     public final MutableLiveData<Geopoint> coordsIndicator = new MutableLiveData<>(); // null if coords indicator should be hidden

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
@@ -139,6 +139,10 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
 
     @Override
     public void remove(final GeoPrimitive item, final Pair<Object, Object> context) {
+        if (context == null) {
+            Log.e("GoogleV2GeoItemLayer.remove: can't remove <null> item"); // todo why does this happen at all? Especially as items still get removed correctly even if this is triggered...
+            return;
+        }
         removeSingle(context.first);
         removeSingle(context.second);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeoItemsLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeoItemsLayer.java
@@ -18,9 +18,6 @@ import java.util.Map;
 
 public class GeoItemsLayer {
 
-    private static final String CACHE_PREFIX = "CACHE_";
-    private static final String WAYPOINT_PREFIX = "WP_";
-
     private Map<String, Integer> lastDisplayedGeocaches = new HashMap<>();
 
 
@@ -38,7 +35,7 @@ public class GeoItemsLayer {
 
                 if (!lastDisplayedGeocaches.containsKey(cache.getGeocode()) || !lastDisplayedGeocaches.get(cache.getGeocode()).equals(cm.hashCode())) {
 
-                    layer.put(CACHE_PREFIX + cache.getGeocode(), GeoPrimitive.createMarker(cache.getCoords(),
+                    layer.put(UnifiedMapViewModel.CACHE_KEY_PREFIX + cache.getGeocode(), GeoPrimitive.createMarker(cache.getCoords(),
                             GeoIcon.builder()
                                     .setBitmap(cm.getBitmap())
                                     .setYAnchor(cm.getBitmap().getHeight() / 2f)
@@ -52,7 +49,7 @@ public class GeoItemsLayer {
             }
 
             for (String geocode : lastDisplayedGeocaches.keySet()) {
-                layer.remove(CACHE_PREFIX + geocode);
+                layer.remove(UnifiedMapViewModel.CACHE_KEY_PREFIX + geocode);
             }
 
             lastDisplayedGeocaches = currentlyDisplayedGeocaches;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/IndividualRouteLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/IndividualRouteLayer.java
@@ -35,7 +35,7 @@ public class IndividualRouteLayer {
         viewModel.individualRoute.observe(activity, individualRoute -> {
 
             for (String key : layer.keySet()) {
-                if (key.startsWith("COORDS!")) {
+                if (key.startsWith(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX)) {
                     layer.remove(key);
                 }
             }
@@ -50,7 +50,7 @@ public class IndividualRouteLayer {
 
                 for (RouteItem item : individualRoute.getRouteItems()) {
                     if (item.getType() == RouteItem.RouteItemType.COORDS) {
-                        layer.put(item.getIdentifier(), GeoPrimitive.createMarker(item.getPoint(), GeoIcon.builder().setBitmap(marker).build()).buildUpon().setZLevel(LayerHelper.ZINDEX_COORD_POINT).build());
+                        layer.put(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX + item.getIdentifier(), GeoPrimitive.createMarker(item.getPoint(), GeoIcon.builder().setBitmap(marker).build()).buildUpon().setZLevel(LayerHelper.ZINDEX_COORD_POINT).build());
                     }
                 }
             }

--- a/main/src/main/res/drawable/marker_routepoint_large.xml
+++ b/main/src/main/res/drawable/marker_routepoint_large.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+        android:fillColor="@color/just_black"/>
+    <path
+        android:pathData="M12,12m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"
+        android:fillColor="@color/dotBg_waypointBg"/>
+</vector>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2591,6 +2591,7 @@
     <string name="map_individual_route_cleared">Individual route cleared</string>
     <string name="sorted_route_saved">Individual route saved</string>
     <string name="load_individual_route_error">Error loading individual route</string>
+    <string name="route_item_point">Route point</string>
     <string name="route_item_not_yet_loaded">Route item not yet loaded</string>
     <plurals name="individual_route_loaded">
         <item quantity="zero">Route loaded with %d route points</item>


### PR DESCRIPTION

- re-enable item click listener on unified map
- show WPs on unified map
- correctly show coord-only-points when being clicked on unified map
- only consider coord-only-points when tap was a longTap on unified map