### PR TITLE
Fix lint: Flag PendingIntent.FLAG_IMMUTABLE not supported for API < 23

### DIFF
--- a/main/src/main/java/cgeo/geocaching/apps/cachelist/MapsMeCacheListApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/cachelist/MapsMeCacheListApp.java
@@ -6,12 +6,12 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.apps.AbstractApp;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.ProcessUtils;
 
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -64,7 +64,7 @@ public class MapsMeCacheListApp extends AbstractApp implements CacheListApp {
 
     private static PendingIntent getPendingIntent(final Context context) {
         final Intent intent = new Intent(context, CacheDetailActivity.class);
-        return PendingIntent.getActivity(context, 0, intent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0);
+        return PendingIntent.getActivity(context, 0, intent, ProcessUtils.getFlagImmutable());
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -13,11 +13,11 @@ import cgeo.geocaching.ui.notifications.NotificationChannels;
 import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ProcessUtils;
 
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Intent;
-import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.RadioGroup;
@@ -162,7 +162,7 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
         shouldStop = false;
         final PendingIntent actionCancelIntent = PendingIntent.getBroadcast(this, 0,
                 new Intent(this, StopCacheDownloadServiceReceiver.class),
-                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0) | PendingIntent.FLAG_UPDATE_CURRENT);
+                ProcessUtils.getFlagImmutable() | PendingIntent.FLAG_UPDATE_CURRENT);
 
         return Notifications.createNotification(this, NotificationChannels.FOREGROUND_SERVICE_NOTIFICATION, R.string.caches_store_background_title)
                 .setProgress(100, 0, true)

--- a/main/src/main/java/cgeo/geocaching/utils/ProcessUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ProcessUtils.java
@@ -146,7 +146,7 @@ public final class ProcessUtils {
                     if (mStartActivity != null) {
                         mStartActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                         // create a pending intent so the application is restarted after System.exit(0) was called.
-                        final PendingIntent mPendingIntent = PendingIntent.getActivity(c, 1633838708, mStartActivity, (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0) | PendingIntent.FLAG_CANCEL_CURRENT);
+                        final PendingIntent mPendingIntent = PendingIntent.getActivity(c, 1633838708, mStartActivity, getFlagImmutable() | PendingIntent.FLAG_CANCEL_CURRENT);
                         final AlarmManager mgr = (AlarmManager) c.getSystemService(Context.ALARM_SERVICE);
                         mgr.set(AlarmManager.RTC, System.currentTimeMillis() + 100, mPendingIntent);
                         System.exit(0);
@@ -162,6 +162,11 @@ public final class ProcessUtils {
         } catch (Exception ex) {
             Log.e("Was not able to restart application");
         }
+    }
+
+    // flag for declaring a PendingIntent as immutable (required since API 31, but supported only on API 23+)
+    public static int getFlagImmutable() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ShareUtils.java
@@ -256,7 +256,7 @@ public class ShareUtils {
                 .setShareState(CustomTabsIntent.SHARE_STATE_ON);
 
         final Intent actionIntent = new Intent(context, ShareBroadcastReceiver.class);
-        final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, actionIntent, (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0) | PendingIntent.FLAG_UPDATE_CURRENT);
+        final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, actionIntent, ProcessUtils.getFlagImmutable() | PendingIntent.FLAG_UPDATE_CURRENT);
         builder.addMenuItem(context.getString(R.string.cache_menu_open_with), pendingIntent);
 
         final CustomTabsIntent customTabsIntent = builder.build();

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoDialogManager.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoDialogManager.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ProcessUtils;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -100,7 +101,7 @@ public class WherigoDialogManager {
             // show title first (and content is cut off)
             .setContentTitle(content)
             .setContentText(content)
-            .setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, WherigoActivity.class), PendingIntent.FLAG_IMMUTABLE))
+            .setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, WherigoActivity.class), ProcessUtils.getFlagImmutable()))
             .setStyle(new NotificationCompat.BigTextStyle().bigText(content))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoGameService.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoGameService.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.ui.notifications.NotificationChannels;
 import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ProcessUtils;
 
 import android.app.PendingIntent;
 import android.app.Service;
@@ -49,7 +50,7 @@ public class WherigoGameService extends Service {
             .setSmallIcon(R.drawable.type_marker_wherigo)
             .setContentTitle(content)
             .setContentText(content)
-            .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, WherigoActivity.class), PendingIntent.FLAG_IMMUTABLE))
+            .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, WherigoActivity.class), ProcessUtils.getFlagImmutable()))
             .setOngoing(true).build());
     }
 


### PR DESCRIPTION
## Description
Starting with API level 31, declaring a `PendingIntent` as either immutable or mutable is mandatory, but this flag is provided for API 23+ only. As we currently support API 21+, we need to add a build version check.

This PR adds the two missing build version checks + extracts the check into a helper method.