### PR TITLE
improve map viewport comparison for live map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/LoadInBackgroundHandler.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/LoadInBackgroundHandler.java
@@ -65,8 +65,8 @@ class LoadInBackgroundHandler {
                 final int currentZoom = map.getCurrentZoom();
 
                 // check if map moved or zoomed
-                final boolean moved = previousViewport == null || currentZoom != previousZoom || mapMoved(previousViewport, currentViewport);
-                if (moved) {
+                final boolean useLastSearchResult = null != lastSearchResult && null != previousViewport && (previousViewport.includes(currentViewport) || !mapMoved(previousViewport, currentViewport));
+                if (!useLastSearchResult) {
                     load(currentViewport);
                     previousZoom = currentZoom;
                     previousViewport = currentViewport;


### PR DESCRIPTION
For UnifiedMap use a similar logic as for old map to compare whether the current viewport requires a new request to server for LiveMap results. Previous implementation was triggered with *any* zoom change.

partially fixes #15942