### PR TITLE
wig gui

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1276,7 +1276,8 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             binding.removeFromWatchlist.setOnClickListener(new RemoveFromWatchlistClickListener());
             updateWatchlistBox(activity);
 
-            // WhereYouGo, ChirpWolf, Adventure Lab
+            // internal WIG player, WhereYouGo, ChirpWolf, Adventure Lab
+            updateWherIGoBox(activity);
             updateWhereYouGoBox(activity);
             updateChirpWolfBox(activity);
             updateALCBox(activity);
@@ -1598,7 +1599,11 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (isEnabled) {
                 CacheUtils.setWherigoLink(activity, cache, binding.sendToWhereyougo);
             }
-            binding.playInCgeo.setVisibility(isEnabled && Settings.enableFeatureWherigo() ? View.VISIBLE : View.GONE);
+        }
+
+        private void updateWherIGoBox(final CacheDetailActivity activity) {
+            final boolean isEnabled = WhereYouGoApp.isWherigo(cache);
+            binding.wherigoBox.setVisibility(isEnabled && Settings.enableFeatureWherigo() ? View.VISIBLE : View.GONE);
             binding.playInCgeo.setOnClickListener(v -> WherigoActivity.startForGuid(activity, WhereYouGoApp.getWhereIGoGuid(cache), cache.getGeocode(), true));
         }
 

