### PR TITLE
Use TextInputEditText instead of plain EditText

### DIFF
--- a/main/src/main/res/layout/authorization_credentials_activity.xml
+++ b/main/src/main/res/layout/authorization_credentials_activity.xml
@@ -25,7 +25,7 @@
             tools:text="Auth text 2"/>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/username"
                 android:inputType="textPersonName"
                 style="@style/textinput_embedded_singleline"
@@ -35,7 +35,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/password"
                 android:inputType="textPassword"
                 android:hint="@string/init_authorization_credential_password"

--- a/main/src/main/res/layout/authorization_token_activity.xml
+++ b/main/src/main/res/layout/authorization_token_activity.xml
@@ -25,7 +25,7 @@
             tools:text="Auth text 2"/>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/username"
                 android:inputType="textPersonName"
                 style="@style/textinput_embedded_singleline"
@@ -34,7 +34,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/password"
                 android:inputType="textPassword"
                 android:hint="@string/init_authorization_credential_password"

--- a/main/src/main/res/layout/calculatedcoordinate_input_guide.xml
+++ b/main/src/main/res/layout/calculatedcoordinate_input_guide.xml
@@ -18,7 +18,7 @@
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext"
             android:id="@+id/cc_guide_value_layout"
             android:layout_centerInParent="true">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/cc_guide_value"
                 style="@style/textinput_embedded"
                 android:textSize="@dimen/textSize_detailsPrimary"

--- a/main/src/main/res/layout/coordinates_input.xml
+++ b/main/src/main/res/layout/coordinates_input.xml
@@ -43,7 +43,7 @@
     </LinearLayout>
 
     <com.google.android.material.textfield.TextInputLayout android:id="@+id/latitudeFrame" style="@style/textinput_edittext_singleline">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/latitude"
             style="@style/textinput_embedded_singleline"
             android:inputType="textNoSuggestions"
@@ -51,7 +51,7 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout android:id="@+id/longitudeFrame" style="@style/textinput_edittext_singleline">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/longitude"
             style="@style/textinput_embedded_singleline"
             android:inputType="textNoSuggestions"

--- a/main/src/main/res/layout/coordinates_input_single.xml
+++ b/main/src/main/res/layout/coordinates_input_single.xml
@@ -14,7 +14,7 @@
         android:textSize="@dimen/textSize_inputCoords"
         android:layout_weight="1" />
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/EditTextLatDeg"
         style="@style/edittext_coordinates"
         android:hint="@string/cc_hint_degrees"
@@ -24,7 +24,7 @@
         android:id="@+id/LatSeparator1"
         style="@style/separator_coordinates" />
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/EditTextLatMin"
         style="@style/edittext_coordinates"
         tools:ignore="LabelFor" />
@@ -34,7 +34,7 @@
         style="@style/separator_coordinates"
         android:layout_weight="0.5" />
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/EditTextLatSec"
         style="@style/edittext_coordinates"
         tools:ignore="LabelFor" />
@@ -43,7 +43,7 @@
         android:id="@+id/LatSeparator3"
         style="@style/separator_coordinates" />
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/EditTextLatSecFrac"
         style="@style/edittext_coordinates"
         tools:ignore="LabelFor" />

--- a/main/src/main/res/layout/coordinatescalculateglobal_dialog.xml
+++ b/main/src/main/res/layout/coordinatescalculateglobal_dialog.xml
@@ -69,7 +69,7 @@
                 android:importantForAutofill="noExcludeDescendants"
                 android:orientation="vertical">
                 <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-                    <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/PlainLat"
                         style="@style/textinput_embedded_singleline"
                         android:inputType="text"
@@ -77,7 +77,7 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-                    <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/PlainLon"
                         style="@style/textinput_embedded_singleline"
                         android:inputType="text"
@@ -146,7 +146,7 @@
                 android:textAlignment="gravity"/>
 
             <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
-                <EditText
+                <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/notes_text"
                     style="@style/textinput_embedded"
                     android:textSize="@dimen/textSize_detailsPrimary"

--- a/main/src/main/res/layout/dialog_edittext.xml
+++ b/main/src/main/res/layout/dialog_edittext.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/input_frame"
     style="@style/textinput_edittext_singleline">
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/input"
         style="@style/textinput_embedded_singleline"
         android:inputType="text"

--- a/main/src/main/res/layout/editwaypoint_activity.xml
+++ b/main/src/main/res/layout/editwaypoint_activity.xml
@@ -118,7 +118,7 @@
             android:id="@+id/note_layout"
             style="@style/textinput_edittext"
             android:hint="@string/waypoint_note" android:labelFor="@id/note">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/note"
                 style="@style/textinput_embedded"
                 android:inputType="textMultiLine|textCapSentences"
@@ -127,7 +127,7 @@
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext"
             android:hint="@string/waypoint_user_note" android:labelFor="@id/user_note">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/user_note"
                 style="@style/textinput_embedded"
                 android:inputType="textMultiLine|textCapSentences"

--- a/main/src/main/res/layout/formula_edittext_view.xml
+++ b/main/src/main/res/layout/formula_edittext_view.xml
@@ -35,7 +35,8 @@
                 android:labelFor="@id/formula_text"
                 >
 
-                <EditText style="@style/textinput_embedded_singleline"
+                <com.google.android.material.textfield.TextInputEditText
+                    style="@style/textinput_embedded_singleline"
                     android:id="@+id/formula_text"
                     android:inputType="text|textNoSuggestions"/>
 

--- a/main/src/main/res/layout/fragment_edit_note.xml
+++ b/main/src/main/res/layout/fragment_edit_note.xml
@@ -11,7 +11,7 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/note"
             style="@style/textinput_embedded"
             android:hint="@string/waypoint_note"

