### PR TITLE
UnifiedMap: Move 'show elevation chart' to long tap menu (fix #16064)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -28,6 +28,7 @@ import cgeo.geocaching.ui.dialog.SimplePopupMenu;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.UriUtils;
+import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Action2;
 import cgeo.geocaching.utils.functions.Func0;
 
@@ -133,24 +134,27 @@ public class RouteTrackUtils {
     // route/track context menu-related methods
 
     /** show a popup for track/individual route, opened by using a long-tap on that item on the map */
-    public void showRouteTrackContextMenu(final int tapX, final int tapY, final Route route) {
+    public void showRouteTrackContextMenu(final int tapX, final int tapY, final Action1<Route> handleLongTapOnRoutesOrTracks, final Route route) {
         final SimplePopupMenu menu = SimplePopupMenu.of(activity).setMenuContent(R.menu.map_routetrack_context).setPosition(new Point(tapX, tapY), 0);
-        menu.setOnCreatePopupMenuListener(menu1 -> configureContextMenu(menu1, route));
-        menu.setOnItemClickListener(item -> handleContextMenuClick(item, route));
+        menu.setOnCreatePopupMenuListener(menu1 -> configureContextMenu(menu1, handleLongTapOnRoutesOrTracks != null, route));
+        menu.setOnItemClickListener(item -> handleContextMenuClick(item, handleLongTapOnRoutesOrTracks, route));
         menu.show();
     }
 
-    public static void configureContextMenu(final Menu menu, final Route route) {
+    public static void configureContextMenu(final Menu menu, final boolean showElevationChart, final Route route) {
         final boolean isIndividualRoute = isIndividualRoute(route);
+        menu.findItem(R.id.menu_showElevationChart).setVisible(showElevationChart);
         menu.findItem(R.id.menu_edit).setVisible(isIndividualRoute);
         menu.findItem(R.id.menu_optimize).setVisible(isIndividualRoute);
         menu.findItem(R.id.menu_invert_order).setVisible(isIndividualRoute);
         menu.findItem(R.id.menu_color).setVisible(!isIndividualRoute);
     }
 
-    public boolean handleContextMenuClick(final MenuItem item, final Route route) {
+    public boolean handleContextMenuClick(final MenuItem item, final Action1<Route> handleLongTapOnRoutesOrTracks, final Route route) {
         final int id = item.getItemId();
-        if (id == R.id.menu_edit) {
+        if (id == R.id.menu_showElevationChart && handleLongTapOnRoutesOrTracks != null) {
+            handleLongTapOnRoutesOrTracks.call(route);
+        } else if (id == R.id.menu_edit) {
             menuEditRoute(route);
         } else if (id == R.id.menu_optimize) {
             if (isIndividualRoute(route)) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChart.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChart.java
@@ -105,8 +105,8 @@ public class ElevationChart {
         if (routeTrackUtils != null) {
             toolbar.getMenu().clear();
             toolbar.inflateMenu(R.menu.map_routetrack_context);
-            RouteTrackUtils.configureContextMenu(toolbar.getMenu(), route);
-            toolbar.setOnMenuItemClickListener(item -> routeTrackUtils.handleContextMenuClick(item, route));
+            RouteTrackUtils.configureContextMenu(toolbar.getMenu(), false, route);
+            toolbar.setOnMenuItemClickListener(item -> routeTrackUtils.handleContextMenuClick(item, null, route));
             // workaround to display icons in overflow menu of toolbar
             if (toolbar.getMenu() instanceof MenuBuilder) {
                 ((MenuBuilder) toolbar.getMenu()).setOptionalIconsVisible(true);

--- a/main/src/main/res/menu/map_routetrack_context.xml
+++ b/main/src/main/res/menu/map_routetrack_context.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/menu_showElevationChart"
+        android:title="@string/showElevationChart"
+        android:icon="@drawable/elevation"
+        app:iconTint="@color/colorText"/>
+    <item
         android:id="@+id/menu_edit"
         android:title="@string/edit"
         android:icon="@drawable/ic_menu_edit"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1726,6 +1726,7 @@
     <string name="context_map_star_show">Show lines to waypoints</string>
     <string name="context_map_star_hide">Hide lines to waypoints</string>
     <string name="edit">Edit</string>
+    <string name="showElevationChart">Show elevation chart</string>
 
     <string name="create_internal_cache">Create user-defined cache</string>
     <string name="create_internal_cache_short">New cache</string>


### PR DESCRIPTION
## Description
Change to route/track tap handling in UnifiedMap (as discussed in https://github.com/cgeo/cgeo/issues/16064#issuecomment-2353638351):
- short tap on route/track no longer opens/closes elevation chart
- long tap on route/track with no elevation chart offers "Show elevation chart" as first menu option
- long tap on route/track with opened elevation chart closes it
