### PR TITLE
supportSettingFoundState - ssue #14672

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -357,7 +357,9 @@ final class ALApi {
             cache.setRating(response.get("RatingsAverage").floatValue());
             cache.setArchived(response.get("IsArchived").asBoolean());
             cache.setHidden(parseDate(response.get("PublishedUtc").asText()));
-            cache.setFound(response.get("IsComplete").asBoolean());
+            if (!Settings.isALCfoundStateManual()) {
+                cache.setFound(response.get("IsComplete").asBoolean());
+            }
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.CACHE));
             return cache;
         } catch (final NullPointerException e) {

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -164,10 +164,12 @@ final class ALApi {
         try {
             final Response response = apiRequest(geocode.substring(2), null, headers).blockingGet();
             final Geocache gc = importCacheFromJSON(response);
-            final Collection<Geocache> matchedLabCaches = search(gc.getCoords(), 1, null);
-            for (Geocache matchedLabCache : matchedLabCaches) {
-                if (matchedLabCache.getGeocode().equals(geocode)) {
-                    gc.setFound(matchedLabCache.isFound());
+            if (!Settings.isALCfoundStateManual()) {
+                final Collection<Geocache> matchedLabCaches = search(gc.getCoords(), 1, null);
+                for (Geocache matchedLabCache : matchedLabCaches) {
+                    if (matchedLabCache.getGeocode().equals(geocode)) {
+                        gc.setFound(matchedLabCache.isFound());
+                    }
                 }
             }
             return gc;

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
@@ -108,7 +108,7 @@ public class ALConnector extends AbstractConnector implements ISearchByGeocode, 
 
     @Override
     public boolean supportsSettingFoundState() {
-        return false;
+        return Settings.isALCfoundStateManual();
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
@@ -108,7 +108,7 @@ public class ALConnector extends AbstractConnector implements ISearchByGeocode, 
 
     @Override
     public boolean supportsSettingFoundState() {
-        return true;
+        return false;
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -703,6 +703,10 @@ public class Settings {
         return getBoolean(R.string.pref_alc_advanced, false);
     }
 
+    public static boolean isALCfoundStateManual() {
+        return getBoolean(R.string.pref_foundstate_al, false);
+    }
+
     public static boolean enableFeatureUnifiedGeoItemLayer() {
         return getBoolean(R.string.pref_feature_unified_geoitem_layer, false);
     }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -70,6 +70,8 @@
     <string translatable="false" name="preference_screen_al">preference_screen_al</string>
     <string translatable="false" name="pref_connectorALActive">connectorLCActive</string><!-- variable stays with "LC" for compatibility reasons -->
     <string translatable="false" name="pref_fakekey_al_website">fakekey_al_website</string>
+    <string translatable="false" name="pref_foundstate_al">foundstate_al</string>
+
 
     <!-- settings for opencaching.de screen -->
     <string translatable="false" name="preference_screen_ocde">preference_screen_ocde</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -921,6 +921,8 @@
     <string name="settings_ec_description">Authorize c:geo with extremcaching.com to search for caches and access/filter your found caches.</string>
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
     <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)\n\nChanging this setting requires a restart.</string>
+    <string name="settings_lc_found_state_title">Found State Handling</string>
+    <string name="settings_lc_found_state_handling">If checked, do not automatically obtain the true found state for Adventure Lab caches, instead, provide controls for the user to manually set the found state</string>
     <string name="lc_default_description">This is a geocaching.com Adventure Lab Cache. Adventures can only be played with the Groundspeak Adventure Lab App. Tap on the Adventure Lab icon on the \"Details\" page to open/install the Adventure Lab App for this adventure from there.\nIf you don\'t want to see Adenture Lab caches on your map and search, you can deactivate using the \"settings\" menu - Services - Geocaching.com Adventure Lab</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>
     <string name="init_oc_de_description">Authorize c:geo with opencaching.de to search for caches and access/filter your found caches.</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -921,7 +921,7 @@
     <string name="settings_ec_description">Authorize c:geo with extremcaching.com to search for caches and access/filter your found caches.</string>
     <string name="settings_su_description">Authorize c:geo with geocaching.su to search for caches.</string>
     <string name="settings_lc_description">Include Adventure Lab caches on the map.\n\n(Available to \"Geocaching.com\" premium members only. Requires an activated \"Geocaching.com\" service.)\n\nChanging this setting requires a restart.</string>
-    <string name="settings_lc_found_state_title">Found State Handling</string>
+    <string name="settings_lc_found_state_title">Manual found state</string>
     <string name="settings_lc_found_state_handling">If checked, do not automatically obtain the true found state for Adventure Lab caches, instead, provide controls for the user to manually set the found state</string>
     <string name="lc_default_description">This is a geocaching.com Adventure Lab Cache. Adventures can only be played with the Groundspeak Adventure Lab App. Tap on the Adventure Lab icon on the \"Details\" page to open/install the Adventure Lab App for this adventure from there.\nIf you don\'t want to see Adenture Lab caches on your map and search, you can deactivate using the \"settings\" menu - Services - Geocaching.com Adventure Lab</string>
     <string name="init_summary_oc_de">Load caches from opencaching.de</string>

--- a/main/src/main/res/xml/preferences_services_geocaching_com_adventure_lab.xml
+++ b/main/src/main/res/xml/preferences_services_geocaching_com_adventure_lab.xml
@@ -16,6 +16,14 @@
         <Preference
             app:summary="@string/settings_lc_description"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_foundstate_al"
+            android:title="@string/settings_lc_found_state_title"
+            app:iconSpaceReserved="false" />
+        <Preference
+            app:summary="@string/settings_lc_found_state_handling"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Back while we weren't aware of methodically retrieving the true found state of a LC in the context of a logged in user, we had controls to manually set the found state to either `found it` or `did not find`.  A few months ago we found appropriate  API methods to determine that state and consequently the explicit controls via the UI are no longer necessary.

This PR implements a change to turn those controls off.