### PR TITLE
Suppress outdated conn error msg on network not available (fix #14740)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -153,7 +153,7 @@ public class MainActivity extends AbstractNavigationBarActivity {
 
                             final TextView connectorStatus = connectorInfo.findViewById(R.id.item_status);
                             final StringBuilder connInfo = new StringBuilder(conn.getNameAbbreviated()).append(Formatter.SEPARATOR).append(conn.getLoginStatusString());
-                            if (conn instanceof GCConnector && !StringUtils.equalsAny(conn.getLoginStatusString(), activity.getString(R.string.init_login_popup_working), activity.getString(R.string.init_login_popup_ok))) {
+                            if (conn instanceof GCConnector && Network.isConnected() && !StringUtils.equalsAny(conn.getLoginStatusString(), activity.getString(R.string.init_login_popup_working), activity.getString(R.string.init_login_popup_ok))) {
                                 final Pair<String, Long> lastError = Settings.getLastLoginErrorGC();
                                 if (lastError != null && StringUtils.isNotBlank(lastError.first) && lastError.second > Settings.getLastLoginSuccessGC()) {
                                     connInfo.append(" (").append(lastError.first).append(")");


### PR DESCRIPTION
Additionally check network availability before displaying GC connector-specific error message to avoid displaying an outdated error message when no network is available