### PR TITLE
Try to fix sheetRemoveFragment crash (rel. to #15247)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -156,11 +156,11 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
         final FragmentManager fm = getSupportFragmentManager();
         final Fragment f1 = fm.findFragmentByTag(TAG_MAPDETAILS_FRAGMENT);
         if (f1 != null) {
-            fm.beginTransaction().remove(f1).commit(); // #15247: consider commitAllowingStateLoss() instead of commit() ?
+            fm.beginTransaction().remove(f1).commitNowAllowingStateLoss();
         }
         final Fragment f2 = fm.findFragmentByTag(TAG_SWIPE_FRAGMENT);
         if (f2 != null) {
-            fm.beginTransaction().remove(f2).commit();
+            fm.beginTransaction().remove(f2).commitNowAllowingStateLoss();
         }
         final FrameLayout v = findViewById(R.id.detailsfragment);
         if (v != null && v.getVisibility() != View.GONE) {


### PR DESCRIPTION
## Description
Tries to fix the crash on info sheet removal by force-commiting and allowing state-loss.
Related to (and hopefully fixes) issue #15247.

Closes #15311 (for a short discussion see over there)
