### PR TITLE
Warning if corrected coords = final coords

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -220,7 +220,8 @@ public final class MapMarkerUtils {
 
         // bottom-right: user modified coords / final waypoint defined
         if (cache.hasUserModifiedCoords() && mainMarkerId != R.drawable.marker_usermodifiedcoords) {
-            insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_usermodifiedcoords, Gravity.BOTTOM | Gravity.RIGHT, getCacheScalingFactor(applyScaling)));
+            final boolean coordsIsOriginal = null != cache.getOriginalWaypoint() && cache.getCoords().equals(cache.getOriginalWaypoint().getCoords());
+            insetsBuilder.withInset(new InsetBuilder(coordsIsOriginal ? R.drawable.marker_usermodifiedcoords_original : R.drawable.marker_usermodifiedcoords, Gravity.BOTTOM | Gravity.RIGHT, getCacheScalingFactor(applyScaling)));
         } else if (cache.hasFinalDefined() && !cache.hasUserModifiedCoords()) {
             insetsBuilder.withInset(new InsetBuilder(R.drawable.marker_hasfinal, Gravity.BOTTOM | Gravity.RIGHT, getCacheScalingFactor(applyScaling)));
         }

--- a/main/src/main/res/drawable/marker_usermodifiedcoords_original.xml
+++ b/main/src/main/res/drawable/marker_usermodifiedcoords_original.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="13dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:fillColor="#01579B"/>
+  <path
+      android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+      android:fillColor="#039BE5"/>
+  <path
+      android:pathData="M13.6,7.5L13.3333,6.1667L7.3333,6.1667L7.3333,17.5L8.6667,17.5L8.6667,12.8333L12.4,12.8333L12.6667,14.1667L17.3333,14.1667L17.3333,7.5L13.6,7.5Z"
+      android:fillColor="#C62828"/>
+</vector>


### PR DESCRIPTION
adds a cache map marker for the case that a cache has modified coords but those are equal to the original cache coordinates.

The visibility isn't perfect but as this is a corner-case that should happen seldomly it's ok enough imho

![image](https://github.com/user-attachments/assets/2f622897-1f71-4916-b397-5b293e459a44)

fixes https://github.com/cgeo/cgeo/issues/16551