### PR TITLE
fix: show user-defined projection for predefined waypoints

### DIFF
--- a/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
@@ -189,7 +189,6 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                 } else {
                     activity.nonEditable(activity.binding.nameLayout, activity.binding.name);
                     activity.nonEditable(activity.binding.noteLayout, activity.binding.note);
-                    activity.projectionType.set(ProjectionType.NO_PROJECTION);
                 }
 
                 if (StringUtils.isBlank(activity.binding.note.getText())) {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
If you add projection to a predefined waypoint, it will not be shown an reopening the waypoint.
Steps to reproduce:
add projection to a predefined waypoint
save the waypoint
reopen the waypoint => "no projection" is selected in the spinner

=> don't set "no projection" for not own waypoint-activity

## Related issues
<!-- List the related issues fixed or improved by this PR -->
found by myself, didn't create an issue yet 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
