### PR TITLE
fix #14811: handle invalid GeoItems passed to GeoItemLayer: don't draw them

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/geoitem/GeoItem.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/GeoItem.java
@@ -36,4 +36,8 @@ public interface GeoItem extends Parcelable {
 
     boolean touches(@NonNull Geopoint tapped, @Nullable ToScreenProjector toScreenCoordFunc);
 
+    static boolean isValid(final GeoItem item) {
+        return item != null && item.isValid();
+    }
+
 }


### PR DESCRIPTION
fix #14811: handle invalid GeoItems passed to GeoItemLayer: don't draw them