### PR TITLE
Shorten map titles to 'Live' and 'Offline' (fix #14369)

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1900,8 +1900,8 @@
 
     <!-- map -->
     <string name="map_map">Map</string>
-    <string name="map_live">Live map</string>
-    <string name="map_offline">Offline map</string>
+    <string name="map_live">Live</string>
+    <string name="map_offline">Offline</string>
     <string name="map_view_map">Map view</string>
     <string name="map_rotation">Map rotation</string>
     <string name="map_dot_mode">Use compact icons</string>


### PR DESCRIPTION
## Description
Shorten map titles from "Live map" to "Live" and from "Offline map" to "Offline", as proposed in the related issue.