### PR TITLE
UnifiedMap: Respect 'zoom includes waypoints' setting for search results

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -353,10 +353,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                     break;
                 case UMTT_SearchResult:
                     // load list of caches and scale map to see them all
-                    final Viewport viewport2 = DataStore.getBounds(mapType.searchResult.getGeocodes());
+                    final Viewport viewport2 = DataStore.getBounds(mapType.searchResult.getGeocodes(), Settings.getZoomIncludingWaypoints());
                     addSearchResultByGeocaches(mapType.searchResult);
                     loadWaypoints(this, viewModel, viewport2);
-                    // tileProvider.getMap().zoomToBounds(Viewport.containing(tempCaches));
                     mapFragment.zoomToBounds(viewport2);
                     break;
                 default:


### PR DESCRIPTION
## Description
Displaying a cache list should take the "zoom includes waypoints" setting into account when calculating zoom level / bounds.

This is related to #15033 (and should actually fix the "waypoints out of viewport" part), ~but VTM seems to zoom to different bounds than the ones given (not fully including the bounds given). Need to investigate further for that part, but this PR is meaningful anyway.~