### PR TITLE
UnifiedMap Mapsforge: restrict zoom to min/max zoom (fix #16352)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
@@ -154,7 +154,7 @@ public abstract class AbstractMapFragment extends Fragment {
     }
 
     public int getZoomMax() {
-        return currentTileProvider == null ? 0 : currentTileProvider.getZoomMax();
+        return currentTileProvider == null ? 18 : currentTileProvider.getZoomMax();
     }
 
     public abstract int getCurrentZoom();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -363,7 +363,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
         final int tileSize = mMapView.getModel().displayModel.getTileSize();
         final byte newZoom = LatLongUtils.zoomForBounds(new Dimension(mMapView.getWidth(), mMapView.getHeight()),
                 new org.mapsforge.core.model.BoundingBox(bounds.getMinLatitude(), bounds.getMinLongitude(), bounds.getMaxLatitude(), bounds.getMaxLongitude()), tileSize);
-        mMapView.setZoomLevel(newZoom);
+        setZoom(newZoom);
     }
 
     @Override
@@ -373,7 +373,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
     @Override
     public void setZoom(final int zoomLevel) {
-        mMapView.setZoomLevel((byte) zoomLevel);
+        mMapView.setZoomLevel((byte) Math.max(Math.min(zoomLevel, getZoomMax()), getZoomMin()));
     }
 
     @Override


### PR DESCRIPTION
## Description
Restricts UnifiedMap Mapsforge's zoom to zoom min/max given by tile provider, even for `zoomToBounds()` call (which is called in UMTT_Viewport mode used by WIG player). This is relevant especially for online tile providers, which do not provide map tiles for higher zoom levels.