### PR TITLE
Formula: allow big-sizes integet ranges (disallow usage of negation), alternative to PR ä15941

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/formulas/IntegerRange.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/IntegerRange.java
@@ -4,44 +4,53 @@ import cgeo.geocaching.utils.TextParser;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.commons.lang3.ArrayUtils;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class IntegerRange {
 
-    private final int[] values;
+    //range values will be stored in map structure mapping start pos of a range to first value of this range:
+    //Example: [:1-3, 8, 5-7] will be stored in a map as 0 -> 1, 3 -> 8, 4 -> 5
 
-    private IntegerRange(final int[] values) {
-        this.values = values;
+    private final TreeMap<Integer, Integer> valueMap;
+    private final int size;
+
+    private IntegerRange(final TreeMap<Integer, Integer> valueMap, final int size) {
+        this.valueMap = valueMap;
+        this.size = size;
     }
 
 
     public int getSize() {
-        return values.length;
+        return size;
     }
 
     public int getValue(final int pos) {
-        return pos < 0 || pos >= values.length ? 0 : values[pos];
+        if (pos < 0 || pos >= size || valueMap.isEmpty()) {
+            return 0;
+        }
+        final Map.Entry<Integer, Integer> entry = valueMap.floorEntry(pos);
+        return entry == null ? 0 : pos - entry.getKey() + entry.getValue();
     }
 
     public static IntegerRange createFromConfig(final String config) {
-        final List<Integer> parsed = parseConfig(config, 20);
-        return parsed == null ? null : new IntegerRange(ArrayUtils.toPrimitive(parsed.toArray(new Integer[0])));
+        final TreeMap<Integer, Integer> targetMap = new TreeMap<>();
+        final int size = parseConfig(config, targetMap);
+        return size <= 0 ? null : new IntegerRange(targetMap, size);
     }
 
     // method readability will not improve by splitting it up
     @SuppressWarnings("PMD.NPathComplexity")
-    private static List<Integer> parseConfig(final String pattern, final int maxLength) {
+    private static int parseConfig(final String pattern, final Map<Integer, Integer> targetMap) {
+
         final List<Integer> result = new ArrayList<>();
         final TextParser tp = new TextParser(pattern);
         StringBuilder currentToken = new StringBuilder();
         String lastToken = null;
         boolean rangeFound = false;
-        boolean negate = false;
+        int pos = 0;
         while (true) {
-            if (tp.ch() == '^') {
-                negate = !negate;
-            } else if (tp.ch() >= '0' && tp.ch() <= '9') {
+            if (tp.ch() >= '0' && tp.ch() <= '9') {
                 currentToken.append(tp.ch());
             } else if (tp.ch() == '-') {
                 rangeFound = true;
@@ -62,28 +71,19 @@ public class IntegerRange {
                         start = end;
                         end = m;
                     }
-                    for (int i = start; i <= end; i++) {
-                        if (negate) {
-                            result.remove((Integer) i);
-                        } else {
-                            result.add(i);
-                            if (result.size() > maxLength) {
-                                break;
-                            }
-                        }
-                    }
+                    targetMap.put(pos, start);
+                    pos += end + 1 - start;
                 }
                 currentToken = new StringBuilder();
-                negate = false;
                 rangeFound = false;
                 lastToken = null;
-                if (tp.eof() || result.size() >= maxLength) {
+                if (tp.eof()) {
                     break;
                 }
             }
             tp.next();
         }
-        return tp.eof() && result.size() <= maxLength && !result.isEmpty() ? result : null;
+        return tp.eof()  ? pos : 0;
 
     }
 
@@ -94,6 +94,5 @@ public class IntegerRange {
             return null;
         }
     }
-
 
 }

--- a/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
@@ -182,8 +182,11 @@ public class FormulaTest {
         assertThat(Formula.compile("[:0-9]").getRangeIndexSize()).isEqualTo(10);
 
         assertThat(Formula.compile("[:0-3]*[:0-4]").getRangeIndexSize()).isEqualTo(20);
+        assertRangeFormula("[:1-2, 8]*3", null, 3, 6, 24);
+        assertRangeFormula("[:2-1, 8]*3", null, 3, 6, 24);
         assertRangeFormula("[:1-2]*[:3-4]", null, 3, 6, 4, 8);
-        assertRangeFormula("[:1-3, ^2]*[:10-20, ^11-19]", null, 10, 30, 20, 60);
+        assertRangeFormula("[:1,3]*[:10,20]", null, 10, 30, 20, 60);
+        assertRangeFormula("[:3,1]*[:10,20]", null, 30, 10, 60, 20);
 
         //assert graceful handling of "strange" formats
         assertRangeFormula("[:abc1]", null, 1);
@@ -193,15 +196,10 @@ public class FormulaTest {
         //assert
         assertThatThrownBy(() -> eval("[:0-3"))
                 .isInstanceOf(FormulaException.class).hasMessageContaining(UNEXPECTED_TOKEN.name()).hasMessageContaining("]");
-        assertThatThrownBy(() -> eval("[:0-5000]")).as("Too many items in range")
-                .isInstanceOf(FormulaException.class).hasMessageContaining(OTHER.name()).hasMessageContaining("0-5000");
         assertThatThrownBy(() -> eval("[:]"))
                 .isInstanceOf(FormulaException.class).hasMessageContaining(OTHER.name());
         assertThatThrownBy(() -> eval("[:  ]"))
                 .isInstanceOf(FormulaException.class).hasMessageContaining(OTHER.name());
-        assertThatThrownBy(() -> eval("[:^1-2]"))
-                .isInstanceOf(FormulaException.class).hasMessageContaining(OTHER.name());
-
     }
 
     private void assertRangeFormula(final String formula, final Func1<String, Value> varMap, final Object... expectedResults) {


### PR DESCRIPTION
Formula: allow big-sizes integet ranges (disallow usage of negation), alternative to PR ä15941

This PR allows integer ranges of any size w/o consuming too much memory. Disadvantage is that this implementation does not support negation operator any more (^). 

![image](https://github.com/user-attachments/assets/35e11937-e70e-4338-b847-4733dbb18ffe)

![image](https://github.com/user-attachments/assets/3c6b719f-19af-4ffc-a0e3-583ffb526fa3)
