### PR TITLE
Export individual route as track with single segment (fix #15684)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/export/IndividualRouteExportTask.java
+++ b/main/src/main/java/cgeo/geocaching/export/IndividualRouteExportTask.java
@@ -88,10 +88,12 @@ public class IndividualRouteExportTask extends AsyncTaskWithProgress<RouteSegmen
 
             gpx.startTag(NS_GPX, exportAsTrack ? "trk" : "rte");
             XmlUtils.simpleText(gpx, NS_GPX, "name", "c:geo individual route " + timeInfo);
+            if (exportAsTrack) {
+                gpx.startTag(null, "trkseg");
+            }
             for (RouteSegment loc : trail) {
                 final String segmentName = loc.getItem().getIdentifier();
                 if (exportAsTrack) {
-                    gpx.startTag(null, "trkseg");
                     final ArrayList<Geopoint> points = loc.getPoints();
                     // trkseg does not have a name entity, so we put the name into the last trkpt
                     final int size = points.size();
@@ -100,12 +102,14 @@ public class IndividualRouteExportTask extends AsyncTaskWithProgress<RouteSegmen
                         exportPoint(gpx, "trkpt", point, current < size ? null : segmentName);
                         current++;
                     }
-                    gpx.endTag(null, "trkseg");
                 } else {
                     exportPoint(gpx, "rtept", loc.getPoint(), segmentName);
                 }
                 countExported++;
                 publishProgress(countExported);
+            }
+            if (exportAsTrack) {
+                gpx.endTag(null, "trkseg");
             }
             gpx.endTag(NS_GPX, exportAsTrack ? "trk" : "rte");
             gpx.endTag(NS_GPX, "gpx");


### PR DESCRIPTION
## Description
Use only a single track segment when exporting an individual route as track