### PR TITLE
UnifiedMap: Fix missing map selection on small screens

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -696,7 +696,11 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             routeTrackUtils.showPopup(viewModel.individualRoute.getValue(), viewModel::setTarget);
         } else if (id == R.id.menu_select_mapview) {
             // dynamically create submenu to reflect possible changes in map sources
-            final View v = findViewById(R.id.menu_select_mapview);
+            View v = findViewById(R.id.menu_select_mapview);
+            if (v == null) {
+                // if map selection is moved to overflow menu, use toggle menu item instead as anchor for popup
+                v = findViewById(R.id.menu_toggle_mypos);
+            }
             if (v != null) {
                 final PopupMenu menu = new PopupMenu(this, v, Gravity.TOP);
                 menu.inflate(R.menu.map_downloader);


### PR DESCRIPTION
Got a user on support who claimed not seeing a map selection menu in UnifiedMap. After some investigation I could reproduce this error on a device with a small screen, that lead to the "map selection" icon being put into the overflow menu (instead of the taskbar), thus it could no longer function as a view anchor for the tileprovider popup menu. This PR creates a mitigation for this situation.