### PR TITLE
Show lastUsedFilterName in filter-dialog

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -510,7 +510,7 @@ public class SimpleDialog {
         if (model.selectSetSupplier != null) {
             this.setNeutralButton(model.selectSetActionText);
         }
-        if (!selectionConfirmedViaButton) {
+        if (!selectionConfirmedViaButton && buttonClickAction == null) {
             //remove "negative/positive" buttons
             setPositiveButton(null);
             setNegativeButton(null);

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -490,6 +490,7 @@
     <string name="caches_map_locus_export">Export to Locus</string>
     <string name="caches_filter_menuitem">Filter</string>
     <string name="caches_filter_title">Filter by</string>
+    <string name="caches_filter_select_last">Previous filter</string>
     <string name="caches_removing_from_history">Removing from History…</string>
     <string name="caches_clear_offlinelogs">Clear offline logs</string>
     <string name="caches_clear_offlinelogs_message">Do you want to clear the offline logs?</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Show the last used filter in filter-selection-dialog, if no filter is active.
So it will be easier, to disable temporarily the current filter and enable the one before.

## Possible implementations
Fixed name is currently the "active" variant

#### With active filter / no previous filter
<img src="https://github.com/user-attachments/assets/9d77b7a9-6b63-4d32-93f7-f55e06311cfc" height="150">
<img src="https://github.com/user-attachments/assets/c979bff0-e564-492f-8ced-b01375fbab58" height="150">

#### Fixed name
<img src="https://github.com/user-attachments/assets/e80a367d-2244-453d-acf3-af96878c76ed" height="150"> <img src="https://github.com/user-attachments/assets/a77c4e1f-39f7-46cd-91c8-300e57b9e60b" height="150">

#### Filter-name / fixed name
<img src="https://github.com/user-attachments/assets/6bb7f69f-69b7-464b-a40f-206143e75930" height="150">  <img src="https://github.com/user-attachments/assets/4c706a47-bab3-44c1-b62e-7dbad59e29dc" height="150">
<img src="https://github.com/user-attachments/assets/e80a367d-2244-453d-acf3-af96878c76ed" height="150"> <img src="https://github.com/user-attachments/assets/a77c4e1f-39f7-46cd-91c8-300e57b9e60b" height="150">

#### Alternative: User displayable string (instead of "previous filter")
<img src="https://github.com/user-attachments/assets/6ea93070-4d2a-4159-b075-30cdbe33b65d" height="150"> <img src="https://github.com/user-attachments/assets/a4d2b07d-9400-45d2-a4a4-270ce00acfae" height="150">

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #16512

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->