### PR TITLE
sheet info: (Delayed) close on swipe-up

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -106,6 +106,7 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
                     if (newState == BottomSheetBehavior.STATE_EXPANDED && onUpSwipeAction != null) {
                         onUpSwipeAction.run();
                         ActivityMixin.overrideTransitionToFade(that);
+                        ActivityMixin.postDelayed(() -> sheetRemoveFragment(), 500);
                     }
                 }
 


### PR DESCRIPTION
## Description
Since retaining cache/waypoint sheet state on rotation etc., sheet was also recreated when returning from `CacheDetailsActivity` called by swiping up in the sheet. - This PR fixes this by (delayed) closing the sheet after starting `CacheDetailsActivity` on swipe-up.