### PR TITLE
confirm overwriting log on quick offline log

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -463,7 +463,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
                 lastSavedState = logEntry;
                 AndroidRxUtils.computationScheduler.scheduleDirect(() -> {
                     try (ContextLogger ccLog = new ContextLogger("LogCacheActivity.saveLog.doInBackground(gc=%s)", cache.getGeocode())) {
-                        cache.logOffline(LogCacheActivity.this, logEntry);
+                        cache.storeLogOffline(LogCacheActivity.this, logEntry);
                         ccLog.add("log=%s", logEntry.log);
                         imageListFragment.adjustImagePersistentState();
                         inventoryAdapter.saveActions();
@@ -870,7 +870,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
 
         @Override
         protected void undoCommand() {
-            cache.logOffline(getContext(), previousState);
+            cache.storeLogOffline(getContext(), previousState);
         }
 
         @Override

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -45,6 +45,7 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.DataStore.StorageLocation;
 import cgeo.geocaching.storage.Folder;
 import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.CommonUtils;
@@ -579,7 +580,23 @@ public class Geocache implements IWaypoint {
         );
     }
 
+    /**
+     * If the cache already has an offline log with log text and the new offline log would overwrite that prompt for confirmation
+     */
     public void logOffline(@NonNull final Activity fromActivity, @NonNull final OfflineLogEntry logEntry) {
+        if (hasLogOffline() && !getOfflineLog().log.isEmpty() && !getOfflineLog().log.equals(logEntry.log)) {
+            SimpleDialog.of(fromActivity)
+                    .setTitle(R.string.caches_overwrite_offline_log)
+                    .setMessage(R.string.caches_overwrite_offline_log_question, getOfflineLog().logType.getL10n())
+                    .confirm(() -> {
+                        storeLogOffline(fromActivity, logEntry);
+                    });
+        } else {
+            storeLogOffline(fromActivity, logEntry);
+        }
+    }
+
+    public void storeLogOffline(@NonNull final Activity fromActivity, @NonNull final OfflineLogEntry logEntry) {
 
         if (logEntry.logType == LogType.UNKNOWN) {
             return;

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -492,6 +492,8 @@
     <string name="caches_clear_offlinelogs">Clear offline logs</string>
     <string name="caches_clear_offlinelogs_message">Do you want to clear the offline logs?</string>
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
+    <string name="caches_overwrite_offline_log">Overwrite offline log</string>
+    <string name="caches_overwrite_offline_log_question">Cache has existing offline log of type "%1$s" with a log text. Do you want to overwrite this log?</string>
     <string name="caches_show_attributes">Show attribute overview</string>
     <string name="caches_set_cache_icon">Set cache icon</string>
     <string name="caches_reset_cache_icons_title">Reset cache icon</string>


### PR DESCRIPTION
On creating a quick offline log show a confirmation prompt if cache already has an offline log stored and
- the old offline log has a log text
- the old and new log texts are different

to avoid accidentally overwriting written log texts with empty logs 

fixes #16244