### PR TITLE
Fix internal brouter connection for dual installations

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
@@ -98,7 +98,7 @@ public final class Routing {
         final Intent intent = new Intent();
         if (Settings.useInternalRouting()) {
             routingServiceConnection = new InternalServiceConnection(SERVICE_CONNECTED_CALLBACK);
-            intent.setClassName("cgeo.geocaching", "cgeo.geocaching.brouter.InternalRoutingService");
+            intent.setClassName(CgeoApplication.getInstance().getPackageName(), "cgeo.geocaching.brouter.InternalRoutingService");
         } else {
             routingServiceConnection = new BRouterServiceConnection(SERVICE_CONNECTED_CALLBACK);
             intent.setClassName("btools.routingapp", "btools.routingapp.BRouterService");


### PR DESCRIPTION
## Description
Apply own package name (which is non-constant since support of dual installations) when connecting to internal routing service

Related to #15101