### PR TITLE
Hide right column for theme options in landscape mode (fix #15459)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettings.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeSettings.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.maps.mapsforge.v6;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.settings.SettingsActivity;
 
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -30,6 +31,7 @@ public class RenderThemeSettings extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.settings_fragment_root, new RenderThemeSettingsFragment())
                 .commit();
+        SettingsActivity.hideRightColumnInLandscapeMode(this);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -520,4 +520,18 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
         return s;
     }
 
+    /** for theme settings, don't show second column in landscape mode */
+    public static void hideRightColumnInLandscapeMode(final AppCompatActivity activity) {
+        final Fragment rightColumn = activity.getSupportFragmentManager().findFragmentById(R.id.settings_fragment_content_root);
+        if (rightColumn != null) {
+            activity.getSupportFragmentManager()
+                    .beginTransaction()
+                    .remove(rightColumn)
+                    .commit();
+            activity.findViewById(R.id.settings_fragment_divider).setVisibility(View.GONE);
+            activity.findViewById(R.id.settings_fragment_content_root).setVisibility(View.GONE);
+        }
+
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettings.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettings.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.unifiedmap.mapsforgevtm;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.settings.SettingsActivity;
 
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -30,6 +31,7 @@ public class MapsforgeThemeSettings extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.settings_fragment_root, new MapsforgeThemeSettingsFragment())
                 .commit();
+        SettingsActivity.hideRightColumnInLandscapeMode(this);
     }
 
 }

--- a/main/src/main/res/layout-land/layout_settings.xml
+++ b/main/src/main/res/layout-land/layout_settings.xml
@@ -14,7 +14,9 @@
         android:layout_height="wrap_content"
         android:layout_weight="2" />
 
-    <View style="@style/separator_vertical" />
+    <View
+        android:id="@+id/settings_fragment_divider"
+        style="@style/separator_vertical" />
 
     <!-- second column in landscape mode only -->
     <androidx.fragment.app.FragmentContainerView


### PR DESCRIPTION
## Description
Two column mode for settings in landscape mode is not supported by theme options, so hide it in landscape mode for theme options