### PR TITLE
Apply tint for ActionBar chooser in light mode (fix #15883)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/CacheListActionBarChooser.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListActionBarChooser.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.list.AbstractList;
 import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.utils.ColorUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.annotation.SuppressLint;
@@ -106,7 +107,12 @@ public class CacheListActionBarChooser {
 
         final AbstractList list = AbstractList.getListById(listId);
         if (list != null) {
-            TextParam.text(list.getTitle()).setImage(StoredList.UserInterface.getImageForList(list, false)).applyTo(titleTv);
+            final ImageParam ip = StoredList.UserInterface.getImageForList(list, false);
+            if (ip.isReferencedById()) { // see #15883
+                TextParam.text(list.getTitle()).setImage(ip).setImageTint(ColorUtils.colorFromResource(R.color.colorTextActionBar)).applyTo(titleTv);
+            } else {
+                TextParam.text(list.getTitle()).setImage(ip).applyTo(titleTv);
+            }
             if (list.getNumberOfCaches() >= 0) {
                 subtitleTv.setVisibility(View.VISIBLE);
                 subtitleTv.setText(getCacheListSubtitle(list));

--- a/main/src/main/java/cgeo/geocaching/ui/ImageParam.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageParam.java
@@ -73,6 +73,10 @@ public class ImageParam {
         this.drawable = drawable;
     }
 
+    public boolean isReferencedById() {
+        return drawableId != -1;
+    }
+
     public void applyTo(final ImageView view) {
         if (this.drawable != null) {
             view.setImageDrawable(this.drawable);

--- a/main/src/main/res/layout/cachelist_chooser_actionbar.xml
+++ b/main/src/main/res/layout/cachelist_chooser_actionbar.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     style="?attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -13,6 +14,7 @@
         android:layout_height="wrap_content"
         android:src="@drawable/expand_more"
         android:layout_centerVertical="true"
+        app:tint="@color/colorTextActionBar"
         android:layout_alignParentRight="true"/>
 
     <LinearLayout


### PR DESCRIPTION
## Description
Applies correct tint to own drawables for ActionBar list chooser (default list icons + dropdown indicator).
Tint does not get applied for emoji list icons.

![image](https://github.com/user-attachments/assets/be7997c3-d383-4b73-836e-822ad92c6cd7)
