### PR TITLE
fix #15993: parse spoiler images with uppercase image type suffix eg JPG (eg GC601B)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -340,6 +340,17 @@ public class GCParserTest {
         assertThat(spoiler.getUrl()).isEqualTo("https://www.dropbox.com/s/1kakwnpny8698hm/QR_Hintergrund.jpg?dl=1");
     }
 
+    @Test
+    public void testSpoilerImageUrlWithStrong() {
+        //from GC601B
+        final String html = "<ul class=\"CachePageImages NoPrint\">\n" +
+                "            <li><a href=\"https://img.geocaching.com/cache/large/baf98e07-b431-4fbf-920d-0df4346c2847.JPG\" class=\"owner-image\" rel=\"owner_image_group\" data-title=\"<strong>Blick vom Weg</strong>\">Blick vom Weg</a></li><li><a href=\"https://img.geocaching.com/cache/large/a6772043-021c-4b6f-91c9-da4a92829f95.JPG\" class=\"owner-image\" rel=\"owner_image_group\" data-title=\"<strong>Da zeige ich auf den Cache</strong>\">Da zeige ich auf den Cache</a></li>\n" +
+                "        </ul>";
+        final List<Image> images = GCParser.parseSpoiler(html);
+        assertThat(images).hasSize(2);
+
+    }
+
     @MediumTest
     @Test
     public void testFullScaleImageUrl() {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -82,7 +82,7 @@ public final class GCConstants {
      * Two groups !
      */
     static final Pattern PATTERN_ATTRIBUTESINSIDE = Pattern.compile("<img src=\"([^\"]+)\" alt=\"([^\"]+?)\"");
-    private static final String IMAGE_FORMATS = "jpg|jpeg|png|gif|bmp";
+    private static final String IMAGE_FORMATS = "jpg|jpeg|png|gif|bmp|JPG|JPEG|PNG|GIF|BMP";
     //Example HTML to match: <a href="https://img.geocaching.com/cache/large/1711f8a1-796a-405b-82ba-8685f2e9f024.jpg" class="owner-image" rel="owner_image_group" data-title="<strong>indy mit text netz Kopie</strong>">indy mit text netz Kopie</a></li>
     static final Pattern PATTERN_SPOILER_IMAGE = Pattern.compile("<a href=\"(https?://img(?:cdn)?\\.geocaching\\.com[^.]+\\.(?:" + IMAGE_FORMATS + "))\"[^>]+>(?:[^>]+</strong>[^>]+>)?" + "([^<]*)</a>" + ".*?(?:description\"[^>]*>([^<]+)</span>)?</li>", Pattern.DOTALL);
     static final Pattern PATTERN_INVENTORY = Pattern.compile("ctl00_ContentBody_uxTravelBugList_uxInventoryLabel\">.*?WidgetBody(.*?)<div");

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -429,23 +429,8 @@ public final class GCParser {
             }
             DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_spoilers);
 
-            final MatcherWrapper matcherSpoilersInside = new MatcherWrapper(GCConstants.PATTERN_SPOILER_IMAGE, page);
+            cacheSpoilers.addAll(parseSpoiler(page));
 
-            while (matcherSpoilersInside.find()) {
-                final String url = fullScaleImageUrl(matcherSpoilersInside.group(1));
-
-                String title = null;
-                if (matcherSpoilersInside.group(2) != null) {
-                    title = matcherSpoilersInside.group(2);
-                }
-                String description = null;
-                if (matcherSpoilersInside.group(3) != null) {
-                    description = matcherSpoilersInside.group(3);
-                }
-                if (title != null) {
-                    cacheSpoilers.add(new Image.Builder().setUrl(url).setTitle(title).setDescription(description).build());
-                }
-            }
         } catch (final RuntimeException e) {
             // failed to parse cache spoilers
             Log.w("GCParser.parseCache: Failed to parse cache spoilers", e);
@@ -602,6 +587,28 @@ public final class GCParser {
 
         cache.setDetailedUpdatedNow();
         return ImmutablePair.of(StatusCode.NO_ERROR, cache);
+    }
+
+    public static List<Image> parseSpoiler(final String html) {
+        final List<Image> cacheSpoilers = new ArrayList<>();
+        final MatcherWrapper matcherSpoilersInside = new MatcherWrapper(GCConstants.PATTERN_SPOILER_IMAGE, html);
+
+        while (matcherSpoilersInside.find()) {
+            final String url = fullScaleImageUrl(matcherSpoilersInside.group(1));
+
+            String title = null;
+            if (matcherSpoilersInside.group(2) != null) {
+                title = matcherSpoilersInside.group(2);
+            }
+            String description = null;
+            if (matcherSpoilersInside.group(3) != null) {
+                description = matcherSpoilersInside.group(3);
+            }
+            if (title != null) {
+                cacheSpoilers.add(new Image.Builder().setUrl(url).setTitle(title).setDescription(description).build());
+            }
+        }
+        return cacheSpoilers;
     }
 
     @Nullable


### PR DESCRIPTION
fix #15993: parse spoiler images with uppercase image type suffix eg JPG (eg GC601B)