### PR TITLE
Update CheckStyle config

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -37,10 +37,10 @@
             <property name="severity" value="warning" />
         </module>
         <module name="FinalLocalVariable">
-            <property name="severity" value="info" />
+            <property name="severity" value="warning" />
         </module>
         <module name="FinalParameters">
-            <property name="severity" value="info" />
+            <property name="severity" value="warning" />
         </module>
         <module name="HideUtilityClassConstructor">
             <property name="severity" value="warning" />
@@ -130,11 +130,14 @@
             <property name="severity" value="info" />
         </module>
         <module name="ImportOrder">
-            <property name="severity" value="info" />
+            <property name="severity" value="warning" />
             <property name="groups" value="cgeo,android,androidx,java,javax,*" />
             <property name="ordered" value="true" />
             <property name="separated" value="true" />
             <property name="option" value="under" />
+        </module>
+        <module name="NestedIfDepth">
+            <property name="max" value="5"/>
         </module>
     </module>
 </module>


### PR DESCRIPTION
## Description
updates checkStyle config:
- missing final on method parameter => severity warning instead of info
- missing final on local variable => severity warning instead of info
- import order => severity warning instead of info
- nested ifs: allow 2 (instead of default 1)

do not merge, PR contains some test bugs

fixes #15142