### PR TITLE
fix sheetRemoveFragment crash #15247

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -154,13 +154,20 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
         }
         clearSheetInfo();
         final FragmentManager fm = getSupportFragmentManager();
+        final FragmentTransaction ft = fm.beginTransaction();
         final Fragment f1 = fm.findFragmentByTag(TAG_MAPDETAILS_FRAGMENT);
         if (f1 != null) {
-            fm.beginTransaction().remove(f1).commit(); // #15247: consider commitAllowingStateLoss() instead of commit() ?
+            ft.remove(f1);
+            if (!fm.isStateSaved()) {
+                ft.commitNow();
+            }
         }
         final Fragment f2 = fm.findFragmentByTag(TAG_SWIPE_FRAGMENT);
         if (f2 != null) {
-            fm.beginTransaction().remove(f2).commit();
+            ft.remove(f2);
+            if (!fm.isStateSaved()) {
+                ft.commitNow();
+            }
         }
         final FrameLayout v = findViewById(R.id.detailsfragment);
         if (v != null && v.getVisibility() != View.GONE) {

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -154,20 +154,13 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
         }
         clearSheetInfo();
         final FragmentManager fm = getSupportFragmentManager();
-        final FragmentTransaction ft = fm.beginTransaction();
         final Fragment f1 = fm.findFragmentByTag(TAG_MAPDETAILS_FRAGMENT);
         if (f1 != null) {
-            ft.remove(f1);
-            if (!fm.isStateSaved()) {
-                ft.commitNow();
-            }
+            fm.beginTransaction().remove(f1).commitNowAllowingStateLoss();
         }
         final Fragment f2 = fm.findFragmentByTag(TAG_SWIPE_FRAGMENT);
         if (f2 != null) {
-            ft.remove(f2);
-            if (!fm.isStateSaved()) {
-                ft.commitNow();
-            }
+            fm.beginTransaction().remove(f2).commitNowAllowingStateLoss();
         }
         final FrameLayout v = findViewById(R.id.detailsfragment);
         if (v != null && v.getVisibility() != View.GONE) {


### PR DESCRIPTION
Check FragmentManager state before removing the Fragment AND use commitNow() to force the commit to happen instantly. With commit() it's enqueued and when it finally happens the FragmentManager might already be saved.