### PR TITLE
fix #15463: prevent NPE when objects are null

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -850,8 +850,10 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     @Override
     public void refreshMapData(final boolean circlesSwitched) {
         markersInvalidated = true;
-        overlayPositionAndScale.repaintRequired();
-        if (circlesSwitched) {
+        if (overlayPositionAndScale != null) {
+            overlayPositionAndScale.repaintRequired();
+        }
+        if (circlesSwitched && mapView != null) {
             mapView.setCircles(Settings.isShowCircles());
             mapView.repaintRequired(null);
         }


### PR DESCRIPTION
fix #15463: prevent NPE when objects are null