### PR TITLE
UnifiedMap: Support start via bottom navigation (fix #14895)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
@@ -24,7 +24,12 @@ public final class DefaultMap {
     }
 
     public static Intent getLiveMapIntent(final Activity fromActivity, final Class<?> cls) {
-        return new MapOptions().newIntent(fromActivity, cls);
+        if (Settings.useUnifiedMap()) {
+            Log.e("Launching UnifiedMap in live mode");
+            return new UnifiedMapType().getLaunchMapIntent(fromActivity);
+        } else {
+            return new MapOptions().newIntent(fromActivity, cls);
+        }
     }
 
     public static Intent getLiveMapIntent(final Activity fromActivity) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -57,11 +57,16 @@ public class UnifiedMapType implements Parcelable {
         this.fromList = fromList;
     }
 
-    /** launch fresh map with current settings */
-    public void launchMap(final Context fromActivity) {
+    /** get launch intent */
+    public Intent getLaunchMapIntent(final Context fromActivity) {
         final Intent intent = new Intent(fromActivity, UnifiedMapActivity.class);
         intent.putExtra(BUNDLE_MAPTYPE, this);
-        fromActivity.startActivity(intent);
+        return intent;
+    }
+
+    /** launch fresh map with current settings */
+    public void launchMap(final Context fromActivity) {
+        fromActivity.startActivity(getLaunchMapIntent(fromActivity));
     }
 
     // ========================================================================


### PR DESCRIPTION
## Description
Support starting UnifiedMap via bottom navigation, if `useUnifiedMap` is enabled