### PR TITLE
fix #15696: introduce search limit for coord/address searches, same as for nearby searches

### DIFF
--- a/main/src/main/java/cgeo/geocaching/loaders/CoordsGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/CoordsGeocacheListLoader.java
@@ -28,12 +28,10 @@ public class CoordsGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
     @Override
     public IGeocacheFilter getAdditionalFilterParameter() {
-        final DistanceGeocacheFilter distanceFilter = (DistanceGeocacheFilter) GeocacheFilterType.DISTANCE.create();
-        if (applyNearbySearchLimit) {
-            final int nearbySearchLimit = Settings.getNearbySearchLimit();
-            if (nearbySearchLimit > 0) {
-                distanceFilter.setMinMaxRange(0.0f, (float) nearbySearchLimit);
-            }
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+        final int searchLimit = applyNearbySearchLimit ? Settings.getNearbySearchLimit() : Settings.getCoordinateSearchLimit();
+        if (searchLimit > 0) {
+            distanceFilter.setMinMaxRange(0.0f, (float) searchLimit);
         }
         distanceFilter.setCoordinate(coords);
         return distanceFilter;

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1710,6 +1710,10 @@ public class Settings {
         return getInt(R.string.pref_nearbySearchLimit, 0);
     }
 
+    public static int getCoordinateSearchLimit() {
+        return getInt(R.string.pref_coordSearchLimit, 0);
+    }
+
     public static int getLogImageScale() {
         final int scale = getInt(R.string.pref_logImageScale, -1);
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -56,6 +56,7 @@
 
     <!-- category nearby search -->
     <string translatable="false" name="pref_nearbySearchLimit">nearbySearchLimit</string>
+    <string translatable="false" name="pref_coordSearchLimit">coordSearchLimit</string>
 
     <!-- settings for geocaching.com service screen -->
     <string translatable="false" name="preference_screen_gc">preference_screen_gc</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -902,9 +902,11 @@
     <string name="settings_title_navigation_menu">Navigation Menu</string>
 
     <string name="settings_category_geocaching_platform">Geocaching Platform</string>
-    <string name="settings_category_nearbysearch">Nearby search</string>
+    <string name="settings_category_locationcentersearch">Location-centered searches</string>
     <string name="init_nearbysearchlimit_title">Nearby search limit</string>
     <string name="init_nearbysearchlimit_description">Limits the distance up to which caches are returned for with nearby search (0=unlimited)</string>
+    <string name="init_coordsearchlimit_title">Coordinate/Address search limit</string>
+    <string name="init_coordsearchlimit_description">Limits the distance up to which caches are returned for with coordinate/address search (0=unlimited)</string>
     <string name="init_settings_description_unlimited">unlimited</string>
 
     <string name="settings_category_geocaching_additionals">Further services and addon</string>

--- a/main/src/main/res/xml/preferences_services.xml
+++ b/main/src/main/res/xml/preferences_services.xml
@@ -83,7 +83,7 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:title="@string/settings_category_nearbysearch"
+        android:title="@string/settings_category_locationcentersearch"
         app:iconSpaceReserved="false">
         <Preference
             android:summary="@string/init_nearbysearchlimit_description"
@@ -92,6 +92,19 @@
             app:iconSpaceReserved="false"/>
         <cgeo.geocaching.settings.ProximityPreference
             android:key="@string/pref_nearbySearchLimit"
+            android:defaultValue="0"
+            app:min="0"
+            app:max="999"
+            app:minValueDescription="@string/init_settings_description_unlimited"
+            app:highRes="false"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:summary="@string/init_coordsearchlimit_description"
+            android:title="@string/init_coordsearchlimit_title"
+            app:allowDividerBelow="false"
+            app:iconSpaceReserved="false"/>
+        <cgeo.geocaching.settings.ProximityPreference
+            android:key="@string/pref_coordSearchLimit"
             android:defaultValue="0"
             app:min="0"
             app:max="999"


### PR DESCRIPTION
fix #15696: introduce search limit for coord/address searches, same as for nearby searches

![image](https://github.com/cgeo/cgeo/assets/6909759/b53d20ed-6100-4417-bebe-9ae6079180da)
