### PR TITLE
fix failing gc viewport test due to archived cache

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCConnectorTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCConnectorTest.java
@@ -26,7 +26,7 @@ public class GCConnectorTest  {
             final SearchResult searchResult = ConnectorFactory.searchByViewport(viewport);
             assertThat(searchResult).isNotNull();
             assertThat(searchResult.isEmpty()).isFalse();
-            assertThat(searchResult.getGeocodes()).contains("GC1J1CT");
+            assertThat(searchResult.getGeocodes()).contains("GC58BD1");
             assertThat(searchResult.getGeocodes()).doesNotContain("GC4ER5H");
         }
 


### PR DESCRIPTION
fix failing gc viewport test due to archived cache

A junit test was failing because one of the caches used was archived today. This PR fixes the broken testcase