### PR TITLE
Move cache store/refresh from popup into background

### DIFF
--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -98,6 +98,15 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
 
     }
 
+    public static void storeCache(final Activity context, final Geocache cache, final boolean fastStoreOnLastSelection, @Nullable final Runnable onStartCallback) {
+        if (Settings.getChooseList() || cache.isOffline()) {
+            // let user select list to store cache in
+            new StoredList.UserInterface(context).promptForMultiListSelection(R.string.lists_title, selectedListIds -> downloadCachesInternal(context, Collections.singleton(cache.getGeocode()), selectedListIds, cache.isOffline(), true, onStartCallback), true, Collections.emptySet(), fastStoreOnLastSelection);
+        } else {
+            downloadCachesInternal(context, Collections.singleton(cache.getGeocode()), Collections.singleton(StoredList.STANDARD_LIST_ID), false, true, onStartCallback);
+        }
+    }
+
     public static void refreshCache(final Activity context, final String geocode, final boolean isOffline, @Nullable final Runnable onStartCallback) {
         askForListsIfNecessaryAndDownload(context, Collections.singleton(geocode), isOffline, true, isOffline, onStartCallback);
     }

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -118,6 +118,16 @@ public class ViewUtils {
     }
 
     /**
+     * Sets enabled/disabled flag for given view (without crashing on null view)
+     */
+    public static void setEnabled(final View view, final boolean enabled) {
+        if (view == null) {
+            return;
+        }
+        view.setEnabled(enabled);
+    }
+
+    /**
      * Sets enabled/disabled flag for given view and all nested child views recursively
      */
     public static void setEnabledDeep(final View view, final boolean enabled) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1566,8 +1566,6 @@
     <string name="cache_dialog_offline_save_message">Saving cache for offline use…</string>
     <string name="cache_dialog_offline_drop_title">Offline</string>
     <string name="cache_dialog_offline_drop_message">Removing cache from device memory…</string>
-    <string name="cache_dialog_refresh_title">Refresh</string>
-    <string name="cache_dialog_refresh_message">Reloading cache details…</string>
     <string name="cache_menu_speechDeactivate">Stop talking</string>
     <string name="cache_menu_speechActivate">Start talking</string>
     <string name="cache_menu_navigate">Navigate</string>


### PR DESCRIPTION
- download caches in background when triggering a store / refresh from cache popup
- disable the refresh / store buttons when starting the download
- update popup contents on having successfully received the cache data
