### PR TITLE
fix hillshading detection in legacy map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/AbstractMapSource.java
+++ b/main/src/main/java/cgeo/geocaching/maps/AbstractMapSource.java
@@ -20,7 +20,7 @@ public abstract class AbstractMapSource implements MapSource {
     @NonNull
     private final MapProvider mapProvider;
     private Integer numericId;
-
+    private boolean supportsHillshading;
 
     protected AbstractMapSource(@NonNull final MapProvider mapProvider, final String name) {
         this.mapProvider = mapProvider;
@@ -71,6 +71,16 @@ public abstract class AbstractMapSource implements MapSource {
 
     public ImmutablePair<String, Boolean> calculateMapAttribution(final Context ctx) {
         return null;
+    }
+
+    @Override
+    public boolean supportsHillshading() {
+        return supportsHillshading;
+    }
+
+    @Override
+    public void setSupportsHillshading(final boolean supportsHillshading) {
+        this.supportsHillshading = supportsHillshading;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
@@ -103,7 +103,7 @@ public class MapProviderFactory {
         }
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
-        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_hillshading, mapSources.size(), activity.getString(R.string.settings_hillshading_enable)).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
+        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_hillshading, mapSources.size(), activity.getString(R.string.settings_hillshading_enable)).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getMapSource().supportsHillshading());
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_download_offlinemap, mapSources.size(), '<' + activity.getString(R.string.downloadmap_title) + '>');
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_delete_offlinemap, mapSources.size() + 1, '<' + activity.getString(R.string.delete_offlinemap_title) + '>');
     }

--- a/main/src/main/java/cgeo/geocaching/maps/interfaces/MapSource.java
+++ b/main/src/main/java/cgeo/geocaching/maps/interfaces/MapSource.java
@@ -24,6 +24,6 @@ public interface MapSource {
 
     boolean supportsHillshading();
 
-    void setSupportsHillshading(final boolean supportsHillshading);
+    void setSupportsHillshading(boolean supportsHillshading);
 
 }

--- a/main/src/main/java/cgeo/geocaching/maps/interfaces/MapSource.java
+++ b/main/src/main/java/cgeo/geocaching/maps/interfaces/MapSource.java
@@ -22,4 +22,8 @@ public interface MapSource {
 
     ImmutablePair<String, Boolean> calculateMapAttribution(Context ctx);
 
+    boolean supportsHillshading();
+
+    void setSupportsHillshading(final boolean supportsHillshading);
+
 }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -121,6 +121,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         public OfflineMapSource(final Uri mapUri, final MapProvider mapProvider, final String name) {
             super(mapProvider, name);
             this.mapUri = mapUri;
+            setSupportsHillshading(true);
         }
 
         public Uri getMapUri() {
@@ -222,6 +223,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
         public OfflineMultiMapSource(final List<ImmutablePair<String, Uri>> mapUris, final MapProvider mapProvider, final String name) {
             super(mapProvider, name);
             this.mapUris = mapUris;
+            setSupportsHillshading(true);
         }
 
         @Override

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -494,7 +494,7 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
             CacheListActivity.startActivityMap(this, new SearchResult(caches.getVisibleCacheGeocodes()));
             ActivityMixin.overrideTransitionToFade(this);
         } else if (id == R.id.menu_hillshading) {
-            Settings.putBoolean(R.string.pref_maphillshading, !Settings.getMapShadingShowLayer());
+            Settings.setMapShadingShowLayer(!Settings.getMapShadingShowLayer());
             item.setChecked(Settings.getMapShadingShowLayer());
             changeMapSource(mapSource);
         } else if (id == R.id.menu_hint) {

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2466,6 +2466,10 @@ public class Settings {
         return getBoolean(R.string.pref_maphillshading_show_layer, true);
     }
 
+    public static void setMapShadingShowLayer(final boolean show) {
+        putBoolean(R.string.pref_maphillshading_show_layer, show);
+    }
+
     public static boolean getMapActionbarAutohide() {
         return getBoolean(R.string.pref_mapActionbarAutohide, false);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -859,7 +859,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 mapFragment.getViewport().filter(vmCaches));
             CacheListActivity.startActivityMap(this, new SearchResult(caches));
         } else if (id == R.id.menu_hillshading) {
-            Settings.putBoolean(R.string.pref_maphillshading, !Settings.getMapShadingShowLayer());
+            Settings.setMapShadingShowLayer(!Settings.getMapShadingShowLayer());
             item.setChecked(Settings.getMapShadingShowLayer());
             changeMapSource(mapFragment.currentTileProvider, getCurrentMapState());
         } else {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1171,7 +1171,7 @@
     <string name="settings_info_themes">c:geo supports custom themes for offline maps. These can be used to change the color style of the map (e.g. to have a nightview map) or to highlight certain objects like cycle paths or height lines within the map.\n\nWorking with non-zipped map themes might decrease map viewer opening performance. In this case, the theme folder may optionally be synchronized to an app-private local folder for faster access (at the cost of some storage space).</string>
     <string name="settings_info_hillshading_title">Info on Hillshading</string>
     <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Slopes will be darkened/lightened to generate a 3D-effect.\nHillshading data can be downloaded from maps overflow menu.</string>
-    <string name="settings_hillshading_enable">Enable Hillshading</string>
+    <string name="settings_hillshading_enable">Hillshading</string>
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="init_local_file_system">Local File System</string>
     <string name="init_base_directory_description">Base folder for public local data</string>


### PR DESCRIPTION
Fix broken detection for old map whether the provider supports hillshading https://github.com/cgeo/cgeo/pull/15415

(it was using the UnifiedMap TileSource previously so it worked in tests but it didn't actually work)