### PR TITLE
UnifiedMap: Try to fix missing waypoint display on setting as target

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -360,6 +360,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                                     mapFragment.setCenter(waypoint.getCoords());
                                 }
                                 viewModel.waypoints.getValue().add(waypoint);
+                                viewModel.waypoints.notifyDataChanged();
                                 viewModel.setTarget(waypoint.getCoords(), waypoint.getName());
                             }
                         } else if (cache.getCoords() != null) { // geocache mode: display geocache and its waypoints


### PR DESCRIPTION
## Description
viewModel.waypoints seems to require a `notifyDataChanged()` after adding a waypoint to display it (at least in some cases / on some devices)

Related to #15137