### PR TITLE
fix #14856: re-add clear button to map long-press filter select dialog

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -245,7 +245,6 @@ public class SimpleDialog {
         setPositiveButton(buttons == null || buttons.length < 1 ? null : buttons[0]);
         setNegativeButton(buttons == null || buttons.length < 2 ? null : buttons[1]);
         setNeutralButton(buttons == null || buttons.length < 3 ? null : buttons[2]);
-
         return this;
     }
 
@@ -453,7 +452,8 @@ public class SimpleDialog {
         }
         if (!selectionConfirmedViaButton) {
             //remove "negative/positive" buttons
-            setButtons(0, 0);
+            setPositiveButton(null);
+            setNegativeButton(null);
         }
 
         final Pair<AlertDialog, DialogSimpleBinding> dialogBinding = constructCommons();

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -56,7 +56,6 @@ public class FilterUtils {
                         .setButtonClickAction(which -> {
                             if (which == DialogInterface.BUTTON_NEUTRAL) {
                                 filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()));
-                                return true;
                             }
                             return false;
                         })


### PR DESCRIPTION
fix #14856: re-add clear button to map long-press filter select dialog