### PR TITLE
use different app id for debug builds

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
     <application
         android:name=".CgeoApplication"
         android:allowBackup="true"
-        android:backupAgent="cgeo.geocaching.backup.CentralBackupAgent"
+        android:backupAgent=".backup.CentralBackupAgent"
         android:icon="${appIcon}"
         android:roundIcon="${appIconRound}"
         android:label="@string/app_name"
@@ -199,7 +199,7 @@
                 android:value="cgeo.geocaching.MainActivity" />
         </activity>
         <activity
-            android:name="cgeo.geocaching.helper.UsefulAppsActivity"
+            android:name=".helper.UsefulAppsActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/helpers"
             android:parentActivityName="cgeo.geocaching.MainActivity"
@@ -209,7 +209,7 @@
                 android:value="cgeo.geocaching.MainActivity" />
         </activity>
         <activity
-            android:name="cgeo.geocaching.helper.QueryMapFile"
+            android:name=".helper.QueryMapFile"
             android:exported="true">
         </activity>
         <activity
@@ -235,7 +235,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="cgeo.geocaching.address.AddressListActivity"
+            android:name=".address.AddressListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/search_address_result"
             android:parentActivityName="cgeo.geocaching.SearchActivity"
@@ -411,11 +411,11 @@
             android:label="@string/map_map" >
         </activity>
         <activity
-            android:name="cgeo.geocaching.log.LogCacheActivity"
+            android:name=".log.LogCacheActivity"
             android:label="@string/log_new_log" >
         </activity>
         <activity
-            android:name="cgeo.geocaching.log.LogTrackableActivity"
+            android:name=".log.LogTrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/trackable_touch"
             android:exported="true">
@@ -636,7 +636,7 @@
         </activity>
 
         <activity
-            android:name="cgeo.geocaching.TrackableActivity"
+            android:name=".TrackableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true">
 
@@ -696,7 +696,7 @@
 
         </activity>
         <activity
-            android:name="cgeo.geocaching.connector.gc.ImportBookmarkLinks"
+            android:name=".connector.gc.ImportBookmarkLinks"
             android:exported="true">
 
             <!-- geocaching.com URL via coord.info redirection -->
@@ -808,7 +808,7 @@
         </activity>
 
         <activity
-            android:name="cgeo.geocaching.connector.trackable.GeokretyAuthorizationActivity"
+            android:name=".connector.trackable.GeokretyAuthorizationActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
@@ -821,7 +821,7 @@
         </activity>
 
         <activity
-            android:name="cgeo.geocaching.settings.GCAuthorizationActivity"
+            android:name=".settings.GCAuthorizationActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
@@ -834,7 +834,7 @@
         </activity>
 
         <activity
-            android:name="cgeo.geocaching.settings.ECAuthorizationActivity"
+            android:name=".settings.ECAuthorizationActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
@@ -847,7 +847,7 @@
         </activity>
 
         <activity
-            android:name="cgeo.geocaching.connector.su.SuAuthorizationActivity"
+            android:name=".connector.su.SuAuthorizationActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
@@ -865,7 +865,7 @@
         </activity>
 
         <activity
-            android:name="cgeo.geocaching.settings.GCVoteAuthorizationActivity"
+            android:name=".settings.GCVoteAuthorizationActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateHidden"
@@ -877,19 +877,19 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="cgeo.geocaching.connector.gc.PocketQueryListActivity"
+            android:name=".connector.gc.PocketQueryListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/search_pocket_title">
         </activity>
         <activity
-            android:name="cgeo.geocaching.connector.gc.BookmarkListActivity"
+            android:name=".connector.gc.BookmarkListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/search_bookmark_list">
         </activity>
         <activity android:name=".downloader.DownloadConfirmationActivity" android:exported="false" />
         <activity android:name=".downloader.PendingDownloadsActivity" android:exported="false" />
         <activity
-            android:name="cgeo.geocaching.downloader.DownloadSelectorActivity"
+            android:name=".downloader.DownloadSelectorActivity"
             android:label="@string/download_title">
         </activity>
         <activity

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -192,21 +192,13 @@
             android:name=".AboutActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/about"
-            android:parentActivityName="cgeo.geocaching.MainActivity"
             android:windowSoftInputMode="stateHidden" >
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="cgeo.geocaching.MainActivity" />
         </activity>
         <activity
             android:name=".helper.UsefulAppsActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/helpers"
-            android:parentActivityName="cgeo.geocaching.MainActivity"
             android:windowSoftInputMode="stateHidden" >
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="cgeo.geocaching.MainActivity" />
         </activity>
         <activity
             android:name=".helper.QueryMapFile"
@@ -222,11 +214,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true"
             android:label="@string/search_destination"
-            android:parentActivityName="cgeo.geocaching.MainActivity"
             android:windowSoftInputMode="stateHidden" >
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="cgeo.geocaching.MainActivity" />
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="geo" />
@@ -238,22 +226,14 @@
             android:name=".address.AddressListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/search_address_result"
-            android:parentActivityName="cgeo.geocaching.SearchActivity"
             android:windowSoftInputMode="stateHidden" >
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="cgeo.geocaching.SearchActivity" />
         </activity>
         <activity
             android:name=".settings.SettingsActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/settings_titlebar"
