### PR TITLE
Update VTM to 0.23.0 to be on par with Mapsforge library

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -387,7 +387,7 @@ dependencies {
 
     // Mapsforge VTM implementation (official version)
     String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '0.22.0'
+    String mapsforgeVTMVersion = '0.23.0'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
     // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'


### PR DESCRIPTION
- VTM 0.23 just got released, see https://github.com/mapsforge/vtm/releases
- we are using Mapsforge in v0.23 already on `release`, so let's get them on par