### PR TITLE
don't enable live map for WIG mapping

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
@@ -146,4 +146,12 @@ public final class DefaultMap {
             mapType.launchMap(fromActivity);
         }
     }
+
+    public static void startActivityWherigoMap(final Activity fromActivity, final Viewport viewport, final String mapTitle) {
+        if (Settings.useUnifiedMap()) { // only supported for UnifiedMap
+            Log.e("Launching UnifiedMap in viewport mode, viewport=" + viewport + ")");
+            final UnifiedMapType mapType = viewport == null ? new UnifiedMapType() : new UnifiedMapType(viewport, mapTitle);
+            mapType.launchMap(fromActivity);
+        }
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -55,6 +55,13 @@ public class UnifiedMapType implements Parcelable {
         this.viewport = viewport;
     }
 
+    /** open map and scale to a given viewport */
+    public UnifiedMapType(final Viewport viewport, final String title) {
+        type = UnifiedMapTypeType.UMTT_Viewport;
+        this.viewport = viewport;
+        this.title = title;
+    }
+
     /** set geocode as target */
     public UnifiedMapType(final String geocode) {
         type = UnifiedMapTypeType.UMTT_TargetGeocode;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -105,7 +105,7 @@ public class UnifiedMapType implements Parcelable {
     }
 
     public boolean enableLiveMap() {
-        return type == UnifiedMapTypeType.UMTT_PlainMap || type == UnifiedMapTypeType.UMTT_TargetCoords || type == UnifiedMapTypeType.UMTT_Viewport;
+        return type == UnifiedMapTypeType.UMTT_PlainMap || type == UnifiedMapTypeType.UMTT_TargetCoords;
     }
     // ========================================================================
     // parcelable methods

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
@@ -211,7 +211,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         final List<Zone> zones = WherigoThingType.LOCATION.getThingsForUserDisplay(Zone.class);
         final Viewport viewport = WherigoUtils.getZonesViewport(zones);
         if (viewport != null && !viewport.isJustADot()) {
-            DefaultMap.startActivityViewport(this, viewport);
+            DefaultMap.startActivityWherigoMap(this, viewport, WherigoGame.get().getCartridgeName());
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
@@ -105,7 +105,7 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
                     switch (thingAction) {
                         case DISPLAY_ON_MAP:
                             control.dismiss();
-                            DefaultMap.startActivityViewport(activity, WherigoUtils.getZonesViewport(Collections.singleton((Zone) eventTable)));
+                            DefaultMap.startActivityWherigoMap(activity, WherigoUtils.getZonesViewport(Collections.singleton((Zone) eventTable)), eventTable.name);
                             break;
                         case LOCATE_ON_CENTER:
                             control.dismiss();


### PR DESCRIPTION
if map filter context is explicitly set to GeocacheFilterContext.FilterType.TRANSIENT don't enable Live mode, no matter what map type is displayed

@moving-bits there's a lot of "magic" happening in determining when to show which caches (only selected, stored, live) that's quite intransparent even after debugging this code. Thus I'm asking for your review as most of this seems to come from you.
Maybe this magic could also be replaced by a more transparent implementation, but I fear that'd be a big rewrite. Or maybe it's not so magic after all and I'm just missing something??

fixes https://github.com/cgeo/cgeo/issues/16338