### PR TITLE
add "corrected coordinates" filter

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/StatusFilterViewHolder.java
@@ -36,6 +36,7 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
     private ButtonToggleGroup statusHasTrackable = null;
     private ButtonToggleGroup statusHasOwnVote = null;
     private ButtonToggleGroup statusSolvedMystery = null;
+    private ButtonToggleGroup statusCorrectedCoordinates = null;
     private ButtonToggleGroup statusHasUserDefinedWaypoints = null;
 
     private final List<ButtonToggleGroup> advancedGroups = new ArrayList<>();
@@ -98,6 +99,7 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         statusHasOwnVote = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OWN_VOTE, true);
         statusHasOfflineLog = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_OFFLINE_LOG, true);
         statusSolvedMystery = createGroup(ll, StatusGeocacheFilter.StatusType.SOLVED_MYSTERY, true);
+        statusCorrectedCoordinates = createGroup(ll, StatusGeocacheFilter.StatusType.CORRECTED_COORDINATES, true);
         statusHasUserDefinedWaypoints = createGroup(ll, StatusGeocacheFilter.StatusType.HAS_USER_DEFINED_WAYPOINTS, true);
 
         setSimpleView(this.simpleView);
@@ -147,6 +149,7 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         setFromBoolean(statusHasTrackable, filter.getStatusHasTrackable());
         setFromBoolean(statusHasOwnVote, filter.getStatusHasOwnVote());
         setFromBoolean(statusSolvedMystery, filter.getStatusSolvedMystery());
+        setFromBoolean(statusCorrectedCoordinates, filter.getStatusCorrectedCoordinates());
         setFromBoolean(statusHasUserDefinedWaypoints, filter.getStatusHasUserDefinedWaypoint());
     }
 
@@ -172,6 +175,7 @@ public class StatusFilterViewHolder extends BaseFilterViewHolder<StatusGeocacheF
         filter.setStatusHasTrackable(getFromGroup(statusHasTrackable));
         filter.setStatusHasOwnVote(getFromGroup(statusHasOwnVote));
         filter.setStatusSolvedMystery(getFromGroup(statusSolvedMystery));
+        filter.setStatusCorrectedCoordinates(getFromGroup(statusCorrectedCoordinates));
         filter.setStatusHasUserDefinedWaypoint(getFromGroup(statusHasUserDefinedWaypoints));
         return filter;
     }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -669,6 +669,7 @@
     <string name="cache_filter_status_select_label_has_offline_log">Has Offline Log</string>
     <string name="cache_filter_status_select_label_has_offline_found_log">Has Offline Found Log</string>
     <string name="cache_filter_status_select_label_solved_mystery">Solved Mystery</string>
+    <string name="cache_filter_status_select_label_corrected_coordinates">Corrected Coordinates</string>
     <string name="cache_filter_status_select_label_has_user_defined_waypoints">Has User Defined Waypoints</string>
     <string name="cache_filter_status_select_infotext_solved_mystery">This filter setting will only affect mystery caches. If you like to exclude other cache types, please define an appropriate cache type filter.\n\nA mystery is considered \'solved\' if it has either changed coordinates or a valid final waypoint filled with coordinates.</string>
 


### PR DESCRIPTION
Add a "corrected coordinates" filter in addition to the existing "Solved Mystery" filter which only ever applies to Type=Mystery or the "Has user defined waypoints" filter which only applies if there's a custom waypoint as well - which doesn't exist if the coords are coorected on gc.com or the custom waypoint is deleted.
Without this new filter it's impossible to filter a list to show only e.g. "Type=Wherigo AND Corrected Coordinates"
