### PR TITLE
enabling grouping for stored filters

### DIFF
--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -184,10 +184,8 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
             if (filters.isEmpty()) {
                 SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_load_delete_title).setMessage(R.string.cache_filter_storage_load_delete_nofilter_message).show();
             } else {
-                final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
+                final SimpleDialog.ItemSelectModel<GeocacheFilter> model = FilterUtils.getGroupedFilterList(filters);
                 model
-                    .setItems(filters)
-                    .setDisplayMapper((f) -> TextParam.text(f.getName()))
                     .setItemActionIconMapper((f) -> ImageParam.id(R.drawable.ic_menu_delete))
                     .setItemActionListener((f) -> {
                         //DELETE action was tapped for a filter
@@ -201,10 +199,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
                                         binding.filterStorageName.setText("");
                                     }
                                 });
-                    })
-                    .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
-                    .activateGrouping(f -> FilterUtils.getGroupFromFilterName(f.getName()))
-                    .setGroupDisplayMapper(gi -> TextParam.text("**" + gi.getGroup() + "** *(" + gi.getContainedItemCount() + ")*").setMarkdown(true));;
+                    });
 
                 SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_load_delete_title)
                                 .selectSingle(model, (f) -> fillViewFromFilter(f.toConfig(), isAdvancedView()));

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -202,7 +202,9 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
                                     }
                                 });
                     })
-                    .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN);
+                    .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
+                    .activateGrouping(f -> FilterUtils.getGroupFromFilterName(f.getName()))
+                    .setGroupDisplayMapper(gi -> TextParam.text("**" + gi.getGroup() + "** *(" + gi.getContainedItemCount() + ")*").setMarkdown(true));;
 
                 SimpleDialog.of(this).setTitle(R.string.cache_filter_storage_load_delete_title)
                                 .selectSingle(model, (f) -> fillViewFromFilter(f.toConfig(), isAdvancedView()));

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -62,13 +62,7 @@ public class FilterUtils {
                 return true;
             }
 
-        final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
-        model
-                .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
-                .setItems(filters)
-                .setDisplayMapper((f) -> TextParam.text(f.getName()))
-                .activateGrouping(f -> getGroupFromFilterName(f.getName()))
-                .setGroupDisplayMapper(gi -> TextParam.text("**" + gi.getGroup() + "** *(" + gi.getContainedItemCount() + ")*").setMarkdown(true));
+        final SimpleDialog.ItemSelectModel<GeocacheFilter> model = getGroupedFilterList(filters);
 
         if (isFilterActive) {
             SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_select_clear_title)
@@ -81,6 +75,18 @@ public class FilterUtils {
                     .selectSingle(model, filteredActivity::refreshWithFilter);
         }
         return true;
+    }
+
+    public static SimpleDialog.ItemSelectModel<GeocacheFilter> getGroupedFilterList(final List<GeocacheFilter> filters) {
+        final SimpleDialog.ItemSelectModel<GeocacheFilter> model = new SimpleDialog.ItemSelectModel<>();
+        model
+                .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
+                .setItems(filters)
+                .setDisplayMapper((f) -> TextParam.text(f.getName()))
+                .activateGrouping(f -> getGroupFromFilterName(f.getName()))
+                .setGroupGroupMapper(FilterUtils::getGroupFromFilterName)
+                .setGroupDisplayMapper(gi -> TextParam.text("**" + gi.getGroup() + "** *(" + gi.getContainedItemCount() + ")*").setMarkdown(true));
+        return model;
     }
 
     public static String getGroupFromFilterName(final String group) {

--- a/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FilterUtils.java
@@ -66,7 +66,9 @@ public class FilterUtils {
         model
                 .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
                 .setItems(filters)
-                .setDisplayMapper((f) -> TextParam.text(f.getName()));
+                .setDisplayMapper((f) -> TextParam.text(f.getName()))
+                .activateGrouping(f -> getGroupFromFilterName(f.getName()))
+                .setGroupDisplayMapper(gi -> TextParam.text("**" + gi.getGroup() + "** *(" + gi.getContainedItemCount() + ")*").setMarkdown(true));
 
         if (isFilterActive) {
             SimpleDialog.of(filteredActivity).setTitle(R.string.cache_filter_storage_select_clear_title)
@@ -79,6 +81,14 @@ public class FilterUtils {
                     .selectSingle(model, filteredActivity::refreshWithFilter);
         }
         return true;
+    }
+
+    public static String getGroupFromFilterName(final String group) {
+        if (group == null) {
+            return null;
+        }
+        final int idx = group.lastIndexOf(":");
+        return idx <= 0 ? null : group.substring(0, idx);
     }
 
     public static void setFilterText(@NonNull final TextView viewField, @Nullable final String filterName, @Nullable final Boolean filterChanged) {


### PR DESCRIPTION
group cache filters by string before ":"

![image](https://github.com/user-attachments/assets/cbf9773c-c750-4e05-a13d-198aa3dde30e)

fixes https://github.com/cgeo/cgeo/issues/16526
