### PR TITLE
UnifiedMap: Fix single cache zoom (rel. to #15003)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -274,7 +274,11 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
     }
 
     public void zoomToBounds(final BoundingBox bounds) {
-        mMap.animator().animateTo(bounds);
+        if (bounds.getLatitudeSpan() == 0 && bounds.getLongitudeSpan() == 0) {
+            mMap.animator().animateTo(new GeoPoint(bounds.getMaxLatitude(), bounds.getMaxLongitude()));
+        } else {
+            mMap.animator().animateTo(bounds);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes mapping a single cache (without waypoints) or waypoint for UnifiedMap VTM.

(Does NOT fix mapping a list or a cache having waypoints, so NOT fixing zooming to bounds which are an area, not a point)