### PR TITLE
WIP show http 429 warning overlay

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -5,15 +5,22 @@ import cgeo.geocaching.CachePopupFragment;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SwipeToOpenFragment;
 import cgeo.geocaching.WaypointPopupFragment;
+import cgeo.geocaching.network.HttpRequest;
 import cgeo.geocaching.unifiedmap.UnifiedMapViewModel;
+import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.content.res.Resources;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,6 +38,7 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
 
     private static final String TAG_MAPDETAILS_FRAGMENT = "mapdetails_fragment";
     private static final String TAG_SWIPE_FRAGMENT = "swipetoopen_fragment";
+    private static long close429warning = 0;
 
     private final ViewTreeObserver.OnGlobalLayoutListener[] layoutListeners = new ViewTreeObserver.OnGlobalLayoutListener[1];
 
@@ -196,4 +204,34 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
         sheetShowDetails(sheetInfo);
     }
 
+    // handling of http429 warning message
+    protected void add429observer() {
+        getLifecycle().addObserver(new LifecycleAwareBroadcastReceiver(this, HttpRequest.HTTP429) {
+            @Override
+            public void onReceive(final Context context, final Intent intent) {
+                synchronized (this) {
+                    if (close429warning == 0) {
+                        final View v = findViewById(R.id.http429warning);
+                        if (v != null) {
+                            ((TextView) v).setText(String.format(getString(R.string.http429_warning), intent.getStringExtra(HttpRequest.HTTP429_ADDRESS)));
+                            new Handler(Looper.getMainLooper()).post(() -> v.setVisibility(View.VISIBLE));
+                        }
+                    }
+                    close429warning = System.currentTimeMillis() + 1000; // show for 1s
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                        synchronized (this) {
+                            if (System.currentTimeMillis() > close429warning) {
+                                final View v = findViewById(R.id.http429warning);
+                                if (v != null) {
+                                    v.setVisibility(View.GONE);
+                                }
+                                close429warning = 0;
+                            }
+                        }
+                    }, 1100);
+                }
+            }
+        });
+
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -1,8 +1,8 @@
 package cgeo.geocaching.network;
 
-import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.utils.JsonUtils;
+import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.RxOkHttpUtils;
 import cgeo.geocaching.utils.functions.Func1;
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.Supplier;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -39,6 +40,8 @@ public class HttpRequest {
     private static final ObjectMapper JSON_MAPPER = JsonUtils.mapper;
 
     private static final String LOGPRAEFIX = "HTTP-";
+    public static final String HTTP429 = "HTTP429";
+    public static final String HTTP429_ADDRESS = "HTTP429ADDRESS";
 
     private Method method = null;
     private String uriBase;
@@ -149,9 +152,7 @@ public class HttpRequest {
             }
             if (response.getStatusCode() == 429) {
                 Log.w("Request throttled: " + this.getRequestUrl());
-                if (Settings.isDebug()) {
-                    ActivityMixin.showApplicationToast("Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host() + "/" + HttpUrl.parse(getRequestUrl()).encodedPath());
-                }
+                LifecycleAwareBroadcastReceiver.sendBroadcast(CgeoApplication.getInstance(), HTTP429, HTTP429_ADDRESS, Objects.requireNonNull(HttpUrl.parse(Objects.requireNonNull(getRequestUrl()))).host());
             }
             return mappedResponse;
         });

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -287,7 +287,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 lastElevationChartRoute = null;
             }
         });
-
+        add429observer();
         findViewById(R.id.map_zoomin).setOnTouchListener(new RepeatOnHoldListener(500, v -> {
             if (mapFragment != null) {
                 mapFragment.zoomInOut(true);

--- a/main/src/main/res/layout/unifiedmap_activity.xml
+++ b/main/src/main/res/layout/unifiedmap_activity.xml
@@ -30,6 +30,22 @@
         <include layout="@layout/map_zoom_control" />
         <include layout="@layout/map_progressbar" />
         <include layout="@layout/map_detailsfragment" />
+
+        <TextView
+            android:id="@+id/http429warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/distanceinfo"
+
+            android:textSize="20sp"
+            android:textColor="@color/colorAccent"
+            android:textFontWeight="800"
+            android:background="@drawable/icon_bcg"
+            android:gravity="center"
+            android:text="@string/http429_warning"
+
+            android:visibility="gone"/>
+
     </RelativeLayout>
 
     <RelativeLayout

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2608,6 +2608,7 @@
     </plurals>
 
     <string name="caches_refresh_all_warning">This action may lead to high network traffic. Are you sure you want to batch refresh all caches?</string>
+    <string name="http429_warning">Please slow down, too many requests to %s</string>
 
     <string name="list_list_headline">Lists:</string>
     <plurals name="extract_waypoints_result">


### PR DESCRIPTION
## Description
Proposal for a new warning when http 429 errors occur. The text is being displayed as a text overlay for one second. If a new one occurs while one is being displayed already, the duration gets reset to one second (but not added on top).

![Screenshot_1721507577](https://github.com/user-attachments/assets/6a95ec40-5a0a-47cb-a194-e8f0c466cf14)

This is a WIP, having been implemented for UnifiedMap only so far. If feedback is "go" I will add it to GMv2 and old Mapsforge as well.