### PR TITLE
fix #15254: make reuse last log work again on immediate log send

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -555,10 +555,11 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     private void onPostExecuteInternal(final StatusResult statusResult) {
         GeocacheChangedBroadcastReceiver.sendBroadcast(this, cache.getGeocode());
         if (statusResult.isOk()) {
+            lastSavedState = getEntryFromView();
+
             //reset Gui and all values
             resetValues();
             refreshGui();
-            lastSavedState = getEntryFromView();
 
             imageListFragment.clearImages();
             imageListFragment.adjustImagePersistentState();


### PR DESCRIPTION
fix #15254: make reuse last log work again on immediate log send