### PR TITLE
show "Save" for log only for new logs (fixes #16668)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -576,7 +576,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         super.onCreateOptionsMenu(menu);
-        menu.findItem(R.id.save).setVisible(true);
+        menu.findItem(R.id.save).setVisible(logEditMode == LogEditMode.CREATE_NEW);
         menu.findItem(R.id.clear).setVisible(true);
         menu.findItem(R.id.menu_sort_trackables_by).setVisible(true);
         switch (Settings.getTrackableComparator()) {


### PR DESCRIPTION
## Description
Same as #16670, but targeted to `release` (rebase of #16670 did not work)
Closes #16670 
