### PR TITLE
Mapsforge: Catch IllegalStateException on unassigning layers

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/caches/AbstractCachesOverlay.java
@@ -355,10 +355,18 @@ public abstract class AbstractCachesOverlay {
                 final GeoitemLayer item = layerList.getItem(code);
                 if (item != null) {
                     geoEntries.remove(new GeoEntry(code, overlayId));
-                    layers.remove(item);
+                    try {
+                        layers.remove(item);
+                    } catch (IllegalStateException ignore) {
+                        // layer may be unassigned
+                    }
                     final Layer circle = item.getCircle();
                     if (circle != null) {
-                        layers.remove(circle);
+                        try {
+                            layers.remove(circle);
+                        } catch (IllegalStateException ignore) {
+                            // layer may be unassigned
+                        }
                     }
                     layerList.remove(item);
                 }


### PR DESCRIPTION
## Description
`NewMap` Mapsforge: Catch IllegalStateException on removing map items (that are not assigned currently), currently most prominent error on Play Store for current release 2024.09.18