### PR TITLE
update mapsforge, use AdaptiveClasyHillShading (hq disabled)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -371,7 +371,7 @@ dependencies {
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = '4d367e7'
+    String mapsforgeVersion = '196bb7733d'
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
     // String mapsforgeSource = 'com.github.cgeo.mapsforge'

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/AbstractMapsforgeMapSource.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/AbstractMapsforgeMapSource.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.download.tilesource.AbstractTileSource;
-import org.mapsforge.map.model.IMapViewPosition;
+import org.mapsforge.map.model.MapViewPosition;
 
 public abstract class AbstractMapsforgeMapSource extends AbstractMapSource {
 
@@ -30,7 +30,7 @@ public abstract class AbstractMapsforgeMapSource extends AbstractMapSource {
     }
 
 
-    public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
+    public ITileLayer createTileLayer(final TileCache tileCache, final MapViewPosition mapViewPosition) {
         source.setUserAgent(MAPNIK_TILE_DOWNLOAD_UA);
         return new DownloadLayer(tileCache, mapViewPosition, source, AndroidGraphicFactory.INSTANCE);
     }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/MapsforgeMapProvider.java
@@ -41,7 +41,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.download.tilesource.OpenStreetMapMapnik;
-import org.mapsforge.map.model.IMapViewPosition;
+import org.mapsforge.map.model.MapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.reader.header.MapFileException;
 
@@ -143,7 +143,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
          * Create new render layer, if mapfile exists
          */
         @Override
-        public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
+        public ITileLayer createTileLayer(final TileCache tileCache, final MapViewPosition mapViewPosition) {
             final InputStream mapStream = createMapFileInputStream(this.mapUri);
             if (mapStream == null) {
                 return null;
@@ -239,7 +239,7 @@ public final class MapsforgeMapProvider extends AbstractMapProvider {
          * Create new render layer, if mapfiles exist
          */
         @Override
-        public ITileLayer createTileLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition) {
+        public ITileLayer createTileLayer(final TileCache tileCache, final MapViewPosition mapViewPosition) {
             final List<MapFile> mapFiles = new ArrayList<>();
             for (ImmutablePair<String, Uri> fileName : mapUris) {
                 final InputStream mapStream = createMapFileInputStream(fileName.right);

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CgeoAdaptiveClasyHillShading.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CgeoAdaptiveClasyHillShading.java
@@ -1,0 +1,18 @@
+package cgeo.geocaching.maps.mapsforge.v6.layers;
+
+import org.mapsforge.map.layer.hills.AClasyHillShading;
+import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading;
+import org.mapsforge.map.layer.hills.HgtFileInfo;
+import org.mapsforge.map.layer.hills.HiResClasyHillShading;
+
+public class CgeoAdaptiveClasyHillShading extends AdaptiveClasyHillShading {
+
+    public CgeoAdaptiveClasyHillShading() {
+        super(false);
+    }
+
+    @Override
+    public int getZoomMax(HgtFileInfo hgtFileInfo) {
+        return 17;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CgeoAdaptiveClasyHillShading.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CgeoAdaptiveClasyHillShading.java
@@ -7,8 +7,8 @@ import org.mapsforge.map.layer.hills.HiResClasyHillShading;
 
 public class CgeoAdaptiveClasyHillShading extends AdaptiveClasyHillShading {
 
-    public CgeoAdaptiveClasyHillShading() {
-        super(false);
+    public CgeoAdaptiveClasyHillShading(final boolean isHqEnabled) {
+        super(isHqEnabled);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CgeoAdaptiveClasyHillShading.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/CgeoAdaptiveClasyHillShading.java
@@ -1,9 +1,7 @@
 package cgeo.geocaching.maps.mapsforge.v6.layers;
 
-import org.mapsforge.map.layer.hills.AClasyHillShading;
 import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading;
 import org.mapsforge.map.layer.hills.HgtFileInfo;
-import org.mapsforge.map.layer.hills.HiResClasyHillShading;
 
 public class CgeoAdaptiveClasyHillShading extends AdaptiveClasyHillShading {
 
@@ -12,7 +10,7 @@ public class CgeoAdaptiveClasyHillShading extends AdaptiveClasyHillShading {
     }
 
     @Override
-    public int getZoomMax(HgtFileInfo hgtFileInfo) {
+    public int getZoomMax(final HgtFileInfo hgtFileInfo) {
         return 17;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/DownloadLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/DownloadLayer.java
@@ -5,7 +5,7 @@ import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.download.TileDownloadLayer;
 import org.mapsforge.map.layer.download.tilesource.TileSource;
-import org.mapsforge.map.model.IMapViewPosition;
+import org.mapsforge.map.model.MapViewPosition;
 
 public class DownloadLayer implements ITileLayer {
 
@@ -13,7 +13,7 @@ public class DownloadLayer implements ITileLayer {
 
     private final TileSource tileSource;
 
-    public DownloadLayer(final TileCache tileCache, final IMapViewPosition mapViewPosition, final TileSource tileSource, final GraphicFactory graphicFactory) {
+    public DownloadLayer(final TileCache tileCache, final MapViewPosition mapViewPosition, final TileSource tileSource, final GraphicFactory graphicFactory) {
         this.tileSource = tileSource;
         tileLayer = new TileDownloadLayer(tileCache, mapViewPosition, tileSource, graphicFactory);
     }

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
@@ -8,7 +8,6 @@ import android.content.Context;
 
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.hills.DemFolderAndroidContent;
-import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading;
 import org.mapsforge.map.layer.hills.DemFolder;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource;
@@ -20,15 +19,14 @@ public class HillShadingLayerHelper {
     }
 
     public static HillsRenderConfig getHillsRenderConfig() {
-        if (!Settings.getMapShadingEnabled() || !Settings.getMapShadingShowLayer()) {
+        if (!Settings.getMapShadingShowLayer()) {
             return null;
         }
 
         final Context context = CgeoApplication.getInstance();
         final DemFolder shadingFolder = new DemFolderAndroidContent(PersistableFolder.OFFLINE_MAP_SHADING.getUri(), context, context.getContentResolver());
 
-        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new AdaptiveClasyHillShading(false), AndroidGraphicFactory.INSTANCE);
-        // avoid lines at between tiles
+        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new CgeoAdaptiveClasyHillShading(), AndroidGraphicFactory.INSTANCE);
         final HillsRenderConfig hillsConfig = new HillsRenderConfig(hillTileSource);
         hillsConfig.indexOnThread();
         return hillsConfig;

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
@@ -8,10 +8,10 @@ import android.content.Context;
 
 import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
 import org.mapsforge.map.android.hills.DemFolderAndroidContent;
+import org.mapsforge.map.layer.hills.AdaptiveClasyHillShading;
 import org.mapsforge.map.layer.hills.DemFolder;
 import org.mapsforge.map.layer.hills.HillsRenderConfig;
 import org.mapsforge.map.layer.hills.MemoryCachingHgtReaderTileSource;
-import org.mapsforge.map.layer.hills.StandardClasyHillShading;
 
 public class HillShadingLayerHelper {
 
@@ -27,9 +27,8 @@ public class HillShadingLayerHelper {
         final Context context = CgeoApplication.getInstance();
         final DemFolder shadingFolder = new DemFolderAndroidContent(PersistableFolder.OFFLINE_MAP_SHADING.getUri(), context, context.getContentResolver());
 
-        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new StandardClasyHillShading(), AndroidGraphicFactory.INSTANCE);
+        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new AdaptiveClasyHillShading(false), AndroidGraphicFactory.INSTANCE);
         // avoid lines at between tiles
-        hillTileSource.setEnableInterpolationOverlap(true);
         final HillsRenderConfig hillsConfig = new HillsRenderConfig(hillTileSource);
         hillsConfig.indexOnThread();
         return hillsConfig;

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/HillShadingLayerHelper.java
@@ -26,7 +26,7 @@ public class HillShadingLayerHelper {
         final Context context = CgeoApplication.getInstance();
         final DemFolder shadingFolder = new DemFolderAndroidContent(PersistableFolder.OFFLINE_MAP_SHADING.getUri(), context, context.getContentResolver());
 
-        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new CgeoAdaptiveClasyHillShading(), AndroidGraphicFactory.INSTANCE);
+        final MemoryCachingHgtReaderTileSource hillTileSource = new MemoryCachingHgtReaderTileSource(shadingFolder, new CgeoAdaptiveClasyHillShading(Settings.getMapShadingHq()), AndroidGraphicFactory.INSTANCE);
         final HillsRenderConfig hillsConfig = new HillsRenderConfig(hillTileSource);
         hillsConfig.indexOnThread();
         return hillsConfig;

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/MultiRendererLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/MultiRendererLayer.java
@@ -7,7 +7,7 @@ import org.mapsforge.map.datastore.MultiMapDataStore;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
-import org.mapsforge.map.model.IMapViewPosition;
+import org.mapsforge.map.model.MapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 import org.mapsforge.map.reader.header.MapFileInfo;
 
@@ -18,7 +18,7 @@ public class MultiRendererLayer implements ITileLayer {
     private byte zoomLevelMax = 0;
 
 
-    public MultiRendererLayer(final TileCache tileCache, final List<MapFile> mapFiles, final IMapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
+    public MultiRendererLayer(final TileCache tileCache, final List<MapFile> mapFiles, final MapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
         final MultiMapDataStore mapDataStore = new MultiMapDataStore(MultiMapDataStore.DataPolicy.RETURN_ALL);
 
         for (MapFile f : mapFiles) {

--- a/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/RendererLayer.java
+++ b/main/src/main/java/cgeo/geocaching/maps/mapsforge/v6/layers/RendererLayer.java
@@ -4,7 +4,7 @@ import org.mapsforge.core.graphics.GraphicFactory;
 import org.mapsforge.map.layer.Layer;
 import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.layer.renderer.TileRendererLayer;
-import org.mapsforge.map.model.IMapViewPosition;
+import org.mapsforge.map.model.MapViewPosition;
 import org.mapsforge.map.reader.MapFile;
 
 public class RendererLayer implements ITileLayer {
@@ -13,7 +13,7 @@ public class RendererLayer implements ITileLayer {
 
     private final MapFile mapDataStore;
 
-    public RendererLayer(final TileCache tileCache, final MapFile mapDataStore, final IMapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
+    public RendererLayer(final TileCache tileCache, final MapFile mapDataStore, final MapViewPosition mapViewPosition, final boolean isTransparent, final boolean renderLabels, final boolean cacheLabels, final GraphicFactory graphicFactory) {
         this.mapDataStore = mapDataStore;
         tileLayer = new TileRendererLayer(tileCache, mapDataStore, mapViewPosition, isTransparent, renderLabels, cacheLabels, graphicFactory, HillShadingLayerHelper.getHillsRenderConfig());
     }

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2468,6 +2468,10 @@ public class Settings {
         return getBoolean(R.string.pref_maphillshading_show_layer, true);
     }
 
+    public static boolean getMapShadingHq() {
+        return getBoolean(R.string.pref_maphillshading_hq, false);
+    }
+
     public static void setMapShadingShowLayer(final boolean show) {
         putBoolean(R.string.pref_maphillshading_show_layer, show);
     }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -229,6 +229,7 @@
     <string translatable="false" name="pref_fakekey_info_offline_maphillshading">fakekey_info_offline_maphillshading</string>
     <string translatable="false" name="pref_maphillshading">maphillshading</string>
     <string translatable="false" name="pref_maphillshading_show_layer">maphillshading_show_layer</string>
+    <string translatable="false" name="pref_maphillshading_hq">maphillshading_hq</string>
     <string translatable="false" name="pref_persistablefolder_offlinemapshading">persistablefolder_offlinemapshading</string>
     <string translatable="false" name="pref_rapidapiKey">rapidapiKey</string>
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1179,10 +1179,10 @@
     <string name="settings_info_themes_title">Info on Map Themes</string>
     <string name="settings_info_themes">c:geo supports custom themes for offline maps. These can be used to change the color style of the map (e.g. to have a nightview map) or to highlight certain objects like cycle paths or height lines within the map.\n\nWorking with non-zipped map themes might decrease map viewer opening performance. In this case, the theme folder may optionally be synchronized to an app-private local folder for faster access (at the cost of some storage space).</string>
     <string name="settings_info_hillshading_title">Info on Hillshading</string>
-    <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Slopes will be darkened/lightened to generate a 3D-effect.\nHillshading data can be downloaded from maps overflow menu.</string>
+    <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Slopes will be darkened/lightened to generate a 3D-effect.\nHillshading data can be downloaded from maps overflow menu.\nNot compatible with UnifiedMap VTM variant.</string>
     <string name="settings_hillshading_enable">Hillshading</string>
     <string name="init_hillshading_hq">High quality hillshading</string>
-    <string name="init_summary_hillshading_hq">More detailed hillshading overlay but ~50% slower rendering when zoomed out</string>
+    <string name="init_summary_hillshading_hq">More detailed hillshading overlay but ~50%% slower rendering when zoomed out</string>
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="init_mapsource_select_legacy">Select Map Source (Legacy)</string>
     <string name="init_local_file_system">Local File System</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1181,6 +1181,8 @@
     <string name="settings_info_hillshading_title">Info on Hillshading</string>
     <string name="settings_info_hillshading">Hillshading is a technique for creating topographic relief maps by adding a lighting effect to the map to indicate changes in elevation. Slopes will be darkened/lightened to generate a 3D-effect.\nHillshading data can be downloaded from maps overflow menu.</string>
     <string name="settings_hillshading_enable">Hillshading</string>
+    <string name="init_hillshading_hq">High quality hillshading</string>
+    <string name="init_summary_hillshading_hq">More detailed hillshading overlay but ~50% slower rendering when zoomed out</string>
     <string name="init_mapsource_select">Select Map Source</string>
     <string name="init_mapsource_select_legacy">Select Map Source (Legacy)</string>
     <string name="init_local_file_system">Local File System</string>

--- a/main/src/main/res/xml/preferences_map_sources.xml
+++ b/main/src/main/res/xml/preferences_map_sources.xml
@@ -122,6 +122,12 @@
             android:dependency="@string/pref_maphillshading"
             android:title="@string/init_mapshading_folder"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:key="@string/pref_maphillshading_hq"
+            android:defaultValue="false"
+            android:title="@string/init_hillshading_hq"
+            android:summary="@string/init_summary_hillshading_hq"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
updates mapsforge to a recent build to be able to use AdaptiveClasyHillShading

switch algorithm to AdaptiveClasyHillShading

adds an user-facing option to enable HQ HS

fixes #16438