### PR TITLE
fix #16382: Adapt clip-board-text, if it contains only "comma-separated-google-formatted" coordinate

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/GeopointFormatter.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointFormatter.java
@@ -1,14 +1,20 @@
 package cgeo.geocaching.location;
 
 import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.MatcherWrapper;
+
+import androidx.annotation.Nullable;
 
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Formatting of Geopoint.
  */
 public class GeopointFormatter {
+
+    private static final Pattern PATTERN_GOOGLE_COMMA = Pattern.compile("(-?\\d+,\\d+)\\s*,\\s*(-?\\d+,\\d+)");
 
     private GeopointFormatter() {
         // utility class
@@ -221,5 +227,20 @@ public class GeopointFormatter {
      */
     public static CharSequence reformatForClipboard(final CharSequence coordinatesToCopy) {
         return coordinatesToCopy.toString().replace(Formatter.SEPARATOR, " ").replaceAll(",", ".");
+    }
+
+    /**
+     * Prepare string from clipboard to parse coordinates
+     * remove additional comma from google maps format, if it only contains coordinates in google-format-
+     */
+    @Nullable
+    public static String adaptFormatFromClipboard(@Nullable final String clipboardText) {
+        // remove additional comma from google maps
+        final MatcherWrapper googleFormatMatcher = new MatcherWrapper(PATTERN_GOOGLE_COMMA, clipboardText);
+        if (!googleFormatMatcher.matches()) {
+            return clipboardText;
+        }
+
+        return googleFormatMatcher.replaceAll("$1 $2");
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -308,12 +308,7 @@ public class CoordinatesInputDialog extends DialogFragment {
     }
 
     private static boolean hasClipboardCoordinates() {
-        try {
-            getGeopointFromClipboard();
-        } catch (final ParseException ignored) {
-            return false;
-        }
-        return true;
+        return null != getGeopointFromClipboard();
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesInputDialog.java
@@ -307,15 +307,26 @@ public class CoordinatesInputDialog extends DialogFragment {
         super.onAttach(activity);
     }
 
-    @SuppressWarnings("unused")
     private static boolean hasClipboardCoordinates() {
         try {
-            new Geopoint(StringUtils.defaultString(ClipboardUtils.getText()));
+            getGeopointFromClipboard();
         } catch (final ParseException ignored) {
             return false;
         }
         return true;
     }
+
+
+    @Nullable
+    private static Geopoint getGeopointFromClipboard() {
+        try {
+            final String fromClipboard = GeopointFormatter.adaptFormatFromClipboard(ClipboardUtils.getText());
+            return new Geopoint(StringUtils.defaultString(fromClipboard));
+        } catch (final ParseException ignored) {
+            return null;
+        }
+    }
+
 
     // splitting up that method would not help improve readability
     @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
@@ -681,7 +692,7 @@ public class CoordinatesInputDialog extends DialogFragment {
         @Override
         public void onClick(final View v) {
             try {
-                gp = new Geopoint(StringUtils.defaultString(ClipboardUtils.getText()));
+                gp = getGeopointFromClipboard();
                 updateGUI();
             } catch (final ParseException ignored) {
             }

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointFormatterTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointFormatterTest.java
@@ -56,4 +56,12 @@ public class GeoPointFormatterTest {
         assertThat(GeopointFormatter.reformatForClipboard("10,123456 -0,123456")).isEqualTo("10.123456 -0.123456");
     }
 
+    @Test
+    public void testAdaptFormatFromClipboardAdaptGoogleFormat() {
+        assertThat(GeopointFormatter.adaptFormatFromClipboard("10,123456, -0,123456")).isEqualTo("10,123456 -0,123456");
+
+        // no adaption
+        assertThat(GeopointFormatter.adaptFormatFromClipboard("10,123456°, -0,123456°")).isEqualTo("10,123456°, -0,123456°");
+        assertThat(GeopointFormatter.adaptFormatFromClipboard("Coordinate 10,123456, -0,123456")).isEqualTo("Coordinate 10,123456, -0,123456");
+    }
 }

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -145,22 +145,42 @@ public class GeoPointParserTest {
     @Test
     public void testFloatingPointLatitude() {
         assertThat(GeopointParser.parseLatitude("47.648883")).isEqualTo(GeopointParser.parseLatitude("N 47° 38.933"), offset(1e-6));
+        assertThat(GeopointParser.parseLatitude("47,648883")).isEqualTo(GeopointParser.parseLatitude("N 47° 38.933"), offset(1e-6));
     }
 
     @Test
     public void testFloatingPointNegativeLatitudeMeansSouth() {
         assertThat(GeopointParser.parseLatitude("-47.648883")).isEqualTo(GeopointParser.parseLatitude("S 47° 38.933"), offset(1e-6));
+        assertThat(GeopointParser.parseLatitude("-47,648883")).isEqualTo(GeopointParser.parseLatitude("S 47° 38.933"), offset(1e-6));
     }
 
     @Test
     public void testFloatingPointBoth() {
         assertGeopointEquals(GeopointParser.parse("47.648883  122.348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47.648883  -122.348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883  122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883  -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+    }
+
+    @Test
+    public void testFloatingPointBothWithSeparator() {
+        assertGeopointEquals(GeopointParser.parse("47.648883, 122.348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47.648883, -122.348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883. 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883. -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+    }
+
+
+    @Test
+    public void testAdaptFormatFromClipboard() {
+        assertGeopointEquals(GeopointParser.parse(GeopointFormatter.adaptFormatFromClipboard("47,648883, 122,348067")), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse(GeopointFormatter.adaptFormatFromClipboard("47,648883, -122,348067")), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
     }
 
     @Test
     public void testFloatingPointNbsp() {
         assertGeopointEquals(GeopointParser.parse("47.648883  122.348067\u00a0"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883  122,348067\u00a0"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
     }
 
     @Test
@@ -179,6 +199,7 @@ public class GeoPointParserTest {
         assertGeopointEquals(GeopointParser.parse("47. 648883 122.348067"), referencePoint, 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47.648883   122. 348067"), referencePoint, 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47. 648883   122. 348067"), referencePoint, 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47, 648883   122, 348067"), referencePoint, 1e-4f);
         assertGeopointEquals(GeopointParser.parse("N 47° 38. 933   E 122° 20. 884"), referencePoint, 1e-4f);
         assertGeopointEquals(GeopointParser.parse("N  47 38. 933  E  122 20. 884"), referencePoint, 1e-4f);
         assertParsingFails("N  47 38.   933  E  122 20.   884");

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -175,6 +175,10 @@ public class GeoPointParserTest {
     public void testAdaptFormatFromClipboard() {
         assertGeopointEquals(GeopointParser.parse(GeopointFormatter.adaptFormatFromClipboard("47,648883, 122,348067")), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse(GeopointFormatter.adaptFormatFromClipboard("47,648883, -122,348067")), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+
+        // assert - without adaption no Geopoint is parsed
+        assertParsingFails("47,648883, 122,348067");
+        assertParsingFails("47,648883, -122,348067");
     }
 
     @Test


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Adapts the text from clipboard, if it only contains a coordinate in "google-format with comma separated", in case of pasting it in the coordinates-dialog

Possible alternative solution to PR #16486 which introduces a new parser

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #16382
fix #13840

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
No change in CoordinatesCalculateGlobalDialog - the format without comma as separation is not supported, so no need to adapt it there