### PR TITLE
Don't adjust activity layout according to keyboard

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -378,15 +378,18 @@
         </activity>
         <activity
             android:name=".maps.google.v2.GoogleMapActivity"
-            android:label="@string/map_map" >
+            android:label="@string/map_map"
+            android:windowSoftInputMode="adjustNothing">
         </activity>
         <activity
             android:name=".maps.mapsforge.v6.NewMap"
-            android:label="@string/map_map" >
+            android:label="@string/map_map"
+            android:windowSoftInputMode="adjustNothing">
         </activity>
         <activity
             android:name=".unifiedmap.UnifiedMapActivity"
-            android:label="@string/map_map" >
+            android:label="@string/map_map"
+            android:windowSoftInputMode="adjustNothing">
         </activity>
         <activity
             android:name=".log.LogCacheActivity"


### PR DESCRIPTION
Implicitly fixes #15120

Instead of messing around with the fragments (;-)) I took a different path: 

The blank sheet effect is caused by the keyboard which takes some time to vanish. By specifying that the activity should be rendered below the keyboard, the blank sheet bug will no longer happen.

I applied this change only to the map activities, as it would make some activities unusable. (e.g. the text fields in "search" wouldn't be accessible). However, I couldn't find such problems in our map activity. We only use the keyboard in some text input dialogs, but they are placed properly at the screen even with this PR applied.