### PR TITLE
fix #15770: add google map options and hybrid map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -562,11 +562,16 @@ public class Settings {
     }
 
     public static void putBoolean(final int prefKeyId, final boolean value) {
+        putBooleanDirect(getKey(prefKeyId), value);
+    }
+
+    public static void putBooleanDirect(final String key, final boolean value) {
+
         if (sharedPrefs == null) {
             return;
         }
         final SharedPreferences.Editor edit = sharedPrefs.edit();
-        edit.putBoolean(getKey(prefKeyId), value);
+        edit.putBoolean(key, value);
         edit.apply();
     }
 
@@ -2360,6 +2365,16 @@ public class Settings {
 
     public static String getSelectedGoogleMapTheme() {
         return getString(R.string.pref_google_map_theme, "DEFAULT");
+    }
+
+    public static boolean isGoogleMapOptionEnabled(final String option, final boolean defaultValue) {
+        final String key = getKey(R.string.pref_google_map_option_enabled) + "." + option;
+        return getBooleanDirect(key, defaultValue);
+    }
+
+    public static void setGoogleMapOptionEnabled(final String option, final boolean enabled) {
+        final String key = getKey(R.string.pref_google_map_option_enabled) + "." + option;
+        putBooleanDirect(key, enabled);
     }
 
     public static boolean getHintAsRot13() {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
@@ -151,6 +151,7 @@ public abstract class AbstractMapFragment extends Fragment {
     // ========================================================================
     // theme & language related methods
 
+
     public void selectTheme(final Activity activity) {
         // default is empty
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -784,7 +784,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         }
         menu.findItem(R.id.menu_map_rotation_auto_precise).setVisible(true); // UnifiedMap supports high precision auto-rotate
 
-        // theming options
+        // map and theming options
         menu.findItem(R.id.menu_theme_mode).setVisible(tileProvider.supportsThemes());
         menu.findItem(R.id.menu_theme_options).setVisible(tileProvider.supportsThemeOptions());
         menu.findItem(R.id.menu_theme_legend).setVisible(tileProvider.supportsThemes() && RenderThemeLegend.supportsLegend());

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
@@ -89,6 +89,7 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
     @Override
     public void onMapReady(final @NonNull GoogleMap googleMap) {
         mMap = googleMap;
+
         mapController.setGoogleMap(googleMap);
         googleMap.getUiSettings().setZoomControlsEnabled(false);
         setMapRotation(Settings.getMapRotation());
@@ -277,18 +278,19 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
     // theme & language related methods
 
     @Override
+    public void selectThemeOptions(final Activity activity) {
+        final int mapType = ((AbstractGoogleTileProvider) currentTileProvider).getMapType();
+        GoogleMapsThemeHelper.selectThemeOptions(activity, mapType, mMap, scaleDrawer);
+    }
+
+    @Override
     public void selectTheme(final Activity activity) {
-        GoogleMapsThemeHelper.selectTheme(activity, mMap, this::applyTheme);
+        GoogleMapsThemeHelper.selectTheme(activity, mMap, scaleDrawer);
     }
 
     @Override
     public void applyTheme() {
-        applyTheme(GoogleMapsThemeHelper.GoogleMapsThemes.getByName(Settings.getSelectedGoogleMapTheme()));
-    }
-
-    public void applyTheme(final GoogleMapsThemeHelper.GoogleMapsThemes theme) {
-        scaleDrawer.setNeedsInvertedColors(theme.needsInvertedColors);
-        GoogleMapsThemeHelper.setTheme(requireActivity(), mMap, theme);
+        GoogleMapsThemeHelper.setCurrentThemeOnMap(mMap, scaleDrawer);
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsThemeHelper.java
@@ -1,74 +1,154 @@
 package cgeo.geocaching.unifiedmap.googlemaps;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.ui.dialog.Dialogs;
-import cgeo.geocaching.utils.functions.Action1;
+import cgeo.geocaching.ui.SimpleItemListModel;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.EnumValueMapper;
+import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.JsonUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+import cgeo.geocaching.utils.Log;
 
 import android.app.Activity;
-import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
+import androidx.annotation.StringRes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.MapStyleOptions;
 
 class GoogleMapsThemeHelper {
 
-    public enum GoogleMapsThemes {
+    private enum GoogleMapsTheme {
         DEFAULT(R.string.google_maps_style_default, 0, false),
         NIGHT(R.string.google_maps_style_night, R.raw.googlemap_style_night, true),
         AUTO(R.string.google_maps_style_auto, 0, false),
         RETRO(R.string.google_maps_style_retro, R.raw.googlemap_style_retro, false),
-        CONTRAST(R.string.google_maps_style_contrast, R.raw.googlemap_style_contrast, false),
-        DETAILS(R.string.google_maps_style_details, R.raw.googlemap_style_details, false);
+        CONTRAST(R.string.google_maps_style_contrast, R.raw.googlemap_style_contrast, false);
 
         final int labelRes;
         final int jsonRes;
         final boolean needsInvertedColors; // for scale bar drawing
 
-        GoogleMapsThemes(final int labelRes, final int jsonRes, final boolean needsInvertedColors) {
+        private static final EnumValueMapper<String, GoogleMapsTheme> NAME_TO_THEME = new EnumValueMapper<>();
+
+        static {
+            for (GoogleMapsTheme type : values()) {
+                NAME_TO_THEME.add(type, type.name());
+            }
+        }
+
+        GoogleMapsTheme(final int labelRes, final int jsonRes, final boolean needsInvertedColors) {
             this.labelRes = labelRes;
             this.jsonRes = jsonRes;
             this.needsInvertedColors = needsInvertedColors;
         }
 
         @Nullable
-        public MapStyleOptions getMapStyleOptions(final Context context) {
+        public ArrayNode getMapStyleOptions() {
             final int jsonResId;
             if (this == AUTO) {
-                jsonResId = Settings.isLightSkin(context) ? DEFAULT.jsonRes : NIGHT.jsonRes;
+                jsonResId = Settings.isLightSkin(CgeoApplication.getInstance()) ? DEFAULT.jsonRes : NIGHT.jsonRes;
             } else {
                 jsonResId = this.jsonRes;
             }
             if (jsonResId != 0) {
-                return MapStyleOptions.loadRawResourceStyle(context, jsonResId);
+                try {
+                    final String rawJson = FileUtils.getRawResourceAsString(CgeoApplication.getInstance(), jsonResId);
+                    return (ArrayNode) JsonUtils.stringToNode(rawJson);
+                } catch (RuntimeException ioe) {
+                    Log.e("FAILED to read Google Maps Style ressource for " + this, ioe);
+                }
             }
             return null;
         }
 
-        @NonNull
-        public static List<String> getLabels(final Context context) {
-            final List<String> themeLabels = new ArrayList<>();
-            for (GoogleMapsThemes theme : GoogleMapsThemes.values()) {
-                themeLabels.add(context.getResources().getString(theme.labelRes));
-            }
-            return themeLabels;
+        public String getLabel() {
+            return LocalizationUtils.getString(this.labelRes);
         }
 
         @NonNull
-        public static GoogleMapsThemes getByName(final String themeName) {
-            for (GoogleMapsThemes theme : GoogleMapsThemes.values()) {
-                if (theme.name().equals(themeName)) {
-                    return theme;
-                }
+        private static GoogleMapsTheme getByName(final String themeName) {
+            return NAME_TO_THEME.get(themeName, DEFAULT);
+        }
+
+        public static GoogleMapsTheme getCurrent() {
+            return getByName(Settings.getSelectedGoogleMapTheme());
+        }
+
+        public static void setCurrent(final GoogleMapsTheme theme) {
+            Settings.setSelectedGoogleMapTheme(theme == null ? DEFAULT.name() : theme.name());
+        }
+    }
+
+    private enum GoogleMapsThemeOption {
+        TRAFFIC(R.string.google_maps_option_show_traffic, null, false, false),
+        BUILDINGS(R.string.google_maps_option_show_buildings, null, false, false),
+        SHOW_FEATURE_THEME(R.string.google_maps_option_show_feature_theme, null, true, true),
+        SHOW_FEATURE_ADMINISTRATIVE_ALL(R.string.google_maps_option_show_feature_administrative_all, "administrative"),
+        SHOW_FEATURE_LANDSCAPE_ALL(R.string.google_maps_option_show_feature_landscape_all, "landscape"),
+        SHOW_FEATURE_POI_ALL(R.string.google_maps_option_show_feature_poi_all, "poi"),
+        SHOW_FEATURE_ROAD_ALL(R.string.google_maps_option_show_feature_road_all, "road"),
+        SHOW_FEATURE_TRANSIT_ALL(R.string.google_maps_option_show_feature_transit_all, "transit"),
+        SHOW_FEATURE_WATER_ALL(R.string.google_maps_option_show_feature_water_all, "water");
+
+        private static final String ALL_THEMES = "all";
+
+        @StringRes
+        final int labelRes;
+        final boolean isThemeSpecific; //true=Map Option, false = Theme option
+        final String featureName; // for named features. Name is json-tag in Google Map Style object
+        final boolean defaultValue; //if no setting is present, this value is used
+
+        GoogleMapsThemeOption(final int labelRes, final String featureName) {
+            this(labelRes, featureName, true, false);
+        }
+        GoogleMapsThemeOption(final int labelRes, final String featureName, final boolean isThemeSpecific, final boolean defaultValue) {
+            this.labelRes = labelRes;
+            this.isThemeSpecific = isThemeSpecific;
+            this.featureName = featureName;
+            this.defaultValue = defaultValue;
+        }
+
+        public String getLabel() {
+            return LocalizationUtils.getString(this.labelRes);
+        }
+
+        public String getFeatureName() {
+            return featureName;
+        }
+
+        public boolean validForMapType(final int googleMapType) {
+            if (TRAFFIC == this) {
+                return true;
             }
-            return DEFAULT;
+            return googleMapType == GoogleMap.MAP_TYPE_NORMAL;
+        }
+
+        public boolean isEnabled(final GoogleMapsTheme theme) {
+            return Settings.isGoogleMapOptionEnabled(settingsKeyPraefix(theme), defaultValue);
+        }
+
+        public void setEnabled(final GoogleMapsTheme theme, final boolean enabled) {
+            Settings.setGoogleMapOptionEnabled(settingsKeyPraefix(theme), enabled);
+        }
+
+        private String settingsKeyPraefix(final GoogleMapsTheme theme) {
+            return (isThemeSpecific ? theme.name() : ALL_THEMES) + "." + name();
         }
     }
 
@@ -76,27 +156,131 @@ class GoogleMapsThemeHelper {
         // utility class
     }
 
-    /** Open theme selection dialog for GM map view, store result in settings */
-    public static void selectTheme(final Activity activity, final GoogleMap googleMap, final Action1<GoogleMapsThemes> onThemeSelected) {
-        final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
-        builder.setTitle(R.string.map_theme_select);
+    /** Open theme selection dialog for GM map view, store result in settings and applies it to map */
+    public static void selectTheme(@NonNull final Activity activity, @NonNull final GoogleMap map, @Nullable final ScaleDrawer scaleDrawer) {
+        final SimpleDialog.ItemSelectModel<GoogleMapsTheme> model = new SimpleDialog.ItemSelectModel<>();
+        model
+            .setItems(Arrays.asList(GoogleMapsTheme.values()))
+            .setDisplayMapper((l) -> TextParam.text(l.getLabel()))
+            .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_RADIO)
+            .setSelectedItems(Collections.singleton(GoogleMapsTheme.getCurrent()));
 
-        final int selectedItem = GoogleMapsThemes.getByName(Settings.getSelectedGoogleMapTheme()).ordinal();
-
-        builder.setSingleChoiceItems(GoogleMapsThemes.getLabels(activity).toArray(new String[0]), selectedItem, (dialog, selection) -> {
-            final GoogleMapsThemes theme = GoogleMapsThemes.values()[selection];
-            Settings.setSelectedGoogleMapTheme(theme.name());
-            onThemeSelected.call(theme);
-            dialog.cancel();
+        SimpleDialog.of(activity).setTitle(R.string.map_theme_select).selectSingle(model, theme -> {
+            GoogleMapsTheme.setCurrent(theme);
+            setCurrentThemeOnMap(map, scaleDrawer);
         });
-
-        builder.show();
     }
 
-    /** Apply selected GM theme to map (use default theme, if none is selected) */
-    public static GoogleMapsThemes setTheme(final Activity activity, final GoogleMap googleMap, final GoogleMapsThemes theme) {
-        googleMap.setMapStyle(theme.getMapStyleOptions(activity));
-        return theme;
+    public static void selectThemeOptions(@NonNull final Activity activity, final int mapType, @NonNull final GoogleMap map, @Nullable final ScaleDrawer scaleDrawer) {
+        final GoogleMapsTheme theme = GoogleMapsTheme.getCurrent();
+        //find out which features should be preselected
+        final Set<GoogleMapsThemeOption> selected = new HashSet<>();
+        for (GoogleMapsThemeOption option : GoogleMapsThemeOption.values()) {
+            if (option.isEnabled(theme)) {
+                selected.add(option);
+            }
+        }
+        //find out which features should be presented for user selection
+        final List<GoogleMapsThemeOption> options = new ArrayList<>();
+        for (GoogleMapsThemeOption option : GoogleMapsThemeOption.values()) {
+            if (option.validForMapType(mapType)) {
+                options.add(option);
+            }
+        }
+
+        //construct dialog
+        final SimpleDialog.ItemSelectModel<GoogleMapsThemeOption> model = new SimpleDialog.ItemSelectModel<>();
+        model
+            .setItems(options)
+            .setDisplayMapper((l) -> TextParam.text(l.getLabel()))
+            .setChoiceMode(SimpleItemListModel.ChoiceMode.MULTI_CHECKBOX)
+            .setSelectedItems(selected)
+            .activateGrouping(l -> LocalizationUtils.getString(l.isThemeSpecific ? R.string.google_maps_option_group_theme : R.string.google_maps_option_group_map))
+            .setGroupDisplayMapper(s -> TextParam.text("**" + s + "**").setMarkdown(true));
+
+        SimpleDialog.of(activity).setTitle(R.string.map_theme_options).selectMultiple(model, selectedOptions -> {
+            for (GoogleMapsThemeOption option : GoogleMapsThemeOption.values()) {
+                option.setEnabled(theme, selectedOptions.contains(option));
+            }
+            setCurrentThemeOnMap(map, scaleDrawer);
+        });
+    }
+
+    /** apply theme options to given GM as currently stored in settings */
+    public static void setCurrentThemeOnMap(@NonNull final GoogleMap map, @Nullable final ScaleDrawer scaleDrawer) {
+        final GoogleMapsTheme theme = GoogleMapsTheme.getCurrent();
+
+        // -- Apply Theme options
+        ArrayNode style = theme.getMapStyleOptions();
+
+        //1. find out if ALL features are enabled
+        boolean allThemeOptionsEnabled = true;
+        for (GoogleMapsThemeOption option : GoogleMapsThemeOption.values()) {
+            if (option.getFeatureName() != null && !option.isEnabled(theme)) {
+                allThemeOptionsEnabled = false;
+                break;
+            }
+        }
+
+        if (allThemeOptionsEnabled) {
+            //2. if yes, then simply set all features to visible
+            style = addStyler(style, GoogleMapsThemeOption.SHOW_FEATURE_THEME, true);
+        } else {
+            //3. if theme options should not be considered, then reset visibilities to "all off" for a stark
+            if (!GoogleMapsThemeOption.SHOW_FEATURE_THEME.isEnabled(theme)) {
+                style = addStyler(style, GoogleMapsThemeOption.SHOW_FEATURE_THEME, false);
+            }
+            //4. then turn on visibilities for all selected features
+            for (GoogleMapsThemeOption option : GoogleMapsThemeOption.values()) {
+                if (option.getFeatureName() == null || !option.isEnabled(theme)) {
+                    continue;
+                }
+                style = addStyler(style, option, true);
+            }
+        }
+        //5. apply map style constructed above to Google Map
+        map.setMapStyle(style == null ? null : new MapStyleOptions(JsonUtils.nodeToString(style)));
+        //6. adjust scaleDrawer as needed
+        if (scaleDrawer != null) {
+            scaleDrawer.setNeedsInvertedColors(theme.needsInvertedColors);
+        }
+
+        // --  Apply map options
+        map.setTrafficEnabled(GoogleMapsThemeOption.TRAFFIC.isEnabled(theme));
+        map.setBuildingsEnabled(GoogleMapsThemeOption.BUILDINGS.isEnabled(theme));
+    }
+
+    private static ArrayNode addStyler(final ArrayNode inputNode, final GoogleMapsThemeOption option, final boolean on) {
+        ArrayNode node = inputNode;
+        if (node == null) {
+            node = JsonUtils.createArrayNode();
+        }
+        node.add(createVisibilityOnStylerForFeatureType(option.getFeatureName(), on));
+        return node;
+    }
+
+    /**
+     * Creates JSON like following example:
+     * {
+     *     "featureType": "parameter",
+     *     "stylers": [
+     *       {
+     *         "visibility": "on"
+     *       }
+     *     ]
+     *   }
+     */
+    private static JsonNode createVisibilityOnStylerForFeatureType(@Nullable final String featureType, final boolean on) {
+        final ObjectNode node = JsonUtils.createObjectNode();
+        if (featureType != null) {
+            JsonUtils.setText(node, "featureType", featureType);
+        }
+        final ObjectNode visibilityNode = JsonUtils.createObjectNode();
+        JsonUtils.setText(visibilityNode, "visibility", on ? "on" : "off");
+        final ArrayNode stylers = JsonUtils.createArrayNode();
+        stylers.add(visibilityNode);
+        JsonUtils.set(node, "stylers", stylers);
+        return node;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractGoogleTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractGoogleTileProvider.java
@@ -20,12 +20,17 @@ public class AbstractGoogleTileProvider extends AbstractTileProvider implements 
         super(2, 21, new Pair<>("", false));
         this.mapType = mapType;
         this.tileProviderName = CgeoApplication.getInstance().getString(nameRes);
+        this.supportsThemeOptions = true;
     }
 
     public void setMapType(final GoogleMap googleMap) {
         if (googleMap != null) {
             googleMap.setMapType(mapType);
         }
+    }
+
+    public int getMapType() {
+        return mapType;
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/GoogleSatelliteSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/GoogleSatelliteSource.java
@@ -7,6 +7,6 @@ import com.google.android.gms.maps.GoogleMap;
 class GoogleSatelliteSource extends AbstractGoogleTileProvider {
 
     GoogleSatelliteSource() {
-        super(GoogleMap.MAP_TYPE_SATELLITE, R.string.map_source_google_satellite);
+        super(GoogleMap.MAP_TYPE_HYBRID, R.string.map_source_google_satellite);
     }
 }

--- a/main/src/main/res/raw/googlemap_style_details.json
+++ b/main/src/main/res/raw/googlemap_style_details.json
@@ -1,9 +1,0 @@
-[
-  {
-    "stylers": [
-      {
-        "visibility": "on"
-      }
-    ]
-  }
-]

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -547,6 +547,7 @@
     <string translatable="false" name="pref_map_routing">map_routing</string>
     <string translatable="false" name="pref_theme_menu">theme_menu</string>
     <string translatable="false" name="pref_google_map_theme">google_map_theme</string>
+    <string translatable="false" name="pref_google_map_option_enabled">google_map_option_enabled</string>
     <string translatable="false" name="pref_mapCacheScaling">mapCacheScaling</string>
     <string translatable="false" name="pref_mapWpScaling">mapWpScaling</string>
     <string translatable="false" name="pref_mapScaleOnly">mapScaleOnly</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1958,6 +1958,17 @@
     <string name="google_maps_style_contrast">High Contrast</string>
     <string name="google_maps_style_auto">Device theme (Day/Night)</string>
     <string name="google_maps_style_details">Details</string>
+    <string name="google_maps_option_group_map">Map Options</string>
+    <string name="google_maps_option_show_traffic">Show Traffic</string>
+    <string name="google_maps_option_show_buildings">Show 3D buildings</string>
+    <string name="google_maps_option_group_theme">Theme Options</string>
+    <string name="google_maps_option_show_feature_theme">Show Theme features</string>
+    <string name="google_maps_option_show_feature_administrative_all">Show Administrative</string>
+    <string name="google_maps_option_show_feature_landscape_all">Show Landscape</string>
+    <string name="google_maps_option_show_feature_poi_all">Show Points of Interest</string>
+    <string name="google_maps_option_show_feature_road_all">Show Roads</string>
+    <string name="google_maps_option_show_feature_transit_all">Show Transit</string>
+    <string name="google_maps_option_show_feature_water_all">Show Water</string>
 
     <!-- search -->
     <string name="geo_search_label">Search caches nearby</string>


### PR DESCRIPTION
rel to #15770: add google map options and hybrid map

* corrects a bug: Google Map option "Satellite" does now use "Hybrid" again (like in old map)
* adds Google Map options to show "traffic" as well as "(3d) buildings", both defaulting to false