### PR TITLE
Avoid flickering on cache list refresh (rel. to 15461)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -125,6 +125,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -508,7 +509,10 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             @Override
             protected void onReceive(final Context context, final String geocode) {
                 if (IterableUtils.matchesAny(adapter.getFilteredList(), geocache -> geocache.getGeocode().equals(geocode))) {
-                    refreshCurrentList();
+                    final Geocache geocache = DataStore.loadCache(geocode, EnumSet.of(LoadFlags.LoadFlag.DB_MINIMAL));
+                    if (geocache != null) {
+                        adapter.setElement(geocache);
+                    }
                 }
             }
         });

--- a/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
@@ -142,6 +142,15 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
         notifyDataSetChanged();
     }
 
+    public void setElement(@NonNull final Geocache geocache) {
+        final String geocode = geocache.getGeocode();
+        for (int i = 0; i < getCount(); i++) {
+            if (getItem(i).getGeocode().equalsIgnoreCase(geocode)) {
+                this.list.set(i, geocache);
+            }
+        }
+    }
+
     public void setStoredLists(final List<AbstractList> storedLists) {
         this.storedLists = storedLists;
     }


### PR DESCRIPTION
Currently cache list gets refreshed completely on refreshing caches for every cache update received, which leads to frequent flickering until the last update got received.

This PR only updates the view for the received cache, thus avoids the flickering.