### PR TITLE
downgrade androidx.work:work-runtime

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -447,7 +447,7 @@ dependencies {
     // implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation 'io.reactivex.rxjava3:rxjava:3.1.8'
+    implementation 'io.reactivex.rxjava3:rxjava:3.1.9'
     implementation "io.reactivex.rxjava3:rxandroid:3.0.2"
 
     // avoid duplicate class, see e.g. https://stackoverflow.com/questions/75712899/duplicate-class-kotlin-random-jdk8-found-in-modules-jetified-kotlin-stdlib-1-8-1

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -466,7 +466,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-reactivestreams:$lifecycleVersion"
 
     // workmanager (to replace foreground services for downloader)
-    implementation "androidx.work:work-runtime:2.9.1"
+    implementation "androidx.work:work-runtime:2.8.1"
 
     // Support Library AppCompat
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -447,7 +447,7 @@ dependencies {
     // implementation 'com.jakewharton:process-phoenix:2.0.0'
 
     // RxJava
-    implementation 'io.reactivex.rxjava3:rxjava:3.1.9'
+    implementation 'io.reactivex.rxjava3:rxjava:3.1.8'
     implementation "io.reactivex.rxjava3:rxandroid:3.0.2"
 
     // avoid duplicate class, see e.g. https://stackoverflow.com/questions/75712899/duplicate-class-kotlin-random-jdk8-found-in-modules-jetified-kotlin-stdlib-1-8-1


### PR DESCRIPTION
With the latest update of androidx.work:work-runtime we have now CI errors.
~~~
08:50:50  Could not load custom lint check jar file /home/jenkins/.gradle/caches/transforms-3/af359fe1ec3ff3d6c14449f8d6618922/transformed/work-runtime-2.9.1/jars/lint.jar 
08:50:50  java.lang.UnsupportedClassVersionError: androidx/work/lint/WorkManagerIssueRegistry has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
~~~
The build is marked a success, so probably the problem was not detected.