### PR TITLE
Bump androidx.browser:browser from 1.4.0 to 1.5.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -477,7 +477,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     // needed for chrome custom tabs
-    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.browser:browser:1.5.0'
 
     // MarkDown view
     implementation 'io.noties.markwon:core:4.6.2'


### PR DESCRIPTION
see https://github.com/cgeo/cgeo/pull/13969

For ReleaseNotes see https://developer.android.com/jetpack/androidx/releases/browser#version_15_2

Important changes since 1.4.0

 - Added CustomTabsIntent.Builder#setInitialActivityHeightPx, which allows developers to specify the initial launch height of a Custom Tab, and optionally the resize behavior (fixed or resizable).
 - Added CustomTabsIntent.Builder#setToolbarCornerRadiusDp which allows developers to specify the toolbar's top corner radius. 
 - Added CustomTabsIntent.Builder#setCloseButtonPosition which allows developers to set the position of the close button on the toolbar. 
 - Added an onActivityResized callback method to interface CustomTabsCallback to let developers know when a Custom Tab is resized. 
 - Make parts of CustomTabsCallback APIs asynchronous. 
 - Populates the current app's language in Accept-Language by default to align to Android’s per-app language experience.
 - Added @RequiresPermission to APIs that require granting the POST_NOTIFICATIONS permission on SDK 33 and above.
