### PR TITLE
ci: Run unit test only on labeled PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,8 @@ name: Unit tests
 on:
   push:
     branches: [ "master", "androidci" ]
-  pull_request:
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       JDK_VERSION:
@@ -17,10 +18,13 @@ env:
 jobs:
   dex-count:
     name: DEX count
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup cgeo preferences and keystore
         uses: ./.github/actions/cgeo-preferences
@@ -74,9 +78,12 @@ jobs:
 
   checkstyle:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup cgeo preferences and keystore
         uses: ./.github/actions/cgeo-preferences
@@ -134,9 +141,12 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup cgeo preferences and keystore
         uses: ./.github/actions/cgeo-preferences
@@ -200,6 +210,7 @@ jobs:
     # > are 2-3 times faster than the macOS ones which are also a lot more expensive.
     # https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     strategy:
       fail-fast: false
       matrix:
@@ -209,6 +220,8 @@ jobs:
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
       - name: Enable KVM group perms


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Run unit test only on labeled PR

implemented from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ as mentionned in https://github.com/cgeo/cgeo/issues/15608#issuecomment-2059798061

Adding the label `safe to test`, should allow PR from all (internal/external) repos to run

(This PR is untested, it's just my understanding from the document - as we're hitting #15630 I don't want to go further in the tests right now.)

Please note this warning from the document
> [!warning]
> Note that this kind of label based verification is still prone to a race condition in which the attacker may push new changes after the workflow was approved (labeled), but has not started yet. 

## Related issues
<!-- List the related issues fixed or improved by this PR -->

- #15608
- #15630

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->