### PR TITLE
UnifiedMap: Enable tracks for elevation chart

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/TracksLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/TracksLayer.java
@@ -12,6 +12,8 @@ import androidx.lifecycle.ViewModelProvider;
 
 public class TracksLayer {
 
+    public static final String TRACK_KEY_PREFIX = "TRACK-";
+
     final UnifiedMapViewModel viewModel;
 
     public TracksLayer(final AppCompatActivity activity, final GeoItemLayer<String> layer) {
@@ -20,7 +22,7 @@ public class TracksLayer {
         viewModel.trackUpdater.observe(activity, event -> event.ifNotHandled((key -> {
             final Tracks.Track track = viewModel.getTracks().getTrack(key);
             if (track == null || track.getRoute().isHidden()) {
-                layer.remove(key);
+                layer.remove(TRACK_KEY_PREFIX + key);
             } else {
 
                 //Apply current chosen default color to all elements and display
@@ -34,7 +36,7 @@ public class TracksLayer {
                         .setStrokeColor(defaultStrokeColor)
                         .setStrokeWidth(defaultWidth).build();
 
-                layer.put(key, track.getRoute().getItem().applyDefaultStyle(defaultStyle));
+                layer.put(TRACK_KEY_PREFIX + key, track.getRoute().getItem().applyDefaultStyle(defaultStyle));
              }
         })));
 


### PR DESCRIPTION
## Description
Enable tracks for elevation chart:
- make tracks clickable
- add prefix to their key to make them identifiable
- allow elevation chart to get completely new data
- show "no elevation data available" in the chart if no elevation data is available

@fm-sys 
One thing is missing, though: How can I observe changes to the track? That may happen if someone changes the routing mode.
(`UnifiedMapViewModel.setTrack` is called in this case, but how to trigger an observer for this, delivering the key of the related track?)
