### PR TITLE
Rearrange buttons in cache bottom sheet

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/utils/FormatterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/utils/FormatterTest.java
@@ -108,16 +108,16 @@ public class FormatterTest  {
         if (!StringUtils.equals(Locale.getDefault().getLanguage(), Locale.ENGLISH.getLanguage())) {
             return;
         }
-        assertThat(Formatter.formatStoredAgo(0)).isEqualTo("Stored in device\n");
-        assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 10, "Stored in device\na few minutes ago");
-        assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 20, "Stored in device\nabout 20 minutes ago");
-        assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 65, "Stored in device\nabout 1 hour ago");
-        assertFormatStoredAgo(DateUtils.HOUR_IN_MILLIS * 45, "Stored in device\nabout 45 hours ago");
-        assertFormatStoredAgo(DateUtils.HOUR_IN_MILLIS * 50, "Stored in device\nabout 2 days ago");
-        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 30, "Stored in device\nabout 30 days ago");
-        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 31, "Stored in device\nabout 1 month ago");
-        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 66, "Stored in device\nabout 2 months ago");
-        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 366, "Stored in device\nover a year ago");
+        assertThat(Formatter.formatStoredAgo(0)).isEqualTo("Stored ");
+        assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 10, "Stored a few minutes ago");
+        assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 20, "Stored about 20 minutes ago");
+        assertFormatStoredAgo(DateUtils.MINUTE_IN_MILLIS * 65, "Stored about 1 hour ago");
+        assertFormatStoredAgo(DateUtils.HOUR_IN_MILLIS * 45, "Stored about 45 hours ago");
+        assertFormatStoredAgo(DateUtils.HOUR_IN_MILLIS * 50, "Stored about 2 days ago");
+        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 30, "Stored about 30 days ago");
+        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 31, "Stored about 1 month ago");
+        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 66, "Stored about 2 months ago");
+        assertFormatStoredAgo(DateUtils.DAY_IN_MILLIS * 366, "Stored over a year ago");
     }
 
     private static void assertFormatStoredAgo(final long agoInMillis, final String expected) {

--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -401,7 +401,7 @@ public final class Formatter {
             ago = CgeoApplication.getInstance().getString(R.string.cache_offline_about_time_year);
         }
 
-        return CgeoApplication.getInstance().getString(R.string.cache_offline_stored) + "\n" + ago;
+        return String.format(CgeoApplication.getInstance().getString(R.string.cache_offline_stored_ago), ago);
     }
 
     /**

--- a/main/src/main/res/layout/popup.xml
+++ b/main/src/main/res/layout/popup.xml
@@ -14,13 +14,13 @@
         layout="@layout/actionbar_popup" />
     <ScrollView
         android:id="@+id/details_list_box"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="4dip" >
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical" >
 
@@ -36,10 +36,107 @@
 
             <LinearLayout
                 android:id="@+id/details_list"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical" >
             </LinearLayout>
+
+            <RelativeLayout style="@style/separator_horizontal_layout" >
+                <View style="@style/separator_horizontal" />
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
+                    android:id="@+id/frame_texts"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_toLeftOf="@id/frame_buttons"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/offline_text"
+                        tools:text="@string/cache_offline_not_ready"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="left"
+                        android:layout_marginLeft="6dip"
+                        android:layout_marginRight="51dip"
+                        android:paddingRight="3dip"
+                        android:textIsSelectable="false"
+                        android:textSize="@dimen/textSize_detailsSecondary"
+                        android:textColor="@color/colorText"/>
+
+                    <TextView
+                        android:id="@+id/offline_lists"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="6dip"
+                        android:paddingRight="3dip"
+                        android:textIsSelectable="false"
+                        android:textSize="@dimen/textSize_detailsSecondary"
+                        tools:text="list 1, list 2"
+                        android:textColor="@color/colorText"/>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/frame_buttons"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_alignParentRight="true">
+
+                    <Button
+                        android:id="@+id/offline_edit"
+                        style="@style/button_icon"
+                        app:icon="@drawable/ic_menu_edit"
+                        android:layout_marginLeft="0dp"
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
+
+                    <Button
+                        android:id="@+id/offline_refresh"
+                        style="@style/button_icon"
+                        app:icon="@drawable/ic_menu_refresh"
+                        android:layout_marginLeft="0dp"/>
+
+                    <Button
+                        android:id="@+id/offline_drop"
+                        style="@style/button_icon"
+                        app:icon="@drawable/ic_menu_delete"
+                        android:layout_marginLeft="0dp"/>
+
+                    <Button
+                        android:id="@+id/offline_store"
+                        style="@style/button_icon"
+                        app:icon="@drawable/ic_menu_save"
+                        android:layout_marginLeft="0dp"/>
+                </LinearLayout>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/offline_hint_separator"
+                style="@style/separator_horizontal_layout"
+                android:visibility="gone" >
+                <View style="@style/separator_horizontal" />
+            </RelativeLayout>
+            <TextView
+                android:id="@+id/offline_hint_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:paddingRight="3dip"
+                android:textIsSelectable="false"
+                android:textSize="@dimen/textSize_detailsSecondary"
+                android:visibility="gone"
+                tools:text="hint"
+                android:textColor="@color/colorText"/>
+
 
             <RelativeLayout
                 android:layout_width="match_parent"
@@ -69,95 +166,6 @@
 
             </RelativeLayout>
 
-            <RelativeLayout style="@style/separator_horizontal_layout" >
-                <View style="@style/separator_horizontal" />
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
-
-                <TextView
-                    android:id="@+id/offline_text"
-                    tools:text="@string/cache_offline_not_ready"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_gravity="left"
-                    android:layout_marginLeft="6dip"
-                    android:layout_marginRight="51dip"
-                    android:paddingRight="3dip"
-                    android:textIsSelectable="false"
-                    android:textSize="@dimen/textSize_detailsSecondary"
-                    android:textColor="@color/colorText"/>
-
-                <Button
-                    android:id="@+id/offline_refresh"
-                    style="@style/button_icon"
-                    app:icon="@drawable/ic_menu_refresh"
-                    android:layout_alignParentRight="true"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content" >
-
-                <TextView
-                    android:id="@+id/offline_lists"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_marginLeft="6dip"
-                    android:layout_toLeftOf="@id/offline_edit"
-                    android:paddingRight="3dip"
-                    android:textIsSelectable="false"
-                    android:textSize="@dimen/textSize_detailsSecondary"
-                    tools:text="list 1, list 2"
-                    android:textColor="@color/colorText"/>
-
-                <Button
-                    android:id="@+id/offline_edit"
-                    style="@style/button_icon"
-                    app:icon="@drawable/ic_menu_edit"
-                    android:layout_toLeftOf="@id/offline_drop"
-                    android:layout_marginLeft="0dp"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
-
-                <Button
-                    android:id="@+id/offline_drop"
-                    style="@style/button_icon"
-                    app:icon="@drawable/ic_menu_delete"
-                    android:layout_marginLeft="0dp"
-                    android:layout_alignParentRight="true"/>
-
-                <Button
-                    android:id="@+id/offline_store"
-                    style="@style/button_icon"
-                    app:icon="@drawable/ic_menu_save"
-                    android:layout_marginLeft="0dp"
-                    android:layout_alignParentRight="true"/>
-
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:id="@+id/offline_hint_separator"
-                style="@style/separator_horizontal_layout"
-                android:visibility="gone" >
-                <View style="@style/separator_horizontal" />
-            </RelativeLayout>
-            <TextView
-                android:id="@+id/offline_hint_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="6dip"
-                android:layout_marginRight="6dip"
-                android:paddingRight="3dip"
-                android:textIsSelectable="false"
-                android:textSize="@dimen/textSize_detailsSecondary"
-                android:visibility="gone"
-                tools:text="hint"
-                android:textColor="@color/colorText"/>
 
         </LinearLayout>
     </ScrollView>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1437,7 +1437,7 @@
     <string name="cache_delete_generated_waypoints_confirm">Remove all generated waypoints from this cache?\n\nWaypoints will be deleted immediately, there is no undo.</string>
     <string name="cache_delete_generated_waypoints_success">Generated waypoints deleted</string>
     <string name="cache_offline_store">Store</string>
-    <string name="cache_offline_stored">Stored in device</string>
+    <string name="cache_offline_stored_ago">Stored %s</string>
     <string name="cache_offline_not_ready">Not available offline</string>
     <string name="cache_offline_time_mins_few">a few minutes ago</string>
     <plurals name="cache_offline_about_time_mins">


### PR DESCRIPTION
## Description
As discussed in our last dev meeting here's a small proposal for rearranging the buttons in cache bottom sheet. It's for discussion only for now, therefore not yet implemented for cache details activity (where it probably should look the same as here).

Changes are:
- Move "More details" button (with optional hint button) to the end
- Move "Edit lists", "Refresh", "Delete" and "Store" buttons into a single horizontal row. (As it can be either "Store" or "Delete", a maximum of three buttons is displayed here)
- Text for "stored ago" and "lists" go to the left of those buttons
- Text for "stored ago" is a bit shortened and without line break
- On enabling hint this will be displayed between the row with the small buttons and the large "More details" button, divided by a separator, so that the "More details" buttons always stays in a fixed place at the bottom of this view

Looks like this:

|unstored|stored 1|stored 2|
|---|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/7c043243-5b70-4137-bce5-a9684e76feba)|![image](https://github.com/cgeo/cgeo/assets/3754370/90a8db2d-e786-4fa7-a148-82f3c072db7d)|![image](https://github.com/cgeo/cgeo/assets/3754370/e0599ffb-96fd-4c99-b8a0-b2b40527ff27)|

A small problem remains, as can be seen in "stored 2": The layouts don't reflow on hiding buttons, so the `LinearLayout` around the buttons will always consume the space for four buttons, even if only up to three are being displayed, leading to text to the left wrapping, although there would be enough space.
How can I let Android dynamically adjust sizes?

(I had started with a `RelativeLayout` first, but then only one button got displayed at all, even though I had `toLeftOf` relationships defined.)
