### PR TITLE
Bring compass hint to front + add background (fix #14831)

### DIFF
--- a/main/src/main/res/layout/compass_activity.xml
+++ b/main/src/main/res/layout/compass_activity.xml
@@ -118,8 +118,6 @@
         </RelativeLayout>
     </LinearLayout>
 
-    <include layout="@layout/compass_hint_and_status" android:id="@+id/hint" />
-
     <view
         android:id="@+id/rose"
         android:layout_width="fill_parent"
@@ -139,5 +137,7 @@
         android:minWidth="289dip"
         android:padding="4dip"
         tools:ignore="NotSibling" />
+
+    <include layout="@layout/compass_hint_and_status" android:id="@+id/hint" />
 
 </RelativeLayout>

--- a/main/src/main/res/layout/compass_hint_and_status.xml
+++ b/main/src/main/res/layout/compass_hint_and_status.xml
@@ -24,7 +24,8 @@
         android:textSize="@dimen/textSize_detailsSecondary"
         android:visibility="gone"
         tools:text="hint"
-        android:textColor="@color/colorText"/>
+        android:textColor="@color/colorText"
+        android:background="@color/colorBackground"/>
     <RelativeLayout
         android:id="@+id/offline_hint_separator2"
         android:layout_above="@id/location_status"


### PR DESCRIPTION
## Description
Brings hint in `CompassActivity` to front (portrait mode only) and adds a background to the hint view:

|small font sizes|large font sizes|
|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/0ea774fa-39be-422e-800d-706dfa4a8bb0)|![image](https://github.com/cgeo/cgeo/assets/3754370/592dd5f8-9855-40aa-87a6-0f29743147b0)|

