### PR TITLE
optimize space usage in search activity

### DIFF
--- a/main/src/main/res/layout/search_activity.xml
+++ b/main/src/main/res/layout/search_activity.xml
@@ -37,7 +37,7 @@
                 android:id="@+id/search_filter_info"
                 android:layout_width="36dp"
                 android:layout_height="36dp"
-                app:srcCompat="@drawable/settings_info"
+                app:srcCompat="@drawable/ic_menu_help"
                 android:layout_marginLeft="0dp"
                 android:layout_marginRight="10dp"
                 android:layout_alignParentRight="true"
@@ -53,24 +53,31 @@
                 android:text="@string/search_geo" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/geocode_input_layout"
-            style="@style/textinput_autocompletetextview"
-            android:hint="@string/search_geo" android:labelFor="@id/geocode">
-            <AutoCompleteTextView
-                android:id="@+id/geocode"
-                style="@style/textinput_embedded_singleline_go"
-                android:text="GC"
-                tools:ignore="HardcodedText"
-                android:inputType="textVisiblePassword"
-                android:importantForAutofill="no" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
 
-        <Button
-            android:id="@+id/display_geocode"
-            style="@style/button_full"
-            android:text="@string/search_geo_button" />
-        <!-- ** -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/geocode_input_layout"
+                style="@style/textinput_autocompletetextview"
+                android:layout_toLeftOf="@+id/display_geocode"
+                android:hint="@string/search_geo" android:labelFor="@id/geocode">
+                <AutoCompleteTextView
+                    android:id="@+id/geocode"
+                    style="@style/textinput_embedded_singleline_go"
+                    android:text="GC"
+                    tools:ignore="HardcodedText"
+                    android:inputType="textVisiblePassword"
+                    android:importantForAutofill="no" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/display_geocode"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+        </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
             <View style="@style/separator_horizontal_heading" />
@@ -79,16 +86,24 @@
                 android:text="@string/search_coordinates" />
         </RelativeLayout>
 
-        <Button
-            android:id="@+id/buttonLatLongitude"
-            style="@style/button_full_double"
-            android:hint="@string/latlongitude" />
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
 
-        <Button
-            android:id="@+id/search_coordinates"
-            style="@style/button_full"
-            android:text="@string/search_coordinates_button" />
-        <!-- ** -->
+            <Button
+                android:id="@+id/buttonLatLongitude"
+                style="@style/button_full_double"
+                android:layout_toLeftOf="@+id/search_coordinates"
+                android:hint="@string/latlongitude" />
+
+            <Button
+                android:id="@+id/search_coordinates"
+                android:tooltipText="@string/search_coordinates_button"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+        </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
             <View style="@style/separator_horizontal_heading" />
@@ -97,18 +112,26 @@
                 android:text="@string/search_address" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/search_address" android:labelFor="@id/address">
-            <AutoCompleteTextView
-                android:id="@+id/address"
-                style="@style/textinput_embedded_singleline_go" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
 
-        <Button
-            android:id="@+id/search_address"
-            style="@style/button_full"
-            android:text="@string/search_address_button" />
-        <!-- ** -->
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+                android:layout_toLeftOf="@+id/search_address"
+                android:hint="@string/search_address" android:labelFor="@id/address">
+                <AutoCompleteTextView
+                    android:id="@+id/address"
+                    style="@style/textinput_embedded_singleline_go" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/search_address"
+                android:tooltipText="@string/search_address_button"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+        </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
             <View style="@style/separator_horizontal_heading" />
@@ -117,26 +140,35 @@
                 android:text="@string/search_kw" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/search_kw_prefill" android:labelFor="@id/keyword">
-            <AutoCompleteTextView
-                android:id="@+id/keyword"
-                style="@style/textinput_embedded_singleline_go" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <Button
-            android:id="@+id/search_keyword"
-            style="@style/button_full"
-            android:text="@string/search_kw_button" />
-        <TextView
-            android:id="@+id/search_keyword_disabled_hint"
-            android:layout_width="match_parent"
+        <RelativeLayout
             android:layout_height="wrap_content"
