### PR TITLE
[rel #16382] Consider not only 2 digits minimum for deg comma parser

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -24,7 +24,7 @@ public class GeopointParser {
 
     private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), ([-+]?\\d{2,})");
     private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. ([-+]?\\d{2,})");
-    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("(\\d{1,3}[\\.,]\\d+), ([-+]?\\d{1,3}[\\.,]\\d+)");
+    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("(\\d{1,3},\\d+), ([-+]?\\d{1,3},\\d+)");
 
     private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -24,7 +24,7 @@ public class GeopointParser {
 
     private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), ([-+]?\\d{2,})");
     private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. ([-+]?\\d{2,})");
-    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("(\\d+[\\.,]\\d+), ([-+]?\\d+[\\.,]\\d+)");
+    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("(\\d{1,3}[\\.,]\\d+), ([-+]?\\d{1,3}[\\.,]\\d+)");
 
     private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -24,6 +24,7 @@ public class GeopointParser {
 
     private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), ([-+]?\\d{2,})");
     private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. ([-+]?\\d{2,})");
+    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("(\\d+[\\.,]\\d+), ([-+]?\\d+[\\.,]\\d+)");
 
     private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 
@@ -504,7 +505,8 @@ public class GeopointParser {
      */
     @NonNull
     private static Set<String> getParseInputs(@NonNull final String text) {
-        final String inputDot = removeSpaceAfterSeparators(text);
+        final String preparedInput = prepareForDegCommaCommaFormat(text);
+        final String inputDot = removeSpaceAfterSeparators(preparedInput);
         final String inputComma = swapDotAndComma(inputDot);
         return CollectionStream.of(new String[]{inputDot, inputComma}).toSet();
     }
@@ -519,6 +521,11 @@ public class GeopointParser {
     private static String removeSpaceAfterSeparators(@NonNull final String text) {
         final String replacedComma = new MatcherWrapper(PATTERN_BAD_BLANK_COMMA, text).replaceAll("$1,$2");
         return new MatcherWrapper(PATTERN_BAD_BLANK_DOT, replacedComma).replaceAll("$1.$2");
+    }
+
+    @NonNull
+    private static String prepareForDegCommaCommaFormat(@NonNull final String text) {
+        return new MatcherWrapper(PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER, text).replaceAll("$1,$2");
     }
 
     private static String swapDotAndComma(@NonNull final String text) {

--- a/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
+++ b/main/src/main/java/cgeo/geocaching/location/GeopointParser.java
@@ -24,7 +24,7 @@ public class GeopointParser {
 
     private static final Pattern PATTERN_BAD_BLANK_COMMA = Pattern.compile("(\\d), ([-+]?\\d{2,})");
     private static final Pattern PATTERN_BAD_BLANK_DOT = Pattern.compile("(\\d)\\. ([-+]?\\d{2,})");
-    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("(\\d{1,3},\\d+), ([-+]?\\d{1,3},\\d+)");
+    private static final Pattern PATTERN_BAD_BLANK_FOR_DEG_COMMA_COMMA_PARSER = Pattern.compile("([-+]?\\d{1,3},\\d+), ([-+]?\\d{1,3},\\d+)");
 
     private static final List<AbstractParser> parsers = Arrays.asList(new MinDecParser(), new MinParser(), new DegParser(), new DMSParser(), new ShortDMSParser(), new DegDecParser(), new ShortDegDecParser(), new UTMParser(), new DegDecCommaParser());
 

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -179,7 +179,7 @@ public class GeoPointParserTest {
         assertGeopointEquals(GeopointParser.parse("47,648883, 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47,648883, +122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47,648883, -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
-        assertGeopointEquals(GeopointParser.parse("47,648883, 9,348067"), GeopointParser.parse("N 47° 38.933 E 9° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("-47,648883, 9,348067"), GeopointParser.parse("S 47° 38.933 E 9° 20.884"), 1e-4f);
 
         // blanks after decimal comma
         assertParsingFails("47, 648883, -122, 348067");

--- a/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
+++ b/main/src/test/java/cgeo/geocaching/location/GeoPointParserTest.java
@@ -168,6 +168,7 @@ public class GeoPointParserTest {
     public void testFloatingPointWithSeparator() {
         assertGeopointEquals(GeopointParser.parse("47.648883,  122.348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47.648883,  -122.348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47.648883,  9.348067"), GeopointParser.parse("N 47° 38.933 E 9° 20.884"), 1e-4f);
 
         assertGeopointEquals(GeopointParser.parse("47,648883. 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47,648883. -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
@@ -178,6 +179,7 @@ public class GeoPointParserTest {
         assertGeopointEquals(GeopointParser.parse("47,648883, 122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47,648883, +122,348067"), GeopointParser.parse("N 47° 38.933 E 122° 20.884"), 1e-4f);
         assertGeopointEquals(GeopointParser.parse("47,648883, -122,348067"), GeopointParser.parse("N 47° 38.933 W 122° 20.884"), 1e-4f);
+        assertGeopointEquals(GeopointParser.parse("47,648883, 9,348067"), GeopointParser.parse("N 47° 38.933 E 9° 20.884"), 1e-4f);
 
         // blanks after decimal comma
         assertParsingFails("47, 648883, -122, 348067");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Fix the regexpr to consider only 1 digit for longitude value before comma (in `getParseInputs` /  `removeSpaceAfterSeparators`)

The other parsers were able to deal with the not removed space, because this was supported in their own regexpressions.
Since I didn't want to change to much for the existing parsers, I added a new method for the special format


## Related issues
<!-- List the related issues fixed or improved by this PR -->
#16382

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->