### PR TITLE
Enable c:geo listing for GPS-less devices (fix #16472)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
     <uses-feature
         android:name="android.hardware.location.gps"
-        android:required="true" />
+        android:required="false" />
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />


### PR DESCRIPTION
## Description
As discussed in #16472: Remove the Play Store restriction to _require_ GPS, make it optional.