### PR TITLE
add shadows to map overlay buttons

### DIFF
--- a/main/src/main/res/drawable/bearing_indicator.xml
+++ b/main/src/main/res/drawable/bearing_indicator.xml
@@ -1,16 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="40.8dp"
-    android:height="40.8dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="37.4dp"
+    android:height="37.4dp"
+    android:viewportWidth="22"
+    android:viewportHeight="22">
   <path
-      android:pathData="M12,12m-11,0a11,11 0,1 1,22 0a11,11 0,1 1,-22 0"
-      android:fillColor="@color/osm_zoomcontrolbackground"
-      android:strokeLineCap="round"/>
+      android:pathData="M11,2.516 L7.903,11h2.297A0.8,0.8 0,0 1,11 10.199,0.8 0.8,0 0,1 11.801,11h2.297z"
+      android:fillColor="#ffd32f2f"/>
   <path
-      android:pathData="M12.0005,3.5156 L8.9029,12H11.1997A0.8,0.8 0,0 1,12.0005 11.1992,0.8 0.8,0 0,1 12.8013,12h2.2969z"
-      android:fillColor="#ffd32f2f" />
-  <path
-      android:pathData="M8.9023,12L12,20.4844L15.0977,12L12.8008,12A0.8,0.8 0,0 1,12 12.8008A0.8,0.8 0,0 1,11.1992 12L8.9023,12z"
-      android:fillColor="#ffbbbbbb" />
+      android:pathData="M7.902,11 L11,19.484 14.098,11L11.801,11A0.8,0.8 0,0 1,11 11.801,0.8 0.8,0 0,1 10.199,11Z"
+      android:fillColor="#ffbbbbbb"/>
 </vector>

--- a/main/src/main/res/drawable/map_bearing_background.xml
+++ b/main/src/main/res/drawable/map_bearing_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@android:color/darker_gray">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/osm_zoomcontrolbackground" />
+        </shape>
+    </item>
+</ripple>

--- a/main/src/main/res/drawable/map_button_background.xml
+++ b/main/src/main/res/drawable/map_button_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@android:color/darker_gray">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/osm_zoomcontrolbackground" />
+            <corners android:radius="2dp" />
+        </shape>
+    </item>
+</ripple>

--- a/main/src/main/res/drawable/map_button_background_bottom.xml
+++ b/main/src/main/res/drawable/map_button_background_bottom.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@android:color/black">
+    android:color="@android:color/darker_gray">
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/osm_zoomcontrolbackground" />
-            <corners android:radius="2dp" />
+            <corners
+                android:bottomLeftRadius="2dp"
+                android:bottomRightRadius="2dp"
+                />
         </shape>
     </item>
 </ripple>

--- a/main/src/main/res/drawable/map_button_background_top.xml
+++ b/main/src/main/res/drawable/map_button_background_top.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@android:color/darker_gray">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/osm_zoomcontrolbackground" />
+            <corners
+                android:topLeftRadius="2dp"
+                android:topRightRadius="2dp"
+                />
+        </shape>
+    </item>
+</ripple>

--- a/main/src/main/res/drawable/map_zoomin.xml
+++ b/main/src/main/res/drawable/map_zoomin.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android" android:color="@android:color/black">
-    <item android:drawable="@drawable/map_zoomin_btn" />
-</ripple>

--- a/main/src/main/res/drawable/map_zoomin_btn.xml
+++ b/main/src/main/res/drawable/map_zoomin_btn.xml
@@ -4,9 +4,6 @@
     android:viewportWidth="10.054"
     android:viewportHeight="10.054">
     <path
-        android:pathData="m0.5292,0c-0.2932,0 -0.5292,0.236 -0.5292,0.5292l0,8.9957 0,0.5292l0.5292,0 8.9957,0 0.5292,0l0,-0.5292 0,-8.9957c0,-0.2932 -0.236,-0.5292 -0.5292,-0.5292l-8.9957,0z"
-        android:fillColor="@color/osm_zoomcontrolbackground" />
-    <path
         android:pathData="m7.4745,5.3767h-2.0978v2.0978h-0.6993v-2.0978h-2.0978v-0.6993h2.0978v-2.0978h0.6993v2.0978h2.0978z"
         android:fillColor="@color/osm_zoomcontrol" />
 </vector>