--- a/main/src/main/java/cgeo/geocaching/enumerations/QuickLaunchItem.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/QuickLaunchItem.java
@@ -67,7 +67,7 @@ public class QuickLaunchItem extends InfoItem {
 
     static {
         if (Settings.enableFeatureWherigo()) {
-            ITEMS.add(new QuickLaunchItem(VALUES.WHERIGO, R.string.wherigo_short, R.drawable.type_marker_wherigo, false));
+            ITEMS.add(new QuickLaunchItem(VALUES.WHERIGO, R.string.wherigo_short, R.drawable.ic_menu_wherigo, false));
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
@@ -169,7 +169,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
                         getDisplayableDistance(LocationDataProvider.getInstance().currentGeo().getCoords(),
                                 new Geopoint(info.getCartridgeFile().latitude, info.getCartridgeFile().longitude));
                 final byte[] iconData = info.getIconData();
-                final ImageParam icon = iconData == null ? ImageParam.id(R.drawable.type_marker_wherigo) :
+                final ImageParam icon = iconData == null ? ImageParam.id(R.drawable.ic_menu_wherigo) :
                         ImageParam.drawable(getDrawableForImageData(null, iconData));
 
                 final WherigolistItemBinding binding = WherigolistItemBinding.bind(view);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoDialogManager.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoDialogManager.java
@@ -233,7 +233,7 @@ public class WherigoDialogManager {
         final String content = LocalizationUtils.getString(R.string.wherigo_notification_waiting, WherigoGame.get().getCartridgeName());
         final Context context = CgeoApplication.getInstance();
         Notifications.send(context, Notifications.ID_WHERIGO_NEW_DIALOG_ID, NotificationChannels.WHERIGO_NOTIFICATION, builder -> builder
-            .setSmallIcon(R.drawable.type_marker_wherigo)
+            .setSmallIcon(R.drawable.ic_menu_wherigo)
             // deliberately set notification info to both title and content, as some devices
             // show title first (and content is cut off)
             .setContentTitle(content)

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoGameService.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoGameService.java
@@ -48,7 +48,7 @@ public class WherigoGameService extends Service {
         final String content = LocalizationUtils.getString(R.string.wherigo_notification_service);
         serviceDisposables.add(geoDirHandler.start(GeoDirHandler.UPDATE_GEODIR));
         startForeground(Notifications.ID_WHERIGO_SERVICE_NOTIFICATION_ID, Notifications.newBuilder(this, NotificationChannels.WHERIGO_NOTIFICATION)
-            .setSmallIcon(R.drawable.type_marker_wherigo)
+            .setSmallIcon(R.drawable.ic_menu_wherigo)
             .setContentTitle(content)
             .setContentText(content)
             .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, WherigoActivity.class), ProcessUtils.getFlagImmutable()))

--- a/main/src/main/res/drawable/ic_menu_wherigo.xml
+++ b/main/src/main/res/drawable/ic_menu_wherigo.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+  <path
+      android:pathData="m12.002,2c-2.563,0 -5.126,0.975 -7.076,2.925 -3.899,3.899 -3.899,10.252 0,14.151 3.899,3.899 10.252,3.899 14.151,0 3.348,-3.348 3.818,-8.504 1.417,-12.364l-1.117,2.272c1.182,2.88 0.602,6.303 -1.743,8.648 -3.119,3.119 -8.145,3.119 -11.264,0s-3.119,-8.145 0,-11.264c2.345,-2.345 5.768,-2.928 8.648,-1.746l2.272,-1.117c-1.612,-1.003 -3.45,-1.506 -5.288,-1.506z"
+      android:fillColor="#fff" />
+  <path
+      android:pathData="m6.132,11.276 l12.973,-6.379 -6.379,12.973z"
+      android:fillColor="#fff"/>
+</vector>

--- a/main/src/main/res/layout/cachedetail_details_page.xml
+++ b/main/src/main/res/layout/cachedetail_details_page.xml
@@ -119,6 +119,47 @@
             </RelativeLayout>
         </LinearLayout>
 
+        <!-- Internal WherIGo player box -->
+
+        <LinearLayout
+            android:id="@+id/wherigo_box"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <View
+                style="@style/separator_horizontal"
+                android:layout_marginBottom="9dp"
+                android:layout_marginTop="9dp" />
+
+            <RelativeLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" >
+
+                <TextView
+                    android:id="@+id/wherigo_text"
+                    android:text="@string/cache_wherigo_start"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_centerVertical="true"
+                    android:layout_gravity="left"
+                    android:layout_marginLeft="6dip"
+                    android:layout_marginRight="100dip"
+                    android:paddingRight="3dip"
+                    android:textSize="@dimen/textSize_detailsSecondary"
+                    android:textColor="@color/colorText"
+                    android:textIsSelectable="false" />
+
+                <Button
+                    android:id="@+id/play_in_cgeo"
+                    android:layout_alignParentRight="true"
+                    style="@style/button_icon"
+                    app:icon="@drawable/ic_menu_wherigo"/>
+            </RelativeLayout>
+        </LinearLayout>
+
         <!-- WhereYouGo box -->
 
         <LinearLayout
@@ -150,16 +191,7 @@
                     android:paddingRight="3dip"
                     android:textSize="@dimen/textSize_detailsSecondary"
                     android:textColor="@color/colorText"
-                    tools:text="Send to WhereYouGo"
                     android:textIsSelectable="false" />
-
-                <Button
-                    android:id="@+id/play_in_cgeo"
-                    style="@style/button_icon_accent"
-                    android:layout_toLeftOf="@+id/send_to_whereyougo"
-                    app:icon="@drawable/ic_menu_select_play"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
 
                 <Button
                     android:id="@+id/send_to_whereyougo"

--- a/main/src/main/res/layout/wherigo_activity.xml
+++ b/main/src/main/res/layout/wherigo_activity.xml
@@ -43,13 +43,13 @@
 
             <Button
                 android:id="@+id/view_cartridges"
-                style="@style/button_icon_accent"
+                style="@style/button_icon"
                 android:tooltipText="@string/wherigo_controls_cartridgelist_hint"
                 app:icon="@drawable/ic_menu_select_play" />
 
             <Button
                 android:id="@+id/download"
-                style="@style/button_icon_accent"
+                style="@style/button_icon"
                 android:tooltipText="@string/wherigo_controls_downloadcartridge_hint"
                 app:icon="@drawable/wherigo_download" />
 
@@ -58,7 +58,7 @@
 
             <Button
                 android:id="@+id/report_problem"
-                style="@style/button_icon_accent"
+                style="@style/button_icon"
                 android:tooltipText="@string/wherigo_controls_reportproblem_hint"
                 app:icon="@drawable/ic_menu_bug_report" />
 
@@ -97,7 +97,7 @@
                     android:text="@string/wherigo_controls_cache_link"/>
                 <Button
                     android:id="@+id/cache_context_remove"
-                    style="@style/button_icon_accent"
+                    style="@style/button_icon"
                     android:layout_alignParentRight="true"
                     app:icon="@drawable/ic_menu_delete" />
             </RelativeLayout>
@@ -126,25 +126,25 @@
 
                 <Button
                     android:id="@+id/load_game"
-                    style="@style/button_icon_accent"
+                    style="@style/button_icon"
                     android:tooltipText="@string/wherigo_controls_loadgame_hint"
                     app:icon="@drawable/wherigo_load" />
 
                 <Button
                     android:id="@+id/save_game"
-                    style="@style/button_icon_accent"
+                    style="@style/button_icon"
                     android:tooltipText="@string/wherigo_controls_savegame_hint"
                     app:icon="@drawable/wherigo_save" />
 
                 <Button
                     android:id="@+id/stop_game"
-                    style="@style/button_icon_accent"
+                    style="@style/button_icon"
                     android:tooltipText="@string/wherigo_controls_stopgame_hint"
                     app:icon="@drawable/wherigo_close" />
 
                 <Button
                     android:id="@+id/map"
-                    style="@style/button_icon_accent"
+                    style="@style/button_icon"
                     android:tooltipText="@string/wherigo_controls_mapzones_hint"
                     app:icon="@drawable/ic_menu_mapmode" />
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1707,6 +1707,7 @@
     <string name="cachedetails_progress_favorite">Added to favorites</string>
     <string name="cachedetails_progress_unfavorite">Removed from favorites</string>
 
+    <string name="cache_wherigo_start">Download and play this WherIGo using c:geo\'s internal player</string>
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>
     <string name="cache_chirpwolf_start">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can open Chirp Wolf.</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1707,7 +1707,7 @@
     <string name="cachedetails_progress_favorite">Added to favorites</string>
     <string name="cachedetails_progress_unfavorite">Removed from favorites</string>
 
-    <string name="cache_wherigo_start">Download and play this WherIGo using c:geo\'s internal player</string>
+    <string name="cache_wherigo_start">Download and play this Wherigo using c:geo\'s internal player</string>
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>
     <string name="cache_chirpwolf_start">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can open Chirp Wolf.</string>


### PR DESCRIPTION
- separate drawable for internal WIG player with correct size

![image](https://github.com/user-attachments/assets/f0642a9d-a63c-4144-ae07-fbc5ed1f4feb)

- separate box on CacheDetailsActivity with its own explanatory text
![image](https://github.com/user-attachments/assets/5ecc786b-030d-4ae7-9c43-6836b4b9d3e3)

- remove the accent style from WIG buttons - this is not used anywhere in c:geo and so shouldn't be used for WIGs either
before
![image](https://github.com/user-attachments/assets/5e361a6b-2272-449b-bc1a-708f9cd7c4e0)

after
![image](https://github.com/user-attachments/assets/86f42283-074e-4804-b847-0511105b4c7c)
