### PR TITLE
Downloader: Optionally keep temporary files for further processing

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -30,6 +30,7 @@ public abstract class AbstractDownloader {
     public final PersistableFolder targetFolder;
     public String forceExtension = "";
     public boolean useCompanionFiles = true; // store source info (uri etc.) in companion files (true) or use date/timestamp and identical uri only (false)?
+    public boolean downloadHasExtraContents = false; // some sources download a zip file containing additional files worthwhile keeping (though not used by c:geo); those zips can be kept using a setting under map => sources
     @DrawableRes public int iconRes = R.drawable.ic_menu_save;
 
     public static final int ICONRES_FOLDER = R.drawable.downloader_folder;

--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -226,7 +226,7 @@ public class DownloaderUtils {
                 .setTitle(filename)
                 .setDescription(String.format(activity.getString(R.string.downloadmap_filename), filename))
                 .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                .setDestinationInExternalFilesDir(activity, Environment.DIRECTORY_DOWNLOADS, filename)
+                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
                 .setAllowedOverMetered(allowMeteredNetwork)
                 .setAllowedOverRoaming(allowMeteredNetwork);
         Log.i("Download enqueued: " + Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/" + filename);

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -26,6 +26,7 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     private MapDownloaderOpenAndroMaps() {
         super(Download.DownloadType.DOWNLOADTYPE_MAP_OPENANDROMAPS, R.string.mapserver_openandromaps_downloadurl, R.string.mapserver_openandromaps_name, R.string.mapserver_openandromaps_info, R.string.mapserver_openandromaps_projecturl, R.string.mapserver_openandromaps_likeiturl);
         companionType = Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS;
+        downloadHasExtraContents = true;
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1229,6 +1229,10 @@ public class Settings {
         putLong(R.string.pref_mapAutoDownloadsLastCheck, calculateNewTimestamp(delay, getMapAutoDownloadsInterval() * 24));
     }
 
+    public static boolean getMapDownloadsKeepTemporaryFiles() {
+        return getBoolean(R.string.pref_mapDownloadsKeepTemporaryFiles, false);
+    }
+
     public static boolean dbNeedsCleanup() {
         return needsIntervalAction(R.string.pref_dbCleanupLastCheck, 24, () -> setDbCleanupLastCheck(false));
     }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -201,6 +201,7 @@
     <!-- category offline maps -->
     <string translatable="false" name="pref_fakekey_info_offline_maps">fakekey_info_offline_maps</string>
     <string translatable="false" name="pref_fakekey_start_downloader">fakekey_start_downloader</string>
+    <string translatable="false" name="pref_mapDownloadsKeepTemporaryFiles">mapDownloadsKeepTemporaryFiles</string>
     <string translatable="false" name="pref_mapAutoDownloadsInterval">mapAutoDownloadsInterval</string>
     <string translatable="false" name="pref_persistablefolder_offlinemaps">persistablefolder_offlinemaps</string>
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2712,6 +2712,8 @@
     <string name="download_title">Download file</string>
     <string name="downloadmap_info">Select a map file for your region by tapping the \"Save\" icon.\n\nThe download is performed in the background. When the transfer is complete, the file is copied to the c:geo map folder and set as the current map.\n\nBe careful: Downloading a map can cause high network traffic!</string>
     <string name="downloadmap_filename">Downloading %s</string>
+    <string name="downloadmap_keep_temporary_files">Keep temporary files</string>
+    <string name="downloadmap_keep_temporary_files_summary">Some download sources support additional files not used by c:geo. Keep those extra files in system\'s download folder instead of deleting it</string>
     <string name="downloadmanager_not_available">File cannot be downloaded, system download manager not available</string>
     <string name="download_started">Downloading started in background</string>
     <string name="download_none_selected">No files selected for download</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -31,6 +31,12 @@
             android:summary="@string/downloadmap_info"
             app:iconSpaceReserved="false" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_mapDownloadsKeepTemporaryFiles"
+            android:summary="@string/downloadmap_keep_temporary_files_summary"
+            android:title="@string/downloadmap_keep_temporary_files"
+            app:iconSpaceReserved="false" />
         <Preference
             android:summary="@string/init_updateinterval_description"
             android:title="@string/init_updateinterval_title"


### PR DESCRIPTION
Optionally keep temporary downloaded files, but only for map sources that support this (currently OAM maps only).
Setting for this is in settings => map sources => keep temporary files (visible in extended settings mode only).