### PR TITLE
Fetch cache-data for unsaved caches without merging data from cache cache (fix #16175)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTest.java
@@ -292,6 +292,82 @@ public class DataStoreTest {
         }
     }
 
+    @Test
+    public void testUpdateOnlineCache() {
+        try {
+            final Geocache cacheOld = new Geocache();
+            cacheOld.setGeocode(ARTIFICIAL_GEOCODE);
+            cacheOld.setCoords(new Geopoint(1, 2));
+            cacheOld.setDescription("Cache description old");
+            cacheOld.setShortDescription("Cache short-description old");
+            cacheOld.setPersonalNote("Personal note old");
+            cacheOld.setDetailed(false);
+
+            DataStore.saveCache(cacheOld, EnumSet.of(LoadFlags.SaveFlag.DB));
+
+            // update cache-data
+            final Geocache cacheNew = new Geocache();
+            cacheNew.setGeocode(ARTIFICIAL_GEOCODE);
+            cacheNew.setDescription("Cache description new");
+            cacheNew.setHint("Cache hint new");
+
+            DataStore.saveCache(cacheNew, EnumSet.of(LoadFlags.SaveFlag.DB));
+
+            final Geocache cacheDb = DataStore.loadCache(ARTIFICIAL_GEOCODE, LoadFlags.LOAD_CACHE_OR_DB);
+
+            assertThat(cacheDb).isNotNull();
+            assertThat(cacheDb.getGeocode()).isEqualTo(ARTIFICIAL_GEOCODE);
+
+            // all data from online cache
+            assertThat(cacheDb.getCoords()).isNull();
+            assertThat(cacheDb.getDescription()).isEqualTo("Cache description new");
+            assertThat(cacheDb.getShortDescription()).isEqualTo("Cache short-description old");
+            assertThat(cacheDb.getPersonalNote()).isNull();
+            assertThat(cacheDb.getHint()).isEqualTo("Cache hint new");
+        } finally {
+            DataStore.removeCache(ARTIFICIAL_GEOCODE, REMOVE_ALL);
+        }
+    }
+
+    @Test
+    public void testUpdateOfflineCache() {
+        try {
+            final Geopoint gp = new Geopoint(1, 2);
+            final Geocache cacheOld = new Geocache();
+            cacheOld.setGeocode(ARTIFICIAL_GEOCODE);
+            cacheOld.setCoords(new Geopoint(1, 2));
+            cacheOld.setDescription("Cache description old");
+            cacheOld.setShortDescription("Cache short-description old");
+            cacheOld.setPersonalNote("Personal note old");
+            cacheOld.setDetailed(true);
+
+            cacheOld.getLists().add(StoredList.STANDARD_LIST_ID);
+            DataStore.saveCache(cacheOld, EnumSet.of(LoadFlags.SaveFlag.DB));
+
+            // update cache-data
+            final Geocache cacheNew = new Geocache();
+            cacheNew.setGeocode(ARTIFICIAL_GEOCODE);
+            cacheNew.setDescription("Cache description new");
+            cacheNew.setHint("Cache hint new");
+
+            DataStore.saveCache(cacheNew, EnumSet.of(LoadFlags.SaveFlag.DB));
+
+            final Geocache cacheDb = DataStore.loadCache(ARTIFICIAL_GEOCODE, LoadFlags.LOAD_CACHE_OR_DB);
+
+            assertThat(cacheDb).isNotNull();
+            assertThat(cacheDb.getGeocode()).isEqualTo(ARTIFICIAL_GEOCODE);
+
+            // all data from online cache, but missing data from old cache
+            assertThat(cacheDb.getCoords()).isEqualTo(gp);
+            assertThat(cacheDb.getDescription()).isEqualTo("Cache description new");
+            assertThat(cacheDb.getShortDescription()).isEqualTo("Cache short-description old");
+            assertThat(cacheDb.getPersonalNote()).isEqualTo("Personal note old");
+            assertThat(cacheDb.getHint()).isEqualTo("Cache hint new");
+        } finally {
+            DataStore.removeCache(ARTIFICIAL_GEOCODE, REMOVE_ALL);
+        }
+    }
+
     private static void assertEqualToBuilder(final OfflineLogEntry dbLogEntry, final OfflineLogEntry.Builder builder) {
         final OfflineLogEntry expectedLogEntry = builder.build();
 

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2655,8 +2655,8 @@ public class DataStore {
         final String geocode = cache.getGeocode();
 
         final List<Waypoint> waypoints = cache.getWaypoints();
+        final List<String> currentWaypointIds = new ArrayList<>();
         if (CollectionUtils.isNotEmpty(waypoints)) {
-            final List<String> currentWaypointIds = new ArrayList<>();
             for (final Waypoint waypoint : waypoints) {
                 final ContentValues values = createWaypointValues(geocode, waypoint);
 
@@ -2669,8 +2669,8 @@ public class DataStore {
                 currentWaypointIds.add(Integer.toString(waypoint.getId()));
             }
 
-            removeOutdatedWaypointsOfCache(cache, currentWaypointIds);
         }
+        removeOutdatedWaypointsOfCache(cache, currentWaypointIds);
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2394,7 +2394,11 @@ public class DataStore {
                 for (final Geocache cache : caches) {
                     final String geocode = cache.getGeocode();
                     final Geocache existingCache = existingCaches.get(geocode);
-                    boolean dbUpdateRequired = !cache.gatherMissingFrom(existingCache) || cacheCache.getCacheFromCache(geocode) != null;
+                    final boolean isOffline = isOffline(geocode, cache.getGuid());
+                    boolean dbUpdateRequired = !isOffline || (cacheCache.getCacheFromCache(geocode) != null);
+                    if (isOffline) {
+                        dbUpdateRequired |= !cache.gatherMissingFrom(existingCache);
+                    }
                     // parse the note AFTER merging the local information in
                     dbUpdateRequired |= cache.addCacheArtefactsFromNotes();
                     cache.addStorageLocation(StorageLocation.CACHE);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Fetch cache-data for unsaved caches without merging from already downloaded cache-data, so the newest version is used
For stored caches merging / gathering missing data from existing cache is performed, so no data will be lost (preserve current behaviour)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #16175 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

PR #16226 is prerequisite for thia PR to fix failing test (Fix the date-format in GC40)