### PR TITLE
Show offline caches mode

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -809,6 +809,19 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         ToggleItemType.LIVE_MODE.toggleMenuItem(itemMapLive, TRUE.equals(viewModel.transientIsLiveEnabled.getValue()));
         itemMapLive.setVisible(true);
 
+        final View liveButton = findViewById(R.id.menu_map_live);
+        if (liveButton != null) {
+            liveButton.setOnLongClickListener(v -> {
+                if (!TRUE.equals(viewModel.transientIsLiveEnabled.getValue())) {
+                    v.callOnClick();
+                    v.postDelayed(v::callOnClick, 100);
+                } else {
+                    v.callOnClick();
+                }
+                return true;
+            });
+        }
+
         // map rotation state
         menu.findItem(R.id.menu_map_rotation).setVisible(true); // @todo: can be visible always (xml definition) when CGeoMap/NewMap is removed
         final int mapRotation = Settings.getMapRotation();


### PR DESCRIPTION
Introduce a long-tap on "Live" button to enter from any offline map (e.g. list map, single cache map) a "database map", showing all caches stored offline in c:geo, no matter which list they are stored.

This "database map" mode can today only be accessed by entering "main map" (live map), disabling live mode, leaving and returning to main map.