### PR TITLE
show images linked in "personal note" in Images tab

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -2231,6 +2231,7 @@ public class Geocache implements IWaypoint {
     @NonNull
     public Collection<Image> getImages() {
         final List<Image> result = new LinkedList<>(getSpoilers());
+        ImageUtils.addImagesFromText(result, getPersonalNote());
         ImageUtils.addImagesFromHtml(result, geocode, getShortDescription(), getDescription());
         for (final LogEntry log : getLogs()) {
             result.addAll(log.logImages);

--- a/main/src/main/java/cgeo/geocaching/models/Image.java
+++ b/main/src/main/java/cgeo/geocaching/models/Image.java
@@ -36,7 +36,8 @@ public class Image implements Parcelable {
         UNCATEGORIZED(R.string.image_category_uncategorized),
         LISTING(R.string.image_category_listing),
         LOG(R.string.image_category_log),
-        OWN(R.string.image_category_own);
+        OWN(R.string.image_category_own),
+        NOTE(R.string.cache_personal_note);
 
         @StringRes
         private final int textId;

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -84,7 +84,7 @@ public final class ImageUtils {
     private static final String[] NO_EXTERNAL = {"geocheck.org"};
 
     private static final Pattern IMG_TAG = Pattern.compile(Pattern.quote("<img") + "\\s[^>]*?" + Pattern.quote("src=\"") + "(.+?)" + Pattern.quote("\""));
-    private static final Pattern IMG_URL = Pattern.compile("(https?://\\S*\\.(jpeg|jpe|jpg|png|webp|gif|svg)\\S*)");
+    private static final Pattern IMG_URL = Pattern.compile("(https?://\\S*\\.(jpeg|jpe|jpg|png|webp|gif|svg)(\\?|#|$|\\)|])\\S*)");
 
     public static class ImageFolderCategoryHandler implements ImageGalleryView.EditableCategoryHandler {
 


### PR DESCRIPTION
Recognizes image URLs in personal note and add them to images tab, treating them the same as Listing / Log images.

![image](https://github.com/cgeo/cgeo/assets/1258173/cfdc67dc-8093-44d9-8ca8-5e1db720ccf3)

- Image URLs are recognized using a regex.
  - Because of this the URL must contain .(jpeg|jpe|jpg|png|webp|gif|svg)
  - Performance shouldn't be an issue as notes are limited to 2500 chars on GC, longer notes could appear in c:geo but are unlikely
- I added a new category "Personal Note" to images tab
  - not sure whether that is needed or they should go into the existing "Own", but the images in that category are editable from the images tab, so they are different in behaviour.
  - The category is placed below Own, before Listing, as I think those images are more likely to be needed than listing images
