### PR TITLE
respect "Show routing menu" setting

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1034,11 +1034,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             if (routeItem != null && Settings.isLongTapOnMapActivated()) {
 
                 final Geocache cache = routeItem.getGeocache();
-                final boolean canHaveStar = MapStarUtils.canHaveStar(cache);
 
-                if (Settings.isShowRouteMenu() || canHaveStar) {
+                if (Settings.isShowRouteMenu()) {
                     final SimplePopupMenu menu = MapUtils.createCacheWaypointLongClickPopupMenu(this, routeItem, tapX, tapY, viewModel.individualRoute.getValue(), viewModel, null);
-                    if (canHaveStar) {
+                    if (MapStarUtils.canHaveStar(cache)) {
                         final String geocode = routeItem.getGeocode();
                         final boolean isStarDrawn = viewModel.cachesWithStarDrawn.getValue().contains(geocode);
                         MapStarUtils.addMenuIfNecessary(menu, cache, isStarDrawn, drawStar -> {


### PR DESCRIPTION
The setting "Show routing menu" (enabled by default) allows users to disable the long-tap menu on map, thus adding/removing caches to the route quickly. On unified map that setting is ignored for all caches that have a waypoint (= for most caches) due to https://github.com/cgeo/cgeo/pull/14993
This PR makes unified map respect the users choice in all cases.