### PR TITLE
Allow manual setting of geofence radius (fix #16436)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -477,6 +477,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             final boolean isOriginalWaypoint = selectedWaypoint.getWaypointType() == WaypointType.ORIGINAL;
             menu.findItem(R.id.menu_waypoint_reset_cache_coords).setVisible(isOriginalWaypoint);
             menu.findItem(R.id.menu_waypoint_edit).setVisible(!isOriginalWaypoint);
+            menu.findItem(R.id.menu_waypoint_geofence).setVisible(selectedWaypoint.canChangeGeofence());
             menu.findItem(R.id.menu_waypoint_duplicate).setVisible(!isOriginalWaypoint);
             menu.findItem(R.id.menu_waypoint_delete).setVisible(!isOriginalWaypoint || selectedWaypoint.belongsToUserDefinedCache());
             final boolean hasCoords = selectedWaypoint.getCoords() != null;
@@ -501,6 +502,27 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             if (selectedWaypoint != null) {
                 ensureSaved();
                 EditWaypointActivity.startActivityEditWaypoint(this, cache, selectedWaypoint.getId());
+                refreshOnResume = true;
+            }
+        } else if (itemId == R.id.menu_waypoint_geofence) {
+            if (selectedWaypoint != null) {
+                ensureSaved();
+                SimpleDialog.of(this)
+                        .setTitle(TextParam.id(R.string.waypoint_geofence))
+                        .setMessage(TextParam.id(R.string.waypoint_geofence_summary))
+                        .input(
+                                new SimpleDialog.InputOptions().setInitialValue(String.valueOf(selectedWaypoint.getGeofence())).setInputType(InputType.TYPE_CLASS_NUMBER),
+                                result -> {
+                                    float newValue = 0;
+                                    try {
+                                        newValue = Float.parseFloat(result);
+                                    } catch (NumberFormatException ignore) {
+                                        // ignore
+                                    }
+                                    selectedWaypoint.setGeofence(newValue);
+                                    saveAndNotify();
+                                }
+                );
                 refreshOnResume = true;
             }
         } else if (itemId == R.id.menu_waypoint_visited) {

--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.models;
 
 import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.al.ALConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CoordinateType;
 import cgeo.geocaching.enumerations.LoadFlags;
@@ -312,6 +313,11 @@ public class Waypoint implements INamedGeoCoordinate {
     @Nullable
     public Float getGeofence() {
         return geofence;
+    }
+
+    public boolean canChangeGeofence() {
+        // currently geofence value is used by AL connector only, so you may set it manually for every other connector
+        return !ALConnector.getInstance().canHandle(geocode);
     }
 
     public void setGeofence(@Nullable final Float geofence) {

--- a/main/src/main/res/menu/waypoint_options.xml
+++ b/main/src/main/res/menu/waypoint_options.xml
@@ -8,6 +8,9 @@
         android:id="@+id/menu_waypoint_edit"
         android:title="@string/waypoint_edit"/>
     <item
+        android:id="@+id/menu_waypoint_geofence"
+        android:title="@string/waypoint_geofence"/>
+    <item
         android:id="@+id/menu_waypoint_visited"
         android:title="@string/waypoint_visited"/>
     <item

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1851,6 +1851,8 @@
     <string name="waypoint_my_coordinates_accuracy">My coordinates (±%s)</string>
     <string name="waypoint_name">Name</string>
     <string name="waypoint_edit">Edit</string>
+    <string name="waypoint_geofence">Geofence</string>
+    <string name="waypoint_geofence_summary">Set radius for geofence (in meters)</string>
     <string name="waypoint_copy_coordinates">Copy coordinates</string>
     <string name="waypoint_clear_coordinates">Clear coordinates</string>
     <string name="waypoint_delete">Delete</string>


### PR DESCRIPTION
## Description
Allow manually setting a "geofence" radius on a per-waypoint basis. Those circles are shown on map if "Circles" option in map quick settings is enabled:

|Waypoint context menu|Editing geofence radius|Result on map|
|---|---|---|
|![image](https://github.com/user-attachments/assets/04acd998-9a11-43cd-bc53-1caa1993bdd3)|![image](https://github.com/user-attachments/assets/44a0b00d-ce5c-4895-89a7-88a5063817c5)|![image](https://github.com/user-attachments/assets/8c68a3e0-83f9-49f2-bb64-bb826050a568)|

This feature is built on top of #16618 (show geofence circles for lab stages) and allows setting a value manually for non-lab waypoints.