### PR TITLE
Refresh map data after opening / closing settings dialog

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
@@ -123,7 +123,7 @@ public abstract class AbstractMap {
         //
     }
 
-    public abstract void refreshMapData(boolean circlesSwitched);
+    public abstract void refreshMapData(boolean circlesSwitched, final boolean filterChanged);
 
     public boolean isTargetSet() {
         return /* StringUtils.isNotBlank(targetGeocode) && */ null != lastNavTarget;

--- a/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/AbstractMap.java
@@ -123,7 +123,7 @@ public abstract class AbstractMap {
         //
     }
 
-    public abstract void refreshMapData(boolean circlesSwitched, final boolean filterChanged);
+    public abstract void refreshMapData(boolean circlesSwitched, boolean filterChanged);
 
     public boolean isTargetSet() {
         return /* StringUtils.isNotBlank(targetGeocode) && */ null != lastNavTarget;

--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -790,7 +790,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             if (mapOptions.isLiveEnabled) {
                 mapOptions.isStoredEnabled = true;
                 mapOptions.filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.LIVE);
-                refreshMapData(false);
+                refreshMapData(false, true);
             }
             markersInvalidated = true;
             lastSearchResult = null;
@@ -847,7 +847,7 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
     }
 
     @Override
-    public void refreshMapData(final boolean circlesSwitched) {
+    public void refreshMapData(final boolean circlesSwitched, final boolean filterChanged) {
         markersInvalidated = true;
         if (overlayPositionAndScale != null) {
             overlayPositionAndScale.repaintRequired();
@@ -856,8 +856,9 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             mapView.setCircles(Settings.isShowCircles());
             mapView.repaintRequired(null);
         }
-        MapUtils.updateFilterBar(activity, mapOptions.filterContext);
-
+        if (filterChanged) {
+            MapUtils.updateFilterBar(activity, mapOptions.filterContext);
+        }
     }
 
     private void routingModeChanged(final RoutingMode newValue) {

--- a/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -141,7 +141,7 @@ public class MapSettingsUtils {
         final Dialog dialog = Dialogs.bottomSheetDialogWithActionbar(activity, dialogView.getRoot(), R.string.quick_settings);
         dialog.setOnDismissListener(d -> {
             boolean filterChanged = false;
-            boolean circleChanged = circlesCb.valueChanged;
+            final boolean circleChanged = circlesCb.valueChanged;
             for (SettingsCheckboxModel item : allCbs) {
                 if (item.valueChanged() && item != circlesCb) {
                     filterChanged = true;

--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapActivity.java
@@ -287,7 +287,7 @@ public class GoogleMapActivity extends AbstractNavigationBarMapActivity implemen
         }
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             mapBase.getMapOptions().filterContext = data.getParcelableExtra(EXTRA_FILTER_CONTEXT);
-            mapBase.refreshMapData(false);
+            mapBase.refreshMapData(false, true);
         }
 
         this.routeTrackUtils.onActivityResult(requestCode, resultCode, data);
@@ -307,7 +307,7 @@ public class GoogleMapActivity extends AbstractNavigationBarMapActivity implemen
     public void refreshWithFilter(final GeocacheFilter filter) {
         mapBase.getMapOptions().filterContext.set(filter);
         MapUtils.filter(mapBase.getCaches(), mapBase.getMapOptions().filterContext);
-        mapBase.refreshMapData(false);
+        mapBase.refreshMapData(false, true);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -467,7 +467,7 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
                 mapOptions.isStoredEnabled = true;
                 mapOptions.filterContext = new GeocacheFilterContext(LIVE);
                 caches.setFilterContext(mapOptions.filterContext);
-                refreshMapData(false);
+                refreshMapData(false, true);
             }
 
             if (mapOptions.mapMode == MapMode.LIVE) {
@@ -530,7 +530,7 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
         return true;
     }
 
-    private void refreshMapData(final boolean circlesSwitched) {
+    private void refreshMapData(final boolean circlesSwitched, final boolean filterChanged) {
         if (circlesSwitched) {
             caches.switchCircles();
         }
@@ -543,7 +543,10 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
         if (null != geoObjectLayer) {
             geoObjectLayer.requestRedraw();
         }
-        MapUtils.updateFilterBar(this, mapOptions.filterContext);
+
+        if (filterChanged) {
+            MapUtils.updateFilterBar(this, mapOptions.filterContext);
+        }
     }
 
     private void routingModeChanged(final RoutingMode newValue) {
@@ -623,7 +626,7 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
     @Override
     public void refreshWithFilter(final GeocacheFilter filter) {
         mapOptions.filterContext.set(filter);
-        refreshMapData(false);
+        refreshMapData(false, true);
     }
 
     private void changeMapSource(@NonNull final MapSource newSource) {
@@ -1543,7 +1546,7 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
         }
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             mapOptions.filterContext = data.getParcelableExtra(EXTRA_FILTER_CONTEXT);
-            refreshMapData(false);
+            refreshMapData(false, true);
         }
 
         this.routeTrackUtils.onActivityResult(requestCode, resultCode, data);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -906,11 +906,11 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private void refreshMapData(final boolean circlesSwitched, final boolean filterChanged) {
         viewModel.caches.write(false, caches -> MapUtils.filter(caches, mapType.filterContext));
         viewModel.waypoints.notifyDataChanged();
-        if (loadInBackgroundHandler != null) {
-            loadInBackgroundHandler.onDestroy();
-            loadInBackgroundHandler = new LoadInBackgroundHandler(this);
-        }
         if (filterChanged) {
+            if (loadInBackgroundHandler != null) {
+                loadInBackgroundHandler.onDestroy();
+                loadInBackgroundHandler = new LoadInBackgroundHandler(this);
+            }
             MapUtils.updateFilterBar(this, mapType.filterContext);
         }
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -443,7 +443,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                         if (setDefaultCenterAndZoom) {
                             mapFragment.zoomToBounds(viewport3.get());
                         }
-                        refreshMapData(false);
+                        refreshMapData(false, true);
                     }
                 });
                 break;
@@ -461,7 +461,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                         if (setDefaultCenterAndZoom) {
                             mapFragment.zoomToBounds(viewport2.get());
                         }
-                        refreshMapData(false);
+                        refreshMapData(false, true);
                     }
                 });
                 break;
@@ -478,7 +478,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         // only initialize loadInBackgroundHandler if caches should actually be loaded
         if (mapType.type == UMTT_PlainMap) {
-            refreshMapData(false);
+            refreshMapData(false, true);
             if (loadInBackgroundHandler == null) {
                 loadInBackgroundHandler = new LoadInBackgroundHandler(this);
             }
@@ -860,7 +860,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             mapType.filterContext = data.getParcelableExtra(EXTRA_FILTER_CONTEXT);
-            refreshMapData(false);
+            refreshMapData(false, true);
         }
     }
 
