### PR TITLE
Prevent stacking of navigation popups (fix #15937)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -958,7 +958,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
      * referenced from XML view
      */
     public void showNavigationMenu(@SuppressWarnings("unused") final View view) {
-        NavigationAppFactory.showNavigationMenu(this, cache, null, null, true, true);
+        NavigationAppFactory.showNavigationMenu(this, cache, null, null, true, true, 0);
     }
 
     public static void startActivity(final Context context, final String geocode, final boolean forceWaypointsPage) {

--- a/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
@@ -350,7 +350,8 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
 
     @Override
     public void showNavigationMenu() {
-        NavigationAppFactory.showNavigationMenu(getActivity(), cache, null, null, true, true);
+        getActivity().findViewById(R.id.menu_navigate).setEnabled(false);
+        NavigationAppFactory.showNavigationMenu(getActivity(), cache, null, null, true, true, R.id.menu_navigate);
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/apps/navi/NavigationAppFactory.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/NavigationAppFactory.java
@@ -21,6 +21,7 @@ import cgeo.geocaching.ui.dialog.Dialogs;
 
 import android.app.Activity;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.ArrayAdapter;
 
 import androidx.annotation.NonNull;
@@ -155,7 +156,7 @@ public final class NavigationAppFactory {
      */
     public static void showNavigationMenu(final Activity activity,
                                           final Geocache cache, final Waypoint waypoint, final Geopoint destination) {
-        showNavigationMenu(activity, cache, waypoint, destination, true, false);
+        showNavigationMenu(activity, cache, waypoint, destination, true, false, 0);
     }
 
     /**
@@ -167,11 +168,12 @@ public final class NavigationAppFactory {
      * @param destination           may be {@code null}
      * @param showInternalMap       should be {@code false} only when called from within the internal map
      * @param showDefaultNavigation should be {@code false} by default
+     * @param menuResToEnableOnDismiss res id of menu item to enable on dialog dismiss (0 if unused)
      * @see #showNavigationMenu(Activity, Geocache, Waypoint, Geopoint)
      */
     public static void showNavigationMenu(final Activity activity,
                                           final Geocache cache, final Waypoint waypoint, final Geopoint destination,
-                                          final boolean showInternalMap, final boolean showDefaultNavigation) {
+                                          final boolean showInternalMap, final boolean showDefaultNavigation, final int menuResToEnableOnDismiss) {
         final List<NavigationAppsEnum> items = new ArrayList<>();
         final int defaultNavigationTool = Settings.getDefaultNavigationTool();
         for (final NavigationAppsEnum navApp : getActiveNavigationApps()) {
@@ -211,6 +213,14 @@ public final class NavigationAppFactory {
             invokeNavigation(activity, cache, waypoint, destination, selectedItem.app);
         });
         final AlertDialog alert = builder.create();
+        if (menuResToEnableOnDismiss != 0) {
+            alert.setOnDismissListener(dialog -> {
+                final View menuItem = activity.findViewById(menuResToEnableOnDismiss);
+                if (menuItem != null) {
+                    menuItem.setEnabled(true);
+                }
+            });
+        }
         alert.show();
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -295,7 +295,7 @@ public class MapUtils {
                     setTarget.call(longClickGeopoint, null);
                     updateRouteTrackButtonVisibility.run();
                 })
-                .addItemClickListener(R.id.menu_navigate, item -> NavigationAppFactory.showNavigationMenu(activity, null, null, longClickGeopoint, false, true));
+                .addItemClickListener(R.id.menu_navigate, item -> NavigationAppFactory.showNavigationMenu(activity, null, null, longClickGeopoint, false, true, 0));
     }
 
     private static void updateRouteTrackButtonVisibility(final Runnable updateRouteTrackButtonVisibility) {


### PR DESCRIPTION
## Description
Long-tapping on navigation button in cache infosheet leads to stacking of navigation app selection, as the menu items fires multiple times.
This PR prevents this by disabling the menu item (and the dialog re-enabling it on dismissal).