### PR TITLE
Set focus in TemplateTextPreference (fix #16072)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/TemplateTextPreference.java
+++ b/main/src/main/java/cgeo/geocaching/settings/TemplateTextPreference.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.settings;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.log.LogTemplateProvider;
 import cgeo.geocaching.log.LogTemplateProvider.LogTemplate;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -77,6 +78,7 @@ public class TemplateTextPreference extends Preference {
         editTitle = v.findViewById(R.id.title);
         editText = v.findViewById(R.id.edit);
 
+        boolean focusOnText = true;
         if (isSignature) {
             editText.setText(Settings.getSignature());
         } else {
@@ -86,8 +88,10 @@ public class TemplateTextPreference extends Preference {
                 editTitle.setText(template.getTitle());
                 editText.setText(template.getText());
             }
+            focusOnText = StringUtils.isNotEmpty(editTitle.getText());
         }
         Dialogs.moveCursorToEnd(editText);
+        Keyboard.show(getContext(), focusOnText ? editText : editTitle);
 
         final AlertDialog dialog = Dialogs.newBuilder(getContext())
                 .setView(v)


### PR DESCRIPTION
## Description
Sets focus on text (or title) input field of `TemplateTextPreference` and opens the keyboard.