### PR TITLE
make short date format configurable

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2522,4 +2522,8 @@ public class Settings {
         newDate.setTimeInMillis(getLong(R.string.pref_last_used_date, newDate.getTimeInMillis()));
         return newDate;
     }
+
+    public static String getShortDateFormat() {
+        return getString(R.string.pref_short_date_format, "");
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -148,8 +148,11 @@ public final class Formatter {
      */
     @NonNull
     public static String formatShortDate(final long date) {
-        final DateFormat dateFormat = android.text.format.DateFormat.getDateFormat(getContext());
-        return dateFormat.format(date);
+        final String dateFormatString = Settings.getShortDateFormat();
+        if (!dateFormatString.isEmpty()) {
+            return new SimpleDateFormat(dateFormatString, Locale.getDefault()).format(date);
+        }
+        return android.text.format.DateFormat.getDateFormat(getContext()).format(date);
     }
 
     private static String formatShortDateIncludingWeekday(final long time) {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -643,15 +643,15 @@
 
     <!-- appearance => short date format -->
     <string translatable="false" name="pref_short_date_format">short_date_format</string>
-    <string translatable="false" name="pref_value_short_date_format_default"></string>
-    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYYYY">DD.MM.YYYY</string>
-    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYY">DD.MM.YY</string>
-    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYYYY">MM/DD/YYYY</string>
-    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYY">MM/DD/YY</string>
-    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYYYY">DD/MM/YYYY</string>
-    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYY">DD/MM/YY</string>
-    <string translatable="false" name="pref_value_short_date_format_YYYYdashMMdashDD">YYYY-MM-DD</string>
-    <string translatable="false" name="pref_value_short_date_format_YYdashMMdashDD">YY-MM-DD</string>
+    <string translatable="false" name="pref_value_short_date_format_default" />
+    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYYYY">dd.MM.YYYY</string>
+    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYY">dd.MM.YY</string>
+    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYYYY">MM/dd/YYYY</string>
+    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYY">MM/dd/YY</string>
+    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYYYY">dd/MM/YYYY</string>
+    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYY">dd/MM/YY</string>
+    <string translatable="false" name="pref_value_short_date_format_YYYYdashMMdashDD">YYYY-MM-dd</string>
+    <string translatable="false" name="pref_value_short_date_format_YYdashMMdashDD">YY-MM-dd</string>
     <string-array name="pref_values_short_date_format">
         <item>@string/pref_value_short_date_format_default</item>
         <item>@string/pref_value_short_date_format_DDdotMMdotYYYY</item>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -641,4 +641,27 @@
     <string translatable="false" name="pref_legacy_filter_config_migrated">legacy_filter_config_migrated</string>
     <string translatable="false" name="pref_last_used_date">last_used_logdate</string>
 
+    <!-- appearance => short date format -->
+    <string translatable="false" name="pref_short_date_format">short_date_format</string>
+    <string translatable="false" name="pref_value_short_date_format_default"></string>
+    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYYYY">DD.MM.YYYY</string>
+    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYY">DD.MM.YY</string>
+    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYYYY">MM/DD/YYYY</string>
+    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYY">MM/DD/YY</string>
+    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYYYY">DD/MM/YYYY</string>
+    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYY">DD/MM/YY</string>
+    <string translatable="false" name="pref_value_short_date_format_YYYYdashMMdashDD">YYYY-MM-DD</string>
+    <string translatable="false" name="pref_value_short_date_format_YYdashMMdashDD">YY-MM-DD</string>
+    <string-array name="pref_values_short_date_format">
+        <item>@string/pref_value_short_date_format_default</item>
+        <item>@string/pref_value_short_date_format_DDdotMMdotYYYY</item>
+        <item>@string/pref_value_short_date_format_DDdotMMdotYY</item>
+        <item>@string/pref_value_short_date_format_MMslashDDslashYYYY</item>
+        <item>@string/pref_value_short_date_format_MMslashDDslashYY</item>
+        <item>@string/pref_value_short_date_format_DDslashMMslashYYYY</item>
+        <item>@string/pref_value_short_date_format_DDslashMMslashYY</item>
+        <item>@string/pref_value_short_date_format_YYYYdashMMdashDD</item>
+        <item>@string/pref_value_short_date_format_YYdashMMdashDD</item>
+    </string-array>
+
 </resources>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1017,14 +1017,14 @@
     <string name="init_date_format_description">Format to use for short dates, e.g. in log view</string>
     <string-array name="init_date_format_values">
         <item>System Default</item>
-        <item>DD.MM.YYYY</item>
-        <item>DD.MM.YY</item>
-        <item>MM/DD/YYYY</item>
-        <item>MM/DD/YY</item>
-        <item>DD/MM/YYYY</item>
-        <item>DD/MM/YY</item>
-        <item>YYYY-MM-DD</item>
-        <item>YY-MM-DD</item>
+        <item>17.02.2024</item>
+        <item>17.02.24</item>
+        <item>02/17/2024</item>
+        <item>02/17/24</item>
+        <item>17/02/2024</item>
+        <item>17/02/24</item>
+        <item>2024-02-17</item>
+        <item>24-02-17</item>
     </string-array>
     <string name="init_showwaypoints">Show waypoints</string>
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
@@ -1074,6 +1074,7 @@
     <string name="init_units">Use Imperial Units</string>
     <string name="init_summary_units">Use Imperial Units instead of Metric Units</string>
     <string name="init_cachelists">Cache Lists</string>
+    <string name="init_localization">Localization</string>
     <string name="init_log_offline">Offline Logging</string>
     <string name="init_summary_log_offline">Enable Offline Logging (Won\'t show online log screen when logging, won\'t upload logs)</string>
     <string name="init_choose_list">Ask for List</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1013,6 +1013,19 @@
     <string name="init_summary_address">Show address instead of coordinates on main screen</string>
     <string name="init_select_language">Select language</string>
     <string name="init_use_default_language">Use default language</string>
+    <string name="init_date_format">Date format</string>
+    <string name="init_date_format_description">Format to use for short dates, e.g. in log view</string>
+    <string-array name="init_date_format_values">
+        <item>System Default</item>
+        <item>DD.MM.YYYY</item>
+        <item>DD.MM.YY</item>
+        <item>MM/DD/YYYY</item>
+        <item>MM/DD/YY</item>
+        <item>DD/MM/YYYY</item>
+        <item>DD/MM/YY</item>
+        <item>YYYY-MM-DD</item>
+        <item>YY-MM-DD</item>
+    </string-array>
     <string name="init_showwaypoints">Show waypoints</string>
     <string name="init_showwaypoint_description">If less than the given amount of caches are displayed on the map, their waypoints are shown additionally.</string>
     <string name="init_zoomincludingwaypoints">Zoom includes waypoints</string>

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -36,23 +36,6 @@
             android:summary="@string/init_summary_plain_logs"
             android:title="@string/init_plain_logs"
             app:iconSpaceReserved="false" />
-        <ListPreference
-            android:key="@string/pref_short_date_format"
-            android:title="@string/init_date_format"
-            android:summary="@string/init_date_format_description"
-            android:entries="@array/init_date_format_values"
-            android:entryValues="@array/pref_values_short_date_format"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/pref_units_imperial"
-            android:summary="@string/init_summary_units"
-            android:title="@string/init_units"
-            app:iconSpaceReserved="false" />
-        <ListPreference
-            android:key="@string/pref_selected_language"
-            android:title="@string/init_select_language"
-            app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_quicklaunchitems"
             android:title="@string/init_quicklaunchitems"
@@ -70,6 +53,28 @@
             android:defaultValue="0"
             android:key="@string/pref_custombnitem"
             android:title="@string/init_custombnitem"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/init_localization"
+        app:iconSpaceReserved="false">
+        <ListPreference
+            android:key="@string/pref_selected_language"
+            android:title="@string/init_select_language"
+            app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_units_imperial"
+            android:summary="@string/init_summary_units"
+            android:title="@string/init_units"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="@string/pref_short_date_format"
+            android:title="@string/init_date_format"
+            android:summary="@string/init_date_format_description"
+            android:entries="@array/init_date_format_values"
+            android:entryValues="@array/pref_values_short_date_format"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 

--- a/main/src/main/res/xml/preferences_appearence.xml
+++ b/main/src/main/res/xml/preferences_appearence.xml
@@ -37,14 +37,21 @@
             android:title="@string/init_plain_logs"
             app:iconSpaceReserved="false" />
         <ListPreference
-            android:key="@string/pref_selected_language"
-            android:title="@string/init_select_language"
+            android:key="@string/pref_short_date_format"
+            android:title="@string/init_date_format"
+            android:summary="@string/init_date_format_description"
+            android:entries="@array/init_date_format_values"
+            android:entryValues="@array/pref_values_short_date_format"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_units_imperial"
             android:summary="@string/init_summary_units"
             android:title="@string/init_units"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="@string/pref_selected_language"
+            android:title="@string/init_select_language"
             app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_quicklaunchitems"


### PR DESCRIPTION
added a new "Localization" section in Settings where I grouped the new option with the old unit and language:
![image](https://github.com/user-attachments/assets/0dad177b-841f-4851-95dc-0ed731ecad90)

available configurable date formats:
![image](https://github.com/user-attachments/assets/40cc909b-8963-4b5e-a86f-54e71eef1595)

in use:
![image](https://github.com/user-attachments/assets/de65cc98-2406-4436-977f-8b6162669e9f)



fixes https://github.com/cgeo/cgeo/issues/16285
fixes https://github.com/cgeo/cgeo/issues/16249