### PR TITLE
generate random IDs for UDCs

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/internal/InternalConnectorTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/internal/InternalConnectorTest.java
@@ -20,7 +20,6 @@ public class InternalConnectorTest {
     public void testPrefix() {
         assertThat(InternalConnector.PREFIX).isEqualTo("ZZ");
         assertThat(InternalConnector.GEOCODE_HISTORY_CACHE).isEqualTo("ZZ0");
-        assertThat(InternalConnector.geocodeFromId(7)).isEqualTo("ZZ7");
     }
 
     @Test
@@ -28,6 +27,7 @@ public class InternalConnectorTest {
         assertCanHandle("ZZ0").isTrue();
         assertCanHandle("GC12345").isFalse();
         assertCanHandle("ZZ1000").isTrue();
+        assertCanHandle("ZZA2C4").isTrue();
     }
 
     @Test

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -46,7 +46,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
 
     // prefix - must not contain regexp characters
     public static final String PREFIX = "ZZ";
-    private static final String GEOCODE_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String GEOCODE_CHARS = "0123456789ABCDEFGHJKLMNPQRTUVWXYZ";
     private static final int GEOCODE_LENGTH = 4;
 
     // predefined id (without prefix) and geocode (with prefix) for certain special caches:

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -231,9 +231,9 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
             // create new cache
             final Geocache cache = new Geocache();
             cache.setGeocode(geocode);
-            cache.setName(name == null ? String.format(context.getString(R.string.internal_cache_default_names), geocode) : name);
+            cache.setName(StringUtils.isEmpty(name) ? String.format(context.getString(R.string.internal_cache_default_names), geocode) : name);
             cache.setOwnerDisplayName(context.getString(R.string.internal_cache_default_owner));
-            cache.setDescription(description == null ? context.getString(R.string.internal_cache_default_description) : description);
+            cache.setDescription(StringUtils.isEmpty(description) ? context.getString(R.string.internal_cache_default_description) : description);
             cache.setAssignedEmoji(assignedEmoji);
             cache.setDetailed(true);
             cache.setType(CacheType.USER_DEFINED);

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -50,13 +50,13 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     private static final int GEOCODE_LENGTH = 4;
 
     // predefined id (without prefix) and geocode (with prefix) for certain special caches:
-    public static final String GEOCODE_HISTORY_CACHE = "ZZ0";
+    public static final String GEOCODE_HISTORY_CACHE = PREFIX + "0";
 
     // store into UDC list
     public static final int UDC_LIST = -1;
 
     // pattern for internal caches id
-    @NonNull private static final Pattern PATTERN_GEOCODE = Pattern.compile("(" + PREFIX + ")[0-9A-Z]{1,4}", Pattern.CASE_INSENSITIVE);
+    @NonNull private static final Pattern PATTERN_GEOCODE = Pattern.compile("(" + PREFIX + ")[0-9A-Z]{1,10}", Pattern.CASE_INSENSITIVE);
 
     private InternalConnector() {
         // singleton
@@ -72,11 +72,6 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     @NonNull
     public static InternalConnector getInstance() {
         return Holder.INSTANCE;
-    }
-
-
-    public static String geocodeFromId(final long id) {
-        return PREFIX + id;
     }
 
     @Override
@@ -220,7 +215,7 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
      * @param geopoint      cache's current location (or null if none)
      * @param listId        cache list's id, may be NEW_LIST
      */
-    protected static void assertCacheExists(final Context context, final String geocode, @Nullable final String name, @Nullable final String description, final int assignedEmoji, @Nullable final Geopoint geopoint, final int listId) {
+    private static void assertCacheExists(final Context context, final String geocode, @Nullable final String name, @Nullable final String description, final int assignedEmoji, @Nullable final Geopoint geopoint, final int listId) {
         if (DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB) == null) {
 
             int newListId = listId;
@@ -279,11 +274,10 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     private static String generateRandomId() {
-        Random random = new Random();
-        StringBuilder sb = new StringBuilder(GEOCODE_LENGTH);
+        final Random random = new Random();
+        final StringBuilder sb = new StringBuilder(GEOCODE_LENGTH);
         for (int i = 0; i < GEOCODE_LENGTH; i++) {
-            int index = random.nextInt(GEOCODE_CHARS.length());
-            sb.append(GEOCODE_CHARS.charAt(index));
+            sb.append(GEOCODE_CHARS.charAt(random.nextInt(GEOCODE_CHARS.length())));
         }
         return sb.toString();
     }

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2018,21 +2018,6 @@ public class DataStore {
         }
     }
 
-    public static synchronized long getNextAvailableInternalCacheId() {
-        return withAccessLock(() -> {
-
-            final int minimum = 1000;
-
-            init();
-            final Cursor c = database.rawQuery("SELECT MAX(CAST(SUBSTR(geocode," + (1 + InternalConnector.PREFIX.length()) + ") AS INTEGER)) FROM " + dbTableCaches + " WHERE substr(geocode,1," + InternalConnector.PREFIX.length() + ") = \"" + InternalConnector.PREFIX + "\"", new String[]{});
-            final Set<Integer> nextId = cursorToColl(c, new HashSet<>(), GET_INTEGER_0);
-            for (Integer i : nextId) {
-                return Math.max(i + 1, minimum);
-            }
-            return minimum;
-        });
-    }
-
     /**
      * Remove obsolete cache directories in c:geo private storage.
      * Also removes caches marked as "to be deleted" immediately (ignoring 72h grace period!)

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1762,7 +1762,7 @@
     <string name="create_internal_cache">Create user-defined cache</string>
     <string name="create_internal_cache_short">New cache</string>
     <string name="create_internal_cache_currentlist">Use current list</string>
-    <string name="internal_cache_default_name">User defined cache #%1$d</string>
+    <string name="internal_cache_default_names">User defined cache #%1$s</string>
     <string name="internal_cache_default_description">This is a user-defined cache</string>
     <string name="internal_cache_default_owner">You</string>
     <string name="internal_goto_targets_title">\'Go to\' targets</string>


### PR DESCRIPTION
fixes https://github.com/cgeo/cgeo/issues/15992 by generating a random ID for UDCs in range ZZ[0-9A-Z]{4}. 1,8 million possibilities should be random enough 😉

also some cleanup that was supposed to be done in 2020 :-)
And a bugfix for getting the default name and description that was previously broken (due to the provided string being "" instead of null)