### PR TITLE
UnifiedMap: Fix NPE in location update

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -645,6 +645,11 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     }
 
     private void handleLocUpdate(final LocUpdater.LocationWrapper locationWrapper) {
+        // no need to handle location update if map fragment is gone
+        if (mapFragment == null) {
+            return;
+        }
+
         final int mapRotation = Settings.getMapRotation();
         if (locationWrapper.needsRepaintForHeading && (mapRotation == MAPROTATION_AUTO_LOWPOWER || mapRotation == MAPROTATION_AUTO_PRECISE)) {
             mapFragment.setBearing(locationWrapper.heading);


### PR DESCRIPTION
no need to handle location update if map fragment is gone (due to sub-map having been requested)