### PR TITLE
UnifiedMap: Enable map quick settings

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -37,6 +37,7 @@ import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemTestLayer;
+import cgeo.geocaching.unifiedmap.layers.CacheCirclesLayer;
 import cgeo.geocaching.unifiedmap.layers.CoordsIndicatorLayer;
 import cgeo.geocaching.unifiedmap.layers.GeoItemsLayer;
 import cgeo.geocaching.unifiedmap.layers.IndividualRouteLayer;
@@ -278,7 +279,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
         layers.clear();
 
         clickableItemsLayer = new GeoItemLayer<>("clickableItems");
-        final GeoItemLayer<String> nonClickableItemsLayer = new GeoItemLayer<>("nonClickableItems");
+        final GeoItemLayer<String> nonClickableItemsLayer = new GeoItemLayer<>("nonClickableItems"); // default layer for all map items not worth an own layer
 
         layers.add(clickableItemsLayer);
         layers.add(nonClickableItemsLayer);
@@ -294,6 +295,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
         new IndividualRouteLayer(this, clickableItemsLayer);
         new GeoItemsLayer(this, clickableItemsLayer);
 
+        final GeoItemLayer<String> circlesLayer = new GeoItemLayer<>("circles");
+        layers.add(circlesLayer);
+        new CacheCirclesLayer(this, circlesLayer);
 
         viewModel.init(routeTrackUtils);
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -311,6 +311,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
 
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 
+        viewModel.mapCenter.observe(this, center -> updateCacheCount());
+        viewModel.caches.observe(this, caches -> updateCacheCount());
+
 //        MapUtils.showMapOneTimeMessages(this, mapMode);
 
         /*
@@ -454,6 +457,15 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
     public void hideProgressSpinner() {
         final View spinner = findViewById(R.id.map_progressbar);
         spinner.setVisibility(View.GONE);
+    }
+
+    private void updateCacheCount() {
+        final int cacheCount = mapFragment.getViewport().count(viewModel.caches.getValue().getAsList());
+        CompactIconModeUtils.forceCompactIconMode(cacheCount);
+        final ActionBar actionbar = getSupportActionBar();
+        if (actionbar != null) {
+            actionbar.setSubtitle(res.getQuantityString(R.plurals.cache_counts, cacheCount, cacheCount));
+        }
     }
 
     public void addSearchResultByGeocaches(final SearchResult searchResult) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -439,7 +439,6 @@ public class UnifiedMapActivity extends AbstractNavigationBarActivity implements
 
     private void compactIconModeChanged(final int newValue) {
         Settings.setCompactIconMode(newValue);
-        // @todo: does not yet trigger switching icon modes
         viewModel.caches.postNotifyDataChanged();
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -57,6 +57,7 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
      */
     public final MutableLiveData<PositionHistory> positionHistory = new MutableLiveData<>(Settings.isMapTrail() ? new PositionHistory() : null);
     public final MutableLiveData<Boolean> followMyLocation = new MutableLiveData<>(Settings.getFollowMyLocation());
+    public final MutableLiveData<Geopoint> mapCenter = new MutableLiveData<>();
 
 
     public void setCurrentPositionAndHeading(final Location location, final float heading) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -81,6 +81,10 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
         individualRoute.getValue().reloadRoute(route -> individualRoute.notifyDataChanged());
     }
 
+    public void reloadTracks(final RouteTrackUtils routeTrackUtils) {
+        tracks = new Tracks(routeTrackUtils, this::setTrack);
+    }
+
     public void clearIndividualRoute() {
         individualRoute.getValue().clearRoute(route -> individualRoute.notifyDataChanged());
     }
