### PR TITLE
fix #15333: geojson display on unifiedmap

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GoogleV2GeoItemLayer.java
@@ -116,8 +116,8 @@ public class GoogleV2GeoItemLayer implements IProviderGeoItemLayer<Pair<Object, 
             case POLYLINE:
             default:
                 context = map.addPolyline(new PolylineOptions()
-                        .width(ViewUtils.dpToPixel(GeoStyle.getStrokeWidth(item.getStyle())))
-                        .color(GeoStyle.getStrokeColor(item.getStyle()))
+                        .width(strokeWidth * 4f / 3f) // factor required to adjust to OSM line width
+                        .color(strokeColor)
                         .addAll(GP_CONVERTER.toList(item.getPoints()))
                         .zIndex(zLevel));
                 break;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
@@ -5,7 +5,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointConverter;
 import cgeo.geocaching.models.geoitem.GeoIcon;
-import cgeo.geocaching.models.geoitem.GeoItem;
 import cgeo.geocaching.models.geoitem.GeoPrimitive;
 import cgeo.geocaching.models.geoitem.GeoStyle;
 import cgeo.geocaching.models.geoitem.ToScreenProjector;
@@ -123,7 +122,7 @@ public class MapsforgeVtmGeoItemLayer implements IProviderGeoItemLayer<Pair<Draw
     public Pair<Drawable, MarkerInterface> add(final GeoPrimitive item) {
 
         final int fillColor = GeoStyle.getFillColor(item.getStyle());
-        final float rawStrokeWidth = GeoStyle.getStrokeWidth(item.getStyle()) / (item.getType() == GeoItem.GeoType.POLYGON ? 1.5f : 2f);
+        final float rawStrokeWidth = GeoStyle.getStrokeWidth(item.getStyle()) / 1.5f;
         final Style style = Style.builder()
                 .strokeWidth(ViewUtils.dpToPixelFloat(rawStrokeWidth))
                 .strokeColor(GeoStyle.getStrokeColor(item.getStyle()))

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointConverter;
 import cgeo.geocaching.models.geoitem.GeoIcon;
+import cgeo.geocaching.models.geoitem.GeoItem;
 import cgeo.geocaching.models.geoitem.GeoPrimitive;
 import cgeo.geocaching.models.geoitem.GeoStyle;
 import cgeo.geocaching.models.geoitem.ToScreenProjector;
@@ -24,7 +25,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.oscim.android.canvas.AndroidBitmap;
 import org.oscim.backend.canvas.Bitmap;
-import org.oscim.backend.canvas.Color;
 import org.oscim.backend.canvas.Paint;
 import org.oscim.core.GeoPoint;
 import org.oscim.core.Point;
@@ -123,12 +123,11 @@ public class MapsforgeVtmGeoItemLayer implements IProviderGeoItemLayer<Pair<Draw
     public Pair<Drawable, MarkerInterface> add(final GeoPrimitive item) {
 
         final int fillColor = GeoStyle.getFillColor(item.getStyle());
-        final float rawStrokeWidth = GeoStyle.getStrokeWidth(item.getStyle());
+        final float rawStrokeWidth = GeoStyle.getStrokeWidth(item.getStyle()) / (item.getType() == GeoItem.GeoType.POLYGON ? 1.5f : 2f);
         final Style style = Style.builder()
                 .strokeWidth(ViewUtils.dpToPixelFloat(rawStrokeWidth))
                 .strokeColor(GeoStyle.getStrokeColor(item.getStyle()))
                 .fillAlpha(1f) // GeoJsonUtils.colorFromJson() already calculates the color using fill and fill-opacity, don't apply it again
-                //.fillAlpha(Color.aToFloat(fillColor))
                 .fillColor(fillColor)
                 .transparent(true) ////See #15029. Following parameter prevents rendering of "darker edges" for overlapping semi-transparent route parts
                 .dropDistance(ViewUtils.dpToPixelFloat(1)) //see #15029. This setting stops rendering route parts at some point when zooming out

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeVtmGeoItemLayer.java
@@ -125,12 +125,13 @@ public class MapsforgeVtmGeoItemLayer implements IProviderGeoItemLayer<Pair<Draw
         final int fillColor = GeoStyle.getFillColor(item.getStyle());
         final float rawStrokeWidth = GeoStyle.getStrokeWidth(item.getStyle());
         final Style style = Style.builder()
-                .strokeWidth(ViewUtils.dpToPixelFloat(rawStrokeWidth) / 2f)
+                .strokeWidth(ViewUtils.dpToPixelFloat(rawStrokeWidth))
                 .strokeColor(GeoStyle.getStrokeColor(item.getStyle()))
-                .fillAlpha(Color.aToFloat(fillColor))
+                .fillAlpha(1f) // GeoJsonUtils.colorFromJson() already calculates the color using fill and fill-opacity, don't apply it again
+                //.fillAlpha(Color.aToFloat(fillColor))
                 .fillColor(fillColor)
                 .transparent(true) ////See #15029. Following parameter prevents rendering of "darker edges" for overlapping semi-transparent route parts
-                .dropDistance(ViewUtils.dpToPixelFloat(2)) //see #15029. This setting stops rendering route parts at some point when zooming out
+                .dropDistance(ViewUtils.dpToPixelFloat(1)) //see #15029. This setting stops rendering route parts at some point when zooming out
                 .cap(Paint.Cap.BUTT)
                 .fixed(true)
                 .build();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/TracksLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/TracksLayer.java
@@ -30,7 +30,7 @@ public class TracksLayer {
                 final float widthFactor = 2f;
                 final float defaultWidth = track.getTrackfile().getWidth() / widthFactor;
                 final int defaultStrokeColor = track.getTrackfile().getColor();
-                final int defaultFillColor = Color.argb(128, Color.red(defaultStrokeColor), Color.green(defaultStrokeColor), Color.blue(defaultStrokeColor));
+                final int defaultFillColor = Color.argb(32, Color.red(defaultStrokeColor), Color.green(defaultStrokeColor), Color.blue(defaultStrokeColor));
                 final GeoStyle defaultStyle = GeoStyle.builder()
                         .setFillColor(defaultFillColor)
                         .setStrokeColor(defaultStrokeColor)

--- a/main/src/main/java/cgeo/geocaching/utils/MapLineUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapLineUtils.java
@@ -89,7 +89,7 @@ public class MapLineUtils {
     // helper methods
 
     public static float getWidthFromRaw(final int rawValue, final boolean unifiedMap) {
-        return unifiedMap ? rawValue / 1.5f : rawValue * DisplayUtils.getDisplayDensity() / 2.0f;
+        return (unifiedMap ? 0.75f : DisplayUtils.getDisplayDensity()) * rawValue / 2.0f;
     }
 
     private static float getWidth(final int prefKeyId, final int defaultValueKeyId, final boolean unifiedMap) {


### PR DESCRIPTION
Align display of geojson between Google Maps and OSM.

#15333 mentions 2 issues:

detail-level of the polygons:
I addressed this by setting dropDistance() to 1 instead of 2

display-style of polygons:

- strokeWidth() was divided by 2, I removed that division. The removed division leads to track lines being twice as wide now though (see screenshot below), seems they don't get the same width set as before?
- fill alpha was applied twice. fillAlpha() applies it from the fill color, but that already includes the alpha (caluclated in GeoJsonUtils.colorFromJson()), so we get alpha = alpha * alpha.
Either fillColor() needs to get only the rgb component of the argb value or - what I did in the current state of the PR or set fillColor() to the value without alpha:
.fillAlpha(Color.aToFloat(fillColor))
.fillColor(Color.setA(fillColor, 255))

Not sure which of those is prefered.
 

After:
![image](https://github.com/cgeo/cgeo/assets/1258173/f2fcbb74-0b38-48e7-bbc1-907a00edad55)
![image](https://github.com/cgeo/cgeo/assets/1258173/a2de84c6-06e6-4bf9-b229-6b2a18ad337c)

Before:
![image](https://github.com/cgeo/cgeo/assets/1258173/01e7d583-b837-4130-b2e7-3247512a827c)
Google Maps (unchanged):
![image](https://github.com/cgeo/cgeo/assets/1258173/e8125d52-20ab-404c-9434-8cceef48a29c)

