### PR TITLE
Mapsforge: Use new HiResStandardClasyHillShading (rel. to #15415)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -371,7 +371,7 @@ dependencies {
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = 'f3350ef261' // master as of 2024-09-18, including rotation & fractional zoom
+    String mapsforgeVersion = '72a8a01' // master as of 2024-10-04, including rotation & fractional zoom + new hillshading algorithms
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
     // String mapsforgeSource = 'com.github.cgeo.mapsforge'

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
@@ -9,9 +9,9 @@ import android.content.Context;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.hills.DemFolderAndroidContent;
 import org.mapsforge.map.layer.hills.DemFolder;
+import org.mapsforge.map.layer.hills.HiResStandardClasyHillShading;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource;
-import org.mapsforge.map.layer.hills.StandardClasyHillShading;
 
 public class HillShadingLayerHelper {
 
@@ -27,7 +27,7 @@ public class HillShadingLayerHelper {
         final Context context = CgeoApplication.getInstance();
         final DemFolder shadingFolder = new DemFolderAndroidContent(PersistableFolder.OFFLINE_MAP_SHADING.getUri(), context, context.getContentResolver());
 
-        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new StandardClasyHillShading(), AndroidGraphicFactory.INSTANCE);
+        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new HiResStandardClasyHillShading(), AndroidGraphicFactory.INSTANCE);
         // avoid lines at between tiles
         hillTileSource.setEnableInterpolationOverlap(true);
         final HillsRenderConfig hillsConfig = new HillsRenderConfig(hillTileSource);


### PR DESCRIPTION
## Description
Updates Mapsforge to latest build to include new hi resolution hillshading algorithm + parallelization while calculating hillshading data