### PR TITLE
Auto-fix email used as login to GC (fix #16397)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -179,6 +179,11 @@ public class MainActivity extends AbstractNavigationBarActivity {
                                             }
                                         }
                                         final String userNameText = FoundNumCounter.getNotBlankUserName(conn);
+                                        if (conn instanceof GCConnector && StringUtils.contains(Settings.getUserName(), '@') && StringUtils.isNotBlank(userNameText)) {
+                                            // auto-fix email address used as login instead of username for GC connector (#16397)
+                                            Settings.setGCUserName(userNameText);
+                                            Log.d("Auto-fixed GC login settings from email to username");
+                                        }
                                         return new Pair<>(userFoundCount, userNameText);
                                     },
                                     p -> {

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -677,6 +677,13 @@ public class Settings {
         return StringUtils.trim(getString(R.string.pref_username, StringUtils.EMPTY));
     }
 
+    /** this method is to be solely used for auto-fixing GC username, see MainActivity.UpdateUserInfoHandler */
+    public static void setGCUserName(final String username) {
+        if (StringUtils.isNotBlank(username)) {
+            putString(R.string.pref_username, username);
+        }
+    }
+
     public static boolean isGCConnectorActive() {
         return getBoolean(R.string.pref_connectorGCActive, false);
     }


### PR DESCRIPTION
## Description
If a user has used an email address as login to GC, automatically switch to username on retrieving username info for connector info on main screen. (Avoids errors on detecting cache ownership, see linked issue.)