### PR TITLE
UnifiedMap VTM: Fix compass rose orientation (fix #15297)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -102,7 +102,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         }
         setZoom(zoomLevel);
         mapUpdateListener = (event, mapPosition) -> {
-            if (event == Map.ROTATE_EVENT) {
+            if (event == Map.ROTATE_EVENT || event == Map.POSITION_EVENT) {
                 repaintRotationIndicator(mapPosition.bearing);
             }
             if (event == Map.MOVE_EVENT) {


### PR DESCRIPTION
## Description
Fix compass rose not turning accordingly on device rotation.

VTM seems to send a `Map.POSITION_EVENT` only if both position and rotation changes, so we need to update compass rose on both events.