### PR TITLE
Show http 429 warning in debug mode only

### DIFF
--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.network;
 
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.RxOkHttpUtils;
@@ -148,7 +149,9 @@ public class HttpRequest {
             }
             if (response.getStatusCode() == 429) {
                 Log.w("Request throttled: " + this.getRequestUrl());
-                ActivityMixin.showApplicationToast("Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host() + "/" + HttpUrl.parse(getRequestUrl()).encodedPath());
+                if (Settings.isDebug()) {
+                    ActivityMixin.showApplicationToast("Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host() + "/" + HttpUrl.parse(getRequestUrl()).encodedPath());
+                }
             }
             return mappedResponse;
         });


### PR DESCRIPTION
## Description
To get our beta user up and running again, switch the "error 429 / slow down" toast to debug mode for now.
If no one objects I'll start building a new beta version including this PR in two hours or so.


I'll try to come up with something less blocking in a separate PR.