### PR TITLE
Add UnifiedMap support for Mapsforge (non-VTM)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -914,6 +914,7 @@
         </activity>
         <activity android:name=".maps.mapsforge.v6.RenderThemeSettings" />
         <activity android:name=".unifiedmap.mapsforgevtm.MapsforgeThemeSettings" />
+        <activity android:name=".unifiedmap.mapsforge.MapsforgeThemeSettings" />
 
         <!-- fileprovider to be able to share files -->
         <provider

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -366,12 +366,12 @@ dependencies {
     // -- Mapsforge / Mapsforge --
 
     // Mapsforge official version
-    String mapsforgeSource = 'org.mapsforge'
-    String mapsforgeVersion = '0.21.0'
+    // String mapsforgeSource = 'org.mapsforge'
+    // String mapsforgeVersion = '0.21.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
-    //String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    //String mapsforgeVersion = 'fbc75a4' // master as of 18.07.22
+    String mapsforgeSource = 'com.github.mapsforge.mapsforge'
+    String mapsforgeVersion = 'd866ea2' // master as of 2024-08-15, including rotation & fractional zoom
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
     // String mapsforgeSource = 'com.github.cgeo.mapsforge'

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/RenderThemeHelper.java
@@ -52,7 +52,7 @@ import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
 import org.mapsforge.map.model.DisplayModel;
 import org.mapsforge.map.rendertheme.ExternalRenderTheme;
-import org.mapsforge.map.rendertheme.InternalRenderTheme;
+import org.mapsforge.map.rendertheme.internal.MapsforgeThemes;
 import org.mapsforge.map.rendertheme.XmlRenderTheme;
 import org.mapsforge.map.rendertheme.XmlRenderThemeMenuCallback;
 import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
@@ -175,12 +175,12 @@ public class RenderThemeHelper implements XmlRenderThemeMenuCallback {
             } catch (final IOException e) {
                 Log.w("Failed to set render theme", e);
                 ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.err_rendertheme_file_unreadable));
-                rendererLayer.setXmlRenderTheme(InternalRenderTheme.OSMARENDER);
+                rendererLayer.setXmlRenderTheme(MapsforgeThemes.OSMARENDER);
                 selectedTheme = null;
             } catch (final Exception e) {
                 Log.w("render theme invalid", e);
                 ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.err_rendertheme_invalid));
-                rendererLayer.setXmlRenderTheme(InternalRenderTheme.OSMARENDER);
+                rendererLayer.setXmlRenderTheme(MapsforgeThemes.OSMARENDER);
                 selectedTheme = null;
             }
         }
@@ -194,7 +194,7 @@ public class RenderThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
     private void applyDefaultTheme(final TileRendererLayer rendererLayer) {
-        rendererLayer.setXmlRenderTheme(InternalRenderTheme.OSMARENDER);
+        rendererLayer.setXmlRenderTheme(MapsforgeThemes.OSMARENDER);
         applyScales(rendererLayer, Settings.RENDERTHEMESCALE_DEFAULTKEY);
     }
 
@@ -639,4 +639,3 @@ public class RenderThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
 }
-

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/SeparatorLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/SeparatorLayer.java
@@ -3,13 +3,13 @@ package cgeo.geocaching.maps.mapsforge.v6.caches;
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.map.layer.Layer;
 
 public class SeparatorLayer extends Layer {
 
     @Override
-    public void draw(final BoundingBox arg0, final byte arg1, final Canvas arg2, final Point arg3) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         // Empty placeholder
     }
-
 }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/AbstractRouteLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/AbstractRouteLayer.java
@@ -17,6 +17,7 @@ import org.mapsforge.core.graphics.Path;
 import org.mapsforge.core.graphics.Style;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
@@ -91,7 +92,7 @@ abstract class AbstractRouteLayer extends Layer {
     }
 
     @Override
