### PR TITLE
UnifiedMap VTM: Add markers in batches (rel. to #15462)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
@@ -205,7 +205,7 @@ public class GeoItemLayer<K> {
                 providerLayer.onMapChangeBatchEnd(processedCount);
             }
             if (addProcessedInBatch > 0 || removeProcessedInBatch > 0 || replaceProcessedInBatch > 0) {
-                Log.i(logPraefix + "BATCH-END - " +
+                Log.e(logPraefix + "BATCH-END - " +
                         "ADDS:" + addProcessedInBatch + "(" + addProcessed + "), " +
                         "REMOVES:" + removeProcessedInBatch + "(" + removeProcessed + "), " +
                         "REPLACES:" + replaceProcessedInBatch + "(" + replaceProcessed + ")");


### PR DESCRIPTION
## Description
For reference purposes only - this is a technology study, not an actual PR, therefore setting "Do not merge" label.

Brings down marker displaying times on VTM from 140s to app. 10s (9k markers) in my (emulated) test environment.

For details see https://github.com/cgeo/cgeo/issues/15462#issuecomment-2094820119
