### PR TITLE
fix #15689: enable finding archived owner caches again (introducing parameter sa=1 in gc.com websearch)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
@@ -128,14 +128,6 @@ public class GCMap {
             fillForBasicFilter(baseFilter, search);
         }
 
-        //special case (see #13891): if we search for owner AND archived caches are not excluded
-        // -> then remove status from filter (otherwise archived caches are not returned from gc.com on Owner search)
-        final StatusGeocacheFilter statusFilter = GeocacheFilter.findInChain(filterAndChain, StatusGeocacheFilter.class);
-        final OwnerGeocacheFilter ownerFilter = GeocacheFilter.findInChain(filterAndChain, OwnerGeocacheFilter.class);
-        if (ownerFilter != null && ownerFilter.isFiltering() && statusFilter != null && !statusFilter.isExcludeArchived()) {
-            search.setStatusEnabled(null);
-        }
-
         search.setSort(GCWebAPI.WebApiSearch.SortType.getByCGeoSortType(sort.getEffectiveType()), sort.isEffectiveAscending());
 
         return search;
@@ -199,7 +191,10 @@ public class GCMap {
                 final StatusGeocacheFilter statusFilter = (StatusGeocacheFilter) basicFilter;
                 search.setStatusFound(statusFilter.getStatusFound());
                 search.setStatusOwn(statusFilter.getStatusOwned());
-                search.setStatusEnabled(statusFilter.isExcludeDisabled() ? Boolean.TRUE : (statusFilter.isExcludeActive() ? FALSE : null));
+                search.setStatusEnabled(
+                        statusFilter.isExcludeDisabled() && statusFilter.isExcludeArchived() ? Boolean.TRUE :
+                                (statusFilter.isExcludeActive() && statusFilter.isExcludeArchived() ? FALSE : null));
+                search.setShowArchived(!statusFilter.isExcludeArchived());
                 break;
             case HIDDEN:
             case EVENT_DATE:

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -108,6 +108,7 @@ public class GCWebAPI {
         private Boolean statusMembership = null;
         private Boolean statusEnabled = null;
         private Boolean statusCorrectedCoordinates = null;
+        private boolean showArchived = true;
 
         private final Set<CacheType> cacheTypes = new HashSet<>();
         private final Set<CacheSize> cacheSizes = new HashSet<>();
@@ -222,6 +223,14 @@ public class GCWebAPI {
          */
         public WebApiSearch setStatusEnabled(final Boolean statusEnabled) {
             this.statusEnabled = statusEnabled;
+            return this;
+        }
+
+        /**
+         * set to true to show archived caches. Note that gc.com respects this setting not in all cases
+         */
+        public WebApiSearch setShowArchived(final boolean showArchived) {
+            this.showArchived = showArchived;
             return this;
         }
 
@@ -440,6 +449,9 @@ public class GCWebAPI {
 
             if (this.statusEnabled != null) {
                 params.put("sd", this.statusEnabled ? "0" : "1");
+            }
+            if (this.showArchived) {
+                params.put("sa", "1");
             }
 
             if (this.statusCorrectedCoordinates != null) {


### PR DESCRIPTION
fix #15689: enable finding archived owner caches again (introducing parameter sa=1 in gc.com websearch)