### PR TITLE
fix hillshading and routing download button visibility

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/CGeoMap.java
@@ -754,7 +754,6 @@ public class CGeoMap extends AbstractMap implements ViewFactory, OnCacheTapListe
             }
             HistoryTrackUtils.onPrepareOptionsMenu(menu);
             // TrackUtils.onPrepareOptionsMenu is in maps/google/v2/GoogleMapActivity only
-            MapUtils.onPrepareOptionsMenu(menu);
         } catch (final RuntimeException e) {
             Log.e("CGeoMap.onPrepareOptionsMenu", e);
         }

--- a/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
@@ -89,8 +89,8 @@ public class MapProviderFactory {
         }
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
-        parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getMapSource().supportsHillshading()).setIcon(R.drawable.ic_menu_hills);
-        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getMapShadingEnabled() && Settings.getMapSource().supportsHillshading());
+        parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(MapUtils.hasHillshadingTiles() && Settings.getMapSource().supportsHillshading()).setIcon(R.drawable.ic_menu_hills);
+        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getMapSource().supportsHillshading());
         parentMenu.findItem(R.id.menu_check_routingdata).setVisible(Settings.useInternalRouting() || ProcessUtils.isInstalled(CgeoApplication.getInstance().getString(R.string.package_brouter)));
         parentMenu.findItem(R.id.menu_manage_offline_maps).setVisible(true);
     }

--- a/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapProviderFactory.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.maps.interfaces.MapSource;
 import cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ProcessUtils;
 
 import android.app.Activity;
 import android.view.Menu;
@@ -89,6 +90,8 @@ public class MapProviderFactory {
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
         parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getMapSource().supportsHillshading()).setIcon(R.drawable.ic_menu_hills);
+        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getMapShadingEnabled() && Settings.getMapSource().supportsHillshading());
+        parentMenu.findItem(R.id.menu_check_routingdata).setVisible(Settings.useInternalRouting() || ProcessUtils.isInstalled(CgeoApplication.getInstance().getString(R.string.package_brouter)));
         parentMenu.findItem(R.id.menu_manage_offline_maps).setVisible(true);
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -246,13 +246,6 @@ public class MapUtils {
         }
     }
 
