### PR TITLE
option to share cache with user data (coords, PN)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheMenuHandler.java
+++ b/main/src/main/java/cgeo/geocaching/CacheMenuHandler.java
@@ -10,7 +10,10 @@ import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.StoredList;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.AbstractUIFactory;
@@ -91,6 +94,28 @@ public final class CacheMenuHandler extends AbstractUIFactory {
         } else if (menuItem == R.id.menu_share || menuItem == R.id.menu_share_from_popup) {
             if (cache != null && activity != null) {
                 ShareUtils.shareLink(activity, cache.getShareSubject(), cache.getUrl());
+            }
+            return true;
+        } else if (menuItem == R.id.menu_share_with_data) {
+            if (cache != null && activity != null) {
+                final StringBuilder shareText = new StringBuilder().append(cache.getShareSubject()).append("\n").append(cache.getUrl()).append("\n\n");
+                final int shareCoordText;
+                final Geopoint shareCoords;
+                if (cache.hasUserModifiedCoords()) {
+                    shareCoordText = R.string.export_modifiedcoords;
+                    shareCoords = cache.getCoords();
+                } else if (cache.getFirstMatchingWaypoint(Waypoint::isFinalWithCoords) != null) {
+                    shareCoordText = R.string.wp_final;
+                    shareCoords = cache.getFirstMatchingWaypoint(Waypoint::isFinalWithCoords).getCoords();
+                } else {
+                    shareCoordText = R.string.cache_coordinates_original;
+                    shareCoords = cache.getCoords();
+                }
+                shareText.append(activity.getString(shareCoordText)).append(": ").append(GeopointFormatter.format(GeopointFormatter.Format.LAT_LON_DECMINUTE, shareCoords));
+                if (null != cache.getPersonalNote()) {
+                    shareText.append("\n").append(activity.getString(R.string.cache_personal_note)).append(": ").append(cache.getPersonalNote());
+                }
+                ShareUtils.sharePlainText(activity, shareText.toString());
             }
             return true;
         } else if (menuItem == R.id.menu_calendar) {

--- a/main/src/main/res/drawable/ic_menu_gpx.xml
+++ b/main/src/main/res/drawable/ic_menu_gpx.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:textColorPrimary">
+    <path
+        android:pathData="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M6.12,15.5L9.86,19.24L11.28,17.83L8.95,15.5L11.28,13.17L9.86,11.76L6.12,15.5M17.28,15.5L13.54,11.76L12.12,13.17L14.45,15.5L12.12,17.83L13.54,19.24L17.28,15.5Z"
+        android:fillColor="#e8eaed"/>
+</vector>

--- a/main/src/main/res/menu/cache_options.xml
+++ b/main/src/main/res/menu/cache_options.xml
@@ -151,15 +151,23 @@
         <menu>
             <item
                 android:id="@+id/menu_share"
-                android:title="@string/cache_menu_share">
+                android:title="@string/cache_menu_share"
+                android:icon="@drawable/ic_menu_share">
+            </item>
+            <item
+                android:id="@+id/menu_share_with_data"
+                android:title="@string/cache_menu_share_with_data"
+                android:icon="@drawable/ic_menu_variable">
             </item>
             <item
                 android:id="@+id/menu_export_gpx"
-                android:title="@string/export_gpx">
+                android:title="@string/export_gpx"
+                android:icon="@drawable/ic_menu_gpx">
             </item>
             <item
                 android:id="@+id/menu_export_fieldnotes"
-                android:title="@string/export_fieldnotes">
+                android:title="@string/export_fieldnotes"
+                android:icon="@drawable/ic_menu_note">
             </item>
         </menu>
     </item>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1646,6 +1646,7 @@
     <string name="cache_menu_details">Details</string>
     <string name="cache_menu_refresh">Refresh</string>
     <string name="cache_menu_share">Share cache</string>
+    <string name="cache_menu_share_with_data">Share incl. user data</string>
     <string name="cache_menu_move_list">Move to different list</string>
     <string name="cache_menu_copy_list">Copy to different list</string>
     <string name="cache_menu_oruxmaps_online">OruxMaps (Online)</string>


### PR DESCRIPTION
add a new share option to share the cache including coordinates (and indicator whether they are original, modified or final WP) and PN

Also add some icons to the menu :-)

![image](https://github.com/user-attachments/assets/ec9cef5b-c868-4ee2-ad68-c18ac89e6915)

![image](https://github.com/user-attachments/assets/d61ce9da-92be-48e5-b23e-bae6241d006f)
