### PR TITLE
AGP 8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,12 @@ systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 
 # AndroidX configuration
 android.useAndroidX=true
+
+# Enable buildConfig build feature
+android.defaults.buildfeatures.buildconfig=true
+
+# Preserve transitive R classes
+android.nonTransitiveRClass=false
+
+# Preserve constant R class values
+android.nonFinalResIds=false

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -66,6 +66,8 @@ android {
 
     buildFeatures {
         viewBinding true
+        // Enable aidl, some modules in this project appear to be using AIDL
+        aidl true
     }
 
     buildTypes {
@@ -79,7 +81,10 @@ android {
             testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt', '../tests/proguard-project.txt'
 
             // code coverage
-            testCoverageEnabled isContinuousIntegrationServer()
+            if (isContinuousIntegrationServer()) {
+                enableAndroidTestCoverage true
+                enableUnitTestCoverage true
+            }
 
             // replace in AndroidManifest.xml
             manifestPlaceholders = [


### PR DESCRIPTION
Lets upgrade AGP step by step.
Step was done using the upgrade assistent.

- Upgrade AGP dependency from 7.4.2 to 8.0.2
- Update default R8 processing mode 
  see https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode => no compatibility mode necessary
- Enable buildConfig build feature 
  see https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes
- Preserve transitive R classes 
  see https://developer.android.com/build/optimize-your-build#use-non-transitive-r-classes
- Preserve constant R class values 
  see https://developer.android.com/build/optimize-your-build#use-non-constant-r-classes
- Enable aidl explicitly where needed 
  see https://developer.android.com/develop/background-work/services/aidl
- Migrate testCoverageEnabled to enableUnitTestCoverage and enableAndroidTestCoverage 
  It will be removed in AGP 9.0.0.

Replaces #15447