### PR TITLE
Close cache/waypoint sheet on opening cache details

### DIFF
--- a/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
@@ -148,6 +148,7 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
 
         buttonMore.setOnClickListener(arg0 -> {
             CacheDetailActivity.startActivity(getActivity(), geocode);
+            MapUtils.sheetRemoveFragment((AbstractNavigationBarMapActivity) requireActivity());
         });
 
         /* Only working combination as it seems */

--- a/main/src/main/java/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/WaypointPopupFragment.java
@@ -121,6 +121,7 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
 
             binding.moreDetails.setOnClickListener(arg0 -> {
                 CacheDetailActivity.startActivity(getActivity(), geocode);
+                MapUtils.sheetRemoveFragment((AbstractNavigationBarMapActivity) requireActivity());
             });
 
             final View view = getView();


### PR DESCRIPTION
## Description
Currently cache/waypoint sheet stays open after opening cache details from sheet info, thus it will be visible again after closing the cache details. This PR fixes this behavior.