### PR TITLE
Info sheet: Add swipe up indicator

### DIFF
--- a/main/src/main/java/cgeo/geocaching/SwipeToOpenFragment.java
+++ b/main/src/main/java/cgeo/geocaching/SwipeToOpenFragment.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 public class SwipeToOpenFragment extends Fragment {
 
     private Runnable onStopCallback = null;
+    private View ownView = null;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -21,9 +22,8 @@ public class SwipeToOpenFragment extends Fragment {
     @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-
-        final View view = inflater.inflate(R.layout.fragment_swipe_to_open, container, false);
-        return view;
+        ownView = inflater.inflate(R.layout.fragment_swipe_to_open, container, false);
+        return ownView;
     }
 
     public void setExpansion(final float expansion, final View alphaView) {
@@ -37,6 +37,9 @@ public class SwipeToOpenFragment extends Fragment {
                 alpha = 0;
             }
             alphaView.setAlpha(alpha);
+            if (ownView != null) {
+                ownView.setAlpha(alpha >= 0.8 ? 0 : 1);
+            }
 
             final ImageView imageview = view.findViewById(R.id.icon);
             imageview.setImageResource(alpha == 0 ? R.drawable.ic_menu_done : R.drawable.expand_less);

--- a/main/src/main/res/drawable/rounded_corners_top.xml
+++ b/main/src/main/res/drawable/rounded_corners_top.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="@color/colorBackgroundDialog"/>
+            <stroke android:width="5dp" android:color="@color/colorBackgroundDialog" />
+            <corners android:topLeftRadius="6dp" android:topRightRadius="6dp"
+                android:bottomLeftRadius="0dp" android:bottomRightRadius="0dp"/>
+        </shape>
+    </item>
+</layer-list>

--- a/main/src/main/res/layout-land/swipe_up_indicator.xml
+++ b/main/src/main/res/layout-land/swipe_up_indicator.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- intentionally left empty, as there's no "swipe up to open" gesture for cache/waypoint sheets in landscape mode -->
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/main/src/main/res/layout/fragment_swipe_to_open.xml
+++ b/main/src/main/res/layout/fragment_swipe_to_open.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:alpha="0"
     tools:context=".SwipeToOpenFragment">
 
     <LinearLayout

--- a/main/src/main/res/layout/popup.xml
+++ b/main/src/main/res/layout/popup.xml
@@ -4,10 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:background="@color/colorBackgroundDialog"
-    android:windowBackground="@color/colorBackgroundTransparent"
+    android:background="@android:color/transparent"
+    android:windowBackground="@android:color/transparent"
     android:orientation="vertical"
     tools:context=".CachePopupFragment">
+
+    <include layout="@layout/swipe_up_indicator" />
 
     <include
         android:id="@+id/toolbar"
@@ -17,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:background="@color/colorBackgroundDialog"
         android:padding="4dip" >
 
         <LinearLayout

--- a/main/src/main/res/layout/swipe_up_indicator.xml
+++ b/main/src/main/res/layout/swipe_up_indicator.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/rounded_corners_top">
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scaleType="center"
+        app:srcCompat="@drawable/mtrl_bottomsheet_drag_handle"
+        app:tint="?colorOnSurface"
+        android:alpha="0.3"
+        android:minHeight="15dp"
+        android:paddingBottom="3dp" />
+</FrameLayout>

--- a/main/src/main/res/layout/waypoint_popup.xml
+++ b/main/src/main/res/layout/waypoint_popup.xml
@@ -4,9 +4,11 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:background="@color/colorBackgroundDialog"
-    android:windowBackground="@color/colorBackgroundTransparent"
-    tools:context=".WaypointPopupFragment" >
+    android:background="@android:color/transparent"
+    android:windowBackground="@android:color/transparent"
+    tools:context=".WaypointPopupFragment">
+
+    <include layout="@layout/swipe_up_indicator" />
 
     <include
         android:id="@+id/toolbar"
@@ -17,6 +19,7 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:orientation="vertical"
+        android:background="@color/colorBackgroundDialog"
         android:padding="4dip" >
 
         <LinearLayout


### PR DESCRIPTION
## Description
Related to #14881 

Adds a "swipe up" indicator to cache/waypoint info sheet (in portrait mode only)

![image](https://github.com/cgeo/cgeo/assets/3754370/97494b47-bc24-4c4b-a20a-e4845d15b71c).![image](https://github.com/cgeo/cgeo/assets/3754370/0fcff637-fcdd-4c3c-a754-0bc4a8510747)
