### PR TITLE
Download selector: Highlight existing downloads (fix #14819)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/CompanionFileUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/CompanionFileUtils.java
@@ -38,6 +38,12 @@ public class CompanionFileUtils {
         public long remoteDate;             // 2020-12-10 (as long)
         public String localFile;            // eg: map43.map (relative to map dir)
         public String displayName;          // eg: Hessen
+
+        @NonNull
+        @Override
+        public String toString() {
+            return "{ n=" + displayName + ", d=" + remoteDate + ", t=" + remoteParsetype + ", u=" + remotePage + "/" + remoteFile + " }";
+        }
     }
 
     private CompanionFileUtils() {

--- a/main/src/main/java/cgeo/geocaching/models/Download.java
+++ b/main/src/main/java/cgeo/geocaching/models/Download.java
@@ -129,6 +129,12 @@ public class Download {
         return iconRes;
     }
 
+    @NonNull
+    @Override
+    public String toString() {
+        return "{ n=" + name + ", t=" + type + ", u=" + uri + ", isDir=" + isDir + ", di=" + dateInfo + " }";
+    }
+
     public enum DownloadType {
         // id values must not be changed as they are referenced in the database & download companion files
         DOWNLOADTYPE_ALL_MAPRELATED(0, 0),         // virtual entry

--- a/main/src/main/res/drawable/downloader_needsupdate.xml
+++ b/main/src/main/res/drawable/downloader_needsupdate.xml
@@ -1,0 +1,13 @@
+<!-- based on https://fonts.google.com/icons: sync -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FFEB3B"
+      android:pathData="M440,950a460,460 0,1 1,100 0Z" />
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M160,800L160,720L270,720L254,706Q202,660 181,601Q160,542 160,482Q160,371 226.5,284.5Q293,198 400,170L400,254Q328,280 284,342.5Q240,405 240,482Q240,527 257,569.5Q274,612 310,648L320,658L320,560L400,560L400,800L160,800ZM560,790L560,706Q632,680 676,617.5Q720,555 720,478Q720,433 703,390.5Q686,348 650,312L640,302L640,400L560,400L560,160L800,160L800,240L690,240L706,254Q755,303 777.5,360.5Q800,418 800,478Q800,589 733.5,675.5Q667,762 560,790Z"/>
+</vector>

--- a/main/src/main/res/drawable/downloader_ok.xml
+++ b/main/src/main/res/drawable/downloader_ok.xml
@@ -1,0 +1,13 @@
+<!-- based on https://fonts.google.com/icons: done -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#4CAF50"
+      android:pathData="M440,950a460,460 0,1 1,100 0Z" />
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M382,720L154,492L211,435L382,606L749,239L806,296L382,720Z"/>
+</vector>

--- a/main/src/main/res/layout/downloader_item.xml
+++ b/main/src/main/res/layout/downloader_item.xml
@@ -19,6 +19,15 @@
         android:text="@null"
         android:layout_alignParentLeft="true" />
 
+    <ImageView
+        android:id="@+id/badge"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:gravity="right|bottom"
+        android:text="@null"
+        android:layout_alignBottom="@id/action"
+        android:layout_alignRight="@id/action" />
+
     <TextView
         android:id="@+id/label"
         android:layout_width="fill_parent"


### PR DESCRIPTION
## Description
Adds a badge to existing downloads' symbols in the download selector, 
- either green - download already exists and is up to date
- or yellow - download exists, but an update is available

![image](https://github.com/cgeo/cgeo/assets/3754370/d6d07f89-c054-4048-9940-0783aebf5d1c)

(Additionally adds some descriptive texts for easier debugging - implements `toString()` for `Download` and `DownloadedFileData`)