### PR TITLE
Enable internal routing and auto tile download by default (fix #15701)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1374,7 +1374,7 @@ public class Settings {
     }
 
     public static boolean isBrouterAutoTileDownloads() {
-        return getBoolean(R.string.pref_brouterAutoTileDownloads, false);
+        return getBoolean(R.string.pref_brouterAutoTileDownloads, true);
     }
 
     public static void setBrouterAutoTileDownloads(final boolean value) {
@@ -2050,7 +2050,7 @@ public class Settings {
     }
 
     public static boolean useInternalRouting() {
-        return getBoolean(R.string.pref_useInternalRouting, false);
+        return getBoolean(R.string.pref_useInternalRouting, true);
     }
 
     public static boolean getBackupLoginData() {

--- a/main/src/main/res/xml/preferences_navigation.xml
+++ b/main/src/main/res/xml/preferences_navigation.xml
@@ -33,7 +33,7 @@
             app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="@string/pref_useInternalRouting"
             android:summary="@string/init_summary_useInternalRouting"
             android:title="@string/init_useInternalRouting"
@@ -46,7 +46,7 @@
             app:iconSpaceReserved="false" />
 
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:dependency="@string/pref_useInternalRouting"
             android:key="@string/pref_brouterAutoTileDownloads"
             android:summary="@string/init_brouterAutoTileDownloads_description"


### PR DESCRIPTION
- If you have a fresh install of c:geo and create a route, c:geo will now automatically ask you if it should try to download missing routing tiles
- does not affect existing installations
