### PR TITLE
 UnifiedMap VTM: make map scales global (fix #15059)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CgeoApplication.java
+++ b/main/src/main/java/cgeo/geocaching/CgeoApplication.java
@@ -30,6 +30,8 @@ import java.security.MessageDigest;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.oscim.backend.CanvasAdapter;
+
 public class CgeoApplication extends Application {
 
     private static CgeoApplication instance;
@@ -82,7 +84,15 @@ public class CgeoApplication extends Application {
             MessageCenterUtils.configureMessageCenterPolling();
 
             LooperLogger.startLogging(Looper.getMainLooper());
+
+            applyVTMScales();
         }
+    }
+
+    private void applyVTMScales() {
+        CanvasAdapter.userScale = Settings.getInt(R.string.pref_vtmUserScale, 100) / 100.0f;
+        CanvasAdapter.textScale = Settings.getInt(R.string.pref_vtmTextScale, 100) / 100f;
+        CanvasAdapter.symbolScale = Settings.getInt(R.string.pref_vtmSymbolScale, 100) / 100f;
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.PreferenceTextAlwaysShow;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Action2;
 
@@ -13,6 +14,7 @@ import android.view.View;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.annotation.XmlRes;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -201,5 +203,18 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             start.setVisible(false);
         }
         return visibleCount;
+    }
+
+    protected void setFlagForRestartRequired() {
+        getActivity().setResult(SettingsActivity.RESTART_NEEDED);
+    }
+
+    protected void setFlagForRestartRequired(final @StringRes int... prefKeyIds) {
+        for (int prefKeyId : prefKeyIds) {
+            findPreference(getString(prefKeyId)).setOnPreferenceChangeListener((preference, newValue) -> {
+                setFlagForRestartRequired();
+                return true;
+            });
+        }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceAppearanceFragment.java
@@ -76,6 +76,8 @@ public class PreferenceAppearanceFragment extends BasePreferenceFragment {
         findPreference(getString(R.string.pref_mapWpScaling)).setOnPreferenceChangeListener(pScaling);
 
         configCustomBNitemPreference();
+
+        setFlagForRestartRequired(R.string.pref_vtmUserScale, R.string.pref_vtmTextScale, R.string.pref_vtmSymbolScale);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -51,7 +51,6 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         }
         hideTileprovidersPref.setEntries(tpEntries);
         hideTileprovidersPref.setEntryValues(tpValues);
-
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
@@ -47,7 +47,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.oscim.android.theme.ContentRenderTheme;
 import org.oscim.android.theme.ContentResolverResourceProvider;
-import org.oscim.backend.CanvasAdapter;
 import org.oscim.map.Map;
 import org.oscim.theme.ExternalRenderTheme;
 import org.oscim.theme.IRenderTheme;
@@ -84,7 +83,6 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
 
     //current Theme style menu settings
     private XmlRenderThemeStyleMenu themeStyleMenu;
-    private String prefThemeStyleKey = "";
 
     //the last used Zip Resource Provider is cached.
     private static String cachedZipProviderFilename = null;
@@ -155,8 +153,6 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
                 rendererLayer.setXmlRenderTheme(xmlRenderTheme);
                 */
                 mTheme = map.setTheme(xmlRenderTheme);
-                //setting xmlrendertheme has filled prefThemeStyleKey -> now apply scales
-                applyScales(prefThemeStyleKey);
             } catch (final IOException e) {
                 Log.w("Failed to set render theme", e);
                 ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.err_rendertheme_file_unreadable));
@@ -179,14 +175,6 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         if (tileProvider.supportsThemes()) {
             mTheme = map.setTheme(VtmThemes.getDefaultVariant());
         }
