### PR TITLE
UnifiedMap: Reload caches/waypoints in onResume (fix #15341)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.service.GeocacheChangedBroadcastReceiver;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.ViewUtils;
@@ -318,6 +319,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
                     Settings.setCreateUDCuseGivenList(useGivenList);
                     final String geocode = createCache(context, binding.name.getText().toString(), null, temporaryCache.getAssignedEmoji(), geopoint, showStoreInCurrentList && !useGivenList ? InternalConnector.UDC_LIST : listId);
                     CacheDetailActivity.startActivity(context, geocode);
+                    GeocacheChangedBroadcastReceiver.sendBroadcast(context, geocode);
                 })
                 .setNegativeButton(android.R.string.cancel, (dialog, whichButton) -> dialog.cancel())
                 .show();


### PR DESCRIPTION
## Description
`NewMap` does a complete reload of all layers, including `StoredOverlay` in `onResume()`. `UnifiedMap`doesn't do this, but on the downside needs to be notified of new UDC.