### PR TITLE
"intelligent" restore map position on mapping a list

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.annotation.StringRes;
+import androidx.preference.Preference;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,11 +44,20 @@ public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment
             MapMarkerUtils.clearCachedItems();
             return true;
         });
+        PreferenceUtils.setOnPreferenceChangeListener(findPreference(getString(R.string.pref_autozoom_consider_lastcenter)), (preference, newValue) -> {
+            setAutozoomSummary(preference, (Boolean) newValue);
+            return true;
+        });
+        setAutozoomSummary(findPreference(getString(R.string.pref_autozoom_consider_lastcenter)), Settings.getBoolean(R.string.pref_autozoom_consider_lastcenter, false));
     }
 
     public void updateNotificationAudioInfo() {
         setButton(true);
         setButton(false);
+    }
+
+    private void setAutozoomSummary(final Preference pref, final boolean value) {
+        pref.setSummary(value ? R.string.init_summary_autozoom_consider_lastcenter_on : R.string.init_summary_autozoom_consider_lastcenter_off);
     }
 
     private void setButton(final boolean first) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -440,7 +440,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 }, () -> {
                     if (viewport3.get() != null) {
                         if (setDefaultCenterAndZoom) {
-                            mapFragment.zoomToBounds(viewport3.get());
+                            restoreOrSetViewport(viewport3.get());
                         }
                         refreshMapData(true);
                     }
@@ -455,7 +455,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 }, () -> {
                     if (viewport2.get() != null) {
                         if (setDefaultCenterAndZoom) {
-                            mapFragment.zoomToBounds(viewport2.get());
+                            restoreOrSetViewport(viewport2.get());
                         }
 
                         if (mapType.coords != null) {
@@ -487,6 +487,15 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         viewModel.liveMapHandler.setEnabled(mapType.enableLiveMap());
         if (mapType.enableLiveMap()) {
             refreshMapData(true);
+        }
+    }
+
+    private void restoreOrSetViewport(final Viewport vp) {
+        final Geopoint storedMapCenter = Settings.getUMMapCenter();
+        if (Settings.getBoolean(R.string.pref_autozoom_consider_lastcenter, false) && vp.contains(storedMapCenter)) {
+            mapFragment.setCenter(storedMapCenter);
+        } else {
+            mapFragment.zoomToBounds(vp);
         }
     }
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -632,6 +632,7 @@
     <string translatable="false" name="pref_last_trackable_log">last_trackable_log</string>
     <string translatable="false" name="pref_home_location">home_location</string>
     <string translatable="false" name="pref_followMyLocation">followMyLocation</string>
+    <string translatable="false" name="pref_autozoom_consider_lastcenter">list_viewport_calculation_consider_lastviewport</string>
 
 
     <!-- ============================================================================================================================================================================== -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1776,6 +1776,9 @@
     <string name="init_summary_show_routing_menu">Long tap on a cache shows a menu with advanced options to add/remove the cache to/from a route. If disabled the cache is just added/removed to/from the route.</string>
     <string name="init_ActionbarAutohide">Hide toolbar on tap</string>
     <string name="init_summary_ActionbarAutohide">Tap on free map space to hide/show the toolbar</string>
+    <string name="init_autozoom_consider_lastcenter">Restore map position on mapping a list</string>
+    <string name="init_summary_autozoom_consider_lastcenter_on">When a list of caches is mapped and map was previously left inside the list boundaries restore preview position, otherwise zoom to fit all caches.</string>
+    <string name="init_summary_autozoom_consider_lastcenter_off">When a list of caches is mapped set map zoom and boundaries to fit all caches.</string>
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -92,6 +92,12 @@
             android:summary="@string/init_summary_ActionbarAutohide"
             android:title="@string/init_ActionbarAutohide"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_autozoom_consider_lastcenter"
+            android:summary="@string/init_summary_autozoom_consider_lastcenter_on"
+            android:title="@string/init_autozoom_consider_lastcenter"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
when opening map from a list or search compare previous map center with viewport required to show the whole list. If it's inside use old viewport, else go to whole list viewport.
This helps in situations where you switch between list and map views so you don't always have to re-zoom the map.

partially addresses https://github.com/cgeo/cgeo/issues/16527
it doesn't add an "fit all" buttons to GUI