--- a/main/src/main/res/drawable/map_zoomout.xml
+++ b/main/src/main/res/drawable/map_zoomout.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android" android:color="@android:color/black">
-  <item android:drawable="@drawable/map_zoomout_btn" />
-</ripple>

--- a/main/src/main/res/drawable/map_zoomout_btn.xml
+++ b/main/src/main/res/drawable/map_zoomout_btn.xml
@@ -4,9 +4,6 @@
     android:viewportWidth="10.054"
     android:viewportHeight="10.054">
     <path
-        android:pathData="m9.525,10.054c0.2932,0 0.5292,-0.236 0.5292,-0.5292v-9.525h-10.054v9.525c0,0.2932 0.236,0.5292 0.5292,0.5292z"
-        android:fillColor="@color/osm_zoomcontrolbackground" />
-    <path
         android:pathData="m7.4745,5.3767h-4.8948v-0.6993h4.8948z"
         android:fillColor="@color/osm_zoomcontrol"/>
 </vector>

--- a/main/src/main/res/layout-land/map_settings_button.xml
+++ b/main/src/main/res/layout-land/map_settings_button.xml
@@ -15,7 +15,7 @@
         <ImageButton
             android:id="@+id/map_settings_popup"
             android:src="@drawable/map_quick_settings"
-            style="@style/map_quicksettingsbutton"
+            style="@style/map_overlaybutton_bg"
             android:tooltipText="@string/quick_settings"
             android:contentDescription="@string/quick_settings"/>
     </LinearLayout>
@@ -28,7 +28,7 @@
         android:visibility="visible">
         <ImageButton
             android:id="@+id/map_individualroute_popup"
-            style="@style/map_quicksettingsbutton"
+            style="@style/map_overlaybutton_bg"
             android:src="@drawable/map_quick_route"
             android:tooltipText="@string/routes_tracks_dialog_title"
             android:contentDescription="@string/routes_tracks_dialog_title"/>
@@ -42,7 +42,7 @@
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_wherigo_popup"
-            style="@style/map_quicksettingsbutton"
+            style="@style/map_overlaybutton_bg"
             android:src="@drawable/map_quick_wherigo"
             android:tooltipText="@string/wherigo_player"
             android:contentDescription="@string/wherigo_player"/>

--- a/main/src/main/res/layout/map_distanceinfo.xml
+++ b/main/src/main/res/layout/map_distanceinfo.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:elevation="0dp"
     android:id="@+id/distanceinfo"
     android:layout_below="@id/filterbar">
 
@@ -77,22 +78,29 @@
             android:background="@drawable/icon_bcg" />
     </LinearLayout>
 
-    <ImageView
-        android:id="@+id/map_compassrose"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <LinearLayout
+        android:id="@+id/map_compassrosecontainer"
         android:layout_below="@id/distancesFrame1"
-        android:layout_marginTop="13dp"
-        android:layout_marginLeft="13dp"
         android:layout_alignParentLeft="true"
-        android:src="@drawable/bearing_indicator" />
+        android:layout_marginTop="11dp"
+        android:layout_marginLeft="11dp"
+        style="@style/map_shadowcontainer"
+        android:layout_centerHorizontal="true">
+        <ImageView
+            android:id="@+id/map_compassrose"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/map_bearing_background"
+            android:elevation="2dp"
+            android:src="@drawable/bearing_indicator" />
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/container_rotationmenu"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/map_compassrose"
-        android:layout_alignTop="@id/map_compassrose"
+        android:layout_toRightOf="@id/map_compassrosecontainer"
+        android:layout_alignTop="@id/map_compassrosecontainer"
         android:layout_marginLeft="5dp"
         android:gravity="left"
         android:visibility="gone"

--- a/main/src/main/res/layout/map_distanceinfo.xml
+++ b/main/src/main/res/layout/map_distanceinfo.xml
@@ -82,8 +82,8 @@
         android:id="@+id/map_compassrosecontainer"
         android:layout_below="@id/distancesFrame1"
         android:layout_alignParentLeft="true"
