### PR TITLE
Update locus with CacheSize "Virtual"

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -360,7 +360,7 @@ dependencies {
     implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
 
     // Locus Maps integration
-    implementation "com.asamm:locus-api-android:0.9.50"
+    implementation "com.asamm:locus-api-android:0.9.55"
 
     // -- Mapsforge / Mapsforge --
 

--- a/main/src/main/java/cgeo/geocaching/apps/AbstractLocusApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/AbstractLocusApp.java
@@ -346,7 +346,7 @@ public abstract class AbstractLocusApp extends AbstractApp {
             case NOT_CHOSEN:
                 return GeocachingData.CACHE_SIZE_NOT_CHOSEN;
             case VIRTUAL:
-                return GeocachingData.CACHE_SIZE_OTHER;
+                return GeocachingData.CACHE_SIZE_VIRTUAL;
             case OTHER:
                 return GeocachingData.CACHE_SIZE_OTHER;
             case UNKNOWN:

--- a/main/src/test/java/cgeo/geocaching/apps/AbstractLocusAppTest.java
+++ b/main/src/test/java/cgeo/geocaching/apps/AbstractLocusAppTest.java
@@ -53,7 +53,8 @@ public class AbstractLocusAppTest {
 
         final HashMap<CacheSize, Integer> testSizeList = new HashMap<>();
         testSizeList.put(CacheSize.NANO, GeocachingData.CACHE_SIZE_MICRO);
-        testSizeList.put(CacheSize.VIRTUAL, GeocachingData.CACHE_SIZE_OTHER);
+        testSizeList.put(CacheSize.VIRTUAL, GeocachingData.CACHE_SIZE_VIRTUAL);
+        testSizeList.put(CacheSize.OTHER, GeocachingData.CACHE_SIZE_OTHER);
         testSizeList.put(CacheSize.UNKNOWN, GeocachingData.CACHE_SIZE_NOT_CHOSEN);
 
         final ArrayList<CacheSize> testCgeoSizes = new ArrayList<>(testSizeList.keySet());


### PR DESCRIPTION
replaces #15700.

As the locus connector now integrates the cache size virtual, we can now map caches with this size in c:geo to the virtual size in Locus.