### PR TITLE
Wherigo: add wherigo player entry in main overflow menu

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -48,6 +48,7 @@ import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.config.LegacyFilterConfig;
 import cgeo.geocaching.utils.functions.Action1;
+import cgeo.geocaching.wherigo.WherigoActivity;
 import static cgeo.geocaching.Intents.EXTRA_MESSAGE_CENTER_COUNTER;
 
 import android.annotation.SuppressLint;
@@ -488,6 +489,8 @@ public class MainActivity extends AbstractNavigationBarActivity {
             DebugUtils.askUserToReportProblem(this, null);
         } else if (id == R.id.menu_helpers) {
             startActivity(new Intent(this, UsefulAppsActivity.class));
+        } else if (id == R.id.menu_wherigo) {
+            startActivity(new Intent(this, WherigoActivity.class));
         } else if (id == R.id.menu_wizard) {
             final Intent wizard = new Intent(this, InstallWizardActivity.class);
             wizard.putExtra(InstallWizardActivity.BUNDLE_MODE, InstallWizardActivity.needsFolderMigration() ? InstallWizardActivity.WizardMode.WIZARDMODE_MIGRATION.id : InstallWizardActivity.WizardMode.WIZARDMODE_RETURNING.id);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoGame.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoGame.java
@@ -273,8 +273,8 @@ public class WherigoGame implements UI {
 
     @Override
     public void showError(final String s) {
-        Log.w(LOG_PRAEFIX + "ERROR" + s);
-        setStatusText("ERROR:" + s);
+        Log.w(LOG_PRAEFIX + "ERROR: " + s);
+        setStatusText("ERROR: " + s);
     }
 
     @Override
@@ -284,7 +284,7 @@ public class WherigoGame implements UI {
 
     @Override
     public void setStatusText(final String s) {
-        runOnUi(() -> ActivityMixin.showApplicationToast("WHERIGO:" + s));
+        runOnUi(() -> ActivityMixin.showApplicationToast("WHERIGO: " + s));
     }
 
     @Override

--- a/main/src/main/res/menu/main_activity_options.xml
+++ b/main/src/main/res/menu/main_activity_options.xml
@@ -47,6 +47,12 @@
         android:title="@string/menu_helpers">
     </item>
 
+    <item
+        android:id="@+id/menu_wherigo"
+        android:icon="@drawable/type_wherigo"
+        android:title="Wherigo Player (exp.)">
+    </item>
+
     <group android:id="@+id/menu_group_settings">
         <item
             android:id="@+id/menu_wizard"


### PR DESCRIPTION
Wherigo: add wherigo player entry in main overflow menu

Referencing this comment https://github.com/cgeo/cgeo/issues/10087#issuecomment-2394972522

I feel like the Wherigo Player deserves at least an overflow menu entry in main activity. Also compared with other stuff mentioned here which is probably used only by some users (pocket queries, bookmar lists, utility program), the player doesn't seem less important.

![image](https://github.com/user-attachments/assets/ed325750-4463-4c4d-977b-45d8ab726c9d)
