### PR TITLE
Allow deleting offline data from map context (rel. to #16357)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -78,6 +78,9 @@ public class DownloaderUtils {
         if (id == R.id.menu_download_offlinemap) {
             activity.startActivity(new Intent(activity, DownloadSelectorActivity.class));
             return true;
+        } else if (id == R.id.menu_delete_offline_data) {
+            deleteOfflineData(activity);
+            return true;
         }
         return false;
     }

--- a/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
@@ -90,6 +90,7 @@ public class MapProviderFactory {
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_hillshading, mapSources.size(), activity.getString(R.string.settings_hillshading_enable)).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getMapSource().supportsHillshading());
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_download_offlinemap, mapSources.size(), '<' + activity.getString(R.string.downloadmap_title) + '>');
+        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_delete_offline_data, mapSources.size() + 1, '<' + activity.getString(R.string.menu_delete_offline_data) + '>');
     }
 
     @Nullable

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -67,6 +67,7 @@ public class TileProviderFactory {
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_hillshading, tileProviders.size(), activity.getString(R.string.settings_hillshading_enable)).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
         parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_download_offlinemap, tileProviders.size(), '<' + activity.getString(R.string.downloadmap_title) + '>');
+        parentMenu.add(R.id.menu_group_offlinemaps, R.id.menu_delete_offline_data, tileProviders.size() + 1, '<' + activity.getString(R.string.menu_delete_offline_data) + '>');
     }
 
     public static HashMap<String, AbstractTileProvider> getTileProviders() {


### PR DESCRIPTION
## Description
Adds "Delete offline data" to map sources menus, which triggers the offline data selection dialog (same as can be reached via home screen => manage offline data => delete offline data)