### PR TITLE
Ensure non-empty display name for trackfiles (rel. to #15567)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/extension/Trackfiles.java
+++ b/main/src/main/java/cgeo/geocaching/storage/extension/Trackfiles.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class Trackfiles extends DataStore.DBExtension {
 
@@ -36,8 +37,10 @@ public class Trackfiles extends DataStore.DBExtension {
         return key;
     }
 
+    @NonNull
+    // must not be null or empty
     public String getDisplayname() {
-        return string1;
+        return StringUtils.isBlank(string1) ? "<???>" : string1;
     }
 
     public boolean isHidden() {
@@ -110,7 +113,9 @@ public class Trackfiles extends DataStore.DBExtension {
         for (DataStore.DBExtension item : getAll(type, null)) {
             result.add(new Trackfiles(item));
         }
-        TextUtils.sortListLocaleAware(result, Trackfiles::getDisplayname);
+        if (result.size() > 0) {
+            TextUtils.sortListLocaleAware(result, Trackfiles::getDisplayname);
+        }
         return result;
     }
 


### PR DESCRIPTION
## Description
Attempts to fix #15567 by
- ensuring `Trackfile.getDisplayname()` never returns an empty or null display name (return a placeholder instead)
- calling sort on returning list of trackfiles only if result set is non-empty

This PR is a shot in the dark, as I have not been able yet to reproduce this error in my environment.