### PR TITLE
fix #15618: Don't overwrite sortContext 

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1146,8 +1146,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     }
 
     private void initAdapter() {
-
-        sortContext = GeocacheSortContext.getFor(type, "" + listId);
         final ListView listView = getListView();
         registerForContextMenu(listView);
 
@@ -1521,6 +1519,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
             Settings.setLastDisplayedList(listId);
         }
+
+        sortContext = GeocacheSortContext.getFor(type, "" + listId);
 
         initAdapter();
         setFilter();


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Use correct sortContext for search with target-coords:
The created sortContext (with target-coords) in CacheListAdapter.onCreate was overwritten by CacheListAdapter.initAdapter, hence the target-coords got lost.
No need to create the sortContext in initAdapter.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #15618

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->