### PR TITLE
move needs maintenance attribute to own category

### DIFF
--- a/main/src/main/java/cgeo/geocaching/enumerations/CacheAttribute.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/CacheAttribute.java
@@ -63,7 +63,7 @@ public enum CacheAttribute {
     THORN(CacheAttributeCategory.CAT_LOCATION, 39, 63, "thorn", R.drawable.attribute_thorn, R.string.attribute_thorn_yes, R.string.attribute_thorn_no),
     STEALTH(CacheAttributeCategory.CAT_LOCATION, 40, 74, "stealth", R.drawable.attribute_stealth, R.string.attribute_stealth_yes, R.string.attribute_stealth_no),
     STROLLER(CacheAttributeCategory.CAT_SURROUNDINGS, 41, -1, "stroller", R.drawable.attribute_stroller, R.string.attribute_stroller_yes, R.string.attribute_stroller_no),
-    FIRSTAID(CacheAttributeCategory.CAT_SURROUNDINGS, 42, -1, "firstaid", R.drawable.attribute_firstaid, R.string.attribute_firstaid_yes, R.string.attribute_firstaid_no),
+    FIRSTAID(CacheAttributeCategory.CAT_STATUS, 42, -1, "firstaid", R.drawable.attribute_firstaid, R.string.attribute_firstaid_yes, R.string.attribute_firstaid_no),
     COW(CacheAttributeCategory.CAT_SURROUNDINGS, 43, -1, "cow", R.drawable.attribute_cow, R.string.attribute_cow_yes, R.string.attribute_cow_no),
     FLASHLIGHT(CacheAttributeCategory.CAT_TOOLS, 44, 52, "flashlight", R.drawable.attribute_flashlight, R.string.attribute_flashlight_yes, R.string.attribute_flashlight_no),
     LANDF(CacheAttributeCategory.CAT_TYPE, 45, -1, "landf", R.drawable.attribute_landf, R.string.attribute_landf_yes, R.string.attribute_landf_no),

--- a/main/src/main/java/cgeo/geocaching/enumerations/CacheAttributeCategory.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/CacheAttributeCategory.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum CacheAttributeCategory {
+    CAT_STATUS(0, R.string.cat_status, R.color.attribute_category_status, R.color.attribute_category_status, R.color.attribute_category_status),
     CAT_TOOLS(10, R.string.cat_tools, R.color.attribute_category_tools, R.color.attribute_category_tools_disabled, R.color.attribute_category_tools_negative),
     CAT_TYPE(20, R.string.cat_type, R.color.attribute_category_type, R.color.attribute_category_type_disabled),
     CAT_LOCATION(30, R.string.cat_location, R.color.attribute_category_location, R.color.attribute_category_location_disabled),
@@ -61,7 +62,7 @@ public enum CacheAttributeCategory {
     }
 
     public static List<CacheAttributeCategory> getOrderedCategoryList() {
-        return new ArrayList<>(Arrays.asList(CAT_TOOLS, CAT_DURATION, CAT_LOCATION, CAT_TYPE, CAT_SURROUNDINGS, CAT_PERMISSIONS));
+        return new ArrayList<>(Arrays.asList(CAT_STATUS, CAT_TOOLS, CAT_DURATION, CAT_LOCATION, CAT_TYPE, CAT_SURROUNDINGS, CAT_PERMISSIONS));
     }
 
     public ColorStateList getCategoryColorStateList(final Boolean state) {

--- a/main/src/main/res/values/colors.xml
+++ b/main/src/main/res/values/colors.xml
@@ -71,6 +71,7 @@
     <color name="marker_rating_45">#ffe64a19</color>
     <color name="marker_rating_50">#ffd32f2f</color>
 
+    <color name="attribute_category_status">#ffC62828</color>
     <color name="attribute_category_tools">#ff7f0000</color>
     <color name="attribute_category_tools_negative">#ff000000</color>
     <color name="attribute_category_type">#ff4e342e</color>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2414,6 +2414,7 @@
     <string name="attribute_unknown">Unknown attribute</string>
 
     <!-- cache attribute categories -->
+    <string name="cat_status">Cache status</string>
     <string name="cat_tools">Equipment</string>
     <string name="cat_type">Type</string>
     <string name="cat_location">Cache location</string>


### PR DESCRIPTION
move the "firstaid" attribute which is only used on GC for "needs maintenance" to its own category:
![image](https://github.com/user-attachments/assets/b29a5f23-f5aa-42c5-bea3-448af9aaa1a4)
![image](https://github.com/user-attachments/assets/5a84f85f-4a1a-400a-b008-4a81b0d8da65)


fixes #16297