### PR TITLE
UnifiedMap VTM: Initialize 'buildings 3D' checkbox

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -875,6 +875,10 @@ public class Settings {
         }
     }
 
+    public static boolean getBuildings3D() {
+        return getBoolean(R.string.pref_buildingLayer3D, true);
+    }
+
     public static boolean isAutotargetIndividualRoute() {
         return getBoolean(R.string.pref_autotarget_individualroute, false);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
@@ -169,7 +169,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         setSelectedTheme(selectedTheme);
 
         if (tileProvider instanceof AbstractMapsforgeOfflineTileProvider) {
-            ((AbstractMapsforgeOfflineTileProvider) tileProvider).switchBuildingLayer(Settings.getBoolean(R.string.pref_buildingLayer3D, true));
+            ((AbstractMapsforgeOfflineTileProvider) tileProvider).switchBuildingLayer(Settings.getBuildings3D());
         }
 
         map.updateMap(true);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeSettingsFragment.java
@@ -75,6 +75,7 @@ public class MapsforgeThemeSettingsFragment extends PreferenceFragmentCompat {
             final CheckBoxPreference cb3D = new CheckBoxPreference(activity);
             cb3D.setKey(activity.getString(R.string.pref_buildingLayer3D));
             cb3D.setTitle(R.string.maptheme_show3Dbuildings);
+            cb3D.setChecked(Settings.getBuildings3D());
             cb3D.setIconSpaceReserved(false);
             this.renderthemeMenu.addPreference(cb3D);
         }


### PR DESCRIPTION
(dynamically created checkbox for "buildings in 3D" option missed initialization, see https://github.com/cgeo/cgeo/issues/15723#issuecomment-2156435095)