### PR TITLE
Support user-defined tile providers (rel. to #15041)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1200,6 +1200,11 @@ public class Settings {
         return sharedPrefs.getStringSet(getKey(R.string.pref_tileprovider_hidden), empty);
     }
 
+    @Nullable
+    public static String getUserDefinedTileProviderUri() {
+        return getString(R.string.pref_userDefinedTileProviderUri, null);
+    }
+
     public static void setMapLanguage(@Nullable final String language) {
         putString(R.string.pref_mapLanguage, StringUtils.isBlank(language) ? "" : language);
     }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -9,6 +9,7 @@ import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.SettingsUtils;
 import cgeo.geocaching.utils.ShareUtils;
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
 import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
@@ -51,6 +52,13 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         }
         hideTileprovidersPref.setEntries(tpEntries);
         hideTileprovidersPref.setEntryValues(tpValues);
+
+        setUserDefinedTileProviderUriSummary(Settings.getUserDefinedTileProviderUri());
+        findPreference(getString(R.string.pref_userDefinedTileProviderUri)).setOnPreferenceChangeListener((preference, newValue) -> {
+            setUserDefinedTileProviderUriSummary(String.valueOf(newValue));
+            return true;
+        });
+
     }
 
     @Override
@@ -153,4 +161,9 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         });
 
     }
+
+    private void setUserDefinedTileProviderUriSummary(final String uri) {
+        SettingsUtils.setPrefSummary(this, R.string.pref_userDefinedTileProviderUri, getString(R.string.settings_userDefinedTileProviderUri) + "\n\n" + uri);
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -160,6 +160,9 @@ public class TileProviderFactory {
         if (offlineMaps.size() > 1) {
             registerTileProvider(new MapsforgeMultiOfflineTileProvider(offlineMaps));
         }
+        if (UserDefinedMapsforgeOnlineSource.isConfigured()) {
+            registerTileProvider(new UserDefinedMapsforgeOnlineSource());
+        }
         for (ImmutablePair<String, Uri> data : offlineMaps) {
             registerTileProvider(new AbstractMapsforgeOfflineTileProvider(data.left, data.right, 0, 18));   // @todo: get actual values for zoomMin/zoomMax
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
@@ -1,0 +1,22 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+import org.apache.commons.lang3.StringUtils;
+import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
+
+public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTileProvider {
+    UserDefinedMapsforgeOnlineSource() {
+        super(CgeoApplication.getInstance().getString(R.string.settings_userDefinedTileProvider), Uri.parse(Settings.getUserDefinedTileProviderUri()), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.settings_userDefinedTileProvider), true));
+    }
+
+    public static boolean isConfigured() {
+        return StringUtils.isNotBlank(Settings.getUserDefinedTileProviderUri());
+    }
+}

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -228,6 +228,7 @@
     <string translatable="false" name="pref_tileprovider_hidden">tileprovider_hidden</string>
     <string translatable="false" name="pref_useUnifiedMap">featureSwitch_useUnifiedMap</string>
     <string translatable="false" name="pref_useDelayedMapFragment">feature_delayedMapFragment</string>
+    <string translatable="false" name="pref_userDefinedTileProviderUri">userDefinedTileProviderUri</string>
 
     <!-- category other -->
     <string translatable="false" name="pref_map_osm_multithreaded">map_osm_multithreaded</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -889,6 +889,8 @@
     <string name="settings_title_map_style">Map style</string>
     <string name="settings_hide_tileproviders_title">Hide Map Sources</string>
     <string name="settings_hide_tileproviders_summary">Exclude one or more map sources from map source selection</string>
+    <string name="settings_userDefinedTileProvider">User-defined tile provider</string>
+    <string name="settings_userDefinedTileProviderUri">Enter full Uri (without trailing slash) to tile provider. Make sure you have checked and comply to their usage conditions.</string>
     <string name="settings_title_data_dir">Geocache data folder</string>
     <string name="settings_title_data_dir_usage">Geocache data folder (%1$s used)</string>
     <string name="calculate_dataDir_title">Geocache data usage</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -132,6 +132,12 @@
             android:title="@string/settings_hide_tileproviders_title"
             android:summary="@string/settings_hide_tileproviders_summary"
             app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.TextPreference
+            android:defaultValue=""
+            android:key="@string/pref_userDefinedTileProviderUri"
+            android:title="@string/settings_userDefinedTileProvider"
+            android:summary="@string/settings_userDefinedTileProviderUri"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
Allows user-entered Uri for tile provider and selection of "User-defined tile provider" if such provider is configured:

![image](https://github.com/cgeo/cgeo/assets/3754370/37c5e414-7a6c-40d2-a992-bfd9618770f6).![image](https://github.com/cgeo/cgeo/assets/3754370/0cb74e57-27f3-4de7-b9f7-36c97f200911)

Implemented for UnifiedMap only.

(Default value is: no user-defined tile provider configured)