### PR TITLE
UnifiedMap: Support parametrized tileprovider uri (fix #15884)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapSourcesFragment.java
@@ -56,6 +56,7 @@ public class PreferenceMapSourcesFragment extends BasePreferenceFragment {
         setUserDefinedTileProviderUriSummary(Settings.getUserDefinedTileProviderUri());
         findPreference(getString(R.string.pref_userDefinedTileProviderUri)).setOnPreferenceChangeListener((preference, newValue) -> {
             setUserDefinedTileProviderUriSummary(String.valueOf(newValue));
+            setFlagForRestartRequired();
             return true;
         });
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -20,10 +20,14 @@ import org.oscim.tiling.source.bitmap.BitmapTileSource;
 
 class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTileProvider {
 
-    private final String tilePath;
+    private String tilePath;
 
     AbstractMapsforgeOnlineTileProvider(final String name, final Uri uri, final String tilePath, final int zoomMin, final int zoomMax, final Pair<String, Boolean> mapAttribution) {
         super(name, uri, zoomMin, zoomMax, mapAttribution);
+        this.tilePath = tilePath;
+    }
+
+    protected void setTilePath(final String tilePath) {
         this.tilePath = tilePath;
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
@@ -13,12 +13,16 @@ import org.oscim.map.Map;
 
 public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider {
 
-    protected final Uri mapUri;
+    protected Uri mapUri;
 
     public AbstractMapsforgeTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax, final Pair<String, Boolean> mapAttribution) {
         super(zoomMin, zoomMax, mapAttribution);
         this.tileProviderName = name;
         this.mapUri = uri;
+    }
+
+    protected void setMapUri(final Uri mapUri) {
+        this.mapUri = mapUri;
     }
 
     public abstract void addTileLayer(MapsforgeVtmFragment fragment, Map map);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
@@ -14,6 +14,21 @@ import static org.oscim.map.Viewport.MIN_ZOOM_LEVEL;
 public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTileProvider {
     UserDefinedMapsforgeOnlineSource() {
         super(CgeoApplication.getInstance().getString(R.string.settings_userDefinedTileProvider), Uri.parse(Settings.getUserDefinedTileProviderUri()), "/{Z}/{X}/{Y}.png", MIN_ZOOM_LEVEL, 18, new Pair<>(CgeoApplication.getInstance().getString(R.string.settings_userDefinedTileProvider), true));
+        final Uri fullUri = Uri.parse(Settings.getUserDefinedTileProviderUri());
+
+        final String mapUri = fullUri.getScheme() + "://" + fullUri.getHost();
+        setMapUri(Uri.parse(mapUri));
+
+        String tilePath = fullUri.getPath();
+        if (tilePath != null) {
+            if (!(tilePath.contains("{X}") && tilePath.contains("{Y}"))) {
+                if (!tilePath.endsWith("/")) {
+                    tilePath += "/";
+                }
+                tilePath += "{Z}/{X}/{Y}.png";
+            }
+            setTilePath(tilePath);
+        }
     }
 
     public static boolean isConfigured() {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -894,7 +894,7 @@
     <string name="settings_hide_tileproviders_title">Hide Map Sources</string>
     <string name="settings_hide_tileproviders_summary">Exclude one or more map sources from map source selection</string>
     <string name="settings_userDefinedTileProvider">User-defined tile provider</string>
-    <string name="settings_userDefinedTileProviderUri">Enter full Uri (without trailing slash) to tile provider. Make sure you have checked and comply to their usage conditions.</string>
+    <string name="settings_userDefinedTileProviderUri">Enter full Uri (without trailing slash) to tile provider, or enter full Uri with parameters (including {X}, {Y} and {Z}). Make sure you have checked and comply to their usage conditions.</string>
     <string name="settings_title_data_dir">Geocache data folder</string>
     <string name="settings_title_data_dir_usage">Geocache data folder (%1$s used)</string>
     <string name="calculate_dataDir_title">Geocache data usage</string>


### PR DESCRIPTION
Supports individual parametrization of tileprovider uri (UnifiedMap only).
If parameters {X} and {Y} are not found, `/{Z}/{X}/{Y}.png` is added automatically (migration support).

![image](https://github.com/user-attachments/assets/b55b1662-f631-4cc0-923d-da256ab1b319)

Also adds a restart to c:geo on changing tileprovider uri.