### PR TITLE
Report error on missing SAF folder selection intent handler (fix #16636)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
+++ b/main/src/main/java/cgeo/geocaching/InstallWizardActivity.java
@@ -439,7 +439,13 @@ public class InstallWizardActivity extends AppCompatActivity {
         forceSkipButton = false;
         if (!ContentStorageActivityHelper.baseFolderIsSet()) {
             prepareFolderDefaultValues();
-            this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.BASE);
+            reportOnMissingHandler(this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.BASE));
+        }
+    }
+
+    private void reportOnMissingHandler(final boolean success) {
+        if (!success) {
+            contentStorageActivityHelper.reportMissingHandler();
         }
     }
 
@@ -461,7 +467,7 @@ public class InstallWizardActivity extends AppCompatActivity {
         forceSkipButton = false;
         if (mapFolderNeedsMigration()) {
             prepareFolderDefaultValues();
-            this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.OFFLINE_MAPS);
+            reportOnMissingHandler(this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.OFFLINE_MAPS));
         }
     }
 
@@ -473,7 +479,7 @@ public class InstallWizardActivity extends AppCompatActivity {
         forceSkipButton = false;
         if (mapThemeFolderNeedsMigration()) {
             prepareFolderDefaultValues();
-            this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.OFFLINE_MAP_THEMES);
+            reportOnMissingHandler(this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.OFFLINE_MAP_THEMES));
         }
     }
 
@@ -485,7 +491,7 @@ public class InstallWizardActivity extends AppCompatActivity {
         forceSkipButton = false;
         if (gpxFolderNeedsMigration()) {
             prepareFolderDefaultValues();
-            this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.GPX);
+            reportOnMissingHandler(this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.GPX));
         }
     }
 
@@ -497,7 +503,7 @@ public class InstallWizardActivity extends AppCompatActivity {
         forceSkipButton = false;
         if (broutertilesFolderNeedsMigration()) {
             prepareFolderDefaultValues();
-            this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.ROUTING_TILES);
+            reportOnMissingHandler(this.contentStorageActivityHelper.migratePersistableFolder(PersistableFolder.ROUTING_TILES));
         }
     }
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2922,6 +2922,8 @@
     <string name="wizard_status_platform">Geocaching services</string>
     <string name="wizard_not_now">Not now</string>
     <string name="wizard_skip_wizard_warning">c:geo might not work as expected until configuration is completed. Depending on the missing configuration c:geo might not be able to read/store data like offline maps, geocaches, logfiles etc.\n\nWhenever you feel ready to finalize setup, either choose \"Configuration wizard\" in main menu or restart c:geo.</string>
+    <string name="saf_missing_activity_title">Warning</string>
+    <string name="saf_missing_activity_message">c:geo could not find any activity being able to handle the requested action, probably due to missing access rights for the required system app.\n\nPlease contact c:geo support for further advice.</string>
 
     <!-- Map Theme helper -->
     <string name="mapthemes_foldersync_finished_toast">%1$s folder synchronization finished after %2$s, %3$d of %4$s needed synchronization</string>


### PR DESCRIPTION
## Description
Display an informational dialog if SAF folder selection cannot be triggered, probably due to user having revoked necessary access rights from the corresponding system apps.

![image](https://github.com/user-attachments/assets/99c4d604-cd31-4768-8811-0a995e0c44ac)

Currently implemented for `InstallWizardActivity` folder migration only, but can be extended to other places and actions if need be.