### PR TITLE
Use bigDecimal for converting double to string in formula

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/formulas/Value.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/Value.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.utils.formulas;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -62,7 +63,8 @@ public class Value {
             if (raw == null) {
                 asString = "";
             } else if (raw instanceof Number && !(raw instanceof Integer) && !(raw instanceof BigInteger)) {
-                asString = DOUBLE_TO_STRING_FORMAT.format(((Number) raw).doubleValue());
+                final BigDecimal bigDecimalValue = new BigDecimal(((Number) raw).doubleValue());
+                asString = DOUBLE_TO_STRING_FORMAT.format(bigDecimalValue);
             } else {
                 asString = raw instanceof String ? (String) raw : raw.toString();
             }

--- a/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
@@ -61,6 +61,13 @@ public class FormulaTest {
     }
 
     @Test
+    public void bigDecimals() {
+        final int doublePowCs = 847; // manually calculated checksum of pow(99^99)
+        assertThat(Formula.evaluate("cs(99^99)").getAsDouble()).isEqualTo(doublePowCs);
+        assertThat(Formula.evaluate("99^99").getAsDouble()).isEqualTo(Math.pow(99, 99));
+    }
+
+    @Test
     public void complex() {
         assertThat(eval("-2.5 + 3 * (4-1) + 3^3")).isEqualTo(33.5d);
     }

--- a/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
@@ -62,11 +62,14 @@ public class FormulaTest {
 
     @Test
     public void bigDecimals() {
-        final int doublePowCs = 847; // manually calculated checksum of pow(99^99)
-        assertThat(Formula.evaluate("cs(99^99)").getAsDouble()).isEqualTo(doublePowCs);
+        final double doubleResult = 3.697296376497268E197;
         assertThat(Formula.evaluate("99^99").getAsDouble()).isEqualTo(Math.pow(99, 99));
-        assertThat(String.valueOf(Formula.evaluate("99^99").getAsString())).isEqualTo("369729637649726802192985226395427290145296428445515959701359650120802601667133273280053721002700400354392780458116125965728631706472588849812738072765460822138161108630185181415759762204338929270784");
+        assertThat(Formula.evaluate("99^99").getAsDouble()).isEqualTo(doubleResult);
         assertThat(String.valueOf(Formula.evaluate("99^99").getAsDouble())).isEqualTo("3.697296376497268E197");
+
+        final int doublePowCs = 847; // manually calculated checksum of pow(99^99)
+        assertThat(String.valueOf(Formula.evaluate("99^99").getAsString())).isEqualTo("369729637649726802192985226395427290145296428445515959701359650120802601667133273280053721002700400354392780458116125965728631706472588849812738072765460822138161108630185181415759762204338929270784");
+        assertThat(Formula.evaluate("cs(99^99)").getAsDouble()).isEqualTo(doublePowCs);
     }
 
     @Test

--- a/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaTest.java
@@ -65,6 +65,8 @@ public class FormulaTest {
         final int doublePowCs = 847; // manually calculated checksum of pow(99^99)
         assertThat(Formula.evaluate("cs(99^99)").getAsDouble()).isEqualTo(doublePowCs);
         assertThat(Formula.evaluate("99^99").getAsDouble()).isEqualTo(Math.pow(99, 99));
+        assertThat(String.valueOf(Formula.evaluate("99^99").getAsString())).isEqualTo("369729637649726802192985226395427290145296428445515959701359650120802601667133273280053721002700400354392780458116125965728631706472588849812738072765460822138161108630185181415759762204338929270784");
+        assertThat(String.valueOf(Formula.evaluate("99^99").getAsDouble())).isEqualTo("3.697296376497268E197");
     }
 
     @Test


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Using `BigDecimal` for more precision for decimal values in evaluation of value to string in formula.

## Related issues
<!-- List the related issues fixed or improved by this PR -->

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
I had a mystery where I had to calculate the checksum of a high pow-value (which is a double value)
With the current implementation not all necessary digits are shown (the scientific-notation is used).
Switching to `BigDecimal` all digits are shown