### PR TITLE
rel to #14948: unified map: put another animation before bound animation to avoid missing map width/height

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/IProviderGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/IProviderGeoItemLayer.java
@@ -64,7 +64,7 @@ public interface IProviderGeoItemLayer<C> {
         // inspired by http://stackoverflow.com/questions/12850143/android-basics-running-code-in-the-ui-thread/25250494#25250494
         // modifications of google map must be run on main (UI) thread
         //new Handler(Looper.getMainLooper()).post(runnable);
-        Log.iForce("AsyncMapWrapper: request Thread for: " + runnable.getClass().getName());
+        Log.v("AsyncMapWrapper: request Thread for: " + runnable.getClass().getName());
 
         AndroidRxUtils.runOnUi(runnable);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -275,7 +275,13 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         if (bounds.getLatitudeSpan() == 0 && bounds.getLongitudeSpan() == 0) {
             mMap.animator().animateTo(new GeoPoint(bounds.getMaxLatitude(), bounds.getMaxLongitude()));
         } else {
-            mMap.animator().animateTo(bounds);
+            if (mMap.getWidth() == 0 || mMap.getHeight() == 0) {
+                //See Bug #14948: w/o map width/height the bounds can't be calculated
+                // -> postphone animation to later on UI thread (where map width/height will be set)
+                mMap.post(() -> mMap.animator().animateTo(bounds));
+            } else {
+                mMap.animator().animateTo(bounds);
+            }
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/AsynchronousMapWrapper.java
+++ b/main/src/main/java/cgeo/geocaching/utils/AsynchronousMapWrapper.java
@@ -367,7 +367,7 @@ public class AsynchronousMapWrapper<K, V, C> {
 
         @Override
         public void run() {
-            Log.iForce("AsyncMapWrapper: run Thread");
+            Log.v("AsyncMapWrapper: run Thread");
             lock.lock();
             try {
                 if (!isDestroyed.get() && mapChangeRequested && processQueue()) {


### PR DESCRIPTION
rel to #14948: unified map: put another animation before bound animation to avoid missing map width/height