### PR TITLE
Internal routing: Don't throw exception on error while reading rawtrack

### DIFF
--- a/main/src/main/java/cgeo/geocaching/brouter/core/OsmTrack.java
+++ b/main/src/main/java/cgeo/geocaching/brouter/core/OsmTrack.java
@@ -128,7 +128,9 @@ public final class OsmTrack {
                     }
                     dis.close();
                 } catch (Exception e) {
-                    throw new RuntimeException("Exception reading rawTrack: " + e);
+                    if (debugInfo != null) {
+                        debugInfo.append("Error reading rawTrack: ").append(e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
see discussion in https://github.com/cgeo/cgeo/issues/14759#issuecomment-1958864817