### PR TITLE
fix #15043: adapt scan pattern for gc.com cache inventory

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -354,4 +354,60 @@ public class GCParserTest {
     public void testGetUsername() {
         assertThat(GCParser.getUsername(MockedCache.readCachePage("GC2CJPF"))).isEqualTo("abft");
     }
+
+    @Test
+    public void parseTrackableInventory() {
+        // Before #15043 happened
+        final String exampleOld = "ctl00_ContentBody_uxTravelBugList_uxInventoryLabel\">Inventory</span>" +
+            "    </h3>" +
+            "    <div class=\"WidgetBody\">" +
+            "                <ul>" +
+            "                <li>" +
+            "                    <a href=\"https://www.geocaching.com/track/details.aspx?guid=e6aab619-9cc0-4060-91ee-dde3412bddc2\" class=\"lnk\">" +
+            "                        <img src=\"/images/WptTypes/sm/3069.gif\" width=\"16\" alt=\"\" /><span>Tuinkabouter</span></a>" +
+            "                </li>" +
+            "                <li>" +
+            "                    <a href=\"https://www.geocaching.com/track/details.aspx?guid=758a8a62-5af9-4183-8386-3249befa075a\" class=\"lnk\">" +
+            "                        <img src=\"/images/WptTypes/sm/4367.gif\" width=\"16\" alt=\"\" /><span>Just Add Water Festival Geocoin</span></a>" +
+            "                </li>" +
+            "                </ul>" +
+            "            <div";
+
+        //New with #15043
+        final String exampleNew = "ctl00_ContentBody_uxTravelBugList_uxInventoryLabel\">Inventory</span>" +
+            " </h3> " +
+            "    <div class=\"WidgetBody\">" +
+            "     <ul>" +
+            "     <li>" +
+            "         <a href=\"https://www.geocaching.com/hide/details.aspx?TB=TB7ZAAK\" class=\"lnk\">" +
+            "               <img src=\"/images/WptTypes/sm/21.gif\" width=\"16\" alt=\"\" /><span>the gambler</span></a>" +
+            "     </li>" +
+            "     <li>" +
+            "         <a href=\"https://www.geocaching.com/hide/details.aspx?TB=TBABCD5\" class=\"lnk\">" +
+            "               <img src=\"/images/WptTypes/sm/4367.gif\" width=\"16\" alt=\"\" /><span>the test tb</span></a>" +
+            "     </li>" +
+            "     </ul>" +
+            "   <div";
+
+        // -> Assert that we can parse both
+
+        final List<Trackable> trackablesOld = GCParser.parseInventory(exampleOld);
+        assertThat(trackablesOld).hasSize(2);
+        assertThat(trackablesOld.get(0).getGuid()).isEqualTo("e6aab619-9cc0-4060-91ee-dde3412bddc2");
+        assertThat(trackablesOld.get(0).getGeocode()).isNull();
+        assertThat(trackablesOld.get(0).getName()).isEqualTo("Tuinkabouter");
+        assertThat(trackablesOld.get(1).getGuid()).isEqualTo("758a8a62-5af9-4183-8386-3249befa075a");
+        assertThat(trackablesOld.get(0).getGeocode()).isNull();
+        assertThat(trackablesOld.get(1).getName()).isEqualTo("Just Add Water Festival Geocoin");
+
+        final List<Trackable> trackablesNew = GCParser.parseInventory(exampleNew);
+        assertThat(trackablesNew).hasSize(2);
+        assertThat(trackablesNew.get(0).getGuid()).isNull();
+        assertThat(trackablesNew.get(0).getGeocode()).isEqualTo("TB7ZAAK");
+        assertThat(trackablesNew.get(0).getName()).isEqualTo("the gambler");
+        assertThat(trackablesNew.get(1).getGuid()).isNull();
+        assertThat(trackablesNew.get(1).getGeocode()).isEqualTo("TBABCD5");
+        assertThat(trackablesNew.get(1).getName()).isEqualTo("the test tb");
+
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -85,7 +85,7 @@ public final class GCConstants {
     private static final String IMAGE_FORMATS = "jpg|jpeg|png|gif|bmp";
     static final Pattern PATTERN_SPOILER_IMAGE = Pattern.compile("<a href=\"(https?://img(?:cdn)?\\.geocaching\\.com[^.]+\\.(?:" + IMAGE_FORMATS + "))\"[^>]+>" + "([^<]*)</a>" + ".*?(?:description\"[^>]*>([^<]+)</span>)?</li>", Pattern.DOTALL);
     static final Pattern PATTERN_INVENTORY = Pattern.compile("ctl00_ContentBody_uxTravelBugList_uxInventoryLabel\">.*?WidgetBody(.*?)<div");
-    static final Pattern PATTERN_INVENTORYINSIDE = Pattern.compile("[^<]*<li>[^<]*<a href=\"[a-z0-9\\-\\_\\.\\?\\/\\:\\@]*\\/track\\/details\\.aspx\\?guid=([0-9a-z\\-]+)[^\"]*\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>([^<]+)<\\/span>[^<]*<\\/a>[^<]*<\\/li>");
+    static final Pattern PATTERN_INVENTORYINSIDE = Pattern.compile("[^<]*<li>[^<]*<a href=\"[a-z0-9\\-\\_\\.\\?\\/\\:\\@]*\\/(?:track|hide)\\/details\\.aspx\\?(guid|TB)=([0-9a-zA-Z\\-]+)[^\"]*\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>([^<]+)<\\/span>[^<]*<\\/a>[^<]*<\\/li>");
     static final Pattern PATTERN_WATCHLIST = Pattern.compile("data-cacheonwatchlist=\"True\"");
     static final Pattern PATTERN_RELATED_WEB_PAGE = Pattern.compile("ctl00_ContentBody_uxCacheUrl.*? href=\"(.*?)\">");
     static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com/");


### PR DESCRIPTION
fix #15043: adapt scan pattern for gc.com cache inventory

Fix will aloow to scan for both "old" pattern and "new" pattern on gc.com pages. Inventory is filled again, and TBs can be accessed from it:

![image](https://github.com/cgeo/cgeo/assets/6909759/c99a4666-eeee-485e-9493-1863d04f5552)
![image](https://github.com/cgeo/cgeo/assets/6909759/03a2bb3b-cf8c-4c9f-8905-4cf16302a5ef)

