### PR TITLE
ticket #926180: remove separate log length check

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -40,7 +40,6 @@ import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
-import cgeo.geocaching.utils.TextUtils;
 
 import android.app.Activity;
 import android.content.Context;
@@ -499,13 +498,9 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
         Log.v("LogCacheActivity.onOptionsItemSelected(" + item.getItemId() + "/" + item.getTitle() + ")");
         final int itemId = item.getItemId();
         if (itemId == R.id.menu_send) {
-            final int logLength = TextUtils.getNormalizedStringLength(binding.log.getText().toString());
+            final int logLength = binding.log.getText().toString().trim().length();
             if (logLength > 0) {
-                if (logLength <= LOG_MAX_LENGTH) {
-                    sendLogAndConfirm();
-                } else {
-                    Toast.makeText(this, R.string.cache_log_too_long, Toast.LENGTH_LONG).show();
-                }
+                sendLogAndConfirm();
             } else {
                 Toast.makeText(this, R.string.cache_empty_log, Toast.LENGTH_LONG).show();
             }

--- a/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
@@ -207,16 +207,6 @@ public final class TextUtils {
     }
 
     /**
-     * @param str input string
-     *            As of performance reasons we non't use a REGEX here. Don't use this function for strings which could contain new-line characters like "\r\n" or "\r"
-     * @return normalized String Length like it is counted at the gc website (count UNIX new-line character "\n" as two characters)
-     */
-    public static int getNormalizedStringLength(@NonNull final String str) {
-        final String newStr = str.trim();
-        return StringUtils.countMatches(newStr, "\n") + newStr.length();
-    }
-
-    /**
      * Quick and naive check for possible rich HTML content in a string.
      *
      * @param str A string containing HTML code.

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1584,7 +1584,6 @@
     <string name="no_browser_found">No browser found</string>
     <string name="cache_menu_open_with">Open with…</string>
     <string name="cache_menu_visit">Log Visit</string>
-    <string name="cache_log_too_long">c:geo couldn\'t submit your log cause it is too long. But thanks for trying to write such an extensive log ;-)</string>
     <string name="cache_empty_log">c:geo couldn\'t submit your log cause it is empty.</string>
     <string name="cache_menu_visit_offline">Quick offline log</string>
     <string name="cache_menu_spoilers">Spoiler images</string>


### PR DESCRIPTION
ticket #926180: remove separate log length check

c:geo contained a separate log length check in addition to the "log text counter" in the text field. This length check counted line break as two characters. This seems to be a legacy thing, as of now gc.com counts line breaks only as one character. Thus this PR removes the separate check.

This solves a problem reported in the mentioned support ticket with log lengths close to 5000 characters