### PR TITLE
introduce flat marker mode (fix #14479)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/geoitem/GeoIcon.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/GeoIcon.java
@@ -22,6 +22,7 @@ public class GeoIcon implements Parcelable {
     private final float xAnchor;
     private final float yAnchor;
     private final float rotation;
+    private final boolean flat;
 
     //lazy initialized
     private int bmWidth = -1;
@@ -140,11 +141,12 @@ public class GeoIcon implements Parcelable {
 
     }
 
-    private GeoIcon(@Nullable final BitmapProvider bitmapProvider, final float xAnchor, final float yAnchor, final float rotation) {
+    private GeoIcon(@Nullable final BitmapProvider bitmapProvider, final float xAnchor, final float yAnchor, final float rotation, final boolean flat) {
         this.bitmapProvider = bitmapProvider;
         this.xAnchor = xAnchor;
         this.yAnchor = yAnchor;
         this.rotation = rotation;
+        this.flat = flat;
     }
 
     @Nullable
@@ -173,6 +175,13 @@ public class GeoIcon implements Parcelable {
     /** Rotation angle for this icon in degrees (0-360°) */
     public float getRotation() {
         return rotation;
+    }
+
+    /**
+     * if the marker should rotate together with the map (flat mode) or should be displayed as billboard popup. Default is billboard.
+     */
+    public boolean isFlat() {
+        return flat;
     }
 
     public boolean touchesIcon(final Geopoint tap, final Geopoint iconBase, @Nullable final ToScreenProjector toScreenCoordFunc) {
@@ -208,7 +217,7 @@ public class GeoIcon implements Parcelable {
 
 
     public Builder buildUpon() {
-        return builder().setBitmapProvider(bitmapProvider).setXAnchor(xAnchor).setYAnchor(yAnchor).setRotation(rotation);
+        return builder().setBitmapProvider(bitmapProvider).setXAnchor(xAnchor).setYAnchor(yAnchor).setRotation(rotation).setFlat(flat);
     }
 
     //equals/hashCode
@@ -223,7 +232,8 @@ public class GeoIcon implements Parcelable {
             Objects.equals(bitmapProvider, other.bitmapProvider) &&
             Objects.equals(xAnchor, other.xAnchor) &&
             Objects.equals(yAnchor, other.yAnchor) &&
-            Objects.equals(rotation, other.rotation);
+            Objects.equals(rotation, other.rotation) &&
+            Objects.equals(flat, other.flat);
     }
 
     @Override
@@ -234,7 +244,7 @@ public class GeoIcon implements Parcelable {
     @Override
     @NonNull
     public String toString() {
-        return "bm:" + bitmapProvider + ", angle:" + getRotation() + ", x/yAnchor:" + xAnchor + "/" + yAnchor;
+        return "bm:" + bitmapProvider + ", angle:" + getRotation() + ", x/yAnchor:" + xAnchor + "/" + yAnchor + ", flat:" + flat;
     }
 
 
@@ -246,6 +256,7 @@ public class GeoIcon implements Parcelable {
         private float xAnchor;
         private float yAnchor;
         private float rotation;
+        private boolean flat = false;
 
         private Builder() {
             setHotspot(Hotspot.CENTER);
@@ -280,8 +291,14 @@ public class GeoIcon implements Parcelable {
             return this;
         }
 
+        /** if the marker should rotate together with the map (flat mode) or should be displayed as billboard popup. */
+        public Builder setFlat(final boolean flat) {
+            this.flat = flat;
+            return this;
+        }
+
         public GeoIcon build() {
-            return new GeoIcon(bitmapProvider, xAnchor, yAnchor, rotation);
+            return new GeoIcon(bitmapProvider, xAnchor, yAnchor, rotation, flat);
         }
     }
 
@@ -292,6 +309,7 @@ public class GeoIcon implements Parcelable {
         xAnchor = in.readFloat();
         yAnchor = in.readFloat();
         rotation = in.readFloat();
+        flat = in.readInt() > 0;
     }
 
     @Override
@@ -300,6 +318,7 @@ public class GeoIcon implements Parcelable {
         dest.writeFloat(xAnchor);
         dest.writeFloat(yAnchor);
         dest.writeFloat(rotation);
+        dest.writeInt(flat ? 1 : 0); // writeBoolean requires API 29
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
@@ -129,6 +129,7 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
             marker = map.addMarker(new MarkerOptions()
                 .icon(BitmapDescriptorCache.toBitmapDescriptor(new BitmapDrawable(resources, icon.getBitmap())))
                 .rotation(icon.getRotation())
+                .flat(icon.isFlat())
                 .position(GP_CONVERTER.to(item.getCenter()))
                 .anchor(icon.getXAnchor(), icon.getYAnchor())
                 .zIndex(zLevel));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
@@ -167,7 +167,7 @@ public class MapsforgeVtmGeoItemLayer implements IProviderGeoItemLayer<Pair<Draw
             final GeoIcon icon = item.getIcon();
             marker = new MarkerItem("", "", GP_CONVERTER.to(item.getCenter()));
             marker.setMarker(new MarkerSymbol(new AndroidBitmap(icon.getBitmap()),
-                    icon.getXAnchor(), icon.getYAnchor(), true));
+                    icon.getXAnchor(), icon.getYAnchor(), !icon.isFlat()));
             marker.setRotation(item.getIcon().getRotation());
             markerLayer.addItem(marker);
             markerLayer.update();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionLayer.java
@@ -53,6 +53,7 @@ public class PositionLayer {
                 layer.put(KEY_POSITION,
                         GeoPrimitive.createMarker(new Geopoint(positionAndHeading.first), GeoIcon.builder()
                                         .setRotation(positionAndHeading.second)
+                                        .setFlat(true)
                                         .setBitmap(markerPosition).build())
                                 .buildUpon().setZLevel(LayerHelper.ZINDEX_POSITION).build());
             }


### PR DESCRIPTION
I tried my best to extend geoItemLayer to our requirements, and implement this styling flag in VTM and gmapV2. It's not necessary to implement it for old mapsforge, as that map cannot be rotated at all, so this flag is useless.

@eddiemuc I would aprechiate a short review. thx!