### PR TITLE
Apply filter on mapping a list content (fix #15485)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1639,7 +1639,11 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         // apply filter settings (if there's a filter)
         final SearchResult searchToUse = getFilteredSearch();
-        DefaultMap.startActivitySearch(this, searchToUse, title, listId);
+        if (Settings.useUnifiedMap() && listId != 0) {
+            DefaultMap.startActivityList(this, listId, currentCacheFilter);
+        } else {
+            DefaultMap.startActivitySearch(this, searchToUse, title, listId);
+        }
         ActivityMixin.overrideTransitionToFade(this);
     }
 

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -151,7 +151,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
             return false;
         }
         new StoredList.UserInterface(this).promptForListSelection(R.string.list_title, selectedListId -> {
-            DefaultMap.startActivityList(this, selectedListId);
+            DefaultMap.startActivityList(this, selectedListId, null);
             ActivityMixin.overrideTransitionToFade(this);
         }, false, PseudoList.NEW_LIST.id);
         return true;

--- a/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
@@ -14,6 +14,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import androidx.annotation.Nullable;
+
 public final class DefaultMap {
 
     private DefaultMap() {
@@ -122,7 +124,8 @@ public final class DefaultMap {
             if (fromList == 0) {
                 new UnifiedMapType(search, title).launchMap(fromActivity); // same as above
             } else {
-                startActivityList(fromActivity, fromList);
+                // no longer allowed / CacheListActivity directly launches into startActivityList in this case
+                startActivityList(fromActivity, fromList, null);
             }
         } else {
             final MapOptions mo = new MapOptions(search, title, fromList);
@@ -131,11 +134,10 @@ public final class DefaultMap {
         }
     }
 
-    public static void startActivityList(final Activity fromActivity, final int fromList) {
-        if (Settings.useUnifiedMap()) { // only supported for UnifiedMap
+    public static void startActivityList(final Activity fromActivity, final int fromList, final @Nullable GeocacheFilterContext filterContext) {
+        if (Settings.useUnifiedMap() && fromList != 0) { // only supported for UnifiedMap
             Log.e("Launching UnifiedMap in list mode, fromList=" + fromList + ")");
-            final UnifiedMapType mapType = new UnifiedMapType(fromList);
-            mapType.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.OFFLINE);
+            final UnifiedMapType mapType = new UnifiedMapType(fromList, filterContext);
             mapType.launchMap(fromActivity);
         }
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -66,8 +66,13 @@ public class UnifiedMapType implements Parcelable {
 
     /** show and scale to list content */
     public UnifiedMapType(final int fromList) {
+        this(fromList, null);
+    }
+
+    /** show and scale to list content with filter applied */
+    public UnifiedMapType(final int fromList, final GeocacheFilterContext filterContext) {
         type = UnifiedMapTypeType.UMTT_List;
-        filterContext = new GeocacheFilterContext(OFFLINE);
+        this.filterContext = filterContext != null ? filterContext : new GeocacheFilterContext(OFFLINE);
         this.fromList = fromList;
     }
 


### PR DESCRIPTION
UnifiedMap does not work with `SearchResult` on displaying a list content but with list id only, which lead to current filter being ignored. This PR applies the current filter instead of using a default (empty) one.