### PR TITLE
make round icon adaptive as well

### DIFF
--- a/main/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/main/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
fixes #14758

some launchers seem to pick the round icon and that one wasn't adaptive. Fixed by making round equal to normal