### PR TITLE
Cardsearch fixes and inline search suggestions

### DIFF
--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -21,6 +21,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.SearchCardView;
 import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.CoordinatesInputDialog;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.ClipboardUtils;
@@ -41,16 +42,18 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.ImageView;
+import android.widget.ListAdapter;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
 import androidx.cardview.widget.CardView;
 
 import java.util.Locale;
 
-import com.google.android.material.textfield.TextInputLayout;
 import de.k3b.geo.api.GeoPointDto;
 import de.k3b.geo.api.IGeoPointInfo;
 import de.k3b.geo.io.GeoUri;
@@ -275,7 +278,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             searchView.setMinWidth(((View) searchView.getParent()).getWidth());
 
             // icon in search field
-            final Drawable drw = getDrawable(icon);
+            final Drawable drw = AppCompatResources.getDrawable(this, icon);
             drw.setTint(getResources().getColor(R.color.colorTextActionBar));
             drw.setBounds(0, 0, (int) searchView.getTextSize(), (int) searchView.getTextSize());
             searchView.setCompoundDrawables(drw, null, null, null);
@@ -300,21 +303,21 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             // Default value
             if (title == R.string.search_geo) {
                 searchView.setText("GC");
-                handlePotentialClipboardGeocode(searchView, binding.searchLabel);
+                handlePotentialClipboardGeocode(searchView);
             } else {
                 searchView.setText("");
             }
 
             // suggestion provider
             if (geocacheSuggestionAdapter) {
-                searchView.setAdapter(new GeocacheAutoCompleteAdapter(searchView.getContext(), suggestionFunction));
-                searchView.setOnItemClickListener((parent, view, position, id) -> {
+                binding.suggestionList.setAdapter(new GeocacheAutoCompleteAdapter(searchView.getContext(), suggestionFunction));
+                binding.suggestionList.setOnItemClickListener((parent, view, position, id) -> {
                     final String searchTerm = (String) parent.getItemAtPosition(position);
                     findByGeocodeFn(searchTerm);
                 });
             } else if (suggestionFunction != null) {
-                searchView.setAdapter(new AutoCompleteAdapter(searchView.getContext(), android.R.layout.simple_dropdown_item_1line, suggestionFunction));
-                searchView.setOnItemClickListener((parent, view, position, id) -> {
+                binding.suggestionList.setAdapter(new AutoCompleteAdapter(searchView.getContext(), R.layout.search_suggestion, suggestionFunction));
+                binding.suggestionList.setOnItemClickListener((parent, view, position, id) -> {
                     final String searchTerm = (String) parent.getItemAtPosition(position);
                     searchView.setText(searchTerm);
                     runnable.run();
@@ -322,6 +325,8 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             } else {
                 searchView.setAdapter(null);
             }
+
+            updateSuggestions();
 
             // caps keyboard
             if (inputFilter != null) {
@@ -334,6 +339,13 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             searchView.setSelection(searchView.getText().length());
             Keyboard.show(this, searchView);
         });
+    }
+
+    private void updateSuggestions() {final ListAdapter adapter = binding.suggestionList.getAdapter();
+
+        if (adapter instanceof ArrayAdapter) {
+            ((ArrayAdapter<?>) adapter).getFilter().filter(searchView.getText());
+        }
     }
 
     private SearchCardView addSearchCard(final int title, final int icon) {
@@ -402,7 +414,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
      * <br>
      * Needs to run async as clipboard access is blocked if activity is not yet created.
      */
-    private void handlePotentialClipboardGeocode(final AutoCompleteTextView geocodeField, final TextInputLayout geocodeInputLayout) {
+    private void handlePotentialClipboardGeocode(final AutoCompleteTextView geocodeField) {
         final String clipboardText = ClipboardUtils.getText();
 
         final String geocode;
@@ -552,6 +564,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
         searchViewItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(@NonNull final MenuItem item) {
+                binding.flipper.showNext();
                 return true;
             }
 
@@ -559,15 +572,17 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             public boolean onMenuItemActionCollapse(@NonNull final MenuItem item) {
                 searchViewItem.setVisible(false);
                 searchButtonItem.setVisible(false);
+                binding.flipper.showPrevious();
                 return true;
             }
         });
         searchButtonItem = menu.findItem(R.id.menu_gosearch_icon);
         searchView = (AutoCompleteTextView) searchViewItem.getActionView();
-        searchView.setBackground(getDrawable(R.drawable.mark_transparent));
+        searchView.setBackground(AppCompatResources.getDrawable(this, R.drawable.mark_transparent));
         // configure keyboard
         searchView.setInputType(InputType.TYPE_CLASS_TEXT);
         searchView.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        searchView.addTextChangedListener(ViewUtils.createSimpleWatcher((s) -> updateSuggestions()));
         return true;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -319,6 +319,8 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
                     searchView.setText(searchTerm);
                     runnable.run();
                 });
+            } else {
+                searchView.setAdapter(null);
             }
 
             // caps keyboard

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -351,7 +351,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             return;
         }
 
-        final CardView geocodecard = addSearchCardWithField(R.string.search_geo, R.drawable.ic_menu_cache, () -> findByGeocodeFn(getSearchFieldInput()), DataStore::getSuggestionsGeocode, true, new InputFilter.AllCaps());
+        final CardView geocodecard = addSearchCardWithField(R.string.search_geo, R.drawable.search_identifier, () -> findByGeocodeFn(getSearchFieldInput()), DataStore::getSuggestionsGeocode, true, new InputFilter.AllCaps());
         geocodecard.setOnLongClickListener(v -> {
             final String clipboardText = ClipboardUtils.getText();
             final String geocode;

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -307,14 +307,18 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
             // suggestion provider
             if (geocacheSuggestionAdapter) {
                 searchView.setAdapter(new GeocacheAutoCompleteAdapter(searchView.getContext(), suggestionFunction));
+                searchView.setOnItemClickListener((parent, view, position, id) -> {
+                    final String searchTerm = (String) parent.getItemAtPosition(position);
+                    findByGeocodeFn(searchTerm);
+                });
             } else if (suggestionFunction != null) {
                 searchView.setAdapter(new AutoCompleteAdapter(searchView.getContext(), android.R.layout.simple_dropdown_item_1line, suggestionFunction));
+                searchView.setOnItemClickListener((parent, view, position, id) -> {
+                    final String searchTerm = (String) parent.getItemAtPosition(position);
+                    searchView.setText(searchTerm);
+                    runnable.run();
+                });
             }
-            searchView.setOnItemClickListener((parent, view, position, id) -> {
-                final String searchTerm = (String) parent.getItemAtPosition(position);
-                searchView.setText(searchTerm);
-                runnable.run();
-            });
 
             // caps keyboard
             if (inputFilter != null) {

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -276,6 +276,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
 
             // icon in search field
             final Drawable drw = getDrawable(icon);
+            drw.setTint(getResources().getColor(R.color.colorTextActionBar));
             drw.setBounds(0, 0, (int) searchView.getTextSize(), (int) searchView.getTextSize());
             searchView.setCompoundDrawables(drw, null, null, null);
             searchView.setCompoundDrawablePadding(16);

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.search.AutoCompleteAdapter;
 import cgeo.geocaching.search.GeocacheAutoCompleteAdapter;
+import cgeo.geocaching.search.SearchAutoCompleteAdapter;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.SearchCardView;
@@ -316,7 +317,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
                     findByGeocodeFn(searchTerm);
                 });
             } else if (suggestionFunction != null) {
-                binding.suggestionList.setAdapter(new AutoCompleteAdapter(searchView.getContext(), R.layout.search_suggestion, suggestionFunction));
+                binding.suggestionList.setAdapter(new SearchAutoCompleteAdapter(searchView.getContext(), R.layout.search_suggestion, icon, suggestionFunction));
                 binding.suggestionList.setOnItemClickListener((parent, view, position, id) -> {
                     final String searchTerm = (String) parent.getItemAtPosition(position);
                     searchView.setText(searchTerm);

--- a/main/src/main/java/cgeo/geocaching/models/Download.java
+++ b/main/src/main/java/cgeo/geocaching/models/Download.java
@@ -154,7 +154,7 @@ public class Download {
         DOWNLOADTYPE_MAP_JUSTDOWNLOAD(50, R.string.downloadmap_othermapdownload, R.drawable.ic_menu_mapmode),
         DOWNLOADTYPE_THEME_JUSTDOWNLOAD(51, R.string.downloadmap_otherthemedownload, R.drawable.downloader_theme),
 
-        DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile, R.drawable.map_quick_route),
+        DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile, R.drawable.ic_menu_route),
         DOWNLOADTYPE_HILLSHADING_TILES(91, R.string.downloadmap_hillshadingfile, R.drawable.ic_menu_hills);
 
         public final int id;

--- a/main/src/main/java/cgeo/geocaching/search/AutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/AutoCompleteAdapter.java
@@ -21,6 +21,12 @@ public class AutoCompleteAdapter extends ArrayAdapter<String> {
     private String[] suggestions = EMPTY;
     private final Func1<String, String[]> suggestionFunction;
 
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    private String searchTerm;
+
     public AutoCompleteAdapter(final Context context, @LayoutRes final int textViewResourceId, final Func1<String, String[]> suggestionFunction) {
         super(context, textViewResourceId);
         this.suggestionFunction = suggestionFunction;
@@ -62,6 +68,7 @@ public class AutoCompleteAdapter extends ArrayAdapter<String> {
             @Override
             protected void publishResults(final CharSequence constraint, final FilterResults filterResults) {
                 if (filterResults != null && filterResults.count > 0) {
+                    searchTerm = constraint.toString();
                     suggestions = (String[]) filterResults.values;
                     notifyDataSetChanged();
                 } else {

--- a/main/src/main/java/cgeo/geocaching/search/AutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/AutoCompleteAdapter.java
@@ -17,15 +17,9 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class AutoCompleteAdapter extends ArrayAdapter<String> {
 
-    private static final String[] EMPTY = new String[0];
-    private String[] suggestions = EMPTY;
-    private final Func1<String, String[]> suggestionFunction;
-
-    public String getSearchTerm() {
-        return searchTerm;
-    }
-
-    private String searchTerm;
+    static final String[] EMPTY = new String[0];
+    String[] suggestions = EMPTY;
+    Func1<String, String[]> suggestionFunction;
 
     public AutoCompleteAdapter(final Context context, @LayoutRes final int textViewResourceId, final Func1<String, String[]> suggestionFunction) {
         super(context, textViewResourceId);
@@ -68,7 +62,6 @@ public class AutoCompleteAdapter extends ArrayAdapter<String> {
             @Override
             protected void publishResults(final CharSequence constraint, final FilterResults filterResults) {
                 if (filterResults != null && filterResults.count > 0) {
-                    searchTerm = constraint.toString();
                     suggestions = (String[]) filterResults.values;
                     notifyDataSetChanged();
                 } else {

--- a/main/src/main/java/cgeo/geocaching/search/GeocacheAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/GeocacheAutoCompleteAdapter.java
@@ -1,12 +1,12 @@
 package cgeo.geocaching.search;
 
+import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.GeoItemSelectorUtils;
 import cgeo.geocaching.utils.functions.Func0;
 import cgeo.geocaching.utils.functions.Func1;
-import cgeo.geocaching.R;
 
 import android.content.Context;
 import android.view.View;

--- a/main/src/main/java/cgeo/geocaching/search/GeocacheAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/GeocacheAutoCompleteAdapter.java
@@ -1,11 +1,12 @@
 package cgeo.geocaching.search;
 
-import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.GeoItemSelectorUtils;
+import cgeo.geocaching.utils.functions.Func0;
 import cgeo.geocaching.utils.functions.Func1;
+import cgeo.geocaching.R;
 
 import android.content.Context;
 import android.view.View;
@@ -14,11 +15,23 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-public class GeocacheAutoCompleteAdapter extends AutoCompleteAdapter {
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class GeocacheAutoCompleteAdapter extends SearchAutoCompleteAdapter {
     private final Context context;
+    boolean isGeoCodeSearch = false;
+    boolean isKeywordSearch = false;
 
     public GeocacheAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction) {
-        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction);
+        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction, 0, null);
+        this.context = context;
+    }
+
+    public GeocacheAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction) {
+        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction, 0, historyFunction);
         this.context = context;
     }
 
@@ -27,9 +40,40 @@ public class GeocacheAutoCompleteAdapter extends AutoCompleteAdapter {
     public View getView(final int position, @Nullable final View convertView, @NonNull final ViewGroup parent) {
         final String geocode = getItem(position);
         final Geocache cache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-        return GeoItemSelectorUtils.createGeocacheItemView(context, cache,
-                GeoItemSelectorUtils.getOrCreateView(context, convertView, parent));
+        final View geoView = GeoItemSelectorUtils.createGeocacheItemView(context, cache, GeoItemSelectorUtils.getOrCreateView(context, convertView, parent));
+        if (isKeywordSearch) {
+            setHighLightedText(geoView.findViewById(R.id.text), searchTerm);
+        }
+        return geoView;
     }
 
+    public static String[] getLastOpenedCachesArray() {
+        final List<String> results = new ArrayList<>();
+        for (final Geocache geocache : DataStore.getLastOpenedCaches()) {
+            results.add(geocache.getGeocode());
+        }
+        return results.toArray(new String[0]);
+    }
+
+    public static class GeocodeAutoCompleteAdapter extends GeocacheAutoCompleteAdapter {
+        public GeocodeAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction) {
+            super(context, geocodeSuggestionFunction, historyFunction);
+            isGeoCodeSearch = true;
+        }
+
+        /**
+         * Usually search starts for 2 letters but for geocodes delay that until at least prefix + 1 letter have been entered
+         */
+        public boolean queryTriggersSearch(final String query) {
+            return StringUtils.length(query) >= 3;
+        }
+    }
+
+    public static class KeywordAutoCompleteAdapter extends GeocacheAutoCompleteAdapter {
+        public KeywordAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction) {
+            super(context, geocodeSuggestionFunction, historyFunction);
+            isKeywordSearch = true;
+        }
+    }
 
 }

--- a/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
@@ -3,50 +3,51 @@ package cgeo.geocaching.search;
 import android.content.Context;
 import android.text.Spannable;
 import android.text.SpannableString;
-import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Filter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.content.res.AppCompatResources;
+
+import org.apache.commons.lang3.StringUtils;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.enumerations.LoadFlags;
-import cgeo.geocaching.models.Geocache;
-import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.ui.GeoItemSelectorUtils;
+import cgeo.geocaching.utils.functions.Func0;
 import cgeo.geocaching.utils.functions.Func1;
 
 public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
 
-    int icon;
+    int suggestionIcon;
+    int historyIcon = R.drawable.ic_menu_recent_history;
     Context context;
+    final Func0<String[]> historyFunction;
+    String searchTerm;
 
-    public SearchAutoCompleteAdapter(Context context, int textViewResourceId, int icon, Func1<String, String[]> suggestionFunction) {
+    public SearchAutoCompleteAdapter(Context context, int textViewResourceId, Func1<String, String[]> suggestionFunction, int suggestionIcon, Func0<String[]> historyFunction) {
         super(context, textViewResourceId, suggestionFunction);
-        this.icon = icon;
+        this.suggestionIcon = suggestionIcon;
         this.context = context;
+        this.historyFunction = historyFunction;
     }
 
     @NonNull
     @Override
     public View getView(final int position, @Nullable final View convertView, @NonNull final ViewGroup parent) {
-        View v = getOrCreateView(context, convertView, parent);
-        final String geocode = getItem(position);
-        TextView textView = v.findViewById(R.id.text);
-        ImageView iconView = v.findViewById(R.id.icon);
-        textView.setText(geocode);
-        setHighLightedText(textView, getSearchTerm().toLowerCase());
-        iconView.setImageResource(icon);
+        final View v = getOrCreateView(context, convertView, parent);
+        final TextView textView = v.findViewById(R.id.text);
+        final ImageView iconView = v.findViewById(R.id.icon);
+
+        textView.setText(getItem(position));
+        setHighLightedText(textView, searchTerm);
+        iconView.setImageResource(queryTriggersSearch(searchTerm) ? suggestionIcon : historyIcon);
+
         return v;
     }
-
-
 
     public static View getOrCreateView(final Context context, final View convertView, final ViewGroup parent) {
         final View view = convertView == null ? LayoutInflater.from(context).inflate(R.layout.search_suggestion, parent, false) : convertView;
@@ -55,25 +56,72 @@ public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
     }
 
     /**
-     * use this method to highlight a text in TextView
-     *
-     * @param tv              TextView or Edittext or Button (or derived from TextView)
-     * @param textToHighlight Text to highlight
+     * Highlight the selected text (case insensitive) in the given TextView
      */
-    public void setHighLightedText(TextView tv, String textToHighlight) {
-        String tvt = tv.getText().toString().toLowerCase();
-        int ofe = tvt.indexOf(textToHighlight, 0);
-        Spannable wordToSpan = new SpannableString(tv.getText());
-        for (int ofs = 0; ofs < tvt.length() && ofe != -1; ofs = ofe + 1) {
-            ofe = tvt.indexOf(textToHighlight, ofs);
-            if (ofe == -1)
+    void setHighLightedText(final TextView tv, final String textToHighlight) {
+        final String text = tv.getText().toString().toLowerCase();
+        int ofe = text.indexOf(textToHighlight, 0);
+        final Spannable wordToSpan = new SpannableString(tv.getText());
+        for (int ofs = 0; ofs < text.length() && ofe != -1; ofs = ofe + 1) {
+            ofe = text.indexOf(textToHighlight, ofs);
+            if (ofe == -1) {
                 break;
-            else {
-                // set color here
+            } else {
                 wordToSpan.setSpan(new ForegroundColorSpan(context.getResources().getColor(R.color.colorAccent)), ofe, ofe + textToHighlight.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                 tv.setText(wordToSpan, TextView.BufferType.SPANNABLE);
             }
         }
     }
 
+    public boolean queryTriggersSearch(final String query) {
+        return StringUtils.length(query) >= 2;
+    }
+
+    @Override
+    @NonNull
+    public Filter getFilter() {
+        final SearchAutoCompleteAdapter adapter = this;
+        return new Filter() {
+
+            @Override
+            protected FilterResults performFiltering(final CharSequence constraint) {
+                final FilterResults filterResults = new FilterResults();
+                if (constraint == null) {
+                    return filterResults;
+                }
+                final String trimmed = StringUtils.trim(constraint.toString());
+                if (adapter.queryTriggersSearch(trimmed)) {
+                    final String[] newResults = suggestionFunction.call(trimmed);
+                    filterResults.values = newResults;
+                    filterResults.count = newResults.length;
+                } else if (null != historyFunction) {
+                    final String[] newResults = historyFunction.call();
+                    filterResults.values = newResults;
+                    filterResults.count = newResults.length;
+                }
+                return filterResults;
+            }
+
+            @Override
+            protected void publishResults(final CharSequence constraint, final FilterResults filterResults) {
+                if (filterResults != null && filterResults.count > 0) {
+                    searchTerm = constraint.toString().toLowerCase();
+                    suggestions = (String[]) filterResults.values;
+                    notifyDataSetChanged();
+                } else {
+                    notifyDataSetInvalidated(); // TODO: This is broken, search keeps showing the last result
+                }
+            }
+        };
+    }
+
+    // TODO: Replace this wherever it's used
+    public static String[] getDummyHistoryValues() {
+        return new String[] { "test", "testABC" };
+    }
+
+    // TODO: Replace this wherever it's used
+    public static String[] getDummyGCHistoryValues() {
+        return new String[] { "GC40", "GCK25B" };
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
@@ -1,5 +1,9 @@
 package cgeo.geocaching.search;
 
+import cgeo.geocaching.R;
+import cgeo.geocaching.utils.functions.Func0;
+import cgeo.geocaching.utils.functions.Func1;
+
 import android.content.Context;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -16,10 +20,6 @@ import androidx.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 
-import cgeo.geocaching.R;
-import cgeo.geocaching.utils.functions.Func0;
-import cgeo.geocaching.utils.functions.Func1;
-
 public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
 
     int suggestionIcon;
@@ -28,7 +28,7 @@ public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
     final Func0<String[]> historyFunction;
     String searchTerm;
 
-    public SearchAutoCompleteAdapter(Context context, int textViewResourceId, Func1<String, String[]> suggestionFunction, int suggestionIcon, Func0<String[]> historyFunction) {
+    public SearchAutoCompleteAdapter(final Context context, final int textViewResourceId, final Func1<String, String[]> suggestionFunction, final int suggestionIcon, final Func0<String[]> historyFunction) {
         super(context, textViewResourceId, suggestionFunction);
         this.suggestionIcon = suggestionIcon;
         this.context = context;
@@ -109,7 +109,8 @@ public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
                     suggestions = (String[]) filterResults.values;
                     notifyDataSetChanged();
                 } else {
-                    notifyDataSetInvalidated(); // TODO: This is broken, search keeps showing the last result
+                    suggestions = new String[0];
+                    notifyDataSetInvalidated();
                 }
             }
         };

--- a/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
@@ -1,0 +1,50 @@
+package cgeo.geocaching.search;
+
+import android.content.Context;
+import android.text.SpannableString;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.GeoItemSelectorUtils;
+import cgeo.geocaching.utils.functions.Func1;
+
+public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
+
+    int icon;
+    Context context;
+
+    public SearchAutoCompleteAdapter(Context context, int textViewResourceId, int icon, Func1<String, String[]> suggestionFunction) {
+        super(context, textViewResourceId, suggestionFunction);
+        this.icon = icon;
+        this.context = context;
+    }
+
+    @NonNull
+    @Override
+    public View getView(final int position, @Nullable final View convertView, @NonNull final ViewGroup parent) {
+        View v = getOrCreateView(context, convertView, parent);
+        final String geocode = getItem(position);
+        TextView textView = v.findViewById(R.id.text);
+        ImageView iconView = v.findViewById(R.id.icon);
+        textView.setText(geocode);
+        iconView.setImageResource(icon);
+        return v;
+    }
+
+    public static View getOrCreateView(final Context context, final View convertView, final ViewGroup parent) {
+        final View view = convertView == null ? LayoutInflater.from(context).inflate(R.layout.search_suggestion, parent, false) : convertView;
+        ((TextView) view.findViewById(R.id.text)).setText(new SpannableString(""));
+        return view;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
@@ -41,7 +41,7 @@ public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
         TextView textView = v.findViewById(R.id.text);
         ImageView iconView = v.findViewById(R.id.icon);
         textView.setText(geocode);
-        setHighLightedText(textView, getSearchTerm());
+        setHighLightedText(textView, getSearchTerm().toLowerCase());
         iconView.setImageResource(icon);
         return v;
     }
@@ -61,7 +61,7 @@ public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
      * @param textToHighlight Text to highlight
      */
     public void setHighLightedText(TextView tv, String textToHighlight) {
-        String tvt = tv.getText().toString();
+        String tvt = tv.getText().toString().toLowerCase();
         int ofe = tvt.indexOf(textToHighlight, 0);
         Spannable wordToSpan = new SpannableString(tv.getText());
         for (int ofs = 0; ofs < tvt.length() && ofe != -1; ofs = ofe + 1) {

--- a/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchAutoCompleteAdapter.java
@@ -1,7 +1,10 @@
 package cgeo.geocaching.search;
 
 import android.content.Context;
+import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +13,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.content.res.AppCompatResources;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -37,14 +41,39 @@ public class SearchAutoCompleteAdapter extends AutoCompleteAdapter {
         TextView textView = v.findViewById(R.id.text);
         ImageView iconView = v.findViewById(R.id.icon);
         textView.setText(geocode);
+        setHighLightedText(textView, getSearchTerm());
         iconView.setImageResource(icon);
         return v;
     }
+
+
 
     public static View getOrCreateView(final Context context, final View convertView, final ViewGroup parent) {
         final View view = convertView == null ? LayoutInflater.from(context).inflate(R.layout.search_suggestion, parent, false) : convertView;
         ((TextView) view.findViewById(R.id.text)).setText(new SpannableString(""));
         return view;
+    }
+
+    /**
+     * use this method to highlight a text in TextView
+     *
+     * @param tv              TextView or Edittext or Button (or derived from TextView)
+     * @param textToHighlight Text to highlight
+     */
+    public void setHighLightedText(TextView tv, String textToHighlight) {
+        String tvt = tv.getText().toString();
+        int ofe = tvt.indexOf(textToHighlight, 0);
+        Spannable wordToSpan = new SpannableString(tv.getText());
+        for (int ofs = 0; ofs < tvt.length() && ofe != -1; ofs = ofe + 1) {
+            ofe = tvt.indexOf(textToHighlight, ofs);
+            if (ofe == -1)
+                break;
+            else {
+                // set color here
+                wordToSpan.setSpan(new ForegroundColorSpan(context.getResources().getColor(R.color.colorAccent)), ofe, ofe + textToHighlight.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                tv.setText(wordToSpan, TextView.BufferType.SPANNABLE);
+            }
+        }
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/GeoItemSelectorUtils.java
@@ -43,7 +43,6 @@ public class GeoItemSelectorUtils {
     }
 
     public static View createGeocacheItemView(final Context context, final Geocache cache, final View view) {
-
         final TextParam cacheName = TextParam.text(TextUtils.coloredCacheText(context, cache, StringUtils.defaultIfBlank(cache.getName(), "")));
         final ImageParam cacheIcon = ImageParam.drawable(MapMarkerUtils.getCacheMarker(context.getResources(), cache, CacheListType.MAP, Settings.getIconScaleEverywhere()).getDrawable());
 

--- a/main/src/main/res/drawable/search_identifier.xml
+++ b/main/src/main/res/drawable/search_identifier.xml
@@ -2,9 +2,9 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
   <path
       android:fillColor="#FF000000"
-      android:pathData="m9,4.5v3H7.5V16.5H9V19.5H3V16.5H4.5V7.5H3v-3h6m9,0c1.665,0 3,1.35 3,3V16.5C21,18.165 19.665,19.5 18,19.5H12V4.5m6,3H15V16.5H18Z"
-      android:strokeWidth="0.999999"/>
+      android:pathData="m9,4.5v3H7.5V16.5H9V19.5H3V16.5H4.5V7.5H3v-3h6m9,0c1.665,0 3,1.35 3,3V16.5C21,18.165 19.665,19.5 18,19.5H12V4.5m6,3H15V16.5H18Z" />
 </vector>

--- a/main/src/main/res/drawable/search_identifier.xml
+++ b/main/src/main/res/drawable/search_identifier.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m9,4.5v3H7.5V16.5H9V19.5H3V16.5H4.5V7.5H3v-3h6m9,0c1.665,0 3,1.35 3,3V16.5C21,18.165 19.665,19.5 18,19.5H12V4.5m6,3H15V16.5H18Z"
+      android:strokeWidth="0.999999"/>
+</vector>

--- a/main/src/main/res/layout/cacheslist_item_select.xml
+++ b/main/src/main/res/layout/cacheslist_item_select.xml
@@ -5,7 +5,6 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     tools:layout_height="60sp"
-    android:background="@color/colorBackgroundDialog"
     android:foreground="?android:attr/selectableItemBackground">
 
     <ImageView

--- a/main/src/main/res/layout/search_activity.xml
+++ b/main/src/main/res/layout/search_activity.xml
@@ -1,46 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:orientation="vertical"
-    tools:context=".SearchActivity" >
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/flipper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/search_activity"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
 
-        <RelativeLayout
-            style="@style/search_content_group"
-            android:id="@+id/search_group"
-            android:visibility="gone">
+        <GridLayout
+            android:id="@+id/grid_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:columnCount="2"
+            android:elevation="0dp"
+            android:orientation="horizontal"
+            android:padding="8dp" />
+    </ScrollView>
 
-            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-                android:layout_toLeftOf="@+id/search_button"
-                android:id="@+id/search_label"
-                android:labelFor="@id/search_field">
-                <AutoCompleteTextView
-                    android:id="@+id/search_field"
-                    android:tag="searchField"
-                    style="@style/textinput_embedded_singleline_go" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Button
-                android:id="@+id/search_button"
-                style="@style/button_icon_search"
-                app:icon="@drawable/ic_menu_search" />
-        </RelativeLayout>
-
-    <GridLayout
-        android:id="@+id/grid_layout"
+    <ListView
+        android:id="@+id/suggestion_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:columnCount="2"
-        android:orientation="horizontal"
-        android:padding="8dp"
-        android:elevation="0dp"/>
-    </LinearLayout>
-</ScrollView>
+        android:layout_margin="5dp" />
+
+</ViewFlipper>

--- a/main/src/main/res/layout/search_card.xml
+++ b/main/src/main/res/layout/search_card.xml
@@ -6,7 +6,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/cardView"
     android:layout_margin="6dp"
-    app:cardElevation="2dp"
+    app:cardElevation="1dp"
     app:cardCornerRadius="4dp"
     app:strokeColor="@color/colorSeparator"
     app:strokeWidth="1dp">

--- a/main/src/main/res/layout/search_suggestion.xml
+++ b/main/src/main/res/layout/search_suggestion.xml
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/text1"
-    android:layout_width="match_parent"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceListItemSmall"
-    android:textColor="@color/colorText"
-    android:gravity="center_vertical"
-    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
-    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
-    android:minHeight="?android:attr/listPreferredItemHeightSmall" />
+    android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dip"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="5dp"
+        android:gravity="center_vertical"
+        app:tint="@color/colorText"
+        />
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:textColor="@color/colorText"
+        android:gravity="center_vertical"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall" />
+
+
+</LinearLayout>

--- a/main/src/main/res/layout/search_suggestion.xml
+++ b/main/src/main/res/layout/search_suggestion.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textAppearance="?android:attr/textAppearanceListItemSmall"
+    android:textColor="@color/colorText"
+    android:gravity="center_vertical"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall" />

--- a/main/src/main/res/layout/search_suggestion.xml
+++ b/main/src/main/res/layout/search_suggestion.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:gravity="center_vertical"
     android:orientation="horizontal">
 
     <ImageView
@@ -10,7 +11,6 @@
         android:layout_width="24dip"
         android:layout_height="wrap_content"
         android:layout_marginLeft="5dp"
-        android:gravity="center_vertical"
         app:tint="@color/colorText"
         />
 


### PR DESCRIPTION
supersedes  https://github.com/cgeo/cgeo/pull/16433

- several bugfixes for cardsearch:
-- keyword search suggestion was broken
-- wrong adapter sometimes used
-- visual tweaks
-- change geocode icon
-- add missing tint
- unrelated fix:
-- wrong icon was used in delete offline data dialog
- inline search suggestions (instead of dropdown)
-- search terms are highlighted in results
-- For all but Geocode search no history function is implemented yet but all the UI logic should be there now (not a regression, just a missing feature ;-))
![image](https://github.com/user-attachments/assets/3620a200-6684-4aff-ae61-0080629fc573)


@fm-sys maybe the "remember search terms and suggest them" part is where you could add as per our discussion in the last dev call - as time permits of course!