### PR TITLE
Shorten system info for filters and paths (fix #10411)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
@@ -186,9 +186,8 @@ public final class SystemInformation {
             body.append(filter.toUserDisplayableString()).append(" (").append(filter.toConfig()).append(")");
         }
         final Collection<GeocacheFilter> storedFilters = GeocacheFilter.Storage.getStoredFilters();
-        body.append("\n\nStored Filters (#").append(storedFilters.size()).append("):");
-        for (GeocacheFilter storedFilter : storedFilters) {
-            body.append("\n- ").append(storedFilter.getName()).append(": ").append(storedFilter.toConfig()).append(")");
+        if (storedFilters.size() > 0) {
+            body.append("\n- ").append("Additional stored filters: ").append(storedFilters.size());
         }
     }
 
@@ -222,10 +221,13 @@ public final class SystemInformation {
             final boolean isAvailable = ContentStorage.get().ensureFolder(folder);
             final FolderUtils.FolderInfo folderInfo = FolderUtils.get().getFolderInfo(folder.getFolder());
             final ImmutablePair<Long, Long> freeSpace = FolderUtils.get().getDeviceInfo(folder.getFolder());
-            body.append("\n  - ").append(folder)
-                    .append(" (Uri: ").append(ContentStorage.get().getUriForFolder(folder.getFolder()))
-                    .append(", Av:").append(isAvailable).append(", ").append(folderInfo)
-                    .append(", free space: ").append(Formatter.formatBytes(freeSpace.left)).append(", files on device: ").append(freeSpace.right).append(")");
+            body.append("\n  - ").append(folder.name()).append(": ")
+                    .append(UriUtils.uriToString(ContentStorage.get().getUriForFolder(folder.getFolder())))
+                    .append(" (av:").append(isAvailable)
+                    .append(", files:>=").append(folderInfo.fileCount)
+                    .append(", size:>=").append(Formatter.formatBytes(folderInfo.totalFileSize))
+                    .append(", free:>=").append(Formatter.formatBytes(freeSpace.left))
+                    .append(")");
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/UriUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/UriUtils.java
@@ -20,6 +20,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
 import java.io.File;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -400,10 +401,16 @@ public final class UriUtils {
         if (uriPerm == null) {
             return "---";
         }
-        return uriPerm.getUri() + " (" + Formatter.formatShortDateTime(uriPerm.getPersistedTime()) +
+        return uriToString(uriPerm.getUri()) + " (" + Formatter.formatShortDateTime(uriPerm.getPersistedTime()) +
                 "):" + (uriPerm.isReadPermission() ? "R" : "-") + (uriPerm.isWritePermission() ? "W" : "-");
     }
 
+    /**
+     * toString()-method for {@link Uri}
+     */
+    public static String uriToString(final Uri uri) {
+        return uri == null ? "---" : URLDecoder.decode(uri.toString());
+    }
 
     /**
      * Returns a PSEUDO-Tree-Uri based on the given path. This URI can be used e.g. as EXTRA_INITIAL_URI when requesting access to a folder


### PR DESCRIPTION
## Description
Shortens system info, partly for privacy reasons:
- only LIVE and OFFLINE filters are documented, for stored filters we show only the amount
- shorten PATH info (printable Uri and some stats)

|before|after|
|---|---|
|![image](https://github.com/cgeo/cgeo/assets/3754370/869070c8-deab-4e46-b182-0a90f1a9f12a)|![image](https://github.com/cgeo/cgeo/assets/3754370/71e5a743-78b7-43f2-b110-f09342808b27)|
