### PR TITLE
Show wallpaper without need for READ_EXTERNAL_STORAGE permission

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -54,12 +54,10 @@ import cgeo.geocaching.utils.functions.Action1;
 import android.annotation.SuppressLint;
 import android.app.DownloadManager;
 import android.app.SearchManager;
-import android.app.WallpaperManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.database.Cursor;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -119,7 +117,6 @@ public class MainActivity extends AbstractNavigationBarActivity {
     private final CompositeDisposable resumeDisposables = new CompositeDisposable();
 
     private final PermissionAction<Void> askLocationPermissionAction = PermissionAction.register(this, PermissionContext.LOCATION, b -> binding.locationStatus.updatePermissions());
-    private final PermissionAction<Void> askShowWallpaperPermissionAction = PermissionAction.register(this, PermissionContext.SHOW_WALLPAPER, b -> setWallpaper());
 
     private Long lastMCTime = 0L;
 
@@ -246,6 +243,7 @@ public class MainActivity extends AbstractNavigationBarActivity {
     public void onCreate(final Bundle savedInstanceState) {
         try (ContextLogger cLog = new ContextLogger(Log.LogLevel.DEBUG, "MainActivity.onCreate")) {
             // don't call the super implementation with the layout argument, as that would set the wrong theme
+            setTheme(R.style.cgeo_withWallpaper);
             super.onCreate(savedInstanceState);
 
             binding = MainActivityBinding.inflate(getLayoutInflater());
@@ -275,10 +273,6 @@ public class MainActivity extends AbstractNavigationBarActivity {
             binding.locationStatus.setPermissionRequestCallback(() -> {
                 this.askLocationPermissionAction.launch(null);
             });
-
-            if (Settings.isWallpaper()) {
-                askShowWallpaperPermissionAction.launch();
-            }
 
             configureMessageCenterPolling();
 
@@ -449,20 +443,12 @@ public class MainActivity extends AbstractNavigationBarActivity {
             updateUserInfoHandler.sendEmptyMessage(-1);
             cLog.add("perm");
 
-            setWallpaper();
-
             init();
         }
 
         if (Log.isEnabled(Log.LogLevel.DEBUG)) {
             binding.getRoot().post(() -> Log.d("Post after MainActivity.onResume"));
         }
-    }
-
-    private void setWallpaper() {
-        final Drawable wallpaper =  (Settings.isWallpaper() && PermissionContext.SHOW_WALLPAPER.hasAllPermissions()) ?
-                WallpaperManager.getInstance(this).getDrawable() : null;
-            ((ImageView) findViewById(R.id.background)).setImageDrawable(wallpaper);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/permission/PermissionContext.java
+++ b/main/src/main/java/cgeo/geocaching/permission/PermissionContext.java
@@ -22,7 +22,6 @@ public enum PermissionContext {
 
     LOCATION(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION}, R.string.permission_location_explanation, R.string.permission_location_explanation_title),
     SEARCH_USER_IN_CONTACTS(new String[]{Manifest.permission.READ_CONTACTS}, R.string.permission_contacts_read_explanation, R.string.permission_contacts_read_explanation_title),
-    SHOW_WALLPAPER(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, R.string.permission_read_external_storage_explanation, R.string.permission_read_external_storage_explanation_title),
     LEGACY_WRITE_EXTERNAL_STORAGE(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, R.string.permission_legacy_write_external_storage_explanation, R.string.permission_legacy_write_external_storage_explanation_title),
     NOTIFICATIONS(new String[]{Manifest.permission.POST_NOTIFICATIONS}, R.string.permission_post_notifications_explanation, R.string.permission_post_notifications_explanation_title);
 

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -887,10 +887,6 @@ public class Settings {
                 GCConstants.DEFAULT_GC_DATE);
     }
 
-    public static boolean isWallpaper() {
-        return getBoolean(R.string.pref_wallpaper, false);
-    }
-
     public static boolean isShowAddress() {
         return getBoolean(R.string.pref_showaddress, true);
     }

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -5,8 +5,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractNavigationBarActivity;
 import cgeo.geocaching.activity.CustomMenuEntryActivity;
 import cgeo.geocaching.maps.mapsforge.v6.RenderThemeHelper;
-import cgeo.geocaching.permission.PermissionAction;
-import cgeo.geocaching.permission.PermissionContext;
 import cgeo.geocaching.search.BaseSearchSuggestionCursor;
 import cgeo.geocaching.search.BaseSuggestionsAdapter;
 import cgeo.geocaching.search.SearchUtils;
@@ -93,8 +91,6 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
 
     private static final ArrayList<BasePreferenceFragment.PrefSearchDescriptor> searchIndex = new ArrayList<>();
 
-    private final PermissionAction<Void> askShowWallpaperPermissionAction = PermissionAction.register(this, PermissionContext.SHOW_WALLPAPER, null);
-
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         ApplicationSettings.setLocale(this);
@@ -154,10 +150,6 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
 
     public BackupUtils getBackupUtils() {
         return backupUtils;
-    }
-
-    public void askShowWallpaperPermission() {
-        this.askShowWallpaperPermissionAction.launch();
     }
 
     private void handleIntent(final Bundle savedInstanceState) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -7,7 +7,6 @@ import cgeo.geocaching.enumerations.CacheListInfoItem;
 import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.models.InfoItem;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NEARBY;
 import static cgeo.geocaching.settings.Settings.CUSTOMBNITEM_NONE;
@@ -83,13 +82,6 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
     public void onResume() {
         super.onResume();
         getActivity().setTitle(R.string.settings_title_appearance);
-
-        setPrefClick(this, R.string.pref_wallpaper, () -> {
-            if (Settings.isWallpaper()) {
-                ((SettingsActivity) this.getActivity()).askShowWallpaperPermission();
-            }
-        });
-
     }
 
     private void configCustomBNitemPreference() {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2544,8 +2544,6 @@
     <string name="permission_contacts_read_explanation">c:geo can search for contacts in your address book using cacher names. To do this, you must authorize c:geo to read your address book. Otherwise, usage of this function is not possible.</string>
     <string name="permission_location_explanation_title">Location permission</string>
     <string name="permission_location_explanation">c:geo is optimized for usage with GPS data (fine location) to locate your position and calculate distance and direction to geocaches. Without this permission, location-based functions will not work as expected.</string>
-    <string name="permission_read_external_storage_explanation_title">Read external Storage permission</string>
-    <string name="permission_read_external_storage_explanation">c:geo can use your systems wallpaper as background for the app. To do this, c:geo needs permission to read your media data on external storage.</string>
     <string name="permission_legacy_write_external_storage_explanation">c:geo will write data onto your phone storage or SD card e.g. when you save geocaches for offline use, import or export files and other functions. On some Android versions, you need to grant an additional permission for these actions.</string>
     <string name="permission_legacy_write_external_storage_explanation_title">Legacy Write External Storage permission</string>
     <string name="permission_post_notifications_explanation">c:geo uses notifications to inform you about downloads and approaching caches (if activated)</string>

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -36,6 +36,11 @@
 
     </style>
 
+    <style name="cgeo.withWallpaper" parent="cgeo">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowShowWallpaper">true</item>
+    </style>
+
     <!-- theme for alert dialogs -->
 
     <style name="materialAlertDialogTheme" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">


### PR DESCRIPTION
## Description
Triggered by a ticket on support (c:geo requesting READ_EXTERNAL_PERMISSION without having a setting for it) I dived into requirements for wallpaper. Currently we are reading the wallpaper as an image file from external storage (which requires this permission), but apparently there is a way to show the wallpaper without the need of manually reading the image file, just by adding an option to the theme.