-        applyScales(Settings.RENDERTHEMESCALE_DEFAULTKEY);
-    }
-
-    private void applyScales(final String themeStyleId) {
-        // todo: restart of map engine necessary, or bug inside VTM? (see #13593)
-        // CanvasAdapter.userScale = Settings.getMapRenderScale(themeStyleId, Settings.RenderThemeScaleType.MAP) / 100f;
-        CanvasAdapter.textScale = Settings.getMapRenderScale(themeStyleId, Settings.RenderThemeScaleType.TEXT) / 100f;
-        CanvasAdapter.symbolScale = Settings.getMapRenderScale(themeStyleId, Settings.RenderThemeScaleType.SYMBOL) / 100f;
     }
 
     protected void disposeTheme() {
@@ -296,7 +284,6 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
     public Set<String> getCategories(final XmlRenderThemeStyleMenu menu) {
         themeStyleMenu = menu;
         final String id = this.sharedPreferences.getString(themeStyleMenu.getId(), themeStyleMenu.getDefaultValue());
-        prefThemeStyleKey = menu.getId() + "-" + id;
         final XmlRenderThemeStyleLayer baseLayer = themeStyleMenu.getLayer(id);
         if (baseLayer == null) {
             Log.w("Invalid style " + id);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
@@ -65,15 +65,6 @@ public class MapsforgeThemeSettingsFragment extends PreferenceFragmentCompat {
         if (Settings.isDefaultMapRenderTheme()) {
             this.renderthemeMenu.addPreference(VtmThemes.getPreference(activity));
         }
-
-        //scale preferences for theme
-        //todo: map scale currently doesn't work for VTM (see #13593)
-        //addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.MAP),
-        //        R.string.maptheme_scale_map_title, R.string.maptheme_scale_map_summary);
-        addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.TEXT),
-                R.string.maptheme_scale_text_title, R.string.maptheme_scale_text_summary);
-        addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.SYMBOL),
-                R.string.maptheme_scale_symbol_title, R.string.maptheme_scale_symbol_summary);
     }
 
     private String createThemePreferences(final Activity activity) {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -176,6 +176,10 @@
     <string translatable="false" name="pref_mapline_accuracycirclecolor">mapline_accuracycirclecolor</string>
     <string translatable="false" name="pref_mapline_accuracycirclefillcolor">mapline_accuracycirclefillcolor</string>
 
+    <!-- category UnifiedMap -->
+    <string translatable="false" name="pref_vtmUserScale">vtmUserScale</string>
+    <string translatable="false" name="pref_vtmTextScale">vtmTextScale</string>
+    <string translatable="false" name="pref_vtmSymbolScale">vtmSymbolScale</string>
 
     <!-- ============================================================================================================================================================================== -->
     <!-- keys for cachedetails screen -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2781,6 +2781,7 @@
     <string name="mapserver_hylly_themes_info">Detailed map theme, built for \"Hylly\" maps</string>
     <string name="brouter_info">Offline routing service</string>
     <string name="maptheme_elevate_categoryinfo">Relevant for: [A] Areas, [P] POI, [R] Routes, [W] Ways</string>
+    <string name="maptheme_vtm_scaling_summary">Scaling options for offline maps (require restart)</string>
     <string name="maptheme_scale_map_title">Map Scale Factor</string>
     <string name="maptheme_scale_map_summary">Scales map; 100% = no scaling</string>
     <string name="maptheme_scale_text_title">Text Scale factor</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -189,4 +189,41 @@
             app:showOpaquenessSlider="true"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
+
+
+    <PreferenceCategory
+        android:title="@string/category_unifiedMap"
+        android:summary="@string/maptheme_vtm_scaling_summary"
+        app:iconSpaceReserved="false">
+        <Preference
+            android:title="@string/maptheme_scale_map_title"
+            android:summary="@string/maptheme_scale_map_summary"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_vtmUserScale"
+            app:min="50"
+            app:max="200"
+            app:defaultValue="100"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:title="@string/maptheme_scale_text_title"
+            android:summary="@string/maptheme_scale_text_summary"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_vtmTextScale"
+            app:min="50"
+            app:max="200"
+            app:defaultValue="100"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:title="@string/maptheme_scale_symbol_title"
+            android:summary="@string/maptheme_scale_symbol_summary"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_vtmSymbolScale"
+            app:min="50"
+            app:max="200"
+            app:defaultValue="100"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Description
- re-adds userScale for VTM, and makes text scale / symbol scale global (instead of theme-specific)
- settings are in settings => appearance => unified map
- changing any of those three settings forces an app restart on closing the settings activity
- setting gets applied in CGeoApplication
