### PR TITLE
use BitmapCompat for scaling log images

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -45,6 +45,7 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
+import androidx.core.graphics.BitmapCompat;
 import androidx.core.util.Supplier;
 import androidx.exifinterface.media.ExifInterface;
 
@@ -211,7 +212,7 @@ public final class ImageUtils {
         final ImmutableTriple<Integer, Integer, Boolean> scaledSize = calculateScaledImageSizes(image.getWidth(), image.getHeight(), maxWidth, maxHeight, minWidth, minHeight);
 
         if (scaledSize.right) {
-            result = Bitmap.createScaledBitmap(image, scaledSize.left, scaledSize.middle, true);
+            result = BitmapCompat.createScaledBitmap(image, scaledSize.left, scaledSize.middle, null, true);
         }
 
         final BitmapDrawable resultDrawable = new BitmapDrawable(app.getResources(), result);
@@ -308,13 +309,7 @@ public final class ImageUtils {
         if (sizeOnlyOptions == null) {
             return null;
         }
-        final int myMaxXY = Math.max(sizeOnlyOptions.outHeight, sizeOnlyOptions.outWidth);
-        final int maxXY = Math.max(maxX <= 0 ? sizeOnlyOptions.outWidth : maxX, maxY <= 0 ? sizeOnlyOptions.outHeight : maxY);
-        final int sampleSize = maxXY <= 0 ? 1 : myMaxXY / maxXY;
         final BitmapFactory.Options sampleOptions = new BitmapFactory.Options();
-        if (sampleSize > 1) {
-            sampleOptions.inSampleSize = sampleSize;
-        }
 
         return readDownsampledImageInternal(imageUri, sampleOptions, adjustOrientation);
     }


### PR DESCRIPTION
use BitmapCompat instead of Bitmap for scaling (log) images as it provides much higher quality images (that are also smaller)

Before:
![temporary_image_](https://github.com/cgeo/cgeo/assets/1258173/0c856a09-c049-4010-87e1-dcbdb91e2885)

After:
![temporary_image](https://github.com/cgeo/cgeo/assets/1258173/8d018d6b-d784-4aa9-8b52-c8828f9e6ef2)
