### PR TITLE
show notification for missing location permission (rel. to #15799)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -262,6 +262,14 @@ public class MainActivity extends AbstractNavigationBarActivity {
             DownloaderUtils.checkForMapUpdates(this);
             cLog.add("mu");
 
+            // location permission currently granted?
+            if (!PermissionContext.LOCATION.getNotGrantedPermissions().isEmpty()) {
+                displayActionItem(R.id.missingLocationPermission, R.string.location_no_permission, false, doAsk -> {
+                    if (doAsk) {
+                        this.askLocationPermissionAction.launch(null);
+                    }
+                });
+            }
             binding.locationStatus.setPermissionRequestCallback(() -> {
                 this.askLocationPermissionAction.launch(null);
             });
@@ -285,7 +293,7 @@ public class MainActivity extends AbstractNavigationBarActivity {
             }
             final int count = intent.getIntExtra(EXTRA_MESSAGE_CENTER_COUNTER, 0);
             new Handler(Looper.getMainLooper()).post(() -> { // needs to be done on UI thread
-                displayActionItem(R.id.mcupdate, res.getQuantityString(R.plurals.mcupdate, count, count), (actionRequested) -> {
+                displayActionItem(R.id.mcupdate, res.getQuantityString(R.plurals.mcupdate, count, count), true, (actionRequested) -> {
                     updateHomeBadge(-1);
                     if (actionRequested) {
                         ShareUtils.openUrl(that, GCConstants.URL_MESSAGECENTER);
@@ -588,25 +596,26 @@ public class MainActivity extends AbstractNavigationBarActivity {
      * display action notifications, e. g. update or backup reminders
      * action callback accepts true, if action is to be performed / false if to be postponed
      */
-    public void displayActionItem(final int layout, final @StringRes int info, final Action1<Boolean> action) {
-        displayActionItem(layout, getString(info), action);
+    public void displayActionItem(final int layout, final @StringRes int info, final boolean withBadge, final Action1<Boolean> action) {
+        displayActionItem(layout, getString(info), withBadge, action);
     }
 
-    public void displayActionItem(final int layout, final String info, final Action1<Boolean> action) {
+    public void displayActionItem(final int layout, final String info, final boolean withBadge, final Action1<Boolean> action) {
+        final int delta = withBadge ? 1 : 0;
         final TextView l = findViewById(layout);
         if (l != null) {
             l.setVisibility(View.VISIBLE);
-            updateHomeBadge(1);
+            updateHomeBadge(delta);
             l.setText(info);
             l.setOnClickListener(v -> {
                 action.call(true);
                 l.setVisibility(View.GONE);
-                updateHomeBadge(-1);
+                updateHomeBadge(-delta);
             });
             l.setOnLongClickListener(v -> {
                 action.call(false);
                 l.setVisibility(View.GONE);
-                updateHomeBadge(-1);
+                updateHomeBadge(-delta);
                 return true;
             });
         }

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -459,6 +459,9 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
     }
 
     public void updateHomeBadge(final int delta) {
+        if (delta == 0) {
+            return;
+        }
         final int badgeColor;
         synchronized (hasHighPrioNotification) {
             badgeColor = hasHighPrioNotification.get() ? 0xffff0000 : 0xff0a67e2;

--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -269,7 +269,7 @@ public class DownloaderUtils {
      * if yes: trigger download(s)
      */
     public static void checkForUpdatesAndDownloadAll(final MainActivity activity, final int layout, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, final Action1<Boolean> callback) {
-        activity.displayActionItem(layout, info, (actionRequested) -> {
+        activity.displayActionItem(layout, info, true, (actionRequested) -> {
             if (actionRequested) {
                 new CheckForDownloadsTask(activity, title, type).execute();
             }

--- a/main/src/main/res/layout/main_activity.xml
+++ b/main/src/main/res/layout/main_activity.xml
@@ -49,6 +49,14 @@
             android:layout_marginBottom="8dp"
             android:visibility="gone" />
 
+        <include
+            android:id="@+id/missingLocationPermission"
+            layout="@layout/mainactivity_action_item"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone" />
+
     </LinearLayout>
 
     <RelativeLayout


### PR DESCRIPTION
Adds a short notification on main screen if location permission has not been granted currently. (This is similar to "check for map updates" notification, but without "blue dot" badge.)
Short tap on that notification opens the permission request, long-tap dismisses the notification, as suggested in https://github.com/cgeo/cgeo/issues/15799#issuecomment-2174993229,