### PR TITLE
Avoid hint cutoff

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -353,12 +353,11 @@ public class MapUtils {
 
             ft.runOnCommit(() -> {
                 final View view = fragment.requireView();
-                view.post(() -> {
-                    b.setPeekHeight(view.getHeight()); // the original height of the cache details
-                    view.setMinimumHeight(Resources.getSystem().getDisplayMetrics().heightPixels); // make view fill whole screen
-                });
+                // make bottom sheet fill whole screen
+                swipeToOpenFragment.requireView().setMinimumHeight(Resources.getSystem().getDisplayMetrics().heightPixels);
+                // set the height of collapsed state to height of the details fragment
+                view.getViewTreeObserver().addOnGlobalLayoutListener(() -> b.setPeekHeight(view.getHeight()));
             });
-
 
             b.addBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
                 Runnable unexecutedUpSwipeAction = onUpSwipeAction;

--- a/main/src/main/res/layout/popup.xml
+++ b/main/src/main/res/layout/popup.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_height="wrap_content"
     android:background="@color/colorBackgroundDialog"
     android:windowBackground="@color/colorBackgroundTransparent"
     android:orientation="vertical"

--- a/main/src/main/res/layout/waypoint_popup.xml
+++ b/main/src/main/res/layout/waypoint_popup.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
     android:background="@color/colorBackgroundDialog"
     android:windowBackground="@color/colorBackgroundTransparent"


### PR DESCRIPTION
The hint got cut off inside the popup. Fix this by adding a ViewTreeObserver and recalculate PeekHeight.