### PR TITLE
Fix zoom controls for old Mapsforge map (rel. to #16225)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -63,6 +63,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.ui.GeoItemSelectorUtils;
+import cgeo.geocaching.ui.RepeatOnHoldListener;
 import cgeo.geocaching.ui.ToggleItemType;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
@@ -138,7 +139,6 @@ import org.mapsforge.core.util.MercatorProjection;
 import org.mapsforge.core.util.Parameters;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.graphics.AndroidResourceBitmap;
-import org.mapsforge.map.android.input.MapZoomControls;
 import org.mapsforge.map.android.util.AndroidUtil;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.Layers;
@@ -293,12 +293,10 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
         mapView.setBuiltInZoomControls(true);
 
         // style zoom controls
-        final MapZoomControls zoomControls = mapView.getMapZoomControls();
-        zoomControls.setZoomControlsOrientation(MapZoomControls.Orientation.VERTICAL_IN_OUT);
-        zoomControls.setZoomInResource(R.drawable.map_zoomin);
-        zoomControls.setZoomOutResource(R.drawable.map_zoomout);
-        zoomControls.setPadding(0, 0, ViewUtils.dpToPixel(13.0f), ViewUtils.dpToPixel(18.0f));
-        zoomControls.setAutoHide(false);
+        mapView.setBuiltInZoomControls(false);
+        findViewById(R.id.map_zoomin).setOnTouchListener(new RepeatOnHoldListener(500, v -> mapView.getModel().mapViewPosition.zoomIn()));
+        findViewById(R.id.map_zoomout).setOnTouchListener(new RepeatOnHoldListener(500, v -> mapView.getModel().mapViewPosition.zoomOut()));
+        ViewUtils.setVisibility(findViewById(R.id.container_followmylocation), View.GONE);
 
         //make room for map attribution icon button
         final int mapAttPx = Math.round(this.getResources().getDisplayMetrics().density * 30);

--- a/main/src/main/res/layout/map_mapsforge_v6.xml
+++ b/main/src/main/res/layout/map_mapsforge_v6.xml
@@ -30,6 +30,7 @@
     <include layout="@layout/filter_sort_bar" />
     <include layout="@layout/map_distanceinfo" />
     <include layout="@layout/map_settings_button" />
+    <include layout="@layout/map_zoom_control" />
     <include layout="@layout/map_progressbar" />
     <include layout="@layout/map_detailsfragment" />
 


### PR DESCRIPTION
## Description
Fixes separator between zoom controls of old Mapsforge map:

|before|after|
|---|---|
|![image](https://github.com/user-attachments/assets/cbb05e5e-48a2-4c47-8b50-5935d611ec28)|![image](https://github.com/user-attachments/assets/905cb2eb-0210-4db0-89d4-bb90d4bd9767)|

