### PR TITLE
UnifiedMap Mapsforge: Fix zoomToBoundsDirect (fix #16135)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -356,6 +356,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
     }
 
     private void zoomToBoundsDirect(final BoundingBox bounds) {
+        setCenter(new Geopoint(bounds.getCenterPoint().getLatitude(), bounds.getCenterPoint().getLongitude()));
         final int tileSize = mMapView.getModel().displayModel.getTileSize();
         final byte newZoom = LatLongUtils.zoomForBounds(new Dimension(mMapView.getWidth(), mMapView.getHeight()),
                 new org.mapsforge.core.model.BoundingBox(bounds.getMinLatitude(), bounds.getMinLongitude(), bounds.getMaxLatitude(), bounds.getMaxLongitude()), tileSize);


### PR DESCRIPTION
zooming to given bounds needs to set map center as well. 
Added this for UnifiedMap Mapsforge (as old `NewMap` has in `zoomToViewport`)