### PR TITLE
fix #15138: add a new formula function to select multiple single chars

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaFunction.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaFunction.java
@@ -41,6 +41,8 @@ public enum FormulaFunction {
             singleValueStringFunction(String::length)),
     SUBSTRING(new String[]{"substring", "sub"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_substring, "Substring", "'';0;1", 1,
             minMaxParamFunction(1, 3, p -> FormulaUtils.substring(p.getAsString(0, ""), (int) p.getAsInt(1, 0), (int) p.getAsInt(2, 1)))),
+    CHARS(new String[]{"chars"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_chars, "Select Chars", "'';1;2", 1,
+        minMaxParamFunction(1, -1, FormulaUtils::selectChars)),
 
     ROT13("rot13", FunctionGroup.COMPLEX_STRING, R.string.formula_function_rot13, "Rotate characters by 13", "''", 1,
             minMaxParamFunction(1, 1, p -> Value.of(FormulaUtils.rot(p.get(0).getAsString(), 13)))),

--- a/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching.utils.formulas;
 
 import cgeo.geocaching.utils.TextUtils;
+import static cgeo.geocaching.utils.formulas.FormulaException.ErrorType.OTHER;
+import static cgeo.geocaching.utils.formulas.FormulaException.ErrorType.WRONG_TYPE;
 
 import android.util.Pair;
 
@@ -101,6 +103,23 @@ public class FormulaUtils {
         }
         return hasElse ? values.get(values.size() - 1) : Value.of(0);
     }
+
+    public static Value selectChars(final ValueList values) {
+        final String value = values.getAsString(0, "");
+        final StringBuilder result = new StringBuilder();
+        for (int i = 1 ; i < values.size(); i++) {
+            if (!values.get(i).isInteger()) {
+                throw new FormulaException(WRONG_TYPE, "positive Integer", values.get(i), values.get(i).getType());
+            }
+            final int vInt = (int) values.get(i).getAsInt();
+            if (vInt < 1 || vInt > value.length()) {
+                throw new FormulaException(OTHER, "index out of range: " + vInt);
+            }
+            result.append(substring(value, vInt - 1, 1));
+        }
+        return Value.of(result.toString());
+    }
+
 
     public static long valueChecksum(final Value value, final boolean iterative) {
         final long cs = value.isInteger() ? checksum(value.getAsInt(), false) : letterValue(value.getAsString());

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1836,6 +1836,7 @@
     <string name="formula_function_if">If</string>
     <string name="formula_function_length">String Length</string>
     <string name="formula_function_substring">Substring</string>
+    <string name="formula_function_chars">Select Chars</string>
     <string name="formula_function_rot13">Rotate characters by 13</string>
     <string name="formula_function_rot">Rotate Characters</string>
     <string name="formula_function_checksum">Checksum</string>


### PR DESCRIPTION
fix #15138: add a new formula function to select multiple single chars:

![image](https://github.com/cgeo/cgeo/assets/6909759/c5e89191-dfd3-40f4-ab5c-15c4176d6f75)
