### PR TITLE
fix #16266: change layout and gui elements according to issue

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/SimpleItemListModel.java
+++ b/main/src/main/java/cgeo/geocaching/ui/SimpleItemListModel.java
@@ -56,14 +56,14 @@ public class SimpleItemListModel<T> {
 
     private String filterTerm = null;
 
-    private T scrollAnchorOnOpen = null;
-
-
     private final Set<T> selectedItems = new HashSet<>();
 
     private final List<Consumer<ChangeType>> changeListeners = new ArrayList<>();
 
     private Consumer<T> actionListener = null;
+
+    private int columnCount = 1;
+    private Function<T, Integer> columnSpanMapper = null;
 
 
     /** Supported display modes for choosing items from a list */
@@ -502,6 +502,21 @@ public class SimpleItemListModel<T> {
     public SimpleItemListModel<T> setItemActionListener(final Consumer<T> actionListener) {
         this.actionListener = actionListener;
         return this;
+    }
+
+    public SimpleItemListModel<T> setColumns(final int columnCount, final Function<T, Integer> columnSpanMapper) {
+        this.columnCount = columnCount;
+        this.columnSpanMapper = columnSpanMapper;
+        triggerChange(ChangeType.COMPLETE);
+        return this;
+    }
+
+    public int getColumnCount() {
+        return this.columnCount;
+    }
+
+    public final Function<T, Integer> getColumnSpanMapper() {
+        return this.columnSpanMapper;
     }
 
     public Consumer<T> getActionListener() {

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
@@ -30,6 +30,8 @@ import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.text.style.StyleSpan;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -116,12 +118,6 @@ public class WherigoActivity extends CustomMenuEntryActivity {
 
         binding.map.setOnClickListener(v -> showOnMap());
 
-        binding.cartridgeDetails.setOnClickListener(v -> {
-            final WherigoCartridgeInfo info = WherigoGame.get().getCartridgeInfo();
-            if (info != null) {
-                WherigoDialogManager.get().display(new WherigoCartridgeDialogProvider(info));
-            }
-        });
         binding.revokeFixedLocation.setOnClickListener(v -> {
             WherigoLocationProvider.get().setFixedLocation(null);
         });
@@ -131,6 +127,27 @@ public class WherigoActivity extends CustomMenuEntryActivity {
             handleCGuidInput(guid);
 
         }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        getMenuInflater().inflate(R.menu.wherigo_options, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        final int menuItem = item.getItemId();
+        if (menuItem == R.id.menu_show_cartridge) {
+            final WherigoCartridgeInfo info = WherigoGame.get().getCartridgeInfo();
+            if (info != null) {
+                WherigoDialogManager.get().display(new WherigoCartridgeDialogProvider(info, true));
+            } else {
+                SimpleDialog.of(this).setTitle(TextParam.id(R.string.wherigo_player))
+                        .setMessage(TextParam.id(R.string.wherigo_no_game_running)).show();
+            }
+        }
+        return true;
     }
 
     private void startGame() {
@@ -164,7 +181,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         SimpleDialog.of(this)
             .setTitle(TextParam.id(R.string.wherigo_choose_cartridge))
             .selectSingle(model, cartridgeInfo -> {
-                WherigoDialogManager.displayDirect(this, new WherigoCartridgeDialogProvider(cartridgeInfo));
+                WherigoDialogManager.displayDirect(this, new WherigoCartridgeDialogProvider(cartridgeInfo, false));
             });
     }
 
@@ -244,7 +261,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
                     wherigoDownloader.downloadWherigo(cguid, name -> ContentStorage.get().create(PersistableFolder.WHERIGO, name));
                 });
         } else {
-            WherigoDialogManager.get().display(new WherigoCartridgeDialogProvider(cguidCartridge));
+            WherigoDialogManager.get().display(new WherigoCartridgeDialogProvider(cguidCartridge, false));
         }
     }
 
