### PR TITLE
add logging and toast for HTTP 429 (Too many request)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.network;
 
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.RxOkHttpUtils;
@@ -102,6 +104,10 @@ public class HttpRequest {
     public <T> Single<T> requestJson(final Class<T> clazz) {
         headers("Accept", "application/json, text/javascript, */*; q=0.01");
         return requestInternal(r -> {
+            if (r.getStatusCode() == 429) {
+                Log.w("Request throttled: " + this.getRequestUrl());
+                ActivityMixin.showToast(CgeoApplication.getInstance(), "Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host());
+            }
             T result;
             final String bodyString = r.getBodyString();
             r.close();

--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -1,6 +1,5 @@
 package cgeo.geocaching.network;
 
-import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
@@ -104,10 +103,6 @@ public class HttpRequest {
     public <T> Single<T> requestJson(final Class<T> clazz) {
         headers("Accept", "application/json, text/javascript, */*; q=0.01");
         return requestInternal(r -> {
-            if (r.getStatusCode() == 429) {
-                Log.w("Request throttled: " + this.getRequestUrl());
-                ActivityMixin.showToast(CgeoApplication.getInstance(), "Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host());
-            }
             T result;
             final String bodyString = r.getBodyString();
             r.close();
@@ -150,6 +145,10 @@ public class HttpRequest {
             final T mappedResponse = mapper.apply(response);
             if (mappedResponse instanceof HttpResponse && response != mappedResponse) {
                 ((HttpResponse) mappedResponse).setFromHttpResponse(response);
+            }
+            if (response.getStatusCode() == 429) {
+                Log.w("Request throttled: " + this.getRequestUrl());
+                ActivityMixin.showApplicationToast("Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host() + "/" + HttpUrl.parse(getRequestUrl()).encodedPath());
             }
             return mappedResponse;
         });


### PR DESCRIPTION
various requests may produce a HTTP 429 Too many requests, e.g. live map on GC.com (https://github.com/cgeo/cgeo/issues/14601)

This PR adds logging for that case and also a Toast to inform the user about the throttling.
![image](https://github.com/cgeo/cgeo/assets/1258173/84c12896-9f2a-43b8-8840-94a8373190e6)


Not sure where in the code to put this kind of error handling - it's a universal thing (that's where I put it for now) but maybe it should be handled case-specific? So setting feedback required for now.

Also hardcoded strings for now ;-)