### PR TITLE
Add track name to toast on import error

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -86,7 +86,7 @@ public final class ActivityMixin {
     }
 
     private static void showCgeoToast(final Context context, final String text, final int toastDuration) {
-        Log.d("[" + context.getClass().getName() + "].showToast(" + text + "){" + toastDuration + "}");
+        Log.iForce("[" + context.getClass().getName() + "].showToast(" + text + "){" + toastDuration + "}");
         try {
             final Toast toast = Toast.makeText(context, text, toastDuration);
             if (Build.VERSION.SDK_INT < 30) {

--- a/main/src/main/java/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.files;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.location.GeoItemHolder;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.geoitem.IGeoItemSupplier;
@@ -13,7 +14,6 @@ import cgeo.geocaching.utils.Log;
 
 import android.content.Context;
 import android.net.Uri;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
@@ -32,7 +32,7 @@ public class GPXTrackOrRouteImporter {
     private GPXTrackOrRouteImporter() {
     }
 
-    public static void doImport(final Context context, final Uri uri, final Route.UpdateRoute callback) {
+    public static void doImport(final Context context, final Uri uri, final String displayName, final Route.UpdateRoute callback) {
         final AtomicBoolean success = new AtomicBoolean(false);
         AndroidRxUtils.andThenOnUi(Schedulers.io(), () -> {
             try {
@@ -52,7 +52,11 @@ public class GPXTrackOrRouteImporter {
             }
         }, () -> {
             if (!success.get()) {
-                Toast.makeText(context, R.string.load_track_error, Toast.LENGTH_SHORT).show();
+                if (displayName == null) {
+                    ActivityMixin.showToast(context, R.string.load_track_error);
+                } else {
+                    ActivityMixin.showToast(context, R.string.load_track_error_named, displayName);
+                }
                 callback.updateRoute(null);
             }
         });

--- a/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -27,6 +27,7 @@ import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.ui.dialog.SimplePopupMenu;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.UriUtils;
 import cgeo.geocaching.utils.functions.Action2;
 import cgeo.geocaching.utils.functions.Func0;
 
@@ -102,7 +103,7 @@ public class RouteTrackUtils {
         if (uris != null && this.updateTrack != null) {
             for (Uri uri : uris) {
                 Log.d("[RouteTrackDebug] Start import of track " + uri);
-                GPXTrackOrRouteImporter.doImport(activity, uri, (route) -> {
+                GPXTrackOrRouteImporter.doImport(activity, uri, UriUtils.getLastPathSegment(uri), (route) -> {
                     Log.d("[RouteTrackDebug] Finished import of track " + uri + ": " + (route == null ? "null returned" : "updating map"));
                     final String key = tracks.add(activity, uri, updateTrack);
                     tracks.setRoute(key, route);
@@ -419,7 +420,7 @@ public class RouteTrackUtils {
     public void reloadTrack(final Trackfiles trackfile, final Tracks.UpdateTrack updateTrack) {
         final Uri uri = Trackfiles.getUriFromKey(trackfile.getKey());
         Log.d("[RouteTrackDebug] Start reloading track from trackfile " + trackfile.getFilename());
-        GPXTrackOrRouteImporter.doImport(activity, uri, (route) -> {
+        GPXTrackOrRouteImporter.doImport(activity, uri, trackfile.getDisplayname(), (route) -> {
             if (route != null) {
                 Log.d("[RouteTrackDebug] Reloading track from trackfile " + trackfile.getFilename() + " finished, updating map");
                 route.setHidden(trackfile.isHidden());

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2652,6 +2652,7 @@
     <!-- individual track -->
     <string name="map_load_track">Load track/route from GPX</string>
     <string name="load_track_error">Error loading track/route</string>
+    <string name="load_track_error_named">Error loading track/route: \"%s\"</string>
     <string name="map_clear_track">Clear route/track</string>
     <string name="map_clear_track_confirm">Do you want to remove route/track \"%s\"?</string>
 


### PR DESCRIPTION
Add track name to toast on import error

This PR, if merged, will add the route/track name to the error toast when an import into map fails:

![image](https://github.com/cgeo/cgeo/assets/6909759/afab11ca-663f-4654-969f-66a205125fa6)
