### PR TITLE
UnifiedMap: Support precise & low poper map autorotation modes

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -779,8 +779,8 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             setMapRotation(item, Settings.MAPROTATION_OFF);
         } else if (id == R.id.menu_map_rotation_manual) {
             setMapRotation(item, Settings.MAPROTATION_MANUAL);
-        } else if (id == R.id.menu_map_rotation_auto) {
-            setMapRotation(item, Settings.MAPROTATION_AUTO);
+        } else if (id == R.id.menu_map_rotation_auto_lowpower) {
+            setMapRotation(item, Settings.MAPROTATION_AUTO_LOWPOWER);
         } else if (id == R.id.menu_filter) {
             getMapActivity().showFilterMenu();
         } else if (id == R.id.menu_map_live) {

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -23,7 +23,8 @@ import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.Intents.ACTION_INVALIDATE_MAPLIST;
 import static cgeo.geocaching.filters.gui.GeocacheFilterActivity.EXTRA_FILTER_CONTEXT;
 import static cgeo.geocaching.maps.google.v2.GoogleMapUtils.isGoogleMapsAvailable;
-import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_LOWPOWER;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_PRECISE;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_OFF;
 
@@ -248,8 +249,9 @@ public class GoogleMapActivity extends AbstractNavigationBarMapActivity implemen
                 case MAPROTATION_MANUAL:
                     menu.findItem(R.id.menu_map_rotation_manual).setChecked(true);
                     break;
-                case MAPROTATION_AUTO:
-                    menu.findItem(R.id.menu_map_rotation_auto).setChecked(true);
+                case MAPROTATION_AUTO_LOWPOWER:
+                case MAPROTATION_AUTO_PRECISE:
+                    menu.findItem(R.id.menu_map_rotation_auto_lowpower).setChecked(true);
                     break;
                 default:
                     break;

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -202,7 +202,7 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
             // check for tap on compass rose, which resets bearing to 0.0
             // only active, if it has been not equal to 0.0 before
             final float bearing = cameraPosition.bearing;
-            if (canDisableAutoRotate && bearing == 0.0f && Settings.getMapRotation() == Settings.MAPROTATION_AUTO) {
+            if (canDisableAutoRotate && bearing == 0.0f && (Settings.getMapRotation() == Settings.MAPROTATION_AUTO_LOWPOWER || Settings.getMapRotation() == Settings.MAPROTATION_AUTO_PRECISE)) {
                 canDisableAutoRotate = false;
                 final Context context = getContext();
                 Dialogs.advancedOneTimeMessage(context, MAP_AUTOROTATION_DISABLE, context.getString(MAP_AUTOROTATION_DISABLE.messageTitle), context.getString(MAP_AUTOROTATION_DISABLE.messageText), "", true, null, () -> {

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -20,7 +20,8 @@ import cgeo.geocaching.unifiedmap.geoitemlayer.GoogleV2GeoItemLayer;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapLineUtils;
-import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_LOWPOWER;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_PRECISE;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 
 import android.location.Location;
@@ -122,7 +123,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
             history.rememberTrailPosition(coordinates);
             mapView.setCoordinates(coordinates);
 
-            if (mapRotation == MAPROTATION_AUTO) {
+            if (mapRotation == MAPROTATION_AUTO_LOWPOWER || mapRotation == MAPROTATION_AUTO_PRECISE) {
                 if (null != lastBearingCoordinates) {
                     final GoogleMap map = mapRef.get();
                     if (null != map) {

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -100,7 +100,8 @@ public class Settings {
 
     public static final int MAPROTATION_OFF = 0;
     public static final int MAPROTATION_MANUAL = 1;
-    public static final int MAPROTATION_AUTO = 2;
+    public static final int MAPROTATION_AUTO_LOWPOWER = 2; // more power-efficient than #3
+    public static final int MAPROTATION_AUTO_PRECISE = 3;  // more precise than #2
 
     public static final int COMPACTICON_OFF = 0;
     public static final int COMPACTICON_ON = 1;
@@ -822,8 +823,10 @@ public class Settings {
         final String prefValue = getString(R.string.pref_mapRotation, "");
         if (prefValue.equals(getKey(R.string.pref_maprotation_off))) {
             return MAPROTATION_OFF;
-        } else if (prefValue.equals(getKey(R.string.pref_maprotation_auto))) {
-            return MAPROTATION_AUTO;
+        } else if (prefValue.equals(getKey(R.string.pref_maprotation_auto_lowpower))) {
+            return MAPROTATION_AUTO_LOWPOWER;
+        } else if (prefValue.equals(getKey(R.string.pref_maprotation_auto_precise))) {
+            return MAPROTATION_AUTO_PRECISE;
         }
         return MAPROTATION_MANUAL;
     }
@@ -836,8 +839,11 @@ public class Settings {
             case MAPROTATION_MANUAL:
                 putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_manual));
                 break;
-            case MAPROTATION_AUTO:
-                putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_auto));
+            case MAPROTATION_AUTO_LOWPOWER:
+                putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_auto_lowpower));
+                break;
+            case MAPROTATION_AUTO_PRECISE:
+                putString(R.string.pref_mapRotation, getKey(R.string.pref_maprotation_auto_precise));
                 break;
             default:
                 // do nothing except satisfy static code analysis

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -68,7 +68,8 @@ import cgeo.geocaching.utils.functions.Func1;
 import static cgeo.geocaching.Intents.ACTION_INDIVIDUALROUTE_CHANGED;
 import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.LIVE;
 import static cgeo.geocaching.filters.gui.GeocacheFilterActivity.EXTRA_FILTER_CONTEXT;
-import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_LOWPOWER;
+import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_PRECISE;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_MANUAL;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_OFF;
 import static cgeo.geocaching.unifiedmap.UnifiedMapState.BUNDLE_MAPSTATE;
@@ -528,8 +529,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     }
 
     private void handleLocUpdate(final LocUpdater.LocationWrapper locationWrapper) {
-
-        if (locationWrapper.needsRepaintForHeading && Settings.getMapRotation() == MAPROTATION_AUTO) {
+        final int mapRotation = Settings.getMapRotation();
+        if (locationWrapper.needsRepaintForHeading && (mapRotation == MAPROTATION_AUTO_LOWPOWER || mapRotation == MAPROTATION_AUTO_PRECISE)) {
             mapFragment.setBearing(locationWrapper.heading);
         }
 
@@ -618,12 +619,16 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             case MAPROTATION_MANUAL:
                 menu.findItem(R.id.menu_map_rotation_manual).setChecked(true);
                 break;
-            case MAPROTATION_AUTO:
-                menu.findItem(R.id.menu_map_rotation_auto).setChecked(true);
+            case MAPROTATION_AUTO_LOWPOWER:
+                menu.findItem(R.id.menu_map_rotation_auto_lowpower).setChecked(true);
+                break;
+            case MAPROTATION_AUTO_PRECISE:
+                menu.findItem(R.id.menu_map_rotation_auto_precise).setChecked(true);
                 break;
             default:
                 break;
         }
+        menu.findItem(R.id.menu_map_rotation_auto_precise).setVisible(true); // UnifiedMap supports high precision auto-rotate
 
         // theming options
         menu.findItem(R.id.menu_theme_mode).setVisible(tileProvider.supportsThemes());
@@ -673,8 +678,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             setMapRotation(item, MAPROTATION_OFF);
         } else if (id == R.id.menu_map_rotation_manual) {
             setMapRotation(item, MAPROTATION_MANUAL);
-        } else if (id == R.id.menu_map_rotation_auto) {
-            setMapRotation(item, MAPROTATION_AUTO);
+        } else if (id == R.id.menu_map_rotation_auto_lowpower) {
+            setMapRotation(item, MAPROTATION_AUTO_LOWPOWER);
+        } else if (id == R.id.menu_map_rotation_auto_precise) {
+            setMapRotation(item, MAPROTATION_AUTO_PRECISE);
         } else if (id == R.id.menu_check_routingdata) {
             final BoundingBox bb = mapFragment.getBoundingBox();
             MapUtils.checkRoutingData(this, bb.getMinLatitude(), bb.getMinLongitude(), bb.getMaxLatitude(), bb.getMaxLongitude());

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -63,6 +63,8 @@ import org.oscim.scalebar.MapScaleBar;
 import org.oscim.scalebar.MapScaleBarLayer;
 import org.oscim.scalebar.MetricUnitAdapter;
 import org.oscim.tiling.TileSource;
+import org.oscim.utils.animation.Easing;
+import static org.oscim.map.Animator.ANIM_ROTATE;
 
 public class MapsforgeVtmFragment extends AbstractMapFragment {
 
@@ -322,7 +324,12 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         final float adjustedBearing = AngleUtils.normalize(360 - bearing); // VTM uses opposite way of calculating bearing compared to GM
         final MapPosition pos = mMap.getMapPosition();
         pos.setBearing(adjustedBearing);
-        mMap.setMapPosition(pos);
+        final float bearingDelta = Math.abs(AngleUtils.difference(360 - pos.bearing, bearing));
+        if (bearingDelta > 10.f) {
+            mMap.animator().animateTo(5000, pos, Easing.Type.QUAD_INOUT, ANIM_ROTATE);
+        } else {
+            mMap.setMapPosition(pos);
+        }
     }
 
     /**

--- a/main/src/main/res/menu/map_activity.xml
+++ b/main/src/main/res/menu/map_activity.xml
@@ -97,8 +97,12 @@
                     android:id="@+id/menu_map_rotation_manual"
                     android:title="@string/switch_manual" />
                 <item
-                    android:id="@+id/menu_map_rotation_auto"
-                    android:title="@string/switch_auto" />
+                    android:id="@+id/menu_map_rotation_auto_lowpower"
+                    android:title="@string/switch_auto_lowpower" />
+                <item
+                    android:id="@+id/menu_map_rotation_auto_precise"
+                    android:title="@string/switch_auto_precise"
+                    android:visible="false"/>
             </group>
         </menu>
     </item>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -413,7 +413,8 @@
     <!-- map => maprotation -->
     <string translatable="false" name="pref_maprotation_off">off</string>
     <string translatable="false" name="pref_maprotation_manual">manual</string>
-    <string translatable="false" name="pref_maprotation_auto">auto</string>
+    <string translatable="false" name="pref_maprotation_auto_lowpower">auto</string>
+    <string translatable="false" name="pref_maprotation_auto_precise">auto_precise</string>
 
     <!-- map => compact icons -->
     <string translatable="false" name="pref_compacticon_off">off</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2657,6 +2657,8 @@
     <string name="switch_on">On</string>
     <string name="switch_manual">Manual</string>
     <string name="switch_auto">Automatic</string>
+    <string name="switch_auto_lowpower">Automatic (low power)</string>
+    <string name="switch_auto_precise">Automatic (precise)</string>
     <string name="switch_default">(default)</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>


### PR DESCRIPTION
## Description
Add support for "Autorotation (precise)" and "Autorotation (low power)" modes 
- "precise" = updates every 80ms / min heading diff = 1° (downgrades to default mode, if speed > 5 km/h or no speed readings)
- "low power" = updates every 500ms / min heading diff = 10°

Implemented for UnifiedMap only, other maps use "low power" mode.

@fm-sys / @eddiemuc 
I've tried to implement the different suggestions, but please cross-check if your needs are covered.