### PR TITLE
change list switch labels

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/AbstractListActivity.java
@@ -43,6 +43,7 @@ public abstract class AbstractListActivity extends CustomMenuEntryActivity {
     @StringRes protected int title;
     @StringRes protected int progressInfo;
     @StringRes protected int errorReadingList;
+    @StringRes protected int switchLabel;
 
     abstract boolean getFiltersetting();
 
@@ -79,6 +80,7 @@ public abstract class AbstractListActivity extends CustomMenuEntryActivity {
                 bar.setDisplayShowCustomEnabled(true);
 
                 switchCompat = customView.findViewById(R.id.switchAB);
+                switchCompat.setText(switchLabel);
                 switchCompat.setVisibility(View.INVISIBLE);
                 switchCompat.setChecked(!getFiltersetting());
                 switchCompat.setOnCheckedChangeListener((a, b) -> checkSwitchState(adapter));
@@ -114,7 +116,7 @@ public abstract class AbstractListActivity extends CustomMenuEntryActivity {
 
     private void fillAdapter(final AbstractListAdapter adapter) {
         pocketQueries.clear();
-        if (filteredList) {
+        if (!filteredList) {
             for (final GCList pq : allPocketQueries) {
                 if (alwaysShow(pq)) {
                     pocketQueries.add(pq);

--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
@@ -13,6 +13,7 @@ public class BookmarkListActivity extends AbstractListActivity {
         title = R.string.menu_lists_bookmarklists;
         progressInfo = R.string.search_bookmark_list;
         errorReadingList = R.string.err_read_bookmark_list;
+        switchLabel = R.string.lists_only_new;
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
@@ -12,6 +12,7 @@ public class PocketQueryListActivity extends AbstractListActivity {
         title = R.string.menu_lists_pocket_queries;
         progressInfo = R.string.search_pocket_loading;
         errorReadingList = R.string.err_read_pocket_query_list;
+        switchLabel = R.string.pq_only_dl;
     }
 
     @Override

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2759,6 +2759,8 @@
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="show_all">Show all</string>
+    <string name="lists_only_new">New only</string>
+    <string name="pq_only_dl">Downloadable</string>
 
     <string name="routingmode_straight">Straight</string>
     <string name="routingmode_walk">Walk</string>


### PR DESCRIPTION
change switch labels for PQ / lists activities from "show all" to specific strings "New only" for lists and "Downloadable only" for PQs. For the old "show all" it's not clear what the other option actually does.

supersedes https://github.com/cgeo/cgeo/pull/16483