### PR TITLE
UnifiedMap: Store theme tileprovider-specific (rel. to #15850)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1659,6 +1659,16 @@ public class Settings {
         return getString(R.string.pref_renderthemefile, "");
     }
 
+    /**
+     * Variant used by UnifiedMap: try tileprovider-specifc first
+     */
+    public static String getSelectedMapRenderTheme(final AbstractTileProvider tileProvider) {
+        final String temp = getStringDirect(CgeoApplication.getInstance().getString(R.string.pref_renderthemefile) + "-" + tileProvider.getId(), "");
+        final String temp2 = StringUtils.isNotBlank(temp) ? temp : getSelectedMapRenderTheme();
+        Log.e("getTheme: " + temp2);
+        return temp2;
+    }
+
     public static boolean isDefaultMapRenderTheme() {
         return StringUtils.isBlank(getSelectedMapRenderTheme());
     }
@@ -1673,6 +1683,15 @@ public class Settings {
      */
     public static void setSelectedMapRenderTheme(final String customRenderThemeFile) {
         putString(R.string.pref_renderthemefile, customRenderThemeFile);
+    }
+
+    /**
+     * variant used by UnifiedMap: store tileprovider-specific (additionally)
+     */
+    public static void setSelectedMapRenderTheme(final String tileProvider, final String customRenderThemeFile) {
+        Log.e("setTheme: " + tileProvider + " / " + customRenderThemeFile);
+        setSelectedMapRenderTheme(customRenderThemeFile);
+        putStringDirect(CgeoApplication.getInstance().getString(R.string.pref_renderthemefile) + "-" + tileProvider, customRenderThemeFile);
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -329,6 +329,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         }
         tileProvider = newSource;
         mapFragment = tileProvider.createMapFragment();
+        Settings.setTileProvider(newSource); // store new tileProvider, so that next getRenderTheme retrieves correct tileProvider-specific theme
 
         if (oldFragment != null) {
             mapFragment.init(oldFragment.getCurrentZoom(), oldFragment.getCenter(), () -> onMapReadyTasks(newSource, true, mapState));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
@@ -139,7 +139,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         }
 
         //try to apply stored value
-        ThemeData selectedTheme = setSelectedMapThemeInternal(Settings.getSelectedMapRenderTheme());
+        ThemeData selectedTheme = setSelectedMapThemeInternal(Settings.getSelectedMapRenderTheme(Settings.getTileProvider()));
 
         if (selectedTheme == null) {
             applyDefaultTheme(map, tileProvider);
@@ -236,7 +236,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         if (!tileProvider.supportsThemes()) {
             return;
         }
-        final String currentThemeId = Settings.getSelectedMapRenderTheme();
+        final String currentThemeId = Settings.getSelectedMapRenderTheme(tileProvider);
 
         final List<String> names = new ArrayList<>();
         names.add(activity.getString(R.string.switch_default));
@@ -278,7 +278,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
     public boolean themeOptionsAvailable() {
-        return StringUtils.isNotBlank(Settings.getSelectedMapRenderTheme());
+        return StringUtils.isNotBlank(Settings.getSelectedMapRenderTheme(Settings.getTileProvider()));
     }
 
     /**
@@ -352,7 +352,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
     private static void setSelectedTheme(final ThemeData theme) {
-        Settings.setSelectedMapRenderTheme(theme == null ? StringUtils.EMPTY : theme.id);
+        Settings.setSelectedMapRenderTheme(Settings.getTileProvider().getId(), theme == null ? StringUtils.EMPTY : theme.id);
     }
 
     /**
@@ -602,7 +602,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
     public static RenderThemeType getRenderThemeType() {
-        final String selectedMapRenderTheme = Settings.getSelectedMapRenderTheme();
+        final String selectedMapRenderTheme = Settings.getSelectedMapRenderTheme(Settings.getTileProvider());
         for (MapsforgeThemeHelper.RenderThemeType rtt : MapsforgeThemeHelper.RenderThemeType.values()) {
             for (String searchPath : rtt.searchPaths) {
                 if (StringUtils.containsIgnoreCase(selectedMapRenderTheme, searchPath)) {


### PR DESCRIPTION
## Description
Store/load currently selected theme per tileprovider for OSM offline maps (UnifiedMap only currently)
If no tileprovider-specific theme is stored, fall back to last used theme.

## Additional context
Example: If you use both OpenAndroMaps and Freizeitkarte with their respective themes, switching from one to the other will load the related theme automatically, no manual switching necessary any more.