### PR TITLE
rel to #16164: add System.err and .out to standard logcat exerpt

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/DebugUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/DebugUtils.java
@@ -94,7 +94,7 @@ public class DebugUtils {
                     if (fullInfo) {
                         builder.command("logcat", "-d", "*:V", "-f", file.getAbsolutePath());
                     } else {
-                        builder.command("logcat", "-d", "AndroidRuntime:E", "cgeo:D", "cgeo.geocachin:I", "*:S", "-f", file.getAbsolutePath());
+                        builder.command("logcat", "-d", "AndroidRuntime:E", "cgeo:V", "System.err:I", "System.out:I", "*:S", "-f", file.getAbsolutePath());
                     }
                 }
                 Log.iForce("[LogCat]Issuing command: " + builder.command());


### PR DESCRIPTION
rel to #16164: add System.err and .out to standard logcat exerpt

Handling #16164 I realized that we need to include also System.out and System.err output in the standard logfiles generated by c:geo. Otherwise it won't be possible to analyze and fix Wherigo-related errors