### PR TITLE
change collapsed group icon to right-arrow instead of up-arrow

### DIFF
--- a/main/src/main/res/drawable/expand_collapsed.xml
+++ b/main/src/main/res/drawable/expand_collapsed.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
+</vector>

--- a/main/src/main/res/layout/simpleitemlist_item_view.xml
+++ b/main/src/main/res/layout/simpleitemlist_item_view.xml
@@ -63,7 +63,7 @@
             android:layout_alignParentLeft="true"
             android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
-            android:src="@drawable/expand_less"/>
+            android:src="@drawable/expand_collapsed"/>
     </RelativeLayout>
 
     <!-- Item Icon (optional) -->


### PR DESCRIPTION
change the "collapsed" icon in simple dialog groups from up-arrow to right-arrow
new:
![image](https://github.com/cgeo/cgeo/assets/1258173/51b3201f-51ed-4275-b15b-a6791f5a26ae)
old:
![image](https://github.com/cgeo/cgeo/assets/1258173/dd3bf8c1-876b-42b3-b350-00eb9fb62904)
