### PR TITLE
add icons to map + list overflow menu

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -534,6 +534,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         ListNavigationSelectionActionProvider.initialize(menu.findItem(R.id.menu_cache_list_app_provider), app -> app.invoke(CacheListAppUtils.filterCoords(adapter.getList()), CacheListActivity.this, getFilteredSearch()));
         FilterUtils.initializeFilterMenu(this, this);
+        MenuUtils.enableIconsInOverflowMenu(menu);
+        MenuUtils.tintToolbarAndOverflowIcons(menu);
 
         return true;
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -847,7 +847,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         menu.findItem(R.id.menu_as_list).setVisible(true);
 
-        MenuUtils.tintToolbarAndOverflowIcons(menu, R.color.just_white, R.color.colorText);
+        MenuUtils.tintToolbarAndOverflowIcons(menu);
 
         return result;
     }
@@ -963,7 +963,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 return super.onOptionsItemSelected(item);
             }
         }
-        MenuUtils.tintToolbarAndOverflowIcons(toolbarMenu, R.color.just_white, R.color.colorText);
+        MenuUtils.tintToolbarAndOverflowIcons(toolbarMenu);
         return true;
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -72,6 +72,7 @@ import cgeo.geocaching.utils.LifecycleAwareBroadcastReceiver;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
+import cgeo.geocaching.utils.MenuUtils;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.functions.Func1;
 import cgeo.geocaching.wherigo.WherigoGame;
@@ -844,6 +845,9 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         menu.findItem(R.id.menu_theme_options).setVisible(tileProvider.supportsThemeOptions());
 
         menu.findItem(R.id.menu_as_list).setVisible(true);
+
+        MenuUtils.enableIconsInOverflowMenu(menu);
+        MenuUtils.tintToolbarAndOverflowIcons(menu, R.color.just_white, R.color.colorText);
 
         return result;
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -161,6 +161,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private CacheReloadState cacheReloadState = CacheReloadState.REFRESH;
 
     private int wherigoListenerId;
+    private Menu toolbarMenu;
 
     private final CacheListActionBarChooser listChooser = new CacheListActionBarChooser(this, this::getSupportActionBar, newListId -> {
         final Optional<AbstractList> lNew = StoredList.UserInterface.getMenuLists(false, PseudoList.NEW_LIST.id).stream().filter(l2 -> l2.id == newListId).findFirst();
@@ -846,7 +847,6 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         menu.findItem(R.id.menu_as_list).setVisible(true);
 
-        MenuUtils.enableIconsInOverflowMenu(menu);
         MenuUtils.tintToolbarAndOverflowIcons(menu, R.color.just_white, R.color.colorText);
 
         return result;
@@ -857,6 +857,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         final boolean result = super.onCreateOptionsMenu(menu);
         getMenuInflater().inflate(R.menu.map_activity, menu);
         FilterUtils.initializeFilterMenu(this, this);
+        MenuUtils.enableIconsInOverflowMenu(menu);
+        this.toolbarMenu = menu;
         return result;
     }
 
@@ -944,25 +946,24 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             Settings.setMapShadingShowLayer(!Settings.getMapShadingShowLayer());
             item.setChecked(Settings.getMapShadingShowLayer());
             changeMapSource(mapFragment.currentTileProvider);
-        } else {
+        } else { // dynamic submenus: Map language, Map source
             final String language = TileProviderFactory.getLanguage(id);
+            final AbstractTileProvider tileProviderLocal = TileProviderFactory.getTileProvider(id);
             if (language != null || id == MAP_LANGUAGE_DEFAULT_ID) {
                 item.setChecked(true);
                 Settings.setMapLanguage(language);
                 mapFragment.setPreferredLanguage(language);
-                return true;
-            }
-            final AbstractTileProvider tileProviderLocal = TileProviderFactory.getTileProvider(id);
-            if (tileProviderLocal != null) {
+            } else if (tileProviderLocal != null) {
                 item.setChecked(true);
                 changeMapSource(tileProviderLocal);
-                return true;
             }
             if (mapFragment.onOptionsItemSelected(item)) {
                 return true;
+            } else {
+                return super.onOptionsItemSelected(item);
             }
-            return super.onOptionsItemSelected(item);
         }
