### PR TITLE
remove non-functional filter from lists activity

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListActivity.java
@@ -35,7 +35,7 @@ public abstract class AbstractListActivity extends CustomMenuEntryActivity {
     @NonNull private final List<GCList> pocketQueries = new ArrayList<>();
 
     private boolean filteredList = false;
-    private final boolean fixed = false;
+    protected boolean fixed = false;
     private boolean startDownload = false;
     private SwitchCompat switchCompat = null;
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
@@ -13,16 +13,16 @@ public class BookmarkListActivity extends AbstractListActivity {
         title = R.string.menu_lists_bookmarklists;
         progressInfo = R.string.search_bookmark_list;
         errorReadingList = R.string.err_read_bookmark_list;
+        fixed = true;
     }
 
     @Override
-    protected boolean getFiltersetting() {
-        return Settings.getBookmarklistsShowNewOnly();
+    boolean getFiltersetting() {
+        return false;
     }
 
     @Override
-    protected void setFiltersetting(final boolean value) {
-        Settings.setBookmarklistsShowNewOnly(value);
+    void setFiltersetting(boolean value) {
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1331,14 +1331,6 @@ public class Settings {
         return getBoolean(R.string.pref_pqShowDownloadableOnly, false);
     }
 
-    public static void setBookmarklistsShowNewOnly(final boolean showNewOnly) {
-        putBoolean(R.string.pref_bookmarklistsShowNewOnly, showNewOnly);
-    }
-
-    public static boolean getBookmarklistsShowNewOnly() {
-        return getBoolean(R.string.pref_bookmarklistsShowNewOnly, false);
-    }
-
     public static boolean isUseCompass() {
         return useCompass;
     }

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -581,7 +581,6 @@
 
     <!-- pq/bookmark list: show downloadable/new only -->
     <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>
-    <string translatable="false" name="pref_bookmarklistsShowNewOnly">bookmarklistsShowNewOnly</string>
 
     <!-- internal version numbers and counters -->
     <string translatable="false" name="pref_version">version</string>


### PR DESCRIPTION
the filter in bookmark lists activity didn't do anything, the preferences weren't used anywhere, so removing it