### PR TITLE
add filters for special events and other cache types

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/filters/TypeGeocacheFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/TypeGeocacheFilterTest.java
@@ -31,7 +31,7 @@ public class TypeGeocacheFilterTest {
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // is done in called test method
     public void grouping() {
-        singleType(c -> c.setType(CacheType.MEGA_EVENT), f -> f.setValues(new HashSet<>(Collections.singletonList(CacheType.EVENT))), true);
+        singleType(c -> c.setType(CacheType.MEGA_EVENT), f -> f.setValues(new HashSet<>(Collections.singletonList(CacheType.COMMUN_CELEBRATION))), true);
     }
 
     private void singleType(final Action1<Geocache> cacheSetter, final Action1<TypeGeocacheFilter> filterSetter, final Boolean expectedResult) {

--- a/main/src/main/java/cgeo/geocaching/enumerations/CacheType.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/CacheType.java
@@ -42,8 +42,6 @@ public enum CacheType {
     // insert other official cache types before USER_DEFINED and UNKNOWN
     USER_DEFINED("userdefined", "User defined cache", "", R.string.userdefined, R.string.userdefined_short, R.drawable.type_cgeo, R.drawable.type_marker_cgeo, "", R.color.cacheType_cgeo),
     UNKNOWN("unknown", "unknown", "", R.string.unknown, R.string.unknown_short, R.drawable.type_unknown, R.drawable.type_marker_unknown, "", R.color.cacheType_unknown),
-    SPECIALEVENT("event_special", "event_special", "", R.string.event_special, R.string.event_special, R.drawable.type_specialevent, R.drawable.type_marker_specialevent, "", R.color.cacheType_event),
-    OTHER("other", "other", "", R.string.other, R.string.other, R.drawable.type_unknown, R.drawable.type_marker_unknown, "", R.color.cacheType_unknown),
     /**
      * No real cache type -> filter
      */

--- a/main/src/main/java/cgeo/geocaching/enumerations/CacheType.java
+++ b/main/src/main/java/cgeo/geocaching/enumerations/CacheType.java
@@ -42,6 +42,8 @@ public enum CacheType {
     // insert other official cache types before USER_DEFINED and UNKNOWN
     USER_DEFINED("userdefined", "User defined cache", "", R.string.userdefined, R.string.userdefined_short, R.drawable.type_cgeo, R.drawable.type_marker_cgeo, "", R.color.cacheType_cgeo),
     UNKNOWN("unknown", "unknown", "", R.string.unknown, R.string.unknown_short, R.drawable.type_unknown, R.drawable.type_marker_unknown, "", R.color.cacheType_unknown),
+    SPECIALEVENT("event_special", "event_special", "", R.string.event_special, R.string.event_special, R.drawable.type_specialevent, R.drawable.type_marker_specialevent, "", R.color.cacheType_event),
+    OTHER("other", "other", "", R.string.other, R.string.other, R.drawable.type_unknown, R.drawable.type_marker_unknown, "", R.color.cacheType_unknown),
     /**
      * No real cache type -> filter
      */

--- a/main/src/main/java/cgeo/geocaching/filters/core/TypeGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/TypeGeocacheFilter.java
@@ -9,14 +9,13 @@ public class TypeGeocacheFilter extends ValueGroupGeocacheFilter<CacheType, Cach
 
     public TypeGeocacheFilter() {
         //gc.com groups in their search their cache types as follows:
-        //* "Tradi" also includes: GCHQ, PROJECT_APE
-        //* "Event" also includes:CITO,mega,giga, gps_exhibit,commun_celeb, gchq_celeb, block_party
+        //* "Unknown" also includes: Unknown, GCHQ, PROJECT_APE
+        //* "Celebration Event" also includes: mega,giga, gps_exhibit,commun_celeb, gchq_celeb, block_party
         //-> unlike gc.com, currently CITO is an OWN search box below (to make number even)
-        addDisplayValues(CacheType.TRADITIONAL, CacheType.TRADITIONAL, CacheType.GCHQ, CacheType.PROJECT_APE);
-        addDisplayValues(CacheType.EVENT, CacheType.EVENT, CacheType.MEGA_EVENT, CacheType.GIGA_EVENT, CacheType.COMMUN_CELEBRATION,
+        addDisplayValues(CacheType.OTHER, CacheType.UNKNOWN, CacheType.GCHQ, CacheType.PROJECT_APE);
+        addDisplayValues(CacheType.SPECIALEVENT, CacheType.MEGA_EVENT, CacheType.GIGA_EVENT, CacheType.COMMUN_CELEBRATION,
                 CacheType.GCHQ_CELEBRATION, CacheType.GPS_EXHIBIT, CacheType.BLOCK_PARTY);
         addDisplayValues(CacheType.VIRTUAL, CacheType.VIRTUAL, CacheType.LOCATIONLESS);
-        addDisplayValues(CacheType.USER_DEFINED, CacheType.USER_DEFINED, CacheType.UNKNOWN);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/core/TypeGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/TypeGeocacheFilter.java
@@ -1,5 +1,7 @@
 package cgeo.geocaching.filters.core;
 
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.models.Geocache;
 
@@ -9,11 +11,10 @@ public class TypeGeocacheFilter extends ValueGroupGeocacheFilter<CacheType, Cach
 
     public TypeGeocacheFilter() {
         //gc.com groups in their search their cache types as follows:
-        //* "Unknown" also includes: Unknown, GCHQ, PROJECT_APE
-        //* "Celebration Event" also includes: mega,giga, gps_exhibit,commun_celeb, gchq_celeb, block_party
-        //-> unlike gc.com, currently CITO is an OWN search box below (to make number even)
-        addDisplayValues(CacheType.OTHER, CacheType.UNKNOWN, CacheType.GCHQ, CacheType.PROJECT_APE);
-        addDisplayValues(CacheType.SPECIALEVENT, CacheType.MEGA_EVENT, CacheType.GIGA_EVENT, CacheType.COMMUN_CELEBRATION,
+        //* "Unknown" is displayed as "Others" and includes: Unknown, GCHQ, PROJECT_APE
+        //* "Celebration Event" is displayed as "Specials" and includes: mega,giga, gps_exhibit,commun_celeb, gchq_celeb, block_party
+        addDisplayValues(CacheType.UNKNOWN, CacheType.UNKNOWN, CacheType.GCHQ, CacheType.PROJECT_APE);
+        addDisplayValues(CacheType.COMMUN_CELEBRATION, CacheType.MEGA_EVENT, CacheType.GIGA_EVENT, CacheType.COMMUN_CELEBRATION,
                 CacheType.GCHQ_CELEBRATION, CacheType.GPS_EXHIBIT, CacheType.BLOCK_PARTY);
         addDisplayValues(CacheType.VIRTUAL, CacheType.VIRTUAL, CacheType.LOCATIONLESS);
     }
@@ -35,7 +36,7 @@ public class TypeGeocacheFilter extends ValueGroupGeocacheFilter<CacheType, Cach
 
     @Override
     public String valueToUserDisplayableValue(final CacheType value) {
-        return value.getShortL10n();
+        return valueDisplayTextGetter(value);
     }
 
     @Override
@@ -48,5 +49,13 @@ public class TypeGeocacheFilter extends ValueGroupGeocacheFilter<CacheType, Cach
         return value.id;
     }
 
+    public static String valueDisplayTextGetter(final CacheType value) {
+        if (CacheType.UNKNOWN == value) {
+            return CgeoApplication.getInstance().getString(R.string.other);
+        } else if (CacheType.COMMUN_CELEBRATION == value) {
+            return CgeoApplication.getInstance().getString(R.string.event_special);
+        }
+        return value.getShortL10n();
+    }
 
 }

--- a/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -69,7 +69,7 @@ public class FilterViewHolderCreator {
                 result = new CheckboxFilterViewHolder<>(
                         ValueGroupFilterAccessor.<CacheType, TypeGeocacheFilter>createForValueGroupFilter()
                                 .setSelectableValues(Arrays.asList(CacheType.TRADITIONAL, CacheType.MULTI, CacheType.MYSTERY, CacheType.LETTERBOX, CacheType.EVENT,
-                                        CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.ADVLAB, CacheType.USER_DEFINED))
+                                        CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.SPECIALEVENT, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.ADVLAB, CacheType.OTHER, CacheType.USER_DEFINED))
                                 .setValueDisplayTextGetter(CacheType::getShortL10n)
                                 .setValueDrawableGetter(ct -> ImageParam.drawable(MapMarkerUtils.getCacheTypeMarker(activity.getResources(), ct))),
                         2, null);

--- a/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -69,8 +69,8 @@ public class FilterViewHolderCreator {
                 result = new CheckboxFilterViewHolder<>(
                         ValueGroupFilterAccessor.<CacheType, TypeGeocacheFilter>createForValueGroupFilter()
                                 .setSelectableValues(Arrays.asList(CacheType.TRADITIONAL, CacheType.MULTI, CacheType.MYSTERY, CacheType.LETTERBOX, CacheType.EVENT,
-                                        CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.SPECIALEVENT, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.OTHER, CacheType.ADVLAB, CacheType.USER_DEFINED))
-                                .setValueDisplayTextGetter(CacheType::getShortL10n)
+                                        CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.COMMUN_CELEBRATION, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.UNKNOWN, CacheType.ADVLAB, CacheType.USER_DEFINED))
+                                .setValueDisplayTextGetter(ct -> TypeGeocacheFilter.valueDisplayTextGetter(ct))
                                 .setValueDrawableGetter(ct -> ImageParam.drawable(MapMarkerUtils.getCacheTypeMarker(activity.getResources(), ct))),
                         2, null);
                 break;

--- a/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -69,7 +69,7 @@ public class FilterViewHolderCreator {
                 result = new CheckboxFilterViewHolder<>(
                         ValueGroupFilterAccessor.<CacheType, TypeGeocacheFilter>createForValueGroupFilter()
                                 .setSelectableValues(Arrays.asList(CacheType.TRADITIONAL, CacheType.MULTI, CacheType.MYSTERY, CacheType.LETTERBOX, CacheType.EVENT,
-                                        CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.SPECIALEVENT, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.ADVLAB, CacheType.OTHER, CacheType.USER_DEFINED))
+                                        CacheType.EARTH, CacheType.CITO, CacheType.WEBCAM, CacheType.SPECIALEVENT, CacheType.VIRTUAL, CacheType.WHERIGO, CacheType.OTHER, CacheType.ADVLAB, CacheType.USER_DEFINED))
                                 .setValueDisplayTextGetter(CacheType::getShortL10n)
                                 .setValueDrawableGetter(ct -> ImageParam.drawable(MapMarkerUtils.getCacheTypeMarker(activity.getResources(), ct))),
                         2, null);

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="advlab">Adventure Lab Cache</string>
     <string name="userdefined">User defined cache</string>
     <string name="unknown">Unknown Type</string>
+    <string name="other">Others</string>
+    <string name="event_special">Specials</string>
 
     <string name="all_types_short">All</string>
     <string name="traditional_short">Trad</string>


### PR DESCRIPTION
added "Specials" and "Others" types to cache filter
![image](https://github.com/user-attachments/assets/3a70bee7-c025-4ae0-b334-2eb62cf0953c)

new groups are:
Other: Unknown, GC HQ, Ape
Special Event: Mega, Giga, CCE, HQ Party, Maze, Block Party

fixes #16376