-        android:layout_marginTop="11dp"
-        android:layout_marginLeft="11dp"
+        android:layout_marginTop="13dp"
+        android:layout_marginLeft="13dp"
         style="@style/map_shadowcontainer"
         android:layout_centerHorizontal="true">
         <ImageView

--- a/main/src/main/res/layout/map_settings_button.xml
+++ b/main/src/main/res/layout/map_settings_button.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="5dp"
+    android:paddingBottom="1dp"
+    android:elevation="0dp"
     android:layout_alignParentBottom="true">
 
     <LinearLayout
         android:id="@+id/container_settings"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/map_shadowcontainer"
         android:layout_centerHorizontal="true">
         <ImageButton
             android:id="@+id/map_settings_popup"
@@ -21,10 +20,9 @@
     </LinearLayout>
     <LinearLayout
         android:id="@+id/container_individualroute"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/map_shadowcontainer"
         android:layout_toRightOf="@id/container_settings"
-        android:layout_marginLeft="6dp"
+        android:layout_marginLeft="-2dp"
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_individualroute_popup"
@@ -35,10 +33,9 @@
     </LinearLayout>
     <LinearLayout
         android:id="@+id/container_wherigo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/map_shadowcontainer"
         android:layout_toRightOf="@id/container_individualroute"
-        android:layout_marginLeft="6dp"
+        android:layout_marginLeft="-2dp"
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_wherigo_popup"

--- a/main/src/main/res/layout/map_settings_button.xml
+++ b/main/src/main/res/layout/map_settings_button.xml
@@ -3,7 +3,6 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="1dp"
     android:elevation="0dp"
     android:layout_alignParentBottom="true">
 
@@ -22,6 +21,7 @@
         android:id="@+id/container_individualroute"
         style="@style/map_shadowcontainer"
         android:layout_toRightOf="@id/container_settings"
+        android:layout_marginLeft="2dp"
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_individualroute_popup"
@@ -34,6 +34,7 @@
         android:id="@+id/container_wherigo"
         style="@style/map_shadowcontainer"
         android:layout_toRightOf="@id/container_individualroute"
+        android:layout_marginLeft="2dp"
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_wherigo_popup"

--- a/main/src/main/res/layout/map_settings_button.xml
+++ b/main/src/main/res/layout/map_settings_button.xml
@@ -15,7 +15,7 @@
         <ImageButton
             android:id="@+id/map_settings_popup"
             android:src="@drawable/map_quick_settings"
-            style="@style/map_quicksettingsbutton"
+            style="@style/map_overlaybutton_bg"
             android:tooltipText="@string/quick_settings"
             android:contentDescription="@string/quick_settings"/>
     </LinearLayout>
@@ -28,7 +28,7 @@
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_individualroute_popup"
-            style="@style/map_quicksettingsbutton"
+            style="@style/map_overlaybutton_bg"
             android:src="@drawable/map_quick_route"
             android:tooltipText="@string/routes_tracks_dialog_title"
             android:contentDescription="@string/routes_tracks_dialog_title"/>
@@ -42,7 +42,7 @@
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_wherigo_popup"
-            style="@style/map_quicksettingsbutton"
+            style="@style/map_overlaybutton_bg"
             android:src="@drawable/map_quick_wherigo"
             android:tooltipText="@string/wherigo_player"
             android:contentDescription="@string/wherigo_player"/>

--- a/main/src/main/res/layout/map_settings_button.xml
+++ b/main/src/main/res/layout/map_settings_button.xml
@@ -22,7 +22,6 @@
         android:id="@+id/container_individualroute"
         style="@style/map_shadowcontainer"
         android:layout_toRightOf="@id/container_settings"
-        android:layout_marginLeft="-2dp"
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_individualroute_popup"
@@ -35,7 +34,6 @@
         android:id="@+id/container_wherigo"
         style="@style/map_shadowcontainer"
         android:layout_toRightOf="@id/container_individualroute"
-        android:layout_marginLeft="-2dp"
         android:visibility="gone">
         <ImageButton
             android:id="@+id/map_wherigo_popup"

