### PR TITLE
Attempt to fix issue #16608

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -304,7 +304,50 @@
 
                 <data android:mimeType="*/*" />
                 <data android:host="*" />
-                <!-- <data android:scheme="xxx" /> neither "file" nor "content" means: both -->
+                <data android:scheme="file" />
+
+                <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
+                <data android:pathPattern=".*\\.map" />
+                <data android:pathPattern=".*\\..*\\.map" />
+                <data android:pathPattern=".*\\..*\\..*\\.map" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.map" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.map" />
+
+                <data android:pathPattern=".*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
+
+                <data android:pathPattern=".*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\..*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ggz" />
+
+                <data android:pathPattern=".*\\.zip" />
+                <data android:pathPattern=".*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.zip" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.zip" />
+
+                <data android:pathPattern=".*\\.gwc" />
+                <data android:pathPattern=".*\\..*\\.gwc" />
+                <data android:pathPattern=".*\\..*\\..*\\.gwc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.gwc" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gwc" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:host="*" />
+                <data android:scheme="content" />
 
                 <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
                 <data android:pathPattern=".*\\.map" />


### PR DESCRIPTION
## Description
One of the recent changes in file handling removed the `<data scheme="file" />` attribute to allow for `scheme="content"` calls additionally. According to the docs, if none scheme is given, both `file` and `content` should be used, but maybe this is different when being opened from apps.

To test this, this PR configures separate blocks for both schemes.

@Lineflyer / @ztNFny: Do you have a chance to test whether this change helps in your use-cases?

Setting "do not merge" label for now.