### PR TITLE
Fix linear WP losing its number on setting as target (fix #15210)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -41,6 +41,7 @@ public class Intents {
     public static final String EXTRA_MESSAGE_CENTER_COUNTER = "mccounter";
 
     public static final String EXTRA_WPTTYPE = PREFIX + "wpttype";
+    public static final String EXTRA_WPTPREFIX = PREFIX + "wptprefix";
     public static final String EXTRA_MAPSTATE = PREFIX + "mapstate";
     public static final String EXTRA_TITLE = PREFIX + "title";
     public static final String EXTRA_MAP_MODE = PREFIX + "mapMode";

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -1451,6 +1451,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
         }
         final Waypoint waypoint = new Waypoint("some place", mapOptions.waypointType != null ? mapOptions.waypointType : WaypointType.WAYPOINT, false);
         waypoint.setCoords(coords);
+        waypoint.setPrefix(mapOptions.waypointPrefix);
         waypoint.setGeocode(mapOptions.geocode);
 
         final CachesOverlayItemImpl item = getWaypointItem(waypoint, Settings.getCompactIconMode() == Settings.COMPACTICON_ON);

--- a/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
@@ -46,7 +46,7 @@ public final class DefaultMap {
             Log.e("Launching UnifiedMap in waypoint mode (1)");
             new UnifiedMapType(waypoint).launchMap(fromActivity);
         } else {
-            new MapOptions(waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getName(), waypoint.getGeocode()).startIntent(fromActivity, cls);
+            new MapOptions(waypoint.getCoords(), waypoint.getWaypointType(), waypoint.getPrefix(), waypoint.getName(), waypoint.getGeocode()).startIntent(fromActivity, cls);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/MapOptions.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapOptions.java
@@ -29,6 +29,7 @@ public class MapOptions {
     public String geocode;
     public Geopoint coords;
     public WaypointType waypointType;
+    public String waypointPrefix;
     public MapState mapState;
     public String title;
     public int fromList;
@@ -43,6 +44,7 @@ public class MapOptions {
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
             coords = extras.getParcelable(Intents.EXTRA_COORDS);
             waypointType = (WaypointType) extras.get(Intents.EXTRA_WPTTYPE);
+            waypointPrefix = extras.getString(Intents.EXTRA_WPTPREFIX);
             mapState = extras.getParcelable(Intents.EXTRA_MAPSTATE);
             title = extras.getString(Intents.EXTRA_TITLE);
             if (null != coords && null == waypointType) {
@@ -89,9 +91,10 @@ public class MapOptions {
         isLiveEnabled = false;
     }
 
-    public MapOptions(final Geopoint coords, final WaypointType type, final String title, final String geocode) {
+    public MapOptions(final Geopoint coords, final WaypointType type, final String waypointPrefix, final String title, final String geocode) {
         this.coords = coords;
         this.waypointType = type;
+        this.waypointPrefix = waypointPrefix;
         this.title = title;
         this.geocode = geocode;
         mapMode = MapMode.COORDS;
@@ -113,6 +116,7 @@ public class MapOptions {
         intent.putExtra(Intents.EXTRA_GEOCODE, mapState != null && StringUtils.isNotBlank(mapState.getTargetGeocode()) ? mapState.getTargetGeocode() : geocode);
         intent.putExtra(Intents.EXTRA_COORDS, coords);
         intent.putExtra(Intents.EXTRA_WPTTYPE, waypointType);
+        intent.putExtra(Intents.EXTRA_WPTPREFIX, waypointPrefix);
         intent.putExtra(Intents.EXTRA_MAPSTATE, mapState);
         intent.putExtra(Intents.EXTRA_TITLE, title);
         intent.putExtra(Intents.EXTRA_LIST_ID, fromList);

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -870,12 +870,12 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
             this.caches = new CachesBundle(this, mapOptions.searchResult, this.mapView, this.mapHandlers);
         } else if (StringUtils.isNotEmpty(mapOptions.geocode)) {
             if (mapOptions.mapMode == MapMode.COORDS && mapOptions.coords != null) {
-                this.caches = new CachesBundle(this, mapOptions.coords, mapOptions.waypointType, this.mapView, this.mapHandlers, mapOptions.geocode);
+                this.caches = new CachesBundle(this, mapOptions.coords, mapOptions.waypointType, mapOptions.waypointPrefix, this.mapView, this.mapHandlers, mapOptions.geocode);
             } else {
                 this.caches = new CachesBundle(this, mapOptions.geocode, this.mapView, this.mapHandlers);
             }
         } else if (mapOptions.coords != null) {
-            this.caches = new CachesBundle(this, mapOptions.coords, mapOptions.waypointType, this.mapView, this.mapHandlers, null);
+            this.caches = new CachesBundle(this, mapOptions.coords, mapOptions.waypointType, mapOptions.waypointPrefix, this.mapView, this.mapHandlers, null);
         } else {
             caches = new CachesBundle(this, this.mapView, this.mapHandlers);
         }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/CachesBundle.java
@@ -116,9 +116,9 @@ public class CachesBundle {
      * @param mapView      the map view this bundle is displayed on
      * @param mapHandlers  the handlers of the map to send events to
      */
-    public CachesBundle(final NewMap map, final Geopoint coords, final WaypointType waypointType, final MfMapView mapView, final MapHandlers mapHandlers, @Nullable final String geocode) {
+    public CachesBundle(final NewMap map, final Geopoint coords, final WaypointType waypointType, final String waypointPrefix, final MfMapView mapView, final MapHandlers mapHandlers, @Nullable final String geocode) {
         this(map, mapView, mapHandlers);
-        this.baseOverlay = new SinglePointOverlay(map, coords, waypointType, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers, geocode);
+        this.baseOverlay = new SinglePointOverlay(map, coords, waypointType, waypointPrefix, BASE_OVERLAY_ID, this.geoEntries, this, separators.get(BASE_SEPARATOR), this.mapHandlers, geocode);
     }
 
     public void handleLiveLayers(final NewMap map, @NonNull final MapOptions mapOptions) {

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/SinglePointOverlay.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/SinglePointOverlay.java
@@ -18,13 +18,15 @@ public class SinglePointOverlay extends AbstractCachesOverlay {
 
     private final Geopoint coords;
     private final WaypointType type;
+    private final String waypointPrefix;
     private final String geocode;
 
-    public SinglePointOverlay(final NewMap map, final Geopoint coords, final WaypointType type, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers, @Nullable final String geocode) {
+    public SinglePointOverlay(final NewMap map, final Geopoint coords, final WaypointType type, final String waypointPrefix, final int overlayId, final Set<GeoEntry> geoEntries, final CachesBundle bundle, final Layer anchorLayer, final MapHandlers mapHandlers, @Nullable final String geocode) {
         super(map, overlayId, geoEntries, bundle, anchorLayer, mapHandlers);
 
         this.coords = coords;
         this.type = type;
+        this.waypointPrefix = waypointPrefix;
         this.geocode = geocode;
 
         AndroidRxUtils.computationScheduler.scheduleDirect(this::fill);
@@ -45,6 +47,7 @@ public class SinglePointOverlay extends AbstractCachesOverlay {
             // construct waypoint
             final Waypoint waypoint = new Waypoint("", type, false);
             waypoint.setCoords(coords);
+            waypoint.setPrefix(waypointPrefix);
             if (StringUtils.isNotBlank(geocode)) {
                 waypoint.setGeocode(geocode);
             }


### PR DESCRIPTION
## Description
Add WP prefix to the intent, so that the old map implementations have stage number available when creating the single waypoint target icon.

(UnifiedMap is not affected, as it puts the whole waypoint into the intent, not just coords and geocode)