### PR TITLE
hide "report problem" when editing a log

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -150,10 +150,10 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
         }
         reportProblem.setValues(possibleReportProblemTypes);
 
-        if (logEditMode != LogEditMode.CREATE_NEW && possibleReportProblemTypes.size() == 1) {
-            binding.reportProblemBox.setVisibility(View.GONE);
-        } else {
+        if (logEditMode == LogEditMode.CREATE_NEW && possibleReportProblemTypes.size() > 1) {
             binding.reportProblemBox.setVisibility(View.VISIBLE);
+        } else {
+            binding.reportProblemBox.setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/cgeo/cgeo/issues/16609

code had && instead of ||. Changed the condition to be more readable