### PR TITLE
rel to #16444: enable substring to be zerobased or onebased, enhance error handling

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaFunction.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaFunction.java
@@ -40,7 +40,7 @@ public enum FormulaFunction {
     LENGTH(new String[]{"length", "len"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_length, "String Length", "''", 1,
             singleValueStringFunction(String::length)),
     SUBSTRING(new String[]{"substring", "substr", "sub"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_substring, "Substring", "'';0;1", 1,
-            FormulaUtils::substring),
+            vl -> FormulaUtils.substring(false, vl)),
     CHARS(new String[]{"chars", "ch"}, FunctionGroup.SIMPLE_STRING, R.string.formula_function_chars, "Select Chars", "'';1;2", 1,
         FormulaUtils::selectChars),
 

--- a/main/src/main/java/cgeo/geocaching/utils/formulas/Value.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/Value.java
@@ -161,7 +161,7 @@ public class Value implements Comparable<Value> {
             if (isNumericZero()) {
                 return "Zero";
             }
-            final StringBuilder str = new StringBuilder(isNumericPositive() ? "+ " : "- ");
+            final StringBuilder str = new StringBuilder(isNumericPositive() ? "+" : "-");
             if (isInteger()) {
                 str.append("Integer");
             } else {

--- a/main/src/main/java/cgeo/geocaching/utils/formulas/ValueList.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/ValueList.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Encapsulates a list of {@link cgeo.geocaching.utils.formulas.Value}'s for handling as parameter lists in {@link Formula}
@@ -69,6 +70,15 @@ public class ValueList implements Iterable<Value> {
 
     public int size() {
         return list.size();
+    }
+
+    public boolean assertCheckType(final int index, final Predicate<Value> test, final String wantedType, final boolean checkOnly) {
+        return assertCheckTypes((v, i) -> {
+            if (index == i) {
+                return test.test(v);
+            }
+            return true;
+        }, i -> wantedType, checkOnly);
     }
 
     public boolean assertCheckTypes(final BiPredicate<Value, Integer> test, final Function<Integer, String> wantedType, final boolean checkOnly) {


### PR DESCRIPTION
rel to #16444: enable substring to be zerobased or onebased, enhance error handling

Enables easy parameterized switch between zero-index-based and one-index-based usage of `FormulaUtils.substring`. Also enhances error handling and unit test coverage.

This PR will NOT change any logic though