### PR TITLE
Show warning for activated gc connector without credentials (fix #16061)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/AbstractClickablePreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/AbstractClickablePreference.java
@@ -27,7 +27,8 @@ abstract class AbstractClickablePreference extends Preference {
                 .setTitle(R.string.auth_forget_title)
                 .setPositiveButton(android.R.string.yes, (dialog, id) -> {
                     revokeAuthorization();
-                    setSummary(R.string.auth_unconnected);
+                    setSummary(R.string.auth_unconnected_tap_here);
+                    setIcon(R.drawable.attribute_firstaid);
                 })
                 .setNegativeButton(android.R.string.cancel, (dialog, id) -> dialog.cancel());
         builder.create().show();

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComFragment.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.settings.fragments;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.settings.Credentials;
+import cgeo.geocaching.settings.CredentialsPreference;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.SettingsUtils;
@@ -54,7 +55,14 @@ public class PreferenceServiceGeocachingComFragment extends PreferenceFragmentCo
         final GCConnector connector = GCConnector.getInstance();
         final Credentials credentials = Settings.getCredentials(connector);
         SettingsUtils.setAuthTitle(this, R.string.pref_fakekey_gc_authorization, StringUtils.isNotBlank(credentials.getUsernameRaw()));
-        findPreference(getString(R.string.pref_fakekey_gc_authorization)).setSummary(credentials.isValid() ? getString(R.string.auth_connected_as, credentials.getUserName()) : getString(R.string.auth_unconnected));
+        final CredentialsPreference credentialsPreference = findPreference(getString(R.string.pref_fakekey_gc_authorization));
+        if (credentials.isValid()) {
+            credentialsPreference.setIcon(null);
+            credentialsPreference.setSummary(getString(R.string.auth_connected_as, credentials.getUserName()));
+        } else {
+            credentialsPreference.setIcon(R.drawable.attribute_firstaid);
+            credentialsPreference.setSummary(R.string.auth_unconnected_tap_here);
+        }
         initBasicMemberPreferences();
     }
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1418,6 +1418,7 @@
     <string name="auth_register">Create an account</string>
     <string name="auth_connected">Connected</string>
     <string name="auth_unconnected">Not connected yet</string>
+    <string name="auth_unconnected_tap_here">Not connected yet - tap here to authorize</string>
     <string name="auth_connected_as">Connected as %s.\nTap here to update or long tap to remove authorization data from c:geo.</string>
     <string name="auth_dialog_waiting">Waiting for %s…</string>
     <string name="auth_explain_short">The following process will allow <b>c:geo</b> to access %s.</string>


### PR DESCRIPTION
## Description
If gc connector is activated, but credentials are missing, show a prominent warning hint:

![image](https://github.com/user-attachments/assets/0bfe24a9-42a2-485e-b36d-40c50ab2beda)
