### PR TITLE
fix #16617: unified live map: don't call server after partial/error result when too close to previous position

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/geoitem/GeoItemUtils.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/GeoItemUtils.java
@@ -103,7 +103,6 @@ public final class GeoItemUtils {
         return (lineWidthPx + 1) / 2;
     }
 
-
     private static boolean touchesLine(final int[] tappedPt, final int[] p1Pt, final int[] p2Pt, final int lineWidthPxHalf) {
 
         if (pointsEqual(p1Pt, p2Pt)) {
@@ -181,8 +180,9 @@ public final class GeoItemUtils {
         return result;
     }
 
-
     private static boolean pointsEqual(final int[] pt1, final int[] pt2) {
         return Arrays.equals(pt1, pt2);
     }
+
+
 }

--- a/main/src/main/java/cgeo/geocaching/models/geoitem/GeoStyle.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/GeoStyle.java
@@ -117,6 +117,23 @@ public class GeoStyle implements Parcelable {
         return new Builder();
     }
 
+    //helpers
+
+    public static GeoStyle solid(final int color, final float width) {
+        return GeoStyle.builder()
+            .setStrokeColor(color)
+            .setFillColor(color)
+            .setStrokeWidth(width).build();
+    }
+
+    /** creates a style where fill color is a transparent version of stroke color */
+    public static GeoStyle transparentFill(final int strokeColor, final int fillTransparency, final float width) {
+        return GeoStyle.builder()
+            .setStrokeColor(strokeColor)
+            .setFillColor(Color.argb(fillTransparency, Color.red(strokeColor), Color.green(strokeColor), Color.blue(strokeColor)))
+            .setStrokeWidth(width).build();
+    }
+
     //equals/hashCode
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapViewModel.java
@@ -61,7 +61,7 @@ public class UnifiedMapViewModel extends ViewModel implements IndividualRoute.Up
 
     public final CollectionLiveData<Geocache, Set<Geocache>> caches = CollectionLiveData.set(() -> new LeastRecentlyUsedSet<>(MAX_CACHES + DataStore.getAllCachesCount()));
     public final CollectionLiveData<Waypoint, Set<Waypoint>> waypoints = CollectionLiveData.set();
-    public final MutableLiveData<LiveMapGeocacheLoader.LiveDataState> liveLoadStatus = new MutableLiveData<>(new LiveMapGeocacheLoader.LiveDataState(LiveMapGeocacheLoader.LoadState.STOPPED, null));
+    public final MutableLiveData<LiveMapGeocacheLoader.LiveDataState> liveLoadStatus = new MutableLiveData<>(new LiveMapGeocacheLoader.LiveDataState(LiveMapGeocacheLoader.LoadState.STOPPED, null, null));
     public final LiveMapDataHandler liveMapHandler = new LiveMapDataHandler(this);
 
     public final CollectionLiveData<String, Set<String>> cachesWithStarDrawn = CollectionLiveData.set(() -> new LeastRecentlyUsedSet<>(MAX_CACHES));


### PR DESCRIPTION
fix #16617: unified live map: don't call server after partial/error result when too close to previous position