### PR TITLE
Use MSL altitude if available (fix #14424)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GooglePositionAndHistory.java
@@ -19,6 +19,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemTestLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GoogleV2GeoItemLayer;
 import cgeo.geocaching.utils.AngleUtils;
+import cgeo.geocaching.utils.GeoHeightUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapLineUtils;
 import static cgeo.geocaching.settings.Settings.MAPROTATION_AUTO_LOWPOWER;
@@ -342,7 +343,7 @@ public class GooglePositionAndHistory implements PositionAndHistory, Tracks.Upda
         }
 
         if (coordinates.hasAltitude() && Settings.showElevation()) {
-            final Bitmap elevationInfo = MapUtils.getElevationBitmap(CgeoApplication.getInstance().getResources(), positionMarker.getIntrinsicHeight(), coordinates.getAltitude());
+            final Bitmap elevationInfo = MapUtils.getElevationBitmap(CgeoApplication.getInstance().getResources(), positionMarker.getIntrinsicHeight(), GeoHeightUtils.getAltitude(coordinates));
             positionObjs.addMarker(new MarkerOptions()
                     .icon(BitmapDescriptorFactory.fromBitmap(elevationInfo))
                     .position(latLng)

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.GeoHeightUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapLineUtils;
 
@@ -95,7 +96,7 @@ public class PositionLayer extends Layer {
             canvas.drawBitmap(localArrow, left, top);
 
             if (coordinates.hasAltitude() && Settings.showElevation()) {
-                final Bitmap elevationInfo = new AndroidBitmap(MapUtils.getElevationBitmap(CgeoApplication.getInstance().getResources(), localArrow.getHeight(), coordinates.getAltitude()));
+                final Bitmap elevationInfo = new AndroidBitmap(MapUtils.getElevationBitmap(CgeoApplication.getInstance().getResources(), localArrow.getHeight(), GeoHeightUtils.getAltitude(coordinates)));
                 canvas.drawBitmap(elevationInfo, centerX - elevationInfo.getWidth() / 2, centerY - elevationInfo.getHeight() / 2);
             }
         } else {

--- a/main/src/main/java/cgeo/geocaching/models/TrailHistoryElement.java
+++ b/main/src/main/java/cgeo/geocaching/models/TrailHistoryElement.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.models;
 
+import cgeo.geocaching.utils.GeoHeightUtils;
+
 import android.location.Location;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -38,7 +40,7 @@ public class TrailHistoryElement implements Parcelable {
     }
 
     public double getAltitude() {
-        return location.getAltitude();
+        return GeoHeightUtils.getAltitude(location);
     }
 
     public long getTimestamp() {

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -54,6 +54,7 @@ import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.EnumValueMapper;
 import cgeo.geocaching.utils.FileNameCreator;
 import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.GeoHeightUtils;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.Log;
@@ -2620,7 +2621,7 @@ public class DataStore {
                 final SQLiteStatement insertTrailpoint = PreparedStatement.INSERT_TRAILPOINT.getStatement();
                 insertTrailpoint.bindDouble(1, location.getLatitude());
                 insertTrailpoint.bindDouble(2, location.getLongitude());
-                insertTrailpoint.bindDouble(3, location.getAltitude());
+                insertTrailpoint.bindDouble(3, GeoHeightUtils.getAltitude(location));
                 insertTrailpoint.bindLong(4, System.currentTimeMillis());
                 insertTrailpoint.executeInsert();
                 database.setTransactionSuccessful();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionLayer.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.unifiedmap.UnifiedMapViewModel;
 import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemLayer;
+import cgeo.geocaching.utils.GeoHeightUtils;
 import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.MapLineUtils;
 
@@ -57,7 +58,7 @@ public class PositionLayer {
                 layer.put(KEY_ELEVATION,
                         GeoPrimitive.createMarker(new Geopoint(locationWrapper.location), GeoIcon.builder()
                                         .setFlat(false)
-                                        .setBitmap(MapUtils.getElevationBitmap(activity.getResources(), markerPosition.getHeight(), locationWrapper.location.getAltitude()))
+                                        .setBitmap(MapUtils.getElevationBitmap(activity.getResources(), markerPosition.getHeight(), GeoHeightUtils.getAltitude(locationWrapper.location)))
                                         .build())
                                 .buildUpon().setZLevel(LayerHelper.ZINDEX_POSITION_ELEVATION).build());
             }

--- a/main/src/main/java/cgeo/geocaching/utils/GeoHeightUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/GeoHeightUtils.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.sensors.GeoData;
 
+import android.location.Location;
 import android.os.Build;
 
 public class GeoHeightUtils {
@@ -17,7 +18,7 @@ public class GeoHeightUtils {
     public static String getAverageHeight(final GeoData geo, final boolean onlyFullReadings) {
         // remember new altitude reading, and calculate average from past MAX_READINGS readings
         if (geo.hasAltitude() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || geo.getVerticalAccuracyMeters() > 0.0)) {
-            altitudeReadings[altitudeReadingPos] = geo.getAltitude();
+            altitudeReadings[altitudeReadingPos] = getAltitude(geo);
             altitudeReadingPos = (++altitudeReadingPos) % altitudeReadings.length;
         }
         double averageAltitude = 0;
@@ -30,5 +31,16 @@ public class GeoHeightUtils {
         }
         averageAltitude /= (double) altitudeReadings.length;
         return averageAltitude == 0 || (onlyFullReadings && countReadings < 5) ? "" : Formatter.SEPARATOR + (countReadings < 5 ? "~ " : "") + Units.getDistanceFromMeters((float) averageAltitude);
+    }
+
+
+    /** returns altitude in meters; prefers msl altitude if available */
+    public static double getAltitude(final Location geo) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            if (geo.hasMslAltitude()) {
+                return geo.getMslAltitudeMeters();
+            }
+        }
+        return geo.getAltitude();
     }
 }


### PR DESCRIPTION
## Description
On Android 14+ systems use the new feature to retrieve MSL-based altitude (see [docs](https://developer.android.com/reference/android/location/Location#getMslAltitudeMeters())), if such data is available for current location.