### PR TITLE
UnifiedMap VTM: Don't reset tilesource on enabling live mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
@@ -70,10 +70,13 @@ public abstract class AbstractMapFragment extends Fragment {
         forEveryLayer(GeoItemLayer::destroy);
     }
 
-    public void setTileSource(final AbstractTileProvider newSource) {
-        currentTileProvider = newSource;
+    public boolean setTileSource(final AbstractTileProvider newSource, final boolean force) {
+        if (currentTileProvider != newSource || force) {
+            currentTileProvider = newSource;
+            return true;
+        }
+        return false;
     }
-
 
     // ========================================================================
     // layer handling

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -324,7 +324,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     private void onMapReadyTasks(final AbstractTileProvider newSource, final boolean mapChanged, @Nullable final UnifiedMapState mapState) {
         TileProviderFactory.resetLanguages();
-        mapFragment.setTileSource(newSource);
+        mapFragment.setTileSource(newSource, false);
         Settings.setTileProvider(newSource);
 
 //        tileProvider.getMap().showSpinner(); - should be handled from UnifiedMapActivity instead

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
@@ -158,9 +158,12 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
     }
 
     @Override
-    public void setTileSource(final AbstractTileProvider newSource) {
-        super.setTileSource(newSource);
-        ((AbstractGoogleTileProvider) newSource).setMapType(mMap);
+    public boolean setTileSource(final AbstractTileProvider newSource, final boolean force) {
+        final boolean needsUpdate = super.setTileSource(newSource, force);
+        if (needsUpdate) {
+            ((AbstractGoogleTileProvider) newSource).setMapType(mMap);
+        }
+        return needsUpdate;
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -248,10 +248,13 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
     }
 
     @Override
-    public void setTileSource(final AbstractTileProvider newSource) {
-        super.setTileSource(newSource);
-        ((AbstractMapsforgeTileProvider) currentTileProvider).addTileLayer(this, mMap);
-        startMap();
+    public boolean setTileSource(final AbstractTileProvider newSource, final boolean force) {
+        final boolean needsUpdate = super.setTileSource(newSource, force);
+        if (needsUpdate) {
+            ((AbstractMapsforgeTileProvider) currentTileProvider).addTileLayer(this, mMap);
+            startMap();
+        }
+        return needsUpdate;
     }
 
 


### PR DESCRIPTION
## Description
Workaround related to #15100 ("black boxes" in @murggel's use case)

@ztNFny @murggel 
Can you please retest your "black boxes" use-cases with this build?
It's up to current `release` branch with those few changes seen below, and for me the black boxes do not appear in the described use-case any longer.