### PR TITLE
UnifiedMap: Replace 'experimental' warning with 'beta' info

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1261,10 +1261,10 @@
     <string name="init_map_other">Other</string>
     <string name="init_map_osm_multithreaded">Multi-threaded (OSM)</string>
     <string name="init_summary_map_osm_multithreaded">Use multiple threads to render OpenStreetMap maps</string>
-    <string name="category_unifiedMap">Unified Map</string>
+    <string name="category_unifiedMap">Unified Map (beta)</string>
     <string name="experimental">(experimental)</string>
     <string name="init_title_useUnifiedMap">Use unified map</string>
-    <string name="init_summary_useUnifiedMap">Use new unified map instead of built-in Google Map / Mapsforge (OSM) maps (experimental / far from being complete / for testing only)</string>
+    <string name="init_summary_useUnifiedMap">Use new unified map instead of built-in Google Map / Mapsforge (OSM) maps</string>
     <string name="localstorage_migrate_title">Migration of local files</string>
     <string name="localstorage_migrate_status_major">Version %1$d</string>
 

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -112,7 +112,6 @@
     <PreferenceCategory
         android:key="@string/pref_fakekey_unifiedmap"
         android:title="@string/category_unifiedMap"
-        android:summary="@string/experimental"
         app:iconSpaceReserved="false">
         <MultiSelectListPreference
             android:key="@string/pref_tileprovider_hidden"


### PR DESCRIPTION
## Description
Removes the "experimental" warnings in settings' category and detail description and adds a "beta" note to the category name