@@ -252,7 +269,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         final WherigoCartridgeInfo cartridgeInfo = WherigoCartridgeInfo.getCartridgeForCGuid(cguid);
         if (result.isOk() && cartridgeInfo != null) {
             ActivityMixin.showToast(this, R.string.wherigo_download_successful_title);
-            WherigoDialogManager.displayDirect(this, new WherigoCartridgeDialogProvider(cartridgeInfo));
+            WherigoDialogManager.displayDirect(this, new WherigoCartridgeDialogProvider(cartridgeInfo, false));
         } else {
             SimpleDialog.of(this).setTitle(TextParam.id(R.string.wherigo_download_failed_title))
                 .setMessage(TextParam.id(R.string.wherigo_download_failed_message, cguid, String.valueOf(result)))
@@ -280,7 +297,6 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         binding.saveGame.setEnabled(game.isPlaying());
         binding.loadGame.setEnabled(game.isPlaying() && game.getCartridgeInfo().getLoadableSavegames().size() > 1);
         binding.stopGame.setEnabled(game.isPlaying());
-        binding.cartridgeDetails.setEnabled(game.isPlaying());
         binding.map.setEnabled(game.isPlaying() && !WherigoThingType.LOCATION.getThingsForUserDisplay().isEmpty());
 
         this.setTitle(game.isPlaying() ? game.getCartridgeName() : getString(R.string.wherigo_player));

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoDialogManager.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoDialogManager.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.wherigo;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.ui.notifications.NotificationChannels;
 import cgeo.geocaching.ui.notifications.Notifications;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -195,6 +197,11 @@ public class WherigoDialogManager {
                     closeCurrentDialog();
                     if (isPause) {
                         state = State.DIALOG_PAUSED;
+                        final Activity currentActivity = CgeoApplication.getInstance().getCurrentForegroundActivity();
+                        if (currentActivity != null) {
+                            SimpleDialog.of(currentActivity).setTitle(TextParam.id(R.string.wherigo_player))
+                                .setMessage(TextParam.id(R.string.wherigo_dialog_pause_info)).show();
+                        }
                     } else {
                         this.currentDialogProvider = null;
                         state = State.NO_DIALOG;

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoInputDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoInputDialogProvider.java
@@ -66,7 +66,7 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
 
         final WherigoGame game = WherigoGame.get();
 
-        final AlertDialog dialog = WherigoUtils.createFullscreenDialog(activity, LocalizationUtils.getString(R.string.wherigo_player));
+        final AlertDialog dialog = WherigoViewUtils.createFullscreenDialog(activity, LocalizationUtils.getString(R.string.wherigo_player));
 
         binding = WherigoThingDetailsBinding.inflate(LayoutInflater.from(activity));
         dialog.setView(binding.getRoot());
@@ -83,8 +83,8 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
 
         if ("Text".equals(type)) {
             binding.dialogInputLayout.setVisibility(VISIBLE);
-            WherigoUtils.setViewActions(Arrays.asList(Boolean.TRUE, Boolean.FALSE),
-                    binding.dialogActionlist, item -> item ? WherigoUtils.TP_OK_BUTTON : WherigoUtils.TP_PAUSE_BUTTON, item -> {
+            WherigoViewUtils.setViewActions(Arrays.asList(Boolean.FALSE, Boolean.TRUE),
+                    binding.dialogActionlist, 2, item -> item ? WherigoUtils.TP_OK_BUTTON : WherigoUtils.TP_CANCEL_BUTTON, item -> {
                 if (item) {
                     control.setPauseOnDismiss(false);
                     control.dismiss();
@@ -125,8 +125,8 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
                     .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_RADIO);
                 binding.dialogItemlistview.setModel(choiceModel);
 
-                WherigoUtils.setViewActions(Arrays.asList(Boolean.TRUE, Boolean.FALSE), binding.dialogActionlist,
-                    item -> item ? WherigoUtils.TP_OK_BUTTON : WherigoUtils.TP_PAUSE_BUTTON, item -> {
+                WherigoViewUtils.setViewActions(Arrays.asList(Boolean.FALSE, Boolean.TRUE), binding.dialogActionlist, 2,
+                    item -> item ? WherigoUtils.TP_OK_BUTTON : WherigoUtils.TP_CANCEL_BUTTON, item -> {
                         if (item) {
                             control.setPauseOnDismiss(false);
                             control.dismiss();
@@ -141,7 +141,7 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
         }
 
         if (!handled) {
-            WherigoUtils.setViewActions(Collections.singleton("ok"), binding.dialogActionlist, item -> WherigoUtils.TP_OK_BUTTON, item -> {
+            WherigoViewUtils.setViewActions(Collections.singleton("ok"), binding.dialogActionlist, 1, item -> WherigoUtils.TP_OK_BUTTON, item -> {
                 control.setPauseOnDismiss(false);
                 control.dismiss();
                 Engine.callEvent(input, "OnGetInput", null);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoPushDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoPushDialogProvider.java
@@ -67,20 +67,22 @@ public class WherigoPushDialogProvider implements IWherigoDialogProvider {
 
     @Override
     public Dialog createAndShowDialog(final Activity activity, final IWherigoDialogControl control) {
-        final AlertDialog dialog = WherigoUtils.createFullscreenDialog(activity, LocalizationUtils.getString(R.string.wherigo_player));
+        control.setPauseOnDismiss(true);
+        final AlertDialog dialog = WherigoViewUtils.createFullscreenDialog(activity, LocalizationUtils.getString(R.string.wherigo_player));
         final WherigoThingDetailsBinding binding = WherigoThingDetailsBinding.inflate(LayoutInflater.from(activity));
         dialog.setView(binding.getRoot());
         final int[] page = new int[]{ 0 };
 
         refreshGui(binding, 0);
 
-        final List<Boolean> options = button2 == null ? Collections.singletonList(TRUE) : Arrays.asList(TRUE, FALSE);
+        final List<Boolean> options = button2 == null ? Collections.singletonList(TRUE) : Arrays.asList(FALSE, TRUE);
 
-        WherigoUtils.setViewActions(options, binding.dialogActionlist, item -> TRUE.equals(item) ?
+        WherigoViewUtils.setViewActions(options, binding.dialogActionlist, button2 == null ? 1 : 2, item -> TRUE.equals(item) ?
                 TextParam.text(button1).setImage(ImageParam.id(R.drawable.ic_menu_done)) :
                 TextParam.text(button2).setImage(ImageParam.id(R.drawable.ic_menu_cancel)),
             item -> {
                 if (FALSE.equals(item)) {
+                    control.setPauseOnDismiss(false);
                     control.dismiss();
                     if (callback != null) {
                         Engine.invokeCallback(callback, "Button2");
@@ -89,6 +91,7 @@ public class WherigoPushDialogProvider implements IWherigoDialogProvider {
                     page[0] ++;
                     refreshGui(binding, page[0]);
                 } else {
+                    control.setPauseOnDismiss(false);
                     control.dismiss();
                     if (callback != null) {
                         Engine.invokeCallback(callback, "Button1");

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
@@ -50,7 +50,7 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
 
     @Override
     public Dialog createAndShowDialog(final Activity activity, final IWherigoDialogControl control) {
-        final AlertDialog dialog = WherigoUtils.createFullscreenDialog(activity, eventTable.name);
+        final AlertDialog dialog = WherigoViewUtils.createFullscreenDialog(activity, eventTable.name);
         final WherigoThingDetailsBinding binding = WherigoThingDetailsBinding.inflate(LayoutInflater.from(activity));
         dialog.setView(binding.getRoot());
 
@@ -91,7 +91,7 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
         }
         actions.add(ThingAction.CLOSE);
 
-        WherigoUtils.setViewActions(actions, binding.dialogActionlist,
+        WherigoViewUtils.setViewActions(actions, binding.dialogActionlist, 1,
                 a -> a instanceof Action ?
                         TextParam.text(WherigoUtils.getActionText((Action) a)).setImage(ImageParam.id(R.drawable.settings_nut)) :
                         ((ThingAction) a).getTextParam(),

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.wherigo;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
-import cgeo.geocaching.databinding.WherigoDialogTitleViewBinding;
 import cgeo.geocaching.databinding.WherigolistItemBinding;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointConverter;
@@ -12,9 +11,7 @@ import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.ui.ImageParam;
 import cgeo.geocaching.ui.SimpleItemListModel;
-import cgeo.geocaching.ui.SimpleItemListView;
 import cgeo.geocaching.ui.TextParam;
-import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.CommonUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -22,7 +19,6 @@ import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.TextUtils;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
@@ -30,8 +26,6 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.text.style.StyleSpan;
-import android.view.LayoutInflater;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -45,8 +39,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -59,7 +51,6 @@ import cz.matejcik.openwig.Thing;
 import cz.matejcik.openwig.Zone;
 import cz.matejcik.openwig.ZonePoint;
 import cz.matejcik.openwig.formats.CartridgeFile;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import se.krka.kahlua.vm.LuaTable;
 
@@ -67,7 +58,7 @@ public final class WherigoUtils {
 
     public static final TextParam TP_OK_BUTTON = TextParam.id(R.string.ok).setImage(ImageParam.id(R.drawable.ic_menu_done));
     public static final TextParam TP_CLOSE_BUTTON = TextParam.id(R.string.close).setImage(ImageParam.id(R.drawable.ic_menu_done));
-    public static final TextParam TP_PAUSE_BUTTON = TextParam.id(R.string.pause).setImage(ImageParam.id(R.drawable.ic_menu_done));
+    public static final TextParam TP_CANCEL_BUTTON = TextParam.id(R.string.cancel).setImage(ImageParam.id(R.drawable.ic_menu_cancel));
 
 
     public static final GeopointConverter<ZonePoint> GP_CONVERTER = new GeopointConverter<>(
@@ -134,18 +125,6 @@ public final class WherigoUtils {
         } else {
             Engine.callEvent(thing, eventName, null);
         }
-    }
-
-    public static <T> void setViewActions(final Iterable<T> actions, final SimpleItemListView view, final Function<T, TextParam> displayMapper, final Consumer<T> clickHandler) {
-        final SimpleItemListModel<T> model = new SimpleItemListModel<>();
-        model
-            .setItems(actions)
-            .setDisplayMapper((item, group) -> displayMapper.apply(item), null, (ctx, parent) -> ViewUtils.createButton(ctx, parent, TextParam.text(""), true))
-            .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
-            .setItemPadding(10, 0)
-            .addSingleSelectListener(clickHandler);
-        view.setModel(model);
-        view.setVisibility(View.VISIBLE);
     }
 
     public static boolean isVisibleToPlayer(final EventTable et) {
@@ -359,18 +338,6 @@ public final class WherigoUtils {
         } else {
             WherigoDialogManager.get().display(new WherigoThingDialogProvider(thing));
         }
-    }
-
-    public static AlertDialog createFullscreenDialog(@NonNull final Activity activity, @Nullable final String title) {
-        final AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.cgeo_fullScreen);
-        final AlertDialog dialog = builder.create();
-        if (!StringUtils.isBlank(title)) {
-            final WherigoDialogTitleViewBinding titleBinding = WherigoDialogTitleViewBinding.inflate(LayoutInflater.from(activity));
-            titleBinding.dialogTitle.setText(title);
-            dialog.setCustomTitle(titleBinding.getRoot());
-        }
-        return dialog;
-
     }
 
     public static Comparator<EventTable> getThingsComparator() {

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
@@ -1,10 +1,28 @@
 package cgeo.geocaching.wherigo;
 
+import cgeo.geocaching.R;
+import cgeo.geocaching.databinding.WherigoDialogTitleViewBinding;
+import cgeo.geocaching.ui.SimpleItemListModel;
+import cgeo.geocaching.ui.SimpleItemListView;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 
+import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.StringUtils;
 
 public final class WherigoViewUtils {
 
@@ -31,4 +49,29 @@ public final class WherigoViewUtils {
         }
     }
 
+    public static AlertDialog createFullscreenDialog(@NonNull final Activity activity, @Nullable final String title) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.cgeo_fullScreen);
+        final AlertDialog dialog = builder.create();
+        if (!StringUtils.isBlank(title)) {
+            final WherigoDialogTitleViewBinding titleBinding = WherigoDialogTitleViewBinding.inflate(LayoutInflater.from(activity));
+            titleBinding.dialogTitle.setText(title);
+            dialog.setCustomTitle(titleBinding.getRoot());
+            titleBinding.dialogBack.setOnClickListener(v -> WherigoViewUtils.safeDismissDialog(dialog));
+        }
+        return dialog;
+
+    }
+
+    public static <T> void setViewActions(final Iterable<T> actions, final SimpleItemListView view, final int columnCount, final Function<T, TextParam> displayMapper, final Consumer<T> clickHandler) {
+        final SimpleItemListModel<T> model = new SimpleItemListModel<>();
+        model
+            .setItems(actions)
+            .setDisplayMapper((item, group) -> displayMapper.apply(item), null, (ctx, parent) -> ViewUtils.createButton(ctx, parent, TextParam.text(""), true))
+            .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
+            .setItemPadding(10, 0)
+            .setColumns(columnCount, null)
+            .addSingleSelectListener(clickHandler);
+        view.setModel(model);
+        view.setVisibility(View.VISIBLE);
+    }
 }

--- a/main/src/main/res/layout/wherigo_activity.xml
+++ b/main/src/main/res/layout/wherigo_activity.xml
@@ -86,14 +86,6 @@
                 android:orientation="horizontal">
 
                 <Button
-                    android:id="@+id/resume_dialog"
-                    style="@style/button"
-                    android:layout_margin="3dp"
-                    android:minWidth="2dp"
-                    android:text="@string/resume"
-                    app:icon="@drawable/ic_menu_owned" />
-
-                <Button
                     android:id="@+id/load_game"
                     style="@style/button_icon_accent"
                     android:tooltipText="@string/wherigo_controls_loadgame_hint"
@@ -112,19 +104,19 @@
                     app:icon="@drawable/wherigo_close" />
 
                 <Button
-                    android:id="@+id/cartridge_details"
-                    style="@style/button_icon_accent"
-                    android:tooltipText="@string/wherigo_cartridge_details"
-                    app:icon="@drawable/settings_info" />
-
-                <Button
                     android:id="@+id/map"
                     style="@style/button_icon_accent"
                     android:tooltipText="@string/wherigo_controls_mapzones_hint"
                     app:icon="@drawable/ic_menu_mapmode" />
 
-
             </LinearLayout>
+
+            <Button
+                android:id="@+id/resume_dialog"
+                style="@style/button_full"
+                android:layout_margin="3dp"
+                android:minWidth="2dp"
+                android:text="@string/wherigo_controls_resume_paused_dialog"/>
 
             <TextView
                 android:id="@+id/game_location"

--- a/main/src/main/res/layout/wherigo_dialog_title_view.xml
+++ b/main/src/main/res/layout/wherigo_dialog_title_view.xml
@@ -3,19 +3,30 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingTop="12dp">
+    android:background="@color/colorBackgroundActionBar"
+    android:paddingVertical="6dp">
+
+    <ImageView
+        android:id="@+id/dialog_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:paddingVertical="3dp"
+        android:layout_centerVertical="true"
+        android:paddingStart="5dp"
+        android:paddingEnd="5dp"
+        android:src="@drawable/arrow_back" />
 
     <TextView
         android:id="@+id/dialog_title"
         style="?android:attr/windowTitleStyle"
-        android:background="@color/colorBackgroundActionBar"
-        android:layout_alignParentLeft="true"
+        android:layout_toRightOf="@id/dialog_back"
         android:layout_alignParentRight="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="6dp"
         android:paddingBottom="6dp"
-        android:paddingLeft="24dp"
+        android:paddingLeft="12dp"
         android:paddingRight="12dp"/>
 
 </RelativeLayout>

--- a/main/src/main/res/menu/wherigo_options.xml
+++ b/main/src/main/res/menu/wherigo_options.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_show_cartridge"
+        android:icon="@drawable/ic_menu_info_details"
+        android:title="@string/wherigo_controls_cartridgelist_hint"
+        app:showAsAction="always"/>
+
+</menu>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2915,6 +2915,9 @@
     <string name="wherigo_controls_mapzones_hint">Show zones of a running game on map</string>
     <string name="wherigo_controls_downloadcartridge_hint">Download a cartridge (cguid needed)</string>
     <string name="wherigo_controls_reportproblem_hint">Report a problem with the wherigo player</string>
+    <string name="wherigo_controls_resume_paused_dialog">Resume paused dialog</string>
+    <string name="wherigo_dialog_pause_info">You cancelled a Wherigo Dialog. You can resume it in Wherigo Player by tapping \"Resume paused dialog\"</string>
+    <string name="wherigo_no_game_running">No wherigo game is currently running</string>
     <string name="wherigo_currently_playing">Currently playing</string>
     <string name="wherigo_cartridge_details">Cartridge details</string>
     <string name="wherigo_locate_on_center">Locate on center</string>


### PR DESCRIPTION
fix #16266: change layout and gui elements according to issue

This PR fixes everything menationed in the issue with one exception: Wherigo Dialog elements still have an actionbar element. In addition, a "back" arrow was implemented inside those action bars. All in all with this PR the "wherigo screens look like activities" pattern is realized/completed.

![image](https://github.com/user-attachments/assets/7cf9dd49-6a86-4efa-a76e-9e2117137895)

![image](https://github.com/user-attachments/assets/6e2c80df-019d-4ecd-90cd-05b4efd3d408)

![image](https://github.com/user-attachments/assets/3b6506a4-2ce4-49de-9925-acc698cf8a7c)