-            android:parentActivityName="cgeo.geocaching.MainActivity"
             android:theme="@style/cgeo"
             android:exported="false">
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="cgeo.geocaching.MainActivity" />
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH"/>
             </intent-filter>
@@ -269,7 +249,6 @@
             android:name=".HandleLocalFilesActivity"
             android:exported="true"
             android:label="@string/localfile_intenttitle">
-            <!-- don't use fixed parent activity, since we may come from main activity, pocket query activity or search activity -->
             <!-- intent filter for local map files -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -293,7 +272,6 @@
         <activity
             android:name=".CacheListActivity"
             android:exported="true">
-            <!-- don't use fixed parent activity, since we may come from main activity, pocket query activity or search activity -->
             <!-- don't add configChanges="orientation|screenSize" as we use different base layouts depending on the device orientation -->
 
             <!-- intent filter for local gpx files -->
@@ -788,7 +766,6 @@
         <activity
             android:name=".CreateShortcutActivity"
             android:label="@string/cgeo_shortcut"
-            android:parentActivityName="cgeo.geocaching.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -73,6 +73,11 @@ android {
             // debug build name contains git commit for better reproduction of bugs
             versionNameSuffix "-" + GitCommit.currentShort() + " developer build"
 
+            // also give a different suffix so that it can be installed in parallel, however we do not want to affect the CI builds
+            if (!isContinuousIntegrationServer()) {
+                applicationIdSuffix ".developer"
+            }
+
             // additional proguard rules just for the test code
             testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt', '../tests/proguard-project.txt'
 

--- a/main/src/debug/res/values/strings_debug.xml
+++ b/main/src/debug/res/values/strings_debug.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- fileprovider for debug builds - must be different from main version as it otherwise cannot be installed im parallel to the main version -->
+    <string translatable="false" name="file_provider_authority">org.cgeo.devfileprovider</string>
+
+    </resources>

--- a/main/src/main/java/cgeo/geocaching/settings/ViewSettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/ViewSettingsActivity.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.settings;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.CustomMenuEntryActivity;
 import cgeo.geocaching.databinding.ViewSettingsAddBinding;
@@ -8,7 +9,6 @@ import cgeo.geocaching.ui.SimpleItemListModel;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
-import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.SettingsUtils;
 import static cgeo.geocaching.utils.SettingsUtils.getType;
 
@@ -31,6 +31,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
+import androidx.preference.PreferenceManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,7 +84,7 @@ public class ViewSettingsActivity extends CustomMenuEntryActivity {
         setUpNavigationEnabled(true);
 
         allItems = new ArrayList<>();
-        prefs = getSharedPreferences(ApplicationSettings.getPreferencesName(), MODE_PRIVATE);
+        prefs = PreferenceManager.getDefaultSharedPreferences(CgeoApplication.getInstance().getBaseContext());
         final Map<String, ?> keys = prefs.getAll();
         for (Map.Entry<String, ?> entry : keys.entrySet()) {
             final Object value = entry.getValue();

--- a/main/src/main/java/cgeo/geocaching/utils/ApplicationSettings.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ApplicationSettings.java
@@ -21,12 +21,17 @@ public class ApplicationSettings {
 
     /**
      * Get the name of the preferences file.
+     * <br/>
+     * ONLY USE THIS METHOD IF NO CONTEXT IS AVAILABLE!
+     * <br/>
+     * Developer builds will have a different preferences name then specified here.
+     * The suggested way of retrieving the preferences is using {@link androidx.preference.PreferenceManager#getDefaultSharedPreferences(android.content.Context)}.
      *
      * @return the name of the shared preferences file without the extension
      */
     public static String getPreferencesName() {
         // There is currently no Android API to get the file name of the shared preferences. Let's hardcode
-        // it without needing a CgeoApplication instance.
+        // it without needing a CgeoApplication instance (see #2317).
         return "cgeo.geocaching_preferences";
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.InstallWizardActivity;
 import cgeo.geocaching.MainActivity;
 import cgeo.geocaching.R;
@@ -25,7 +26,6 @@ import static cgeo.geocaching.utils.SettingsUtils.SettingsType.TYPE_UNKNOWN;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.ProgressDialog;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -42,6 +42,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.util.Consumer;
+import androidx.preference.PreferenceManager;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -382,7 +383,7 @@ public class BackupUtils {
             final InputStream file = ContentStorage.get().openForRead(getSettingsFile(backupDir).uri);
 
             // open shared prefs for writing
-            final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), Context.MODE_PRIVATE);
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(CgeoApplication.getInstance().getBaseContext());
             final SharedPreferences.Editor editor = prefs.edit();
 
             // parse xml
@@ -550,7 +551,7 @@ public class BackupUtils {
     }
 
     private boolean createSettingsBackupInternal(final Folder backupDir, final Boolean fullBackup) {
-        final SharedPreferences prefs = activityContext.getSharedPreferences(ApplicationSettings.getPreferencesName(), Context.MODE_PRIVATE);
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(CgeoApplication.getInstance().getBaseContext());
         final Map<String, ?> keys = prefs.getAll();
         final HashSet<String> ignoreKeys = new HashSet<>();
 


### PR DESCRIPTION
From time to time I need to debug some code on my primary device which is a real hassle currently. This PR makes our manifest app id independent (use relative names and remove unnecessary usage of parent activity flag) and adds a applicationIdSuffix to developer builds. This allows c:geo dev builds to be installed in parallel to the main version.