### PR TITLE
 Update GH action setup-java

### DIFF
--- a/.github/workflows/avd-build-and-cache.yml
+++ b/.github/workflows/avd-build-and-cache.yml
@@ -3,7 +3,7 @@ name: Build AVD cache
 on:
   schedule:
     - cron:  '0 10 * * *'
-  workflow_dispatch: 
+  workflow_dispatch:
     inputs:
       JDK_VERSION:
         description: The JDK version to use
@@ -31,7 +31,7 @@ jobs:
             sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: temurin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           PREF_PASSWORD: ${{ secrets.PREF_PASSWORD }}
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: temurin
@@ -109,7 +109,7 @@ jobs:
           PREF_PASSWORD: ${{ secrets.PREF_PASSWORD }}
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: temurin
@@ -169,7 +169,7 @@ jobs:
           PREF_PASSWORD: ${{ secrets.PREF_PASSWORD }}
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: temurin
@@ -248,7 +248,7 @@ jobs:
           PREF_PASSWORD: ${{ secrets.PREF_PASSWORD }}
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: temurin

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -64,7 +64,7 @@ jobs:
           PREF_PASSWORD: ${{ secrets.PREF_PASSWORD }}
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: temurin


### PR DESCRIPTION
 From GHA "avd_cache_update" result at https://github.com/cgeo/cgeo/actions/runs/8687394730.
 `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3.`


