### PR TITLE
UnifiedMap: Highlight selected cache/waypoint (fix #15801)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/RouteItem.java
+++ b/main/src/main/java/cgeo/geocaching/models/RouteItem.java
@@ -166,6 +166,14 @@ public class RouteItem implements Parcelable {
         return DataStore.loadCache(cacheGeocode, LoadFlags.LOAD_CACHE_OR_DB);
     }
 
+    @Nullable
+    public Waypoint getWaypoint() {
+        if (waypointId != 0) {
+            return null;
+        }
+        return DataStore.loadWaypoint(waypointId);
+    }
+
     @NonNull
     public String getShortGeocode() {
         return generateShortGeocode(cacheGeocode);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/LayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/LayerHelper.java
@@ -5,12 +5,14 @@ public class LayerHelper {
     // constants for layer ordering (higher = more visible)
     // layer index numbers must be consecutive, starting with 1 for ZINDEX_BASEMAP
 
+    public static final int ZINDEX_CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM = 101;
+    public static final int ZINDEX_CACHE_WAYPOINT_HIGHLIGHTER_MARKER = 100;
+
     public static final int ZINDEX_ELEVATIONCHARTMARKERPOSITION = 16;
     public static final int ZINDEX_POSITION = 15;
     public static final int ZINDEX_POSITION_ELEVATION = 14;
     public static final int ZINDEX_SEARCHCENTER = 13;
-    // some OSM-only layers
-    public static final int ZINDEX_SCALEBAR = 12;
+    public static final int ZINDEX_SCALEBAR = 12;   // OSM only
     public static final int ZINDEX_GEOCACHE = 11;
     public static final int ZINDEX_WAYPOINT = 10;
     public static final int ZINDEX_COORD_POINT = 9;
@@ -19,8 +21,8 @@ public class LayerHelper {
     public static final int ZINDEX_POSITION_ACCURACY_CIRCLE = 6;
     public static final int ZINDEX_HISTORY = 5;
     public static final int ZINDEX_CIRCLE = 4;
-    public static final int ZINDEX_LABELS = 3;
-    public static final int ZINDEX_BUILDINGS = 2;
+    public static final int ZINDEX_LABELS = 3;      // OSM only
+    public static final int ZINDEX_BUILDINGS = 2;   // OSM only
     public static final int ZINDEX_BASEMAP = 1;     // this is hard-coded in VTM:Map.java
 
     private LayerHelper() {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -34,6 +34,8 @@ import cgeo.geocaching.models.MapSelectableItem;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.RouteItem;
 import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.models.geoitem.GeoIcon;
+import cgeo.geocaching.models.geoitem.GeoPrimitive;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.service.CacheDownloaderService;
@@ -71,6 +73,7 @@ import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.HistoryTrackUtils;
 import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.functions.Func1;
 import cgeo.geocaching.wherigo.WherigoDialogManager;
 import cgeo.geocaching.wherigo.WherigoGame;
@@ -93,6 +96,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.graphics.Bitmap;
 import android.graphics.Point;
 import android.location.Location;
 import android.os.Bundle;
@@ -103,6 +107,7 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -133,6 +138,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private static final String BUNDLE_OVERRIDEPOSITIONANDZOOM = "overridePositionAndZoom";
 
     private static final String ROUTING_SERVICE_KEY = "UnifiedMap";
+
+    private static final String CACHE_WAYPOINT_HIGHLIGHTER_BACKGROUND = "cacheWaypointHighlighterBackground";
+    private static final String CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM = "cacheWaypointHighlighterGeoitem";
 
     private UnifiedMapViewModel viewModel = null;
     private AbstractTileProvider tileProvider = null;
@@ -1060,12 +1068,22 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             }
         } else if (routeItem != null) {
             // open popup for element
+            Bitmap b1 = null;
             if (routeItem.getType() == RouteItem.RouteItemType.GEOCACHE) {
                 viewModel.sheetInfo.setValue(new UnifiedMapViewModel.SheetInfo(routeItem.getGeocode(), 0));
                 sheetShowDetails(viewModel.sheetInfo.getValue());
+                b1 = MapMarkerUtils.getCacheMarker(getResources(), routeItem.getGeocache(), null, true).getBitmap();
             } else if (routeItem.getType() == RouteItem.RouteItemType.WAYPOINT && routeItem.getWaypointId() != 0) {
                 viewModel.sheetInfo.setValue(new UnifiedMapViewModel.SheetInfo(routeItem.getGeocode(), routeItem.getWaypointId()));
                 sheetShowDetails(viewModel.sheetInfo.getValue());
+                b1 = MapMarkerUtils.getWaypointMarker(getResources(), routeItem.getWaypoint(), true, true).getBitmap();
+            }
+            if (b1 != null) {
+                final Bitmap b = ViewUtils.drawableToBitmap(AppCompatResources.getDrawable(this, R.drawable.background_gc_hightlighted));
+                final GeoPrimitive gp = GeoPrimitive.createMarker(routeItem.getPoint(), GeoIcon.builder().setBitmap(b).setHotspot(GeoIcon.Hotspot.BOTTOM_CENTER).build()).buildUpon().setZLevel(LayerHelper.ZINDEX_CACHE_WAYPOINT_HIGHLIGHTER_MARKER).build();
+                nonClickableItemsLayer.put(CACHE_WAYPOINT_HIGHLIGHTER_BACKGROUND, gp);
+                final GeoPrimitive gp1 = GeoPrimitive.createMarker(routeItem.getPoint(), GeoIcon.builder().setBitmap(b1).setHotspot(GeoIcon.Hotspot.BOTTOM_CENTER).build()).buildUpon().setZLevel(LayerHelper.ZINDEX_CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM).build();
+                nonClickableItemsLayer.put(CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM, gp1);
             }
         } else if (item.getRoute() != null) {
             // elevation charts for individual route and/or routes/tracks
@@ -1103,6 +1121,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     @Override
     protected void clearSheetInfo() {
+        nonClickableItemsLayer.remove(CACHE_WAYPOINT_HIGHLIGHTER_GEOITEM);
+        nonClickableItemsLayer.remove(CACHE_WAYPOINT_HIGHLIGHTER_BACKGROUND);
         viewModel.sheetInfo.setValue(null);
     }
 

--- a/main/src/main/res/drawable/background_gc_hightlighted.xml
+++ b/main/src/main/res/drawable/background_gc_hightlighted.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+    <path
+        android:pathData="M0,18a18,18 0,1 0,36 0a18,18 0,1 0,-36 0z"
+        android:fillColor="@color/colorAccent"/>
+</vector>


### PR DESCRIPTION
## Description
This is a technical demo for highlighting the active cache on the map (so far UnifiedMap only).
As soon as you tap on a cache (which opens the cache info sheet), a "corona" is being displayed around the cache icon. (Same could be done for waypoint icons and for compact icon variants.)

From looking at `marker.xml` and `marker_pin.xml` as well as `MapMarkerUtils.createCacheMarker` I would have expected a different result, though. Both drawables have 36dp width and height, and their viewports are 36/36 as well, so I would have expected, that `marker_pin.xml` is sort of an overlay to `marker.xml` (which would fit at being treated as inset).

Thus: aligning another drawable at "bottom center" should create an exact overlay, if that drawable has the same size.

But it does not, it aligns to the `marker.xml`'s visual bottom border, above the pins visible top.

Having said that, the result would still be working as a highlighting indicator for a selected cache, though:

|GC.com cache highlighted|UDC cache hightlighted|
|---|---|
|![Screenshot_1720901625](https://github.com/user-attachments/assets/617a5679-a379-48d1-88c0-e6eab6ef5c16)|![Screenshot_1720903345](https://github.com/user-attachments/assets/07b534f1-dffd-431d-a8ae-7f0be2e085c7)|

(Although one would probably want to adjust the highlighter's size and choose a different color, as the current one is too close to the UDF's background color.)

Marking this PR as draft.