### PR TITLE
rel to #2012: activate gc logging api unit tests in Watchdog Tests

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCLogAPITest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCLogAPITest.java
@@ -34,7 +34,7 @@ public class GCLogAPITest {
     private static final String TEST_TRAVELBUG = "TB7YFQV"; // The shirt, the duck and the sea
 
     @Test
-    @NotForIntegrationTests // this blocks execution on CI -> decision needed whether execution is allowed there
+    @NotForIntegrationTests
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") //Asserts are in submethods
     public void cacheLoggingLifecycleTest() {
         GCLogin.getInstance().login();
@@ -48,8 +48,8 @@ public class GCLogAPITest {
     }
 
     @Test
-    @NotForIntegrationTests // this blocks execution on CI -> decision needed whether execution is allowed there
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") //Asserts are in submethods
+    @NotForIntegrationTests
     public void trackableLoggingLifecycleTest() {
         GCLogin.getInstance().login();
 

--- a/main/src/androidTest/java/cgeo/watchdog/WatchdogTest.java
+++ b/main/src/androidTest/java/cgeo/watchdog/WatchdogTest.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.ec.ECConnector;
+import cgeo.geocaching.connector.gc.GCLogAPITest;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.oc.OCApiConnector;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
@@ -61,6 +62,18 @@ public class WatchdogTest {
     @Test
     public void testOpenCachingUS() {
         downloadOpenCaching("OU0331");
+    }
+
+    @NotForIntegrationTests
+    @Test
+    public void testGeocachingLogCache() {
+        new GCLogAPITest().cacheLoggingLifecycleTest();
+    }
+
+    @NotForIntegrationTests
+    @Test
+    public void testGeocachingLogTrackable() {
+        new GCLogAPITest().trackableLoggingLifecycleTest();
     }
 
     private static void downloadOpenCaching(final String geocode) {


### PR DESCRIPTION
rel to #2012: activate gc logging api unit tests in Watchdog Tests

This PR will activate the GC Logging API Unit tests on c:geo CI inside Watchdog Tests. 
This means that on each CI Watchdog test run a series of cache/trackable log create/edit/delete events it executed by the gc test user configured in CI. Other CI runs (e.g. PR request runs) are not affected