--- a/main/src/main/res/layout/gpx_export_individual_route_dialog.xml
+++ b/main/src/main/res/layout/gpx_export_individual_route_dialog.xml
@@ -10,7 +10,7 @@
     <com.google.android.material.textfield.TextInputLayout
         style="@style/textinput_edittext_singleline"
         app:endIconMode="clear_text">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/filename"
             style="@style/textinput_embedded_singleline"
             android:inputType="textUri"

--- a/main/src/main/res/layout/imageedit_activity.xml
+++ b/main/src/main/res/layout/imageedit_activity.xml
@@ -69,7 +69,7 @@
             style="@style/textinput_edittext_singleline"
             app:counterEnabled="true"
             app:counterMaxLength="50">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/caption"
                 style="@style/textinput_embedded_singleline"
                 android:layout_height="wrap_content"
@@ -84,7 +84,7 @@
             style="@style/textinput_edittext"
             app:counterEnabled="true"
             app:counterMaxLength="250">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/description"
                 style="@style/textinput_embedded"
                 android:layout_height="wrap_content"

--- a/main/src/main/res/layout/logcache_activity.xml
+++ b/main/src/main/res/layout/logcache_activity.xml
@@ -50,7 +50,7 @@
                     style="@style/textinput_edittext"
                     app:counterEnabled="true"
                     app:counterMaxLength="5000">
-                    <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/log"
                         style="@style/textinput_embedded"
                         android:hint="@string/log_new_log_text"
@@ -79,7 +79,7 @@
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
-                        <EditText
+                        <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/log_password"
                             style="@style/textinput_embedded"
                             android:hint="@string/log_hint_log_password"

--- a/main/src/main/res/layout/logtrackable_activity.xml
+++ b/main/src/main/res/layout/logtrackable_activity.xml
@@ -80,7 +80,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/trackingFrame"
             style="@style/textinput_edittext_singleline">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/tracking"
                 style="@style/textinput_embedded_singleline"
                 android:hint="@string/trackable_code"
@@ -89,7 +89,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/log"
                 style="@style/textinput_embedded"
                 android:hint="@string/log_new_log_text"

--- a/main/src/main/res/layout/simple_dialog_title_view.xml
+++ b/main/src/main/res/layout/simple_dialog_title_view.xml
@@ -26,7 +26,7 @@
         android:src="@drawable/ic_menu_search"
     />
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/dialog_search"
         style="@style/textinput_embedded_singleline"
         android:inputType="text"

--- a/main/src/main/res/layout/simple_dialog_view.xml
+++ b/main/src/main/res/layout/simple_dialog_view.xml
@@ -23,7 +23,7 @@
         android:id="@+id/dialog_input_layout"
         android:visibility="gone"
         style="@style/textinput_edittext_singleline">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/dialog_input_edittext"
             style="@style/textinput_embedded_singleline"
             android:inputType="text"

--- a/main/src/main/res/layout/template_preference_dialog.xml
+++ b/main/src/main/res/layout/template_preference_dialog.xml
@@ -11,7 +11,7 @@
         android:id="@+id/titleLayout"
         android:visibility="gone"
         style="@style/textinput_edittext">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/title"
             style="@style/textinput_embedded"
             android:inputType="textEmailSubject"
@@ -20,7 +20,7 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/edit"
             style="@style/textinput_embedded"
             android:inputType="textMultiLine|textCapSentences"

--- a/main/src/main/res/layout/udc_create.xml
+++ b/main/src/main/res/layout/udc_create.xml
@@ -10,7 +10,7 @@
     <com.google.android.material.textfield.TextInputLayout
         style="@style/textinput_edittext_singleline"
         app:endIconMode="clear_text">
-        <EditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/name"
             style="@style/textinput_embedded_singleline"
             android:hint="@string/cache_name"

--- a/main/src/main/res/layout/variable_list_item_advanced.xml
+++ b/main/src/main/res/layout/variable_list_item_advanced.xml
@@ -62,7 +62,8 @@
                     android:layout_width="0dp"
                     android:layout_weight="1">
 
-                    <EditText style="@style/textinput_embedded_singleline"
+                    <com.google.android.material.textfield.TextInputEditText
+                        style="@style/textinput_embedded_singleline"
                         android:id="@+id/variable_formula_text"
                         android:inputType="text|textNoSuggestions"
                         tools:ignore="LabelFor" />

--- a/main/src/main/res/layout/variable_list_item_minimalistic.xml
+++ b/main/src/main/res/layout/variable_list_item_minimalistic.xml
@@ -32,7 +32,7 @@
         /><!-- intended use of dp text size and of hardcoded size -->
 
 
-    <EditText
+    <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/variable_formula_text"
         android:layout_height="wrap_content"
         android:layout_width="0dp"

--- a/main/src/main/res/layout/view_settings_add.xml
+++ b/main/src/main/res/layout/view_settings_add.xml
@@ -12,8 +12,7 @@
         android:orientation="vertical">
 
         <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext_singleline">
-
-            <EditText
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/preference_name"
                 style="@style/textinput_embedded_singleline"
                 android:hint="@string/add_setting_preference_name"

--- a/main/src/main/res/layout/wherigo_thing_details.xml
+++ b/main/src/main/res/layout/wherigo_thing_details.xml
@@ -49,7 +49,7 @@
                 android:id="@+id/dialog_input_layout"
                 android:visibility="gone"
                 style="@style/textinput_edittext_singleline">
-                <EditText
+                <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/dialog_input_edittext"
                     style="@style/textinput_embedded_singleline"
                     android:inputType="text"


### PR DESCRIPTION
## Description
Use TextInputEditText instead of plain EditText when nested within TextInputLayout (fix #15357)
