### PR TITLE
proper fix of the missing icon tint on rot13 icon

### DIFF
--- a/main/src/main/res/drawable/ic_menu_rot13.xml
+++ b/main/src/main/res/drawable/ic_menu_rot13.xml
@@ -2,11 +2,12 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
   <path
-      android:fillColor="@color/colorText"
+      android:fillColor="#FF000000"
       android:pathData="m4,2c-1.105,0 -2,0.895 -2,2v8h2v-4h2v4h2v-8c0,-1.105 -0.895,-2 -2,-2h-2m0,2h2v2h-2m1.79,15.61 l-1.58,-1.22 14,-18 1.58,1.22z"/>
   <path
-      android:fillColor="@color/colorText"
+      android:fillColor="#FF000000"
       android:pathData="m16,12v10h2v-5l2,5h2v-10h-2v5l-2,-5z"/>
 </vector>


### PR DESCRIPTION
replaces https://github.com/cgeo/cgeo/commit/fddee1615b75cd4b99d4b5f2dff89bdaa7efd7fc