### PR TITLE
Revert "use eventCacheData JS object as event time source"

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -64,7 +64,7 @@ public final class GCConstants {
     static final Pattern PATTERN_TYPE = Pattern.compile("<use xlink:href=\"/app/ui-icons/sprites/cache-types.svg#icon-([0-9a-f]+)");
     static final Pattern PATTERN_HIDDEN = Pattern.compile("ctl00_ContentBody_mcd2[^:]+:\\s*([^<]+?)<");
     static final Pattern PATTERN_HIDDENEVENT = Pattern.compile(":\\s*([0-9-/]+)\\s*<div id=\"calLinks\">", Pattern.DOTALL);
-    static final Pattern PATTERN_EVENTTIMES = Pattern.compile("start: new Date\\([0-9]+, [0-9]+-1, [0-9]+, ([0-9]+), ([0-9]+)\\) , end: new Date\\([0-9]+, [0-9]+-1, [0-9]+, ([0-9]+), ([0-9]+)\\)");
+    static final Pattern PATTERN_EVENTTIMES = Pattern.compile("<div id=\"mcd3\">\\s*[^<]*?\\s+([APM ]*)([0-9]+)[\\.:]([0-9]+)([APM ]*)\\s*</div>\\s*<div id=\"mcd4\">\\s*[^<]*?\\s+([APM ]*)([0-9]+)[\\.:]([0-9]+)([APM ]*)\\s*</div>");
     static final Pattern PATTERN_IS_FAVORITE = Pattern.compile("<div id=\"pnlFavoriteCache\">"); // without 'class="hideMe"' inside the tag !
     static final Pattern PATTERN_FAVORITECOUNT = Pattern.compile("<span class=\"favorite-value\">\\D*([0-9]+?)\\D*</span>");
     static final Pattern PATTERN_COUNTLOGS = Pattern.compile("<span id=\"ctl00_ContentBody_lblFindCounts\"><ul(.+?)</ul></span>");

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -382,18 +382,18 @@ public final class GCParser {
         if (cache.isEventCache()) {
             try {
                 // add event start / end info to beginning of listing
-                final MatcherWrapper eventTimesMatcher = new MatcherWrapper(GCConstants.PATTERN_EVENTTIMES, page);
+                final MatcherWrapper eventTimesMatcher = new MatcherWrapper(GCConstants.PATTERN_EVENTTIMES, tableInside);
                 if (eventTimesMatcher.find()) {
                     sDesc.append("<b>")
                             .append(new SimpleDateFormat("dd MMMM yyyy", Locale.getDefault()).format(cache.getHiddenDate()))
                             .append(", ")
-                            .append(Formatter.formatNumberTwoDigits(eventTimesMatcher.group(1)))
+                            .append(Formatter.formatNumberTwoDigits(Integer.parseInt(eventTimesMatcher.group(2)) + (null != eventTimesMatcher.group(1) && eventTimesMatcher.group(1).trim().equals("PM") ? 12 : 0) + (null != eventTimesMatcher.group(4) && eventTimesMatcher.group(4).trim().equals("PM") ? 12 : 0) - (("12".equals(eventTimesMatcher.group(2))) ? 12 : 0)))
                             .append(":")
-                            .append(Formatter.formatNumberTwoDigits(eventTimesMatcher.group(2)))
-                            .append(" - ")
                             .append(Formatter.formatNumberTwoDigits(eventTimesMatcher.group(3)))
+                            .append(" - ")
+                            .append(Formatter.formatNumberTwoDigits(Integer.parseInt(eventTimesMatcher.group(6)) + (null != eventTimesMatcher.group(5) && eventTimesMatcher.group(5).trim().equals("PM") ? 12 : 0) + (null != eventTimesMatcher.group(8) && eventTimesMatcher.group(8).trim().equals("PM") ? 12 : 0) - (("12".equals(eventTimesMatcher.group(6))) ? 12 : 0)))
                             .append(":")
-                            .append(Formatter.formatNumberTwoDigits(eventTimesMatcher.group(4)))
+                            .append(Formatter.formatNumberTwoDigits(eventTimesMatcher.group(7)))
                             .append("</b>");
                 }
             } catch (Exception e) {

--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -529,4 +529,8 @@ public final class Formatter {
         return String.format(Locale.getDefault(), "%02d", Integer.parseInt(number));
     }
 
+    public static String formatNumberTwoDigits(final int number) {
+        return String.format(Locale.getDefault(), "%02d", number);
+    }
+
 }


### PR DESCRIPTION
revert back to using the HTML as source for event date as that one is in events timezone

see https://github.com/cgeo/cgeo/issues/16367 for discussion