### PR TITLE
Revert "Update VTM to 0.23.0 to be on par with Mapsforge library"

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -387,7 +387,7 @@ dependencies {
 
     // Mapsforge VTM implementation (official version)
     String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '0.23.0'
+    String mapsforgeVTMVersion = '0.22.0'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
     // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'


### PR DESCRIPTION
Reverts #16678 (see https://github.com/cgeo/cgeo/pull/16707#issuecomment-2695521606)