### PR TITLE
Show http 429 warning notification

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -5,11 +5,19 @@ import cgeo.geocaching.CachePopupFragment;
 import cgeo.geocaching.R;
 import cgeo.geocaching.SwipeToOpenFragment;
 import cgeo.geocaching.WaypointPopupFragment;
+import cgeo.geocaching.network.HttpRequest;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.unifiedmap.UnifiedMapViewModel;
+import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.content.res.Resources;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
@@ -31,6 +39,7 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
 
     private static final String TAG_MAPDETAILS_FRAGMENT = "mapdetails_fragment";
     private static final String TAG_SWIPE_FRAGMENT = "swipetoopen_fragment";
+    private static long close429warning = 0;
 
     private final ViewTreeObserver.OnGlobalLayoutListener[] layoutListeners = new ViewTreeObserver.OnGlobalLayoutListener[1];
 
@@ -196,4 +205,34 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
         sheetShowDetails(sheetInfo);
     }
 
+    // handling of http429 warning message
+    protected void add429observer() {
+        getLifecycle().addObserver(new LifecycleAwareBroadcastReceiver(this, HttpRequest.HTTP429) {
+            @Override
+            public void onReceive(final Context context, final Intent intent) {
+                synchronized (this) {
+                    if (close429warning == 0) {
+                        final View v = findViewById(R.id.http429warning);
+                        if (v != null) {
+                            v.setOnClickListener(v1 -> SimpleDialog.ofContext(AbstractNavigationBarMapActivity.this).setMessage(TextParam.text(String.format(getString(R.string.http429_warning), intent.getStringExtra(HttpRequest.HTTP429_ADDRESS)))).show());
+                            new Handler(Looper.getMainLooper()).post(() -> v.setVisibility(View.VISIBLE));
+                        }
+                    }
+                    close429warning = System.currentTimeMillis() + 1000; // show for 1s
+                    new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                        synchronized (this) {
+                            if (System.currentTimeMillis() > close429warning) {
+                                final View v = findViewById(R.id.http429warning);
+                                if (v != null) {
+                                    v.setVisibility(View.GONE);
+                                }
+                                close429warning = 0;
+                            }
+                        }
+                    }, 1100);
+                }
+            }
+        });
+
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -1,8 +1,8 @@
 package cgeo.geocaching.network;
 
-import cgeo.geocaching.activity.ActivityMixin;
-import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.utils.JsonUtils;
+import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.RxOkHttpUtils;
 import cgeo.geocaching.utils.functions.Func1;
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.core.util.Supplier;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -39,6 +40,8 @@ public class HttpRequest {
     private static final ObjectMapper JSON_MAPPER = JsonUtils.mapper;
 
     private static final String LOGPRAEFIX = "HTTP-";
+    public static final String HTTP429 = "HTTP429";
+    public static final String HTTP429_ADDRESS = "HTTP429ADDRESS";
 
     private Method method = null;
     private String uriBase;
@@ -149,9 +152,7 @@ public class HttpRequest {
             }
             if (response.getStatusCode() == 429) {
                 Log.w("Request throttled: " + this.getRequestUrl());
-                if (Settings.isDebug()) {
-                    ActivityMixin.showApplicationToast("Please slow down, too many requests to " + HttpUrl.parse(getRequestUrl()).host() + "/" + HttpUrl.parse(getRequestUrl()).encodedPath());
-                }
+                LifecycleAwareBroadcastReceiver.sendBroadcast(CgeoApplication.getInstance(), HTTP429, HTTP429_ADDRESS, Objects.requireNonNull(HttpUrl.parse(Objects.requireNonNull(getRequestUrl()))).host());
             }
             return mappedResponse;
         });

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -287,6 +287,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 lastElevationChartRoute = null;
             }
         });
+        add429observer();
 
         findViewById(R.id.map_zoomin).setOnTouchListener(new RepeatOnHoldListener(500, v -> {
             if (mapFragment != null) {

--- a/main/src/main/res/drawable/warning.xml
+++ b/main/src/main/res/drawable/warning.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorAccent">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M40,840L480,80L920,840L40,840ZM178,760L782,760L480,240L178,760ZM480,720Q497,720 508.5,708.5Q520,697 520,680Q520,663 508.5,651.5Q497,640 480,640Q463,640 451.5,651.5Q440,663 440,680Q440,697 451.5,708.5Q463,720 480,720ZM440,600L520,600L520,400L440,400L440,600ZM480,500L480,500L480,500Z"/>
+</vector>

--- a/main/src/main/res/layout/unifiedmap_activity.xml
+++ b/main/src/main/res/layout/unifiedmap_activity.xml
@@ -23,6 +23,18 @@
         <include layout="@layout/map_zoom_control" />
         <include layout="@layout/map_progressbar" />
         <include layout="@layout/map_detailsfragment" />
+
+        <ImageView
+            android:id="@+id/http429warning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:layout_marginLeft="17dp"
+            android:padding="5dp"
+            android:layout_below="@+id/distanceinfo"
+            android:src="@drawable/warning"
+            android:background="@drawable/icon_bcg"
+            android:visibility="visible"/>
     </RelativeLayout>
 
     <RelativeLayout

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2608,6 +2608,7 @@
     </plurals>
 
     <string name="caches_refresh_all_warning">This action may lead to high network traffic. Are you sure you want to batch refresh all caches?</string>
+    <string name="http429_warning">Please slow down, too many requests to %s</string>
 
     <string name="list_list_headline">Lists:</string>
     <plurals name="extract_waypoints_result">


### PR DESCRIPTION
## Description
This is an alternative approach to #15889: 

Show a small notification icon below the compass rose, if http 429 limit is reached. Tapping on that icon reveals the specific error message (with server name):

![image](https://github.com/user-attachments/assets/610bdf86-6837-4637-a677-fa65c66baf95).![image](https://github.com/user-attachments/assets/5720afe5-7e3b-4c1c-92f1-b4b61eb3fe20)


By this you get a visual indicator, if network requests fail due to limit having been reached, but that indicator does not block a huge part of the map (as in the linked PR). As a regular user you can act accordingly, but if you are unfamiliar with this warning, you can tap on it to get more info.

Positioning and formatting of the icon TBD.

Closes #15889