### PR TITLE
Enable linking to specific preferences

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -243,6 +243,12 @@
                 <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/settings_scheme" />
+            </intent-filter>
         </activity>
         <activity android:name=".settings.ViewSettingsActivity" />
         <activity

--- a/main/src/main/res/raw/changelog_base.md
+++ b/main/src/main/res/raw/changelog_base.md
@@ -1,5 +1,5 @@
 ### Map
-- New: [Unified Map](https://github.com/cgeo/cgeo/wiki/UnifiedMap) (beta), see Settings => Map Sources => Unified Map
+- New: [Unified Map](https://github.com/cgeo/cgeo/wiki/UnifiedMap) (beta), see [Settings => Map Sources => Unified Map](cgeo-setting://featureSwitch_useUnifiedMap)
 - New: Highlight existing downloads in download manager
 - New: Show cache's found state on waypoint icons
 - New: Long-tap option to connect a cache with its waypoints by lines

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -55,6 +55,7 @@
     <string translatable="false" name="settings_gc_legal_note_url">https://www.geocaching.com/account/documents/termsofuse</string>
     <string translatable="false" name="settings_send2cgeo_url">https://send2.cgeo.org/</string>
     <string translatable="false" name="settings_facebook_login_url">https://faq.cgeo.org/#facebook-login</string>
+    <string translatable="false" name="settings_scheme">cgeo-setting</string>
 
     <string translatable="false" name="map_attribution_openstreetmap_html"><![CDATA[<a href="https://www.openstreetmap.org/copyright">© OpenStreetMap contributors</a>]]></string>
     <string translatable="false" name="map_attribution_openstreetmapde_html"><![CDATA[© <a href="https://openstreetmap.de/">OpenStreetMap DE</a>, map data <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>]]></string>


### PR DESCRIPTION
## Description
Allows deep linking to specific c:geo settings. Useful for linking from changelog / manual / FAQ to a certain setting.

Format is `cgeo-setting://<prefkey>`, eg.: `cgeo-setting://theme_setting` for theme switching etc.

This PR also links the changelog entry about UnifiedMap to the switch for enabling/disabling UnifiedMap.