### PR TITLE
Use pull_request_target to allow secrets access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Unit tests
 on:
   push:
     branches: [ "master", "androidci" ]
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
     inputs:
       JDK_VERSION:


### PR DESCRIPTION
See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/