### PR TITLE
reword "pref_logimages" setting

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1052,8 +1052,8 @@
     <string name="init_summary_customtabs_as_browser">External websites will be displayed without leaving c:geo (only possible if Chrome is installed)</string>
     <string name="init_rot13_hint">Encrypt hint</string>
     <string name="init_summary_rot13_hint">Show hint text ROT-13 encrypted until tapped</string>
-    <string name="init_save_log_img">Save Images</string>
-    <string name="init_summary_save_log_img">Save Images from Logs</string>
+    <string name="init_save_log_img">Store log images</string>
+    <string name="init_summary_save_log_img">Download and store images from logs in addition to those from the cache</string>
     <string name="init_units">Use Imperial Units</string>
     <string name="init_summary_units">Use Imperial Units instead of Metric Units</string>
     <string name="init_cachelists">Cache Lists</string>


### PR DESCRIPTION
"Save images" title previously used is wrong as images are saved regardless, this setting only affects log images. Because of this wording issue I was about to re-implement this as I didn't realize the setting already existed.