### PR TITLE
Add option to remove caches from all lists (fix #15402)

### DIFF
--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -69,6 +69,10 @@
                 android:title="@string/caches_remove_all"
                 app:showAsAction="ifRoom|withText"/>
             <item
+                android:id="@+id/menu_drop_caches_all_lists"
+                android:title="@string/caches_remove_all_completely"
+                app:showAsAction="ifRoom|withText"/>
+            <item
                 android:id="@+id/menu_add_to_route"
                 android:title="@string/caches_append_to_route_all"
                 app:showAsAction="ifRoom|withText"/>


### PR DESCRIPTION
## Description
Adds an option to remove selected/all caches from all lists, effectively marking them as "to be deleted" (which they will after the grace period). Suports undo.

Closes #16110 (which deleted selected / all caches immediately from database after a confirmation dialog)