### PR TITLE
manually add event date + start/end time to listing text

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -64,6 +64,7 @@ public final class GCConstants {
     static final Pattern PATTERN_TYPE = Pattern.compile("<use xlink:href=\"/app/ui-icons/sprites/cache-types.svg#icon-([0-9a-f]+)");
     static final Pattern PATTERN_HIDDEN = Pattern.compile("ctl00_ContentBody_mcd2[^:]+:\\s*([^<]+?)<");
     static final Pattern PATTERN_HIDDENEVENT = Pattern.compile(":\\s*([0-9-/]+)\\s*<div id=\"calLinks\">", Pattern.DOTALL);
+    static final Pattern PATTERN_EVENTTIMES = Pattern.compile("<div id=\"mcd3\">\\s*[^:]*:\\s+([0-9]+):([0-9]+)( PM| AM)?\\s*</div>\\s*<div id=\"mcd4\">\\s*[^:]*:\\s+([0-9]+):([0-9]+)( PM| AM)?\\s*</div>");
     static final Pattern PATTERN_IS_FAVORITE = Pattern.compile("<div id=\"pnlFavoriteCache\">"); // without 'class="hideMe"' inside the tag !
     static final Pattern PATTERN_FAVORITECOUNT = Pattern.compile("<span class=\"favorite-value\">\\D*([0-9]+?)\\D*</span>");
     static final Pattern PATTERN_COUNTLOGS = Pattern.compile("<span id=\"ctl00_ContentBody_lblFindCounts\"><ul(.+?)</ul></span>");

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -46,6 +46,7 @@ import androidx.core.text.HtmlCompat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -376,7 +377,26 @@ public final class GCParser {
         cache.setPersonalNote(personalNoteWithLineBreaks, true);
 
         // cache short description
-        cache.setShortDescription(TextUtils.getMatch(page, GCConstants.PATTERN_SHORTDESC, true, ""));
+        final StringBuilder sDesc = new StringBuilder();
+        if (cache.isEventCache()) {
+            // add event start / end info to beginning of listing
+            final MatcherWrapper eventTimesMatcher = new MatcherWrapper(GCConstants.PATTERN_EVENTTIMES, tableInside);
+            if (eventTimesMatcher.find()) {
+                sDesc.append("<b>")
+                        .append(new SimpleDateFormat("dd MMMM yyyy", Locale.getDefault()).format(cache.getHiddenDate()))
+                        .append(", ")
+                        .append(Integer.parseInt(eventTimesMatcher.group(1)) + (eventTimesMatcher.group(3).equals(" PM") ? 12 : 0))
+                        .append(":")
+                        .append(eventTimesMatcher.group(2))
+                        .append(" - ")
+                        .append(Integer.parseInt(eventTimesMatcher.group(4)) + (eventTimesMatcher.group(6).equals(" PM") ? 12 : 0))
+                        .append(":")
+                        .append(eventTimesMatcher.group(5))
+                        .append("</b>");
+            }
+        }
+        sDesc.append(TextUtils.getMatch(page, GCConstants.PATTERN_SHORTDESC, true, ""));
+        cache.setShortDescription(sDesc.toString());
 
         // cache description
         final String longDescription = TextUtils.getMatch(page, GCConstants.PATTERN_DESC, true, "");


### PR DESCRIPTION
GC removed the event date + start / end times from listings. Because of this it's no longer possible to see the event times anywhere in c:geo and functions relying on these dates, like creating calendar entries, are failing.

With this PR the event times are manually prefixed to the events description, making it appear and function exactly like before the change.

fixes #16229

Targeted against release as this is a breaking change.