### PR TITLE
Follow my location in elevation chart (fix #15763)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/location/Units.java
+++ b/main/src/main/java/cgeo/geocaching/location/Units.java
@@ -60,9 +60,9 @@ public class Units {
 
         final ImmutablePair<Double, String> scaled = scaleDistance(distanceKilometers);
         final String formatString;
-        if (scaled.left >= 100) {
+        if (Math.abs(scaled.left) >= 100) {
             formatString = "%.0f %s";
-        } else if (scaled.left >= 10) {
+        } else if (Math.abs(scaled.left) >= 10) {
             formatString = "%.1f %s";
         } else {
             formatString = "%.2f %s";

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -778,6 +778,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 viewModel.proximityNotification.getValue().checkDistance(getClosestDistanceInM(new Geopoint(locationWrapper.location.getLatitude(), locationWrapper.location.getLongitude()), viewModel));
             }
         }
+
+        if (elevationChartUtils != null) {
+            elevationChartUtils.showPositionOnTrack(new Geopoint(locationWrapper.location.getLatitude(), locationWrapper.location.getLongitude()));
+        }
     }
 
     private void checkDrivingMode() {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChart.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/ElevationChart.java
@@ -21,7 +21,6 @@ import static cgeo.geocaching.utils.DisplayUtils.getDimensionInDp;
 import android.content.res.Resources;
 import android.view.View;
 
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.res.ResourcesCompat;
@@ -82,7 +81,7 @@ public class ElevationChart {
             chart.setOnChartValueSelectedListener(new OnChartValueSelectedListener() {
                 @Override
                 public void onValueSelected(final Entry e, final Highlight h) {
-                    final Geopoint center = findClosestByDistance(route, e.getX());
+                    final Geopoint center = (Geopoint) e.getData();
                     // update marker if position found
                     if (center != null) {
                         final GeoItem marker = GeoPrimitive.createMarker(center, GeoIcon.builder().setBitmap(ImageUtils.convertToBitmap(ResourcesCompat.getDrawable(CgeoApplication.getInstance().getResources(), R.drawable.circle, null))).build()).buildUpon().setZLevel(ZINDEX_ELEVATIONCHARTMARKERPOSITION).build();
@@ -139,7 +138,7 @@ public class ElevationChart {
                 lastPoint = point;
                 final float elev = it.hasNext() ? it.next() : Float.NaN;
                 if (!Float.isNaN(elev)) {
-                    entries.add(new Entry(distance, elev));
+                    entries.add(new Entry(distance, elev, point));
                 }
             }
         }
@@ -194,24 +193,5 @@ public class ElevationChart {
         chartBlock.setVisibility(View.GONE);
         geoItemLayer.remove(ELEVATIONCHART_MARKER);
         LifecycleAwareBroadcastReceiver.sendBroadcast(chart.getContext(), Intents.ACTION_ELEVATIONCHART_CLOSED);
-    }
-
-    /** find position in route corresponding to distance from start */
-    @Nullable
-    private static Geopoint findClosestByDistance(final Route route, final float distance) {
-        float done = 0.0f;
-        Geopoint lastPoint = null;
-        for (RouteSegment segment : route.getSegments()) {
-            for (Geopoint point : segment.getPoints()) {
-                if (lastPoint != null) {
-                    done += lastPoint.distanceTo(point);
-                }
-                if (done >= distance) {
-                    return point;
-                }
-                lastPoint = point;
-            }
-        }
-        return null;
     }
 }


### PR DESCRIPTION
## Description
Elevation charts "follows current location", marking the closest nearby point on the current track and adapting the x-axis labels to it. Maximum allowed distance between current location and point on track is 100m. Minimum distance between two updates is 50m.

![image](https://github.com/user-attachments/assets/7cb6a0ba-0fd3-4922-8fed-a68f0a944711)
