### PR TITLE
refine icons in log context menu, consistenly use the same icon for "open in browser"

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/CacheLogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/CacheLogsViewCreator.java
@@ -152,7 +152,7 @@ public class CacheLogsViewCreator extends LogsViewCreator {
         if (canShareLog) {
             ctxMenu.addItem(R.string.context_share_as_link, R.drawable.ic_menu_share, it -> ShareUtils.shareLink(activity, getCache().getShareSubject(), logUrl));
             ctxMenu.addItem(LocalizationUtils.getString(R.string.cache_menu_browser),
-                    R.drawable.ic_menu_info_details, it -> ShareUtils.openUrl(activity, logUrl, true));
+                    R.drawable.ic_menu_open_in_browser, it -> ShareUtils.openUrl(activity, logUrl, true));
         }
         if (isOfflineLog(log)) {
             ctxMenu.setTitle(LocalizationUtils.getString(R.string.log_your_saved_log));

--- a/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
@@ -143,7 +143,7 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
             final ContextMenuDialog ctxMenu = new ContextMenuDialog(activity).setTitle(title);
 
             //Decrypt/encrypt
-            ctxMenu.addItem(R.string.cache_log_menu_decrypt, 0, new DecryptTextClickListener(holder.binding.log));
+            ctxMenu.addItem(R.string.cache_log_menu_decrypt, R.drawable.ic_menu_rot13, new DecryptTextClickListener(holder.binding.log));
 
             //Edit/Delete Log Entry
             if (!StringUtils.isBlank(getGeocode())) {

--- a/main/src/main/java/cgeo/geocaching/log/TrackableLogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/TrackableLogsViewCreator.java
@@ -91,7 +91,7 @@ public class TrackableLogsViewCreator extends LogsViewCreator {
         final Trackable trackable = getTrackable();
         if (trackable != null && trackable.canShareLog(log)) {
             ctxMenu.addItem(getActivity().getString(R.string.cache_menu_browser),
-                    R.drawable.ic_menu_info_details, it -> ShareUtils.openUrl(getActivity(), trackable.getServiceSpecificLogUrl(log)));
+                    R.drawable.ic_menu_open_in_browser, it -> ShareUtils.openUrl(getActivity(), trackable.getServiceSpecificLogUrl(log)));
         }
         return ctxMenu;
     }

--- a/main/src/main/res/drawable/ic_menu_open_in_browser.xml
+++ b/main/src/main/res/drawable/ic_menu_open_in_browser.xml
@@ -1,11 +1,10 @@
-<!-- taken from "open in browser" / material.io -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="48"
-    android:viewportHeight="48"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
     android:tint="?android:textColorPrimary">
   <path
-      android:fillColor="@android:color/white"
-      android:pathData="M22.5,42V27.8L18.35,31.95L16.2,29.8L24,22L31.8,29.8L29.65,31.95L25.5,27.8V42ZM28.5,39H39Q39,39 39,39Q39,39 39,39V12H9V39Q9,39 9,39Q9,39 9,39H19.5V42H9Q7.8,42 6.9,41.1Q6,40.2 6,39V9Q6,7.8 6.9,6.9Q7.8,6 9,6H39Q40.2,6 41.1,6.9Q42,7.8 42,9V39Q42,40.2 41.1,41.1Q40.2,42 39,42H28.5Z"/>
+      android:pathData="M200,840q-33,0 -56.5,-23.5T120,760v-560q0,-33 23.5,-56.5T200,120h560q33,0 56.5,23.5T840,200v560q0,33 -23.5,56.5T760,840L600,840v-80h160v-480L200,280v480h160v80L200,840ZM440,840v-246l-64,64 -56,-58 160,-160 160,160 -56,58 -64,-64v246h-80Z"
+      android:fillColor="#e8eaed"/>
 </vector>

--- a/main/src/main/res/drawable/ic_menu_rot13.xml
+++ b/main/src/main/res/drawable/ic_menu_rot13.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m4,2c-1.105,0 -2,0.895 -2,2v8h2v-4h2v4h2v-8c0,-1.105 -0.895,-2 -2,-2h-2m0,2h2v2h-2m1.79,15.61 l-1.58,-1.22 14,-18 1.58,1.22z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m16,12v10h2v-5l2,5h2v-10h-2v5l-2,-5z"/>
+</vector>

--- a/main/src/main/res/menu/cache_options.xml
+++ b/main/src/main/res/menu/cache_options.xml
@@ -66,7 +66,7 @@
     </item>
     <item
         android:id="@+id/menu_show_in_browser"
-        android:icon="@drawable/ic_menu_info_details"
+        android:icon="@drawable/ic_menu_open_in_browser"
         android:title="@string/cache_menu_browser"
         app:showAsAction="ifRoom">
     </item>


### PR DESCRIPTION
old:
![image](https://github.com/user-attachments/assets/232d65b5-5050-4279-bb72-fc9a2b193f4f)

new:
![image](https://github.com/user-attachments/assets/d7091920-247c-4c77-95af-5975ae52fdbc)
