### PR TITLE
UnifiedMap: Don't override target on reloading caches (fix #15488)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -386,7 +386,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                                 mapFragment.setCenter(waypoint.getCoords());
                             }
                             viewModel.waypoints.getValue().add(waypoint);
-                            onReceiveTargetUpdate(new AbstractDialogFragment.TargetInfo(waypoint.getCoords(), waypoint.getName()));
+                            if (!isTargetSet()) {
+                                onReceiveTargetUpdate(new AbstractDialogFragment.TargetInfo(waypoint.getCoords(), waypoint.getName()));
+                            }
                         }
                     } else if (cache.getCoords() != null) { // geocache mode: display geocache and its waypoints
                         viewModel.caches.getValue().add(cache);
@@ -395,7 +397,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                             mapFragment.setCenter(cache.getCoords());
                         }
                         viewModel.waypoints.getValue().addAll(cache.getWaypoints());
-                        onReceiveTargetUpdate(new AbstractDialogFragment.TargetInfo(cache.getCoords(), cache.getGeocode()));
+                        if (!isTargetSet()) {
+                            onReceiveTargetUpdate(new AbstractDialogFragment.TargetInfo(cache.getCoords(), cache.getGeocode()));
+                        }
                     }
                     viewModel.waypoints.notifyDataChanged();
                 }


### PR DESCRIPTION
## Description
Attempts to fix #15488 by not overriding an existing target on reloading caches