### PR TITLE
Clear filter should be possible, if no filter is defined

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActivity;
 import cgeo.geocaching.activity.FilteredActivity;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
@@ -38,27 +39,40 @@ public class FilterUtils {
                 filteredList, true);
     }
 
-    public static <T extends Activity & FilteredActivity> boolean openFilterList(final T filteredActivity, final GeocacheFilterContext filterContext) {
+    public static <T extends AbstractActivity & FilteredActivity> boolean openFilterList(final T filteredActivity, final GeocacheFilterContext filterContext) {
         final List<GeocacheFilter> filters = new ArrayList<>(GeocacheFilter.Storage.getStoredFilters());
         final boolean isFilterActive = filterContext.get().isFiltering();
 
-        if (filters.isEmpty() && !isFilterActive) {
+        if (filters.isEmpty()) {
+            filteredActivity.showToast(R.string.cache_filter_storage_load_delete_nofilter_message);
+
+            if (isFilterActive) {
+                SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_clear_title)
+                        .setPositiveButton(null)
+                        .setNeutralButton(TextParam.id(R.string.cache_filter_storage_clear_button))
+                        .setNeutralAction(() ->
+                                filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()))
+                        ).show();
+                return true;
+            }
             return false;
-        } else {
-            final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
-            model
+        }
+
+        final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
+        model
                 .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
                 .setItems(filters)
                 .setDisplayMapper((f) -> TextParam.text(f.getName()));
 
-            SimpleDialog.of(filteredActivity).setTitle(filters.isEmpty() ? R.string.cache_filter_storage_clear_title : R.string.cache_filter_storage_select_clear_title)
-                    .setNeutralButton(isFilterActive ? TextParam.id(R.string.cache_filter_storage_clear_button) : null)
-                    .setNeutralAction(() -> {
-                                if (isFilterActive) {
-                                    filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()));
-                                }
-                            }
+        if (isFilterActive) {
+            SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_select_clear_title)
+                    .setNeutralButton(TextParam.id(R.string.cache_filter_storage_clear_button))
+                    .setNeutralAction(() ->
+                            filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()))
                     ).selectSingle(model, filteredActivity::refreshWithFilter);
+        } else {
+            SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_select_title)
+                    .selectSingle(model, filteredActivity::refreshWithFilter);
         }
         return true;
     }

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -40,27 +40,25 @@ public class FilterUtils {
 
     public static <T extends Activity & FilteredActivity> boolean openFilterList(final T filteredActivity, final GeocacheFilterContext filterContext) {
         final List<GeocacheFilter> filters = new ArrayList<>(GeocacheFilter.Storage.getStoredFilters());
+        final boolean isFilterActive = filterContext.get().isFiltering();
 
-        if (filters.isEmpty()) {
+        if (filters.isEmpty() && !isFilterActive) {
             return false;
         } else {
-            final boolean isFilterActive = filterContext.get().isFiltering();
             final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
             model
                 .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
                 .setItems(filters)
                 .setDisplayMapper((f) -> TextParam.text(f.getName()));
 
-            if (isFilterActive) {
-                SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_select_clear_title)
-                    .setNeutralButton(TextParam.id(R.string.cache_filter_storage_clear_button))
-                    .setNeutralAction(() ->
-                            filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()))
+            SimpleDialog.of(filteredActivity).setTitle(filters.isEmpty() ? R.string.cache_filter_storage_clear_title : R.string.cache_filter_storage_select_clear_title)
+                    .setNeutralButton(isFilterActive ? TextParam.id(R.string.cache_filter_storage_clear_button) : null)
+                    .setNeutralAction(() -> {
+                                if (isFilterActive) {
+                                    filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()));
+                                }
+                            }
                     ).selectSingle(model, filteredActivity::refreshWithFilter);
-            } else {
-                SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_select_title)
-                        .selectSingle(model, filteredActivity::refreshWithFilter);
-            }
         }
         return true;
     }

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -49,7 +49,7 @@ public class FilterUtils {
         }
 
         if (filters.isEmpty()) {
-            TextParam message = TextParam.concat(TextParam.id(R.string.cache_filter_storage_load_delete_nofilter_message),
+            final TextParam message = TextParam.concat(TextParam.id(R.string.cache_filter_storage_load_delete_nofilter_message),
                     TextParam.text(System.getProperty("line.separator")),
                     TextParam.id(R.string.cache_filter_storage_clear_message));
                 SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_clear_title)

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -43,20 +43,23 @@ public class FilterUtils {
         final List<GeocacheFilter> filters = new ArrayList<>(GeocacheFilter.Storage.getStoredFilters());
         final boolean isFilterActive = filterContext.get().isFiltering();
 
-        if (filters.isEmpty()) {
+        if (filters.isEmpty() && !isFilterActive) {
             filteredActivity.showToast(R.string.cache_filter_storage_load_delete_nofilter_message);
-
-            if (isFilterActive) {
-                SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_clear_title)
-                        .setPositiveButton(null)
-                        .setNeutralButton(TextParam.id(R.string.cache_filter_storage_clear_button))
-                        .setNeutralAction(() ->
-                                filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()))
-                        ).show();
-                return true;
-            }
             return false;
         }
+
+        if (filters.isEmpty()) {
+            TextParam message = TextParam.concat(TextParam.id(R.string.cache_filter_storage_load_delete_nofilter_message),
+                    TextParam.text(System.getProperty("line.separator")),
+                    TextParam.id(R.string.cache_filter_storage_clear_message));
+                SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_clear_title)
+                        .setPositiveButton(TextParam.id(R.string.cache_filter_storage_clear_button))
+                        .setMessage(message)
+                        .confirm(() ->
+                                filteredActivity.refreshWithFilter(GeocacheFilter.createEmpty(filterContext.get().isOpenInAdvancedMode()))
+                        );
+                return true;
+            }
 
         final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
         model

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -625,6 +625,7 @@
     <string name="cache_filter_storage_delete_title">Delete filter</string>
     <string name="cache_filter_storage_delete_message">Do you really want to delete this filter config?</string>
     <string name="cache_filter_storage_select_clear_title">Select filter or clear current filter</string>
+    <string name="cache_filter_storage_clear_title">Clear current filter</string>
     <string name="cache_filter_storage_load_delete_nofilter_message">No filter are stored yet.</string>
     <string name="cache_filter_storage_save_title">Save filter with name</string>
     <string name="cache_filter_storage_save_confirm_title">Save filter overwrite</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -630,6 +630,7 @@
     <string name="cache_filter_storage_save_title">Save filter with name</string>
     <string name="cache_filter_storage_save_confirm_title">Save filter overwrite</string>
     <string name="cache_filter_storage_save_confirm_message">A filter with name \'%s\' and different configuration already exists. Overwrite it?</string>
+    <string name="cache_filter_storage_clear_message">Do you want to clear the current filter?</string>
 
     <string name="cache_filter_stringfilter_matchcase">Match Case</string>
     <string name="cache_filter_stringfilter_searchtext_hint">Search Text</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
If a filter is currently active, but no filter is saved (only "temporary" filter), the long click on the filter-icon does nothing. At least I should have the possibility to clear the current active filter.

first proposal
<img src="https://github.com/user-attachments/assets/b6449802-b3c1-425b-bdb7-7653edeb7190" width=300/>

second proposal
<img src="https://github.com/user-attachments/assets/dadea6d7-e90c-4045-b874-6456a4645608" width=300/>


## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
I reused the current dialog-box and just kept the "clear" button, that is, why it looks probably weird.

