### PR TITLE
add "Edit Personal Note" button to CachePopup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -263,12 +263,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         String name = null;
         String guid = null;
         boolean forceWaypointsPage = false;
+        boolean forceEditPersonalNote = false;
 
         if (extras != null) {
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
             name = extras.getString(Intents.EXTRA_NAME);
             guid = extras.getString(Intents.EXTRA_GUID);
             forceWaypointsPage = extras.getBoolean(EXTRA_FORCE_WAYPOINTSPAGE);
+            forceEditPersonalNote = extras.getBoolean(EXTRA_EDIT_PERSONALNOTE);
         }
 
         // When clicking a cache in MapsWithMe, we get back a PendingIntent
@@ -326,7 +328,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
         final LoadCacheHandler loadCacheHandler = new LoadCacheHandler(this, progress);
 
-        if (extras.getBoolean(EXTRA_EDIT_PERSONALNOTE)) {
+        if (forceEditPersonalNote) {
             progress.setOnDismissListener((dialog) -> {
                 activityIsStartedForEditNote = true;
                 editPersonalNote(cache, this);

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -195,6 +195,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     private static final int MESSAGE_SUCCEEDED = 1;
 
     private static final String EXTRA_FORCE_WAYPOINTSPAGE = "cgeo.geocaching.extra.cachedetail.forceWaypointsPage";
+    private static final String EXTRA_EDIT_PERSONALNOTE = "cgeo.geocaching.extra.cachedetail.editPersonalNote";
 
     /**
      * Minimal contrast ratio. If description:background contrast ratio is less than this value
@@ -247,6 +248,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     private final PermissionAction<String> openContactCardAction = PermissionAction.register(this, PermissionContext.SEARCH_USER_IN_CONTACTS, user -> {
         new ContactsHelper(this).openContactCard(user);
     });
+    private boolean activityIsStartedForEditNote = false;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -323,6 +325,13 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         setCacheTitleBar(geocode, name, null);
 
         final LoadCacheHandler loadCacheHandler = new LoadCacheHandler(this, progress);
+
+        if (extras.getBoolean(EXTRA_EDIT_PERSONALNOTE)) {
+            progress.setOnDismissListener((dialog) -> {
+                activityIsStartedForEditNote = true;
+                editPersonalNote(cache, this);
+            });
+        }
 
         try {
             String title = res.getString(R.string.cache);
@@ -943,6 +952,13 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         final Intent detailIntent = new Intent(context, CacheDetailActivity.class);
         detailIntent.putExtra(Intents.EXTRA_GEOCODE, geocode);
         detailIntent.putExtra(EXTRA_FORCE_WAYPOINTSPAGE, forceWaypointsPage);
+        context.startActivity(detailIntent);
+    }
+
+    public static void startActivityForEditNote(final Context context, final String geocode) {
+        final Intent detailIntent = new Intent(context, CacheDetailActivity.class);
+        detailIntent.putExtra(Intents.EXTRA_GEOCODE, geocode);
+        detailIntent.putExtra(EXTRA_EDIT_PERSONALNOTE, true);
         context.startActivity(detailIntent);
     }
 
@@ -2717,6 +2733,13 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         setNewPersonalNote(note, preventWaypointsFromNote);
         if (uploadNote) {
             checkAndUploadPersonalNote(ConnectorFactory.getConnectorAs(cache, PersonalNoteCapability.class));
+        }
+    }
+
+    @Override
+    public void onDismissEditNoteDialog() {
+        if (activityIsStartedForEditNote) {
+            finish();
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
@@ -4,6 +4,8 @@ import cgeo.geocaching.activity.AbstractNavigationBarMapActivity;
 import cgeo.geocaching.activity.Progress;
 import cgeo.geocaching.apps.cache.WhereYouGoApp;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.databinding.PopupBinding;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -146,6 +148,15 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
             details = new CacheDetailsCreator(getActivity(), binding.detailsList);
 
             addCacheDetails(false);
+
+            final PersonalNoteCapability connector = ConnectorFactory.getConnectorAs(cache, PersonalNoteCapability.class);
+            if (connector != null && connector.canAddPersonalNote(cache)) {
+                binding.editPersonalnote.setVisibility(View.VISIBLE);
+                binding.editPersonalnote.setOnClickListener(arg0 -> {
+                    CacheDetailActivity.startActivityForEditNote(getActivity(), geocode);
+                    ((AbstractNavigationBarMapActivity) requireActivity()).sheetRemoveFragment();
+                });
+            }
 
             // Wherigo
             if (WhereYouGoApp.isWherigo(cache)) {

--- a/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
@@ -4,8 +4,6 @@ import cgeo.geocaching.activity.AbstractNavigationBarMapActivity;
 import cgeo.geocaching.activity.Progress;
 import cgeo.geocaching.apps.cache.WhereYouGoApp;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
-import cgeo.geocaching.connector.ConnectorFactory;
-import cgeo.geocaching.connector.capability.PersonalNoteCapability;
 import cgeo.geocaching.databinding.PopupBinding;
 import cgeo.geocaching.enumerations.CacheListType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -149,14 +147,11 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
 
             addCacheDetails(false);
 
-            final PersonalNoteCapability connector = ConnectorFactory.getConnectorAs(cache, PersonalNoteCapability.class);
-            if (connector != null && connector.canAddPersonalNote(cache)) {
-                binding.editPersonalnote.setVisibility(View.VISIBLE);
-                binding.editPersonalnote.setOnClickListener(arg0 -> {
-                    CacheDetailActivity.startActivityForEditNote(getActivity(), geocode);
-                    ((AbstractNavigationBarMapActivity) requireActivity()).sheetRemoveFragment();
-                });
-            }
+            binding.editPersonalnote.setVisibility(View.VISIBLE);
+            binding.editPersonalnote.setOnClickListener(arg0 -> {
+                CacheDetailActivity.startActivityForEditNote(getActivity(), geocode);
+                ((AbstractNavigationBarMapActivity) requireActivity()).sheetRemoveFragment();
+            });
 
             // Wherigo
             if (WhereYouGoApp.isWherigo(cache)) {

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/EditNoteDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/EditNoteDialog.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.ui.dialog;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.Keyboard;
 
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -30,6 +31,7 @@ public class EditNoteDialog extends AbstractFullscreenDialog {
 
     public interface EditNoteDialogListener {
         void onFinishEditNoteDialog(String inputText, boolean preventWaypointsFromNote, boolean uploadNote);
+        void onDismissEditNoteDialog();
     }
 
     /**
@@ -100,5 +102,11 @@ public class EditNoteDialog extends AbstractFullscreenDialog {
         });
 
         Keyboard.show(requireActivity(), mEditText);
+    }
+
+    @Override
+    public void onDismiss(final @NonNull DialogInterface dialog) {
+        super.onDismiss(dialog);
+        ((EditNoteDialogListener) requireActivity()).onDismissEditNoteDialog();
     }
 }

--- a/main/src/main/res/drawable/ic_menu_note.xml
+++ b/main/src/main/res/drawable/ic_menu_note.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M14,10H19.5L14,4.5V10M5,3H15L21,9V19A2,2 0 0,1 19,21H5C3.89,21 3,20.1 3,19V5C3,3.89 3.89,3 5,3M5,12V14H19V12H5M5,16V18H14V16H5Z" />
+</vector>

--- a/main/src/main/res/drawable/ic_menu_note_edit.xml
+++ b/main/src/main/res/drawable/ic_menu_note_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m5,3c-1.11,0 -2,0.89 -2,2v14c0,1.1 0.89,2 2,2h3,3v-1.869l1.139,-1.139 6.035,-6.023 -0.006,-0.006 1.223,-1.223c0.44,-0.44 0.999,-0.68 1.609,-0.74v-1l-6,-6h-10zM14,4.5 L19.5,10h-5.5v-5.5zM5,12h10.311l-2.004,2h-8.307v-2zM21.166,12c-0.131,0 -0.26,0.05 -0.355,0.15l-0.98,0.98 2.039,2.039 0.98,-0.98c0.2,-0.19 0.2,-0.519 0,-0.719l-1.32,-1.32c-0.1,-0.1 -0.232,-0.15 -0.363,-0.15zM19.131,13.83 L13,19.961v2.039h2.039l6.131,-6.131 -2.039,-2.039zM5,16h6.303l-2.002,2h-4.301v-2z"/>
+</vector>

--- a/main/src/main/res/layout/popup.xml
+++ b/main/src/main/res/layout/popup.xml
@@ -87,7 +87,7 @@
                     android:orientation="horizontal">
                 <Button
                     android:id="@+id/edit_personalnote"
-                    style="@style/button_icon_colored"
+                    style="@style/button_icon"
                     android:tooltipText="@string/cache_personal_note"
                     app:icon="@drawable/ic_menu_note_edit"
                     android:visibility="gone"

--- a/main/src/main/res/layout/popup.xml
+++ b/main/src/main/res/layout/popup.xml
@@ -86,6 +86,13 @@
                     android:layout_alignParentRight="true"
                     android:orientation="horizontal">
                 <Button
+                    android:id="@+id/edit_personalnote"
+                    style="@style/button_icon_colored"
+                    android:tooltipText="@string/cache_personal_note"
+                    app:icon="@drawable/ic_menu_note_edit"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+                <Button
                     android:id="@+id/send_to_whereyougo"
                     style="@style/button_icon_colored"
                     app:icon="@drawable/icon_whereyougo"


### PR DESCRIPTION
add a "Edit personal note" button to CachePopup for quick access to editing the note.
As all the "storing the note and handling updates" stuff is in CacheDetailActivity, not in EditNoteDialog, an intermediate CacheDetailActivity is started and finished.

![image](https://github.com/cgeo/cgeo/assets/1258173/861fea4f-9cc6-44ba-be6b-08f4c5c65611)
