### PR TITLE
UnifiedMap: Reload after enabling live mode (rel. to #15386)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -803,6 +803,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 ActivityMixin.invalidateOptionsMenu(this);
                 setTitle();
                 setMapModeFromMapType();
+                if (Boolean.TRUE.equals(viewModel.transientIsLiveEnabled.getValue())) {
+                    reloadCachesAndWaypoints(false);
+                }
             } else {
                 mapType = new UnifiedMapType();
                 viewModel.transientIsLiveEnabled.setValue(true);


### PR DESCRIPTION
## Description
Trigger a reload of caches/waypoints after enabling live mode to load caches from live map.
Related to https://github.com/cgeo/cgeo/issues/15386#issuecomment-2080153730 (first part)