### PR TITLE
Improve reset to original coordinates (rel #15735)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -2461,10 +2461,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     private void resetCoords(final Geocache cache, final Handler handler, final Waypoint wpt, final boolean local, final boolean remote) {
         AndroidRxUtils.networkScheduler.scheduleDirect(() -> {
             if (local) {
-                cache.setCoords(wpt.getCoords());
-                cache.setUserModifiedCoords(false);
-                cache.deleteWaypointForce(wpt);
-                DataStore.saveUserModifiedCoords(cache);
+                cache.resetUserModifiedCoords(wpt);
                 handler.sendEmptyMessage(HandlerResetCoordinates.LOCAL);
             }
 

--- a/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
@@ -500,6 +500,11 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
                 }
 
                 calcStateString = waypoint.getCalcStateConfig();
+                
+                final boolean resetFromOriginal = (WaypointType.ORIGINAL == waypoint.getWaypointType());
+                binding.modifyCacheCoordinatesLocal.setText(resetFromOriginal ? R.string.waypoint_localy_reset_cache_coords : R.string.waypoint_set_as_cache_coords);
+                binding.modifyCacheCoordinatesLocalAndRemote.setText(resetFromOriginal ? R.string.waypoint_reset_local_and_remote_cache_coords : R.string.waypoint_save_and_modify_on_website);
+
                 loadWaypointHandler.sendMessage(Message.obtain());
             } catch (final Exception e) {
                 Log.e("EditWaypointActivity.loadWaypoint.run", e);

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -1649,6 +1649,13 @@ public class Geocache implements IWaypoint {
         userModifiedCoords = coordsChanged;
     }
 
+    public void resetUserModifiedCoords(final Waypoint waypoint) {
+        setCoords(waypoint.getCoords());
+        setUserModifiedCoords(false);
+        deleteWaypointForce(waypoint);
+        DataStore.saveUserModifiedCoords(this);
+    }
+
     /**
      * Duplicate a waypoint.
      *


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
For waypoint "original coordinates" 
* rename the function "set as cache-coordinates" to "reset in c:geo" (same string used as in the dialog for reseting from context-menu)
* delete the waypoint "original coordinates" and reset the flag for corrected coordinates


## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #15735 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

<img src="https://github.com/user-attachments/assets/3185e3e3-3016-409c-bff4-9ebd7c5e49a5" height="250" > <img src="https://github.com/user-attachments/assets/2913d591-a156-48da-b15c-95ed55aba578" height="250" >

