### PR TITLE
Fix cause for NPE in getElevation()

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
@@ -184,7 +184,7 @@ public final class Routing {
     }
 
     public static float getElevation(final Geopoint current) {
-        if (routingServiceConnection == null) {
+        if (routingServiceConnection == null || !routingServiceConnection.isConnected()) {
             return NO_ELEVATION_AVAILABLE;
         }
         final Bundle params = new Bundle();


### PR DESCRIPTION
Prevent NPE in `getElevation()` when routing service is not yet connected