### PR TITLE
add parser for DD,DDDDDDD format

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -417,7 +417,7 @@ public class GeopointParser {
 
         //                                        (       1       )
         private static final String STRING_LON = "(-?(\\d++),(\\d++))\\b°?";
-        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.=-]*";
+        private static final String STRING_SEPARATOR = ", ";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -384,10 +384,10 @@ public class GeopointParser {
      */
     private static final class DegDecParser extends AbstractLatLonParser {
         //                                        (       1       )
-        private static final String STRING_LAT = "(-?\\d++\\.\\d++)°?";
+        private static final String STRING_LAT = "(-?\\d{1,2}+\\.\\d{5,}+)°?";
 
         //                                        (       1       )
-        private static final String STRING_LON = "(-?\\d++\\.\\d++)\\b°?";
+        private static final String STRING_LON = "(-?\\d{1,3}+\\.\\d{5,}+)\\b°?";
         private static final String STRING_SEPARATOR = "[^\\w'′\"″°.=-]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -384,10 +384,10 @@ public class GeopointParser {
      */
     private static final class DegDecParser extends AbstractLatLonParser {
         //                                        (       1       )
-        private static final String STRING_LAT = "(-?\\d{1,2}+\\.\\d{5,}+)°?";
+        private static final String STRING_LAT = "(-?\\d++\\.\\d++)°?";
 
         //                                        (       1       )
-        private static final String STRING_LON = "(-?\\d{1,3}+\\.\\d{5,}+)\\b°?";
+        private static final String STRING_LON = "(-?\\d++\\.\\d++)\\b°?";
         private static final String STRING_SEPARATOR = "[^\\w'′\"″°.=-]*";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -25,7 +25,7 @@ public class GeopointParser {
     private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), (\\d{2,})");
     private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. (\\d{2,})");
 
-    private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser());
+    private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 
     private GeopointParser() {
         // utility class
@@ -404,6 +404,35 @@ public class GeopointParser {
         @Nullable
         public Double parse(@NonNull final List<String> groups) {
             final String group1 = groups.get(0);
+            return createCoordinate("", group1, "", "");
+        }
+    }
+
+    /**
+     * Parser for DegDec format: DD,DDDDDDD°.
+     */
+    private static final class DegDecCommaParser extends AbstractLatLonParser {
+        //                                        (       1       )
+        private static final String STRING_LAT = "(-?(\\d++),(\\d++))°?";
+
+        //                                        (       1       )
+        private static final String STRING_LON = "(-?(\\d++),(\\d++))\\b°?";
+        private static final String STRING_SEPARATOR = "[^\\w'′\"″°.=-]*";
+        private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
+        private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);
+        private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);
+
+        DegDecCommaParser() {
+            super(PATTERN_LAT, PATTERN_LON, PATTERN_LATLON);
+        }
+
+        /**
+         * @see AbstractLatLonParser#parse(List)
+         */
+        @Override
+        @Nullable
+        public Double parse(@NonNull final List<String> groups) {
+            final String group1 = groups.get(1) + "." + groups.get(2);
             return createCoordinate("", group1, "", "");
         }
     }

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -22,8 +22,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class GeopointParser {
 
-    private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), (-?\\d{2,})");
-    private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. (-?\\d{2,})");
+    private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), ([-+]?\\d{2,})");
+    private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. ([-+]?\\d{2,})");
 
     private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 
