### PR TITLE
Split SeekbarPreference into pref & UI parts (fix #15372)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettingsFragment.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.maps.mapsforge.v6;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.SeekbarPreference;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.SeekbarUI;
 
 import android.app.Activity;
 import android.content.Context;
@@ -168,8 +169,8 @@ public class RenderThemeSettingsFragment extends PreferenceFragmentCompat {
         info.setIconSpaceReserved(false);
         cat.addPreference(info);
 
-        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "", "%",
-                new SeekbarPreference.FactorizeValueMapper(10));
+        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "%",
+                new SeekbarUI.FactorizeValueMapper(10));
         seek.setDefaultValue(100);
         seek.setKey(prefKey);
         cat.addPreference(seek);

--- a/main/src/main/java/cgeo/geocaching/settings/BackupSeekbarPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/BackupSeekbarPreference.java
@@ -45,7 +45,7 @@ public class BackupSeekbarPreference extends SeekbarPreference {
 
     public void setValue(final int value) {
         seekBar.setProgress(value);
-        valueView.setText(getValueString(value));
+        valueView.setText(value);
         saveSetting(value);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/settings/SeekbarPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SeekbarPreference.java
@@ -1,81 +1,52 @@
 package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.ui.TextParam;
-import cgeo.geocaching.ui.dialog.Dialogs;
-import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.ui.SeekbarUI;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.FrameLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
-import java.util.Locale;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class SeekbarPreference extends Preference {
 
     /**
-     * Naming conventions:
-     * - progress     - the internal value of the android widget (0 to max) - always int
-     * - value        - actual value (may differ from "progress" if non linear or other boundaries) - always int
-     * - shownValue   - displayed value (may differ from "value", if conversions are involved) - in:float out:float or int converted to string
-     * This applies to derived values (like minProgress etc.) as well.
-     *
-     * Parameters for using in XML preferences:
-     * - min          - minimum allowed value
-     * - max          - maximum allowed value
-     * - stepSize     - value will be rounded down to nearest stepSize
-     * - logScaling   - use logarithmic scaling for seekbar display
-      */
+     * for naming conventions see SeekBarUI
+     * parameters for using in XML preferences: min, max, stepSize, logScaling, ui
+     * (ui must be the canonical name of a class providing UI for this preference,
+     * either SeekbarUI or a class derived from it)
+     */
 
-    private TextView valueView;
-    protected int minValue = 0;
-    protected int maxValue = 100;
-    protected int minProgress = minValue;
-    protected int maxProgress = minProgress;
-    protected String minValueDescription;
-    protected String maxValueDescription;
-    protected int stepSize = 0;
-    protected int startProgress = 0;
-    protected final int defaultValue = 10;
-    protected boolean hasDecimals = false;
-    protected boolean useLogScaling = false;
-    protected String label = "";
-    protected String unitValue = "";
+    private static final int DEFAULT_UNSET = -1;
+    private boolean restoreStoredValue = true;
+
     protected Context context = null;
-    private ValueProgressMapper valueProgressMapper = null;
+    private SeekbarUI seekbarUI = null;
 
-    public interface ValueProgressMapper {
-        int valueToProgress(int value);
-
-        int progressToValue(int progress);
-    }
-
-    public static class FactorizeValueMapper implements ValueProgressMapper {
-        private final int factor;
-
-        public FactorizeValueMapper(final int factor) {
-            this.factor = factor;
-        }
-
-        @Override
-        public int valueToProgress(final int value) {
-            return value / factor;
-        }
-
-        @Override
-        public int progressToValue(final int progress) {
-            return progress * factor;
-        }
-    }
+    // temporary place holders for SeekbarUI variables
+    private int tempMinValue = 0;
+    private int tempMaxValue = 100;
+    private int tempDefaultValue = DEFAULT_UNSET;
+    private String tempMinValueDescription = "";
+    private String tempMaxValueDescription = "";
+    private int tempStepSize = 0;
+    private boolean tempHasDecimals = false;
+    private boolean tempUseLogScaling = false;
+    private String tempUnitValue = "";
+    private String tempTemplate = "";
+    private SeekbarUI.ValueProgressMapper tempValueProgressMapper = null;
+    private TypedArray tempAttributes = null;
 
     public SeekbarPreference(final Context context) {
         this(context, null);
@@ -94,67 +65,35 @@ public class SeekbarPreference extends Preference {
     /**
      * for programmatic creation
      */
-    public SeekbarPreference(final Context context, final int min, final int max, final String label, final String unitValue, final ValueProgressMapper valueProgressMapper) {
+    public SeekbarPreference(final Context context, final int min, final int max, final String unitValue, final SeekbarUI.ValueProgressMapper valueProgressMapper) {
         super(context, null, android.R.attr.preferenceStyle);
         this.context = context;
-        this.minValue = min;
-        this.maxValue = max;
-        this.label = label == null ? "" : label;
-        this.unitValue = unitValue == null ? "" : unitValue;
-        this.valueProgressMapper = valueProgressMapper;
+        tempMinValue = min;
+        tempMaxValue = max;
+        tempUnitValue = unitValue == null ? "" : unitValue;
+        tempValueProgressMapper = valueProgressMapper;
         initInternal(null);
     }
 
     private void initInternal(final AttributeSet attrs) {
         setPersistent(true);
-        setLayoutResource(R.layout.preference_seekbar);
+        setLayoutResource(R.layout.preference_generic_extendable);
 
         // analyze given parameters
-        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SeekbarPreference);
-        useLogScaling = a.getBoolean(R.styleable.SeekbarPreference_logScaling, useLogScaling);
-        minValue = a.getInt(R.styleable.SeekbarPreference_min, minValue);
-        maxValue = a.getInt(R.styleable.SeekbarPreference_max, maxValue);
-        minProgress = valueToProgress(minValue);
-        maxProgress = valueToProgress(maxValue);
-        minValueDescription = a.getString(R.styleable.SeekbarPreference_minValueDescription);
-        maxValueDescription = a.getString(R.styleable.SeekbarPreference_maxValueDescription);
-        stepSize = a.getInt(R.styleable.SeekbarPreference_stepSize, stepSize);
-        final String temp = a.getString(R.styleable.SeekbarPreference_label);
-        if (null != temp) {
-            label = temp;
-        }
-        hasDecimals = a.getBoolean(R.styleable.SeekbarPreference_hasDecimals, useDecimals());
-        a.recycle();
+        tempAttributes = context.obtainStyledAttributes(attrs, R.styleable.SeekbarPreference);
+
+        tempUseLogScaling = tempAttributes.getBoolean(R.styleable.SeekbarPreference_logScaling, tempUseLogScaling);
+        tempMinValue = tempAttributes.getInt(R.styleable.SeekbarPreference_min, tempMinValue);
+        tempMaxValue = tempAttributes.getInt(R.styleable.SeekbarPreference_max, tempMaxValue);
+        tempMinValueDescription = tempAttributes.getString(R.styleable.SeekbarPreference_minValueDescription);
+        tempMaxValueDescription = tempAttributes.getString(R.styleable.SeekbarPreference_maxValueDescription);
+        tempStepSize = tempAttributes.getInt(R.styleable.SeekbarPreference_stepSize, tempStepSize);
+        tempTemplate = tempAttributes.getString(R.styleable.SeekbarPreference_ui);
+        tempHasDecimals = tempAttributes.getBoolean(R.styleable.SeekbarPreference_hasDecimals, tempHasDecimals);
+
+        // recycle for tempAttributes is done in onBindViewHolder intentionally
 
         init();
-    }
-
-    protected int valueToProgressHelper(final int value) {
-        return useLogScaling
-                ? (int) Math.sqrt((long) (value - minValue) * (maxValue - minValue))
-                : value - minValue;
-    }
-
-    protected int valueToProgress(final int value) {
-        return valueProgressMapper != null ? valueProgressMapper.valueToProgress(value) : valueToProgressHelper(value);
-    }
-
-    protected int progressToValue(final int progress) {
-        if (valueProgressMapper != null) {
-            return valueProgressMapper.progressToValue(progress);
-        }
-        final int value = useLogScaling
-                ? (int) Math.round((minValue + (double) Math.pow(progress, 2) / (maxValue - minValue)))
-                : progress + minValue;
-        return stepSize > 0 ? progress == maxProgress ? maxValue : ((int) Math.round((double) value / stepSize)) * stepSize : value;
-    }
-
-    protected String valueToShownValue(final int value) {
-        return useDecimals() ? String.format(Locale.US, "%.2f", (float) value) : String.valueOf(value);
-    }
-
-    protected int shownValueToValue(final float shownValue) {
-        return Math.round(shownValue);
     }
 
     protected void init() {
@@ -162,136 +101,105 @@ public class SeekbarPreference extends Preference {
         // so override and put initialization stuff in there (if needed)
     }
 
-    protected String getValueString(final int progress) {
-        if (progress == minProgress && minValueDescription != null) {
-            return minValueDescription;
-        }
-        if (progress == maxProgress && maxValueDescription != null) {
-            return maxValueDescription;
-        }
-        return valueToShownValue(progressToValue(progress)) + getUnitString();
-    }
-
-    /**
-     * Get unit-label for progress value.
-     *
-     * @return string for the unit label
-     */
-    protected String getUnitString() {
-        return unitValue;
-    }
-
-    /**
-     * hasDecimals is parameter from SeekbarPreference, but can be overwritten.
-     * So use useDecimals instead of member
-     *
-     * @return hasDecimals
-     */
-    protected boolean useDecimals() {
-        return hasDecimals;
-    }
-
-    private boolean atLeastMin(final SeekBar seekBar, final int progress) {
-        if (progress < minProgress) {
-            seekBar.setProgress(minProgress);
-            return false;
-        }
-        return true;
-    }
-
     protected void saveSetting(final int progress) {
         if (callChangeListener(progress)) {
-            persistInt(progressToValue(progress));
+            persistInt(seekbarUI.progressToValue(progress));
             notifyChanged();
             // workaround for Android 7, as onCreateView() gets called unexpectedly after saveSetting(),
             // and the the old startValue would be used, leading to a jumping slider
-            startProgress = progress;
+            seekbarUI.setStartProgress(progress);
         }
     }
 
     @Override
     protected void onSetInitialValue(final boolean restoreValue, final Object defaultValue) {
-        final int defValue = null != defaultValue ? (Integer) defaultValue : this.defaultValue;
-        final int defaultProgress = valueToProgress(restoreValue ? getPersistedInt(defValue) : defValue);
-        startProgress = defaultProgress < minProgress ? minProgress : Math.min(defaultProgress, maxProgress);
+        if (seekbarUI != null) {
+            setInitialValue(restoreValue, defaultValue == null ? SeekbarUI.defaultValue : (int) defaultValue);
+            return;
+        }
+        restoreStoredValue = restoreValue;
+        if (defaultValue != null) {
+            tempDefaultValue = (Integer) defaultValue;
+        }
+    }
+
+    private void setInitialValue(final boolean restoreValue, final int defaultValue) {
+        final int defaultProgress = seekbarUI.valueToProgress(restoreValue ? getPersistedInt(defaultValue) : defaultValue);
+        seekbarUI.setStartProgress(defaultProgress < seekbarUI.getMinProgress() ? seekbarUI.getMinProgress() : Math.min(defaultProgress, seekbarUI.getMaxProgress()));
     }
 
     @Override
     protected Object onGetDefaultValue(final TypedArray a, final int index) {
-        return a.getInt(index, defaultValue);
+        return a.getInt(index, SeekbarUI.defaultValue);
     }
 
     @Override
-    public void onBindViewHolder(final PreferenceViewHolder holder) {
+    public void onBindViewHolder(@NonNull final PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
 
-        // get views
-        final SeekBar seekBar = (SeekBar) holder.findViewById(R.id.preference_seekbar);
-        valueView = (TextView) holder.findViewById(R.id.preference_seekbar_value_view);
-        holder.setDividerAllowedAbove(false);
+        if (seekbarUI == null) {
+            if (StringUtils.isBlank(tempTemplate)) {
+                tempTemplate = SeekbarUI.class.getCanonicalName();
+            }
+            tempTemplate = SeekbarUI.class.getCanonicalName(); // @test
+            try {
+                final Class c = Class.forName(tempTemplate);
+                final Class[] types = { Context.class };
+                final Constructor constructor = c.getConstructor(types);
+                final Object[] parameters = { getContext() };
+                seekbarUI = (SeekbarUI) constructor.newInstance(parameters);
+            } catch (IllegalAccessException | InstantiationException | ClassNotFoundException |
+                     NoSuchMethodException |
+                     InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+            setExtraView(holder);
 
-        // init seekbar
-        seekBar.setMax(maxProgress);
-        seekBar.setProgress(startProgress);
-        valueView.setText(getValueString(startProgress));
+            final boolean hasTitle = StringUtils.isNotBlank(((TextView) holder.findViewById(android.R.id.title)).getText());
+            final boolean hasSummary = StringUtils.isNotBlank(((TextView) holder.findViewById(android.R.id.summary)).getText());
+            if (!hasTitle) {
+                holder.findViewById(android.R.id.title).setVisibility(View.GONE);
+            }
+            if (!hasSummary) {
+                holder.findViewById(android.R.id.summary).setVisibility(View.GONE);
+            }
+            if (tempAttributes != null) {
+                seekbarUI.loadAdditionalAttributes(getContext(), tempAttributes, android.R.attr.preferenceStyle);
+                tempAttributes.recycle();
+                tempAttributes = null;
+            }
 
-        // set label (if given)
-        if (null != label && !label.isEmpty()) {
-            final TextView labelView = (TextView) holder.findViewById(R.id.preference_seekbar_label_view);
-            labelView.setVisibility(View.VISIBLE);
-            labelView.setText(label);
+            seekbarUI.setMinValue(tempMinValue);
+            seekbarUI.setMaxValue(tempMaxValue);
+            seekbarUI.setMinProgress(seekbarUI.valueToProgress(tempMinValue));
+            seekbarUI.setMaxProgress(seekbarUI.valueToProgress(tempMaxValue));
+            seekbarUI.setMinValueDescription(tempMinValueDescription);
+            seekbarUI.setMaxValueDescription(tempMaxValueDescription);
+            seekbarUI.setStepSize(tempStepSize);
+            seekbarUI.setHasDecimals(tempHasDecimals);
+            seekbarUI.setUseLogScaling(tempUseLogScaling);
+            seekbarUI.setUnitValue(tempUnitValue);
+            seekbarUI.setValueProgressMapper(tempValueProgressMapper);
+            seekbarUI.setSaveProgressListener(this::saveSetting);
+            setInitialValue(restoreStoredValue, tempDefaultValue);
+            seekbarUI.init();
+        } else {
+            setExtraView(holder);
         }
+    }
 
-        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
-                if (fromUser && atLeastMin(seekBar, progress)) {
-                    valueView.setText(getValueString(progress));
-                }
-            }
-
-            @Override
-            public void onStartTrackingTouch(final SeekBar seekBar) {
-                // abstract method needs to be implemented, but is not used here
-            }
-
-            @Override
-            public void onStopTrackingTouch(final SeekBar seekBar) {
-                if (atLeastMin(seekBar, seekBar.getProgress())) {
-                    saveSetting(seekBar.getProgress());
-                }
-            }
-        });
-
-        valueView.setOnClickListener(v2 -> {
-            final String currentValue = valueToShownValue(progressToValue(seekBar.getProgress()));
-            int inputType = InputType.TYPE_CLASS_NUMBER;
-            if (useDecimals()) {
-                inputType |= InputType.TYPE_NUMBER_FLAG_DECIMAL;
-            }
-            SimpleDialog.ofContext(context).setTitle(TextParam.id(R.string.number_input_title, valueToShownValue(minValue), valueToShownValue(maxValue)))
-                    .input(new SimpleDialog.InputOptions()
-                            .setInputType(inputType)
-                            .setInitialValue(currentValue)
-                            .setSuffix(getUnitString()), input -> {
-                try {
-                    final int newValue = (int) Dialogs.checkInputRange(getContext(), shownValueToValue(Float.parseFloat(input)), minValue, maxValue);
-                    final int newProgress = valueToProgress(newValue);
-                    seekBar.setProgress(newProgress);
-                    saveSetting(seekBar.getProgress());
-                    valueView.setText(getValueString(newProgress));
-                } catch (NumberFormatException e) {
-                    Toast.makeText(context, R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
-                }
-            });
-        });
+    private void setExtraView(final PreferenceViewHolder holder) {
+        final FrameLayout widget = (FrameLayout) holder.findViewById(R.id.widget_extra);
+        widget.removeAllViews();
+        widget.addView(seekbarUI);
+        widget.setVisibility(View.VISIBLE);
     }
 
     /** apply mapping to change notifications */
     @Override
     public boolean callChangeListener(final Object newValue) {
         final OnPreferenceChangeListener opcl = getOnPreferenceChangeListener();
-        return opcl == null || opcl.onPreferenceChange(this, progressToValue((int) newValue));
+        return opcl == null || opcl.onPreferenceChange(this, seekbarUI.progressToValue((int) newValue));
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -61,7 +61,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             // offline data
             // whole section disabled in basic mode
             // routing / navigation
-            R.string.pref_fakekey_brouterDistanceThresholdTitle, R.string.pref_brouterDistanceThreshold,
+            R.string.pref_brouterDistanceThreshold,
             R.string.pref_defaultNavigationTool, R.string.pref_defaultNavigationTool2, R.string.pref_fakekey_navigationMenu,
             // system
             R.string.pref_persistablefolder_basedir,

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -141,7 +141,6 @@ public class PreferenceNavigationFragment extends BasePreferenceFragment {
 
     private void updateRoutingPrefs(final boolean useInternalRouting) {
         final boolean anyRoutingAvailable = useInternalRouting || ProcessUtils.isInstalled(getString(R.string.package_brouter));
-        findPreference(getString(R.string.pref_fakekey_brouterDistanceThresholdTitle)).setEnabled(anyRoutingAvailable);
         findPreference(getString(R.string.pref_brouterDistanceThreshold)).setEnabled(anyRoutingAvailable);
         findPreference(getString(R.string.pref_brouterShowBothDistances)).setEnabled(anyRoutingAvailable);
     }

--- a/main/src/main/java/cgeo/geocaching/ui/ProximityPreferenceUI.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ProximityPreferenceUI.java
@@ -1,37 +1,24 @@
-package cgeo.geocaching.settings;
+package cgeo.geocaching.ui;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.location.IConversion;
+import cgeo.geocaching.settings.Settings;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.util.AttributeSet;
 
 import java.util.Locale;
 
-public class ProximityPreference extends SeekbarPreference {
-
+public class ProximityPreferenceUI extends SeekbarUI {
     private boolean highRes = false;
 
-    public ProximityPreference(final Context context) {
-        this(context, null);
-    }
-
-    public ProximityPreference(final Context context, final AttributeSet attrs) {
-        this(context, attrs, android.R.attr.preferenceStyle);
-    }
-
-    public ProximityPreference(final Context context, final AttributeSet attrs, final int defStyle) {
-        super(context, attrs, defStyle);
-
-        final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ProximityPreference);
-        highRes = a.getBoolean(R.styleable.ProximityPreference_highRes, false);
-        a.recycle();
+    public ProximityPreferenceUI(final Context context) {
+        super(context);
     }
 
     // init() gets called by super constructor, therefore before class constructor / class variable assignments!
     @Override
-    protected void init() {
+    public void init() {
         minProgress = 1;
     }
 
@@ -41,7 +28,7 @@ public class ProximityPreference extends SeekbarPreference {
     }
 
     @Override
-    protected int progressToValue(final int progress) {
+    public int progressToValue(final int progress) {
         final int value = (int) Math.pow(10, (double) progress / 250.0) - 1;
         return Math.max(value, 0);
     }
@@ -62,8 +49,13 @@ public class ProximityPreference extends SeekbarPreference {
     }
 
     @Override
-    protected boolean useDecimals() {
+    public boolean getHasDecimals() {
         // unit settings can be changed while ProximityPreference is already initialized
         return Settings.useImperialUnits();
+    }
+
+    @Override
+    public void loadAdditionalAttributes(final Context context, final TypedArray attrs, final int defStyle) {
+        highRes = attrs.getBoolean(R.styleable.ProximityPreference_highRes, false);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/SeekbarUI.java
+++ b/main/src/main/java/cgeo/geocaching/ui/SeekbarUI.java
@@ -1,0 +1,313 @@
+package cgeo.geocaching.ui;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.SeekbarBinding;
+import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.functions.Action1;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.text.InputType;
+import android.util.AttributeSet;
+import android.view.ContextThemeWrapper;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+
+import java.util.Locale;
+
+/**
+ * Naming conventions:
+ * - progress     - the internal value of the android widget (0 to max) - always int
+ * - value        - actual value (may differ from "progress" if non linear or other boundaries) - always int
+ * - shownValue   - displayed value (may differ from "value", if conversions are involved) - in:float out:float or int converted to string
+ * This applies to derived values (like minProgress etc.) as well.
+ * <br />
+ * Parameters for using in XML preferences:
+ * - min          - minimum allowed value
+ * - max          - maximum allowed value
+ * - stepSize     - value will be rounded down to nearest stepSize
+ * - logScaling   - use logarithmic scaling for seekbar display
+ */
+public class SeekbarUI extends LinearLayout {
+
+    private SeekbarBinding binding;
+    private TextView valueView;
+    protected int minValue = 0;
+    protected int maxValue = 100;
+    protected int minProgress = minValue;
+    protected int maxProgress = minProgress;
+    protected String minValueDescription;
+    protected String maxValueDescription;
+    protected int stepSize = 0;
+    protected int startProgress = 0;
+    public static final int defaultValue = 10;
+    protected boolean hasDecimals = false;
+    protected boolean useLogScaling = false;
+    protected String unitValue = "";
+    private ValueProgressMapper valueProgressMapper = null;
+    private Action1<Integer> saveProgressListener = null;
+
+    public interface ValueProgressMapper {
+        int valueToProgress(int value);
+
+        int progressToValue(int progress);
+    }
+
+    public static class FactorizeValueMapper implements ValueProgressMapper {
+        private final int factor;
+
+        public FactorizeValueMapper(final int factor) {
+            this.factor = factor;
+        }
+
+        @Override
+        public int valueToProgress(final int value) {
+            return value / factor;
+        }
+
+        @Override
+        public int progressToValue(final int progress) {
+            return progress * factor;
+        }
+    }
+
+    public SeekbarUI(final Context context) {
+        this(context, null);
+    }
+
+    public SeekbarUI(final Context context, final @Nullable AttributeSet attrs) {
+        this(context, attrs, android.R.attr.preferenceStyle);
+    }
+
+    public SeekbarUI(final Context context, final @Nullable AttributeSet attrs, final int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public SeekbarUI(final Context context, final @Nullable AttributeSet attrs, final int defStyleAttr, final int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        Log.e("new SeekbarUI");
+        createView();
+        init();
+    }
+
+    private void createView() {
+        setOrientation(VERTICAL);
+        final ContextThemeWrapper ctw = new ContextThemeWrapper(getContext(), R.style.cgeo);
+        inflate(ctw, R.layout.seekbar, this);
+        binding = SeekbarBinding.bind(this);
+    }
+
+    public void init() {
+        // get views
+        final SeekBar seekBar = binding.preferenceSeekbar;
+        valueView = binding.preferenceSeekbarValueView;
+
+        // init seekbar
+        seekBar.setMax(maxProgress);
+        seekBar.setProgress(startProgress);
+        valueView.setText(getValueString(startProgress));
+
+        seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(final SeekBar seekBar, final int progress, final boolean fromUser) {
+                if (fromUser && atLeastMin(seekBar, progress)) {
+                    valueView.setText(getValueString(progress));
+                }
+            }
+
+            @Override
+            public void onStartTrackingTouch(final SeekBar seekBar) {
+                // abstract method needs to be implemented, but is not used here
+            }
+
+            @Override
+            public void onStopTrackingTouch(final SeekBar seekBar) {
+                if (atLeastMin(seekBar, seekBar.getProgress())) {
+                    if (saveProgressListener != null) {
+                        saveProgressListener.call(seekBar.getProgress());
+                    }
+                }
+            }
+        });
+
+        valueView.setOnClickListener(v2 -> {
+            final String currentValue = valueToShownValue(progressToValue(seekBar.getProgress()));
+            int inputType = InputType.TYPE_CLASS_NUMBER;
+            if (getHasDecimals()) {
+                inputType |= InputType.TYPE_NUMBER_FLAG_DECIMAL;
+            }
+            SimpleDialog.ofContext(getContext()).setTitle(TextParam.id(R.string.number_input_title, valueToShownValue(minValue), valueToShownValue(maxValue)))
+                    .input(new SimpleDialog.InputOptions()
+                            .setInputType(inputType)
+                            .setInitialValue(currentValue)
+                            .setSuffix(getUnitString()), input -> {
+                        try {
+                            final int newValue = (int) Dialogs.checkInputRange(getContext(), shownValueToValue(Float.parseFloat(input)), minValue, maxValue);
+                            final int newProgress = valueToProgress(newValue);
+                            seekBar.setProgress(newProgress);
+                            if (saveProgressListener != null) {
+                                saveProgressListener.call(seekBar.getProgress());
+                            }
+                            valueView.setText(getValueString(newProgress));
+                        } catch (NumberFormatException e) {
+                            Toast.makeText(getContext(), R.string.number_input_err_format, Toast.LENGTH_SHORT).show();
+                        }
+                    });
+        });
+
+    }
+
+    // ------------------------------------------------------------------------
+
+    protected int valueToProgressHelper(final int value) {
+        return useLogScaling
+                ? (int) Math.sqrt((long) (value - minValue) * (maxValue - minValue))
+                : value - minValue;
+    }
+
+    public int valueToProgress(final int value) {
+        return valueProgressMapper != null ? valueProgressMapper.valueToProgress(value) : valueToProgressHelper(value);
+    }
+
+    public int progressToValue(final int progress) {
+        if (valueProgressMapper != null) {
+            return valueProgressMapper.progressToValue(progress);
+        }
+        final int value = useLogScaling
+                ? (int) Math.round((minValue + (double) Math.pow(progress, 2) / (maxValue - minValue)))
+                : progress + minValue;
+        return stepSize > 0 ? progress == maxProgress ? maxValue : ((int) Math.round((double) value / stepSize)) * stepSize : value;
+    }
+
+    protected String valueToShownValue(final int value) {
+        return getHasDecimals() ? String.format(Locale.US, "%.2f", (float) value) : String.valueOf(value);
+    }
+
+    protected int shownValueToValue(final float shownValue) {
+        return Math.round(shownValue);
+    }
+
+    public String getValueString(final int progress) {
+        if (progress == minProgress && minValueDescription != null) {
+            return minValueDescription;
+        }
+        if (progress == maxProgress && maxValueDescription != null) {
+            return maxValueDescription;
+        }
+        return valueToShownValue(progressToValue(progress)) + getUnitString();
+    }
+
+    /**
+     * Get unit-label for progress value.
+     *
+     * @return string for the unit label
+     */
+    protected String getUnitString() {
+        return unitValue;
+    }
+
+    private boolean atLeastMin(final SeekBar seekBar, final int progress) {
+        if (progress < minProgress) {
+            seekBar.setProgress(minProgress);
+            return false;
+        }
+        return true;
+    }
+
+    public int getCurrentProgress() {
+        return binding.preferenceSeekbar.getProgress();
+    }
+
+    // ------------------------------------------------------------------------
+    // getter / setter methods (mainly for interfacing with preferences)
+    // all of those may not be called anymore after init() has been called!
+
+    public int getMinValue() {
+        return minValue;
+    }
+
+    public void setMinValue(final int minValue) {
+        this.minValue = minValue;
+    }
+
+    public int getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMaxValue(final int maxValue) {
+        this.maxValue = maxValue;
+    }
+
+    public int getMinProgress() {
+        return minProgress;
+    }
+
+    public void setMinProgress(final int minProgress) {
+        this.minProgress = minProgress;
+    }
+
+    public int getMaxProgress() {
+        return maxProgress;
+    }
+
+    public void setMaxProgress(final int maxProgress) {
+        this.maxProgress = maxProgress;
+    }
+
+    public void setMinValueDescription(final String minValueDescription) {
+        this.minValueDescription = minValueDescription;
+    }
+
+    public void setMaxValueDescription(final String maxValueDescription) {
+        this.maxValueDescription = maxValueDescription;
+    }
+
+    public void setStepSize(final int stepSize) {
+        this.stepSize = stepSize;
+    }
+
+    public void setStartProgress(final int startProgress) {
+        this.startProgress = startProgress;
+    }
+
+    public void setUnitValue(final String unitValue) {
+        this.unitValue = unitValue;
+    }
+
+    public void setUseLogScaling(final boolean useLogScaling) {
+        this.useLogScaling = useLogScaling;
+    }
+
+    /** can be overriden! so always use getHasDecimals instead of local member */
+    public boolean getHasDecimals() {
+        return hasDecimals;
+    }
+
+    public void setHasDecimals(final boolean hasDecimals) {
+        this.hasDecimals = hasDecimals;
+    }
+
+    public ValueProgressMapper getValueProgressMapper() {
+        return valueProgressMapper;
+    }
+
+    public void setValueProgressMapper(final ValueProgressMapper valueProgressMapper) {
+        this.valueProgressMapper = valueProgressMapper;
+    }
+
+    public void setSaveProgressListener(final Action1<Integer> saveProgressListener) {
+        this.saveProgressListener = saveProgressListener;
+    }
+
+    /** read any non-default attributes here */
+    public void loadAdditionalAttributes(final Context context, final TypedArray attrs, final int defStyle) {
+        // nothing to do per default
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.SeekbarPreference;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.SeekbarUI;
 
 import android.app.Activity;
 import android.content.Context;
@@ -173,8 +174,8 @@ public class MapsforgeThemeSettingsFragment extends PreferenceFragmentCompat {
         info.setIconSpaceReserved(false);
         cat.addPreference(info);
 
-        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "", "%",
-                new SeekbarPreference.FactorizeValueMapper(10));
+        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "%",
+                new SeekbarUI.FactorizeValueMapper(10));
         seek.setDefaultValue(100);
         seek.setKey(prefKey);
         cat.addPreference(seek);

--- a/main/src/main/res/layout/preference_generic_extendable.xml
+++ b/main/src/main/res/layout/preference_generic_extendable.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <include
+        layout="@layout/preference_material"
+        tools:ignore="PrivateResource" />
+
+    <FrameLayout
+        android:id="@+id/widget_extra"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/main/src/main/res/layout/seekbar.xml
+++ b/main/src/main/res/layout/seekbar.xml
@@ -9,14 +9,6 @@
     android:orientation="vertical"
     tools:context=".settings.SettingsActivity" >
 
-    <TextView
-        android:id="@+id/preference_seekbar_label_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="left"
-        android:visibility="gone"
-        android:gravity="left"/>
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/main/src/main/res/values/attrs.xml
+++ b/main/src/main/res/values/attrs.xml
@@ -38,6 +38,7 @@
         <attr name="label" format="string" />
         <attr name="hasDecimals" format="boolean" />
         <attr name="logScaling" format="boolean" />
+        <attr name="ui" format="string" />
     </declare-styleable>
 
     <!-- custom attributes for ProximityPreference -->

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -309,7 +309,6 @@
     <!-- ============================================================================================================================================================================== -->
 
     <!-- category offlinerouting -->
-    <string translatable="false" name="pref_fakekey_brouterDistanceThresholdTitle">fakekey_brouterDistanceThresholdTitle</string>
     <string translatable="false" name="pref_brouterDistanceThreshold">brouterDistanceThreshold</string>
     <string translatable="false" name="pref_brouterShowBothDistances">pref_brouterShowBothDistances</string>
     <string translatable="false" name="pref_useInternalRouting">useInternalRouting</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -69,13 +69,10 @@
     <PreferenceCategory
         android:title="@string/init_cachelists"
         app:iconSpaceReserved="false">
-        <Preference
-            android:title="@string/init_list_initial_load_limit"
-            android:summary="@string/init_summary_list_initial_load_limit"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_list_initial_load_limit"
+            android:title="@string/init_list_initial_load_limit"
+            android:summary="@string/init_summary_list_initial_load_limit"
             android:defaultValue="@integer/list_load_limit_default"
             app:min="0"
             app:max="@integer/list_load_limit_max"
@@ -93,22 +90,18 @@
     <PreferenceCategory
         android:title="@string/init_iconsizes"
         app:iconSpaceReserved="false">
-        <Preference
-            android:title="@string/init_mapCacheScaling_title"
-            android:summary="@string/init_mapCacheScaling_description"
-            app:iconSpaceReserved="false" />
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_mapCacheScaling"
+            android:title="@string/init_mapCacheScaling_title"
+            android:summary="@string/init_mapCacheScaling_description"
             android:defaultValue="100"
             app:min="50"
             app:max="200"
             app:iconSpaceReserved="false" />
-        <Preference
-            android:title="@string/init_mapWpScaling_title"
-            android:summary="@string/init_mapWpScaling_description"
-            app:iconSpaceReserved="false" />
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_mapWpScaling"
+            android:title="@string/init_mapWpScaling_title"
+            android:summary="@string/init_mapWpScaling_description"
             android:defaultValue="100"
             app:min="50"
             app:max="200"

--- a/main/src/main/res/xml/preferences_backup.xml
+++ b/main/src/main/res/xml/preferences_backup.xml
@@ -11,12 +11,10 @@
         app:iconSpaceReserved="false">
         <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/init_backup_summary" app:iconSpaceReserved="false" />
 
-        <Preference
-            android:title="@string/init_backup_history_length_title"
-            android:summary="@string/init_backup_history_length_summary"
-            app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.BackupSeekbarPreference
             android:key="@string/pref_backup_backup_history_length"
+            android:title="@string/init_backup_history_length_title"
+            android:summary="@string/init_backup_history_length_summary"
             android:defaultValue="@integer/backup_history_length_default"
             app:min="0"
             app:max="@integer/backup_history_length_max"
@@ -55,12 +53,10 @@
     <PreferenceCategory
         android:title="@string/init_backup_automatic"
         app:iconSpaceReserved="false">
-        <Preference
-            android:title="@string/init_backup_automatic"
-            android:summary="@string/init_backup_automatic_summary"
-            app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_backup_interval"
+            android:title="@string/init_backup_automatic"
+            android:summary="@string/init_backup_automatic_summary"
             android:defaultValue="@integer/backup_interval_default"
             app:max="@integer/backup_interval_max"
             app:logScaling="true"

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -15,13 +15,10 @@
             android:summary="@string/init_summary_maptrail"
             android:title="@string/init_maptrail"
             app:iconSpaceReserved="false" />
-        <Preference
-            android:title="@string/init_maptrail_length"
-            android:summary="@string/init_maptrail_length_summary"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false" />
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_maptrail_length"
+            android:title="@string/init_maptrail_length"
+            android:summary="@string/init_maptrail_length_summary"
             android:defaultValue="@integer/historytrack_length_default"
             app:min="100"
             app:max="@integer/historytrack_length_max"
@@ -51,13 +48,10 @@
     <PreferenceCategory
         android:title="@string/settings_title_waypoints"
         app:iconSpaceReserved="false">
-        <Preference
-            android:summary="@string/init_showwaypoint_description"
-            android:title="@string/init_showwaypoints"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false" />
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_showwaypointsthreshold"
+            android:summary="@string/init_showwaypoint_description"
+            android:title="@string/init_showwaypoints"
             android:defaultValue="@integer/waypoint_threshold_default"
             app:min="0"
             app:max="@integer/waypoint_threshold_max"
@@ -104,20 +98,22 @@
         android:title="@string/settings_title_proximityNotification"
         app:allowDividerBelow="false"
         app:iconSpaceReserved="false">
-        <cgeo.geocaching.settings.ProximityPreference
+        <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_proximityDistanceFar"
+            android:title="@string/far_distance"
+            app:ui="cgeo.geocaching.ui.ProximityPreferenceUI"
             android:defaultValue="@integer/proximitynotification_far_default"
             app:min="1"
             app:max="@integer/proximitynotification_distance_max"
-            app:label="@string/far_distance"
             app:highRes="true"
             app:iconSpaceReserved="false" />
-        <cgeo.geocaching.settings.ProximityPreference
+        <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_proximityDistanceNear"
+            android:title="@string/near_distance"
+            app:ui="cgeo.geocaching.ui.ProximityPreferenceUI"
             android:defaultValue="@integer/proximitynotification_near_default"
             app:min="1"
             app:max="@integer/proximitynotification_distance_max"
-            app:label="@string/near_distance"
             app:highRes="true"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -37,13 +37,10 @@
             android:summary="@string/downloadmap_keep_temporary_files_summary"
             android:title="@string/downloadmap_keep_temporary_files"
             app:iconSpaceReserved="false" />
-        <Preference
-            android:summary="@string/init_updateinterval_description"
-            android:title="@string/init_updateinterval_title"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_mapAutoDownloadsInterval"
+            android:summary="@string/init_updateinterval_description"
+            android:title="@string/init_updateinterval_title"
             android:defaultValue="@integer/map_updateinterval_default"
             app:max="@integer/map_updateinterval_max"
             app:minValueDescription="@string/switch_off"

--- a/main/src/main/res/xml/preferences_navigation.xml
+++ b/main/src/main/res/xml/preferences_navigation.xml
@@ -11,14 +11,11 @@
         app:iconSpaceReserved="false">
         <cgeo.geocaching.settings.PreferenceTextAlwaysShow android:summary="@string/settings_summary_offline_routing" app:iconSpaceReserved="false" />
 
-        <Preference
-            android:key="@string/pref_fakekey_brouterDistanceThresholdTitle"
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_brouterDistanceThreshold"
             android:title="@string/init_brouterThreshold"
             android:summary="@string/init_brouterThreshold_description"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false"/>
-        <cgeo.geocaching.settings.ProximityPreference
-            android:key="@string/pref_brouterDistanceThreshold"
+            app:ui="cgeo.geocaching.ui.ProximityPreferenceUI"
             android:defaultValue="@integer/brouter_threshold_default"
             app:min="1"
             app:max="@integer/brouter_threshold_max"
@@ -53,13 +50,10 @@
             android:title="@string/init_autoDownloads"
             app:iconSpaceReserved="false" />
 
-        <Preference
-            android:title="@string/init_updateinterval_title"
-            android:summary="@string/init_updateinterval_description"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.SeekbarPreference
             android:key="@string/pref_brouterAutoTileDownloadsInterval"
+            android:title="@string/init_updateinterval_title"
+            android:summary="@string/init_updateinterval_description"
             android:defaultValue="@integer/brouter_updateinterval_default"
             app:max="@integer/brouter_updateinterval_max"
             app:minValueDescription="@string/switch_off"

--- a/main/src/main/res/xml/preferences_services.xml
+++ b/main/src/main/res/xml/preferences_services.xml
@@ -85,13 +85,11 @@
     <PreferenceCategory
         android:title="@string/settings_category_nearbysearch"
         app:iconSpaceReserved="false">
-        <Preference
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_nearbySearchLimit"
             android:summary="@string/init_nearbysearchlimit_description"
             android:title="@string/init_nearbysearchlimit_title"
-            app:allowDividerBelow="false"
-            app:iconSpaceReserved="false"/>
-        <cgeo.geocaching.settings.ProximityPreference
-            android:key="@string/pref_nearbySearchLimit"
+            app:ui="cgeo.geocaching.ui.ProximityPreferenceUI"
             android:defaultValue="0"
             app:min="0"
             app:max="999"


### PR DESCRIPTION
## Description
- splits `SeekbarPreference` into pref & UI parts (to be able to use seekbar preferences in both xml preferences and programmatically)
- adds support for title/summary fields in custom preferences (getting rid of some plain preferences used for title/summary only)
- provides a `preference_generic_extendable.xml` layout file for extendable preference layouts

(sorry, no `ContinuousRangeSlider` integration yet)
