### PR TITLE
Harmonize map scale slider range

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
@@ -168,7 +168,7 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
         info.setIconSpaceReserved(false);
         cat.addPreference(info);
 
-        final SeekbarPreference seek = new SeekbarPreference(context, 10, 500, "", "%",
+        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "", "%",
                 new SeekbarPreference.FactorizeValueMapper(10));
         seek.setDefaultValue(100);
         seek.setKey(prefKey);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
@@ -173,7 +173,7 @@ public class MapsforgeThemeSettingsFragment extends PreferenceFragmentCompat {
         info.setIconSpaceReserved(false);
         cat.addPreference(info);
 
-        final SeekbarPreference seek = new SeekbarPreference(context, 10, 500, "", "%",
+        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "", "%",
                 new SeekbarPreference.FactorizeValueMapper(10));
         seek.setDefaultValue(100);
         seek.setKey(prefKey);


### PR DESCRIPTION
Reduce map scale slider range to what we allow for cache markers. (fix #14965)
