### PR TITLE
Don't show 'swipe to open' in landscape format (fix #14982)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -357,17 +357,20 @@ public class MapUtils {
 
     private static void configureDetailsFragment(final Fragment fragment, final AppCompatActivity activity, final Runnable onUpSwipeAction) {
 
-        final FragmentTransaction ft = activity.getSupportFragmentManager().beginTransaction();
-        final SwipeToOpenFragment swipeToOpenFragment = new SwipeToOpenFragment();
-        ft.replace(R.id.detailsfragment, swipeToOpenFragment, TAG_SWIPE_FRAGMENT);
-        ft.add(R.id.detailsfragment, fragment, TAG_MAPDETAILS_FRAGMENT);
-
-        ft.commit();
-
         final FrameLayout fl = activity.findViewById(R.id.detailsfragment);
         final ViewGroup.LayoutParams params = fl.getLayoutParams();
         final CoordinatorLayout.Behavior<?> behavior = ((CoordinatorLayout.LayoutParams) params).getBehavior();
         final boolean isBottomSheet = behavior instanceof BottomSheetBehavior;
+
+        final FragmentTransaction ft = activity.getSupportFragmentManager().beginTransaction();
+        final SwipeToOpenFragment swipeToOpenFragment = isBottomSheet ? new SwipeToOpenFragment() : null;
+        if (isBottomSheet) {
+            ft.replace(R.id.detailsfragment, swipeToOpenFragment, TAG_SWIPE_FRAGMENT);
+            ft.add(R.id.detailsfragment, fragment, TAG_MAPDETAILS_FRAGMENT);
+        } else {
+            ft.replace(R.id.detailsfragment, fragment, TAG_MAPDETAILS_FRAGMENT);
+        }
+        ft.commit();
 
         if (isBottomSheet) { // portrait mode uses BottomSheet
             final BottomSheetBehavior<FrameLayout> b = BottomSheetBehavior.from(fl);
@@ -404,7 +407,6 @@ public class MapUtils {
 
             b.addBottomSheetCallback(callback);
             swipeToOpenFragment.setOnStopCallback(() -> b.removeBottomSheetCallback(callback));
-
         } else { // landscape mode uses SideSheet
             final SideSheetBehavior<FrameLayout> b = SideSheetBehavior.from(fl);
             b.setState(SideSheetBehavior.STATE_EXPANDED);
@@ -424,8 +426,6 @@ public class MapUtils {
             };
 
             b.addCallback(callback);
-            swipeToOpenFragment.setOnStopCallback(() -> b.removeCallback(callback));
-
         }
 
         fl.setVisibility(View.VISIBLE);

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -410,12 +410,16 @@ public class MapUtils {
         } else { // landscape mode uses SideSheet
             final SideSheetBehavior<FrameLayout> b = SideSheetBehavior.from(fl);
             b.setState(SideSheetBehavior.STATE_EXPANDED);
+            final SideSheetCallback[] callbackStore = new SideSheetCallback[] { null };
 
             final SideSheetCallback callback = new SideSheetCallback() {
                 @Override
                 public void onStateChanged(@NonNull final View sheet, final int newState) {
                     if (newState == SideSheetBehavior.STATE_HIDDEN) {
                         removeDetailsFragment(activity);
+                        if (callbackStore[0] != null) {
+                            b.removeCallback(callbackStore[0]);
+                        }
                     }
                 }
 
@@ -424,7 +428,7 @@ public class MapUtils {
                     // nothing
                 }
             };
-
+            callbackStore[0] = callback;
             b.addCallback(callback);
         }
 

--- a/main/src/main/res/layout-land/map_detailsfragment.xml
+++ b/main/src/main/res/layout-land/map_detailsfragment.xml
@@ -15,7 +15,7 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_weight="5"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <FrameLayout
             android:id="@+id/detailsfragment"


### PR DESCRIPTION
Cache/waypoint side sheet (landscape format):
- Don't show 'swipe to open'
- Make free space below side sheet touchable (to allow map movements on tablets)
