### PR TITLE
fix #15169: redesign MapMarkerUtils/InsetBuilder to mutate all created drawables

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ScalableDrawable;
 import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Func1;
 import cgeo.geocaching.utils.functions.Func2;
@@ -53,17 +54,21 @@ import android.widget.TextView;
 import static android.view.MenuItem.SHOW_AS_ACTION_ALWAYS;
 
 import androidx.annotation.AttrRes;
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.annotation.StyleableRes;
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.content.res.ResourcesCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.util.LinkifyCompat;
 import androidx.core.util.Consumer;
 import androidx.core.util.Predicate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -668,5 +673,23 @@ public class ViewUtils {
                 a.recycle();
             }
         }
+    }
+
+    public static Drawable getDrawable(@DrawableRes final int drwId, final boolean mutate) {
+        return getDrawable(drwId, 1.0f, mutate);
+    }
+
+    public static Drawable getDrawable(@DrawableRes final int drwId, final float scalingFactor, final boolean mutate) {
+        Drawable result = DrawableCompat.wrap(Objects.requireNonNull(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), drwId, null)));
+        if (mutate) {
+            result.mutate();
+        }
+        if (scalingFactor != 1.0f) {
+            result = new ScalableDrawable(result, scalingFactor);
+            if (mutate) {
+                result.mutate();
+            }
+        }
+        return result;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/builders/InsetsBuilder.java
+++ b/main/src/main/java/cgeo/geocaching/utils/builders/InsetsBuilder.java
@@ -11,12 +11,15 @@ public class InsetsBuilder {
     private final int width;
     private final int height;
 
+    private final boolean mutate;
+
     private final List<InsetBuilder> insetBuilders = new ArrayList<>();
 
-    public InsetsBuilder(final Resources res, final int width, final int height) {
+    public InsetsBuilder(final Resources res, final int width, final int height, final boolean mutate) {
         this.res = res;
         this.width = width;
         this.height = height;
+        this.mutate = mutate;
     }
 
     public void withInset(final InsetBuilder ib) {
@@ -25,7 +28,7 @@ public class InsetsBuilder {
 
     public void build(final List<Drawable> layers, final List<int[]> insets) {
         for (final InsetBuilder insetBuilder : insetBuilders) {
-            final int[] inset = insetBuilder.build(res, layers, width, height);
+            final int[] inset = insetBuilder.build(res, layers, width, height, mutate);
             insets.add(inset);
         }
     }


### PR DESCRIPTION
fix #15169: redesign MapMarkerUtils/InsetBuilder to mutate all created drawables

This PR refactors MapMarkerUtils (and the InsetBuilder-classes) to mutate ALL "base" drawables used in the markers on the point of their creation. This should be ok memory-wise because the created markers are always cached and reused anyway.

@moving-bits , @ztNFny since you are the experts in these classes, I would be glad if you could take a look at the code