### PR TITLE
Add 'delete caches immediately' action (fix #15402)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/command/AbstractCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/AbstractCommand.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 public abstract class AbstractCommand implements Command {
 
     private static final int UNDO_DURATION_MILLISEC = 5_000;
+    protected boolean undoSupported = true;
 
     @NonNull
     private final Activity context;
@@ -57,7 +58,11 @@ public abstract class AbstractCommand implements Command {
      * This runs in a <b>non</b> UI thread.
      * </p>
      */
-    protected abstract void undoCommand();
+    protected void undoCommand() {
+        if (undoSupported) {
+            throw new IllegalStateException("missing undo implementation for " + this.getClass());
+        }
+    }
 
     /**
      * Called after the execution of {@link #doCommand()} or {@link #undoCommand()} finished.
@@ -118,7 +123,9 @@ public abstract class AbstractCommand implements Command {
         protected void onPostExecuteInternal(final Void result) {
             onFinished();
             final String resultMessage = getResultMessage();
-            showUndoToast(resultMessage);
+            if (undoSupported) {
+                showUndoToast(resultMessage);
+            }
         }
 
         @SuppressLint("WrongConstant")
@@ -133,7 +140,9 @@ public abstract class AbstractCommand implements Command {
 
         @Override
         public void onClick(final View view) {
-            new UndoTask(context).execute();
+            if (undoSupported) {
+                new UndoTask(context).execute();
+            }
         }
     }
 

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -69,6 +69,10 @@
                 android:title="@string/caches_remove_all"
                 app:showAsAction="ifRoom|withText"/>
             <item
+                android:id="@+id/menu_delete_caches_immediately"
+                android:title="Delete caches immediately"
+                app:showAsAction="ifRoom|withText"/>
+            <item
                 android:id="@+id/menu_add_to_route"
                 android:title="@string/caches_append_to_route_all"
                 app:showAsAction="ifRoom|withText"/>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2551,6 +2551,15 @@
         <item quantity="many">Copied %d caches</item>
         <item quantity="other">Copied %d caches</item>
     </plurals>
+    <plurals name="command_delete_caches">
+        <item quantity="zero">Delete %d cache</item>
+        <item quantity="one">Delete %d cache</item>
+        <item quantity="two">Delete %d caches</item>
+        <item quantity="few">Delete %d caches</item>
+        <item quantity="many">Delete %d caches</item>
+        <item quantity="other">Delete %d caches</item>
+    </plurals>
+    <string name="command_delete_caches_immediately">This will remove the caches from c:geo database immediately as well as temporary data downloaded for those.\n\nThis action cannot be undone!\n\nDo you want to proceed?</string>
     <string name="command_delete_caches_progress">Deleting caches</string>
     <plurals name="command_delete_caches_result">
         <item quantity="zero">Deleted %d caches</item>


### PR DESCRIPTION
## Description
Adds a "Delete caches immediately" action to `CacheListActivity` => Manage Caches menu.

After a confirmed dialog this will remove the selected caches from database immediately (no 72 hours grace period) as well as the cache data folder in the local filesystem that holds log pictures etc. downloaded for those caches.

![image](https://github.com/user-attachments/assets/6a30c3ef-45ae-437c-b335-2a7d17d7a70a)
