### PR TITLE
change position of "Elevation" menu item

### DIFF
--- a/main/src/main/res/menu/map_longclick.xml
+++ b/main/src/main/res/menu/map_longclick.xml
@@ -21,16 +21,16 @@
         android:title="@string/context_map_show_coords">
     </item>
     <item
+        android:id="@+id/menu_elevation"
+        android:title=""
+        android:visible="false">
+    </item>
+    <item
         android:id="@+id/menu_target"
         android:title="@string/cache_menu_target">
     </item>
     <item
         android:id="@+id/menu_navigate"
         android:title="@string/cache_menu_navigate">
-    </item>
-    <item
-        android:id="@+id/menu_elevation"
-        android:title=""
-        android:visible="false">
     </item>
 </menu>


### PR DESCRIPTION
https://github.com/cgeo/cgeo/pull/15127 added an "Elevation" item to map long-tap menu that's "not perfect" imho:

The "last" (just like "first") menu-item-position is special because it's the one menu item that can be used without further looking at the screen - you just know to hit the menu at its bottom. For all other menu items you have to carefully aim your tap. And now this special position is used by an item that never needs to be clicked (because there's no click action), thus making it harder to tap "Navigate"

Solution is easy: Move the menu item, my proposal would be below "copy coordinates", which is what this PR does.
![image](https://github.com/cgeo/cgeo/assets/1258173/cd0b393f-a4a5-4357-8b64-f85684ec9432)


My second issue (and the reason for the "Feedback required" tag) is that there are now 2 related/similar menu items: Copy coords & Elevation.
They are both giving you information about the point you tapped on the map, taken from the same source. Height is just another (usually hidden) dimension of coordinates.
So they could get combined into 1 line. The question is a) whether that's wanted and b) in which way.

My initial thought was to show both coords and elevation, but that results in a very long string - ugly:
![image](https://github.com/cgeo/cgeo/assets/1258173/856d6f9a-5178-440c-b184-782b4eeda7dd)

Maybe just have 1 menu item which shows the Elevation (if available) and on click the "Copy coordinates" dialog? Menu item text would be "Copy coords" with elevation not available, "Elevation X m" with elevation available - but that has the disadvantage of inconsistency, depending on the selected map, also not great.