### PR TITLE
Dynamic image size

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.test.CgeoTestUtils;
 import cgeo.geocaching.test.R;
 import cgeo.geocaching.test.mock.MockedCache;
 import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.ImageUtils;
 import cgeo.test.Compare;
 import static cgeo.geocaching.connector.gc.GCParser.deleteModifiedCoordinates;
 import static cgeo.geocaching.connector.gc.GCParser.editModifiedCoordinates;
@@ -354,9 +355,9 @@ public class GCParserTest {
     @MediumTest
     @Test
     public void testFullScaleImageUrl() {
-        assertThat(GCParser.fullScaleImageUrl("https://www.dropbox.com/s/1kakwnpny8698hm/QR_Hintergrund.jpg?dl=1"))
+        assertThat(ImageUtils.getGCFullScaleImageUrl("https://www.dropbox.com/s/1kakwnpny8698hm/QR_Hintergrund.jpg?dl=1"))
                 .isEqualTo("https://www.dropbox.com/s/1kakwnpny8698hm/QR_Hintergrund.jpg?dl=1");
-        assertThat(GCParser.fullScaleImageUrl("http://imgcdn.geocaching.com/track/display/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg"))
+        assertThat(ImageUtils.getGCFullScaleImageUrl("http://imgcdn.geocaching.com/track/display/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg"))
                 .isEqualTo("http://imgcdn.geocaching.com/track/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg");
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -89,8 +89,8 @@ public final class GCConstants {
     static final Pattern PATTERN_INVENTORYINSIDE = Pattern.compile("[^<]*<li>[^<]*<a href=\"[a-z0-9\\-\\_\\.\\?\\/\\:\\@]*\\/(?:track|hide)\\/details\\.aspx\\?(guid|TB)=([0-9a-zA-Z\\-]+)[^\"]*\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>([^<]+)<\\/span>[^<]*<\\/a>[^<]*<\\/li>");
     static final Pattern PATTERN_WATCHLIST = Pattern.compile("data-cacheonwatchlist=\"True\"");
     static final Pattern PATTERN_RELATED_WEB_PAGE = Pattern.compile("ctl00_ContentBody_uxCacheUrl.*? href=\"(.*?)\">");
-    static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com(?::443)?(?:/[a-z]*)?/([^/]*)");
-    static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com(?::443)?/gs-geo-images/(.*)(_l|_d|_sm|_t)?(\\." + IMAGE_FORMATS + ")");
+    static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com(?::443)?(?:/[a-z/]*)?/([^/]*)");
+    static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com(?::443)?/gs-geo-images/(.*?)(?:_l|_d|_sm|_t)?(\\." + IMAGE_FORMATS + ")");
     static final Pattern PATTERN_BACKGROUND_IMAGE = Pattern.compile("<body background=\"(.+?)\"");
     static final String PATTERN_GC_CHECKER = "ctl00_ContentBody_lblSolutionChecker";
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -89,8 +89,8 @@ public final class GCConstants {
     static final Pattern PATTERN_INVENTORYINSIDE = Pattern.compile("[^<]*<li>[^<]*<a href=\"[a-z0-9\\-\\_\\.\\?\\/\\:\\@]*\\/(?:track|hide)\\/details\\.aspx\\?(guid|TB)=([0-9a-zA-Z\\-]+)[^\"]*\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>([^<]+)<\\/span>[^<]*<\\/a>[^<]*<\\/li>");
     static final Pattern PATTERN_WATCHLIST = Pattern.compile("data-cacheonwatchlist=\"True\"");
     static final Pattern PATTERN_RELATED_WEB_PAGE = Pattern.compile("ctl00_ContentBody_uxCacheUrl.*? href=\"(.*?)\">");
-    static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com/");
-    static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com/gs-geo-images/(.*)_(l|d|sm|t)\\." + IMAGE_FORMATS);
+    static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com(?::443)?(?:/[a-z]*)?/([^/]*)");
+    static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com(?::443)?/gs-geo-images/(.*)(_l|_d|_sm|_t)?(\\." + IMAGE_FORMATS + ")");
     static final Pattern PATTERN_BACKGROUND_IMAGE = Pattern.compile("<body background=\"(.+?)\"");
     static final String PATTERN_GC_CHECKER = "ctl00_ContentBody_lblSolutionChecker";
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -89,8 +89,6 @@ public final class GCConstants {
     static final Pattern PATTERN_INVENTORYINSIDE = Pattern.compile("[^<]*<li>[^<]*<a href=\"[a-z0-9\\-\\_\\.\\?\\/\\:\\@]*\\/(?:track|hide)\\/details\\.aspx\\?(guid|TB)=([0-9a-zA-Z\\-]+)[^\"]*\"[^>]*>[^<]*<img src=\"[^\"]+\"[^>]*>[^<]*<span>([^<]+)<\\/span>[^<]*<\\/a>[^<]*<\\/li>");
     static final Pattern PATTERN_WATCHLIST = Pattern.compile("data-cacheonwatchlist=\"True\"");
     static final Pattern PATTERN_RELATED_WEB_PAGE = Pattern.compile("ctl00_ContentBody_uxCacheUrl.*? href=\"(.*?)\">");
-    static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com(?::443)?(?:/[a-z/]*)?/([^/]*)");
-    static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com(?::443)?/gs-geo-images/(.*?)(?:_l|_d|_sm|_t)?(\\." + IMAGE_FORMATS + ")");
     static final Pattern PATTERN_BACKGROUND_IMAGE = Pattern.compile("<body background=\"(.+?)\"");
     static final String PATTERN_GC_CHECKER = "ctl00_ContentBody_lblSolutionChecker";
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -90,6 +90,7 @@ public final class GCConstants {
     static final Pattern PATTERN_WATCHLIST = Pattern.compile("data-cacheonwatchlist=\"True\"");
     static final Pattern PATTERN_RELATED_WEB_PAGE = Pattern.compile("ctl00_ContentBody_uxCacheUrl.*? href=\"(.*?)\">");
     static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com/");
+    static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com/gs-geo-images/(.*)_(l|d|sm|t)\\." + IMAGE_FORMATS);
     static final Pattern PATTERN_BACKGROUND_IMAGE = Pattern.compile("<body background=\"(.+?)\"");
     static final String PATTERN_GC_CHECKER = "ctl00_ContentBody_lblSolutionChecker";
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -30,7 +30,6 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.DisposableHandler;
-import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
@@ -440,7 +439,7 @@ public final class GCParser {
         // background image, to be added only if the image is not already present in the cache listing
         final MatcherWrapper matcherBackgroundImage = new MatcherWrapper(GCConstants.PATTERN_BACKGROUND_IMAGE, page);
         if (matcherBackgroundImage.find()) {
-            final String url = ImageUtils.getGCFullScaleImageUrl(matcherBackgroundImage.group(1));
+            final String url = matcherBackgroundImage.group(1);
             boolean present = false;
             for (final Image image : cache.getSpoilers()) {
                 if (StringUtils.equals(image.getUrl(), url)) {
@@ -595,7 +594,7 @@ public final class GCParser {
         final MatcherWrapper matcherSpoilersInside = new MatcherWrapper(GCConstants.PATTERN_SPOILER_IMAGE, html);
 
         while (matcherSpoilersInside.find()) {
-            final String url = ImageUtils.getGCFullScaleImageUrl(matcherSpoilersInside.group(1));
+            final String url = matcherSpoilersInside.group(1);
 
             String title = null;
             if (matcherSpoilersInside.group(2) != null) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -650,10 +650,20 @@ public final class GCParser {
 
     @NonNull
     static String fullScaleImageUrl(@NonNull final String imageUrl) {
-        // For images from geocaching.com: the original spoiler URL
-        // (include .../display/... contains a low-resolution image
-        // if we shorten the URL we get the original-resolution image
-        return GCConstants.PATTERN_GC_HOSTED_IMAGE.matcher(imageUrl).find() ? imageUrl.replace("/display", "") : imageUrl;
+        // Images from geocaching.com exist in original + 4 generated sizes: large, display, small, thumb
+        // Manipulate the URL to load the requested size.
+        String fullscaleUrl = imageUrl;
+        if (GCConstants.PATTERN_GC_HOSTED_IMAGE.matcher(imageUrl).find()) {
+            for (String urlpath : new String[] {"/large/", "/display/", "/small/", "/thumb/"}) {
+                fullscaleUrl = imageUrl.replace(urlpath, "/");
+            }
+        }
+        if (GCConstants.PATTERN_GC_HOSTED_IMAGE_S3.matcher(imageUrl).find()) {
+            for (String urlpath : new String[] {"_l", "_d", "_sm", "_t"}) {
+                fullscaleUrl = imageUrl.replace(urlpath, "");
+            }
+        }
+        return fullscaleUrl;
     }
 
     private static SearchResult searchByMap(final IConnector con, final Parameters params) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -30,6 +30,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MatcherWrapper;
@@ -439,7 +440,7 @@ public final class GCParser {
         // background image, to be added only if the image is not already present in the cache listing
         final MatcherWrapper matcherBackgroundImage = new MatcherWrapper(GCConstants.PATTERN_BACKGROUND_IMAGE, page);
         if (matcherBackgroundImage.find()) {
-            final String url = fullScaleImageUrl(matcherBackgroundImage.group(1));
+            final String url = ImageUtils.getGCFullScaleImageUrl(matcherBackgroundImage.group(1));
             boolean present = false;
             for (final Image image : cache.getSpoilers()) {
                 if (StringUtils.equals(image.getUrl(), url)) {
@@ -594,7 +595,7 @@ public final class GCParser {
         final MatcherWrapper matcherSpoilersInside = new MatcherWrapper(GCConstants.PATTERN_SPOILER_IMAGE, html);
 
         while (matcherSpoilersInside.find()) {
-            final String url = fullScaleImageUrl(matcherSpoilersInside.group(1));
+            final String url = ImageUtils.getGCFullScaleImageUrl(matcherSpoilersInside.group(1));
 
             String title = null;
             if (matcherSpoilersInside.group(2) != null) {
@@ -646,46 +647,6 @@ public final class GCParser {
     @Nullable
     private static String getNumberString(@Nullable final String numberWithPunctuation) {
         return StringUtils.replaceChars(numberWithPunctuation, ".,", "");
-    }
-
-    @NonNull
-    public static String fullScaleImageUrl(@NonNull final String imageUrl) {
-        // Images from geocaching.com exist in original + 4 generated sizes: large, display, small, thumb
-        // Manipulate the URL to load the requested size.
-        final GCImageSize preferredSize = GCImageSize.ORIGINAL;
-        MatcherWrapper matcherViewstates = new MatcherWrapper(GCConstants.PATTERN_GC_HOSTED_IMAGE, imageUrl);
-        if (matcherViewstates.find()) {
-            return "https://img.geocaching.com/" + preferredSize.getPathname() + matcherViewstates.group(1);
-        }
-        matcherViewstates = new MatcherWrapper(GCConstants.PATTERN_GC_HOSTED_IMAGE_S3, imageUrl);
-        if (matcherViewstates.find()) {
-            return "https://s3.amazonaws.com/gs-geo-images/" + matcherViewstates.group(1) + preferredSize.getSuffix() + matcherViewstates.group(2);
-        }
-        return imageUrl;
-    }
-
-    public enum GCImageSize {
-        ORIGINAL("", ""),
-        LARGE("_l", "large/"),
-        DISPLAY("_d", "display/"),
-        SMALL("_sm", "small/"),
-        THUMB("_t", "thumb/");
-
-        private final String suffix;
-        private final String pathname;
-
-        GCImageSize(final String suffix, final String pathname) {
-            this.suffix = suffix;
-            this.pathname = pathname;
-        }
-
-        public String getPathname() {
-            return pathname;
-        }
-
-        public String getSuffix() {
-            return suffix;
-        }
     }
 
     private static SearchResult searchByMap(final IConnector con, final Parameters params) {

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -2130,7 +2130,7 @@ public class Geocache implements IWaypoint {
                 for (final LogEntry log : cache.getLogs()) {
                     if (log.hasLogImages()) {
                         for (final Image oneLogImg : log.logImages) {
-                            imgGetter.getDrawable(oneLogImg.getUrl());
+                            //imgGetter.getDrawable(oneLogImg.getUrl());
                         }
                     }
                 }
@@ -2235,7 +2235,17 @@ public class Geocache implements IWaypoint {
             result.addAll(log.logImages);
         }
         addLocalSpoilersTo(result);
-        return result;
+
+        // Deduplicate images and return them in requested size
+        final List<Image> uniqueImages = new LinkedList<>();
+        final List<String> uniqueUrls = new ArrayList<>();
+        for (final Image img : result) {
+            if (!uniqueUrls.contains(img.getUrl())) {
+                uniqueUrls.add(img.getUrl());
+                uniqueImages.add(img.buildUpon().setUrl(img.getUrl()).build());
+            }
+        }
+        return uniqueImages;
     }
 
     @NonNull

--- a/main/src/main/java/cgeo/geocaching/models/Image.java
+++ b/main/src/main/java/cgeo/geocaching/models/Image.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.models;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.UriUtils;
@@ -307,7 +308,7 @@ public class Image implements Parcelable {
         if (isEmpty()) {
             return "";
         }
-        return uri.toString();
+        return ImageUtils.getGCFullScaleImageUrl(uri.toString());
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Image;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.Folder;
 import cgeo.geocaching.storage.LocalStorage;
@@ -537,7 +538,7 @@ public final class ImageUtils {
     public static String getGCFullScaleImageUrl(@NonNull final String imageUrl) {
         // Images from geocaching.com exist in original + 4 generated sizes: large, display, small, thumb
         // Manipulate the URL to load the requested size.
-        final GCImageSize preferredSize = GCImageSize.ORIGINAL;
+        final GCImageSize preferredSize = ImageUtils.GCImageSize.valueOf(Settings.getString(R.string.pref_gc_imagesize, "ORIGINAL"));
         MatcherWrapper matcherViewstates = new MatcherWrapper(PATTERN_GC_HOSTED_IMAGE, imageUrl);
         if (matcherViewstates.find()) {
             return "https://img.geocaching.com/" + preferredSize.getPathname() + matcherViewstates.group(1);

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -484,10 +484,9 @@ public final class ImageUtils {
     public static void addImagesFromHtml(final Collection<Image> images, final String geocode, final String... htmlText) {
         final Set<String> urls = new LinkedHashSet<>();
         for (final Image image : images) {
-            urls.add(imageUrlForSpoilerCompare(getGCFullScaleImageUrl(image.getUrl())));
+            urls.add(imageUrlForSpoilerCompare(image.getUrl()));
         }
         forEachImageUrlInHtml(source -> {
-            source = getGCFullScaleImageUrl(source);
                 if (!urls.contains(imageUrlForSpoilerCompare(source)) && canBeOpenedExternally(source)) {
                     images.add(new Image.Builder()
                             .setUrl(source, "https")
@@ -545,7 +544,8 @@ public final class ImageUtils {
         }
         matcherViewstates = new MatcherWrapper(PATTERN_GC_HOSTED_IMAGE_S3, imageUrl);
         if (matcherViewstates.find()) {
-            return "https://s3.amazonaws.com/gs-geo-images/" + matcherViewstates.group(1) + preferredSize.getSuffix() + matcherViewstates.group(2);
+            return "https://img.geocaching.com/" + preferredSize.getPathname() + matcherViewstates.group(1) + matcherViewstates.group(2);
+            //return "https://s3.amazonaws.com/gs-geo-images/" + matcherViewstates.group(1) + preferredSize.getSuffix() + matcherViewstates.group(2);
         }
         return imageUrl;
     }

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.connector.gc.GCParser;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.Folder;
@@ -485,6 +486,7 @@ public final class ImageUtils {
             urls.add(imageUrlForSpoilerCompare(image.getUrl()));
         }
         forEachImageUrlInHtml(source -> {
+            source = GCParser.fullScaleImageUrl(source);
                 if (!urls.contains(imageUrlForSpoilerCompare(source)) && canBeOpenedExternally(source)) {
                     images.add(new Image.Builder()
                             .setUrl(source, "https")

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -460,6 +460,18 @@
         <item>@string/pref_value_startscreen_nearby</item>
     </string-array>
 
+    <!-- Geocaching.com => image size -->
+    <string translatable="false" name="pref_value_gc_imagesize_original">ORIGINAL</string>
+    <string translatable="false" name="pref_value_gc_imagesize_large">LARGE</string>
+    <string translatable="false" name="pref_value_gc_imagesize_display">DISPLAY</string>
+    <string translatable="false" name="pref_value_gc_imagesize_small">SMALL</string>
+    <string-array name="pref_gc_imagesize_values">
+        <item>@string/pref_value_gc_imagesize_original</item>
+        <item>@string/pref_value_gc_imagesize_large</item>
+        <item>@string/pref_value_gc_imagesize_display</item>
+        <item>@string/pref_value_gc_imagesize_small</item>
+    </string-array>
+
     <!-- ============================================================================================================================================================================== -->
     <!-- other preference keys (not used directly in our preferences) -->
     <!-- ============================================================================================================================================================================== -->
@@ -606,6 +618,7 @@
     <string translatable="false" name="pref_dbReindexLastCheck">dbReindexLastCheck</string>
     <string translatable="false" name="pref_pendingDownloadsLastCheck">pendingDownloadsLastCheck</string>
     <string translatable="false" name="pref_pollMessageCenter">pollMessageCenter</string>
+    <string translatable="false" name="pref_gc_imagesize">gc_imagesize</string>
     <string translatable="false" name="pref_simple_list_model_config">simple_list_model_config</string>
 
     <string translatable="false" name="pref_caches_history">caches_history</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3310,6 +3310,16 @@
         <item quantity="other">%d unread messages in message center</item>
     </plurals>
 
+    <!-- GC image size conversion -->
+    <string name="settings_gc_imagesize_title">Preferred Image Size</string>
+    <string name="settings_gc_imagesize_summary">Images from Geocaching.com in listing, logs and trackables are available in different sizes. Select the size to be loaded when loading and storing a cache.</string>
+    <string-array name="settings_gc_imagesize_entries">
+        <item>Original</item>
+        <item>640px</item>
+        <item>320px</item>
+        <item>120px</item>
+    </string-array>
+
     <!-- db inspection -->
     <string name="view_database">View database</string>
     <string name="dbi_select_title">(Select table)</string>

--- a/main/src/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/src/main/res/xml/preferences_services_geocaching_com.xml
@@ -35,6 +35,15 @@
             android:defaultValue="false"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="@string/pref_value_gc_imagesize_original"
+            android:entries="@array/settings_gc_imagesize_entries"
+            android:entryValues="@array/pref_gc_imagesize_values"
+            android:key="@string/pref_gc_imagesize"
+            android:title="@string/settings_gc_imagesize_title"
+            android:summary="@string/settings_gc_imagesize_summary"
+            app:iconSpaceReserved="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Since 2016 there's actually some code to load original instead of "/display/", but only for that 1 out of 4 generated sizes. And it applies only to listing background and spoiler images (but not to inline images which are more commonly used today).

PR adds code to handle all 5 sizes, applies it to all listing images, always requests the original one and fixes some smaller issues.

Open question:

- (How) do we let the user decide about the prefered size (New setting?)?
- What's the default size?
- Is it the same for all types of images (listing, listing background, TB, log)?

Open todos:

- Apply the same to logs, TBs. 
- Rewrite the listing html code before loading it to apply the different image size there as well - right now it only applies to images tab, resulting in the image (maybe) getting loaded twice.

Discussion in https://github.com/cgeo/cgeo/issues/15929 please