### PR TITLE
Fix projection for predefined waypoint

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -464,6 +464,14 @@ public class Waypoint implements IWaypoint {
             changed = true;
         }
 
+        if (getCoords() == null && !hasProjection() && parsedWaypoint.hasProjection()) {
+            setProjection(parsedWaypoint.getProjectionType(), parsedWaypoint.getProjectionDistanceUnit(),
+                    parsedWaypoint.getProjectionFormula1(), parsedWaypoint.getProjectionFormula2());
+            setPreprojectedCoords(parsedWaypoint.getPreprojectedCoords());
+            setCoordsPure(parsedWaypoint.getCoords());
+            changed = true;
+        }
+
         //coordinates
         if (getCoords() == null && parsedWaypoint.getCoords() != null) {
             setCoords(parsedWaypoint.getCoords());

--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -199,10 +199,8 @@ public class Waypoint implements IWaypoint {
      * the waypoint was modified by the user
      */
     public boolean isUserModified() {
-        return
-            isUserDefined() || isVisited() ||
-                (isOriginalCoordsEmpty() && (getCoords() != null || getCalcStateConfig() != null)) ||
-                StringUtils.isNotBlank(getUserNote());
+        final boolean hasModifiedCoordinates = (isOriginalCoordsEmpty() && (getCoords() != null || getCalcStateConfig() != null) || hasProjection());
+        return isUserDefined() || isVisited() || hasModifiedCoordinates || StringUtils.isNotBlank(getUserNote());
     }
 
     public void setUserDefined() {
@@ -363,8 +361,8 @@ public class Waypoint implements IWaypoint {
      * Returns whether a recalculation was actually done
      */
     public boolean recalculateVariableDependentValues(final VariableList varList) {
-        //coords and proprojectedcoords are variable-dependent. Let's see whether we have to recalculate
-        final boolean hasProjection = this.getProjectionType() != ProjectionType.NO_PROJECTION;
+        //coords and projectedcoords are variable-dependent. Let's see whether we have to recalculate
+        final boolean hasProjection = hasProjection();
         boolean calcDone = false;
         if (this.isCalculated()) {
             final CalculatedCoordinate cc = getCalculated();


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Projection for predefined waypoints are not considered on extracting to PN.
If predefined waypoint has projection, the waypoint is now considered as user-modified and the projection gets written to the PN.

On adding waypoints from PN the projeciton is also now considered, if coords of the waypoint are empty

## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->