### PR TITLE
fix #15938: fix sort order for lists, make _ on top of uppercase letters

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -335,8 +335,8 @@ dependencies {
     implementation 'net.sf.geographiclib:GeographicLib-Java:2.0'
 
     // DB inspection
-    implementation 'com.github.moving-bits:datatables:-SNAPSHOT'
-    implementation 'com.github.moving-bits:dbinspection:a717370360'
+    implementation 'com.github.moving-bits:datatables:v0.1.0'
+    implementation 'com.github.moving-bits:dbinspection:v0.1.0'
 
     // Jackson XML processing
     // Jackson 2.14++ needs minSdk 26


### PR DESCRIPTION
fix #15938: fix sort order for lists, make _ on top of uppercase letters

@moving-bits : this PR changes the version of datatables to be included. I was not able to compile otherwise since SNAPSHOT version seems not to be available on jitpack.io