### PR TITLE
Only run watchdog from cgeo repo + Check for secret presence and fail is missing

### DIFF
--- a/.github/actions/cgeo-preferences/action.yml
+++ b/.github/actions/cgeo-preferences/action.yml
@@ -84,6 +84,14 @@ runs:
   using: "composite"
   steps:
 
+    - name: Check secrets
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.KEY_STORE }}" ]; then
+          echo "::error::Secrets seems missing from this repo."
+          exit 1
+        fi
+
     - name: Set the emulator preferences
       shell: bash
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Unit tests
 
+concurrency:
+  group: ci-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Unit tests
 
 on:
   push:
-    branches: [ "master", "release" ]
   pull_request:
     types: [labeled]
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ env:
   JDK_VERSION: ${{ inputs.JDK_VERSION || '17' }}
 
 permissions:
-  contents: read
+  contents: write
   checks: write
   pull-requests: write
 
@@ -158,7 +158,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     strategy:
-      max-parallel: 1
       fail-fast: false
       matrix:
         api-level: [26, 29, 30]
@@ -238,6 +237,16 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
+
+      # Allow only one job at a time (prevent errors on live GC tests)
+      - uses: suzuki-shunsuke/lock-action@latest
+        with:
+          mode: lock
+          key: unit-test
+          # Try to acquire a lock every 30 seconds until acquiring a lock or 30 minutes pass.
+          max_wait_seconds: "1800"
+          wait_interval_seconds: "30"
+          post_unlock: "true"
 
       - name: Run Unit Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   watchdog-tests:
     runs-on: ubuntu-latest
+    if: github.repository == 'cgeo/cgeo'
     strategy:
       matrix:
         branch: [ "master", "release" ]


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->

- Only run watchdog from cgeo repo
- Check for secret presence and fail is missing

+ Run the test workflow from any branch
+ Only allow one run per ref branch or tag
+ Allow only one concurrent live run over all branches (using https://github.com/suzuki-shunsuke/lock-action?tab=readme-ov-file, that creates a new branch `lock__unit-test` to maintain the lock and history)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#15608

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->