@@ -99,7 +103,7 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
     }
 
     public void init(final RouteTrackUtils routeTrackUtils) {
-        tracks = new Tracks(routeTrackUtils, this::setTrack);
+        reloadTracks(routeTrackUtils);
     }
 
     // ========================================================================

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
@@ -114,6 +114,7 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
         });
         mMap.setOnCameraIdleListener(() -> {
             lastBounds = mMap.getProjection().getVisibleRegion().latLngBounds;
+            viewModel.mapCenter.setValue(getCenter());
 //            if (activityMapChangeListener != null) {
 //                final CameraPosition pos = mMap.getCameraPosition();
 //                activityMapChangeListener.call(new UnifiedMapPosition(pos.target.latitude, pos.target.longitude, (int) pos.zoom, pos.bearing));
@@ -169,6 +170,9 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
 
     @Override
     public BoundingBox getBoundingBox() {
+        if (lastBounds == null) {
+            return new BoundingBox(0, 0, 0, 0);
+        }
         // mMap.getProjection() needs to be called on UI thread
         return new BoundingBox(lastBounds.southwest.latitude, lastBounds.southwest.longitude, lastBounds.northeast.latitude, lastBounds.northeast.longitude);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/CacheCirclesLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/CacheCirclesLayer.java
@@ -1,0 +1,74 @@
+package cgeo.geocaching.unifiedmap.layers;
+
+import cgeo.geocaching.location.IConversion;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.models.geoitem.GeoPrimitive;
+import cgeo.geocaching.models.geoitem.GeoStyle;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.unifiedmap.LayerHelper;
+import cgeo.geocaching.unifiedmap.UnifiedMapViewModel;
+import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemLayer;
+import cgeo.geocaching.utils.MapLineUtils;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
+
+import java.util.Set;
+
+public class CacheCirclesLayer {
+
+    private static final float radius = (float) (528.0 * IConversion.FEET_TO_KILOMETER);
+
+
+    public CacheCirclesLayer(final AppCompatActivity activity, final GeoItemLayer<String> layer) {
+        final UnifiedMapViewModel viewModel = new ViewModelProvider(activity).get(UnifiedMapViewModel.class);
+
+
+        viewModel.caches.observe(activity, caches -> {
+
+            if (Settings.isShowCircles()) {
+                for (Geocache cache : caches.getAsList()) { // Creates a clone to avoid ConcurrentModificationException
+                    if (cache.applyDistanceRule()) {
+
+                        layer.put(cache.getGeocode(),
+                                GeoPrimitive.createCircle(cache.getCoords(), radius, GeoStyle.builder()
+                                        .setStrokeWidth(2.0f)
+                                        .setStrokeColor(MapLineUtils.getCircleColor())
+                                        .setFillColor(MapLineUtils.getCircleFillColor())
+                                        .build()
+                                ).buildUpon().setZLevel(LayerHelper.ZINDEX_CIRCLE).build());
+                    }
+                }
+
+            } else {
+                // only possible cause we use a separate layer just for cache circles.
+                // Not finally decided if this makes sense and we really want to split rendering into multiple layers.
+                for (String key : layer.keySet()) {
+                    layer.remove(key);
+                }
+            }
+
+        });
+
+
+        viewModel.waypoints.observe(activity, waypoints -> {
+
+            if (Settings.isShowCircles()) {
+                for (Waypoint waypoint : (Set<Waypoint>) waypoints.clone()) { // Creates a clone to avoid ConcurrentModificationExceptions
+                    if (waypoint.applyDistanceRule()) {
+
+                        layer.put(UnifiedMapViewModel.CACHE_KEY_PREFIX + waypoint.getFullGpxId(),
+                                GeoPrimitive.createCircle(waypoint.getCoords(), radius, GeoStyle.builder()
+                                        .setStrokeWidth(2.0f)
+                                        .setStrokeColor(MapLineUtils.getCircleColor())
+                                        .setFillColor(MapLineUtils.getCircleFillColor())
+                                        .build()
+                                ).buildUpon().setZLevel(LayerHelper.ZINDEX_CIRCLE).build());
+                    }
+                }
+            }
+        });
+
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeoItemsLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeoItemsLayer.java
@@ -34,7 +34,7 @@ public class GeoItemsLayer {
 
             final Map<String, Integer> currentlyDisplayedGeocaches = new HashMap<>();
 
-            final boolean forceCompactIconMode = CompactIconModeUtils.forceCompactIconMode(caches.size()); // todo: only use caches in viewport and update while moving the map
+            final boolean forceCompactIconMode = CompactIconModeUtils.forceCompactIconMode();
             if (lastForceCompactIconMode != forceCompactIconMode) {
                 lastForceCompactIconMode = forceCompactIconMode;
                 viewModel.waypoints.notifyDataChanged();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -90,8 +90,11 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
             if (event == Map.ROTATE_EVENT) {
                 repaintRotationIndicator(mapPosition.bearing);
             }
-            if (event == Map.MOVE_EVENT && Boolean.TRUE.equals(viewModel.followMyLocation.getValue())) {
-                viewModel.followMyLocation.setValue(false);
+            if (event == Map.MOVE_EVENT) {
+                if (Boolean.TRUE.equals(viewModel.followMyLocation.getValue())) {
+                    viewModel.followMyLocation.setValue(false);
+                }
+                viewModel.mapCenter.setValue(new Geopoint(mapPosition.getLatitude(), mapPosition.getLongitude()));
             }
 //            if (event == Map.POSITION_EVENT || event == Map.ROTATE_EVENT) {
 //                activityMapChangeListener.call(new UnifiedMapPosition(mapPosition.getLatitude(), mapPosition.getLongitude(), mapPosition.zoomLevel, mapPosition.bearing));

--- a/main/src/main/java/cgeo/geocaching/utils/CompactIconModeUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/CompactIconModeUtils.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 public class CompactIconModeUtils {
 
     private static int compactIconModeThreshold = -1;
+    private static boolean forceCompactIconMode = Settings.getCompactIconMode() == Settings.COMPACTICON_ON;
 
     private CompactIconModeUtils() {
         // utility class
@@ -31,6 +32,15 @@ public class CompactIconModeUtils {
             setCompactIconModeThreshold(Resources.getSystem());
         }
         final int compactIconMode = Settings.getCompactIconMode();
-        return compactIconMode == Settings.COMPACTICON_ON || (compactIconMode == Settings.COMPACTICON_AUTO && size >= compactIconModeThreshold);
+        forceCompactIconMode = compactIconMode == Settings.COMPACTICON_ON || (compactIconMode == Settings.COMPACTICON_AUTO && size >= compactIconModeThreshold);
+        return forceCompactIconMode;
+    }
+
+    /**
+     *
+     * @return return whether compact icons should be used based on the last received cache count
+     */
+    public static boolean forceCompactIconMode() {
+        return forceCompactIconMode;
     }
 }


### PR DESCRIPTION
## Description
Enables the map quick settings menu. Most of its functions do work already, including changing routing mode.

Functions yet missing are:
- [x] circles
- [ ] proximity notifications are not yet available in UnifiedMap (see #12927 as reminder)
- [x] switching compact icon mode does not yet trigger drawing small icons
