### PR TITLE
Do not scale elevation on main screen (fix #16046)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/Units.java
+++ b/main/src/main/java/cgeo/geocaching/location/Units.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.location;
 
 import cgeo.geocaching.settings.Settings;
 
+import java.text.NumberFormat;
 import java.util.Locale;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -26,11 +27,10 @@ public class Units {
         }
     }
 
-    /* formats elevation in m according to useImperialUnits() setting */
-    public static String formatElevation(final float elevationInM) {
-        // Float.isNaN() is equivalent to Routing.NO_ELEVATION_AVAILABLE
-        final double temp = Float.isNaN(elevationInM) ? Double.NaN : Settings.useImperialUnits() ? elevationInM * IConversion.METERS_TO_FEET : elevationInM;
-        return Double.isNaN(temp) ? "" : String.format(Locale.getDefault(), "%.0f", temp) + (Settings.useImperialUnits() ? " ft" : " m");
+    /** formats given elevation in meters or feet, no fractions, no kilometers/miles */
+    public static String formatElevation(final float meters) {
+        final NumberFormat nf = NumberFormat.getIntegerInstance(Locale.getDefault());
+        return Float.isNaN(meters) ? "" : Settings.useImperialUnits() ? nf.format(meters * IConversion.METERS_TO_FEET) + " ft" : nf.format(meters) + " m";
     }
 
     public static float generateSmartRoundedAverageDistance(final float newDistance, final float lastDistance) {

--- a/main/src/main/java/cgeo/geocaching/utils/GeoHeightUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/GeoHeightUtils.java
@@ -29,6 +29,6 @@ public class GeoHeightUtils {
             }
         }
         averageAltitude /= (double) altitudeReadings.length;
-        return averageAltitude == 0 || (onlyFullReadings && countReadings < 5) ? "" : Formatter.SEPARATOR + (countReadings < 5 ? "~ " : "") + Units.getDistanceFromMeters((float) averageAltitude);
+        return averageAltitude == 0 || (onlyFullReadings && countReadings < 5) ? "" : Formatter.SEPARATOR + (countReadings < 5 ? "~ " : "") + Units.formatElevation((float) averageAltitude);
     }
 }


### PR DESCRIPTION
## Description
Show elevation on home screen in "meters" or "feet", do not scale to "kilometers" or "miles".

Additionally:
- use internationalization for formatting number (decimal "points")
- use identical formatter for elevation info on home screen and for position info on map
