### PR TITLE
UnifiedMap Support http 429 warning in landscape mode

### DIFF
--- a/main/src/main/res/layout-land/unifiedmap_activity.xml
+++ b/main/src/main/res/layout-land/unifiedmap_activity.xml
@@ -24,6 +24,7 @@
         <include layout="@layout/map_zoom_control" />
         <include layout="@layout/map_progressbar" />
         <include layout="@layout/map_detailsfragment" />
+        <include layout="@layout/map_429warning" />
     </RelativeLayout>
 
     <RelativeLayout

--- a/main/src/main/res/layout/map_429warning.xml
+++ b/main/src/main/res/layout/map_429warning.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView  xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/http429warning"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="5dp"
+    android:layout_marginLeft="17dp"
+    android:padding="5dp"
+    android:layout_below="@+id/distanceinfo"
+    android:src="@drawable/warning"
+    android:background="@drawable/icon_bcg"
+    android:visibility="gone"/>

--- a/main/src/main/res/layout/unifiedmap_activity.xml
+++ b/main/src/main/res/layout/unifiedmap_activity.xml
@@ -23,18 +23,8 @@
         <include layout="@layout/map_zoom_control" />
         <include layout="@layout/map_progressbar" />
         <include layout="@layout/map_detailsfragment" />
+        <include layout="@layout/map_429warning" />
 
-        <ImageView
-            android:id="@+id/http429warning"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:layout_marginLeft="17dp"
-            android:padding="5dp"
-            android:layout_below="@+id/distanceinfo"
-            android:src="@drawable/warning"
-            android:background="@drawable/icon_bcg"
-            android:visibility="visible"/>
     </RelativeLayout>
 
     <RelativeLayout


### PR DESCRIPTION
## Description
Extends support for http 429 warning to landscape mode.
Also fixes icon default state (see https://github.com/cgeo/cgeo/pull/15889#issuecomment-2525044730)