### PR TITLE
Fix lint: inconsistent layout (fix #15592)

### DIFF
--- a/main/src/main/res/layout-land/layout_settings.xml
+++ b/main/src/main/res/layout-land/layout_settings.xml
@@ -14,11 +14,13 @@
         android:layout_height="wrap_content"
         android:layout_weight="2" />
 
+    <!-- second column in landscape mode only -->
+
     <View
+        tools:ignore="InconsistentLayout"
         android:id="@+id/settings_fragment_divider"
         style="@style/separator_vertical" />
 
-    <!-- second column in landscape mode only -->
     <androidx.fragment.app.FragmentContainerView
         tools:ignore="InconsistentLayout"
         android:id="@+id/settings_fragment_content_root"


### PR DESCRIPTION
## Description
Second column is used in landscape only, including the vertical divider, so add hints for the checking tools.