### PR TITLE
fix #16627: make custom button texts case sensitive

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/TextParam.java
+++ b/main/src/main/java/cgeo/geocaching/ui/TextParam.java
@@ -17,6 +17,8 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.text.HtmlCompat;
 
+import java.util.Locale;
+
 import io.noties.markwon.Markwon;
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,6 +45,7 @@ public class TextParam {
     private final CharSequence text;
     private final TextParam[] concatTexts;
 
+    private boolean allCaps = false;
     private boolean useHtml = false;
     private boolean useMarkdown = false;
     private int linkifyMask = 0;
@@ -77,6 +80,12 @@ public class TextParam {
      */
     public static TextParam concat(final TextParam... texts) {
         return new TextParam(0, null, texts);
+    }
+
+    /** convert text to all-caps */
+    public TextParam setAllCaps(final boolean allCaps) {
+        this.allCaps = allCaps;
+        return this;
     }
 
     /**
@@ -224,6 +233,11 @@ public class TextParam {
         //parameters
         if (this.textParams != null && this.textParams.length > 0) {
             text = LocalizationUtils.getStringWithFallback(0, text.toString(), this.textParams);
+        }
+
+        //capitalize
+        if (this.allCaps) {
+            text = text.toString().toUpperCase(Locale.ROOT);
         }
 
         //markdown

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -60,6 +60,7 @@ import static android.view.MenuItem.SHOW_AS_ACTION_ALWAYS;
 
 import androidx.annotation.AttrRes;
 import androidx.annotation.DrawableRes;
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
@@ -270,11 +271,11 @@ public class ViewUtils {
     }
 
     public static Button createButton(final Context context, @Nullable final ViewGroup root, final TextParam text) {
-        return createButton(context, root, text, false);
+        return createButton(context, root, text, R.layout.button_view);
     }
 
-    public static Button createButton(final Context context, @Nullable final ViewGroup root, final TextParam text, final boolean fillParent) {
-        final Button button = (Button) LayoutInflater.from(wrap(root == null ? context : root.getContext())).inflate(fillParent ? R.layout.button_fillparent_view : R.layout.button_view, root, false);
+    public static Button createButton(final Context context, @Nullable final ViewGroup root, final TextParam text, @LayoutRes final int buttonLayout) {
+        final Button button = (Button) LayoutInflater.from(wrap(root == null ? context : root.getContext())).inflate(buttonLayout, root, false);
         text.applyTo(button);
         return button;
     }

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoCartridgeDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoCartridgeDialogProvider.java
@@ -27,9 +27,9 @@ public class WherigoCartridgeDialogProvider implements IWherigoDialogProvider {
     private final boolean infoOnly;
 
     private enum CartridgeAction {
-        PLAY(TextParam.id(R.string.play).setImage(ImageParam.id(R.drawable.ic_menu_select_play))),
-        DELETE(TextParam.id(R.string.delete).setImage(ImageParam.id(R.drawable.ic_menu_delete))),
-        CLOSE(TextParam.id(R.string.close).setImage(ImageParam.id(R.drawable.wherigo_close)));
+        PLAY(TextParam.id(R.string.play).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_select_play))),
+        DELETE(TextParam.id(R.string.delete).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_delete))),
+        CLOSE(TextParam.id(R.string.close).setAllCaps(true).setImage(ImageParam.id(R.drawable.wherigo_close)));
 
         private final TextParam tp;
 

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
@@ -28,8 +28,8 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
     private final EventTable eventTable;
 
     private enum ThingAction {
-        DISPLAY_ON_MAP(TextParam.id(R.string.caches_on_map).setImage(ImageParam.id(R.drawable.ic_menu_mapmode))),
-        LOCATE_ON_CENTER(TextParam.id(R.string.wherigo_locate_on_center).setImage(ImageParam.id(R.drawable.map_followmylocation_btn))),
+        DISPLAY_ON_MAP(TextParam.id(R.string.caches_on_map).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_mapmode))),
+        LOCATE_ON_CENTER(TextParam.id(R.string.wherigo_locate_on_center).setAllCaps(true).setImage(ImageParam.id(R.drawable.map_followmylocation_btn))),
         CLOSE(WherigoUtils.TP_CLOSE_BUTTON);
 
         private final TextParam tp;
@@ -81,7 +81,7 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
         //"actions" will be filled with instance of both "Action" and "ThingAction"
         final List<Object> actions = new ArrayList<>();
         if (eventTable instanceof Thing) {
-            actions.addAll(WherigoUtils.getActions((Thing) eventTable, false));
+            actions.addAll(WherigoUtils.getActions((Thing) eventTable, WherigoGame.get().isDebugModeForCartridge()));
         }
         if (eventTable instanceof Zone) {
             actions.add(ThingAction.DISPLAY_ON_MAP);
@@ -93,8 +93,8 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
 
         WherigoViewUtils.setViewActions(actions, binding.dialogActionlist, 1,
                 a -> a instanceof Action ?
-                        TextParam.text(WherigoUtils.getActionText((Action) a)).setImage(ImageParam.id(R.drawable.settings_nut)) :
-                        ((ThingAction) a).getTextParam(),
+                    TextParam.text(WherigoUtils.getActionText((Action) a)).setImage(ImageParam.id(R.drawable.settings_nut)) :
+                    ((ThingAction) a).getTextParam(),
                 item -> {
                     if (item instanceof Action) {
                         WherigoUtils.callAction((Thing) eventTable, (Action) item);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
@@ -65,9 +65,9 @@ import se.krka.kahlua.vm.LuaTable;
 
 public final class WherigoUtils {
 
-    public static final TextParam TP_OK_BUTTON = TextParam.id(R.string.ok).setImage(ImageParam.id(R.drawable.ic_menu_done));
-    public static final TextParam TP_CLOSE_BUTTON = TextParam.id(R.string.close).setImage(ImageParam.id(R.drawable.ic_menu_done));
-    public static final TextParam TP_CANCEL_BUTTON = TextParam.id(R.string.cancel).setImage(ImageParam.id(R.drawable.ic_menu_cancel));
+    public static final TextParam TP_OK_BUTTON = TextParam.id(R.string.ok).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_done));
+    public static final TextParam TP_CLOSE_BUTTON = TextParam.id(R.string.close).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_done));
+    public static final TextParam TP_CANCEL_BUTTON = TextParam.id(R.string.cancel).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_cancel));
 
     private static final Pattern PATTERN_CARTRIDGE_LINK = Pattern.compile("https?" + Pattern.quote("://www.wherigo.com/cartridge/") + "(?:details|download)" + Pattern.quote(".aspx?") + "[Cc][Gg][Uu][Ii][Dd]=([-0-9a-zA-Z]*)");
     private static final String WHERIGO_URL_BASE = "https://www.wherigo.com/cartridge/download.aspx?CGUID=";
@@ -121,7 +121,7 @@ public final class WherigoUtils {
         if (action == null || action.text == null) {
             return "-";
         }
-        return action.isEnabled()  ? action.text : action.text + " (disabled)";
+        return (action.isEnabled() && action.getActor().visibleToPlayer()) ? action.text : action.text + " (debug)";
     }
 
     public static void callAction(final Thing thing, final Action action) {

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
@@ -97,7 +97,7 @@ public final class WherigoViewUtils {
         final SimpleItemListModel<T> model = new SimpleItemListModel<>();
         model
             .setItems(actions)
-            .setDisplayMapper((item, group) -> displayMapper.apply(item), null, (ctx, parent) -> ViewUtils.createButton(ctx, parent, TextParam.text(""), true))
+            .setDisplayMapper((item, group) -> displayMapper.apply(item), null, (ctx, parent) -> ViewUtils.createButton(ctx, parent, TextParam.text(""), R.layout.button_wherigo_view))
             .setChoiceMode(SimpleItemListModel.ChoiceMode.SINGLE_PLAIN)
             .setItemPadding(10, 0)
             .setColumns(columnCount, null)

--- a/main/src/main/res/layout/button_wherigo_view.xml
+++ b/main/src/main/res/layout/button_wherigo_view.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="32dp"
+    style="@style/button_wherigo" />

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -111,12 +111,8 @@
 
     <!-- buttons -->
 
-    <style name="button" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
+    <style name="button_base" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:padding">6dip</item>
-        <item name="android:lines">1</item>
-        <item name="android:singleLine">true</item>
         <item name="android:scrollHorizontally">true</item>
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">@dimen/textSize_buttonsPrimary</item>
@@ -124,13 +120,29 @@
         <item name="iconTint">@color/colorText</item>
     </style>
 
-    <style name="button_full" parent="button">
+    <style name="button_full_base" parent="button_base">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>
-
         <item name="android:layout_marginLeft">6dip</item>
         <item name="android:layout_marginRight">6dip</item>
         <item name="android:layout_marginBottom">5dip</item>
+    </style>
+
+    <style name="button" parent="button_base">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:lines">1</item>
+        <item name="android:singleLine">true</item>
+    </style>
+
+    <style name="button_full" parent="button_full_base">
+        <item name="android:lines">1</item>
+        <item name="android:singleLine">true</item>
+    </style>
+
+    <style name="button_wherigo" parent="button_full_base">
+        <item name="android:maxLines">10</item>
+        <item name="android:textAllCaps">false</item>
     </style>
 
     <style name="button_full_double" parent="button_full">


### PR DESCRIPTION
fix #16627: make custom button texts case sensitive

![image](https://github.com/user-attachments/assets/afce4d10-a359-46f3-8128-97f478c6383f)

Note: the "custom button" is faked in the above image for demonstration purposes. If a cartridge provides a very long text for a button it would look like this