### PR TITLE
Fix Hylly theme download error 404 (fix #11793)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -96,7 +96,7 @@ public abstract class AbstractDownloader {
     }
 
     // extra file to download?
-    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity, final Uri mapUri) {
         return null;
     }
 

--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -130,7 +130,7 @@ public class DownloaderUtils {
                         // check for required extra files (e. g.: map theme)
                         final AbstractDownloader downloader = Download.DownloadType.getInstance(type);
                         if (downloader != null) {
-                            final DownloadDescriptor extraFile = downloader.getExtrafile(activity);
+                            final DownloadDescriptor extraFile = downloader.getExtrafile(activity, uri);
                             if (extraFile != null) {
                                 addDownload(activity, downloadManager, extraFile.type, extraFile.uri, extraFile.filename, allowMeteredNetwork);
                             }

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderFreizeitkarte.java
@@ -101,7 +101,7 @@ public class MapDownloaderFreizeitkarte extends AbstractMapDownloader {
     }
 
     @Override
-    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity, final Uri mapUri) {
         return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_freizeitkarte_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_FREIZEITKARTE);
     }
 

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderHylly.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderHylly.java
@@ -53,8 +53,14 @@ public class MapDownloaderHylly extends AbstractMapDownloader {
     }
 
     @Override
-    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
-        return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_hylly_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY);
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity, final Uri mapUri) {
+        // themes are stored in same subfolder as map is, named dynamically, so copy the path prefix from map's uri
+        String base = activity.getString(R.string.mapserver_hylly_themes_downloadurl);
+        if (mapUri != null && mapUri.getLastPathSegment() != null) {
+            final String newUri = mapUri.toString();
+            base = newUri.substring(0, newUri.length() - mapUri.getLastPathSegment().length());
+        }
+        return getExtrafile(THEME_FILES, base, Download.DownloadType.DOWNLOADTYPE_THEME_HYLLY);
     }
 
     @NonNull

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOSMPaws.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOSMPaws.java
@@ -100,7 +100,7 @@ public class MapDownloaderOSMPaws extends AbstractMapDownloader {
     }
 
     @Override
-    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity, final Uri mapUri) {
         return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_osmpaws_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_PAWS);
     }
 

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMaps.java
@@ -68,7 +68,7 @@ public class MapDownloaderOpenAndroMaps extends AbstractMapDownloader {
     }
 
     @Override
-    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity) {
+    public DownloaderUtils.DownloadDescriptor getExtrafile(final Activity activity, final Uri mapUri) {
         return getExtrafile(THEME_FILES, activity.getString(R.string.mapserver_openandromaps_themes_downloadurl), Download.DownloadType.DOWNLOADTYPE_THEME_OPENANDROMAPS);
     }
 


### PR DESCRIPTION
## Description
When map downloaded initiates a map download, it also checks for required theme file. If that cannot be found, it initiates that download as well.
For Hylly, it used a fixed url prefix for the theme file, but their website now (?) placed the files into the same subfolder as the map, so let's use that one.