### PR TITLE
Reduce toolbar space between back button and content

### DIFF
--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -14,6 +14,7 @@
         <item name="materialAlertDialogTheme">@style/materialAlertDialogTheme</item>
         <item name="android:textAppearanceMedium">@style/text_default</item>
         <item name="android:spinnerStyle">@style/spinnerStyle</item>
+        <item name="toolbarStyle">@style/AppTheme.Toolbar</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>
@@ -34,6 +35,10 @@
         <!-- forward style references to make them accessible in code -->
         <item name="quickLaunchButtonStyle">@style/quicklaunch_button</item>
 
+    </style>
+
+    <style name="AppTheme.Toolbar" parent="Widget.MaterialComponents.Toolbar">
+        <item name="contentInsetStartWithNavigation">0dp</item>
     </style>
 
     <style name="cgeo.withWallpaper" parent="cgeo">


### PR DESCRIPTION
## Description
Reduces the extra space between toolbar's back button and following content:

|before|after|
|---|---|
|![image](https://github.com/user-attachments/assets/a5526b2a-b549-4322-8b9f-4bbcaeed06c9)|![image](https://github.com/user-attachments/assets/d38f0dee-98b3-4aa5-a280-fc23dc0a861e)|
|![image](https://github.com/user-attachments/assets/c42cf7b1-7751-4d56-8704-37e0b17ca256)|![image](https://github.com/user-attachments/assets/a2d2b7a5-c6b6-4828-b472-f62e0cd503e7)|

(Related to discussion in https://github.com/cgeo/cgeo/issues/16151#issuecomment-2406914336)

