### PR TITLE
fix "Open in browser" for TB logs (#16115)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -49,13 +49,13 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     @Override
     @NonNull
     public String getUrl(@NonNull final Trackable trackable) {
-        return getHostUrl() + "//track/details.aspx?tracker=" + trackable.getGeocode();
+        return getHostUrl() + "/track/details.aspx?tracker=" + trackable.getGeocode();
     }
 
     @Override
     public String getLogUrl(@NonNull final LogEntry logEntry) {
         if (StringUtils.isNotBlank(logEntry.serviceLogId)) {
-            return "https://www.geocaching.com/track/log.aspx?LUID=" + logEntry.serviceLogId;
+            return "https://www.geocaching.com/live/log/" + logEntry.serviceLogId;
         }
         return null;
     }


### PR DESCRIPTION
"Open in browser" was open for TB logs due to outdated URL