### PR TITLE
Don't show notification after succ. cache download from infosheet

### DIFF
--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -252,7 +252,7 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
         if (downloadQuery.size() > 0) {
             showEndNotification(getString(shouldStop ? R.string.caches_store_background_result_canceled : R.string.caches_store_background_result_failed,
                     cachesDownloaded.get(), cachesDownloaded.get() + downloadQuery.size()));
-        } else {
+        } else if (cachesDownloaded.get() != 1) { // see #15881
             showEndNotification(getResources().getQuantityString(R.plurals.caches_store_background_result, cachesDownloaded.get(), cachesDownloaded.get()));
         }
         downloadQuery.clear();


### PR DESCRIPTION
## Description
Currently there is a system notification "1 cache downloaded" for every cache you store or update using the cache infosheet, which can get pretty annoying. This PR changes this behavior to not show the final "1 cache downloaded" system notification, if only a single cache got triggered for current `CacheDownloaderService" and that download has been completed successfully. The progress notification is still being displayed (and removed on finishing the download, as is today).

Fixes #15881