### PR TITLE
Update Mapsforge and VTM to v0.24

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -372,7 +372,7 @@ dependencies {
 
     // Mapsforge official version
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = '0.23.0'
+    String mapsforgeVersion = '0.24.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     // String mapsforgeSource = 'com.github.mapsforge.mapsforge'
@@ -392,7 +392,7 @@ dependencies {
 
     // Mapsforge VTM implementation (official version)
     String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '0.22.0'
+    String mapsforgeVTMVersion = '0.24.0'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
     // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
@@ -408,7 +408,7 @@ dependencies {
     implementation "$mapsforgeVTMSource:vtm:$mapsforgeVTMVersion"
     implementation "$mapsforgeVTMSource:vtm-themes:$mapsforgeVTMVersion"
     implementation "$mapsforgeVTMSource:vtm-jts:$mapsforgeVTMVersion"
-    implementation "org.locationtech.jts:jts-core:1.16.1"
+    implementation "org.locationtech.jts:jts-core:1.20.0"
 
     runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-armeabi-v7a"
     runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-arm64-v8a"


### PR DESCRIPTION
## Description
Updates Mapsforge and VTM to v0.24 (and jts-core, which is a dependency for VTM, to v1.20)

supersedes #16706 
supersedes #16707 