### PR TITLE
Allow changing coordinates for UDC

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -53,6 +53,7 @@ import cgeo.geocaching.log.LogCacheActivity;
 import cgeo.geocaching.log.LoggingUI;
 import cgeo.geocaching.models.CacheArtefactParser;
 import cgeo.geocaching.models.CalculatedCoordinate;
+import cgeo.geocaching.models.CoordinateInputData;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.models.Trackable;
@@ -81,6 +82,7 @@ import cgeo.geocaching.ui.ToggleItemType;
 import cgeo.geocaching.ui.TrackableListAdapter;
 import cgeo.geocaching.ui.UserClickListener;
 import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.ui.dialog.CoordinatesInputDialog;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.EditNoteDialog;
 import cgeo.geocaching.ui.dialog.EditNoteDialog.EditNoteDialogListener;
@@ -101,6 +103,7 @@ import cgeo.geocaching.utils.ImageUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
+import cgeo.geocaching.utils.MenuUtils;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ProgressBarDisposableHandler;
 import cgeo.geocaching.utils.ProgressButtonDisposableHandler;
@@ -187,7 +190,7 @@ import org.apache.commons.text.StringEscapeUtils;
  * e.g. details, description, logs, waypoints, inventory, variables...
  */
 public class CacheDetailActivity extends TabbedViewPagerActivity
-        implements IContactCardProvider, CacheMenuHandler.ActivityInterface, INavigationSource, EditNoteDialogListener {
+        implements IContactCardProvider, CacheMenuHandler.ActivityInterface, INavigationSource, EditNoteDialogListener, CoordinatesInputDialog.CoordinateUpdate {
 
     private static final int MESSAGE_FAILED = -1;
     private static final int MESSAGE_SUCCEEDED = 1;
@@ -666,6 +669,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
         CacheMenuHandler.onPrepareOptionsMenu(menu, cache, false);
         LoggingUI.onPrepareOptionsMenu(menu, cache);
+        MenuUtils.setVisible(menu.findItem(R.id.menu_set_coordinates), isUDC);
 
         if (cache != null) {
             // top level menu items
@@ -728,6 +732,8 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             ShareUtils.openUrl(this, "https://project-gc.com/Challenges/" + cache.getGeocode());
         } else if (menuItem == R.id.menu_ignore) {
             ignoreCache();
+        } else if (menuItem == R.id.menu_set_coordinates) {
+            setCoordinates();
         } else if (menuItem == R.id.menu_extract_waypoints) {
             final String searchText = cache.getShortDescription() + ' ' + cache.getDescription();
             extractWaypoints(searchText, cache);
@@ -790,6 +796,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 DataStore.removeCache(cache.getGeocode(), EnumSet.of(RemoveFlag.DB));
             }
         });
+    }
+
+    private void setCoordinates() {
+        ensureSaved();
+        final CoordinateInputData cid = new CoordinateInputData();
+        cid.setGeopoint(cache.getCoords());
+        cid.setGeocode(cache.getGeocode());
+        CoordinatesInputDialog.show(getSupportFragmentManager(), cid);
     }
 
     private void showVoteDialog() {
@@ -2854,4 +2868,28 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     public void setNeedsRefresh() {
         refreshOnResume = true;
     }
+
+
+    // methods for implementing CoordinateUpdate interface
+
+    @Override
+    public void updateCoordinates(final Geopoint gp) {
+        cache.setCoords(gp);
+        if (cache.isOffline()) {
+            storeCache(cache.getLists());
+        } else {
+            storeCache(false);
+        }
+    };
+
+    @Override
+    public boolean supportsNullCoordinates() {
+        return false;
+    };
+
+    @Override
+    public boolean supportsCalculatedCoordinates() {
+        return false;
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -257,7 +257,7 @@ public class CoordinatesInputDialog extends DialogFragment {
             binding.cache.setVisibility(View.GONE);
         }
 
-        if (inputData.getGeocode() != null) {
+        if (inputData.getGeocode() != null && ((CoordinateUpdate) requireActivity()).supportsCalculatedCoordinates()) {
             binding.calculateGlobal.setVisibility(View.VISIBLE);
             binding.calculateGlobal.setOnClickListener(vv -> {
                 inputData.setGeopoint(gp);
@@ -707,6 +707,10 @@ public class CoordinatesInputDialog extends DialogFragment {
         void updateCoordinates(Geopoint gp);
 
         boolean supportsNullCoordinates();
+
+        default boolean supportsCalculatedCoordinates() {
+            return true;
+        }
 
         default void updateCoordinates(CoordinateInputData coordinateInputData) {
             updateCoordinates(coordinateInputData.getGeopoint());

--- a/main/src/main/res/menu/cache_options.xml
+++ b/main/src/main/res/menu/cache_options.xml
@@ -94,6 +94,11 @@
         android:visible="false">
     </item>
     <item
+        android:id="@+id/menu_set_coordinates"
+        android:icon="@drawable/ic_menu_save"
+        android:title="@string/cache_set_coordinates"
+        android:visible="false"/>
+    <item
         android:id="@+id/menu_waypoints"
         android:title="@string/cache_waypoints"
         app:showAsAction="never"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1519,6 +1519,7 @@
     <string name="cache_premium">Premium</string>
     <string name="cache_inventory">Inventory</string>
     <string name="cache_log_image_default_title">Photo</string>
+    <string name="cache_set_coordinates">Set coordinates</string>
     <string name="cache_personal_note">Personal note</string>
     <string name="cache_menu_preventWaypointsFromNote">Prevent waypoints from note</string>
     <string name="cache_menu_allowWaypointExtraction">Allow waypoints from note</string>


### PR DESCRIPTION
## Description
Allow changing coordinates for UDC by using a menu entry "set coordinates", which opens the coordinate input dialog:

|menu|dialog|calculate|
|---|---|---|
|![image](https://github.com/user-attachments/assets/50b1690e-6c86-4ce7-9b9f-e9b7937f658b)|![image](https://github.com/user-attachments/assets/167b6757-6053-4918-bab8-6d4b3b0244b8)|![image](https://github.com/user-attachments/assets/c18b6ee4-0f60-4323-8f6e-ce0f8db5ae43)|

@eddiemuc 
When using calculated coordinates, I need a `calcStateString`, which would normally be stored in a waypoint. Do we have a place for it on cache level already, and how would I retrieve the new calc string, if a user changes the formula?

Setting WIP label for now