### PR TITLE
Show refresh button only for caches already stored

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -2751,7 +2751,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             offlineEdit.setOnLongClickListener(moveCacheListener);
         }
 
-        offlineRefresh.setVisibility(cache.supportsRefresh() ? View.VISIBLE : View.GONE);
+        offlineRefresh.setVisibility(cache.supportsRefresh() && cache.isOffline() ? View.VISIBLE : View.GONE);
         offlineRefresh.setClickable(true);
         offlineRefresh.setOnClickListener(refreshCacheClickListener);
 


### PR DESCRIPTION
## Description
While working on cache popup / cache details "offlinebox" layout I've stumbled upon the fact, that the "refresh" button is always being displayed when a connectors supports it. IMHO this does not make sense for caches not yet stored offline - "store" button is sufficient in this case. - This PR removes the "refresh" button when the cache is not yet stored offline.