### PR TITLE
allow up to 200 waypoints to be calculated

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/formulas/IntegerRange.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/IntegerRange.java
@@ -25,7 +25,7 @@ public class IntegerRange {
     }
 
     public static IntegerRange createFromConfig(final String config) {
-        final List<Integer> parsed = parseConfig(config, 20);
+        final List<Integer> parsed = parseConfig(config, 200);
         return parsed == null ? null : new IntegerRange(ArrayUtils.toPrimitive(parsed.toArray(new Integer[0])));
     }
 


### PR DESCRIPTION
calculating coordinates supports placeholders (e,g, [:0-9]) in formulas to then draw multiple waypoints. This functionality is currently limited to 20 waypoints  - if the formula+variables would result in 21 or more waypoints the option to draw the waypoints is disabled.
In real life use i've often encountered the situation where this 20 limit is not enough, e.g. when I'm missing 2 out of 6 bonus numbers when it'll be 100 waypoints. Even in this situation just drawing all 100 of them will usually point to a reasonable spot on the map that enables finding the cache.

This PR raises the limit of 20 (arbitrary number I guess) to 200 (another arbitrary number). Could also be 1000 to support 3 vars missing ...