### PR TITLE
Fix #15904: Route not updating on appending a geo item

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
@@ -70,6 +70,7 @@ public class IndividualRoute extends Route implements Parcelable {
             Log.d("[RouteTrackDebug] Individual route: Removed first element from route (" + item.getIdentifier() + ")");
         }
         ViewUtils.showShortToast(context, result == ToggleItemState.ADDED ? R.string.individual_route_added : result == ToggleItemState.REMOVED ? R.string.individual_route_removed : R.string.individual_route_error_toggling_waypoint);
+        updateRoute(routeUpdater);
         saveRoute();
     }
 


### PR DESCRIPTION
## Description
While refactoring a `updateRoute(routeUpdater);` got removed inadvertently, leading to routes no longer being updated on adding a geo item. This PR fixes this.
