### PR TITLE
Fix filtering caches on live map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -455,6 +455,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                         if (setDefaultCenterAndZoom) {
                             mapFragment.zoomToBounds(viewport2.get());
                         }
+                        refreshMapData(false);
                     }
                 });
                 break;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -473,6 +473,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         // only initialize loadInBackgroundHandler if caches should actually be loaded
         if (mapType.type == UMTT_PlainMap) {
             refreshMapData(false);
+            if (loadInBackgroundHandler == null) {
+                loadInBackgroundHandler = new LoadInBackgroundHandler(this);
+            }
         }
     }
 
@@ -884,8 +887,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         viewModel.waypoints.notifyDataChanged();
         if (loadInBackgroundHandler != null) {
             loadInBackgroundHandler.onDestroy();
+            loadInBackgroundHandler = new LoadInBackgroundHandler(this);
         }
-        loadInBackgroundHandler = new LoadInBackgroundHandler(this);
         MapUtils.updateFilterBar(this, mapType.filterContext);
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -471,10 +471,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         // only initialize loadInBackgroundHandler if caches should actually be loaded
         if (mapType.type == UMTT_PlainMap) {
-            if (loadInBackgroundHandler != null) {
-                loadInBackgroundHandler.onDestroy();
-            }
-            loadInBackgroundHandler = new LoadInBackgroundHandler(this);
+            refreshMapData(false);
         }
     }
 
@@ -886,8 +883,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         viewModel.waypoints.notifyDataChanged();
         if (loadInBackgroundHandler != null) {
             loadInBackgroundHandler.onDestroy();
-            loadInBackgroundHandler = new LoadInBackgroundHandler(this);
         }
+        loadInBackgroundHandler = new LoadInBackgroundHandler(this);
         MapUtils.updateFilterBar(this, mapType.filterContext);
     }
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
As of my limited understanding of the filtering and loading stuff of caches - but debugging and trying:
when on `UnifiedMapActivity::reloadCachesAndWaypoints`  not only the `loadInBackgroundHandler` is initialized for `UMTT_PlainMap`
but the map data is refreshed (filter on `viewModel.caches` is applied (again(?)) via `UnifiedMapActivity::refreshMapData`) everything works fine.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #15470

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
This PR is not a fix for #15614 