### PR TITLE
UnifiedMap: Set waypoint as center in target mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -352,6 +352,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                     // load cache/waypoint, focus map on it, and set it as target
                     final Geocache cache = DataStore.loadCache(mapType.target, LoadFlags.LOAD_WAYPOINTS);
                     if (cache != null) {
+                        if (setDefaultCenterAndZoom) {
+                            mapFragment.zoomToBounds(DataStore.getBounds(mapType.target, Settings.getZoomIncludingWaypoints()));
+                        }
                         viewModel.waypoints.getValue().clear();
                         if (mapType.waypointId > 0) { // single waypoint mode: display waypoint only
                             final Waypoint waypoint = cache.getWaypointById(mapType.waypointId);
@@ -370,9 +373,6 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                             }
                             viewModel.waypoints.getValue().addAll(cache.getWaypoints());
                             viewModel.setTarget(cache.getCoords(), cache.getGeocode());
-                        }
-                        if (setDefaultCenterAndZoom) {
-                            mapFragment.zoomToBounds(DataStore.getBounds(mapType.target, Settings.getZoomIncludingWaypoints()));
                         }
                     }
                     break;


### PR DESCRIPTION
## Description
When using a waypoint as target, center map on it (in contrast to mapping a geocache, which zooms to boundaries of cache including waypoints (if configured)).

Related to support ticket 261131