### PR TITLE
Use compact D/T view for cache details in map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
@@ -116,8 +116,7 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
 
         cacheDistance = details.addDistance(cache, cacheDistance);
 
-        details.addDifficulty(cache);
-        details.addTerrain(cache);
+        details.addDifficultyTerrain(cache);
         details.addEventDate(cache);
 
         // rating

--- a/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.UnknownTagsHandler;
+import static cgeo.geocaching.utils.Formatter.SEPARATOR;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -219,6 +220,17 @@ public final class CacheDetailsCreator {
         if (cache.getTerrain() > 0) {
             addStars(R.string.cache_terrain, cache.getTerrain(), ConnectorFactory.getConnector(cache).getMaxTerrain());
         }
+    }
+
+    public void addDifficultyTerrain(final Geocache cache) {
+        final StringBuilder sb = new StringBuilder();
+        if (cache.getDifficulty() > 0) {
+            sb.append("D ").append(cache.getDifficulty());
+        }
+        if (cache.getTerrain() > 0) {
+            sb.append(sb.length() > 0 ? SEPARATOR : "").append("T ").append(cache.getTerrain());
+        }
+        add(R.string.cache_difficulty_terrain, sb);
     }
 
     public void addBetterCacher(final Geocache cache) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1620,6 +1620,7 @@
     <string name="cache_distance">Distance</string>
     <string name="cache_difficulty">Difficulty</string>
     <string name="cache_terrain">Terrain</string>
+    <string name="cache_difficulty_terrain">D/T</string>
     <string name="cache_rating">Rating</string>
     <string name="cache_own_rating">Your Rating</string>
     <string name="cache_rating_of_new">%1$.1f of %2$d</string>


### PR DESCRIPTION
## Description
Applies compact D/T line for the new cache details view in maps, as discussed in yesterdays's dev meeting.
(D/T only, no FP part)