### PR TITLE
UnifiedMap: Show bottom navigation in 'coords target' mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -693,7 +693,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     @Override
     public int getSelectedBottomItemId() {
-        return mapType == null || mapType.type == UMTT_PlainMap || mapType.type == UMTT_List ? MENU_MAP : MENU_HIDE_NAVIGATIONBAR;
+        return mapType == null || mapType.type == UMTT_PlainMap || mapType.type == UMTT_List || mapType.type == UMTT_TargetCoords ? MENU_MAP : MENU_HIDE_NAVIGATIONBAR;
     }
 
     // ========================================================================


### PR DESCRIPTION
## Description
Show bottom navigation in UnifiedMap, when hitting the "map" icon after a successful address search (and thus entering map in "coords target" mode)