### PR TITLE
Adapt MapsforgeDownloader test to new map structure

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
@@ -58,7 +58,7 @@ public class DownloaderTest {
         assertThat(list.get(0).isDir()).isTrue();
 
         // number of dirs found
-        assertThat(count(list, true)).isEqualTo(5);
+        assertThat(count(list, true)).isEqualTo(7);
 
         // number of non-dirs found
         assertThat(count(list, false)).isBetween(49, 53);


### PR DESCRIPTION
## Description
Mapsforge seems to have two more countries in Europe with state-specific sub maps, therefore need to adapt the Mapsforge downloader test