### PR TITLE
Update Mapsforge and VTM to v0.22.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -371,7 +371,7 @@ dependencies {
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = 'f3350ef261' // master as of 2024-09-18, including rotation & fractional zoom
+    String mapsforgeVersion = '0.22.0'
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
     // String mapsforgeSource = 'com.github.cgeo.mapsforge'
@@ -386,8 +386,8 @@ dependencies {
     // -- Mapsforge / VTM --
 
     // Mapsforge VTM implementation (official version)
-    String mapsforgeVTMSource = 'org.mapsforge'
-    String mapsforgeVTMVersion = '0.21.0'
+    String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
+    String mapsforgeVTMVersion = '0.22.0'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
     // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'


### PR DESCRIPTION
## Description
Updates both Mapsforge and VTM to the newly released v0.22.0 (to include Mapsforge rotation etc. from a regular release).
Also changes source for VTM to Jitpack, as it does seem to be no longer available from the old source.