### PR TITLE
UnifiedMap: Set displayName for downloaded offline maps (fix #16586)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/CompanionFileUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/CompanionFileUtils.java
@@ -2,12 +2,15 @@ package cgeo.geocaching.downloader;
 
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.storage.Folder;
+import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.CalendarUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,6 +77,31 @@ public class CompanionFileUtils {
         }
     }
 
+    @Nullable
+    public static DownloadedFileData readData(final Folder folder, final String filename) {
+        if (filename.endsWith(INFOFILE_SUFFIX)) {
+            try (InputStream input = ContentStorage.get().openForRead(folder, filename)) {
+                if (input != null) {
+                    final DownloadedFileData offlineMapData = new DownloadedFileData();
+                    final Properties prop = new Properties();
+                    prop.load(input);
+                    offlineMapData.remoteParsetype = Integer.parseInt(prop.getProperty(PROP_PARSETYPE));
+                    offlineMapData.remotePage = prop.getProperty(PROP_REMOTEPAGE);
+                    offlineMapData.remoteFile = prop.getProperty(PROP_REMOTEFILE);
+                    offlineMapData.remoteDate = CalendarUtils.parseYearMonthDay(prop.getProperty(PROP_REMOTEDATE));
+                    offlineMapData.localFile = prop.getProperty(PROP_LOCALFILE);
+                    offlineMapData.displayName = prop.getProperty(PROP_DISPLAYNAME);
+                    return offlineMapData;
+                } else {
+                    Log.d("Cannot open property file " + filename + " for reading: ");
+                }
+            } catch (IOException | NumberFormatException | NullPointerException e) {
+                Log.d("Offline map property file error for " + filename + ": " + e.getMessage());
+            }
+        }
+        return null;
+    }
+
     /**
      * returns a list of downloaded offline map related files from all sources which are still available in the local filesystem
      */
