### PR TITLE
UnifiedMap Mapsforge: Adjust overdraw factor in driving mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -369,8 +369,8 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
     @Override
     public void setDrivingMode(final boolean enabled) {
-        // todo: cross-check
         mMapView.setMapViewCenterY(enabled ? 0.75f : 0.5f);
+        mMapView.getModel().frameBufferModel.setOverdrawFactor(Math.max(mMapView.getModel().frameBufferModel.getOverdrawFactor(), mMapView.getMapViewCenterY() * 2));
     }
 
 


### PR DESCRIPTION
## Description
If map rotation center is shifted away from view center, map's overdraw factor should be adjusted for cleaner map display