+        MenuUtils.tintToolbarAndOverflowIcons(toolbarMenu, R.color.just_white, R.color.colorText);
         return true;
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -12,6 +12,7 @@ import androidx.appcompat.view.menu.MenuItemImpl;
 import javax.annotation.Nullable;
 
 import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
 
 public class MenuUtils {
 
@@ -61,7 +62,7 @@ public class MenuUtils {
     }
 
     @SuppressLint("RestrictedApi")
-    public static void tintToolbarAndOverflowIcons(@Nullable final Menu menu, final int toolbarIconTint, final int overflowIconTint) {
+    public static void tintToolbarAndOverflowIcons(@Nullable final Menu menu) {
         if (null == menu) {
             return;
         }
@@ -79,7 +80,7 @@ public class MenuUtils {
             final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
             final Drawable icon = item.getIcon();
             if (icon != null) {
-                icon.setTint(context.getResources().getColor(item.isActionButton() ? toolbarIconTint : overflowIconTint));
+                icon.setTint(context.getResources().getColor(item.isActionButton() ? R.color.colorTextActionBar : R.color.colorText));
             }
         }
     }

--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -1,5 +1,8 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.R;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
@@ -10,9 +13,6 @@ import androidx.appcompat.view.menu.MenuBuilder;
 import androidx.appcompat.view.menu.MenuItemImpl;
 
 import javax.annotation.Nullable;
-
-import cgeo.geocaching.CgeoApplication;
-import cgeo.geocaching.R;
 
 public class MenuUtils {
 
@@ -80,7 +80,7 @@ public class MenuUtils {
             final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
             final Drawable icon = item.getIcon();
             if (icon != null) {
-                icon.setTint(context.getResources().getColor(item.isActionButton() ? R.color.colorTextActionBar : R.color.colorText));
+                icon.setTint(context.getResources().getColor(item.isActionButton() ? R.color.colorIconActionBar : R.color.colorIconOverflow));
             }
         }
     }

--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -65,12 +65,21 @@ public class MenuUtils {
         if (null == menu) {
             return;
         }
+        // Menu might not yet have been initialized due to timing issues, only run if there's at least 1 toolbar item
+        boolean anyMenuItemVisible = false;
+        for (int i = 0; i < menu.size(); i++) {
+            final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
+            anyMenuItemVisible = anyMenuItemVisible || item.isActionButton();
+        }
+        if (!anyMenuItemVisible) {
+            return;
+        }
         final Context context = CgeoApplication.getInstance();
         for (int i = 0; i < menu.size(); i++) {
             final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
             final Drawable icon = item.getIcon();
             if (icon != null) {
-                icon.setTint(context.getResources().getColor((item).isActionButton() ? toolbarIconTint : overflowIconTint));
+                icon.setTint(context.getResources().getColor(item.isActionButton() ? toolbarIconTint : overflowIconTint));
             }
         }
     }

--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -1,12 +1,17 @@
 package cgeo.geocaching.utils;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.appcompat.view.menu.MenuBuilder;
+import androidx.appcompat.view.menu.MenuItemImpl;
 
 import javax.annotation.Nullable;
+
+import cgeo.geocaching.CgeoApplication;
 
 public class MenuUtils {
 
@@ -52,6 +57,21 @@ public class MenuUtils {
     public static void enableIconsInOverflowMenu(@Nullable final Menu menu) {
         if (menu instanceof MenuBuilder) {
             ((MenuBuilder) menu).setOptionalIconsVisible(true);
+        }
+    }
+
+    @SuppressLint("RestrictedApi")
+    public static void tintToolbarAndOverflowIcons(@Nullable final Menu menu, final int toolbarIconTint, final int overflowIconTint) {
+        if (null == menu) {
+            return;
+        }
+        final Context context = CgeoApplication.getInstance();
+        for (int i = 0; i < menu.size(); i++) {
+            final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
+            final Drawable icon = item.getIcon();
+            if (icon != null) {
+                icon.setTint(context.getResources().getColor((item).isActionButton() ? toolbarIconTint : overflowIconTint));
+            }
         }
     }
 }

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -46,6 +46,7 @@
         app:showAsAction="ifRoom|withText"/>
     <item
         android:id="@+id/menu_caches"
+        android:icon="@drawable/ic_menu_cache"
         android:title="@string/menu_caches"
         app:showAsAction="never|withText">
         <!-- Cache operations -->
@@ -113,6 +114,7 @@
     </item>
     <item
         android:id="@+id/menu_lists"
+        android:icon="@drawable/ic_menu_list"
         android:title="@string/menu_lists"
         app:showAsAction="never|withText">
         <!-- List operations -->
@@ -149,37 +151,46 @@
     </item>
     <item
         android:id="@+id/menu_import"
+        android:icon="@drawable/wherigo_load"
         android:title="@string/list_menu_import"
         app:showAsAction="never|withText">
         <menu>
             <item
                 android:id="@+id/menu_import_pq"
-                android:title="@string/menu_lists_pocket_queries"/>
+                android:title="@string/menu_lists_pocket_queries"
+                android:icon="@drawable/ic_menu_pocket_query" />
             <item
                 android:id="@+id/menu_bookmarklists"
-                android:title="@string/menu_lists_bookmarklists"/>
+                android:title="@string/menu_lists_bookmarklists"
+                android:icon="@drawable/ic_menu_bookmarks" />
             <item
                 android:id="@+id/menu_import_gpx"
-                android:title="@string/gpx_import_title"/>
+                android:title="@string/gpx_import_title"
+                android:icon="@drawable/ic_menu_gpx" />
             <item
                 android:id="@+id/menu_import_web"
-                android:title="@string/web_import_title"/>
+                android:title="@string/web_import_title"
+                android:icon="@drawable/wherigo_download" />
         </menu>
     </item>
     <item
         android:id="@+id/menu_export"
+        android:icon="@drawable/ic_menu_share"
         android:title="@string/export"
         app:showAsAction="never|withText">
         <menu>
             <item
                 android:id="@+id/menu_export_gpx"
-                android:title="@string/export_gpx"/>
+                android:title="@string/export_gpx"
+                android:icon="@drawable/ic_menu_gpx" />
             <item
                 android:id="@+id/menu_export_fieldnotes"
-                android:title="@string/export_fieldnotes"/>
+                android:title="@string/export_fieldnotes"
+                android:icon="@drawable/ic_menu_note_edit" />
             <item
                 android:id="@+id/menu_export_persnotes"
-                android:title="@string/export_persnotes"/>
+                android:title="@string/export_persnotes"
+                android:icon="@drawable/ic_menu_note" />
         </menu>
     </item>
     <item

--- a/main/src/main/res/menu/map_activity.xml
+++ b/main/src/main/res/menu/map_activity.xml
@@ -24,37 +24,31 @@
                     android:id="@+id/menu_hillshading"
                     android:title="@string/settings_hillshading_enable"
                     android:icon="@drawable/ic_menu_hills"
-                    app:iconTint="@color/colorText"
                     android:checkable="true"
                     android:visible="false" />
                 <item
                     android:orderInCategory="91"
                     android:id="@+id/menu_manage_offline_maps"
                     android:icon="@drawable/wherigo_download"
-                    app:iconTint="@color/colorText"
                     android:title="@string/menu_manage_offline_data"
                     android:visible="false">
                     <menu>
                         <item
                             android:id="@+id/menu_download_offlinemap"
                             android:title="@string/downloadmap_title"
-                            android:icon="@drawable/ic_menu_mapmode"
-                            app:iconTint="@color/colorText" />
+                            android:icon="@drawable/ic_menu_mapmode" />
                         <item
                             android:id="@+id/menu_check_routingdata"
                             android:icon="@drawable/ic_menu_route"
-                            app:iconTint="@color/colorText"
                             android:title="@string/check_tiles_menu" />
                         <item
                             android:id="@+id/menu_check_hillshadingdata"
                             android:icon="@drawable/ic_menu_hills"
-                            android:title="@string/check_hillshading_tiles_menu"
-                            app:iconTint="@color/colorText" />
+                            android:title="@string/check_hillshading_tiles_menu" />
                         <item
                             android:id="@+id/menu_delete_offline_data"
                             android:icon="@drawable/ic_menu_delete"
-                            android:title="@string/menu_delete_offline_data"
-                            app:iconTint="@color/colorText" />
+                            android:title="@string/menu_delete_offline_data" />
                     </menu>
                 </item>
             </group>
@@ -174,25 +168,21 @@
             <item
                 android:id="@+id/menu_trail_show"
                 android:icon="@drawable/visibility"
-                app:iconTint="@color/colorText"
                 android:title="@string/map_trail_show">
             </item>
             <item
                 android:id="@+id/menu_trail_hide"
                 android:icon="@drawable/visibility_off"
-                app:iconTint="@color/colorText"
                 android:title="@string/map_trail_hide">
             </item>
             <item
                 android:id="@+id/menu_export_trailhistory"
                 android:icon="@drawable/ic_menu_gpx"
-                app:iconTint="@color/colorText"
                 android:title="@string/export_trailhistory_title">
             </item>
             <item
                 android:id="@+id/menu_clear_trailhistory"
                 android:icon="@drawable/ic_menu_delete"
-                app:iconTint="@color/colorText"
                 android:title="@string/map_clear_trailhistory">
             </item>
         </menu>

--- a/main/src/main/res/menu/map_activity.xml
+++ b/main/src/main/res/menu/map_activity.xml
@@ -113,6 +113,7 @@
     </item>
     <item
         android:id="@+id/menu_map_rotation"
+        android:icon="@drawable/compass_rose_mini"
         android:title="@string/map_rotation"
         android:visible="false"
         app:showAsAction="ifRoom|withText">
@@ -138,7 +139,7 @@
     </item>
     <item
         android:id="@+id/menu_theme_mode"
-        android:icon="@drawable/ic_menu_preferences"
+        android:icon="@drawable/downloader_theme"
         android:showAsAction="ifRoom|withText"
         android:title="@string/map_theme_select"
         android:visible="false"
@@ -154,6 +155,7 @@
     </item>
     <item
         android:id="@+id/menu_select_language"
+        android:icon="@drawable/ic_menu_translate"
         android:title="@string/map_language"
         android:visible="false"
         app:showAsAction="ifRoom|withText">
@@ -166,28 +168,38 @@
     </item>
     <item
         android:id="@+id/menu_trailhistory"
+        android:icon="@drawable/ic_menu_recent_history"
         android:title="@string/trailhistory">
         <menu>
             <item
                 android:id="@+id/menu_trail_show"
+                android:icon="@drawable/visibility"
+                app:iconTint="@color/colorText"
                 android:title="@string/map_trail_show">
             </item>
             <item
                 android:id="@+id/menu_trail_hide"
+                android:icon="@drawable/visibility_off"
+                app:iconTint="@color/colorText"
                 android:title="@string/map_trail_hide">
             </item>
             <item
                 android:id="@+id/menu_export_trailhistory"
+                android:icon="@drawable/ic_menu_gpx"
+                app:iconTint="@color/colorText"
                 android:title="@string/export_trailhistory_title">
             </item>
             <item
                 android:id="@+id/menu_clear_trailhistory"
+                android:icon="@drawable/ic_menu_delete"
+                app:iconTint="@color/colorText"
                 android:title="@string/map_clear_trailhistory">
             </item>
         </menu>
     </item>
     <item
         android:id="@+id/menu_routetrack"
+        android:icon="@drawable/ic_menu_route"
         android:title="@string/routes_tracks_menu" />
     <item
         android:id="@+id/menu_as_list"

--- a/main/src/main/res/values-night/colors_dark.xml
+++ b/main/src/main/res/values-night/colors_dark.xml
@@ -10,6 +10,8 @@
 
     <color name="colorTextHeadline">#88FFFFFF</color>
     <color name="colorTextHintActionBar">@color/colorTextHint</color>
+    <color name="colorIconActionBar">#FFE3E3E3</color>
+    <color name="colorIconOverflow">#FFE4E4E4</color>
 
     <color name="colorBackground">#FF000000</color>
     <color name="colorBackgroundTransparent">#44000000</color>

--- a/main/src/main/res/values/colors_light.xml
+++ b/main/src/main/res/values/colors_light.xml
@@ -10,6 +10,8 @@
 
     <color name="colorTextHeadline">#88000000</color>
     <color name="colorTextHintActionBar">#FFAAAAAA</color>
+    <color name="colorIconActionBar">#FFFFFFFF</color>
+    <color name="colorIconOverflow">#FF1B1B1B</color>
 
     <color name="colorBackground">#FFFFFFFF</color>
     <color name="colorBackgroundTransparent">#44FFFFFF</color>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6df92e6a-9223-4794-ac2e-f7216cd31721)
![image](https://github.com/user-attachments/assets/34f7ce76-0b56-4c7c-9883-335da741b799)


Tinting the icons properly requires some elaborate workarounds to determine whether the icon is shown in toolbar or overflow menu. Those are redrawn frequently which requires even more workarounds (those are all in the helper method in MenuUtils)