### PR TITLE
[unified map] fix cache/WP popup in landscape

### DIFF
--- a/main/src/main/res/layout-land/unifiedmap_activity.xml
+++ b/main/src/main/res/layout-land/unifiedmap_activity.xml
@@ -21,7 +21,7 @@
         <include layout="@layout/map_distanceinfo" />
         <include layout="@layout/map_settings_button" />
         <include layout="@layout/map_progressbar" />
-
+        <include layout="@layout/map_detailsfragment" />
     </RelativeLayout>
 
     <RelativeLayout


### PR DESCRIPTION
We forgot to include `@layout/map_detailsfragment` in unified map landscape...