### PR TITLE
Increase log length to 5000

### DIFF
--- a/main/src/androidTest/res/raw/log_with_2tb.htm
+++ b/main/src/androidTest/res/raw/log_with_2tb.htm
@@ -389,7 +389,7 @@ select{margin:0 !important;}
             </dt>
             <dd>
                 <span id="ctl00_ContentBody_LogBookPanel1_valLogInfoMaxLength" style="color:Red;display:none;">[Max Length Reached]</span>
-                <textarea name="ctl00$ContentBody$LogBookPanel1$uxLogInfo" rows="10" cols="80" id="ctl00_ContentBody_LogBookPanel1_uxLogInfo" class="Textarea Editor" CKEMaxLength="4000" style="width:99%;">
+                <textarea name="ctl00$ContentBody$LogBookPanel1$uxLogInfo" rows="10" cols="80" id="ctl00_ContentBody_LogBookPanel1_uxLogInfo" class="Textarea Editor" CKEMaxLength="5000" style="width:99%;">
 </textarea>
                 &nbsp;
             </dd>

--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -79,7 +79,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     private static final int LOADER_ID_LOGGING_INFO = 409809;
     private static final String SAVED_STATE_LOGENTRY = "cgeo.geocaching.saved_state_logentry";
     private static final String SAVED_STATE_AVAILABLE_FAV_POINTS  = "cgeo.geocaching.saved_state_available_fav_points";
-    private static final int LOG_MAX_LENGTH = 4000;
+    private static final int LOG_MAX_LENGTH = 5000;
 
     private enum SaveMode { NORMAL, FORCE, SKIP }
 

--- a/main/src/main/res/layout/logcache_activity.xml
+++ b/main/src/main/res/layout/logcache_activity.xml
@@ -48,16 +48,16 @@
                 <com.google.android.material.textfield.TextInputLayout
                     style="@style/textinput_edittext"
                     app:counterEnabled="true"
-                    app:counterMaxLength="4000">
+                    app:counterMaxLength="5000">
                     <EditText
                         android:id="@+id/log"
                         style="@style/textinput_embedded"
                         android:hint="@string/log_new_log_text"
                         android:autofillHints="@string/log_new_log_text"
                         android:inputType="textMultiLine|textCapSentences"
-                        android:maxLength="4000"
+                        android:maxLength="5000"
                         android:minLines="5"
-                        tools:text="The log text is limited to 4000 characters."/>
+                        tools:text="The log text is limited to 5000 characters."/>
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <LinearLayout

--- a/main/src/main/res/layout/logtrackable_activity.xml
+++ b/main/src/main/res/layout/logtrackable_activity.xml
@@ -96,7 +96,7 @@
                 android:autofillHints="@string/log_new_log_text"
                 android:inputType="textMultiLine|textCapSentences"
                 android:lines="5"
-                android:maxLength="4000" />
+                android:maxLength="5000" />
         </com.google.android.material.textfield.TextInputLayout>
 
     </LinearLayout>


### PR DESCRIPTION


<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Increase log length to 5000 characters

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Since 2 November 2023 the allowed log length has been increased to 5000 characters.


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
See also:
https://forums.geocaching.com/GC/index.php?/topic/394827-release-notes-website-new-geocache-and-trackable-logging-flow-november-2-2023/
