### PR TITLE
UnifiedMap: Add tile provider selection in settings

### DIFF
--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -113,6 +113,13 @@
         android:key="@string/pref_fakekey_unifiedmap"
         android:title="@string/category_unifiedMap"
         app:iconSpaceReserved="false">
+        <ListPreference
+            android:defaultValue="0"
+            android:dialogTitle="@string/init_mapsource_select"
+            android:key="@string/pref_tileprovider"
+            android:summary="%s"
+            android:title="@string/init_mapsource_select"
+            app:iconSpaceReserved="false" />
         <MultiSelectListPreference
             android:key="@string/pref_tileprovider_hidden"
             android:title="@string/settings_hide_tileproviders_title"


### PR DESCRIPTION
While debugging a different issue I found Google Maps on that specific emulator always crashing, but I had no (easy) way to select a different tile provider for UnifiedMap (Settings => Map sources => Select Map Source is for the old map implementation only). This PR adds an option to the UnifiedMap section in Settings => Map Sources where the user can select a different tile provider (externally called "Map Source")