### PR TITLE
Make dark background solid black + fix cache list divider (fix #15864)

### DIFF
--- a/main/src/main/res/layout/cacheslist_activity.xml
+++ b/main/src/main/res/layout/cacheslist_activity.xml
@@ -29,6 +29,7 @@
         android:layout_margin="0dip"
         android:clipToPadding="false"
         android:dividerHeight="1dip"
+        android:divider="@color/colorSeparator"
         android:fastScrollEnabled="false"
         android:padding="0dip"
         android:scrollbarStyle="outsideOverlay"

--- a/main/src/main/res/values-night/colors_dark.xml
+++ b/main/src/main/res/values-night/colors_dark.xml
@@ -11,7 +11,7 @@
     <color name="colorTextHeadline">#88FFFFFF</color>
     <color name="colorTextHintActionBar">@color/colorTextHint</color>
 
-    <color name="colorBackground">#FF141414</color>
+    <color name="colorBackground">#FF000000</color>
     <color name="colorBackgroundTransparent">#44000000</color>
     <color name="colorBackgroundDialog">#FF353535</color>
     <color name="colorBackgroundSelected">#FF444444</color>


### PR DESCRIPTION
## Description
- Set solid black as background color in dark mode
- Fix cache list: missing divider color

![image](https://github.com/user-attachments/assets/a521180e-25d7-4677-9fb1-66d7859984a9)
