### PR TITLE
UnifiedMap: Support waypoints as targets

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
@@ -43,7 +43,7 @@ public final class DefaultMap {
     public static void startActivityCoords(final Context fromActivity, final Class<?> cls, final Waypoint waypoint) {
         if (Settings.useUnifiedMap()) {
             Log.e("Launching UnifiedMap in waypoint mode (1)");
-            new UnifiedMapType(waypoint.getGeocode()).launchMap(fromActivity);
+            new UnifiedMapType(waypoint).launchMap(fromActivity);
         } else {
             new MapOptions(waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName(), waypoint.getGeocode()).startIntent(fromActivity, cls);
         }
@@ -52,7 +52,7 @@ public final class DefaultMap {
     public static void startActivityCoords(final Context fromActivity, final Waypoint waypoint) {
         if (Settings.useUnifiedMap()) {
             Log.e("Launching UnifiedMap in waypoint mode (2)");
-            new UnifiedMapType(waypoint.getGeocode()).launchMap(fromActivity);
+            new UnifiedMapType(waypoint).launchMap(fromActivity);
         } else {
             startActivityCoords(fromActivity, getDefaultMapClass(), waypoint);
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -339,17 +339,29 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                     }
                     break;
                 case UMTT_TargetGeocode:
-                    // load cache, focus map on it, and set it as target
-                    final Geocache cache = DataStore.loadCache(mapType.target, LoadFlags.LOAD_CACHE_OR_DB);
+                    // load cache/waypoint, focus map on it, and set it as target
+                    final Geocache cache = DataStore.loadCache(mapType.target, LoadFlags.LOAD_WAYPOINTS);
                     if (cache != null && cache.getCoords() != null) {
                         viewModel.caches.getValue().add(cache);
                         viewModel.caches.notifyDataChanged();
                         loadWaypoints(this, viewModel, mapFragment.getViewport());
+                        if (mapType.waypointId <= 0) {
+                            if (setDefaultCenterAndZoom) {
+                                mapFragment.setCenter(cache.getCoords());
+                            }
+                            viewModel.setTarget(cache.getCoords(), cache.getGeocode());
+                        } else {
+                            final Waypoint waypoint = cache.getWaypointById(mapType.waypointId);
+                            if (waypoint != null) {
+                                if (setDefaultCenterAndZoom) {
+                                    mapFragment.setCenter(waypoint.getCoords());
+                                }
+                                viewModel.setTarget(waypoint.getCoords(), waypoint.getName());
+                            }
+                        }
                         if (setDefaultCenterAndZoom) {
-                            mapFragment.setCenter(cache.getCoords());
                             mapFragment.zoomToBounds(DataStore.getBounds(mapType.target, Settings.getZoomIncludingWaypoints()));
                         }
-                        viewModel.setTarget(cache.getCoords(), cache.getGeocode());
                     }
                     break;
                 case UMTT_TargetCoords:

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -3,12 +3,15 @@ package cgeo.geocaching.unifiedmap;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.models.Waypoint;
 import static cgeo.geocaching.filters.core.GeocacheFilterContext.FilterType.LIVE;
 
 import android.content.Context;
 import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
 
 public class UnifiedMapType implements Parcelable {
 
@@ -29,6 +32,7 @@ public class UnifiedMapType implements Parcelable {
     public SearchResult searchResult = null;
     public String title = null;
     public int fromList = 0;
+    public int waypointId = 0;
     public GeocacheFilterContext filterContext = new GeocacheFilterContext(LIVE);
     public boolean followMyLocation = false;
     // reminder: add additional fields to parcelable methods below
@@ -43,6 +47,12 @@ public class UnifiedMapType implements Parcelable {
     public UnifiedMapType(final String geocode) {
         type = UnifiedMapTypeType.UMTT_TargetGeocode;
         target = geocode;
+    }
+
+    /** set waypoint as target */
+    public UnifiedMapType(@NonNull final Waypoint waypoint) {
+        this(waypoint.getGeocode());
+        waypointId = waypoint.getId();
     }
 
     /** set coords as target */
@@ -83,6 +93,7 @@ public class UnifiedMapType implements Parcelable {
         fromList = in.readInt();
         filterContext = in.readParcelable(GeocacheFilterContext.class.getClassLoader());
         followMyLocation = (in.readInt() > 0); // readBoolean available from SDK 29 on
+        waypointId = in.readInt();
         // ...
     }
 
@@ -101,6 +112,7 @@ public class UnifiedMapType implements Parcelable {
         dest.writeInt(fromList);
         dest.writeParcelable(filterContext, 0);
         dest.writeInt(followMyLocation ? 1 : 0);
+        dest.writeInt(waypointId);
         // ...
     }
 


### PR DESCRIPTION
## Description
Up until now UnifiedMap only supported geocaches as targets, and even if selected navigation to a waypoint, it chose the waypoint's geocache's coordinates as target. This PR fixes this behavior.