--- a/main/src/main/res/layout/map_zoom_control.xml
+++ b/main/src/main/res/layout/map_zoom_control.xml
@@ -9,8 +9,7 @@
         style="@style/map_shadowcontainer"
         android:layout_above="@id/container_zoom"
         android:layout_alignParentRight="true"
-        android:layout_marginRight="11dp"
-        android:layout_marginBottom="-4dp">
+        android:layout_marginRight="11dp">
         <ImageButton
             android:id="@+id/map_followmylocation_btn"
             android:src="@drawable/map_followmylocation_btn"

--- a/main/src/main/res/layout/map_zoom_control.xml
+++ b/main/src/main/res/layout/map_zoom_control.xml
@@ -13,8 +13,8 @@
         android:layout_marginBottom="6dp">
         <ImageButton
             android:id="@+id/map_followmylocation_btn"
-            android:src="@drawable/map_quick_settings"
-            style="@style/map_quicksettingsbutton"
+            android:src="@drawable/map_followmylocation_btn"
+            style="@style/map_overlaybutton_bg"
             android:tooltipText="@string/menu_centerposition"
             android:contentDescription="@string/menu_centerposition"/>
     </RelativeLayout>
@@ -31,18 +31,21 @@
         android:layout_marginBottom="18dp">
         <ImageButton
             android:id="@+id/map_zoomin"
-            android:src="@drawable/map_zoomin"
+            android:src="@drawable/map_zoomin_btn"
             android:contentDescription="@string/zoom_in"
-            style="@style/map_zoombutton" />
+            style="@style/map_overlaybutton"
+            android:background="@drawable/map_button_background_top" />
         <ImageButton
             android:id="@+id/map_zoomdivider"
             android:src="@drawable/map_zoom_divider"
             android:layout_height="1dp"
-            style="@style/map_zoombutton" />
+            style="@style/map_overlaybutton"
+            android:background="@drawable/mark_transparent" />
         <ImageButton
             android:id="@+id/map_zoomout"
-            android:src="@drawable/map_zoomout"
+            android:src="@drawable/map_zoomout_btn"
             android:contentDescription="@string/zoom_out"
-            style="@style/map_zoombutton" />
+            style="@style/map_overlaybutton"
+            android:background="@drawable/map_button_background_bottom" />
     </LinearLayout>
 </RelativeLayout>

--- a/main/src/main/res/layout/map_zoom_control.xml
+++ b/main/src/main/res/layout/map_zoom_control.xml
@@ -9,8 +9,8 @@
         style="@style/map_shadowcontainer"
         android:layout_above="@id/container_zoom"
         android:layout_alignParentRight="true"
-        android:layout_marginRight="9dp"
-        android:layout_marginBottom="-2dp">
+        android:layout_marginRight="11dp"
+        android:layout_marginBottom="-4dp">
         <ImageButton
             android:id="@+id/map_followmylocation_btn"
             android:src="@drawable/map_followmylocation_btn"
@@ -26,8 +26,8 @@
         android:layout_alignParentRight="true"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
-        android:layout_marginRight="9dp"
-        android:layout_marginBottom="14dp">
+        android:layout_marginRight="11dp"
+        android:layout_marginBottom="12dp">
         <ImageButton
             android:id="@+id/map_zoomin"
             android:src="@drawable/map_zoomin_btn"

--- a/main/src/main/res/layout/map_zoom_control.xml
+++ b/main/src/main/res/layout/map_zoom_control.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_height="fill_parent"
+    android:elevation="0dp">
 
     <RelativeLayout
         android:id="@+id/container_followmylocation"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/map_shadowcontainer"
         android:layout_above="@id/container_zoom"
         android:layout_alignParentRight="true"
-        android:layout_marginRight="13dp"
-        android:layout_marginBottom="6dp">
+        android:layout_marginRight="9dp"
+        android:layout_marginBottom="-2dp">
         <ImageButton
             android:id="@+id/map_followmylocation_btn"
             android:src="@drawable/map_followmylocation_btn"
@@ -22,13 +22,12 @@
     <LinearLayout
         android:id="@+id/container_zoom"
         android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/map_shadowcontainer"
         android:layout_alignParentRight="true"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
