### PR TITLE
Mark visited waypoints with semi-transparent bg (optional)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1340,6 +1340,10 @@ public class Settings {
         return getInt(R.string.pref_showwaypointsthreshold, getKeyInt(R.integer.waypoint_threshold_default));
     }
 
+    public static boolean getVisitedWaypointsSemiTransparent() {
+        return getBoolean(R.string.pref_visitedWaypointsSemiTransparent, false);
+    }
+
     /**
      * The threshold for brouter routing (max. distance)
      */

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
@@ -38,6 +38,10 @@ public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment
             MapMarkerUtils.clearCachedItems();
             return true;
         });
+        findPreference(getString(R.string.pref_visitedWaypointsSemiTransparent)).setOnPreferenceChangeListener((preference, newValue) -> {
+            MapMarkerUtils.clearCachedItems();
+            return true;
+        });
     }
 
     public void updateNotificationAudioInfo() {

--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -328,8 +328,11 @@ public final class MapMarkerUtils {
             }
             addListMarkers(res, insetsBuilder, getAssignedMarkers(cache), false, applyScaling);
         }
-
-        return buildLayerDrawable(insetsBuilder, 8, 8);
+        final LayerDrawable ld = buildLayerDrawable(insetsBuilder, 8, 8);
+        if ((waypoint.isVisited() || (cache != null && cache.isFound())) && Settings.getVisitedWaypointsSemiTransparent()) {
+            ld.setAlpha(144);
+        }
+        return ld;
     }
 
     /**

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -244,6 +244,7 @@
     <string translatable="false" name="pref_excludeWpParking">excludeWpParking</string>
     <string translatable="false" name="pref_excludeWpVisited">excludeWpVisited</string>
     <string translatable="false" name="pref_zoomincludingwaypoints">zoomincludingwaypoints</string>
+    <string translatable="false" name="pref_visitedWaypointsSemiTransparent">visitedWaypointsSemiTransparent</string>
 
     <!-- category map behavior -->
     <string translatable="false" name="pref_longTapOnMap">pref_longTapOnMap</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -988,6 +988,8 @@
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_zoomincludingwaypoints">Zoom includes waypoints</string>
     <string name="init_zoomincludingwaypoints_description">If mapping a single cache: Should zoom be adjusted to include all its waypoints?</string>
+    <string name="init_visitedWaypointsSemiTransparent">Visited waypoints semi-transparent</string>
+    <string name="init_visitedWaypointsSemiTransparent_description">Mark visited waypoints with semi transparent background</string>
     <string name="init_brouterThreshold">Calculate route</string>
     <string name="init_brouterThreshold_description">Maximum distance up to which offline routing will calculate a route.</string>
     <string name="init_brouterShowBothDistances">Show straight distance</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -69,6 +69,12 @@
             android:summary="@string/init_zoomincludingwaypoints_description"
             android:title="@string/init_zoomincludingwaypoints"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_visitedWaypointsSemiTransparent"
+            android:summary="@string/init_visitedWaypointsSemiTransparent_description"
+            android:title="@string/init_visitedWaypointsSemiTransparent"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
as discussed in yesterday's dev meeting
marked as WIP

![image](https://github.com/cgeo/cgeo/assets/3754370/aec412ce-1c83-4e80-84e0-cf72cfa18458)

Setting is configurable in settings => map content & behavior => waypoints

Edit: to be discussed, whether the little green check mark should still be displayed, if semi-transparency is configured