### PR TITLE
Add "contained in individual route" filter (fix #11532)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/core/BooleanGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/BooleanGeocacheFilter.java
@@ -1,0 +1,100 @@
+package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.SqlBuilder;
+import cgeo.geocaching.utils.JsonUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public abstract class BooleanGeocacheFilter extends BaseGeocacheFilter {
+
+    public static final String yesFlag = "yes";
+    public static final String noFlag = "no";
+
+    private Boolean value = null;
+
+
+    @Override
+    public Boolean filter(final Geocache cache) {
+        return value == null || filter(cache, value);
+    }
+
+    public abstract Boolean filter(Geocache cache, boolean value);
+
+
+    public Boolean getValue() {
+        return value;
+    }
+
+    public void setValue(final Boolean value) {
+        this.value = value;
+    }
+
+    private void setConfigInternal(final List<String> configValues) {
+        value = null;
+
+        for (String value : configValues) {
+            if (checkBooleanFlag(yesFlag, value)) {
+                this.value = true;
+            }
+            if (checkBooleanFlag(noFlag, value)) {
+                this.value = false;
+            }
+
+        }
+    }
+
+    private List<String> getConfigInternal() {
+        final List<String> result = new ArrayList<>();
+        if (value != null) {
+            result.add(value ? yesFlag : noFlag);
+        }
+        return result;
+    }
+
+
+    @Override
+    public boolean isFiltering() {
+        return value != null;
+    }
+
+    @Override
+    public void addToSql(final SqlBuilder sqlBuilder) {
+        if (value == null) {
+            sqlBuilder.addWhereTrue();
+        } else {
+            addToSql(sqlBuilder, value);
+        }
+    }
+
+    public abstract void addToSql(SqlBuilder sqlBuilder, boolean value);
+
+    @Override
+    protected String getUserDisplayableConfig() {
+        if (value != null) {
+            return LocalizationUtils.getString(value ? R.string.cache_filter_status_select_yes : R.string.cache_filter_status_select_no);
+        }
+        return LocalizationUtils.getString(R.string.cache_filter_userdisplay_none);
+    }
+
+    @Nullable
+    @Override
+    public ObjectNode getJsonConfig() {
+        final ObjectNode node = JsonUtils.createObjectNode();
+        JsonUtils.setTextCollection(node, "values", getConfigInternal());
+        return node;
+    }
+
+    @Override
+    public void setJsonConfig(@NonNull final ObjectNode node) {
+        setConfigInternal(JsonUtils.getTextList(node, "values"));
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilterType.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilterType.java
@@ -23,6 +23,7 @@ public enum GeocacheFilterType {
     DIFFICULTY_TERRAIN_MATRIX("difficulty_terrain_matrix", R.string.cache_filter_difficulty_terrain_matrix, R.string.cache_filtergroup_details, DifficultyTerrainMatrixGeocacheFilter::new),
     RATING("rating", R.string.cache_filter_rating, R.string.cache_filtergroup_details, RatingGeocacheFilter::new),
     STATUS("status", R.string.cache_filter_status, R.string.cache_filtergroup_basic, StatusGeocacheFilter::new),
+    INDIVIDUAL_ROUTE("individualroute", R.string.cache_filter_individualroute, R.string.cache_filtergroup_userspecific, IndividualRouteGeocacheFilter::new),
     ATTRIBUTES("attributes", R.string.cache_filter_attributes, R.string.cache_filtergroup_details, AttributesGeocacheFilter::new),
     OFFLINE_LOG("offlinelog", R.string.cache_filter_offlinelog, R.string.cache_filtergroup_userspecific, OfflineLogGeocacheFilter::new),
     FAVORITES("favorites", R.string.cache_filter_favorites, R.string.cache_filtergroup_details, FavoritesGeocacheFilter::new),

--- a/main/src/main/java/cgeo/geocaching/filters/core/IndividualRouteGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/IndividualRouteGeocacheFilter.java
@@ -1,0 +1,26 @@
+package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.RouteItem;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.storage.SqlBuilder;
+
+import java.util.ArrayList;
+
+public class IndividualRouteGeocacheFilter extends BooleanGeocacheFilter {
+
+    @Override
+    public Boolean filter(final Geocache cache, final boolean value) {
+        final ArrayList<RouteItem> routeItems = DataStore.loadIndividualRoute();
+        return routeItems.stream().anyMatch(item -> cache.getGeocode().equals(item.getGeocode())) == value;
+    }
+
+    @Override
+    public void addToSql(final SqlBuilder sqlBuilder, final boolean value) {
+        final String routeTableId = sqlBuilder.getNewTableId();
+
+        sqlBuilder.addWhere((value ? "" : "NOT ") +
+                "EXISTS(SELECT id FROM cg_route " + routeTableId + " WHERE " + routeTableId + ".id = " + sqlBuilder.getMainTableId() + ".geocode)");
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/filters/gui/BooleanFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/BooleanFilterViewHolder.java
@@ -1,0 +1,72 @@
+package cgeo.geocaching.filters.gui;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.ButtontogglegroupLabeledItemBinding;
+import cgeo.geocaching.filters.core.BooleanGeocacheFilter;
+import cgeo.geocaching.ui.ButtonToggleGroup;
+import cgeo.geocaching.ui.ImageParam;
+
+import android.view.View;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
+public class BooleanFilterViewHolder extends BaseFilterViewHolder<BooleanGeocacheFilter> {
+
+    private ButtonToggleGroup valueGroup = null;
+
+    @StringRes
+    public final int labelId;
+    public final ImageParam icon;
+
+
+    public BooleanFilterViewHolder(final int labelId, @Nullable final ImageParam icon) {
+        this.labelId = labelId;
+        this.icon = icon;
+    }
+
+    @Override
+    public View createView() {
+
+        final View view = inflateLayout(R.layout.buttontogglegroup_labeled_item);
+        final ButtontogglegroupLabeledItemBinding binding = ButtontogglegroupLabeledItemBinding.bind(view);
+        binding.itemText.setText(labelId);
+        if (icon != null) {
+            icon.applyTo(binding.itemIcon);
+        }
+
+        binding.itemTogglebuttongroup.addButtons(R.string.cache_filter_status_select_all, R.string.cache_filter_status_select_yes, R.string.cache_filter_status_select_no);
+
+        valueGroup = binding.itemTogglebuttongroup;
+
+        return view;
+    }
+
+    @Override
+    public void setViewFromFilter(final BooleanGeocacheFilter filter) {
+        setFromBoolean(valueGroup, filter.getValue());
+    }
+
+    @Override
+    public BooleanGeocacheFilter createFilterFromView() {
+        final BooleanGeocacheFilter filter = createFilter();
+        filter.setValue(getFromGroup(valueGroup));
+        return filter;
+    }
+
+    private void setFromBoolean(final ButtonToggleGroup btg, final Boolean status) {
+        btg.setCheckedButtonByIndex(status == null ? 0 : (status ? 1 : 2), true);
+    }
+
+    private Boolean getFromGroup(final ButtonToggleGroup btg) {
+        switch (btg.getCheckedButtonIndex()) {
+            case 1:
+                return true;
+            case 2:
+                return false;
+            case 0:
+            default:
+                return null;
+        }
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -94,6 +94,9 @@ public class FilterViewHolderCreator {
             case STATUS:
                 result = new StatusFilterViewHolder();
                 break;
+            case INDIVIDUAL_ROUTE:
+                result = new BooleanFilterViewHolder(R.string.cache_filter_boolean_individualroute_contained, ImageParam.id(R.drawable.map_quick_route));
+                break;
             case ATTRIBUTES:
                 result = new AttributesFilterViewHolder();
                 break;

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -568,6 +568,7 @@
     <string name="cache_filter_difficulty_terrain_matrix">Difficulty / Terrain Matrix</string>
     <string name="cache_filter_rating">Rating</string>
     <string name="cache_filter_status">Status</string>
+    <string name="cache_filter_individualroute">Individual route</string>
     <string name="cache_filter_attributes">Cache Attributes</string>
     <string name="cache_filter_favorites">Favorites</string>
     <string name="cache_filter_distance">Distance</string>
@@ -676,6 +677,8 @@
     <string name="cache_filter_status_exclude_active">Exclude Active</string>
     <string name="cache_filter_status_exclude_disabled">Exclude Disabled</string>
     <string name="cache_filter_status_exclude_archived">Exclude Archived</string>
+
+    <string name="cache_filter_boolean_individualroute_contained">Contained in route</string>
 
     <string name="cache_filter_difficulty_terrain_include_caches_without_dt">Include caches without D/T</string>
 


### PR DESCRIPTION
Implements a "contained in individual route" filter, like suggested in #11532.

I've abstracted a generic `BooleanGeocacheFilter`, so that we can potentially split up our way too long status filter in a next step.