### PR TITLE
Fix search by coordinates with empty coordinates

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -650,6 +650,9 @@ public class ViewUtils {
 
     public static Geopoint getCoordinates(final TextView textView) {
         final String[] latlonText = textView.getText().toString().split("\n");
+        if (latlonText.length < 2) {
+            return null;
+        }
         final String latText = StringUtils.trim(latlonText[0]);
         final String lonText = StringUtils.trim(latlonText[1]);
 


### PR DESCRIPTION
## Description
Reported on support: "search by coordinates" crashes the app when called without having entered coordinates before. This used to work. (ticket 897982)

Caused by c97a75c022e21c3e098643b3f055674f919f6d5c (which removed an array length check in calling method) and fixed with this PR.