### PR TITLE
Show testDir preference in developer builds only (fix #16071)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -16,6 +16,9 @@ import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+
 public class PreferenceSystemFragment extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(final Bundle savedInstanceState, final String rootKey) {
@@ -37,7 +40,18 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
         setPrefClick(this, R.string.pref_fakekey_generate_logcat, () -> DebugUtils.createLogcat(activity));
         setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
 
-        findPreference(getString(R.string.pref_persistablefolder_testdir)).setVisible(BranchDetectionHelper.isDeveloperBuild());
+        if (BranchDetectionHelper.isDeveloperBuild()) {
+            Preference testDir = findPreference(getString(R.string.pref_persistablefolder_testdir));
+            if (testDir == null) {
+                testDir = new Preference(getActivity());
+                testDir.setKey(getString(R.string.pref_persistablefolder_testdir));
+                testDir.setTitle("Directory for Unit Tests. This setting is only needed for development and only visible in developer builds");
+                testDir.setIconSpaceReserved(false);
+
+                final PreferenceCategory localFileSystem = findPreference(getString(R.string.pref_fakekey_local_filesystem));
+                localFileSystem.addPreference(testDir);
+            }
+        }
 
         findPreference(getString(R.string.pref_debug)).setOnPreferenceChangeListener((pref, newValue) -> {
             Log.setDebug((Boolean) newValue);

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -373,6 +373,7 @@
     <!-- category local filesystem -->
     <string translatable="false" name="pref_persistablefolder_basedir">persistablefolder_basedir</string>
     <string translatable="false" name="pref_persistablefolder_testdir">persistablefolder_testdir</string>
+    <string translatable="false" name="pref_fakekey_local_filesystem">fakekey_local_filesystem</string>
 
     <!-- category geolocation -->
     <string translatable="false" name="pref_googleplayservices">googleplayservices</string>

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -6,17 +6,13 @@
     app:key="@string/preference_screen_system">
 
     <PreferenceCategory
+        android:key="@string/pref_fakekey_local_filesystem"
         android:title="@string/init_local_file_system"
         app:iconSpaceReserved="false">
         <Preference
             android:key="@string/pref_persistablefolder_basedir"
             android:title="@string/init_base_directory_description"
             app:iconSpaceReserved="false" />
-        <Preference
-            android:key="@string/pref_persistablefolder_testdir"
-            android:title="Directory for Unit Tests. This setting is only needed for development and only visible in Debug mode"
-            app:iconSpaceReserved="false"
-            app:isPreferenceVisible="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Toggles testDir preference behavior:
Instead of having it included by default and removing it in non-developer builds, do not have it included by default, but add it dynamically in developer builds (to avoid the effect of vanishing blank space as described in #16071).