@@ -896,21 +896,23 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         return mapType.filterContext;
     }
 
-    private void refreshMapDataAfterSettingsChanged(final boolean circlesSwitched) {
-        if (loadInBackgroundHandler == null) {
+    private void refreshMapDataAfterSettingsChanged(final boolean circlesSwitched, final boolean filterChanged) {
+        if (loadInBackgroundHandler == null && filterChanged) {
             reloadCachesAndWaypoints(false);
         }
-        refreshMapData(circlesSwitched);
+        refreshMapData(circlesSwitched, filterChanged);
     }
 
-    private void refreshMapData(final boolean circlesSwitched) {
+    private void refreshMapData(final boolean circlesSwitched, final boolean filterChanged) {
         viewModel.caches.write(false, caches -> MapUtils.filter(caches, mapType.filterContext));
         viewModel.waypoints.notifyDataChanged();
         if (loadInBackgroundHandler != null) {
             loadInBackgroundHandler.onDestroy();
             loadInBackgroundHandler = new LoadInBackgroundHandler(this);
         }
-        MapUtils.updateFilterBar(this, mapType.filterContext);
+        if (filterChanged) {
+            MapUtils.updateFilterBar(this, mapType.filterContext);
+        }
     }
 
     // ========================================================================

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -897,6 +897,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     }
 
     private void refreshMapDataAfterSettingsChanged(final boolean circlesSwitched) {
+        if (loadInBackgroundHandler == null) {
+            reloadCachesAndWaypoints(false);
+        }
         refreshMapData(circlesSwitched);
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -349,7 +349,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         if (mapChanged) {
             final boolean setDefaultCenterAndZoom = !overridePositionAndZoom && mapState == null;
             // map settings popup
-            findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(this, viewModel.individualRoute.getValue(), this::refreshMapData, this::routingModeChanged, this::compactIconModeChanged, () -> viewModel.configureProximityNotification(), mapType.filterContext));
+            findViewById(R.id.map_settings_popup).setOnClickListener(v -> MapSettingsUtils.showSettingsPopup(this, viewModel.individualRoute.getValue(), this::refreshMapDataAfterSettingsChanged, this::routingModeChanged, this::compactIconModeChanged, () -> viewModel.configureProximityNotification(), mapType.filterContext));
 
             // routes / tracks popup
             findViewById(R.id.map_individualroute_popup).setOnClickListener(v -> routeTrackUtils.showPopup(viewModel.individualRoute.getValue(), viewModel::setTarget));
@@ -894,6 +894,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     protected GeocacheFilterContext getFilterContext() {
         return mapType.filterContext;
+    }
+
+    private void refreshMapDataAfterSettingsChanged(final boolean circlesSwitched) {
+        refreshMapData(circlesSwitched);
     }
 
     private void refreshMapData(final boolean circlesSwitched) {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
With my limited understanding of the BackgroundHandler and loading caches - but with debugging and trying:
If no `loadInBackgroundHandler` is set, then the caches / waypoints have to be reloaded via `reloadCachesAndWaypoints` to adapt to the possible changes made in the settings-popup.
Reloading and recreating the loadInBackgroundHandler is only done, if the relevant settings have changed.
Therefore I enhanced the `SettingsCheckboxModel` with the possibility to get that information.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #15611
fix #15614
fix #15661

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
