### PR TITLE
rel to #15492: introduces CollectionLiveData which helps prevent concurrent-modification-exceptions on unified map model objects

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -242,7 +242,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         CompactIconModeUtils.setCompactIconModeThreshold(getResources());
 
         viewModel.mapCenter.observe(this, center -> updateCacheCountSubtitle());
-        viewModel.caches.observe(this, caches -> updateCacheCountSubtitle());
+        viewModel.caches.observeForNotification(this, this::updateCacheCountSubtitle);
 
         MapUtils.showMapOneTimeMessages(this, compatibilityMapMode);
 
@@ -389,8 +389,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                             onReceiveTargetUpdate(new AbstractDialogFragment.TargetInfo(waypoint.getCoords(), waypoint.getName()));
                         }
                     } else if (cache.getCoords() != null) { // geocache mode: display geocache and its waypoints
-                        viewModel.caches.getValue().add(cache);
-                        viewModel.caches.notifyDataChanged();
+                        viewModel.caches.write(false, c -> c.add(cache));
+                        //viewModel.caches.getValue().add(cache);
+                        //viewModel.caches.notifyDataChanged();
                         if (setDefaultCenterAndZoom) {
                             mapFragment.setCenter(cache.getCoords());
                         }
@@ -465,7 +466,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     private void compactIconModeChanged(final int newValue) {
         Settings.setCompactIconMode(newValue);
-        viewModel.caches.postNotifyDataChanged();
+        viewModel.caches.notifyDataChanged(true); // TODO: necessary?
     }
 
     public void showProgressSpinner() {
@@ -480,7 +481,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     public static void loadWaypoints(final UnifiedMapActivity activity, final UnifiedMapViewModel viewModel, final Viewport viewport) {
         viewModel.waypoints.getValue().clear();
-        if (viewport.count(viewModel.caches.getValue().getAsList()) < Settings.getWayPointsThreshold()) {
+        if (viewModel.caches.readWithResult(viewport::count) < Settings.getWayPointsThreshold()) {
             final Set<Waypoint> waypoints;
             if (Boolean.TRUE.equals(viewModel.transientIsLiveEnabled.getValue())) {
                 //All visible waypoints
@@ -488,9 +489,12 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             } else {
                 waypoints = new HashSet<>();
                 //All waypoints from the viewed caches
-                for (final Geocache c : viewModel.caches.getValue().getAsList()) {
-                    waypoints.addAll(c.getWaypoints());
-                }
+                viewModel.caches.read(caches -> {
+                    for (final Geocache c : caches) {
+                        waypoints.addAll(c.getWaypoints());
+                    }
+                });
+
             }
             Log.d("load.waypoints: " + waypoints.size());
             MapUtils.filter(waypoints, activity.getFilterContext());
@@ -500,10 +504,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     }
 
     private void updateCacheCountSubtitle() {
-        if (mapFragment == null) {
+        if (mapFragment == null || mapFragment.getViewport() == null) {
             return;
         }
-        final int cacheCount = mapFragment.getViewport().count(viewModel.caches.getValue().getAsList());
+        final int cacheCount = viewModel.caches.readWithResult(caches -> mapFragment.getViewport().count(caches));
         String subtitle = res.getQuantityString(R.plurals.cache_counts, cacheCount, cacheCount);
 
         // for single cache map show cache details instead
@@ -526,36 +530,23 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         final Set<Geocache> geocaches = DataStore.loadCaches(searchResult.getGeocodes(), LoadFlags.LOAD_CACHE_OR_DB);
         CommonUtils.filterCollection(geocaches, cache -> cache != null && cache.getCoords() != null);
         if (!geocaches.isEmpty()) {
-            viewModel.caches.getValue().removeAll(geocaches);
-            viewModel.caches.getValue().addAll(geocaches);
-            viewModel.caches.postNotifyDataChanged(); // use post to make it background capable
+            viewModel.caches.write(true, caches -> { // use post to make it background capable
+                caches.removeAll(geocaches);
+                caches.addAll(geocaches);
+            });
         }
     }
 
     public void addSearchResultByGeocaches(final Set<Geocache> searchResult) {
         Log.d("addSearchResult: " + searchResult.size());
-        viewModel.caches.getValue().removeAll(searchResult);
-        for (Geocache geocache : searchResult) {
-            if (geocache.getCoords() != null) {
-                viewModel.caches.getValue().add(geocache);
+        viewModel.caches.write(true, caches -> { // use post to make it background capable
+            caches.removeAll(searchResult);
+            for (Geocache geocache : searchResult) {
+                if (geocache.getCoords() != null) {
+                    caches.add(geocache);
+                }
             }
-        }
-        viewModel.caches.postNotifyDataChanged(); // use post to make it background capable
-
-    }
-
-    public void addSearchResultByGeocodes(final Set<String> searchResult) {
-        final StringBuilder s = new StringBuilder();
-        for (String geocode : searchResult) {
-            s.append(" ").append(geocode);
-            final Geocache temp = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-            if (temp != null && temp.getCoords() != null) {
-                viewModel.caches.getValue().remove(temp);
-                viewModel.caches.getValue().add(temp);
-                viewModel.caches.postNotifyDataChanged(); // use post to make it background capable
-            }
-        }
-        Log.d("add [" + s + "]");
+        });
     }
 
     private void setTitle() {
@@ -826,12 +817,13 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         } else if (id == R.id.menu_filter) {
             showFilterMenu();
         } else if (id == R.id.menu_store_caches) {
-            final Set<String> geocodes = mapFragment.getViewport()
-                    .filter(viewModel.caches.getValue().getAsList())
-                    .stream()
-                    .map(Geocache::getGeocode)
-                    .collect(Collectors.toSet());
-            CacheDownloaderService.downloadCaches(this, geocodes, false, false, () -> viewModel.caches.notifyDataChanged());
+            final Set<String> geocodes = viewModel.caches.readWithResult(caches ->
+                mapFragment.getViewport()
+                .filter(caches)
+                .stream()
+                .map(Geocache::getGeocode)
+                .collect(Collectors.toSet()));
+            CacheDownloaderService.downloadCaches(this, geocodes, false, false, () -> viewModel.caches.notifyDataChanged(false));
         } else if (id == R.id.menu_theme_mode) {
             mapFragment.selectTheme(this);
         } else if (id == R.id.menu_theme_options) {
@@ -853,7 +845,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 menu.show();
             }
         } else if (id == R.id.menu_as_list) {
-            final Collection<Geocache> caches = mapFragment.getViewport().filter(viewModel.caches.getValue().getAsList());
+            final Collection<Geocache> caches = viewModel.caches.readWithResult(vmCaches ->
+                mapFragment.getViewport().filter(vmCaches));
             CacheListActivity.startActivityMap(this, new SearchResult(caches));
         } else {
             final String language = TileProviderFactory.getLanguage(id);
@@ -914,7 +907,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     @Override
     public void showFilterMenu() {
-        FilterUtils.openFilterActivity(this, mapType.filterContext, viewModel.caches.getValue());
+        FilterUtils.openFilterActivity(this, mapType.filterContext, viewModel.caches.getListCopy());
     }
 
     @Override
@@ -933,8 +926,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     }
 
     private void refreshMapData(final boolean circlesSwitched) {
-        MapUtils.filter(viewModel.caches.getValue(), mapType.filterContext);
-        viewModel.caches.notifyDataChanged();
+        viewModel.caches.write(false, caches -> MapUtils.filter(caches, mapType.filterContext));
         viewModel.waypoints.notifyDataChanged();
         if (loadInBackgroundHandler != null) {
             loadInBackgroundHandler.onDestroy();
@@ -1109,12 +1101,12 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private static WaypointDistanceInfo getClosestDistanceInM(final Geopoint coord, final UnifiedMapViewModel viewModel) {
         WaypointDistanceInfo result;
         // work on a copy to avoid race conditions
-        result = getClosestDistanceInM(coord, new ArrayList<>(viewModel.caches.getValue()), Integer.MAX_VALUE, item -> ((Geocache) item).getShortGeocode() + " " + ((Geocache) item).getName());
+        result = getClosestDistanceInM(coord, viewModel.caches.getListCopy(), Integer.MAX_VALUE, item -> ((Geocache) item).getShortGeocode() + " " + ((Geocache) item).getName());
         result = getClosestDistanceInM(coord, new ArrayList<>(viewModel.waypoints.getValue()), result.meters, item -> ((Waypoint) item).getName() + " (" + ((Waypoint) item).getWaypointType().gpx + ")");
         return result;
     }
 
-    private static WaypointDistanceInfo getClosestDistanceInM(final Geopoint center, final ArrayList<IWaypoint> items, final int minDistanceOld, final Func1<IWaypoint, String> getName) {
+    private static WaypointDistanceInfo getClosestDistanceInM(final Geopoint center, final List<? extends IWaypoint> items, final int minDistanceOld, final Func1<IWaypoint, String> getName) {
         int minDistance = minDistanceOld;
         String name = "";
         for (IWaypoint item : items) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.models.geoitem.IGeoItemSupplier;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.LeastRecentlyUsedSet;
+import cgeo.geocaching.utils.livedata.CollectionLiveData;
 import cgeo.geocaching.utils.livedata.ConstantLiveData;
 import cgeo.geocaching.utils.livedata.Event;
 
@@ -49,7 +50,8 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
     public final MutableLiveData<Target> target = new MutableLiveData<>();
     public final MutableLiveData<SheetInfo> sheetInfo = new MutableLiveData<>();
 
-    public final ConstantLiveData<LeastRecentlyUsedSet<Geocache>> caches = new ConstantLiveData<>(new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount()));
+    //public final ConstantLiveData<LeastRecentlyUsedSet<Geocache>> caches = new ConstantLiveData<>(new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount()));
+    public final CollectionLiveData<Geocache, LeastRecentlyUsedSet<Geocache>> caches = new CollectionLiveData<>(() -> new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount()));
     public final ConstantLiveData<HashSet<Waypoint>> waypoints = new ConstantLiveData<>(new HashSet<>());
 
     public final ConstantLiveData<LeastRecentlyUsedSet<String>> cachesWithStarDrawn = new ConstantLiveData<>(new LeastRecentlyUsedSet<>(MAX_CACHES));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/CacheCirclesLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/CacheCirclesLayer.java
@@ -28,12 +28,12 @@ public class CacheCirclesLayer {
     public CacheCirclesLayer(final AppCompatActivity activity, final GeoItemLayer<String> layer) {
         final UnifiedMapViewModel viewModel = new ViewModelProvider(activity).get(UnifiedMapViewModel.class);
 
-        viewModel.caches.observe(activity, caches -> {
+        viewModel.caches.observeForRead(activity, caches -> {
 
             if (Settings.isShowCircles()) {
                 final GeoGroup.Builder geoGroup = GeoGroup.builder();
 
-                for (Geocache cache : caches.getAsList()) { // Creates a clone to avoid ConcurrentModificationException
+                for (Geocache cache : caches) { // Creates a clone to avoid ConcurrentModificationException
                     if (cache.applyDistanceRule()) {
                         geoGroup.addItems(
                                 GeoPrimitive.createCircle(cache.getCoords(), radius, GeoStyle.builder()

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeoItemsLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeoItemsLayer.java
@@ -36,7 +36,7 @@ public class GeoItemsLayer {
         final UnifiedMapViewModel viewModel = new ViewModelProvider(activity).get(UnifiedMapViewModel.class);
 
 
-        viewModel.caches.observe(activity, caches -> { // this is always executed on UI thread, thus doesn't need to be thread save
+        viewModel.caches.observeForRead(activity, caches -> { // this is always executed on UI thread, thus doesn't need to be thread save
 
             final Map<String, Integer> currentlyDisplayedGeocaches = new HashMap<>();
 
@@ -46,7 +46,7 @@ public class GeoItemsLayer {
                 viewModel.waypoints.notifyDataChanged();
             }
 
-            for (Geocache cache : caches.getAsList()) { // Creates a clone to avoid ConcurrentModificationExceptions
+            for (Geocache cache : caches) { // Creates a clone to avoid ConcurrentModificationExceptions
                 final CacheMarker cm = forceCompactIconMode ? MapMarkerUtils.getCacheDotMarker(activity.getResources(), cache) : MapMarkerUtils.getCacheMarker(activity.getResources(), cache, null, true);
                 currentlyDisplayedGeocaches.put(cache.getGeocode(), cm.hashCode());
 


### PR DESCRIPTION
rel to #15492: introduces CollectionLiveData which helps prevent concurrent-modification-exceptions on unified map model objects

Unified map deals with multiple livedata collection objects and reads/modifies them in various locationss and threads. To control this better, this PR introduces class CollectionLiveData which controls such access via a read/write lock.

This PR introduces CollectionLiveData and applies it to the caches object in the unified map viewmodel

Feedback/review is requested for this PR as it changes view model updates on collections significantly.