-    public static void onPrepareOptionsMenu(final Menu menu) {
-        // use same condition as in checkRoutingData() above
-        MenuUtils.setVisible(menu.findItem(R.id.menu_check_routingdata), Settings.useInternalRouting() || ProcessUtils.isInstalled(CgeoApplication.getInstance().getString(R.string.package_brouter)));
-        // use same condition as in checkHillshadingData() above
-        MenuUtils.setVisible(menu.findItem(R.id.menu_check_hillshadingdata), Settings.getMapShadingEnabled());
-    }
-
     @WorkerThread
     private static void checkTiles(final HashMap<String, String> requiredTiles, final ArrayList<Download> missingDownloads, final AtomicBoolean hasUnsupportedTiles) {
         // read tiles already stored

--- a/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapUtils.java
@@ -39,7 +39,6 @@ import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.FilterUtils;
 import cgeo.geocaching.utils.MenuUtils;
-import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Action2;
 import static cgeo.geocaching.brouter.BRouterConstants.BROUTER_TILE_FILEEXTENSION;
@@ -56,7 +55,6 @@ import android.graphics.Point;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.TextPaint;
-import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
 
@@ -208,42 +206,40 @@ public class MapUtils {
     // check whether hillshading tile data is available for the whole viewport given
     // and offer to download missing hillshading data
     public static void checkHillshadingData(final Activity activity, final double minLatitude, final double minLongitude, final double maxLatitude, final double maxLongitude) {
-        if (Settings.getMapShadingEnabled()) {
-            ActivityMixin.showToast(activity, R.string.downloadmap_checking);
+        ActivityMixin.showToast(activity, R.string.downloadmap_checking);
 
-            final HashMap<String, String> requiredTiles = new HashMap<>();
-            final ArrayList<Download> missingDownloads = new ArrayList<>();
-            final AtomicBoolean hasUnsupportedTiles = new AtomicBoolean(false);
+        final HashMap<String, String> requiredTiles = new HashMap<>();
+        final ArrayList<Download> missingDownloads = new ArrayList<>();
+        final AtomicBoolean hasUnsupportedTiles = new AtomicBoolean(false);
 
-            AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> {
-                // calculate affected routing tiles
-                int curLat = (int) Math.floor(minLatitude);
-                final int maxLat = (int) Math.floor(maxLatitude);
-                final int maxLon = (int) Math.floor(maxLongitude);
-                while (curLat <= maxLat) {
-                    int curLon = (int) Math.floor(minLongitude);
-                    while (curLon <= maxLon) {
-                        final String curLat02d = String.format(Locale.US, "%02d", Math.abs(curLat));
-                        final String filenameBase = (curLat < 0 ? "S" : "N") + curLat02d + (curLon < 0 ? "W" : "E") + String.format(Locale.US, "%03d", Math.abs(curLon)) + HILLSHADING_TILE_FILEEXTENSION;
-                        final String dirName = (curLat < 0 ? "S" : "N") + curLat02d;
-                        requiredTiles.put(filenameBase, dirName);
-                        curLon += 1;
-                    }
-                    curLat += 1;
+        AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> {
+            // calculate affected routing tiles
+            int curLat = (int) Math.floor(minLatitude);
+            final int maxLat = (int) Math.floor(maxLatitude);
+            final int maxLon = (int) Math.floor(maxLongitude);
+            while (curLat <= maxLat) {
+                int curLon = (int) Math.floor(minLongitude);
+                while (curLon <= maxLon) {
+                    final String curLat02d = String.format(Locale.US, "%02d", Math.abs(curLat));
+                    final String filenameBase = (curLat < 0 ? "S" : "N") + curLat02d + (curLon < 0 ? "W" : "E") + String.format(Locale.US, "%03d", Math.abs(curLon)) + HILLSHADING_TILE_FILEEXTENSION;
+                    final String dirName = (curLat < 0 ? "S" : "N") + curLat02d;
+                    requiredTiles.put(filenameBase, dirName);
+                    curLon += 1;
                 }
-                checkHillshadingTiles(requiredTiles, missingDownloads, hasUnsupportedTiles);
-            }, () -> {
-                // give feedback to the user + offer to download missing tiles (if available)
-                if (missingDownloads.isEmpty()) {
-                    ActivityMixin.showShortToast(activity, hasUnsupportedTiles.get() ? R.string.check_hillshading_unsupported : R.string.check_hillshading_found);
-                } else {
-                    if (hasUnsupportedTiles.get()) {
-                        ActivityMixin.showShortToast(activity, R.string.check_hillshading_unsupported);
-                    }
-                    DownloaderUtils.triggerDownloads(activity, R.string.downloadtile_title, R.string.check_hillshading_missing, missingDownloads, null);
+                curLat += 1;
+            }
+            checkHillshadingTiles(requiredTiles, missingDownloads, hasUnsupportedTiles);
+        }, () -> {
+            // give feedback to the user + offer to download missing tiles (if available)
+            if (missingDownloads.isEmpty()) {
+                ActivityMixin.showShortToast(activity, hasUnsupportedTiles.get() ? R.string.check_hillshading_unsupported : R.string.check_hillshading_found);
+            } else {
+                if (hasUnsupportedTiles.get()) {
+                    ActivityMixin.showShortToast(activity, R.string.check_hillshading_unsupported);
                 }
-            });
-        }
+                DownloaderUtils.triggerDownloads(activity, R.string.downloadtile_title, R.string.check_hillshading_missing, missingDownloads, null);
+            }
+        });
     }
 
     @WorkerThread
@@ -295,6 +291,16 @@ public class MapUtils {
                 }
             }
         }
