### PR TITLE
Switch BRouter foreground service type to dataSync

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" android:minSdkVersion="34" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" android:minSdkVersion="34" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" android:minSdkVersion="34" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -762,7 +761,7 @@
             android:exported="false"
             android:enabled="true"
             android:process=":brouter_service"
-            android:foregroundServiceType="location">
+            android:foregroundServiceType="dataSync">
         </service>
 
         <activity


### PR DESCRIPTION
## Description
Currently integrated BRouter service is declared as service type "location", which seemed to be obvious, as it performs routing calculation based on given locations. But reading the [service type specs](https://developer.android.com/about/versions/14/changes/fgs-types-required), type location seems to be meant for something different, for "Long-running use cases that require location access, such as navigation and location sharing." But BRouter service itself does not need location access, it simply calculates a route between two given sets of coordinates. Additionally, BRouter service is able to run with location permissions not being granted, whereas the docs for service type location explicitly list granted location permissions as a runtime prerequisite for this service type. Thus I think service type "location" is inappropriate.

Service type "dataSync" seems to be suitable, though, as both "Fetch data" and "Local file processing" use-cases listed in the docs do fit.