### PR TITLE
SDK34: Add foreground service types

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -736,13 +736,15 @@
 
         <service
             android:name=".speech.SpeechService"
-            android:label="@string/tts_service" >
+            android:label="@string/tts_service"
+            android:foregroundServiceType="mediaPlayback">
         </service>
         <service
             android:name=".brouter.InternalRoutingService"
             android:exported="false"
             android:enabled="true"
-            android:process=":brouter_service">
+            android:process=":brouter_service"
+            android:foregroundServiceType="location">
         </service>
 
         <activity
@@ -915,10 +917,14 @@
         </receiver>
 
         <!-- Map import service -->
-        <service android:name=".downloader.ReceiveDownloadService" />
+        <service
+            android:name=".downloader.ReceiveDownloadService"
+            android:foregroundServiceType="dataSync"/>
 
         <!-- Background cache downloader -->
-        <service android:name=".service.CacheDownloaderService" />
+        <service
+            android:name=".service.CacheDownloaderService"
+            android:foregroundServiceType="dataSync"/>
         <receiver android:name=".service.StopCacheDownloadServiceReceiver"/>
 
         <!-- Receiver for custom tabs share intent -->


### PR DESCRIPTION
## Description
Related to #14619

One of the requirements for SDK34 update is to declare the service type for all services used by our app, see [foreground service type](https://developer.android.com/about/versions/14/behavior-changes-14#fgs-types)