### PR TITLE
more toolbar icons for Cache/Waypoint Popup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.CacheDetailsCreator;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
@@ -179,6 +180,7 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
         toolbar.inflateMenu(R.menu.cache_options);
         CacheMenuHandler.onPrepareOptionsMenu(menu, geocache, true);
         CacheMenuHandler.initDefaultNavigationMenuItem(menu, navigationSource);
+        ViewUtils.extendMenuActionBarDisplayItemCount(toolbar.getContext(), menu);
         menu.findItem(R.id.menu_target).setVisible(true);
         LoggingUI.onPrepareOptionsMenu(menu, geocache);
     }


### PR DESCRIPTION
apply the same tweak we use for CacheDetails to show more toolbar icons also to CachePopup and WaypointPopup.

Causes the toolbar to show up to 4 icons instead of 2 (if there's space)