### PR TITLE
fix #15748: allow favorite point change on log editing

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogUtils.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogUtils.java
@@ -271,6 +271,16 @@ public final class LogUtils {
         });
         //adapt commons in database
         adaptCacheCommonsAfterLogging(cache, loggingManager, oldEntry, adaptedNewLogEntry);
+        // adapt cache facvorite status and stored favorite points
+        if (loggingManager.supportsLogWithFavorite() && newEntry instanceof OfflineLogEntry) {
+            final boolean oldWasFavorite = cache.isFavorite();
+            final boolean isFavorite = ((OfflineLogEntry) newEntry).favorite;
+            if (oldWasFavorite != isFavorite) {
+                cache.setFavorite(isFavorite);
+                cache.setFavoritePoints(cache.getFavoritePoints() + (isFavorite ? 1 : -1));
+            }
+        }
+        //store
         DataStore.saveChangedCache(cache);
 
         //Cleanup

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2542,12 +2542,12 @@
         <item quantity="other">Recommend this cache (%d remaining)</item>
     </plurals>
     <plurals name="fav_points_remaining">
-        <item quantity="zero">Add this cache to favorites (%d remaining)</item>
-        <item quantity="one">Add this cache to favorites (%d remaining)</item>
-        <item quantity="two">Add this cache to favorites (%d remaining)</item>
-        <item quantity="few">Add this cache to favorites (%d remaining)</item>
-        <item quantity="many">Add this cache to favorites (%d remaining)</item>
-        <item quantity="other">Add this cache to favorites (%d remaining)</item>
+        <item quantity="zero">Make this cache a favorite (%d remaining)</item>
+        <item quantity="one">Make this cache a favorite (%d remaining)</item>
+        <item quantity="two">Make this cache a favorite (%d remaining)</item>
+        <item quantity="few">Make this cache a favorite (%d remaining)</item>
+        <item quantity="many">Make this cache a favorite (%d remaining)</item>
+        <item quantity="other">Make this cache a favorite (%d remaining)</item>
     </plurals>
     <string name="command_set_cache_icons_progress">Setting cache icons</string>
     <plurals name="command_set_cache_icons_result">


### PR DESCRIPTION
fix #15748: allow favorite point change on log editing

I had to change the wording of the favorite point checkbox in the log dialog so it matches both the "create log" and the "edit log" situation:

Before: Add this cache to favorites (%d remaining)
After: Make this cache a favorite (%d remaining)