### PR TITLE
UnifiedMap: Consider driving mode when calculating tile cache size

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -76,7 +76,11 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
         setMapRotation(Settings.getMapRotation());
         mapAttribution = requireView().findViewById(R.id.map_attribution);
 
-        tileCache = AndroidUtil.createTileCache(getContext(), "mapcache", mMapView.getModel().displayModel.getTileSize(), 2f, mMapView.getModel().frameBufferModel.getOverdrawFactor());
+        // create tile cache (taking driving mode into account when calculating tile cache size)
+        setDrivingMode(true);
+        tileCache = AndroidUtil.createTileCache(requireContext(), "mapcache", mMapView.getModel().displayModel.getTileSize(), 2f, mMapView.getModel().frameBufferModel.getOverdrawFactor());
+        setDrivingMode(false);
+
         themeHelper = new MapsforgeThemeHelper(requireActivity());
 
         if (position != null) {


### PR DESCRIPTION
## Description
UnifiedMap Mapsforge: Take driving mode into account when calculating tile cache size
(see related [discussion](https://github.com/mapsforge/mapsforge/discussions/1545) on Mapsforge for details)