### PR TITLE
Include active trackfiles in backup (rel. to #14706)

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1123,6 +1123,7 @@
     <string name="init_backup_unavailable">not available</string>
     <string name="init_backup_last_no">There is no file with a backup.</string>
     <string name="init_restore_version_error">Unexpected format - cannot restore database.\n\nExpected version is %1$d,\nbackup has version %2$d</string>
+    <string name="backup_tracks_error">Error creating backup of tracks.</string>
 
     <string name="settings_title_backup">Backup / Restore</string>
     <string name="settings_summary_backup">Perform backup and restore of cache/waypoint data and program settings.</string>


### PR DESCRIPTION
## Description
Includes active track files into database backup/restore.
"active" meaning: those, which are selected for display on the map, disregarding their enabled/disabled state.
(Contents of configured GPX folder are not backed up by this feature.)

Backup/restore is performed when database gets backed up or restored, no separate selection for track files provided. (This is intentionally, as "active" track files are referenced in the database, and this data should be kept in sync.)