### PR TITLE
fix crash opening UnifiedMap with non-Google map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -579,8 +579,12 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private void refreshListChooser() {
         //try to get count of visible caches
         int visibleCaches = 0;
-        if (mapFragment != null && mapFragment.getViewport() != null && viewModel != null) {
-            visibleCaches = mapFragment.getViewport().count(viewModel.caches.getValue().getAsList());
+        try {
+            if (mapFragment != null && mapFragment.getViewport() != null && viewModel != null) {
+                visibleCaches = mapFragment.getViewport().count(viewModel.caches.getValue().getAsList());
+            }
+        } catch (NullPointerException e) {
+            Log.e("UnifiedMapActivity:refreshListChooser", e);
         }
 
         if (mapType.fromList != 0) {


### PR DESCRIPTION
https://github.com/cgeo/cgeo/pull/15416 introduced a crash opening Unified Map with non-google maps. This PR doesn't "solve" the problem but at least the crash by catching it - it's a band-aid until the issue can be properly fixed