### PR TITLE
UnifiedMap: Use VTM as default for now

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1275,7 +1275,7 @@ public class Settings {
         try {
             return Integer.parseInt(getString(R.string.pref_unifiedMapVariants, String.valueOf(UNIFIEDMAP_VARIANT_MAPSFORGE)));
         } catch (NumberFormatException ignore) {
-            return UNIFIEDMAP_VARIANT_MAPSFORGE;
+            return UNIFIEDMAP_VARIANT_VTM;
         }
     }
 


### PR DESCRIPTION
## Description
As discussed in today's dev meeting:
Use VTM as default for UnifiedMap for now for smoother update transition for upcoming beta.

This should be changed back to UnifiedMap Mapsforge as soon as we have reached enough stability to make UnifiedMap Mapsforge the default map (and degrade the old map types).