### PR TITLE
Remove WhereYouGo from 'useful apps' list

### DIFF
--- a/main/src/main/java/cgeo/geocaching/helper/UsefulAppsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/helper/UsefulAppsActivity.java
@@ -15,7 +15,6 @@ public final class UsefulAppsActivity extends AbstractActionBarActivity {
     private static final HelperApp[] HELPER_APPS = {
             new HelperApp(R.string.helper_sendtocgeo_title, R.string.helper_sendtocgeo_description, R.mipmap.ic_launcher_send2cgeo, R.string.settings_send2cgeo_url),
             new HelperApp(R.string.helper_google_translate_title, R.string.helper_google_translate_description, R.drawable.helper_google_translate, R.string.package_google_translate),
-            new HelperApp(R.string.helper_where_you_go_title, R.string.helper_where_you_go_description, R.drawable.icon_whereyougo, R.string.package_whereyougo),
             new HelperApp(R.string.helper_gpsstatus_title, R.string.helper_gpsstatus_description, R.drawable.helper_gpsstatus, R.string.package_gpsstatus),
             new HelperApp(R.string.helper_bluetoothgps_title, R.string.helper_bluetoothgps_description, R.drawable.helper_bluetoothgps, R.string.package_bluetoothgps),
             new HelperApp(R.string.helper_gps_locker_title, R.string.helper_gps_locker_description, R.drawable.helper_gps_locker, R.string.package_gpslocker),

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2160,7 +2160,6 @@
     <string name="helper_gps_locker_description">GPS Locker keeps GPS signal active when switching between applications and when your device\'s screen is off.</string>
     <string name="helper_google_translate_title">Google Translate</string>
     <string name="helper_google_translate_description">If you download translation packages in the Google Translate app, then you can easily translate cache descriptions in c:geo by a long tap on the cache description text (without an Internet connection).</string>
-    <string name="helper_where_you_go_description">WhereYouGo allows playing and searching geocaches of type Wherigo. c:geo can automatically trigger the download of cartridges within this app.</string>
     <string name="helper_chirpwolf_description">Chirp Wolf allows you to read the data from ANT+/Garmin chirp tags, which is needed for ANT+/chirp geocaches.</string>
     <string name="helper_alc_description">Adventure Lab Player app for your phone or tablet.</string>
     <string name="helper_gcwizard_description">GC Wizard contains numerous tools for simple cryptography, geodetic and scientific calculations as well as hundreds of sets of various symbols.</string>

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -262,7 +262,6 @@
     <string translatable="false" name="helper_gpsstatus_title">GPS Status &amp; Toolbox</string>
     <string translatable="false" name="helper_bluetoothgps_title">Bluetooth GPS</string>
     <string translatable="false" name="helper_gps_locker_title">GPS Locker</string>
-    <string translatable="false" name="helper_where_you_go_title">WhereYouGo</string>
     <string translatable="false" name="helper_chirpwolf">Chirp Wolf</string>
     <string translatable="false" name="helper_alc">Adventure Lab</string>
     <string translatable="false" name="helper_gcwizard">GC Wizard</string>


### PR DESCRIPTION
## Description
Since having an integrated Wherigo player, a reference to WhereYouGo in "useful apps" list is no longer required