### PR TITLE
NewMap: Prevent crash on missing rotation arrow

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
@@ -126,7 +126,7 @@ public class PositionLayer extends Layer {
     }
 
     private void rotateArrow() {
-        if (arrowNative == null) {
+        if (arrowNative == null || arrowNative.getWidth() == 0 || arrowNative.getHeight() == 0) {
             return;
         }
 


### PR DESCRIPTION
## Description
Adds checks for arrow dimensions to let the user continue using the map even when rotation arrow is missing.
It's just a mitigation for #15158, but won't close it,