### PR TITLE
fix #15029: stops rendering of dark edges, stops painting routes when zooming out

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ subprojects {
         maven {
             url 'https://jitpack.io'
         }
+        // Used for Mapsforge and VTM Snapshots
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 
     // disable warning of annotation processor about annotation types with no registered processor (like @NonNull)

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -360,6 +360,8 @@ dependencies {
     // Locus Maps integration
     implementation "com.asamm:locus-api-android:0.9.50"
 
+    // -- Mapsforge / Mapsforge --
+
     // Mapsforge official version
     String mapsforgeSource = 'org.mapsforge'
     String mapsforgeVersion = '0.20.0'
@@ -378,9 +380,22 @@ dependencies {
     implementation "$mapsforgeSource:mapsforge-map-reader:$mapsforgeVersion"
     implementation "$mapsforgeSource:mapsforge-themes:$mapsforgeVersion"
 
-    // Mapsforge VTM implementation
-    String mapsforgeVTMSource = 'org.mapsforge'
-    String mapsforgeVTMVersion = '0.20.0'
+    // -- Mapsforge / VTM --
+
+    // Mapsforge VTM implementation (official version)
+    //String mapsforgeVTMSource = 'org.mapsforge'
+    //String mapsforgeVTMVersion = '0.20.0'
+
+    // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
+    String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
+    String mapsforgeVTMVersion = '7879086e56' // LineBucket: transparent lines (9d68bdb) + dropDistance (31646b3)
+
+    // Mapsforge VTM Snapshots (created by project itself)
+    // See https://github.com/mapsforge/vtm/blob/master/docs/Integration.md#snapshots
+    // For available snapshots see https://oss.sonatype.org/content/repositories/snapshots/org/mapsforge/
+    //String mapsforgeVTMSource = 'org.mapsforge'
+    //String mapsforgeVTMVersion = 'master-SNAPSHOT'  // the really latest SNAPSHOT of master. Do not use for official builds!
+    //String mapsforgeVTMVersion = 'master-20231222.081736-913'
 
     implementation "$mapsforgeVTMSource:vtm:$mapsforgeVTMVersion"
     implementation "$mapsforgeVTMSource:vtm-themes:$mapsforgeVTMVersion"

--- a/main/src/main/java/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/main/java/cgeo/geocaching/CgeoApplication.java
@@ -30,6 +30,8 @@ import java.security.MessageDigest;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.oscim.utils.Parameters;
+
 public class CgeoApplication extends Application {
 
     private static CgeoApplication instance;
@@ -80,6 +82,8 @@ public class CgeoApplication extends Application {
             // Log.e("app hashkey: " + getApplicationHashkey(this));
 
             MessageCenterUtils.configureMessageCenterPolling();
+
+            initializeMaps();
 
             LooperLogger.startLogging(Looper.getMainLooper());
         }
@@ -164,6 +168,11 @@ public class CgeoApplication extends Application {
             return e.toString();
         }
         return sb.toString();
+    }
+
+    private void initializeMaps() {
+        //VTM map: global settings
+        Parameters.TRANSPARENT_LINES = true; //See #15029. This prevents rendering of "darker edges"git a for overlapping semi-transparent route parts
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
@@ -129,6 +129,7 @@ public class MapsforgeVtmGeoItemLayer implements IProviderGeoItemLayer<Pair<Draw
                 .strokeColor(GeoStyle.getStrokeColor(item.getStyle()))
                 .fillAlpha(Color.aToFloat(fillColor))
                 .fillColor(fillColor)
+                .dropDistance(ViewUtils.dpToPixelFloat(2)) //see #15029. This setting stops rendering route parts at some point when zooming out
                 .cap(Paint.Cap.BUTT)
                 .fixed(true)
                 .build();


### PR DESCRIPTION
fix #15029: stops rendering of dark edges, stops painting routes when zooming out

Note: this PR links c:geo to Snapshot libraries of VTM because the changes needed on VTM side are not yet in its latest release