### PR TITLE
Update jacksonVersion from 2.12.5 to 2.13.5

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -338,7 +338,9 @@ dependencies {
     implementation 'net.sf.geographiclib:GeographicLib-Java:2.0'
 
     // Jackson XML processing
-    String jacksonVersion = '2.12.5'
+    // Jackson 2.14++ needs minSdk 26
+    //noinspection GradleDependency
+    String jacksonVersion = '2.13.5'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"


### PR DESCRIPTION
see https://github.com/FasterXML/jackson/wiki/Jackson-Releases and https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13

Higher versions of Jackson need minSdk 26.