-    public synchronized void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public synchronized void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         synchronized (cache) {
             for (CachedRoute c : cache.values()) {
                 // route hidden, no route or route too short?

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CoordsMarkerLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CoordsMarkerLayer.java
@@ -14,6 +14,7 @@ import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.overlay.Marker;
@@ -46,9 +47,9 @@ public class CoordsMarkerLayer extends Layer {
     }
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         if (coordsMarker != null) {
-            coordsMarker.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+            coordsMarker.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation);
         }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HistoryLayer.java
@@ -15,6 +15,7 @@ import org.mapsforge.core.graphics.Path;
 import org.mapsforge.core.graphics.Style;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
@@ -50,7 +51,7 @@ public class HistoryLayer extends Layer {
     }
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         if (coordinates == null) {
             return;
         }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/NavigationLayer.java
@@ -13,6 +13,7 @@ import org.mapsforge.core.graphics.Path;
 import org.mapsforge.core.graphics.Style;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
@@ -52,7 +53,7 @@ public class NavigationLayer extends Layer {
     }
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         if (destinationCoords == null || currentCoords == null || !Settings.isMapDirection()) {
             return;
         }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/PositionLayer.java
@@ -23,6 +23,7 @@ import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Rectangle;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.map.android.graphics.AndroidBitmap;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
@@ -42,7 +43,7 @@ public class PositionLayer extends Layer {
     private int heightArrowHalf = 0;
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
 
         if (coordinates == null || location == null) {
             return;
@@ -65,7 +66,7 @@ public class PositionLayer extends Layer {
         if (accuracy >= 0) {
             final Circle circle = new Circle(location, accuracy, accuracyCircleFill, accuracyCircle);
             circle.setDisplayModel(getDisplayModel());
-            circle.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+            circle.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation);
         }
 
         // prepare heading indicator

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/RouteLayer.java
@@ -12,6 +12,7 @@ import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.LayerManager;
 
@@ -62,8 +63,8 @@ public class RouteLayer extends AbstractRouteLayer implements IndividualRoute.Up
     }
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
-        super.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
+        super.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation);
 
         if (postRealRouteDistance != null) {
             postRealRouteDistance.postRealDistance(distance);

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/TapHandlerLayer.java
@@ -15,6 +15,7 @@ import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.overlay.Marker;
@@ -33,7 +34,7 @@ public class TapHandlerLayer extends Layer {
     }
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         // display a pin marker if a long click was performed, otherwise nothing visible here
         if (longTapLatLong != null) {
             if (markerBitmap == null) {
@@ -41,7 +42,7 @@ public class TapHandlerLayer extends Layer {
             }
             final Marker marker = new Marker(longTapLatLong, markerBitmap, 0, -markerBitmap.getHeight() / 2);
             marker.setDisplayModel(this.getDisplayModel());
-            marker.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+            marker.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1247,6 +1247,11 @@ public class Settings {
         return getBoolean(R.string.pref_useUnifiedMap, !BranchDetectionHelper.isProductionBuild());
     }
 
+    /** use Mapsforge as additional map view for UnifiedMap */
+    public static boolean useMapsforgeInUnifiedMap() {
+        return getBoolean(R.string.pref_useMapsforgeInUnifiedMap, false);
+    }
+
     public static void setMapDownloaderSource(final int source) {
         putInt(R.string.pref_mapdownloader_source, source);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1177,6 +1177,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             saveCenterAndZoom();
             lastMapStateFromOnPause = getCurrentMapState();
         }
+        if (tileProvider != null) {
+            tileProvider.onPause();
+        }
         if (!Settings.isFeatureEnabledDefaultTrue(R.string.pref_useDelayedMapFragment)) {
             destroyMapFragment();
         }
@@ -1214,12 +1217,18 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         super.onResume();
         reloadCachesAndWaypoints(false);
         MapUtils.updateFilterBar(this, mapType.filterContext);
+        if (tileProvider != null) {
+            tileProvider.onResume();
+        }
     }
 
     @Override
     protected void onDestroy() {
         if (loadInBackgroundHandler != null) {
             loadInBackgroundHandler.onDestroy();
+        }
+        if (tileProvider != null) {
+            tileProvider.onDestroy();
         }
         super.onDestroy();
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeV6GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/MapsforgeV6GeoItemLayer.java
@@ -28,6 +28,7 @@ import org.mapsforge.core.graphics.Style;
 import org.mapsforge.core.model.BoundingBox;
 import org.mapsforge.core.model.LatLong;
 import org.mapsforge.core.model.Point;
+import org.mapsforge.core.model.Rotation;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.LayerManager;
@@ -168,11 +169,11 @@ public class MapsforgeV6GeoItemLayer extends Layer implements IProviderGeoItemLa
 
 
     @Override
-    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint) {
+    public void draw(final BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
         layerLock.lock();
         try {
             for (Layer layer : layers) {
-                layer.draw(boundingBox, zoomLevel, canvas, topLeftPoint);
+                layer.draw(boundingBox, zoomLevel, canvas, topLeftPoint, rotation);
             }
         } finally {
             layerLock.unlock();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -35,14 +35,17 @@ import androidx.core.text.HtmlCompat;
 import androidx.core.util.Pair;
 
 import org.apache.commons.lang3.StringUtils;
+import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.Dimension;
 import org.mapsforge.core.model.LatLong;
+import org.mapsforge.core.model.Point;
 import org.mapsforge.core.model.Rotation;
 import org.mapsforge.core.util.LatLongUtils;
 import org.mapsforge.core.util.Parameters;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.util.AndroidUtil;
 import org.mapsforge.map.android.view.MapView;
+import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.model.common.Observer;
 import org.mapsforge.map.view.InputListener;
@@ -81,8 +84,6 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
         tileCache = AndroidUtil.createTileCache(getContext(), "mapcache", mMapView.getModel().displayModel.getTileSize(), 1f, mMapView.getModel().frameBufferModel.getOverdrawFactor());
         themeHelper = new MapsforgeThemeHelper(requireActivity());
-
-
 
         if (position != null) {
             setCenter(position);
@@ -203,10 +204,8 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
             applyTheme(); // @todo: There must be a less resource-intensive way of applying style-changes...
             doReapplyTheme = false;
         }
-//        mMapLayers.add(new MapEventsReceiver(mMap));
-
+        mMapView.getLayerManager().getLayers().add(new MapEventsReceiver());
         mMapView.getModel().mapViewPosition.addObserver(this);
-
     }
 
     @Override
@@ -407,6 +406,26 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
     // ========================================================================
     // Tap handling methods
+
+    class MapEventsReceiver extends Layer {
+
+        @Override
+        public boolean onLongPress(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
+            onTapCallback(tapLatLong.getLatitudeE6(), tapLatLong.getLongitudeE6(), (int) tapXY.x, (int) tapXY.y, true);
+            return true;
+        }
+
+        @Override
+        public boolean onTap(final LatLong tapLatLong, final Point layerXY, final Point tapXY) {
+            onTapCallback(tapLatLong.getLatitudeE6(), tapLatLong.getLongitudeE6(), (int) tapXY.x, (int) tapXY.y, false);
+            return true;
+        }
+
+        @Override
+        public void draw(final org.mapsforge.core.model.BoundingBox boundingBox, final byte zoomLevel, final Canvas canvas, final Point topLeftPoint, final Rotation rotation) {
+            // nothing to do
+        }
+    }
 
     @Override
     public void adaptLayoutForActionBar(@Nullable final Boolean actionBarShowing) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -1,0 +1,415 @@
+package cgeo.geocaching.unifiedmap.mapsforge;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.Viewport;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.unifiedmap.AbstractMapFragment;
+import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
+import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeV6GeoItemLayer;
+import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeTileProvider;
+import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
+import cgeo.geocaching.utils.AngleUtils;
+import cgeo.geocaching.utils.ImageUtils;
+import static cgeo.geocaching.storage.extension.OneTimeDialogs.DialogType.MAP_AUTOROTATION_DISABLE;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.Matrix;
+import android.os.Bundle;
+import android.text.SpannableString;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.res.ResourcesCompat;
+import androidx.core.text.HtmlCompat;
+import androidx.core.util.Pair;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mapsforge.core.model.Dimension;
+import org.mapsforge.core.model.LatLong;
+import org.mapsforge.core.model.Rotation;
+import org.mapsforge.core.util.LatLongUtils;
+import org.mapsforge.core.util.Parameters;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.android.util.AndroidUtil;
+import org.mapsforge.map.android.view.MapView;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.model.common.Observer;
+import org.mapsforge.map.view.InputListener;
+import org.oscim.core.BoundingBox;
+
+public class MapsforgeFragment extends AbstractMapFragment implements Observer {
+
+    private MapView mMapView;
+    private TileCache tileCache;
+    private MapsforgeThemeHelper themeHelper;
+    private View mapAttribution;
+    private boolean doReapplyTheme = false;
+
+    private final Bitmap rotationIndicator = ImageUtils.convertToBitmap(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.bearing_indicator, null));
+    private final int rotationWidth = rotationIndicator.getWidth();
+    private final int rotationHeight = rotationIndicator.getHeight();
+
+    public MapsforgeFragment() {
+        super(R.layout.unifiedmap_mapsforge_fragment);
+        AndroidGraphicFactory.createInstance(CgeoApplication.getInstance());
+    }
+
+    @Override
+    public void onViewCreated(final @NonNull View view, final @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        // set some parameters for Mapsforge library
+        // Support for multi-threaded map painting
+        Parameters.NUMBER_OF_THREADS = Settings.getMapOsmThreads();
+        // Use fast parent tile rendering to increase performance when zooming in
+        Parameters.PARENT_TILES_RENDERING = Parameters.ParentTilesRendering.SPEED;
+
+        mMapView = requireView().findViewById(R.id.mapViewMapsforge);
+        setMapRotation(Settings.getMapRotation());
+        mapAttribution = requireView().findViewById(R.id.map_attribution);
+
+        tileCache = AndroidUtil.createTileCache(getContext(), "mapcache", mMapView.getModel().displayModel.getTileSize(), 1f, mMapView.getModel().frameBufferModel.getOverdrawFactor());
+        themeHelper = new MapsforgeThemeHelper(requireActivity());
+
+
+
+        if (position != null) {
+            setCenter(position);
+        }
+        setZoom(zoomLevel);
+
+        mMapView.addInputListener(new InputListener() {
+            @Override
+            public void onMoveEvent() {
+                if (Boolean.TRUE.equals(viewModel.followMyLocation.getValue())) {
+                    viewModel.followMyLocation.setValue(false);
+                }
+                final LatLong center = mMapView.getModel().mapViewPosition.getCenter();
+                viewModel.mapCenter.setValue(new Geopoint(center.getLatitude(), center.getLongitude()));
+            }
+
+            @Override
+            public void onZoomEvent() {
+
+            }
+        });
+
+        if (onMapReadyTasks != null) {
+            onMapReadyTasks.run();
+        }
+    }
+
+    @Override
+    public void onChange() {
+        /// todo: can this be used as observer?
+
+        //        mapUpdateListener = (event, mapPosition) -> {
+//            if (event == Map.ROTATE_EVENT || event == Map.POSITION_EVENT) {
+//                repaintRotationIndicator(mapPosition.bearing);
+//            }
+//        };
+        repaintRotationIndicator(mMapView.getMapRotation().degrees);
+    }
+
+    private void startMap() {
+        mMapView.getMapScaleBar().setVisible(true);
+        mMapView.getMapScaleBar().setDistanceUnitAdapter(mMapView.getMapScaleBar().getDistanceUnitAdapter());
+        mMapView.setBuiltInZoomControls(false);
+
+        //make room for map attribution icon button
+        final int mapAttPx = Math.round(this.getResources().getDisplayMetrics().density * 30);
+        mMapView.getMapScaleBar().setMarginHorizontal(mapAttPx);
+
+        if (this.mapAttribution != null) {
+            this.mapAttribution.setOnClickListener(v -> displayMapAttribution());
+        }
+    }
+
+    private void displayMapAttribution() {
+        final Pair<String, Boolean> mapAttribution = currentTileProvider.getMapAttribution();
+        if (mapAttribution == null || StringUtils.isBlank(mapAttribution.first)) {
+            return;
+        }
+
+        //create text message
+        CharSequence message = HtmlCompat.fromHtml(mapAttribution.first, HtmlCompat.FROM_HTML_MODE_LEGACY);
+        if (mapAttribution.second) {
+            final SpannableString s = new SpannableString(message);
+            ViewUtils.safeAddLinks(s, Linkify.ALL);
+            message = s;
+        }
+
+        final AlertDialog alertDialog = Dialogs.newBuilder(getContext())
+                .setTitle(getContext().getString(R.string.map_source_attribution_dialog_title))
+                .setCancelable(true)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.ok, (dialog, pos) -> dialog.dismiss())
+                .create();
+        alertDialog.show();
+
+        // Make the URLs in TextView clickable. Must be called after show()
+        // Note: we do NOT use the "setView()" option of AlertDialog because this screws up the layout
+        ((TextView) alertDialog.findViewById(android.R.id.message)).setMovementMethod(LinkMovementMethod.getInstance());
+    }
+
+    protected void repaintRotationIndicator(final float bearing) {
+        final View currentView = getView();
+        if (currentView == null) {
+            return;
+        }
+
+        requireActivity().runOnUiThread(() -> {
+            final ImageView compassrose = currentView.findViewById(R.id.bearingIndicator);
+            if (bearing == 0.0f) {
+                compassrose.setImageBitmap(null);
+            } else {
+                adaptLayoutForActionBar(null);
+
+                final Matrix matrix = new Matrix();
+                matrix.setRotate(bearing, rotationWidth / 2.0f, rotationHeight / 2.0f);
+                compassrose.setImageBitmap(Bitmap.createBitmap(rotationIndicator, 0, 0, rotationWidth, rotationHeight, matrix, true));
+                compassrose.setOnClickListener(v -> {
+                    final boolean isRotated = getCurrentBearing() != 0f;
+                    setBearing(0.0f);
+                    repaintRotationIndicator(0.0f);
+                    if (isRotated && (Settings.getMapRotation() == Settings.MAPROTATION_AUTO_LOWPOWER || Settings.getMapRotation() == Settings.MAPROTATION_AUTO_PRECISE)) {
+                        Dialogs.advancedOneTimeMessage(getContext(), MAP_AUTOROTATION_DISABLE, getString(MAP_AUTOROTATION_DISABLE.messageTitle), getString(MAP_AUTOROTATION_DISABLE.messageText), "", true, null, () -> Settings.setMapRotation(Settings.MAPROTATION_MANUAL));
+                    }
+                });
+            }
+        });
+    }
+
+
+    // ========================================================================
+    // lifecycle methods
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        initLayers();
+        if (doReapplyTheme) {
+            applyTheme(); // @todo: There must be a less resource-intensive way of applying style-changes...
+            doReapplyTheme = false;
+        }
+//        mMapLayers.add(new MapEventsReceiver(mMap));
+
+        mMapView.getModel().mapViewPosition.addObserver(this);
+
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // mMapView.onResume();
+
+    }
+
+    @Override
+    public void onPause() {
+        // mMapView.onPause();
+        super.onPause();
+
+        mMapView.getModel().mapViewPosition.removeObserver(this);
+    }
+
+    @Override
+    public void onDestroyView() {
+//        themeHelper.disposeTheme();
+        mMapView.destroyAll();
+        AndroidGraphicFactory.clearResourceMemoryCache();
+        super.onDestroyView();
+    }
+
+
+    // ========================================================================
+    // tilesource handling
+
+    public TileCache getTileCache() {
+        return tileCache;
+    }
+
+    @Override
+    public boolean supportsTileSource(final AbstractTileProvider newSource) {
+        return newSource instanceof AbstractMapsforgeTileProvider;
+    }
+
+    @Override
+    public void prepareForTileSourceChange() {
+        ((AbstractMapsforgeTileProvider) currentTileProvider).prepareForTileSourceChange(mMapView);
+        super.prepareForTileSourceChange();
+    }
+
+    @Override
+    public boolean setTileSource(final AbstractTileProvider newSource, final boolean force) {
+        final boolean needsUpdate = super.setTileSource(newSource, force);
+        if (needsUpdate) {
+            ((AbstractMapsforgeTileProvider) currentTileProvider).addTileLayer(this, mMapView);
+            startMap();
+        }
+        return needsUpdate;
+    }
+
+
+    // ========================================================================
+    // layer handling
+
+    @Override
+    public IProviderGeoItemLayer<?> createGeoItemProviderLayer() {
+        return new MapsforgeV6GeoItemLayer(mMapView.getLayerManager(), mMapView.getMapViewProjection());
+    }
+
+
+    // ========================================================================
+    // position related methods
+
+    @Override
+    public void setCenter(final Geopoint geopoint) {
+        mMapView.setCenter(new LatLong(geopoint.getLatitude(), geopoint.getLongitude()));
+    }
+
+    @Override
+    public Geopoint getCenter() {
+        final LatLong pos = mMapView.getModel().mapViewPosition.getMapPosition().latLong;
+        return new Geopoint(pos.getLatitude(), pos.getLongitude());
+    }
+
+    @NonNull
+    @Override
+    public BoundingBox getBoundingBox() {
+        if (mMapView == null) {
+            return new BoundingBox(0, 0, 0, 0);
+        }
+        final org.mapsforge.core.model.BoundingBox bb = mMapView.getBoundingBox();
+        return new BoundingBox(bb.minLatitude, bb.minLongitude, bb.maxLatitude, bb.minLongitude);
+    }
+
+    @Override
+    public void setDrivingMode(final boolean enabled) {
+        // todo: cross-check
+        mMapView.setMapViewCenterY(enabled ? 0.75f : 0.5f);
+    }
+
+
+    // ========================================================================
+    // zoom, bearing & heading methods
+
+    @Override
+    public void zoomToBounds(final Viewport bounds) {
+        zoomToBounds(new BoundingBox(bounds.bottomLeft.getLatitudeE6(), bounds.bottomLeft.getLongitudeE6(), bounds.topRight.getLatitudeE6(), bounds.topRight.getLongitudeE6()));
+    }
+
+    public void zoomToBounds(final BoundingBox bounds) {
+        if (bounds.getLatitudeSpan() == 0 && bounds.getLongitudeSpan() == 0) {
+            setCenter(new Geopoint(bounds.getCenterPoint().getLatitude(), bounds.getCenterPoint().getLongitude()));
+        } else {
+            // add some margin to not cut-off items at the edge
+            // Google Maps does this implicitly, so we need to add it here map-specific
+            final BoundingBox extendedBounds = bounds.extendMargin(1.1f);
+            if (mMapView.getWidth() == 0 || mMapView.getHeight() == 0) {
+                //See Bug #14948: w/o map width/height the bounds can't be calculated
+                // -> postpone animation to later on UI thread (where map width/height will be set)
+                mMapView.post(() -> zoomToBoundsDirect(extendedBounds));
+            } else {
+                zoomToBoundsDirect(extendedBounds);
+            }
+        }
+    }
+
+    private void zoomToBoundsDirect(final BoundingBox bounds) {
+        final int tileSize = mMapView.getModel().displayModel.getTileSize();
+        final byte newZoom = LatLongUtils.zoomForBounds(new Dimension(mMapView.getWidth(), mMapView.getHeight()),
+                new org.mapsforge.core.model.BoundingBox(bounds.getMinLatitude(), bounds.getMinLongitude(), bounds.getMaxLatitude(), bounds.getMaxLongitude()), tileSize);
+        mMapView.setZoomLevel(newZoom);
+    }
+
+    @Override
+    public int getCurrentZoom() {
+        return mMapView.getModel().mapViewPosition.getZoomLevel();
+    }
+
+    @Override
+    public void setZoom(final int zoomLevel) {
+        mMapView.setZoomLevel((byte) zoomLevel);
+    }
+
+    @Override
+    public void zoomInOut(final boolean zoomIn) {
+        if (zoomIn) {
+            mMapView.getModel().mapViewPosition.zoomIn();
+        } else {
+            mMapView.getModel().mapViewPosition.zoomOut();
+        }
+    }
+
+    @Override
+    public void setMapRotation(final int mapRotation) {
+        super.setMapRotation(mapRotation);
+
+        // enable or disable gestures for rotating the map
+        Parameters.ROTATION_GESTURE = (mapRotation == Settings.MAPROTATION_MANUAL);
+
+        repaintRotationIndicator(mMapView.getMapRotation().degrees);
+    }
+
+    @Override
+    public float getCurrentBearing() {
+        return AngleUtils.normalize(360 - mMapView.getMapRotation().degrees); // Mapsforge uses opposite way of calculating bearing compared to GM
+    }
+
+    @Override
+    public void setBearing(final float bearing) {
+        final float adjustedBearing = AngleUtils.normalize(360 - bearing); // Mapsforge uses opposite way of calculating bearing compared to GM
+        mMapView.rotate(new Rotation(adjustedBearing, mMapView.getWidth() * 0.5f, mMapView.getHeight() * 0.5f));
+        mMapView.getLayerManager().redrawLayers();
+    }
+
+
+    // ========================================================================
+    // theme & language related methods
+
+    @Override
+    public void selectTheme(final Activity activity) {
+        themeHelper.selectMapTheme(((AbstractMapsforgeTileProvider) currentTileProvider).getTileLayer(), tileCache);
+    }
+
+    @Override
+    public void selectThemeOptions(final Activity activity) {
+        themeHelper.selectMapThemeOptions();
+        doReapplyTheme = true;
+    }
+
+    @Override
+    public void applyTheme() {
+        themeHelper.reapplyMapTheme(((AbstractMapsforgeTileProvider) currentTileProvider).getTileLayer(), tileCache);
+    }
+
+    @Override
+    public void setPreferredLanguage(final String language) {
+        currentTileProvider.setPreferredLanguage(language);
+    }
+
+
+    // ========================================================================
+    // additional menu entries
+
+
+    // ========================================================================
+    // Tap handling methods
+
+    @Override
+    public void adaptLayoutForActionBar(@Nullable final Boolean actionBarShowing) {
+        adaptLayoutForActionBar(requireView().findViewById(R.id.bearingIndicator), actionBarShowing);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeThemeHelper.java
@@ -1,4 +1,4 @@
-package cgeo.geocaching.unifiedmap.mapsforgevtm;
+package cgeo.geocaching.unifiedmap.mapsforge;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
@@ -7,15 +7,10 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.ContentStorage.FileInformation;
 import cgeo.geocaching.storage.Folder;
-import cgeo.geocaching.storage.FolderUtils;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.dialog.Dialogs;
-import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeVTMOfflineTileProvider;
-import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
-import cgeo.geocaching.utils.FileUtils;
-import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.TextUtils;
@@ -25,11 +20,9 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.AsyncTask;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.core.util.Consumer;
 import androidx.preference.PreferenceManager;
 
 import java.io.File;
@@ -40,25 +33,35 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipInputStream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.oscim.android.theme.ContentRenderTheme;
-import org.oscim.android.theme.ContentResolverResourceProvider;
-import org.oscim.map.Map;
-import org.oscim.theme.ExternalRenderTheme;
-import org.oscim.theme.IRenderTheme;
-import org.oscim.theme.ThemeFile;
-import org.oscim.theme.XmlRenderThemeMenuCallback;
-import org.oscim.theme.XmlRenderThemeStyleLayer;
-import org.oscim.theme.XmlRenderThemeStyleMenu;
-import org.oscim.theme.XmlThemeResourceProvider;
-import org.oscim.theme.ZipRenderTheme;
-import org.oscim.theme.ZipXmlThemeResourceProvider;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.android.rendertheme.ContentRenderTheme;
+import org.mapsforge.map.android.rendertheme.ContentResolverResourceProvider;
+import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.renderer.TileRendererLayer;
+import org.mapsforge.map.model.DisplayModel;
+import org.mapsforge.map.rendertheme.ExternalRenderTheme;
+import org.mapsforge.map.rendertheme.XmlRenderTheme;
+import org.mapsforge.map.rendertheme.XmlRenderThemeMenuCallback;
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleMenu;
+import org.mapsforge.map.rendertheme.XmlThemeResourceProvider;
+import org.mapsforge.map.rendertheme.ZipRenderTheme;
+import org.mapsforge.map.rendertheme.ZipXmlThemeResourceProvider;
+import org.mapsforge.map.rendertheme.internal.MapsforgeThemes;
 
+
+/**
+ * Helper class for Map Theme selection and related tasks.
+ *
+ * Works in conjunction with {@link MapsforgeThemeSettings} (for theme settings GUI).
+ *
+ * Note: this class is an attempt to bundle all large parts of this code were simply moved from class
+ * NewMap and might need refactoring.
+ */
 public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
 
     private static final PersistableFolder MAP_THEMES_FOLDER = PersistableFolder.OFFLINE_MAP_THEMES;
@@ -79,11 +82,12 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
 
     private static final Object cachedZipMutex = new Object();
 
+    private final Activity activity;
     private final SharedPreferences sharedPreferences;
-    private IRenderTheme mTheme;
 
     //current Theme style menu settings
     private XmlRenderThemeStyleMenu themeStyleMenu;
+    private String prefThemeStyleKey = "";
 
     //the last used Zip Resource Provider is cached.
     private static String cachedZipProviderFilename = null;
@@ -91,8 +95,6 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
 
     // cache most recent resource provider
     private XmlThemeResourceProvider resourceProvider = null;
-
-    private static MapThemeFolderSynchronizer syncTask = null;
 
     private static class ThemeData {
         public final String id;
@@ -126,69 +128,68 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         }
     }
 
-    protected MapsforgeThemeHelper(final Activity activity) {
+    public MapsforgeThemeHelper(final Activity activity) {
+        this.activity = activity;
         this.sharedPreferences = PreferenceManager.getDefaultSharedPreferences(activity);
     }
 
-    protected void reapplyMapTheme(final Map map, final AbstractTileProvider tileProvider) {
-        if (mTheme != null) {
-            disposeTheme();
-        }
-        if (!tileProvider.supportsThemes()) {
+    public void reapplyMapTheme(final TileLayer rendererLayer, final TileCache tileCache) {
+        if (!(rendererLayer instanceof TileRendererLayer)) {
             return;
         }
 
         //try to apply stored value
-        ThemeData selectedTheme = setSelectedMapThemeInternal(Settings.getSelectedMapRenderTheme(Settings.getTileProvider()));
+        ThemeData selectedTheme = setSelectedMapTheme(Settings.getSelectedMapRenderTheme());
 
         if (selectedTheme == null) {
-            applyDefaultTheme(map, tileProvider);
+            applyDefaultTheme((TileRendererLayer) rendererLayer);
         } else {
             try {
                 //get the theme
-                final ThemeFile xmlRenderTheme = createThemeFor(selectedTheme);
+                final XmlRenderTheme xmlRenderTheme = createThemeFor(selectedTheme);
 
                 // Validate the theme
-                /* @todo
                 org.mapsforge.map.rendertheme.rule.RenderThemeHandler.getRenderTheme(AndroidGraphicFactory.INSTANCE, new DisplayModel(), xmlRenderTheme);
-                rendererLayer.setXmlRenderTheme(xmlRenderTheme);
-                */
-                mTheme = map.setTheme(xmlRenderTheme);
+                ((TileRendererLayer) rendererLayer).setXmlRenderTheme(xmlRenderTheme);
+                //setting xmlrendertheme has filled prefThemeStyleKey -> now apply scales
+                applyScales((TileRendererLayer) rendererLayer, prefThemeStyleKey);
             } catch (final IOException e) {
                 Log.w("Failed to set render theme", e);
                 ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.err_rendertheme_file_unreadable));
-                applyDefaultTheme(map, tileProvider);
+                ((TileRendererLayer) rendererLayer).setXmlRenderTheme(MapsforgeThemes.OSMARENDER);
                 selectedTheme = null;
             } catch (final Exception e) {
                 Log.w("render theme invalid", e);
                 ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.err_rendertheme_invalid));
-                applyDefaultTheme(map, tileProvider);
+                ((TileRendererLayer) rendererLayer).setXmlRenderTheme(MapsforgeThemes.OSMARENDER);
                 selectedTheme = null;
             }
         }
         setSelectedTheme(selectedTheme);
 
-        if (tileProvider instanceof AbstractMapsforgeVTMOfflineTileProvider) {
-            ((AbstractMapsforgeVTMOfflineTileProvider) tileProvider).switchBuildingLayer(Settings.getBuildings3D());
+        // tile cache needs purging upon theme (re)select
+        if (tileCache != null) {
+            tileCache.purge();
         }
-
-        map.updateMap(true);
-        map.render();
+        rendererLayer.requestRedraw();
     }
 
-    private void applyDefaultTheme(final Map map, final AbstractTileProvider tileProvider) {
-        if (tileProvider.supportsThemes()) {
-            mTheme = map.setTheme(VtmThemes.getDefaultVariant());
-        }
+    private void applyDefaultTheme(final TileRendererLayer rendererLayer) {
+        rendererLayer.setXmlRenderTheme(MapsforgeThemes.OSMARENDER);
+        applyScales(rendererLayer, Settings.RENDERTHEMESCALE_DEFAULTKEY);
     }
 
-    protected void disposeTheme() {
-        if (mTheme != null) {
-            mTheme.dispose();
-        }
+    private void applyScales(final TileRendererLayer rendererLayer, final String themeStyleId) {
+        final int mapScale = Settings.getMapRenderScale(themeStyleId, Settings.RenderThemeScaleType.MAP);
+        final int textScale = Settings.getMapRenderScale(themeStyleId, Settings.RenderThemeScaleType.TEXT);
+        final int symbolScale = Settings.getMapRenderScale(themeStyleId, Settings.RenderThemeScaleType.SYMBOL);
+
+        rendererLayer.getDisplayModel().setUserScaleFactor(mapScale / 100f);
+        rendererLayer.setTextScale(textScale / 100f);
+        DisplayModel.symbolScale = symbolScale / 100f;
     }
 
-    private ThemeFile createThemeFor(@NonNull final ThemeData theme) throws IOException {
+    private XmlRenderTheme createThemeFor(@NonNull final ThemeData theme) throws IOException {
         final String[] themeIdTokens = theme.id.split(ZIP_THEME_SEPARATOR);
         final boolean isZipTheme = themeIdTokens.length == 2;
 
@@ -196,14 +197,14 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
             return null;
         }
 
-        ThemeFile xmlRenderTheme = null;
+        XmlRenderTheme xmlRenderTheme = null;
         try {
             if (!isZipTheme) {
                 if (UriUtils.isFileUri(theme.fileInfo.uri)) {
-                    xmlRenderTheme = new ExternalRenderTheme(theme.fileInfo.uri.toString(), this);
+                    xmlRenderTheme = new ExternalRenderTheme(UriUtils.toFile(theme.fileInfo.uri), this);
                 } else {
                     //this is the SLOW THEME path. Show OneTimeDialog to warn user about this
-                    Dialogs.basicOneTimeMessage(CgeoApplication.getInstance(), OneTimeDialogs.DialogType.MAP_THEME_FIX_SLOWNESS);
+                    Dialogs.basicOneTimeMessage(activity, OneTimeDialogs.DialogType.MAP_THEME_FIX_SLOWNESS);
                     xmlRenderTheme = new ContentRenderTheme(getContentResolver(), theme.fileInfo.uri, this);
                     xmlRenderTheme.setResourceProvider(new ContentResolverResourceProvider(getContentResolver(), ContentStorage.get().getUriForFolder(theme.containingFolder), true));
                 }
@@ -232,19 +233,17 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         return xmlRenderTheme;
     }
 
-    protected void selectMapTheme(final Activity activity, final Map map, final AbstractTileProvider tileProvider) {
-        if (!tileProvider.supportsThemes()) {
-            return;
-        }
-        final String currentThemeId = Settings.getSelectedMapRenderTheme(tileProvider);
+    public void selectMapTheme(final TileLayer tileLayer, final TileCache tileCache) {
+        final String currentThemeId = Settings.getSelectedMapRenderTheme();
+        final boolean debugMode = Settings.isDebug();
 
         final List<String> names = new ArrayList<>();
-        names.add(activity.getString(R.string.switch_default));
+        names.add(LocalizationUtils.getString(R.string.switch_default));
         int currentItem = 0;
         int idx = 1;
         final List<ThemeData> selectableAvThemes = getAvailableThemes();
         for (final ThemeData theme : selectableAvThemes) {
-            names.add(theme.userDisplayableName);
+            names.add(theme.userDisplayableName + (debugMode ? " (" + theme.id + ")" : ""));
             if (StringUtils.equals(currentThemeId, theme.id)) {
                 currentItem = idx;
             }
@@ -252,44 +251,49 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         }
 
         final AlertDialog.Builder builder = Dialogs.newBuilder(activity);
-        builder.setTitle(activity.getString(R.string.map_theme_select));
+        String title = activity.getString(R.string.map_theme_select);
+        if (debugMode) {
+            title = title + " (debug mode, sync = " + (isThemeSynchronizationActive() ? "ON" : "off") + ")";
+        }
+
+        builder.setTitle(title);
+
         builder.setSingleChoiceItems(names.toArray(new String[0]), currentItem, (dialog, newItem) -> {
             // Adjust index because of <default> selection
             setSelectedTheme(newItem > 0 ? selectableAvThemes.get(newItem - 1) : null);
-            reapplyMapTheme(map, tileProvider);
+            reapplyMapTheme(tileLayer, tileCache);
             dialog.cancel();
         });
 
         builder.show();
     }
 
-    public void selectMapThemeOptions(final Activity activity, final AbstractTileProvider tileProvider) {
-        if (!tileProvider.supportsThemeOptions()) {
-            return;
-        }
-
+    public void selectMapThemeOptions() {
         final Intent intent = new Intent(activity, MapsforgeThemeSettings.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
         if (themeOptionsAvailable() && themeStyleMenu != null) {
             intent.putExtra(MapsforgeThemeSettingsFragment.RENDERTHEME_MENU, themeStyleMenu);
-            intent.putExtra(MapsforgeThemeSettingsFragment.SHOW3DOPTION, tileProvider instanceof AbstractMapsforgeVTMOfflineTileProvider);
         }
         activity.startActivity(intent);
     }
 
     public boolean themeOptionsAvailable() {
-        return StringUtils.isNotBlank(Settings.getSelectedMapRenderTheme(Settings.getTileProvider()));
+        return StringUtils.isNotBlank(Settings.getSelectedMapRenderTheme());
     }
 
     /**
-     * Callback handling for theme settings upon MapsforgeVTM theme options selection
-     * Note: map theme settings are "spilled" into c:geo shared preferences
+     * Callback handling for theme settings upon new Map Theme selection
+     * Note: code was copied 1:1 in February 2021 from NewMap and might need refactoring.
+     * <p>
+     * Code works in conjunction with {@link MapsforgeThemeSettings} somehow.
+     * Apparently map theme settings are "spilled" into c:geo shared preferences
      * (Observation: when using OpenAndroMaps Elevate, those settings usually related settings start with "elmt-")
      */
     @Override
     public Set<String> getCategories(final XmlRenderThemeStyleMenu menu) {
         themeStyleMenu = menu;
         final String id = this.sharedPreferences.getString(themeStyleMenu.getId(), themeStyleMenu.getDefaultValue());
+        prefThemeStyleKey = menu.getId() + "-" + id;
         final XmlRenderThemeStyleLayer baseLayer = themeStyleMenu.getLayer(id);
         if (baseLayer == null) {
             Log.w("Invalid style " + id);
@@ -307,18 +311,11 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         return result;
     }
 
-    /** set new theme and report result, gets called after successful download of a new theme */
-    /* @todo
-    public static boolean setSelectedMapThemeDirect(final String themeIdCandidate) {
-        return setSelectedMapThemeInternal(themeIdCandidate) != null;
-    }
-    */
-
     /**
      * Set a new map theme. The theme is evaluated against available themes and possibly corrected.
      * Next time a map viewer is opened, the theme will be evaluated and used if possible
      */
-    private static ThemeData setSelectedMapThemeInternal(final String themeIdCandidate) {
+    private static ThemeData setSelectedMapTheme(final String themeIdCandidate) {
         //try to apply stored value
         ThemeData selectedTheme = null;
         final List<ThemeData> avThemes = getAvailableThemes();
@@ -352,29 +349,14 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
     }
 
     private static void setSelectedTheme(final ThemeData theme) {
-        Settings.setSelectedMapRenderTheme(Settings.getTileProvider().getId(), theme == null ? StringUtils.EMPTY : theme.id);
-    }
-
-    /**
-     * Depending on whether map theme folder synchronization is currently turned off or on, this
-     * method does two different things:
-     * * if turned off: app-private local folder is safely deleted
-     * * if turned on: folder is re-synced (every change in source folder is synced to target folder)
-     *
-     * In any case, this method will take care of thread syncrhonization e.g. when a sync is currently running then
-     * this sync will first be aborted, and only after that either target folder is deleted (if sync=off) or sync is restarted (if sync=on)
-     *
-     * Call this method whenever you feel that there might be a change in Map Theme files in
-     * public folder. Sync will be done in background task and reports its progress via toasts
-     */
-    public static void resynchronizeOrDeleteMapThemeFolder() {
-        MapThemeFolderSynchronizer.requestResynchronization(MAP_THEMES_FOLDER.getFolder(), MAP_THEMES_INTERNAL_FOLDER, isThemeSynchronizationActive());
+        Settings.setSelectedMapRenderTheme(theme == null ? StringUtils.EMPTY : theme.id);
     }
 
     /**
      * recalculate available themes out of the currently active folder
      */
     private static void recalculateAvailableThemes() {
+
         final List<ThemeData> newAvailableThemes = new ArrayList<>();
         addAvailableThemes(isThemeSynchronizationActive() ? Folder.fromFile(MAP_THEMES_INTERNAL_FOLDER) : MAP_THEMES_FOLDER.getFolder(), newAvailableThemes, "", 0);
 
@@ -410,6 +392,7 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
             } else if (candidate.name.endsWith(".xml")) {
                 final String themeId = prefix + candidate.name;
                 themes.add(new ThemeData(themeId, toUserDisplayableName(candidate, null), candidate, dir));
+
             } else if (candidate.name.endsWith(".zip") && candidate.size <= ZIP_FILE_SIZE_LIMIT) {
                 try (InputStream is = ContentStorage.get().openForRead(candidate.uri)) {
                     for (String zipXmlTheme : ZipXmlThemeResourceProvider.scanXmlThemes(new ZipInputStream(is))) {
@@ -441,119 +424,6 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         return userDisplay;
     }
 
-    private static class MapThemeFolderSynchronizer extends AsyncTask<Void, Void, FolderUtils.FolderProcessResult> {
-
-        private enum AfterSyncRequest { EXIT_NORMAL, REDO, ABORT_DELETE }
-
-        private static final Object syncTaskMutex = new Object();
-
-        private final Folder source;
-        private final File target;
-        private final boolean doSync;
-
-        private final AtomicBoolean cancelFlag = new AtomicBoolean(false);
-
-        private final Object requestRedoMutex = new Object();
-        private boolean taskIsDone = false;
-        private AfterSyncRequest afterSyncRequest = AfterSyncRequest.EXIT_NORMAL;
-        private long startTime = System.currentTimeMillis();
-
-        public static void requestResynchronization(final Folder source, final File target, final boolean doSync) {
-            synchronized (syncTaskMutex) {
-                if (syncTask == null || !syncTask.requestAfter(doSync ? MapThemeFolderSynchronizer.AfterSyncRequest.REDO : MapThemeFolderSynchronizer.AfterSyncRequest.ABORT_DELETE)) {
-                    Log.i("[MapThemeFolderSync] start synchronization " + source + " -> " + target);
-                    syncTask = new MapThemeFolderSynchronizer(source, target, doSync);
-                    syncTask.execute();
-                }
-            }
-        }
-
-        private MapThemeFolderSynchronizer(final Folder source, final File target, final boolean doSync) {
-            this.source = source;
-            this.target = target;
-            this.doSync = doSync;
-        }
-
-        /**
-         * Requests for a running task to redo sync after finished. May fail if task is already done, but in this case the task may safely be discarted
-         */
-        public boolean requestAfter(final AfterSyncRequest afterSyncRequest) {
-            synchronized (requestRedoMutex) {
-                if (taskIsDone || !doSync) {
-                    return false;
-                }
-                Log.i("[MapThemeFolderSync] Requesting '" + afterSyncRequest + "' " + source + " -> " + target);
-                cancelFlag.set(true);
-                this.afterSyncRequest = afterSyncRequest;
-                startTime = System.currentTimeMillis();
-                return true;
-            }
-        }
-
-        @Override
-        protected FolderUtils.FolderProcessResult doInBackground(final Void[] params) {
-            Log.i("[MapThemeFolderSync] start synchronization " + source + " -> " + target + " (doSync=" + doSync + ")");
-            FolderUtils.FolderProcessResult result = null;
-            if (!doSync) {
-                FileUtils.deleteDirectory(target);
-            } else {
-                boolean cont = true;
-                while (cont) {
-                    result = FolderUtils.get().synchronizeFolder(source, target, MapThemeFolderSynchronizer::shouldBeSynced, cancelFlag, null);
-                    synchronized (requestRedoMutex) {
-                        switch (afterSyncRequest) {
-                            case EXIT_NORMAL:
-                                taskIsDone = true;
-                                cont = false;
-                                break;
-                            case ABORT_DELETE:
-                                FileUtils.deleteDirectory(target);
-                                cont = false;
-                                break;
-                            case REDO:
-                                Log.i("[MapThemeFolderSync] redo synchronization " + source + " -> " + target);
-                                cancelFlag.set(false);
-                                break;
-                            default:
-                                break;
-                        }
-                    }
-                }
-            }
-
-            synchronized (availableThemesMutex) {
-                if (result == null || !availableThemesInitialized || result.result != FolderUtils.ProcessResult.OK || result.filesModified > 0) {
-                    recalculateAvailableThemes();
-                }
-            }
-            return result;
-        }
-
-        @Override
-        protected void onPostExecute(final FolderUtils.FolderProcessResult result) {
-            Log.i("[MapThemeFolderSync] Finished synchronization (state=" + afterSyncRequest + ")");
-            //show toast only if something actually happened
-            if (result != null && result.filesModified > 0) {
-                showToast(R.string.mapthemes_foldersync_finished_toast,
-                        LocalizationUtils.getString(R.string.persistablefolder_offline_maps_themes),
-                        Formatter.formatDuration(System.currentTimeMillis() - startTime),
-                        result.filesModified, LocalizationUtils.getPlural(R.plurals.file_count, result.filesInSource, "file(s)"));
-            }
-            Log.i("[MapThemeFolderSync] Finished synchronization callback");
-        }
-
-        private static boolean shouldBeSynced(final FileInformation fileInfo) {
-            return fileInfo != null && !fileInfo.name.endsWith(".map") && fileInfo.size <= FILESYNC_MAX_FILESIZE;
-        }
-
-        private static void showToast(final int resId, final Object... params) {
-            final ImmutablePair<String, String> msgs = LocalizationUtils.getMultiPurposeString(resId, "RenderTheme", params);
-            ActivityMixin.showApplicationToast(msgs.left);
-            Log.iForce("[RenderThemeHelper.ThemeFolderSyncTask]" + msgs.right);
-        }
-
-    }
-
     private static ContentResolver getContentResolver() {
         return CgeoApplication.getInstance().getContentResolver();
     }
@@ -562,47 +432,8 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
         return Settings.getSyncMapRenderThemeFolder();
     }
 
-    /**
-     * Method is called after user has changed the sync state in Settings Activity
-     */
-    public static boolean changeSyncSetting(final Activity activity, final boolean doSync, final Consumer<Boolean> callback) {
-        if (doSync) {
-            //this means user just turned sync on. Ask user if he/she is really shure about this.-
-            final FolderUtils.FolderInfo themeFolderInfo = FolderUtils.get().getFolderInfo(PersistableFolder.OFFLINE_MAP_THEMES.getFolder(), -1);
-            final String folderName = MAP_THEMES_FOLDER.getFolder().toUserDisplayableString();
-            final ImmutableTriple<String, String, String> folderInfoStrings = themeFolderInfo.getUserDisplayableFolderInfoStrings();
-            Dialogs.newBuilder(activity)
-                    .setTitle(R.string.init_renderthemefolder_synctolocal_dialog_title)
-                    .setMessage(LocalizationUtils.getString(R.string.init_renderthemefolder_synctolocal_dialog_message, folderName, folderInfoStrings.left, folderInfoStrings.middle, folderInfoStrings.right))
-                    .setPositiveButton(android.R.string.ok, (d, c) -> {
-                        d.dismiss();
-                        //start sync
-                        resynchronizeOrDeleteMapThemeFolder();
-                        callback.accept(true);
-                    })
-                    .setNegativeButton(android.R.string.cancel, (d, c) -> {
-                        d.dismiss();
-                        callback.accept(false);
-                        //following method will DELETE any existing data in sync folder (because sync is set to off in settings)
-                        resynchronizeOrDeleteMapThemeFolder();
-                    })
-                    .create().show();
-        } else {
-            //this means user just turned sync OFF
-            Settings.setSyncMapRenderThemeFolder(false);
-            //start sync will delete any existing data in sync folder
-            resynchronizeOrDeleteMapThemeFolder();
-            callback.accept(false);
-        }
-        return true;
-    }
-
-    public XmlThemeResourceProvider getResourceProvider() {
-        return resourceProvider;
-    }
-
     public static RenderThemeType getRenderThemeType() {
-        final String selectedMapRenderTheme = Settings.getSelectedMapRenderTheme(Settings.getTileProvider());
+        final String selectedMapRenderTheme = Settings.getSelectedMapRenderTheme();
         for (MapsforgeThemeHelper.RenderThemeType rtt : MapsforgeThemeHelper.RenderThemeType.values()) {
             for (String searchPath : rtt.searchPaths) {
                 if (StringUtils.containsIgnoreCase(selectedMapRenderTheme, searchPath)) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeThemeSettings.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeThemeSettings.java
@@ -1,0 +1,37 @@
+package cgeo.geocaching.unifiedmap.mapsforge;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.settings.SettingsActivity;
+
+import android.os.Bundle;
+import android.view.MenuItem;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class MapsforgeThemeSettings extends AppCompatActivity {
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        ActivityMixin.setDisplayHomeAsUpEnabled(this, true);
+        setContentView(R.layout.layout_settings);
+
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.settings_fragment_root, new MapsforgeThemeSettingsFragment())
+                .commit();
+        SettingsActivity.hideRightColumnInLandscapeMode(this);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeThemeSettingsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeThemeSettingsFragment.java
@@ -1,0 +1,179 @@
+package cgeo.geocaching.unifiedmap.mapsforge;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.SeekbarPreference;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.ui.SeekbarUI;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.StringRes;
+import androidx.preference.CheckBoxPreference;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceManager;
+import androidx.preference.PreferenceViewHolder;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleLayer;
+import org.mapsforge.map.rendertheme.XmlRenderThemeStyleMenu;
+
+public class MapsforgeThemeSettingsFragment extends PreferenceFragmentCompat {
+    public static final String RENDERTHEME_MENU = "renderthememenu";
+
+    ListPreference baseLayerPreference;
+
+    XmlRenderThemeStyleMenu renderthemeOptions;
+    PreferenceCategory renderthemeMenu;
+
+    @Override
+    public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
+        setPreferencesFromResource(R.xml.theme_prefs, rootKey);
+
+        // if the render theme has a style menu, its data is delivered via the intent
+        renderthemeOptions = (XmlRenderThemeStyleMenu) getActivity().getIntent().getSerializableExtra(RENDERTHEME_MENU);
+        // the preference category serves as the hook to add a list preference to allow users to select a style
+        this.renderthemeMenu = (PreferenceCategory) findPreference(getString(R.string.pref_theme_menu));
+        createRenderthemeMenu();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getActivity().setTitle(R.string.settings_title_map_style);
+    }
+
+    private void createRenderthemeMenu() {
+        final Activity activity = getActivity();
+
+        this.renderthemeMenu.removeAll();
+
+        final String themeStylePrefKey;
+        if (renderthemeOptions != null) {
+            final String themePrefKey = createThemePreferences(activity);
+            themeStylePrefKey = themePrefKey + "-" + PreferenceManager.getDefaultSharedPreferences(activity).getString(themePrefKey, "none");
+        } else {
+            themeStylePrefKey = Settings.RENDERTHEMESCALE_DEFAULTKEY;
+        }
+
+        //scale preferences for theme
+        addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.MAP),
+                R.string.maptheme_scale_map_title, R.string.maptheme_scale_map_summary);
+        addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.TEXT),
+                R.string.maptheme_scale_text_title, R.string.maptheme_scale_text_summary);
+        addScalePreference(activity, renderthemeMenu, Settings.getMapRenderScalePreferenceKey(themeStylePrefKey, Settings.RenderThemeScaleType.SYMBOL),
+                R.string.maptheme_scale_symbol_title, R.string.maptheme_scale_symbol_summary);
+
+    }
+
+    private String createThemePreferences(final Activity activity) {
+        this.baseLayerPreference = new ListPreference(activity);
+        baseLayerPreference.setTitle(R.string.settings_title_map_style);
+
+        // the id of the setting is the id of the stylemenu, that allows this
+        // app to store different settings for different render themes.
+        final String themePrefKey = this.renderthemeOptions.getId();
+        baseLayerPreference.setKey(themePrefKey);
+
+
+        // this is the user language for the app, in 'en', 'de' etc format
+        // no dialects are supported at the moment
+        final String language = Locale.getDefault().getLanguage();
+
+        // build data structure for the ListPreference
+        final Map<String, XmlRenderThemeStyleLayer> baseLayers = renderthemeOptions.getLayers();
+
+        int visibleStyles = 0;
+        for (final XmlRenderThemeStyleLayer baseLayer : baseLayers.values()) {
+            if (baseLayer.isVisible()) {
+                ++visibleStyles;
+            }
+        }
+
+        final CharSequence[] entries = new CharSequence[visibleStyles];
+        final CharSequence[] values = new CharSequence[visibleStyles];
+        int i = 0;
+        for (final XmlRenderThemeStyleLayer baseLayer : baseLayers.values()) {
+            if (baseLayer.isVisible()) {
+                // build up the entries in the list
+                entries[i] = baseLayer.getTitle(language);
+                values[i] = baseLayer.getId();
+                ++i;
+            }
+        }
+
+        baseLayerPreference.setEntries(entries);
+        baseLayerPreference.setEntryValues(values);
+        baseLayerPreference.setEnabled(true);
+        baseLayerPreference.setPersistent(true);
+        baseLayerPreference.setDefaultValue(renderthemeOptions.getDefaultValue());
+        baseLayerPreference.setIconSpaceReserved(false);
+        baseLayerPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            // need to persist the new value before recreating the renderthemeMenu
+            Settings.setSelectedMapRenderThemeStyle(preference.getKey(), newValue.toString());
+            createRenderthemeMenu();
+            return true;
+        });
+        renderthemeMenu.addPreference(baseLayerPreference);
+
+
+        // additional theme info
+        if (MapsforgeThemeHelper.getRenderThemeType() == MapsforgeThemeHelper.RenderThemeType.RTT_ELEVATE) {
+            final Preference info = new Preference(activity);
+            info.setSummary(R.string.maptheme_elevate_categoryinfo);
+            info.setIconSpaceReserved(false);
+            renderthemeMenu.addPreference(info);
+        }
+
+        String selection = baseLayerPreference.getValue();
+        // need to check that the selection stored is actually a valid getLayer in the current rendertheme.
+        if (selection == null || !renderthemeOptions.getLayers().containsKey(selection)) {
+            selection = renderthemeOptions.getLayer(renderthemeOptions.getDefaultValue()).getId();
+        }
+        // the new Android style is to display information here, not instruction
+        baseLayerPreference.setSummary(renderthemeOptions.getLayer(selection).getTitle(language));
+
+        for (final XmlRenderThemeStyleLayer overlay : this.renderthemeOptions.getLayer(selection).getOverlays()) {
+            final CheckBoxPreference checkbox = new CheckBoxPreference(activity);
+            checkbox.setKey(overlay.getId());
+            checkbox.setPersistent(true);
+            checkbox.setTitle(overlay.getTitle(language));
+            if (findPreference(overlay.getId()) == null) {
+                // value has never been set, so set from default
+                checkbox.setChecked(overlay.isEnabled());
+            }
+            checkbox.setIconSpaceReserved(false);
+            this.renderthemeMenu.addPreference(checkbox);
+        }
+        return themePrefKey;
+    }
+
+    private void addScalePreference(final Context context, final PreferenceGroup cat, final String prefKey, @StringRes final int titleId, @StringRes final int summaryId) {
+
+        final Preference info = new Preference(context) {
+            public void onBindViewHolder(final PreferenceViewHolder holder) {
+                super.onBindViewHolder(holder);
+                holder.setDividerAllowedAbove(false);
+                holder.setDividerAllowedBelow(false);
+            }
+        };
+        info.setTitle(titleId);
+        info.setSummary(summaryId);
+        info.setIconSpaceReserved(false);
+        cat.addPreference(info);
+
+        final SeekbarPreference seek = new SeekbarPreference(context, 50, 200, "%",
+                new SeekbarUI.FactorizeValueMapper(10));
+        seek.setDefaultValue(100);
+        seek.setKey(prefKey);
+        cat.addPreference(seek);
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -11,7 +11,7 @@ import cgeo.geocaching.unifiedmap.AbstractMapFragment;
 import cgeo.geocaching.unifiedmap.LayerHelper;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeVtmGeoItemLayer;
-import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeTileProvider;
+import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeVTMTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.GroupedList;
@@ -236,7 +236,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
 
     @Override
     public boolean supportsTileSource(final AbstractTileProvider newSource) {
-        return newSource instanceof AbstractMapsforgeTileProvider;
+        return newSource instanceof AbstractMapsforgeVTMTileProvider;
     }
 
     @Override
@@ -262,7 +262,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
     public boolean setTileSource(final AbstractTileProvider newSource, final boolean force) {
         final boolean needsUpdate = super.setTileSource(newSource, force);
         if (needsUpdate) {
-            ((AbstractMapsforgeTileProvider) currentTileProvider).addTileLayer(this, mMap);
+            ((AbstractMapsforgeVTMTileProvider) currentTileProvider).addTileLayer(this, mMap);
             startMap();
         }
         return needsUpdate;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
@@ -2,8 +2,7 @@ package cgeo.geocaching.unifiedmap.tileproviders;
 
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
-import cgeo.geocaching.unifiedmap.LayerHelper;
-import cgeo.geocaching.unifiedmap.mapsforgevtm.MapsforgeVtmFragment;
+import cgeo.geocaching.unifiedmap.mapsforge.MapsforgeFragment;
 import cgeo.geocaching.utils.Log;
 
 import android.net.Uri;
@@ -11,20 +10,23 @@ import android.net.Uri;
 import androidx.core.util.Pair;
 
 import java.io.FileInputStream;
+import java.io.InputStream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.oscim.layers.tile.buildings.BuildingLayer;
-import org.oscim.layers.tile.vector.VectorTileLayer;
-import org.oscim.layers.tile.vector.labeling.LabelLayer;
-import org.oscim.map.Map;
-import org.oscim.tiling.source.mapfile.IMapFileTileSource;
-import org.oscim.tiling.source.mapfile.MapFileTileSource;
-import org.oscim.tiling.source.mapfile.MapInfo;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.layer.labels.LabelLayer;
+import org.mapsforge.map.layer.labels.MapDataStoreLabelStore;
+import org.mapsforge.map.layer.labels.ThreadedLabelLayer;
+import org.mapsforge.map.layer.renderer.TileRendererLayer;
+import org.mapsforge.map.reader.MapFile;
+import org.mapsforge.map.reader.header.MapFileException;
+import org.mapsforge.map.reader.header.MapFileInfo;
+import org.mapsforge.map.view.MapView;
 
 public class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileProvider {
 
-    IMapFileTileSource tileSource;
-    private BuildingLayer buildingLayer;
+    private MapFile mapFile = null;
+    private MapDataStoreLabelStore labelStore = null;
 
     AbstractMapsforgeOfflineTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax) {
         super(name, uri, zoomMin, zoomMax, new Pair<>("", false));
@@ -33,49 +35,57 @@ public class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileP
     }
 
     @Override
-    public void addTileLayer(final MapsforgeVtmFragment fragment, final Map map) {
-        tileSource = new MapFileTileSource();
-        tileSource.setPreferredLanguage(Settings.getMapLanguage());
-        ((MapFileTileSource) tileSource).setMapFileInputStream((FileInputStream) ContentStorage.get().openForRead(mapUri));
-        final VectorTileLayer tileLayer = (VectorTileLayer) fragment.setBaseMap((MapFileTileSource) tileSource);
-        buildingLayer = new BuildingLayer(map, tileLayer);
-        fragment.addLayer(LayerHelper.ZINDEX_BUILDINGS, buildingLayer);
-        fragment.addLayer(LayerHelper.ZINDEX_LABELS, new LabelLayer(map, tileLayer));
-        fragment.applyTheme();
+    public void addTileLayer(final MapsforgeFragment fragment, final MapView map) {
+        final InputStream mapStream = ContentStorage.get().openForRead(mapUri, true);
+        if (mapStream != null) {
+            try {
+                mapFile = new MapFile((FileInputStream) mapStream, 0, Settings.getMapLanguage());
+            } catch (MapFileException mfe) {
+                Log.e("Problem opening map file '" + mapUri + "'", mfe);
+            }
+        }
+        if (mapFile != null) {
+            final MapFileInfo info = mapFile.getMapFileInfo();
+            if (info != null) {
+                supportsLanguages = StringUtils.isNotBlank(info.languagesPreference);
+                if (supportsLanguages) {
+                    TileProviderFactory.setLanguages(info.languagesPreference.split(","));
+                }
+                zoomMin = info.zoomLevelMin;
+                zoomMax = info.zoomLevelMax;
+                // map attribution
+                if (StringUtils.isNotBlank(info.comment)) {
+                    setMapAttribution(new Pair<>(info.comment, true));
+                } else if (StringUtils.isNotBlank(info.createdBy)) {
+                    setMapAttribution(new Pair<>(info.createdBy, true));
+                }
+            }
 
-        final MapInfo info = ((MapFileTileSource) tileSource).getMapInfo();
-        if (info != null) {
-            supportsLanguages = StringUtils.isNotBlank(info.languagesPreference);
-            if (supportsLanguages) {
-                TileProviderFactory.setLanguages(info.languagesPreference.split(","));
-            }
-            parseZoomLevel(info.zoomLevel);
-            // map attribution
-            if (StringUtils.isNotBlank(info.comment)) {
-                setMapAttribution(new Pair<>(info.comment, true));
-            } else if (StringUtils.isNotBlank(info.createdBy)) {
-                setMapAttribution(new Pair<>(info.createdBy, true));
-            }
+            // create layers for tiles and labels
+            tileLayer = new TileRendererLayer(fragment.getTileCache(), mapFile, map.getModel().mapViewPosition, false, false, false, AndroidGraphicFactory.INSTANCE);
+
+            tileLayer.setCacheTileMargin(1);
+            tileLayer.setCacheZoomMinus(1);
+            tileLayer.setCacheZoomPlus(2);
+            map.getLayerManager().getLayers().add(tileLayer);
+
+            // theme must be applied before creating labelStore
+            fragment.applyTheme();
+
+            final MapDataStoreLabelStore labelStore = new MapDataStoreLabelStore(mapFile, ((TileRendererLayer) tileLayer).getRenderThemeFuture(),
+                    ((TileRendererLayer) tileLayer).getTextScale(), tileLayer.getDisplayModel(), AndroidGraphicFactory.INSTANCE);
+            final LabelLayer labelLayer = new ThreadedLabelLayer(AndroidGraphicFactory.INSTANCE, labelStore);
+            map.getLayerManager().getLayers().add(labelLayer);
         }
     }
 
     @Override
     public void setPreferredLanguage(final String language) {
-        if (tileSource != null) {
-            tileSource.setPreferredLanguage(language);
+        if (mapFile != null) {
+            // @todo: mapFile.setPreferredLanguage(language);
         } else {
             Log.w("AbstractMapsforgeOfflineTileProvider.setPreferredLanguage: tilesource is null");
         }
     }
 
-    public boolean isBuildingLayerEnabled() {
-        return buildingLayer != null && buildingLayer.isEnabled();
-    }
-
-    public void switchBuildingLayer(final boolean enabled) {
-        if (buildingLayer == null) {
-            return;
-        }
-        buildingLayer.setEnabled(enabled);
-    }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
@@ -26,7 +26,6 @@ import org.mapsforge.map.view.MapView;
 public class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileProvider {
 
     private MapFile mapFile = null;
-    private MapDataStoreLabelStore labelStore = null;
 
     AbstractMapsforgeOfflineTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax) {
         super(name, uri, zoomMin, zoomMax, new Pair<>("", false));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -1,46 +1,64 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
-import cgeo.geocaching.storage.LocalStorage;
-import cgeo.geocaching.unifiedmap.LayerHelper;
-import cgeo.geocaching.unifiedmap.mapsforgevtm.MapsforgeVtmFragment;
+import cgeo.geocaching.unifiedmap.mapsforge.MapsforgeFragment;
+import static cgeo.geocaching.maps.mapsforge.AbstractMapsforgeMapSource.MAPNIK_TILE_DOWNLOAD_UA;
 
 import android.net.Uri;
 
 import androidx.core.util.Pair;
 
-import java.io.File;
-import java.util.Collections;
+import java.net.MalformedURLException;
+import java.net.URL;
 
-import okhttp3.Cache;
-import okhttp3.OkHttpClient;
-import org.oscim.layers.tile.bitmap.BitmapTileLayer;
-import org.oscim.map.Map;
-import org.oscim.tiling.source.OkHttpEngine;
-import org.oscim.tiling.source.bitmap.BitmapTileSource;
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.layer.download.TileDownloadLayer;
+import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
+import org.mapsforge.map.view.MapView;
 
-class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTileProvider {
+public class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTileProvider {
 
-    private final String tilePath;
+    private final AbstractTileSource mfTileSource;
 
     AbstractMapsforgeOnlineTileProvider(final String name, final Uri uri, final String tilePath, final int zoomMin, final int zoomMax, final Pair<String, Boolean> mapAttribution) {
         super(name, uri, zoomMin, zoomMax, mapAttribution);
-        this.tilePath = tilePath;
+        mfTileSource = new AbstractTileSource(new String[]{ uri.getHost() }, 443) {
+            @Override
+            public int getParallelRequestsLimit() {
+                return 8;
+            }
+
+            @Override
+            public URL getTileUrl(final Tile tile) throws MalformedURLException {
+                // tilePath: "/cyclosm/{Z}/{X}/{Y}.png"
+                final String path = tilePath
+                        .replace("{Z}", String.valueOf(tile.zoomLevel))
+                        .replace("{X}", String.valueOf(tile.tileX))
+                        .replace("{Y}", String.valueOf(tile.tileY));
+                return new URL("https", getHostName(), this.port, path);
+            }
+
+            @Override
+            public byte getZoomLevelMax() {
+                return (byte) zoomMin;
+            }
+
+            @Override
+            public byte getZoomLevelMin() {
+                return (byte) zoomMax;
+            }
+
+            @Override
+            public boolean hasAlpha() {
+                return false;
+            }
+        };
     }
 
     @Override
-    public void addTileLayer(final MapsforgeVtmFragment fragment, final Map map) {
-        final OkHttpClient.Builder httpBuilder = new OkHttpClient.Builder();
-        final Cache cache = new Cache(new File(LocalStorage.getExternalPrivateCgeoDirectory(), "tiles"), 20 * 1024 * 1024);
-        httpBuilder.cache(cache);
-        final BitmapTileSource tileSource = BitmapTileSource.builder()
-                .url(mapUri.toString())
-                .tilePath(tilePath)
-                .zoomMax(zoomMax)
-                .zoomMin(zoomMin)
-                .build();
-        tileSource.setHttpEngine(new OkHttpEngine.OkHttpFactory(httpBuilder));
-        tileSource.setHttpRequestHeaders(Collections.singletonMap("User-Agent", "cgeo-android"));
-        fragment.addLayer(LayerHelper.ZINDEX_BASEMAP, new BitmapTileLayer(map, tileSource));
+    public void addTileLayer(final MapsforgeFragment fragment, final MapView map) {
+        mfTileSource.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA); // @todo
+        tileLayer = new TileDownloadLayer(fragment.getTileCache(), map.getModel().mapViewPosition, mfTileSource, AndroidGraphicFactory.INSTANCE);
+        map.getLayerManager().getLayers().add(tileLayer);
     }
-
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -40,12 +40,12 @@ public class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTilePr
 
             @Override
             public byte getZoomLevelMax() {
-                return (byte) zoomMin;
+                return (byte) zoomMax;
             }
 
             @Override
             public byte getZoomLevelMin() {
-                return (byte) zoomMax;
+                return (byte) zoomMin;
             }
 
             @Override
@@ -60,5 +60,27 @@ public class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTilePr
         mfTileSource.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA); // @todo
         tileLayer = new TileDownloadLayer(fragment.getTileCache(), map.getModel().mapViewPosition, mfTileSource, AndroidGraphicFactory.INSTANCE);
         map.getLayerManager().getLayers().add(tileLayer);
+        onResume(); // start tile downloader
+    }
+
+    // ========================================================================
+    // Lifecycle methods
+
+    @Override
+    public void onPause() {
+        ((TileDownloadLayer) tileLayer).onPause();
+        super.onPause();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        ((TileDownloadLayer) tileLayer).onResume();
+    }
+
+    @Override
+    public void onDestroy() {
+        tileLayer.onDestroy();
+        super.onDestroy();
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
@@ -41,6 +41,7 @@ public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider
 
     public void prepareForTileSourceChange(final MapView mapView) {
         if (tileLayer != null) {
+            onPause(); // notify tileProvider
             mapView.getLayerManager().getLayers().remove(tileLayer);
             tileLayer.onDestroy();
             tileLayer.getTileCache().purge();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
@@ -1,19 +1,20 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
 import cgeo.geocaching.unifiedmap.AbstractMapFragment;
-import cgeo.geocaching.unifiedmap.mapsforgevtm.MapsforgeVtmFragment;
+import cgeo.geocaching.unifiedmap.mapsforge.MapsforgeFragment;
 
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
-import org.oscim.map.Map;
+import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.view.MapView;
 
 public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider {
 
     protected final Uri mapUri;
+    protected TileLayer tileLayer; // either TileRendererLayer or TileDownloadLayer
 
     public AbstractMapsforgeTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax, final Pair<String, Boolean> mapAttribution) {
         super(zoomMin, zoomMax, mapAttribution);
@@ -21,20 +22,11 @@ public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider
         this.mapUri = uri;
     }
 
-    public abstract void addTileLayer(MapsforgeVtmFragment fragment, Map map);
+    public abstract void addTileLayer(MapsforgeFragment fragment, MapView map);
 
     @Override
     public AbstractMapFragment createMapFragment() {
-        return new MapsforgeVtmFragment();
-    }
-
-    protected void parseZoomLevel(@Nullable final int[] zoomLevel) {
-        if (zoomLevel != null) {
-            for (int level : zoomLevel) {
-                zoomMin = Math.min(zoomMin, level);
-                zoomMax = Math.max(zoomMax, level);
-            }
-        }
+        return new MapsforgeFragment();
     }
 
     protected Uri getMapUri() {
@@ -45,6 +37,19 @@ public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider
     @NonNull
     public String getId() {
         return super.getId() + ":" + mapUri.getLastPathSegment();
+    }
+
+    public void prepareForTileSourceChange(final MapView mapView) {
+        if (tileLayer != null) {
+            mapView.getLayerManager().getLayers().remove(tileLayer);
+            tileLayer.onDestroy();
+            tileLayer.getTileCache().purge();
+            tileLayer = null;
+        }
+    }
+
+    public TileLayer getTileLayer() {
+        return tileLayer;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOfflineTileProvider.java
@@ -1,0 +1,81 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.unifiedmap.LayerHelper;
+import cgeo.geocaching.unifiedmap.mapsforgevtm.MapsforgeVtmFragment;
+import cgeo.geocaching.utils.Log;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+import java.io.FileInputStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.oscim.layers.tile.buildings.BuildingLayer;
+import org.oscim.layers.tile.vector.VectorTileLayer;
+import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.map.Map;
+import org.oscim.tiling.source.mapfile.IMapFileTileSource;
+import org.oscim.tiling.source.mapfile.MapFileTileSource;
+import org.oscim.tiling.source.mapfile.MapInfo;
+
+public class AbstractMapsforgeVTMOfflineTileProvider extends AbstractMapsforgeVTMTileProvider {
+
+    IMapFileTileSource tileSource;
+    private BuildingLayer buildingLayer;
+
+    AbstractMapsforgeVTMOfflineTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax) {
+        super(name, uri, zoomMin, zoomMax, new Pair<>("", false));
+        supportsThemes = true;
+        supportsThemeOptions = true; // rule of thumb, not all themes support options
+    }
+
+    @Override
+    public void addTileLayer(final MapsforgeVtmFragment fragment, final Map map) {
+        tileSource = new MapFileTileSource();
+        tileSource.setPreferredLanguage(Settings.getMapLanguage());
+        ((MapFileTileSource) tileSource).setMapFileInputStream((FileInputStream) ContentStorage.get().openForRead(mapUri));
+        final VectorTileLayer tileLayer = (VectorTileLayer) fragment.setBaseMap((MapFileTileSource) tileSource);
+        buildingLayer = new BuildingLayer(map, tileLayer);
+        fragment.addLayer(LayerHelper.ZINDEX_BUILDINGS, buildingLayer);
+        fragment.addLayer(LayerHelper.ZINDEX_LABELS, new LabelLayer(map, tileLayer));
+        fragment.applyTheme();
+
+        final MapInfo info = ((MapFileTileSource) tileSource).getMapInfo();
+        if (info != null) {
+            supportsLanguages = StringUtils.isNotBlank(info.languagesPreference);
+            if (supportsLanguages) {
+                TileProviderFactory.setLanguages(info.languagesPreference.split(","));
+            }
+            parseZoomLevel(info.zoomLevel);
+            // map attribution
+            if (StringUtils.isNotBlank(info.comment)) {
+                setMapAttribution(new Pair<>(info.comment, true));
+            } else if (StringUtils.isNotBlank(info.createdBy)) {
+                setMapAttribution(new Pair<>(info.createdBy, true));
+            }
+        }
+    }
+
+    @Override
+    public void setPreferredLanguage(final String language) {
+        if (tileSource != null) {
+            tileSource.setPreferredLanguage(language);
+        } else {
+            Log.w("AbstractMapsforgeOfflineTileProvider.setPreferredLanguage: tilesource is null");
+        }
+    }
+
+    public boolean isBuildingLayerEnabled() {
+        return buildingLayer != null && buildingLayer.isEnabled();
+    }
+
+    public void switchBuildingLayer(final boolean enabled) {
+        if (buildingLayer == null) {
+            return;
+        }
+        buildingLayer.setEnabled(enabled);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOnlineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOnlineTileProvider.java
@@ -1,0 +1,46 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.storage.LocalStorage;
+import cgeo.geocaching.unifiedmap.LayerHelper;
+import cgeo.geocaching.unifiedmap.mapsforgevtm.MapsforgeVtmFragment;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+import java.io.File;
+import java.util.Collections;
+
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+import org.oscim.layers.tile.bitmap.BitmapTileLayer;
+import org.oscim.map.Map;
+import org.oscim.tiling.source.OkHttpEngine;
+import org.oscim.tiling.source.bitmap.BitmapTileSource;
+
+class AbstractMapsforgeVTMOnlineTileProvider extends AbstractMapsforgeVTMTileProvider {
+
+    private final String tilePath;
+
+    AbstractMapsforgeVTMOnlineTileProvider(final String name, final Uri uri, final String tilePath, final int zoomMin, final int zoomMax, final Pair<String, Boolean> mapAttribution) {
+        super(name, uri, zoomMin, zoomMax, mapAttribution);
+        this.tilePath = tilePath;
+    }
+
+    @Override
+    public void addTileLayer(final MapsforgeVtmFragment fragment, final Map map) {
+        final OkHttpClient.Builder httpBuilder = new OkHttpClient.Builder();
+        final Cache cache = new Cache(new File(LocalStorage.getExternalPrivateCgeoDirectory(), "tiles"), 20 * 1024 * 1024);
+        httpBuilder.cache(cache);
+        final BitmapTileSource tileSource = BitmapTileSource.builder()
+                .url(mapUri.toString())
+                .tilePath(tilePath)
+                .zoomMax(zoomMax)
+                .zoomMin(zoomMin)
+                .build();
+        tileSource.setHttpEngine(new OkHttpEngine.OkHttpFactory(httpBuilder));
+        tileSource.setHttpRequestHeaders(Collections.singletonMap("User-Agent", "cgeo-android"));
+        fragment.addLayer(LayerHelper.ZINDEX_BASEMAP, new BitmapTileLayer(map, tileSource));
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMTileProvider.java
@@ -1,0 +1,50 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.unifiedmap.AbstractMapFragment;
+import cgeo.geocaching.unifiedmap.mapsforgevtm.MapsforgeVtmFragment;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
+
+import org.oscim.map.Map;
+
+public abstract class AbstractMapsforgeVTMTileProvider extends AbstractTileProvider {
+
+    protected final Uri mapUri;
+
+    public AbstractMapsforgeVTMTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax, final Pair<String, Boolean> mapAttribution) {
+        super(zoomMin, zoomMax, mapAttribution);
+        this.tileProviderName = name;
+        this.mapUri = uri;
+    }
+
+    public abstract void addTileLayer(MapsforgeVtmFragment fragment, Map map);
+
+    @Override
+    public AbstractMapFragment createMapFragment() {
+        return new MapsforgeVtmFragment();
+    }
+
+    protected void parseZoomLevel(@Nullable final int[] zoomLevel) {
+        if (zoomLevel != null) {
+            for (int level : zoomLevel) {
+                zoomMin = Math.min(zoomMin, level);
+                zoomMax = Math.max(zoomMax, level);
+            }
+        }
+    }
+
+    protected Uri getMapUri() {
+        return mapUri;
+    }
+
+    @Override
+    @NonNull
+    public String getId() {
+        return super.getId() + ":" + mapUri.getLastPathSegment();
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractTileProvider.java
@@ -85,4 +85,19 @@ public abstract class AbstractTileProvider {
         return zoomMax;
     }
 
+    // ========================================================================
+    // Lifecycle methods
+
+    public void onPause() {
+        // do nothing by default
+    }
+
+    public void onResume() {
+        // do nothing by default
+    }
+
+    public void onDestroy() {
+        // do nothing by default
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/CyclosmSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/CyclosmSource.java
@@ -7,8 +7,8 @@ import android.net.Uri;
 
 import androidx.core.util.Pair;
 
-class CyclosmSource extends AbstractMapsforgeVTMOnlineTileProvider {
+class CyclosmSource extends AbstractMapsforgeOnlineTileProvider {
     CyclosmSource() {
-        super("CyclOSM", Uri.parse("https://a.tile-cyclosm.openstreetmap.fr"), "/cyclosm/{Z}/{X}/{Y}.png", 0, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_cyclosm_html), true));
+        super("CyclOSM (MF)", Uri.parse("https://a.tile-cyclosm.openstreetmap.fr"), "/cyclosm/{Z}/{X}/{Y}.png", 0, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_cyclosm_html), true));
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/CyclosmSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/CyclosmSource.java
@@ -7,7 +7,7 @@ import android.net.Uri;
 
 import androidx.core.util.Pair;
 
-class CyclosmSource extends AbstractMapsforgeOnlineTileProvider {
+class CyclosmSource extends AbstractMapsforgeVTMOnlineTileProvider {
     CyclosmSource() {
         super("CyclOSM", Uri.parse("https://a.tile-cyclosm.openstreetmap.fr"), "/cyclosm/{Z}/{X}/{Y}.png", 0, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_cyclosm_html), true));
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/CyclosmVTMSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/CyclosmVTMSource.java
@@ -1,0 +1,14 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+class CyclosmVTMSource extends AbstractMapsforgeVTMOnlineTileProvider {
+    CyclosmVTMSource() {
+        super("CyclOSM", Uri.parse("https://a.tile-cyclosm.openstreetmap.fr"), "/cyclosm/{Z}/{X}/{Y}.png", 0, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_cyclosm_html), true));
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeVTMMultiOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/MapsforgeVTMMultiOfflineTileProvider.java
@@ -26,11 +26,11 @@ import org.oscim.tiling.source.mapfile.MapFileTileSource;
 import org.oscim.tiling.source.mapfile.MapInfo;
 import org.oscim.tiling.source.mapfile.MultiMapFileTileSource;
 
-class MapsforgeMultiOfflineTileProvider extends AbstractMapsforgeOfflineTileProvider {
+class MapsforgeVTMMultiOfflineTileProvider extends AbstractMapsforgeVTMOfflineTileProvider {
 
     private final List<ImmutablePair<String, Uri>> maps;
 
-    MapsforgeMultiOfflineTileProvider(final List<ImmutablePair<String, Uri>> maps) {
+    MapsforgeVTMMultiOfflineTileProvider(final List<ImmutablePair<String, Uri>> maps) {
         super(CgeoApplication.getInstance().getString(R.string.map_source_osm_offline_combined), Uri.parse(""), 999, 0);
         this.maps = maps;
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapSource.java
@@ -7,11 +7,9 @@ import android.net.Uri;
 
 import androidx.core.util.Pair;
 
-import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
-
-class OpenTopoMapSource extends AbstractMapsforgeVTMOnlineTileProvider {
+class OpenTopoMapSource extends AbstractMapsforgeOnlineTileProvider {
     OpenTopoMapSource() {
-        super("OpenTopoMap", Uri.parse("https://c.tile.opentopomap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_opentopomap_html), true));
+        super("OpenTopoMap (MF)", Uri.parse("https://c.tile.opentopomap.org"), "/{Z}/{X}/{Y}.png", 2, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_opentopomap_html), true));
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapSource.java
@@ -9,7 +9,7 @@ import androidx.core.util.Pair;
 
 import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
 
-class OpenTopoMapSource extends AbstractMapsforgeOnlineTileProvider {
+class OpenTopoMapSource extends AbstractMapsforgeVTMOnlineTileProvider {
     OpenTopoMapSource() {
         super("OpenTopoMap", Uri.parse("https://c.tile.opentopomap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_opentopomap_html), true));
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapVTMSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OpenTopoMapVTMSource.java
@@ -1,0 +1,17 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
+
+class OpenTopoMapVTMSource extends AbstractMapsforgeVTMOnlineTileProvider {
+    OpenTopoMapVTMSource() {
+        super("OpenTopoMap", Uri.parse("https://c.tile.opentopomap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_opentopomap_html), true));
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmDeSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmDeSource.java
@@ -7,10 +7,8 @@ import android.net.Uri;
 
 import androidx.core.util.Pair;
 
-import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
-
 class OsmDeSource extends AbstractMapsforgeOnlineTileProvider {
     OsmDeSource() {
-        super("OSM.de", Uri.parse("https://tile.openstreetmap.de"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmapde_html), true));
+        super("OSM.de (MF)", Uri.parse("https://tile.openstreetmap.de"), "/{Z}/{X}/{Y}.png", 2, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmapde_html), true));
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmDeVTMSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmDeVTMSource.java
@@ -1,0 +1,16 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
+
+class OsmDeVTMSource extends AbstractMapsforgeVTMOnlineTileProvider {
+    OsmDeVTMSource() {
+        super("OSM.de", Uri.parse("https://tile.openstreetmap.de"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmapde_html), true));
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmOrgSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmOrgSource.java
@@ -7,11 +7,9 @@ import android.net.Uri;
 
 import androidx.core.util.Pair;
 
-import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
-
-class OsmOrgSource extends AbstractMapsforgeVTMOnlineTileProvider {
+class OsmOrgSource extends AbstractMapsforgeOnlineTileProvider {
     OsmOrgSource() {
-        super("OSM.org", Uri.parse("https://tile.openstreetmap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmap_html), true));
+        super("OSM.org (MF)", Uri.parse("https://tile.openstreetmap.org"), "/{Z}/{X}/{Y}.png", 2, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmap_html), true));
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmOrgSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmOrgSource.java
@@ -9,7 +9,7 @@ import androidx.core.util.Pair;
 
 import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
 
-class OsmOrgSource extends AbstractMapsforgeOnlineTileProvider {
+class OsmOrgSource extends AbstractMapsforgeVTMOnlineTileProvider {
     OsmOrgSource() {
         super("OSM.org", Uri.parse("https://tile.openstreetmap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmap_html), true));
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmOrgVTMSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/OsmOrgVTMSource.java
@@ -1,0 +1,16 @@
+package cgeo.geocaching.unifiedmap.tileproviders;
+
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+
+import android.net.Uri;
+
+import androidx.core.util.Pair;
+
+import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
+
+public class OsmOrgVTMSource extends AbstractMapsforgeVTMOnlineTileProvider {
+    OsmOrgVTMSource() {
+        super("OSM.org", Uri.parse("https://tile.openstreetmap.org"), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.map_attribution_openstreetmap_html), true));
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -145,13 +145,13 @@ public class TileProviderFactory {
             registerTileProvider(new GoogleTerrainSource());
         }
 
-        // OSM online tile providers
-        registerTileProvider(new OsmOrgSource());
+        // OSM online tile providers (VTM)
+        registerTileProvider(new OsmOrgVTMSource());
         registerTileProvider(new OsmDeVTMSource());
-        registerTileProvider(new CyclosmSource());
-        registerTileProvider(new OpenTopoMapSource());
+        registerTileProvider(new CyclosmVTMSource());
+        registerTileProvider(new OpenTopoMapVTMSource());
 
-        // OSM offline tile providers
+        // OSM offline tile providers (VTM)
         final List<ImmutablePair<String, Uri>> offlineMaps =
                 CollectionStream.of(ContentStorage.get().list(PersistableFolder.OFFLINE_MAPS, true))
                         .filter(fi -> !fi.isDirectory && fi.name.toLowerCase(Locale.getDefault()).endsWith(FileUtils.MAP_FILE_EXTENSION) && isValidMapFile(fi.uri))
@@ -167,17 +167,24 @@ public class TileProviderFactory {
             registerTileProvider(new AbstractMapsforgeVTMOfflineTileProvider(data.left, data.right, 0, 18));   // @todo: get actual values for zoomMin/zoomMax
         }
 
-        // test: show Mapsforge-backed tile providers below the others, so far for a subset only
+        // --------------------------------------------------------------------
+        // test: show Mapsforge-backed tile providers below the others
+        // --------------------------------------------------------------------
         if (Settings.useMapsforgeInUnifiedMap()) {
             // OSM online tile providers
+            registerTileProvider(new OsmOrgSource());
             registerTileProvider(new OsmDeSource());
+            registerTileProvider(new CyclosmSource());
+            registerTileProvider(new OpenTopoMapSource());
+
+            // @todo: combined, user-defined
 
             // OSM offline tile providers
             for (ImmutablePair<String, Uri> data : offlineMaps) {
-                registerTileProvider(new AbstractMapsforgeOfflineTileProvider(data.left + " (MF)", data.right, 0, 18));   // @todo: get actual values for zoomMin/zoomMax
+                registerTileProvider(new AbstractMapsforgeOfflineTileProvider(data.left + " (MF)", data.right, 2, 18));   // @todo: get actual values for zoomMin/zoomMax
             }
-
         }
+        // --------------------------------------------------------------------
 
     }
 
@@ -201,7 +208,6 @@ public class TileProviderFactory {
     }
 
     private static void registerTileProvider(final AbstractTileProvider tileProvider) {
-        Log.e("put tileprovider: id=" + tileProvider.getId() + ", tileprovider=" + tileProvider);
         tileProviders.put(tileProvider.getId(), tileProvider);
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
@@ -11,8 +11,8 @@ import androidx.core.util.Pair;
 import org.apache.commons.lang3.StringUtils;
 import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
 
-public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTileProvider {
-    UserDefinedMapsforgeOnlineSource() {
+public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnlineTileProvider {
+    UserDefinedMapsforgeVTMOnlineSource() {
         super(CgeoApplication.getInstance().getString(R.string.settings_userDefinedTileProvider), Uri.parse(Settings.getUserDefinedTileProviderUri()), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.settings_userDefinedTileProvider), true));
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/HideActionBarUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/HideActionBarUtils.java
@@ -97,6 +97,7 @@ public class HideActionBarUtils {
             minHeight += v.getHeight();
         }
 
-        compassRose.animate().translationY(minHeight).start();
+        final int finalMinHeight = minHeight;
+        activity.runOnUiThread(() -> compassRose.animate().translationY(finalMinHeight).start());
     }
 }

--- a/main/src/main/res/layout/unifiedmap_mapsforge_fragment.xml
+++ b/main/src/main/res/layout/unifiedmap_mapsforge_fragment.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/unifiedmap_vtm"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+
+    <org.mapsforge.map.android.view.MapView
+        android:id="@+id/mapViewMapsforge"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+
+    <include layout="@layout/map_bearingindicator" />
+
+    <ImageView
+        android:id="@+id/map_attribution"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginLeft="6dp"
+        android:layout_marginBottom="11dp"
+        android:scaleType="centerInside"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentBottom="true"
+        android:layout_gravity="left"
+        android:src="@drawable/copyright"
+        tools:src="@drawable/copyright"/>
+</RelativeLayout>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -559,6 +559,7 @@
     <string translatable="false" name="pref_mapCacheScaling">mapCacheScaling</string>
     <string translatable="false" name="pref_mapWpScaling">mapWpScaling</string>
     <string translatable="false" name="pref_mapScaleOnly">mapScaleOnly</string>
+    <string translatable="false" name="pref_useMapsforgeInUnifiedMap">useMapsforgeInUnifiedMap</string>
 
     <!-- pq/bookmark list: show downloadable/new only -->
     <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>


### PR DESCRIPTION
## Description
Optionally offer Mapsforge bitmap-based maps for UnifiedMap.

Implementation is based on the first commit of @fm-sys in many areas, and using @eddiemuc's implementation of `GeoItemLayer` for Mapsforge.

Supports both offline and online maps from Mapsforge (except "combined" and "user-defined"). Rotation by gestures does work already, general labels stay horizontally.

To activate Mapsforge in UnifiedMap, create a new setting named `useMapsforgeInUnifiedMap`of type `boolean` and set it to `true`.

When activated, it adds all supported (and not deactivated) map sources to the map selection menu, adding a "(MF)" suffix to the name.
