### PR TITLE
UnifiedMap Mapsforge: Add setting to toggle usage

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -893,6 +893,8 @@
     <string name="settings_title_map_style">Map style</string>
     <string name="settings_hide_tileproviders_title">Hide Map Sources</string>
     <string name="settings_hide_tileproviders_summary">Exclude one or more map sources from map source selection</string>
+    <string name="settings_useMapsforgeInUnifiedMap_title">Mapsforge + VTM</string>
+    <string name="settings_useMapsforgeInUnifiedMap_summary">Offer both VTM + Mapsforge engines for Mapsforge maps (for testing purposes)</string>
     <string name="settings_userDefinedTileProvider">User-defined tile provider</string>
     <string name="settings_userDefinedTileProviderUri">Enter full Uri (without trailing slash) to tile provider, or enter full Uri with parameters (including {X}, {Y} and {Z}). Make sure you have checked and comply to their usage conditions.</string>
     <string name="settings_title_data_dir">Geocache data folder</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -132,6 +132,12 @@
             android:title="@string/settings_hide_tileproviders_title"
             android:summary="@string/settings_hide_tileproviders_summary"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:key="@string/pref_useMapsforgeInUnifiedMap"
+            android:title="@string/settings_useMapsforgeInUnifiedMap_title"
+            android:summary="@string/settings_useMapsforgeInUnifiedMap_summary"
+            android:defaultValue="false"
+            app:iconSpaceReserved="false" />
         <cgeo.geocaching.settings.TextPreference
             android:defaultValue=""
             android:key="@string/pref_userDefinedTileProviderUri"


### PR DESCRIPTION
## Description
Adds a checkbox setting to Settings => Map Sources => Unified Map section to enable Mapsforge engine in addition to VTM in UnifiedMap