-        android:layout_marginRight="13dp"
-        android:layout_marginBottom="18dp">
+        android:layout_marginRight="9dp"
+        android:layout_marginBottom="14dp">
         <ImageButton
             android:id="@+id/map_zoomin"
             android:src="@drawable/map_zoomin_btn"

--- a/main/src/main/res/values/colors.xml
+++ b/main/src/main/res/values/colors.xml
@@ -20,7 +20,7 @@
     <color name="colorTextActionBar">#FFE4E4E4</color>
 
     <color name="osm_zoomcontrol">#FF666666</color>
-    <color name="osm_zoomcontrolbackground">#D9FFFFFF</color>
+    <color name="osm_zoomcontrolbackground">#FFFFFFFF</color>
 
     <!-- default colors for map lines -->
 

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -528,7 +528,7 @@
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:padding">8dp</item>
-        <item name="android:elevation">1dp</item>
+        <item name="android:elevation">2dp</item>
     </style>
     <style name="map_overlaybutton_bg" parent="map_overlaybutton">
         <item name="android:background">@drawable/map_button_background</item>
@@ -537,7 +537,10 @@
     <style name="map_shadowcontainer">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:padding">4dp</item>
+        <item name="android:paddingBottom">6dp</item>
+        <item name="android:paddingTop">2dp</item>
+        <item name="android:paddingLeft">2dp</item>
+        <item name="android:paddingRight">2dp</item>
         <item name="android:clipToPadding">false</item>
     </style>
 

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -529,11 +529,8 @@
         <item name="android:insetBottom">0dp</item>
         <item name="android:padding">8dp</item>
     </style>
-    <style name="map_quicksettingsbutton" parent="map_overlaybutton">
-        <item name="android:background">@drawable/white_bcg</item>
-    </style>
-    <style name="map_zoombutton" parent="map_overlaybutton">
-        <item name="android:background">@drawable/mark_transparent</item>
+    <style name="map_overlaybutton_bg" parent="map_overlaybutton">
+        <item name="android:background">@drawable/map_button_background</item>
     </style>
 
     <!-- authorization styles -->

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -528,9 +528,17 @@
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:padding">8dp</item>
+        <item name="android:elevation">1dp</item>
     </style>
     <style name="map_overlaybutton_bg" parent="map_overlaybutton">
         <item name="android:background">@drawable/map_button_background</item>
+    </style>
+
+    <style name="map_shadowcontainer">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:padding">4dp</item>
+        <item name="android:clipToPadding">false</item>
     </style>
 
     <!-- authorization styles -->


### PR DESCRIPTION
As requested by @moving-bits a [long time ago](https://github.com/cgeo/cgeo/pull/13063#issuecomment-1146778743) this PR now adds a shadow effect to all map buttons (zoom, quick settings, location, compass).

Small but unavoidable side effect: The buttons get a bit darker. This is because the buttons have white background with a slight transparency and the shadow is drawn behind the whole button - so also behind the transparent part.
As the buttons are already #FFF there's no way to make them whiter to offset the shadow. Reducing the transparency would make them whiter - but also less transparent, which they already are only slightly.

Alternative: We remove the transparency completly. (Transparency levels between old and none don't work, even old has only little transparency, any tuning very quickly arrives at no transparency)

(this PR relies on/includes https://github.com/cgeo/cgeo/pull/16290)

| Before | After |
| :---:   | :---: |
| ![Screenshot_20241031_190942](https://github.com/user-attachments/assets/1a53372b-52e8-43ba-b1ac-689a2cfa1c52) | ![Screenshot_20241031_201203](https://github.com/user-attachments/assets/860dc1c1-10ff-4604-a813-eab9662b5f6c) |

| darker transparent buttons = After | Non-transparent buttons | 
| :---: | :---: |
| ![Screenshot_20241031_201203](https://github.com/user-attachments/assets/860dc1c1-10ff-4604-a813-eab9662b5f6c) | ![Screenshot_20241031_201311](https://github.com/user-attachments/assets/b71ac98e-c020-4bb8-9e24-d9cbcce334a2) |



