### PR TITLE
Update Mapsforge to newly released 0.23.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -366,12 +366,12 @@ dependencies {
     // -- Mapsforge / Mapsforge --
 
     // Mapsforge official version
-    // String mapsforgeSource = 'org.mapsforge'
-    // String mapsforgeVersion = '0.21.0'
+    String mapsforgeSource = 'com.github.mapsforge.mapsforge'
+    String mapsforgeVersion = '0.23.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
-    String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = '4674895'
+    // String mapsforgeSource = 'com.github.mapsforge.mapsforge'
+    // String mapsforgeVersion = '4674895'
 
     // Mapsforge Snapshot from cgeo's GitHub repository (via https://jitpack.io/#cgeo/mapsforge)
     // String mapsforgeSource = 'com.github.cgeo.mapsforge'


### PR DESCRIPTION
An official release 0.23.0 got published yesterday, so we can move from specific build back to official release