### PR TITLE
Show warning on missing WRITE_EXTERNAL_STORAGE permission (fix #15823)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -10,6 +10,7 @@ import cgeo.geocaching.maps.MapProviderFactory;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.network.Network;
 import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.permission.PermissionContext;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
@@ -31,6 +32,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.view.View;
 import android.widget.CheckBox;
@@ -123,20 +125,23 @@ public class DownloaderUtils {
                     final DownloadManager downloadManager = (DownloadManager) activity.getSystemService(DOWNLOAD_SERVICE);
                     if (null != downloadManager) {
                         final long id = addDownload(activity, downloadManager, type, uri, filename, allowMeteredNetwork);
-                        if (downloadStartedCallback != null) {
-                            downloadStartedCallback.accept(id);
-                        }
-
-                        // check for required extra files (e. g.: map theme)
-                        final AbstractDownloader downloader = Download.DownloadType.getInstance(type);
-                        if (downloader != null) {
-                            final DownloadDescriptor extraFile = downloader.getExtrafile(activity, uri);
-                            if (extraFile != null) {
-                                addDownload(activity, downloadManager, extraFile.type, extraFile.uri, extraFile.filename, allowMeteredNetwork);
+                        if (id != -1) {
+                            if (downloadStartedCallback != null) {
+                                downloadStartedCallback.accept(id);
                             }
-                        }
 
-                        ActivityMixin.showShortToast(activity, R.string.download_started);
+                            // check for required extra files (e. g.: map theme)
+                            final AbstractDownloader downloader = Download.DownloadType.getInstance(type);
+                            if (downloader != null) {
+                                final DownloadDescriptor extraFile = downloader.getExtrafile(activity, uri);
+                                if (extraFile != null) {
+                                    addDownload(activity, downloadManager, extraFile.type, extraFile.uri, extraFile.filename, allowMeteredNetwork);
+                                }
+                            }
+                            ActivityMixin.showShortToast(activity, R.string.download_started);
+                        } else {
+                            ActivityMixin.showShortToast(activity, R.string.download_enqueing_error);
+                        }
                     } else {
                         ActivityMixin.showToast(activity, R.string.downloadmanager_not_available);
                     }
@@ -220,6 +225,11 @@ public class DownloaderUtils {
     }
 
     private static long addDownload(final Activity activity, final DownloadManager downloadManager, final int type, final Uri uri, final String filename, final boolean allowMeteredNetwork) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P && !PermissionContext.LEGACY_WRITE_EXTERNAL_STORAGE.hasAllPermissions()) {
+            // those versions still need WRITE_EXTERNAL_STORAGE permission to enqueue a download
+            SimpleDialog.ofContext(activity).setTitle(TextParam.id(R.string.permission_missing)).setMessage(TextParam.id(R.string.storage_permission_needed)).show();
+            return -1;
+        }
         final DownloadManager.Request request = new DownloadManager.Request(uri)
                 .setTitle(filename)
                 .setDescription(String.format(activity.getString(R.string.downloadmap_filename), filename))

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2570,6 +2570,7 @@
     <string name="list_confirm_debug_message">The debug mode causes instabilities! Do you want to deactivate the debug mode?</string>
 
     <!-- permission handling -->
+    <string name="permission_missing">Missing permission</string>
     <string name="permission_ask_again">Ask me again</string>
     <string name="permission_goto_app_details">Open Application Info</string>
 
@@ -2744,6 +2745,7 @@
     <string name="downloadmap_keep_temporary_files_summary">Some download sources support additional files not used by c:geo. Keep those extra files in system\'s download folder instead of deleting it</string>
     <string name="downloadmanager_not_available">File cannot be downloaded, system download manager not available</string>
     <string name="download_started">Downloading started in background</string>
+    <string name="download_enqueing_error">Error on trying to start download</string>
     <string name="download_none_selected">No files selected for download</string>
     <string name="downloadmap_target_not_writable">The selected target \"%s\" is not writable - the downloaded map file is saved in the system download folder and must be moved manually to the map folder.</string>
     <string name="downloadmap_allow_metered_network">Allow download over metered network (e.g.: mobile connection)</string>


### PR DESCRIPTION
## Description
On Android 7.0 - 9.0: Check for WRITE_EXTERNAL_STORAGE permission being granted before enqueing a download via integrated download manager, and display an error message on missing permission.
