### PR TITLE
Manage downloaded files (fix #16118)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -518,6 +518,8 @@ public class MainActivity extends AbstractNavigationBarActivity {
             DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, DownloaderUtils::returnFromTileUpdateCheck);
         } else if (id == R.id.menu_update_mapdata) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, DownloaderUtils::returnFromMapUpdateCheck);
+        } else if (id == R.id.menu_delete_offline_data) {
+            DownloaderUtils.deleteOfflineData(this);
         } else if (id == R.id.menu_pending_downloads) {
             startActivity(new Intent(this, PendingDownloadsActivity.class));
         } else {

--- a/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
@@ -105,54 +105,6 @@ public class MapProviderFactory {
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_hillshading, mapSources.size(), activity.getString(R.string.settings_hillshading_enable)).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_download_offlinemap, mapSources.size(), '<' + activity.getString(R.string.downloadmap_title) + '>');
-        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_delete_offlinemap, mapSources.size() + 1, '<' + activity.getString(R.string.delete_offlinemap_title) + '>');
-    }
-
-    /** displays a list of offline map sources and deletes selected item after confirmation */
-    public static void showDeleteMenu(final Activity activity) {
-        final int currentSource = Settings.getMapSource().getNumericalId();
-
-        // build list of available offline map sources except currently active one
-        final List<Pair<String, Integer>> list = new ArrayList<>();
-        for (MapSource mapSource : mapSources.values()) {
-            if (mapSource instanceof MapsforgeMapProvider.OfflineMapSource && mapSource.getNumericalId() != currentSource) {
-                list.add(new Pair<>(mapSource.getName(), mapSource.getNumericalId()));
-            }
-        }
-        if (list.isEmpty()) {
-            ActivityMixin.showToast(activity, R.string.no_deletable_offlinemaps);
-            return;
-        }
-
-        final SimpleDialog.ItemSelectModel<Pair<String, Integer>> model = new SimpleDialog.ItemSelectModel<>();
-        model
-                .setItems(list)
-                        .setDisplayMapper((l) -> TextParam.text(l.first))
-                                .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN);
-
-        SimpleDialog.of(activity).setTitle(TextParam.id(R.string.delete_offlinemap_title))
-                .selectSingle(model, (l) -> {
-            final MapsforgeMapProvider.OfflineMapSource mapSource = (MapsforgeMapProvider.OfflineMapSource) getMapSource(l.second);
-            if (mapSource != null) {
-                final ContentStorage cs = ContentStorage.get();
-                final ContentStorage.FileInformation fi = cs.getFileInfo(mapSource.getMapUri());
-                if (fi != null) {
-                    SimpleDialog.of(activity).setTitle(TextParam.id(R.string.delete_offlinemap_title)).setMessage(TextParam.text(String.format(activity.getString(R.string.delete_file_confirmation), fi.name))).confirm(() -> {
-                        final Uri cf = CompanionFileUtils.companionFileExists(cs.list(PersistableFolder.OFFLINE_MAPS), fi.name);
-                        cs.delete(mapSource.getMapUri());
-                        if (cf != null) {
-                            cs.delete(cf);
-                        }
-                        ActivityMixin.showShortToast(activity, String.format(activity.getString(R.string.file_deleted_info), fi.name));
-                        MapsforgeMapProvider.getInstance().updateOfflineMaps();
-                        if (Settings.showUnifiedMap()) {
-                            TileProviderFactory.buildTileProviderList(true);
-                        }
-                        ActivityMixin.invalidateOptionsMenu(activity);
-                    });
-                }
-            }
-        });
     }
 
     public static CheckBox createLocSwitchMenuItem(final Activity activity, final Menu menu) {

--- a/main/src/main/java/cgeo/geocaching/models/Download.java
+++ b/main/src/main/java/cgeo/geocaching/models/Download.java
@@ -138,38 +138,47 @@ public class Download {
 
     public enum DownloadType {
         // id values must not be changed as they are referenced in the database & download companion files
-        DOWNLOADTYPE_ALL_MAPRELATED(0, 0),         // virtual entry
-        DOWNLOADTYPE_MAP_MAPSFORGE(1, R.string.downloadmap_mapfile),
-        DOWNLOADTYPE_MAP_OPENANDROMAPS(2, R.string.downloadmap_mapfile),
-        DOWNLOADTYPE_THEME_OPENANDROMAPS(3, R.string.downloadmap_themefile),
-        DOWNLOADTYPE_MAP_FREIZEITKARTE(4, R.string.downloadmap_mapfile),
-        DOWNLOADTYPE_THEME_FREIZEITKARTE(5, R.string.downloadmap_themefile),
-        DOWNLOADTYPE_MAP_HYLLY(6, R.string.downloadmap_mapfile),
-        DOWNLOADTYPE_THEME_HYLLY(7, R.string.downloadmap_themefile),
-        DOWNLOADTYPE_MAP_PAWS(8, R.string.downloadmap_mapfile),
-        DOWNLOADTYPE_THEME_PAWS(9, R.string.downloadmap_themefile),
+        DOWNLOAD_TYPE_ALL_MAPS(-2, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),       // virtual entry
+        DOWNLOAD_TYPE_ALL_THEMES(-1, R.string.downloadmap_themefile, R.drawable.downloader_theme),  // virtual entry
+        DOWNLOADTYPE_ALL_MAPRELATED(0, 0, R.drawable.ic_menu_mapmode),                 // virtual entry
+        DOWNLOADTYPE_MAP_MAPSFORGE(1, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
+        DOWNLOADTYPE_MAP_OPENANDROMAPS(2, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
+        DOWNLOADTYPE_THEME_OPENANDROMAPS(3, R.string.downloadmap_themefile, R.drawable.downloader_theme),
+        DOWNLOADTYPE_MAP_FREIZEITKARTE(4, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
+        DOWNLOADTYPE_THEME_FREIZEITKARTE(5, R.string.downloadmap_themefile, R.drawable.downloader_theme),
+        DOWNLOADTYPE_MAP_HYLLY(6, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
+        DOWNLOADTYPE_THEME_HYLLY(7, R.string.downloadmap_themefile, R.drawable.downloader_theme),
+        DOWNLOADTYPE_MAP_PAWS(8, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
+        DOWNLOADTYPE_THEME_PAWS(9, R.string.downloadmap_themefile, R.drawable.downloader_theme),
 
-        DOWNLOADTYPE_MAP_JUSTDOWNLOAD(50, R.string.downloadmap_othermapdownload),
-        DOWNLOADTYPE_THEME_JUSTDOWNLOAD(51, R.string.downloadmap_otherthemedownload),
+        DOWNLOADTYPE_MAP_JUSTDOWNLOAD(50, R.string.downloadmap_othermapdownload, R.drawable.ic_menu_mapmode),
+        DOWNLOADTYPE_THEME_JUSTDOWNLOAD(51, R.string.downloadmap_otherthemedownload, R.drawable.downloader_theme),
 
-        DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile),
-        DOWNLOADTYPE_HILLSHADING_TILES(91, R.string.downloadmap_hillshadingfile);
+        DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile, R.drawable.map_quick_route),
+        DOWNLOADTYPE_HILLSHADING_TILES(91, R.string.downloadmap_hillshadingfile, R.drawable.elevation);
 
         public final int id;
         @StringRes final int typeNameResId;
+        @DrawableRes final int iconResId;
         public static final int DEFAULT = DOWNLOADTYPE_MAP_MAPSFORGE.id;
         private static final ArrayList<DownloadTypeDescriptor> offlineMapTypes = new ArrayList<>();
         private static final ArrayList<DownloadTypeDescriptor> offlineMapThemeTypes = new ArrayList<>();
         private static final ArrayList<DownloadTypeDescriptor> downloadTypes = new ArrayList<>();
 
-        DownloadType(final int id, @StringRes final int typeNameResId) {
+        DownloadType(final int id, @StringRes final int typeNameResId, @DrawableRes final int iconResId) {
             this.id = id;
             this.typeNameResId = typeNameResId;
+            this.iconResId = iconResId;
         }
 
         public static ArrayList<DownloadTypeDescriptor> getOfflineMapTypes() {
             buildTypelist();
             return offlineMapTypes;
+        }
+
+        public static ArrayList<DownloadTypeDescriptor> getOfflineMapThemeTypes() {
+            buildTypelist();
+            return offlineMapThemeTypes;
         }
 
         public static ArrayList<DownloadTypeDescriptor> getOfflineAllMapRelatedTypes() {
@@ -190,9 +199,23 @@ public class Download {
             return null;
         }
 
+        public static DownloadType getFromId(final int typeId) {
+            for (DownloadType type : DownloadType.values()) {
+                if (type.id == typeId) {
+                    return type;
+                }
+            }
+            return null;
+        }
+
         @StringRes
         public int getTypeNameResId() {
             return typeNameResId;
+        }
+
+        @DrawableRes
+        public int getIconResId() {
+            return iconResId;
         }
 
         private static void buildTypelist() {

--- a/main/src/main/res/menu/main_activity_options.xml
+++ b/main/src/main/res/menu/main_activity_options.xml
@@ -64,17 +64,18 @@
             android:title="@string/menu_backup">
         </item>
         <item
-            android:title="@string/menu_update"
+            android:title="@string/menu_manage_offline_data"
             android:icon="@drawable/ic_menu_refresh">
             <menu>
                 <item
                     android:id="@+id/menu_update_routingdata"
-                    android:title="@string/menu_update_routingdata">
-                </item>
+                    android:title="@string/menu_update_routingdata" />
                 <item
                     android:id="@+id/menu_update_mapdata"
-                    android:title="@string/menu_update_mapdata">
-                </item>
+                    android:title="@string/menu_update_mapdata" />
+                <item
+                    android:id="@+id/menu_delete_offline_data"
+                    android:title="@string/menu_delete_offline_data" />
             </menu>
         </item>
         <item

--- a/main/src/main/res/menu/map_activity.xml
+++ b/main/src/main/res/menu/map_activity.xml
@@ -30,9 +30,6 @@
                 <item
                     android:id="@+id/menu_download_offlinemap"
                     android:visible="false" />
-                <item
-                    android:id="@+id/menu_delete_offlinemap"
-                    android:visible="false" />
             </group>
         </menu>
     </item>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -381,9 +381,10 @@
     <string name="menu_helpers">Utility programs</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_backup">Backup / restore</string>
-    <string name="menu_update">Update offline data</string>
-    <string name="menu_update_routingdata">Routing data</string>
-    <string name="menu_update_mapdata">Map data</string>
+    <string name="menu_manage_offline_data">Manage offline data</string>
+    <string name="menu_update_routingdata">Update routing data</string>
+    <string name="menu_update_mapdata">Update map data</string>
+    <string name="menu_delete_offline_data">Delete offline data</string>
     <string name="menu_history">History</string>
     <string name="menu_search_clipboard">Load geocode from clipboard</string>
     <string name="menu_history_longstring">Finds history</string>
@@ -2780,10 +2781,6 @@
 
     <!-- Download map preference and menu entry -->
     <string name="downloadmap_title">Download offline map</string>
-    <string name="delete_offlinemap_title">Delete offline map</string>
-    <string name="no_deletable_offlinemaps">No deletable offline maps</string>
-    <string name="delete_file_confirmation">Delete %s?</string>
-    <string name="file_deleted_info">%s deleted</string>
     <string name="download_title">Download file</string>
     <string name="downloadmap_info">Select a map file for your region by tapping the \"Save\" icon.\n\nThe download is performed in the background. When the transfer is complete, the file is copied to the c:geo map folder and set as the current map.\n\nBe careful: Downloading a map can cause high network traffic!</string>
     <string name="downloadmap_filename">Downloading %s</string>
@@ -2792,7 +2789,6 @@
     <string name="downloadmanager_not_available">File cannot be downloaded, system download manager not available</string>
     <string name="download_started">Downloading started in background</string>
     <string name="download_enqueing_error">Error on trying to start download</string>
-    <string name="download_none_selected">No files selected for download</string>
     <string name="downloadmap_target_not_writable">The selected target \"%s\" is not writable - the downloaded map file is saved in the system download folder and must be moved manually to the map folder.</string>
     <string name="downloadmap_allow_metered_network">Allow download over metered network (e.g.: mobile connection)</string>
     <string name="download_confirmation">%1$sDownload file \"%2$s\"?%3$s</string>
@@ -2831,6 +2827,16 @@
     <string name="mapupdate_info">Tap here to check for updates of map and theme files. Long-tap to postpone.</string>
     <string name="no_updates_found">No updates found</string>
     <string name="updates_check">Updates check</string>
+    <string name="delete_items">Delete items</string>
+    <plurals name="files_deleted">
+        <item quantity="zero">%1$d files deleted</item>
+        <item quantity="one">%1$d file deleted</item>
+        <item quantity="two">%1$d files deleted</item>
+        <item quantity="few">%1$d files deleted</item>
+        <item quantity="many">%1$d files deleted</item>
+        <item quantity="other">%1$d files deleted</item>
+    </plurals>
+    <string name="no_files_selected">No files selected</string>
     <string name="mapserver_mapsforge_info">Basic maps, no map themes required</string>
     <string name="mapserver_openandromaps_info">Detailed maps, require map theme \"Elevate\"</string>
     <string name="mapserver_openandromaps_themes_info">Detailed map theme, built for \"OpenAndroMaps\" maps</string>
@@ -2917,6 +2923,7 @@
     <string name="optimize">Optimize</string>
     <string name="expand">Expand</string>
     <string name="close">Close</string>
+    <string name="delete">Delete</string>
 
     <!-- Multi-Selections -->
     <string name="multiselect_selectall">Select All</string>


### PR DESCRIPTION
## Description
Adds a "Delete offline data" to the "Manage offline data" menu entry, which opens a dialog offering all downloaded files for deletion (maps, themes, routing tiles, hillshading tiles):

![image](https://github.com/user-attachments/assets/a81020bd-eb30-4acc-a8c2-2acc5a8d7d8e)

Also removes "Delete offline maps" from map selection menus.

