### PR TITLE
rel to #15029: set vtm transparent attribute on a per-line basis

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -390,7 +390,7 @@ dependencies {
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
     String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '7879086e56' // LineBucket: transparent lines (9d68bdb) + dropDistance (31646b3)
+    String mapsforgeVTMVersion = 'b3ff48fcc6' // LineBucket: transparent lines (9d68bdb) + dropDistance (31646b3) + line transparent style option (b3ff48fcc6)
 
     // Mapsforge VTM Snapshots (created by project itself)
     // See https://github.com/mapsforge/vtm/blob/master/docs/Integration.md#snapshots

--- a/main/src/main/java/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/main/java/cgeo/geocaching/CgeoApplication.java
@@ -81,8 +81,6 @@ public class CgeoApplication extends Application {
 
             MessageCenterUtils.configureMessageCenterPolling();
 
-            initializeMaps();
-
             LooperLogger.startLogging(Looper.getMainLooper());
         }
     }
@@ -166,14 +164,6 @@ public class CgeoApplication extends Application {
             return e.toString();
         }
         return sb.toString();
-    }
-
-    private void initializeMaps() {
-        //VTM map: global settings
-
-        //See #15029. Following parameter prevents rendering of "darker edges" for overlapping semi-transparent route parts
-        // -> deactivate for now due to #15100, see comment https://github.com/cgeo/cgeo/issues/15100#issuecomment-1937077277
-        //Parameters.TRANSPARENT_LINES = true;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
@@ -129,6 +129,7 @@ public class MapsforgeVtmGeoItemLayer implements IProviderGeoItemLayer<Pair<Draw
                 .strokeColor(GeoStyle.getStrokeColor(item.getStyle()))
                 .fillAlpha(Color.aToFloat(fillColor))
                 .fillColor(fillColor)
+                .transparent(true) ////See #15029. Following parameter prevents rendering of "darker edges" for overlapping semi-transparent route parts
                 .dropDistance(ViewUtils.dpToPixelFloat(2)) //see #15029. This setting stops rendering route parts at some point when zooming out
                 .cap(Paint.Cap.BUTT)
                 .fixed(true)


### PR DESCRIPTION
rel to #15029: set vtm transparent attribute on a per-line basis

This PR upgrades VTM to latest version on VTM master, in order to use new "per-line" transparency flag (see VTM  https://github.com/mapsforge/vtm/pull/1100)