### PR TITLE
current navigation method icon shouldn't be larger than text

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/TextParam.java
+++ b/main/src/main/java/cgeo/geocaching/ui/TextParam.java
@@ -32,6 +32,8 @@ import io.noties.markwon.Markwon;
 public class TextParam {
 
     public static final int IMAGE_SIZE_INTRINSIC_BOUND = 0;
+    public static final int IMAGE_SIZE_EQUAL_TEXT_SIZE = -2;
+    public static final int IMAGE_SIZE_LARGER_TEXT_SIZE = -1;
 
     @StringRes
     private final int textId;
@@ -46,8 +48,8 @@ public class TextParam {
     private boolean useMovement = false;
 
     private ImageParam image;
-    private int imageHeightInDp = -1;
-    private int imageWidthInDp = -1;
+    private int imageHeightInDp = IMAGE_SIZE_LARGER_TEXT_SIZE;
+    private int imageWidthInDp = IMAGE_SIZE_LARGER_TEXT_SIZE;
     @ColorInt private int imageTintColor = 1;
 
 
@@ -241,12 +243,15 @@ public class TextParam {
             //if wanted imageSize is set explicitely -> use it. Otherwise deduct a sensible default from text size
             final int imageWidthInPixel;
             final int imageHeightInPixel;
-            if (imageHeightInDp < 0 || imageWidthInDp < 0) {
-                imageHeightInPixel = (int) (view.getTextSize() * 1.5f);
-                imageWidthInPixel = (int) (view.getTextSize() * 1.5f);
+            if (imageHeightInDp == IMAGE_SIZE_EQUAL_TEXT_SIZE) {
+                imageHeightInPixel = (int) (view.getTextSize());
+                imageWidthInPixel = (int) (view.getTextSize());
             } else if (imageHeightInDp == IMAGE_SIZE_INTRINSIC_BOUND) {
                 imageHeightInPixel = imageDrawable.getIntrinsicHeight();
                 imageWidthInPixel = imageDrawable.getIntrinsicWidth();
+            } else if (imageHeightInDp < 0 || imageWidthInDp < 0) {
+                imageHeightInPixel = (int) (view.getTextSize() * 1.5f);
+                imageWidthInPixel = (int) (view.getTextSize() * 1.5f);
             } else {
                 imageHeightInPixel = ViewUtils.dpToPixel(imageHeightInDp);
                 imageWidthInPixel = ViewUtils.dpToPixel(imageWidthInDp);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/UnifiedTargetAndDistancesHandler.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/UnifiedTargetAndDistancesHandler.java
@@ -155,7 +155,7 @@ public class UnifiedTargetAndDistancesHandler {
             distanceSupersizeView.setVisibility(View.VISIBLE);
             targetView.setBackground(null);
             distances1.setBackgroundResource(0);
-            TextParam.text(supersizeInfo.second).setImage(ImageParam.id(supersizeInfo.first)).setImageTint(-1).applyTo(distanceSupersizeView);
+            TextParam.text(supersizeInfo.second).setImage(ImageParam.id(supersizeInfo.first), TextParam.IMAGE_SIZE_EQUAL_TEXT_SIZE).setImageTint(-1).applyTo(distanceSupersizeView);
         }
     }
 


### PR DESCRIPTION
The icon for the currently selected navigation method in large view is overly large, adjust it to text height

Before
![Screenshot_20240220_104218](https://github.com/cgeo/cgeo/assets/1258173/6cdcda9f-7299-4979-a377-dab96933ccbb)
![2024-02-20_10-51-37](https://github.com/cgeo/cgeo/assets/1258173/9af838b9-b9d9-4b2f-8905-a24b412850e0)

After
![Screenshot_20240220_104611](https://github.com/cgeo/cgeo/assets/1258173/e09515bd-cfdd-4d82-806e-fe009a82aaa4)
![2024-02-20_10-52-09](https://github.com/cgeo/cgeo/assets/1258173/b507abb4-325e-459b-a586-9c6f4d5ed19c)

