### PR TITLE
UnifiedMap: Avoid zooming out extremely on map start (fix #15040)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
@@ -48,9 +48,6 @@ class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileProvider
                 TileProviderFactory.setLanguages(info.languagesPreference.split(","));
             }
             parseZoomLevel(info.zoomLevel);
-            if (!info.boundingBox.contains(map.getMapPosition().getGeoPoint())) {
-                fragment.zoomToBounds(info.boundingBox);
-            }
             // map attribution
             if (StringUtils.isNotBlank(info.comment)) {
                 setMapAttribution(new Pair<>(info.comment, true));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeMultiOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeMultiOfflineTileProvider.java
@@ -80,10 +80,6 @@ class MapsforgeMultiOfflineTileProvider extends AbstractMapsforgeOfflineTileProv
         fragment.addLayer(LayerHelper.ZINDEX_BUILDINGS, new BuildingLayer(map, tileLayer));
         fragment.addLayer(LayerHelper.ZINDEX_LABELS, new LabelLayer(map, tileLayer));
         fragment.applyTheme();
-
-        if (boundingBox != null && !boundingBox.contains(map.getMapPosition().getGeoPoint())) {
-            fragment.zoomToBounds(boundingBox);
-        }
     }
 
     private void checkLanguage(final ArrayList<String> languages, final String languagesPreference) {


### PR DESCRIPTION
## Description
Do not adjust map boundaries on VTM tilesource change to include current map position (which may be 0/0 on initially opening the map!) - position & zoom level get restored in a different place