### PR TITLE
Add option to reset all one-time messages

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -3,6 +3,9 @@ package cgeo.geocaching.settings.fragments;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.settings.ViewSettingsActivity;
+import cgeo.geocaching.storage.extension.OneTimeDialogs;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.Log;
@@ -11,6 +14,7 @@ import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Toast;
 
 public class PreferenceSystemFragment extends BasePreferenceFragment {
     @Override
@@ -26,6 +30,10 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
         activity.setTitle(R.string.settings_title_system);
 
         setPrefClick(this, R.string.pref_fakekey_memory_dump, () -> DebugUtils.createMemoryDump(activity));
+        setPrefClick(this, R.string.pref_fakekey_reset_otm, () -> SimpleDialog.of(getActivity()).setMessage(TextParam.id(R.string.init_reset_otm_confirm)).confirm((d, w) -> {
+            OneTimeDialogs.resetAll();
+            Toast.makeText(activity, R.string.init_reset_otm_done, Toast.LENGTH_SHORT).show();
+        }));
         setPrefClick(this, R.string.pref_fakekey_generate_logcat, () -> DebugUtils.createLogcat(activity));
         setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
 

--- a/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -147,4 +147,11 @@ public class OneTimeDialogs extends DataStore.DBExtension {
             }
         }
     }
+
+    public static void resetAll() {
+        for (DialogType key : DialogType.values()) {
+            removeAll(type, key.name());
+        }
+        initializeOnFreshInstall();
+    }
 }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -380,6 +380,7 @@
     <string translatable="false" name="pref_debug">debug</string>
     <string translatable="false" name="pref_fakekey_generate_logcat">fakekey_generate_logcat</string>
     <string translatable="false" name="pref_fakekey_memory_dump">fakekey_memory_dump</string>
+    <string translatable="false" name="pref_fakekey_reset_otm">fakekey_reset_otm</string>
     <string translatable="false" name="pref_fakekey_view_settings">fakekey_view_settings</string>
 
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1228,6 +1228,9 @@
     <string name="init_create_memory_dump">Create memory dump</string>
     <string name="init_memory_dump">Memory dump</string>
     <string name="init_memory_dumped">Memory dumped to %s</string>
+    <string name="init_reset_otm">Reset one-time messages</string>
+    <string name="init_reset_otm_confirm">Do you want to reset all one-time messages?</string>
+    <string name="init_reset_otm_done">One-time messages have been reset</string>
     <string name="init_please_wait">Please wait…</string>
     <string name="settings_open_website">Open website</string>
     <string name="settings_open_geokretymap_website">Open GeoKretyMap.org website</string>

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -72,6 +72,11 @@
             android:title="@string/init_create_memory_dump"
             app:iconSpaceReserved="false" />
         <Preference
+            android:key="@string/pref_fakekey_reset_otm"
+            android:layout="@layout/preference_button"
+            android:title="@string/init_reset_otm"
+            app:iconSpaceReserved="false" />
+        <Preference
             android:key="@string/pref_fakekey_view_settings"
             android:layout="@layout/preference_button"
             android:title="@string/view_settings"


### PR DESCRIPTION
## Description
Resets all internal data for one-time messages' view status.
(I needed this for debugging a different thing, so I added it to preferences => system => debug)