### PR TITLE
Add event date to cache selector (fix #15704)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import java.util.Date;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
@@ -48,6 +49,12 @@ public class GeoItemSelectorUtils {
         }
         if (cache.getTerrain() > 0.1f) {
             text.append(Formatter.SEPARATOR).append("T ").append(cache.getTerrain());
+        }
+        if (cache.isEventCache()) {
+            final Date d = cache.getHiddenDate();
+            if (d != null) {
+                text.append(Formatter.SEPARATOR).append(Formatter.formatShortDate(d.getTime()));
+            }
         }
 
         setViewValues(view, cacheName, TextParam.text(text), cacheIcon);


### PR DESCRIPTION
## Description
Adds event date to map's item selector for event type-caches:

![image](https://github.com/cgeo/cgeo/assets/3754370/df041b0f-05c3-4218-bc02-2d47cbb9a761)
