### PR TITLE
Mark waypointMarker as mutated

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -252,9 +252,14 @@ public final class MapMarkerUtils {
                     .append(cache.isArchived())
                     .append(cache.isLinearAlc() ? waypoint.getPrefix() : false)
                     .append(cache.getAssignedEmoji())
-                    .append(cache.getType());
+                    .append(cache.getType())
+                    .append(cache.isFound());
         }
         final int hashcode = hcb.toHashCode();
+
+        if (cache != null && StringUtils.equals(cache.getName(), "Der Hausmeister vom Palast der Republik")) {
+            Log.e("wpt hash=" + hashcode + ", v=" + waypoint.isVisited() + ", cf=" + (cache != null ? cache.isFound() : "---") + " wpt=" + waypoint.getName() + (cache != null ? " (" + cache.getName() + ")" : ""));
+        }
 
         synchronized (overlaysCache) {
             CacheMarker marker = overlaysCache.get(hashcode);
@@ -329,7 +334,9 @@ public final class MapMarkerUtils {
             addListMarkers(res, insetsBuilder, getAssignedMarkers(cache), false, applyScaling);
         }
         final LayerDrawable ld = buildLayerDrawable(insetsBuilder, 8, 8);
+        ld.mutate(); // @todo: somehow this does NOT mark all included parts as mutated
         if ((waypoint.isVisited() || (cache != null && cache.isFound())) && Settings.getVisitedWaypointsSemiTransparent()) {
+            Log.e("wpt v=" + waypoint.isVisited() + ", cf=" + (cache != null ? cache.isFound() : "---") + " wpt=" + waypoint.getName() + (cache != null ? " (" + cache.getName() + ")" : ""));
             ld.setAlpha(144);
         }
         return ld;


### PR DESCRIPTION
## Description
Attempts to fix the artefacts described in #15084, but still shows some of them (therefore marked as draft).
Even though the created waypoint marker gets marked as mutated (which marks all elements of the `LayerDrawable` as mutated) still somehow the marker displayed on the map switches to a semi-transparent one.

Details / test case:
- Have "semi transparency for visited waypoints" enabled
- Display a map with visited and unvisited waypoints
- Even if a waypoint of an unvisited waypoint may be ok in the beginning, it switches to being marked as visited (with semi-transparency) after some time, if you open and close this marker. It looks like once there has been a single waypoint marker with semi-transparency, all waypoint markers being drawn after that one get semi-transparency as well, even though the code does NOT add it per se & even though the `LayerDrawables` are marked as mutated.

What else is missing?