@@ -101,31 +129,9 @@ public class CompanionFileUtils {
         if (downloader.useCompanionFiles) {
             for (ContentStorage.FileInformation fi : files) {
                 final String filename = fi.name;
-                if (!filename.endsWith(INFOFILE_SUFFIX)) {
-                    continue;
-                }
-                try (InputStream input = ContentStorage.get().openForRead(downloader.targetFolder.getFolder(), filename)) {
-                    if (input != null) {
-                        final DownloadedFileData offlineMapData = new DownloadedFileData();
-                        final Properties prop = new Properties();
-                        prop.load(input);
-                        offlineMapData.remoteParsetype = Integer.parseInt(prop.getProperty(PROP_PARSETYPE));
-                        if (offlineMapData.remoteParsetype == filter.id) {
-                            offlineMapData.remotePage = prop.getProperty(PROP_REMOTEPAGE);
-                            offlineMapData.remoteFile = prop.getProperty(PROP_REMOTEFILE);
-                            offlineMapData.remoteDate = CalendarUtils.parseYearMonthDay(prop.getProperty(PROP_REMOTEDATE));
-                            offlineMapData.localFile = prop.getProperty(PROP_LOCALFILE);
-                            offlineMapData.displayName = prop.getProperty(PROP_DISPLAYNAME);
-
-                            if (StringUtils.isNotBlank(offlineMapData.localFile) && filesMap.containsKey(offlineMapData.localFile)) {
-                                result.add(offlineMapData);
-                            }
-                        }
-                    } else {
-                        Log.d("Cannot open property file " + filename + " for reading");
-                    }
-                } catch (IOException | NumberFormatException | NullPointerException e) {
-                    Log.d("Offline map property file error for " + filename + ": " + e.getMessage());
+                final DownloadedFileData offlineMapData = readData(downloader.targetFolder.getFolder(), filename);
+                if (offlineMapData != null && offlineMapData.remoteParsetype == filter.id && StringUtils.isNotBlank(offlineMapData.localFile) && filesMap.containsKey(offlineMapData.localFile)) {
+                    result.add(offlineMapData);
                 }
             }
         } else {
@@ -164,6 +170,19 @@ public class CompanionFileUtils {
             pos = name.indexOf("-", pos + 1);
         }
         return tempName;
+    }
+
+    @Nullable
+    public static String getDisplaynameForMap(final Uri uri) {
+        String f = uri.getLastPathSegment();
+        if (f != null) {
+            f = f.substring(f.lastIndexOf('/') + 1) + INFOFILE_SUFFIX;
+            final DownloadedFileData temp = readData(PersistableFolder.OFFLINE_MAPS.getFolder(), f);
+            if (temp != null && StringUtils.isNotBlank(temp.displayName)) {
+                return temp.displayName;
+            }
+        }
+        return null;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/downloader/ReceiveDownload.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/ReceiveDownload.java
@@ -122,6 +122,16 @@ class ReceiveDownload {
 
     private Worker.Result handleMapFile(final Context context, final NotificationManagerCompat notificationManager, final NotificationCompat.Builder notification, final Runnable updateForegroundNotification,
                                final boolean isZipFile, final String nameWithinZip) {
+        // try to preserve displayName (if download supports that)
+        String displayName = "";
+        if (downloader.useCompanionFiles && StringUtils.isNotBlank(sourceURL)) {
+            final AbstractDownloader downloader = Download.DownloadType.getInstance(offlineMapTypeId);
+            final CompanionFileUtils.DownloadedFileData old = downloader == null ? null : CompanionFileUtils.readData(downloader.targetFolder.getFolder(), filename + CompanionFileUtils.INFOFILE_SUFFIX);
+            if (old != null && StringUtils.isNotBlank(old.displayName)) {
+                displayName = old.displayName;
+            }
+        }
+
         cleanupFolder();
 
         Worker.Result resultId = Worker.Result.failure();
@@ -144,7 +154,7 @@ class ReceiveDownload {
             case SUCCESS:
                 resultMsg = String.format(context.getString(R.string.receivedownload_success), fileinfo);
                 if (downloader.useCompanionFiles && StringUtils.isNotBlank(sourceURL)) {
-                    CompanionFileUtils.writeInfo(sourceURL, filename, CompanionFileUtils.getDisplayName(fileinfo), sourceDate, offlineMapTypeId);
+                    CompanionFileUtils.writeInfo(sourceURL, filename, StringUtils.isNotBlank(displayName) ? displayName : CompanionFileUtils.getDisplayName(fileinfo), sourceDate, offlineMapTypeId);
                 }
                 TileProviderFactory.buildTileProviderList(true);
                 resultId = Worker.Result.success();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
+import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.maps.mapsforge.v6.layers.HillShadingLayerHelper;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
@@ -8,6 +9,7 @@ import cgeo.geocaching.utils.Log;
 
 import android.net.Uri;
 
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
 import java.io.FileInputStream;
@@ -26,12 +28,14 @@ import org.mapsforge.map.view.MapView;
 public class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileProvider {
 
     private MapFile mapFile = null;
+    private final String displayName;
 
     AbstractMapsforgeOfflineTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax) {
         super(name, uri, zoomMin, zoomMax, new Pair<>("", false));
         supportsThemes = true;
         supportsThemeOptions = true; // rule of thumb, not all themes support options
         supportsHillshading = true;
+        displayName = CompanionFileUtils.getDisplaynameForMap(uri);
     }
 
     @Override
@@ -86,6 +90,11 @@ public class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileP
         } else {
             Log.w("AbstractMapsforgeOfflineTileProvider.setPreferredLanguage: tilesource is null");
         }
+    }
+
+    @Override
+    public String getDisplayName(@Nullable final String defaultDisplayName) {
+        return StringUtils.isNotBlank(displayName) ? displayName : defaultDisplayName;
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOfflineTileProvider.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.unifiedmap.tileproviders;
 
+import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.unifiedmap.LayerHelper;
@@ -8,6 +9,7 @@ import cgeo.geocaching.utils.Log;
 
 import android.net.Uri;
 
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
 import java.io.FileInputStream;
@@ -25,12 +27,14 @@ public class AbstractMapsforgeVTMOfflineTileProvider extends AbstractMapsforgeVT
 
     IMapFileTileSource tileSource;
     private BuildingLayer buildingLayer;
+    private final String displayName;
 
     AbstractMapsforgeVTMOfflineTileProvider(final String name, final Uri uri, final int zoomMin, final int zoomMax) {
         super(name, uri, zoomMin, zoomMax, new Pair<>("", false));
         supportsThemes = true;
         supportsThemeOptions = true; // rule of thumb, not all themes support options
         supportsHillshading = true;
+        displayName = CompanionFileUtils.getDisplaynameForMap(uri);
     }
 
     @Override
@@ -74,5 +78,10 @@ public class AbstractMapsforgeVTMOfflineTileProvider extends AbstractMapsforgeVT
             return;
         }
         buildingLayer.setEnabled(enabled);
+    }
+
+    @Override
+    public String getDisplayName(@Nullable final String defaultDisplayName) {
+        return StringUtils.isNotBlank(displayName) ? displayName : defaultDisplayName;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractTileProvider.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.unifiedmap.tileproviders;
 
 import cgeo.geocaching.unifiedmap.AbstractMapFragment;
 
+import androidx.annotation.Nullable;
 import androidx.core.util.Pair;
 
 import java.util.HashMap;
@@ -53,6 +54,11 @@ public abstract class AbstractTileProvider {
 
     public String getTileProviderName() {
         return tileProviderName;
+    }
+
+    @Nullable
+    public String getDisplayName(@Nullable final String defaultDisplayName) {
+        return defaultDisplayName;
     }
 
     public String getId() {


### PR DESCRIPTION
## Description
Allow configuring displayname for offline map sources downloaded with c:geo:

|map selection|folder data|companion file|
|---|---|---|
|![image](https://github.com/user-attachments/assets/976004de-ca4d-4839-8b69-13b195455316)|![image](https://github.com/user-attachments/assets/d5dee193-82ae-4919-8907-a31d0f88b49f)|![image](https://github.com/user-attachments/assets/1d317e95-2039-40e6-8d83-df422d8db678)|

Only `displayname` property in companion file needs to be changed, everything else is untouched. Updating such a map source does work, `displayname` gets preserved. Map sources are sorted by `displayname` within their respective categories.



