### PR TITLE
rename pmd ruleset

### DIFF
--- a/cgeo-contacts/build.gradle
+++ b/cgeo-contacts/build.gradle
@@ -103,7 +103,7 @@ pmd {
 tasks.register('pmd', Pmd) {
     group 'verification'
     description 'Identifying potential problems mainly dead code, duplicated code, cyclomatic complexity and overcomplicated expressions'
-    ruleSetFiles = rootProject.files("pmd-ruleset.xml")
+    ruleSetFiles = rootProject.files("ruleset.xml")
     source = fileTree('src')
     include '**/*.java'
     exclude '**/gen/**'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -775,7 +775,7 @@ pmd {
 tasks.register('pmd', Pmd) {
     group 'verification'
     description 'Identifying potential problems mainly dead code, duplicated code, cyclomatic complexity and overcomplicated expressions'
-    ruleSetFiles = rootProject.files("pmd-ruleset.xml")
+    ruleSetFiles = rootProject.files("ruleset.xml")
     source = fileTree('src/main/java')
     include '**/*.java'
     exclude '**/gen/**','**/brouter/**'

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 
-<ruleset name="c:geo rules"
+<ruleset name="c:geo pmd rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
-    <description>c:geo standard rules</description>
+    <description>c:geo standard pmd rules</description>
 
     <!-- exclude mapsme -->
     <exclude-pattern>.*/mapswithme-api/.*</exclude-pattern>


### PR DESCRIPTION
 Codacy did not detect our `pmd-ruleset.xml`.
 I found in the codacy docs (https://docs.codacy.com/v6.0/repositories-configure/configuring-code-patterns/), that this name is not supported. We have to use `ruleset.xml`
