### PR TITLE
Fix failing tests: Consider new filters in test

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/filters/GeocacheFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/GeocacheFilterTest.java
@@ -269,6 +269,8 @@ public class GeocacheFilterTest {
             case INDIVIDUAL_ROUTE:
             case NAMED_FILTER:
             case LOGICAL_FILTER_GROUP:
+            case LIST_ID:
+            case VIEWPORT:
                 // nothing to do
                 break;
             default:


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
The 2 new filters "LIST_ID" and "VIEWPORT" (https://github.com/cgeo/cgeo/commit/857a61bfc44aeef83cdd6e395dff780b021cf961) has to be considered in getFilledInstance.

## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
The intention of the assert is, that all filters are considered in the generic filled test (at least, if not considered, then on purpose)

