### PR TITLE
logging: long-tap on date to set "previous date" (fixes #16085)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -283,7 +283,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
 
     private void fillViewFromEntry(final LogEntry logEntry) {
         logType.set(logEntry.logType);
-        date.setDate(new Date(logEntry.date));
+        date.setDate(logEntry.getDate());
         setLogText(logEntry.log);
         reportProblem.set(logEntry.reportProblem);
         imageListFragment.setImages(logEntry.logImages);

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -70,6 +70,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2482,5 +2483,15 @@ public class Settings {
         final boolean isMigrated = getBoolean(R.string.pref_legacy_filter_config_migrated, false);
         putBoolean(R.string.pref_legacy_filter_config_migrated, true);
         return isMigrated;
+    }
+
+    public static void setLastUsedDate(final Calendar date) {
+        putLong(R.string.pref_last_used_date, date.getTimeInMillis());
+    }
+
+    public static Calendar getLastUsedDate() {
+        final Calendar newDate = Calendar.getInstance();
+        newDate.setTimeInMillis(getLong(R.string.pref_last_used_date, newDate.getTimeInMillis()));
+        return newDate;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/DateTimeEditor.java
+++ b/main/src/main/java/cgeo/geocaching/ui/DateTimeEditor.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.ui;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.functions.Action1;
@@ -55,6 +56,7 @@ public class DateTimeEditor {
         this.date = Calendar.getInstance();
 
         this.dateButton.setOnClickListener(new DateListener());
+        this.dateButton.setOnLongClickListener(new DateLongListener());
         if (this.timeButton != null) {
             this.timeButton.setOnClickListener(new TimeListener());
         }
@@ -149,9 +151,21 @@ public class DateTimeEditor {
 
                 // only update the date, but keep the previous time
                 date.set(newDate.get(Calendar.YEAR), newDate.get(Calendar.MONTH), newDate.get(Calendar.DAY_OF_MONTH));
+                Settings.setLastUsedDate(newDate);
                 triggerChange();
             });
             dateDialog.show(fragmentManager, "date_dialog");
+        }
+    }
+
+    private class DateLongListener implements View.OnLongClickListener {
+
+        @Override
+        public boolean onLongClick(final View arg0) {
+            final Calendar newDate = Settings.getLastUsedDate();
+            date.set(newDate.get(Calendar.YEAR), newDate.get(Calendar.MONTH), newDate.get(Calendar.DAY_OF_MONTH));
+            triggerChange();
+            return true;
         }
     }
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -639,5 +639,6 @@
     <string translatable="false" name="old_pref_showListsInCacheList">showListsInCacheList</string>
 
     <string translatable="false" name="pref_legacy_filter_config_migrated">legacy_filter_config_migrated</string>
+    <string translatable="false" name="pref_last_used_date">last_used_logdate</string>
 
 </resources>


### PR DESCRIPTION
add a long-tap listener to set the (log) date to the previously used date.

Alternative: I'd like to have extended MaterialDatePicker with a 3rd button, but that class is final and I really don't want to implement so much stuff for just that 3rd button (there are PRs for that open at the upstream repo for a long time)