### PR TITLE
fix #15194, fix #15363: autogroup list by name part, add list icon to list spinner

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -804,6 +804,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         markerId = newListMarker;
         MapMarkerUtils.resetLists();
         adapter.notifyDataSetChanged();
+        refreshSpinnerAdapter();
+        refreshCurrentList();
     }
 
     private void setPreventAskForDeletion(final boolean prevent) {

--- a/main/src/main/java/cgeo/geocaching/CacheListSpinnerAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListSpinnerAdapter.java
@@ -1,6 +1,8 @@
 package cgeo.geocaching;
 
 import cgeo.geocaching.list.AbstractList;
+import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.ui.TextParam;
 
 import android.view.LayoutInflater;
 import android.view.View;
@@ -55,7 +57,7 @@ class CacheListSpinnerAdapter extends ArrayAdapter<AbstractList> {
         }
 
         final AbstractList list = getItem(position);
-        holder.title.setText(list.getTitle());
+        TextParam.text(list.getTitle()).setImage(StoredList.UserInterface.getImageForList(list)).applyTo(holder.title);
         if (list.getNumberOfCaches() >= 0) {
             holder.subtitle.setVisibility(View.VISIBLE);
             holder.subtitle.setText(cacheListActivity.getCacheListSubtitle(list));

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -116,14 +116,8 @@ public final class StoredList extends AbstractList {
                     .setSelectAction(TextParam.id(R.string.cache_list_select_last), () -> lastSelectedListSet)
                     .setChoiceMode(SimpleItemListModel.ChoiceMode.MULTI_CHECKBOX)
                     .setItems(lists)
-                    .setDisplayMapper((item) -> TextParam.text(item.getTitleAndCount()))
-                    .setDisplayIconMapper((item) -> {
-                        if (item instanceof StoredList && ((StoredList) item).markerId > 0) {
-                            return ImageParam.emoji(((StoredList) item).markerId, 30);
-                        }
-                        return ImageParam.id(R.drawable.ic_menu_list);
-                    })
                     .setSelectedItems(selectedListSet);
+            setListDisplay(model);
 
             SimpleDialog.of(activityRef.get()).setTitle(TextParam.id(titleId))
                 .setNegativeButton(null)
@@ -148,8 +142,8 @@ public final class StoredList extends AbstractList {
             final SimpleDialog.ItemSelectModel<AbstractList> model = new SimpleDialog.ItemSelectModel<>();
             model
                 .setItems(lists)
-                .setDisplayMapper((item) -> TextParam.text(item.getTitleAndCount()))
                 .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN);
+            setListDisplay(model);
 
             SimpleDialog.of(activityRef.get()).setTitle(titleId).selectSingle(model, item -> {
                         if (item == PseudoList.NEW_LIST) {
@@ -160,6 +154,24 @@ public final class StoredList extends AbstractList {
                         }
                     }
             );
+        }
+
+        private void setListDisplay(final SimpleDialog.ItemSelectModel<AbstractList> model) {
+            model.setDisplayMapper((item) -> TextParam.text(item.getTitleAndCount()))
+                .setDisplayIconMapper(UserInterface::getImageForList);
+
+            model.activateGrouping(item -> {
+                final int idx = item.getTitle().indexOf(":");
+                return idx > 0 ? item.getTitle().substring(0, idx) : null;
+            }).setGroupDisplayMapper((t, cnt) -> TextParam.text(t + " (" + cnt + ")"))
+                .setMinCountPerGroup(2);
+        }
+
+        public static ImageParam getImageForList(final AbstractList item) {
+            if (item instanceof StoredList && ((StoredList) item).markerId > 0) {
+                return ImageParam.emoji(((StoredList) item).markerId, 30);
+            }
+            return ImageParam.id(R.drawable.ic_menu_list);
         }
 
         public static List<AbstractList> getMenuLists(final boolean onlyConcreteLists, final int exceptListId) {

--- a/main/src/main/java/cgeo/geocaching/ui/SimpleItemListView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/SimpleItemListView.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.utils.functions.Func4;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -126,7 +127,11 @@ public class SimpleItemListView extends LinearLayout {
                     break;
                 default:
                     //handling of groups and items
-                    applyItemView(binding, data.value, data.type == ListItemType.GROUPHEADER ? model.getGroupingOptions().getGroupDisplayViewMapper() : model.getDisplayViewMapper());
+                    if (data.type == ListItemType.GROUPHEADER) {
+                        applyItemView(binding, new Pair<>(data.value, data.groupCount), model.getGroupingOptions().getGroupDisplayViewMapper());
+                    } else {
+                        applyItemView(binding, data.value, model.getDisplayViewMapper());
+                    }
 
                     final boolean showIcon = data.icon != null || (data.type == ListItemType.GROUPHEADER ? groupsHaveIcons : itemsHaveIcons);
                     if (showIcon) {
@@ -155,7 +160,7 @@ public class SimpleItemListView extends LinearLayout {
             binding.itemViewAnchor.setPadding(ViewUtils.dpToPixel(leftPaddingInDp), 0, 0, 0);
         }
 
-        private void applyItemView(final SimpleitemlistItemViewBinding itemBinding, final Object value, final Func4<Object, Context, View, ViewGroup, View> viewMapper) {
+        private <T> void applyItemView(final SimpleitemlistItemViewBinding itemBinding, final T value, final Func4<T, Context, View, ViewGroup, View> viewMapper) {
             final View currentView = itemBinding.itemViewAnchor.getChildAt(0);
             final View newView = viewMapper.call(value, getContext(), currentView, itemBinding.itemViewAnchor);
 
@@ -429,7 +434,8 @@ public class SimpleItemListView extends LinearLayout {
 
         CommonUtils.groupList(model.getItems(),
                 model.getGroupingOptions().getGroupMapper(), model.getGroupingOptions().getGroupComparator(),
-                model.getGroupingOptions().getMinActivationGroupCount(),
+                model.getGroupingOptions().getMinCountPerGroup(),
+                model.getGroupingOptions().getDefaultGroup(),
                 (group, firstItemIdx, size) -> list.add(createForGroup(group, firstItemIdx + 2, size)),
                 (value, originalIdx, group, groupIdx) -> list.add(createForItem(value, originalIdx, group)));
 

--- a/main/src/main/java/cgeo/geocaching/ui/TextSpinner.java
+++ b/main/src/main/java/cgeo/geocaching/ui/TextSpinner.java
@@ -408,7 +408,7 @@ public class TextSpinner<T> implements AdapterView.OnItemSelectedListener {
 
             if (this.textGroupMapper != null) {
                 model.activateGrouping((v) -> this.textGroupMapper.call(v))
-                        .setGroupDisplayMapper(s -> TextParam.text("**" + s + "**").setMarkdown(true));
+                        .setGroupDisplayMapper((s, c) -> TextParam.text("**" + s + "**").setMarkdown(true));
             }
             sd.selectSingle(model, this::set);
         }

--- a/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -416,7 +416,7 @@ public class FormulaUtils {
             .setDisplayMapper(FormulaUtils::getFunctionDisplayString)
             .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN);
 
-        model.activateGrouping(FormulaFunction::getGroup).setGroupDisplayMapper(FormulaUtils::getFunctionGroupDisplayString);
+        model.activateGrouping(FormulaFunction::getGroup).setGroupDisplayMapper((s, c) -> FormulaUtils.getFunctionGroupDisplayString(s));
 
         SimpleDialog.ofContext(context).setTitle(TextParam.id(R.string.formula_choose_function))
             .selectSingle(model, f -> {

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
@@ -70,7 +70,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
 
     public WherigoActivity() {
         this.wherigoThingsModel.activateGrouping(EventTable::getClass)
-            .setGroupDisplayMapper(c -> TextParam.text(c.getSimpleName()))
+            .setGroupDisplayMapper((c, cnt) -> TextParam.text(c.getSimpleName()))
             .setGroupDisplayIconMapper(WherigoActivity::imageForEventType);
     }
 

--- a/main/src/test/java/cgeo/geocaching/utils/CommonUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/CommonUtilsTest.java
@@ -27,7 +27,7 @@ public class CommonUtilsTest {
         final List<String> data = Arrays.asList("blue", "red", "green", "x-red", "yellow", "gray", "brown", "x-pink");
         //for test, group list after first letter with standard group order. "x" is not part of a group
         final List<List<Object>> groupedList = new ArrayList<>();
-        CommonUtils.groupList(data, (s) -> s.startsWith("x-") ? null : s.substring(0, 1), null, 1,
+        CommonUtils.groupList(data, (s) -> s.startsWith("x-") ? null : s.substring(0, 1), null, 1, null,
                 (group, firstIdx, size) -> groupedList.add(Arrays.asList(group, true, firstIdx, size)),
                 (item, originalIdx, group, groupIndex) -> groupedList.add(Arrays.asList(item, false, originalIdx, group, groupIndex)));
 
@@ -51,20 +51,24 @@ public class CommonUtilsTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void groupListMinGroup() {
-        //Original Index of test data:          0       1      2
-        final List<String> data = Arrays.asList("blue", "red", "green");
+    public void groupListMinCountPerGroup() {
+        //Original Index of test data:          0        1      2        3
+        final List<String> data = Arrays.asList("brown", "red", "green", "blue");
         //for test, group list after first letter with standard group order. "x" is not part of a group
         final List<List<Object>> groupedList = new ArrayList<>();
-        CommonUtils.groupList(data, (s) -> s.substring(0, 1), null, 100,
+        CommonUtils.groupList(data, (s) -> s.substring(0, 1), null, 2, null,
                 (group, firstIdx, size) -> groupedList.add(Arrays.asList(group, true, firstIdx, size)),
                 (item, originalIdx, group, groupIndex) -> groupedList.add(Arrays.asList(item, false, originalIdx, group, groupIndex)));
 
+        //expect that the one grtop with 2 items is created, but the others are not
         assertThat(groupedList).containsExactly(
-                //no grouping shall be done -> original order
-                Arrays.asList("blue", false, 0, null, -1),
+                //grouping shall be done only for 'b'. Order inside 'b' shall be as in original list. Ungrouped items shall go on top
                 Arrays.asList("red", false, 1, null, -1),
-                Arrays.asList("green", false, 2, null, -1));
+                Arrays.asList("green", false, 2, null, -1),
+                Arrays.asList("b", true, 3, 2),
+                Arrays.asList("brown", false, 0, "b", 2),
+                Arrays.asList("blue", false, 3, "b", 2)
+        );
     }
 
     @Test


### PR DESCRIPTION
fix #15194, fix #15363: autogroup list by name part, add list icon to list spinner

This PR tries to resolve the mentioned feature request by auto-grouping all stored list names after the name part before the first found `-` character. This may e.g. look like this:

![image](https://github.com/cgeo/cgeo/assets/6909759/b2755427-df4b-470d-9cfe-ec240f888f7d)

With groups deflated:
![image](https://github.com/cgeo/cgeo/assets/6909759/6d3f63af-c868-41d2-b51f-c59b10d69026)