-            android:layout_marginLeft="6dip"
-            android:layout_marginRight="6dip"
-            android:text="@string/search_kw_disabled_hint"
-            android:visibility="gone" />
-        <!-- ** -->
+            android:layout_width="match_parent">
+
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+                android:layout_toLeftOf="@+id/search_keyword"
+                android:hint="@string/search_kw_prefill" android:labelFor="@id/keyword">
+                <AutoCompleteTextView
+                    android:id="@+id/keyword"
+                    style="@style/textinput_embedded_singleline_go" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/search_keyword"
+                android:tooltipText="@string/search_kw_button"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+
+            <TextView
+                android:id="@+id/search_keyword_disabled_hint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:text="@string/search_kw_disabled_hint"
+                android:visibility="gone" />
+        </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
             <View style="@style/separator_horizontal_heading" />
@@ -145,18 +177,26 @@
                 android:text="@string/search_hbu" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/search_hbu_prefill" android:labelFor="@id/owner">
-            <AutoCompleteTextView
-                android:id="@+id/owner"
-                style="@style/textinput_embedded_singleline_go" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
 
-        <Button
-            android:id="@+id/search_owner"
-            style="@style/button_full"
-            android:text="@string/search_hbu_button" />
-        <!-- ** -->
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+                android:layout_toLeftOf="@+id/search_owner"
+                android:hint="@string/search_hbu_prefill" android:labelFor="@id/owner">
+                <AutoCompleteTextView
+                    android:id="@+id/owner"
+                    style="@style/textinput_embedded_singleline_go" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/search_owner"
+                android:tooltipText="@string/search_hbu_button"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+        </RelativeLayout>
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
             <View style="@style/separator_horizontal_heading" />
@@ -165,18 +205,26 @@
                 android:text="@string/search_finder" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/search_finder_prefill" android:labelFor="@id/finder">
-            <AutoCompleteTextView
-                android:id="@+id/finder"
-                style="@style/textinput_embedded_singleline_go" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
 
-        <Button
-            android:id="@+id/search_finder"
-            style="@style/button_full"
-            android:text="@string/search_finder_button" />
-        <!-- ** -->
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+                android:layout_toLeftOf="@+id/search_finder"
+                android:hint="@string/search_finder_prefill" android:labelFor="@id/finder">
+                <AutoCompleteTextView
+                    android:id="@+id/finder"
+                    style="@style/textinput_embedded_singleline_go" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/search_finder"
+                android:tooltipText="@string/search_finder_button"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+        </RelativeLayout>
 
 
         <RelativeLayout style="@style/separator_horizontal_layout" >
@@ -186,19 +234,28 @@
                 android:text="@string/search_tb" />
         </RelativeLayout>
 
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/search_tb_hint" android:labelFor="@id/trackable">
-            <AutoCompleteTextView
-                android:id="@+id/trackable"
-                style="@style/textinput_embedded_singleline_go"
-                android:inputType="textVisiblePassword"
-                android:importantForAutofill="no" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <RelativeLayout
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent">
 
-        <Button
-            android:id="@+id/display_trackable"
-            style="@style/button_full"
-            android:text="@string/search_tb_button" />
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+                android:layout_toLeftOf="@+id/display_trackable"
+                android:hint="@string/search_tb_hint" android:labelFor="@id/trackable">
+                <AutoCompleteTextView
+                    android:id="@+id/trackable"
+                    style="@style/textinput_embedded_singleline_go"
+                    android:inputType="textVisiblePassword"
+                    android:importantForAutofill="no" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/display_trackable"
+                android:tooltipText="@string/search_tb_button"
+                style="@style/button_icon"
+                android:layout_centerVertical="true"
+                app:icon="@drawable/ic_menu_search"
+                android:layout_alignParentRight="true" />
+        </RelativeLayout>
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
Restyling the search dialog by removing the 3-times duplicated information what to search by turning the button into an icon button

before:
![image](https://github.com/user-attachments/assets/248f09ce-e9ab-4495-96df-88e609bb187f)

after:
![image](https://github.com/user-attachments/assets/49e9cff2-1242-4f67-8f08-6e5f3678353b)