### PR TITLE
rel to #15462: try to reduce database accesses for list loading

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -523,13 +523,12 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     public void addSearchResultByGeocaches(final SearchResult searchResult) {
         Log.d("add " + searchResult.getGeocodes());
-        for (String geocode : searchResult.getGeocodes()) {
-            final Geocache temp = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-            if (temp != null && temp.getCoords() != null) {
-                viewModel.caches.getValue().remove(temp);
-                viewModel.caches.getValue().add(temp);
-                viewModel.caches.postNotifyDataChanged(); // use post to make it background capable
-            }
+        final Set<Geocache> geocaches = DataStore.loadCaches(searchResult.getGeocodes(), LoadFlags.LOAD_CACHE_OR_DB);
+        CommonUtils.filterCollection(geocaches, cache -> cache != null && cache.getCoords() != null);
+        if (!geocaches.isEmpty()) {
+            viewModel.caches.getValue().removeAll(geocaches);
+            viewModel.caches.getValue().addAll(geocaches);
+            viewModel.caches.postNotifyDataChanged(); // use post to make it background capable
         }
     }
 


### PR DESCRIPTION
rel to #15462: try to reduce database accesses for list loading

A first step to work on performance issues on loading of large lists into unified map: load all caches from DB at once (not cache-by-cache).

@moving-bits could you take a look at this PR?