### PR TITLE
Refine username detection during login

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/CgeoApplicationTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/CgeoApplicationTest.java
@@ -52,7 +52,7 @@ public class CgeoApplicationTest {
     @MediumTest
     public void testRegEx() {
         final String page = MockedCache.readCachePage("GC2CJPF");
-        assertThat(TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME, true, "???")).isEqualTo("abft");
+        assertThat(TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME2, true, "???")).isEqualTo("abft");
     }
 
     /**

--- a/main/src/androidTest/java/cgeo/geocaching/CgeoApplicationTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/CgeoApplicationTest.java
@@ -39,6 +39,7 @@ import androidx.test.filters.SmallTest;
 
 import java.util.GregorianCalendar;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.junit.Test;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -53,6 +54,19 @@ public class CgeoApplicationTest {
     public void testRegEx() {
         final String page = MockedCache.readCachePage("GC2CJPF");
         assertThat(TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME2, true, "???")).isEqualTo("abft");
+
+        // test special character handling in usernames during login
+        testUsername("Max\\u0026Moritz"); // JS-escaped Unicode character
+        testUsername("Hello\\\"World\\\""); // JS-escaped double quote
+        testUsername("Hello\\\"Max\\u0026Moritz\\\""); // combination of both
+    }
+
+    private void testUsername(final String username) {
+        // pagePrefix / pagePostfix is part of the surrounding JS code around the username parameter
+        final String pagePrefix = "\"publicGuid\":\"abcdef01-2345-6789-abcd-ef0123456789\",\"referenceCode\":\"PRABCDE\",\"id\":1234567,\"username\":\"";
+        final String pagePostfix = "\",\"dateCreated\":\"2010-01-01T00:00:00\"";
+        final String purifiedUsername = StringEscapeUtils.unescapeEcmaScript(username); // unescape JS-escaped Unicode characters
+        assertThat(GCParser.getUsername(pagePrefix + username + pagePostfix)).isEqualTo(purifiedUsername);
     }
 
     /**

--- a/main/src/androidTest/java/cgeo/geocaching/test/mock/MockedCache.java
+++ b/main/src/androidTest/java/cgeo/geocaching/test/mock/MockedCache.java
@@ -38,7 +38,7 @@ public abstract class MockedCache extends Geocache {
         this.coords = coords;
         this.data = MockedCache.readCachePage(getGeocode());
         // for mocked caches the user logged in is the user who saved the html file(s)
-        this.mockedDataUser = TextUtils.getMatch(data, GCConstants.PATTERN_LOGIN_NAME, true, "");
+        this.mockedDataUser = TextUtils.getMatch(data, GCConstants.PATTERN_LOGIN_NAME2, true, "");
     }
 
     public String getMockedDataUser() {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -95,11 +95,11 @@ public final class GCConstants {
 
     //Try to find pattern as follows:
     //"publicGuid":"abc.def","referenceCode":"PRxyz","id":1234567,"username":"user","dateCreated":"2012-01-21T20:51:14","findCount":15123,
-    public static final Pattern PATTERN_LOGIN_NAME_CACHE_COUNT = Pattern.compile("\"publicGuid\":\"[^\"]+\",\"referenceCode\":\"[^\"]+\",\"id\":[0-9]+,\"username\":\"([^\"]+)\",\"dateCreated\":\"[0-9:T-]+\",\"findCount\":([0-9]+),");
+    public static final Pattern PATTERN_LOGIN_NAME1 = Pattern.compile(",\"referenceCode\":\"[^\"]+\",\"id\":[0-9]+,\"username\":\\s*\"(([^\\\\\\\"]*(\\\\[a-z\\\"])*)*)\\\",");
     public static final Pattern PATTERN_FINDCOUNT = Pattern.compile("\"findCount\":\\s*([0-9]+)[,\\s]");
 
     // Info box top-right
-    public static final Pattern PATTERN_LOGIN_NAME = Pattern.compile("\\swindow(?>\\.|\\[')(?:headerSettings|chromeSettings)(?>'\\])?\\s*=\\s*\\{[\\S\\s]*\"username\":\\s*\"([^\"]*)\",?[\\S\\s]*\\}");
+    public static final Pattern PATTERN_LOGIN_NAME2 = Pattern.compile("\\swindow(?>\\.|\\[')(?:headerSettings|chromeSettings)(?>'\\])?\\s*=\\s*\\{[\\S\\s]*\"username\":\\s*\"([^\"]*)\",?[\\S\\s]*\\}");
     /**
      * Use replaceAll("[,.]","") on the resulting string before converting to an int
      */

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1700,13 +1700,16 @@ public final class GCParser {
 
     @Nullable
     public static String getUsername(@NonNull final String page) {
-        String username = TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME_CACHE_COUNT, null);
+        String username = TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME1, null);
         if (StringUtils.isNotBlank(username)) {
+            if (username.contains("\\")) {
+                username = StringEscapeUtils.unescapeEcmaScript(username);
+            }
             return username;
         }
 
         //second try
-        username = TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME, null);
+        username = TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME2, null);
         if (StringUtils.isNotBlank(username)) {
             return username;
         }


### PR DESCRIPTION
## Description
- do not terminate detection on JS-escaped double quotes in username
- check for and unescape JS-escaped Unicode characters
- along the way: shortens username detection regexp to look for username only, as findcount is detected otherwise meanwhile

(switching to reading `serverParameters` seems to be non-feasable here, as it is not yet available during login)