### PR TITLE
[unified map] increase autorotation to 10 FPS

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/LocUpdater.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/LocUpdater.java
@@ -19,7 +19,7 @@ public class LocUpdater extends GeoDirHandler {
 
     // minimum time in milliseconds between position overlay updates
     private static final long MIN_UPDATE_INTERVAL = 500;
-    private static final long MIN_UPDATE_INTERVAL_AUTOROTATION = 200;
+    private static final long MIN_UPDATE_INTERVAL_AUTOROTATION = 100;
     private long timeLastPositionOverlayCalculation = 0;
     // minimum change of heading in grad for position overlay update
     private static final float MIN_HEADING_DELTA = 15f;


### PR DESCRIPTION
Tested PR #15080 on emulator and real device. I think the fix was a bit too optimistic ;-)

Rotating the map only after 200 + x ms (<5 FPS) caused autorotation to look really laggy. 

We trigger location updates via `postValue`, which means they only get processed as soon as the UI thread goes idle. So posting too many updates would simply cause them to be skipped. 

Still, we should avoid unnecessary CPU consumption, so I gave it 10 FPS as compromise. (Actually, it's still even less as 10 FPS, as location updates only get delivered every 50-200ms measured after the 100ms delay is over.)