### PR TITLE
avoid NPE in refreshListChooser(), fixes #15676

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -571,9 +571,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private void refreshListChooser() {
         //try to get count of visible caches
         int visibleCaches = 0;
-        final Viewport viewport = mapFragment.getViewport();
-        if (mapFragment != null && viewport != null && viewModel != null) {
-            visibleCaches = viewModel.caches.readWithResult(viewport::count);
+        if (mapFragment != null && mapFragment.getViewport() != null && viewModel != null) {
+            visibleCaches = viewModel.caches.readWithResult(mapFragment.getViewport()::count);
         }
 
         if (mapType.fromList != 0) {


### PR DESCRIPTION
attempt to fix a NPE in UnifiedMapActivity which was apparently introduced by a conflict resolution merge in https://github.com/cgeo/cgeo/commit/74d93a20d0408549ee4442c811f37332cbefdfc8