@@ -413,10 +413,10 @@ public class GeopointParser {
      */
     private static final class DegDecCommaParser extends AbstractLatLonParser {
         //                                        (     1     ) , (    2   )
-        private static final String STRING_LAT = "(-?\\d{1,2}+),(\\d{5,}+)°?";
+        private static final String STRING_LAT = "([-+]?\\d{1,2}+),(\\d{5,}+)°?";
 
         //                                        (     1     ) , (    2   )
-        private static final String STRING_LON = "(-?\\d{1,3}+),(\\d{5,}+)\\b°?";
+        private static final String STRING_LON = "([-+]?\\d{1,3}+),(\\d{5,}+)\\b°?";
         private static final String STRING_SEPARATOR = ",";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -22,8 +22,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class GeopointParser {
 
-    private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), (\\d{2,})");
-    private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. (\\d{2,})");
+    private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), (-?\\d{2,})");
+    private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. (-?\\d{2,})");
 
     private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 
@@ -412,12 +412,12 @@ public class GeopointParser {
      * Parser for DegDec format: DD,DDDDDDD°.
      */
     private static final class DegDecCommaParser extends AbstractLatLonParser {
-        //                                        (       1       )
-        private static final String STRING_LAT = "(-?(\\d++),(\\d++))°?";
+        //                                        (     1     ) , (    2   )
+        private static final String STRING_LAT = "(-?\\d{1,2}+),(\\d{5,}+)°?";
 
-        //                                        (       1       )
-        private static final String STRING_LON = "(-?(\\d++),(\\d++))\\b°?";
-        private static final String STRING_SEPARATOR = ", ";
+        //                                        (     1     ) , (    2   )
+        private static final String STRING_LON = "(-?\\d{1,3}+),(\\d{5,}+)\\b°?";
+        private static final String STRING_SEPARATOR = ",";
         private static final Pattern PATTERN_LAT = Pattern.compile(STRING_LAT, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LON = Pattern.compile(STRING_LON, Pattern.CASE_INSENSITIVE);
         private static final Pattern PATTERN_LATLON = Pattern.compile(STRING_LAT + STRING_SEPARATOR + STRING_LON, Pattern.CASE_INSENSITIVE);
@@ -432,7 +432,7 @@ public class GeopointParser {
         @Override
         @Nullable
         public Double parse(@NonNull final List<String> groups) {
-            final String group1 = groups.get(1) + "." + groups.get(2);
+            final String group1 = groups.get(0) + "." + groups.get(1);
             return createCoordinate("", group1, "", "");
         }
     }

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -159,6 +159,12 @@ public class GeoPointParserTest {
     }
 
     @Test
+    public void testFloatingPointCommaBoth() {
+        assertGeopointEquals(GeopointParser.parse("47,648883  122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883  -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+    }
+
+    @Test
     public void testFloatingPointNbsp() {
         assertGeopointEquals(GeopointParser.parse("47.648883  122.348067\u00a0"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
     }

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -153,14 +153,39 @@ public class GeoPointParserTest {
     }
 
     @Test
-    public void testFloatingPointBoth() {
+    public void testFloatingPointPoint() {
         assertGeopointEquals(GeopointParser.parse("47.648883  122.348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47.648883  -122.348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
     }
 
     @Test
-    public void testFloatingPointCommaBoth() {
-        assertGeopointEquals(GeopointParser.parse("45,480067 9,210533"), GeopointParser.parse("N 45° 28.804 E 009° 12.632"), 1e-4f);
+    public void testFloatingPointComma() {
+        assertGeopointEquals(GeopointParser.parse("47,648883  122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883  -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+    }
+
+    @Test
+    public void testFloatingPointWithSeparator() {
+        assertGeopointEquals(GeopointParser.parse("47.648883,  122.348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47.648883,  -122.348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+
+        assertGeopointEquals(GeopointParser.parse("47,648883. 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883. -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+    }
+
+    @Test
+    public void testDegDecCommaParser() {
+        assertGeopointEquals(GeopointParser.parse("47,648883, 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883, -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+
+        // blanks after decimal comma
+        assertParsingFails("47, 648883, -122, 348067");
+        // more than one blank after comma separator
+        assertParsingFails("47,648883,  122,348067");
+        // too few digits after comma separator
+        assertParsingFails("47,6488, 122,3480");
+        // no coordinates should be detected
+        assertParsingFails("47, 648, 122, 3480");
     }
 
     @Test

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -176,6 +176,7 @@ public class GeoPointParserTest {
     @Test
     public void testDegDecCommaParser() {
         assertGeopointEquals(GeopointParser.parse("47,648883, 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883, +122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47,648883, -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
 
         // blanks after decimal comma

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -160,8 +160,7 @@ public class GeoPointParserTest {
 
     @Test
     public void testFloatingPointCommaBoth() {
-        assertGeopointEquals(GeopointParser.parse("47,648883  122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
-        assertGeopointEquals(GeopointParser.parse("47,648883  -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("45,480067 9,210533"), GeopointParser.parse("N 45° 28.804 E 009° 12.632"), 1e-4f);
     }
 
     @Test

--- a/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
@@ -64,11 +64,14 @@ public class CacheArtefactParserTest {
         final String note = "1. 0815\n2. 4711\nn 45° 3.565 e 27° 7.578";
         final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
         final Collection<Waypoint> waypoints = cacheArtefactParser.parse(note).getWaypoints();
-        assertThat(waypoints).hasSize(1);
+        assertThat(waypoints).hasSize(2);
         final Iterator<Waypoint> iterator = waypoints.iterator();
         final Waypoint wp1 = iterator.next();
-        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 01° 4.890 E 2°28.266"));
         assertThat(wp1.getUserNote()).isEmpty();
+        final Waypoint wp2 = iterator.next();
+        assertWaypoint(wp2, "Prefix 2", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertThat(wp2.getUserNote()).isEmpty();
     }
 
     @Test
@@ -76,11 +79,14 @@ public class CacheArtefactParserTest {
         final String note = "1. 0815  2. 4711. 0815 2.4711 \n n 45° 3.565 e 27° 7.578";
         final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
         final Collection<Waypoint> waypoints = cacheArtefactParser.parse(note).getWaypoints();
-        assertThat(waypoints).hasSize(1);
+        assertThat(waypoints).hasSize(2);
         final Iterator<Waypoint> iterator = waypoints.iterator();
         final Waypoint wp1 = iterator.next();
-        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 45°3.565 E 27°7.578"));
-        assertThat(wp1.getUserNote()).isEmpty();
+        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 01° 4.890 E 2°28.266"));
+        assertThat(wp1.getUserNote()).isEqualTo(". 0815 2.4711");
+        final Waypoint wp2 = iterator.next();
+        assertWaypoint(wp2, "Prefix 2", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertThat(wp2.getUserNote()).isEmpty();
     }
 
     private static void parseAndAssertFirstWaypoint(final String text, final String name, final WaypointType wpType, final String userNote) {
@@ -605,18 +611,18 @@ public class CacheArtefactParserTest {
     @Test
     public void testParseFormulaContainingPlainCoords() {
         final CacheArtefactParser parser = createParser("Praefix");
-        assertWaypoint(parser.parse("37.00000 +0.12345").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(37d, 0.12345d));
-        assertWaypoint(parser.parse("16.00000 -0.54321").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(16d, -0.54321d));
+        assertWaypoint(parser.parse("37.000 +0.123").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(37d, 0.123d));
+        assertWaypoint(parser.parse("16.000 -0.321").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(16d, -0.321d));
 
         //Formulas may contain text which would be parseable as standalone coord.
         //In this case however, such standalone coord should NOT be parsed
         final Collection<Waypoint> wps =
-                parser.parse("@Finale (F) {CC|N47° (37.00000 +0.12345)|E012° (16.00000 -0.54321)}").getWaypoints();
+                parser.parse("@Finale (F) {CC|N47° (37.000 +0.123)|E012° (16.000 -0.321)}").getWaypoints();
         assertThat(wps).hasSize(1);
         final Waypoint wp = wps.iterator().next();
-        assertThat(wp.getCalcStateConfig()).isEqualTo("{CC|N47° (37.00000 +0.12345)|E012° (16.00000 -0.54321)}");
+        assertThat(wp.getCalcStateConfig()).isEqualTo("{CC|N47° (37.000 +0.123)|E012° (16.000 -0.321)}");
 
-        final Collection<Waypoint> wps2 = parser.parse("{CC|N48|E11} 13.50000 8.30000 {CC|N34|E09}").getWaypoints();
+        final Collection<Waypoint> wps2 = parser.parse("{CC|N48|E11} 13.5 8.3 {CC|N34|E09}").getWaypoints();
         assertThat(wps2).hasSize(3);
         Waypoint nonCalc = null;
         int nonCalcCnt = 0;

--- a/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/CacheArtefactParserTest.java
@@ -64,14 +64,11 @@ public class CacheArtefactParserTest {
         final String note = "1. 0815\n2. 4711\nn 45° 3.565 e 27° 7.578";
         final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
         final Collection<Waypoint> waypoints = cacheArtefactParser.parse(note).getWaypoints();
-        assertThat(waypoints).hasSize(2);
+        assertThat(waypoints).hasSize(1);
         final Iterator<Waypoint> iterator = waypoints.iterator();
         final Waypoint wp1 = iterator.next();
-        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 01° 4.890 E 2°28.266"));
+        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 45°3.565 E 27°7.578"));
         assertThat(wp1.getUserNote()).isEmpty();
-        final Waypoint wp2 = iterator.next();
-        assertWaypoint(wp2, "Prefix 2", new Geopoint("N 45°3.565 E 27°7.578"));
-        assertThat(wp2.getUserNote()).isEmpty();
     }
 
     @Test
@@ -79,14 +76,11 @@ public class CacheArtefactParserTest {
         final String note = "1. 0815  2. 4711. 0815 2.4711 \n n 45° 3.565 e 27° 7.578";
         final CacheArtefactParser cacheArtefactParser = createParser("Prefix");
         final Collection<Waypoint> waypoints = cacheArtefactParser.parse(note).getWaypoints();
-        assertThat(waypoints).hasSize(2);
+        assertThat(waypoints).hasSize(1);
         final Iterator<Waypoint> iterator = waypoints.iterator();
         final Waypoint wp1 = iterator.next();
-        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 01° 4.890 E 2°28.266"));
-        assertThat(wp1.getUserNote()).isEqualTo(". 0815 2.4711");
-        final Waypoint wp2 = iterator.next();
-        assertWaypoint(wp2, "Prefix 2", new Geopoint("N 45°3.565 E 27°7.578"));
-        assertThat(wp2.getUserNote()).isEmpty();
+        assertWaypoint(wp1, "Prefix 1", new Geopoint("N 45°3.565 E 27°7.578"));
+        assertThat(wp1.getUserNote()).isEmpty();
     }
 
     private static void parseAndAssertFirstWaypoint(final String text, final String name, final WaypointType wpType, final String userNote) {
@@ -611,18 +605,18 @@ public class CacheArtefactParserTest {
     @Test
     public void testParseFormulaContainingPlainCoords() {
         final CacheArtefactParser parser = createParser("Praefix");
-        assertWaypoint(parser.parse("37.000 +0.123").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(37d, 0.123d));
-        assertWaypoint(parser.parse("16.000 -0.321").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(16d, -0.321d));
+        assertWaypoint(parser.parse("37.00000 +0.12345").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(37d, 0.12345d));
+        assertWaypoint(parser.parse("16.00000 -0.54321").getWaypoints().iterator().next(), "Praefix 1", new Geopoint(16d, -0.54321d));
 
         //Formulas may contain text which would be parseable as standalone coord.
         //In this case however, such standalone coord should NOT be parsed
         final Collection<Waypoint> wps =
-                parser.parse("@Finale (F) {CC|N47° (37.000 +0.123)|E012° (16.000 -0.321)}").getWaypoints();
+                parser.parse("@Finale (F) {CC|N47° (37.00000 +0.12345)|E012° (16.00000 -0.54321)}").getWaypoints();
         assertThat(wps).hasSize(1);
         final Waypoint wp = wps.iterator().next();
-        assertThat(wp.getCalcStateConfig()).isEqualTo("{CC|N47° (37.000 +0.123)|E012° (16.000 -0.321)}");
+        assertThat(wp.getCalcStateConfig()).isEqualTo("{CC|N47° (37.00000 +0.12345)|E012° (16.00000 -0.54321)}");
 
-        final Collection<Waypoint> wps2 = parser.parse("{CC|N48|E11} 13.5 8.3 {CC|N34|E09}").getWaypoints();
+        final Collection<Waypoint> wps2 = parser.parse("{CC|N48|E11} 13.50000 8.30000 {CC|N34|E09}").getWaypoints();
         assertThat(wps2).hasSize(3);
         Waypoint nonCalc = null;
         int nonCalcCnt = 0;


### PR DESCRIPTION
add parser for DD,DDDDDDD format used by e.g. Google Maps in German/Russian

fixes https://github.com/cgeo/cgeo/issues/16382

This will require some good testing though, the coordinate format seems to be prone to false positives - hence marking as Feedback required.