### PR TITLE
Add "none"-entry to routing-profiles-selection

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -113,14 +113,15 @@ public class MapSettingsUtils {
         boolean useUser1 = false;
         boolean useUser2 = false;
         if (useInternalRouting) {
+            final String profileNoneString = activity.getResources().getString(R.string.routingmode_none);
             final StringBuilder sb = new StringBuilder();
             final String temp1 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER1), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
-            if (StringUtils.isNotBlank(temp1)) {
+            if (StringUtils.isNotBlank(temp1) && !temp1.equals(profileNoneString)) {
                 sb.append("1: ").append(temp1);
                 useUser1 = true;
             }
             final String temp2 = StringUtils.removeEndIgnoreCase(Settings.getRoutingProfile(RoutingMode.USER2), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
-            if (StringUtils.isNotBlank(temp2)) {
+            if (StringUtils.isNotBlank(temp2) && !temp2.equals(profileNoneString)) {
                 sb.append(StringUtils.isNotBlank(sb) ? " - " : "").append("2: ").append(temp2);
                 useUser2 = true;
             }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -18,11 +18,10 @@ import androidx.annotation.StringRes;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 
 public class PreferenceNavigationFragment extends BasePreferenceFragment {
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -18,6 +18,8 @@ import androidx.annotation.StringRes;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -104,24 +106,31 @@ public class PreferenceNavigationFragment extends BasePreferenceFragment {
                 profiles.add(file.name);
             }
         }
-        final CharSequence[] entries = profiles.toArray(new CharSequence[0]);
-        final CharSequence[] values = profiles.toArray(new CharSequence[0]);
-        updateRoutingProfilePref(R.string.pref_brouterProfileWalk, RoutingMode.WALK, entries, values, 0);
-        updateRoutingProfilePref(R.string.pref_brouterProfileBike, RoutingMode.BIKE, entries, values, 0);
-        updateRoutingProfilePref(R.string.pref_brouterProfileCar, RoutingMode.CAR, entries, values, 0);
-        updateRoutingProfilePref(R.string.pref_brouterProfileUser1, RoutingMode.USER1, entries, values, 1);
-        updateRoutingProfilePref(R.string.pref_brouterProfileUser2, RoutingMode.USER2, entries, values, 2);
+
+        updateRoutingProfilePref(R.string.pref_brouterProfileWalk, RoutingMode.WALK, profiles, 0);
+        updateRoutingProfilePref(R.string.pref_brouterProfileBike, RoutingMode.BIKE, profiles, 0);
+        updateRoutingProfilePref(R.string.pref_brouterProfileCar, RoutingMode.CAR, profiles, 0);
+        updateRoutingProfilePref(R.string.pref_brouterProfileUser1, RoutingMode.USER1, profiles, 1);
+        updateRoutingProfilePref(R.string.pref_brouterProfileUser2, RoutingMode.USER2, profiles, 2);
     }
 
-    private void updateRoutingProfilePref(@StringRes final int prefId, final RoutingMode mode, final CharSequence[] entries, final CharSequence[] values, final int number) {
-        final String current = Settings.getRoutingProfile(mode);
+    private void updateRoutingProfilePref(@StringRes final int prefId, final RoutingMode mode, final ArrayList<String> profiles, final int number) {
+        final String current = StringUtils.defaultIfBlank(Settings.getRoutingProfile(mode), getString(R.string.routingmode_none));
         final ListPreference pref = findPreference(getString(prefId));
         assert pref != null;
+
+        final ArrayList<String> prefProfiles = new ArrayList<>(profiles);
         if (number > 0) {
+            prefProfiles.add(getString(R.string.routingmode_none));
+
             final String title = String.format(getString(R.string.init_brouterProfileUserNumber), number);
             pref.setDialogTitle(title);
             pref.setTitle(title);
         }
+
+        final CharSequence[] entries = prefProfiles.toArray(new CharSequence[0]);
+        final CharSequence[] values = prefProfiles.toArray(new CharSequence[0]);
+
         pref.setEntries(entries);
         pref.setEntryValues(values);
         pref.setSummary(current);
@@ -129,12 +138,11 @@ public class PreferenceNavigationFragment extends BasePreferenceFragment {
             preference.setSummary(newValue.toString());
             return true;
         });
-        if (current != null) {
-            for (int i = 0; i < entries.length; i++) {
-                if (current.contentEquals(entries[i])) {
-                    pref.setValueIndex(i);
-                    break;
-                }
+
+        for (int i = 0; i < entries.length; i++) {
+            if (current.contentEquals(entries[i])) {
+                pref.setValueIndex(i);
+                break;
             }
         }
     }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2722,6 +2722,7 @@
     <string name="routingmode_car">Car</string>
     <string name="routingmode_user1">User 1</string>
     <string name="routingmode_user2">User 2</string>
+    <string name="routingmode_none">(none)</string>
 
     <!-- view settings -->
     <string name="view_settings">View settings</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Once you selected a profile for the user-defined profiles 1 or 2, you can't get rid of it easily (go to the settings and delete the key).

This PR adds an entry "(none)" to the profile-selection-list (like for the launch-buttons)

## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

<img src="https://github.com/cgeo/cgeo/assets/70113341/11f6b289-b9b2-4aec-82b7-857f5ce2cac8" width="200">


<img src="https://github.com/cgeo/cgeo/assets/70113341/b2c18749-41de-4465-9aaf-23d463b345d8" width="200"> 


