### PR TITLE
UnifiedMap Mapsforge: Fix NPE in online tile provider

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -81,12 +81,16 @@ public class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTilePr
     @Override
     public void onResume() {
         super.onResume();
-        ((TileDownloadLayer) tileLayer).onResume();
+        if (tileLayer != null) {
+            ((TileDownloadLayer) tileLayer).onResume();
+        }
     }
 
     @Override
     public void onDestroy() {
-        tileLayer.onDestroy();
+        if (tileLayer != null) {
+            tileLayer.onDestroy();
+        }
         super.onDestroy();
     }
 }


### PR DESCRIPTION
(fix error reported by Play Store stats for current beta 2024.12.17-RC)