+    }
+
+    public static boolean hasHillshadingTiles() {
+        final List<ContentStorage.FileInformation> files = ContentStorage.get().list(PersistableFolder.OFFLINE_MAP_SHADING.getFolder());
+        for (ContentStorage.FileInformation fi : files) {
+            if (fi.name.endsWith(HILLSHADING_TILE_FILEEXTENSION)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/NewMap.java
@@ -435,7 +435,6 @@ public class NewMap extends AbstractNavigationBarMapActivity implements Observer
                 LoggingUI.onPrepareOptionsMenu(menu, getSingleModeCache());
             }
             HistoryTrackUtils.onPrepareOptionsMenu(menu);
-            MapUtils.onPrepareOptionsMenu(menu);
         } catch (final RuntimeException e) {
             Log.e("NewMap.onPrepareOptionsMenu", e);
         }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
@@ -20,7 +20,7 @@ public class HillShadingLayerHelper {
     }
 
     public static HillsRenderConfig getHillsRenderConfig() {
-        if (!Settings.getMapShadingEnabled() || !Settings.getMapShadingShowLayer()) {
+        if (!Settings.getMapShadingShowLayer()) {
             return null;
         }
 

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2460,10 +2460,6 @@ public class Settings {
         return !getBoolean(R.string.pref_mapScaleOnly, true);
     }
 
-    public static boolean getMapShadingEnabled() {
-        return getBoolean(R.string.pref_maphillshading, false);
-    }
-
     public static boolean getMapShadingShowLayer() {
         return getBoolean(R.string.pref_maphillshading_show_layer, true);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -780,7 +780,6 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         menu.findItem(R.id.menu_theme_options).setVisible(tileProvider.supportsThemeOptions());
 
         menu.findItem(R.id.menu_as_list).setVisible(true);
-        MapUtils.onPrepareOptionsMenu(menu);
 
         return result;
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -126,7 +126,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         renderer.setOffset(30 * CanvasAdapter.getScale(), 0); // make room for attribution
         addLayer(LayerHelper.ZINDEX_SCALEBAR, mapScaleBarLayer);
 
-        if (Settings.getMapShadingEnabled() && Settings.getMapShadingShowLayer() && !Settings.getString(R.string.pref_rapidapiKey, "").isEmpty()) {
+        if (Settings.getMapShadingShowLayer() && !Settings.getString(R.string.pref_rapidapiKey, "").isEmpty()) {
             addLayer(2, new MapilionVTMHillshadingSource().getBitmapTileLayer(mMap));
             //addLayer(2, new MapToolkitVTMHillshadingSource().getBitmapTileLayer(mMap));
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.unifiedmap.tileproviders;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
+import cgeo.geocaching.maps.MapUtils;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
@@ -66,8 +67,8 @@ public class TileProviderFactory {
         }
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
-        parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
-        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
+        parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(MapUtils.hasHillshadingTiles() && Settings.getTileProvider().supportsHillshading());
+        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getTileProvider().supportsHillshading());
         parentMenu.findItem(R.id.menu_check_routingdata).setVisible(Settings.useInternalRouting() || ProcessUtils.isInstalled(CgeoApplication.getInstance().getString(R.string.package_brouter)));
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.TextUtils;
 import static cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider.isValidMapFile;
 
@@ -66,6 +67,8 @@ public class TileProviderFactory {
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
         parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
+        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getMapShadingEnabled() && Settings.getTileProvider().supportsHillshading());
+        parentMenu.findItem(R.id.menu_check_routingdata).setVisible(Settings.useInternalRouting() || ProcessUtils.isInstalled(CgeoApplication.getInstance().getString(R.string.package_brouter)));
     }
 
     public static HashMap<String, AbstractTileProvider> getTileProviders() {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -227,7 +227,6 @@
 
     <!-- category offline maps hillshading -->
     <string translatable="false" name="pref_fakekey_info_offline_maphillshading">fakekey_info_offline_maphillshading</string>
-    <string translatable="false" name="pref_maphillshading">maphillshading</string>
     <string translatable="false" name="pref_maphillshading_show_layer">maphillshading_show_layer</string>
     <string translatable="false" name="pref_persistablefolder_offlinemapshading">persistablefolder_offlinemapshading</string>
     <string translatable="false" name="pref_rapidapiKey">rapidapiKey</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -112,14 +112,8 @@
             android:summary="@string/settings_info_hillshading"
             android:title="@string/settings_info_hillshading_title"
             app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:key="@string/pref_maphillshading"
-            android:defaultValue="false"
-            android:title="@string/settings_hillshading_enable"
-            app:iconSpaceReserved="false" />
         <Preference
             android:key="@string/pref_persistablefolder_offlinemapshading"
-            android:dependency="@string/pref_maphillshading"
             android:title="@string/init_mapshading_folder"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>


### PR DESCRIPTION
download routing/hillshading buttons were visible when they shouldn't be

change the logic for activating hillshading buttons from 1 master toggle in preferences to "any hillshading files are downloaded"