### PR TITLE
re-add all caches to map before applying a new filter (fixes #15399)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -925,6 +925,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     @Override
     public void refreshWithFilter(final GeocacheFilter filter) {
+        reloadCachesAndWaypoints(false);
         mapType.filterContext.set(filter);
         MapUtils.updateFilterBar(this, mapType.filterContext);
         refreshMapData(false);


### PR DESCRIPTION
When selecting a different filter this new filter seems to be applied on top of the old one. This PR fixes that by reloading all caches, making applying a new and clearing a filter work as expected.