### PR TITLE
handle cache connectors not supporting rating in MapMarkerUtils only

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -724,8 +724,12 @@ public class Geocache implements INamedGeoCoordinate {
         return getConnector().getLoggingManager(this);
     }
 
+    public boolean supportsDifficultyTerrain() {
+        return getConnector().supportsDifficultyTerrain();
+    }
+
     public float getDifficulty() {
-        return getConnector().supportsDifficultyTerrain() ? difficulty : -1;
+        return difficulty;
     }
 
     @Override
@@ -756,7 +760,7 @@ public class Geocache implements INamedGeoCoordinate {
     }
 
     public float getTerrain() {
-        return getConnector().supportsDifficultyTerrain() ? terrain : -1;
+        return terrain;
     }
 
     public boolean isArchived() {

--- a/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
@@ -256,7 +256,7 @@ public final class CacheDetailsCreator {
         final LinearLayout linearLayout = layout.findViewById(R.id.linearlayout);
 
         final ImageView catIcon = new ImageView(context);
-        catIcon.setBackground(createDTRatingMarker(res, cache.getDifficulty(), cache.getTerrain(), 1.47f)); // 1.47 = scaling factor required to make D/T marker the same size as log smileys
+        catIcon.setBackground(createDTRatingMarker(res, cache.supportsDifficultyTerrain(), cache.getDifficulty(), cache.getTerrain(), 1.47f)); // 1.47 = scaling factor required to make D/T marker the same size as log smileys
         linearLayout.addView(catIcon);
     }
 

--- a/main/src/main/res/drawable/marker_rating_d_0.xml
+++ b/main/src/main/res/drawable/marker_rating_d_0.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="13dp"
-    android:height="13dp"
-    android:viewportWidth="13"
-    android:viewportHeight="13">
-    <path
-        android:pathData="m6.125 6.5v6.125l-1.885-0.32356z"
-        android:fillColor="@color/marker_rating_0" />
-</vector>

--- a/main/src/main/res/drawable/marker_rating_t_0.xml
+++ b/main/src/main/res/drawable/marker_rating_t_0.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="13dp"
-    android:height="13dp"
-    android:viewportWidth="13"
-    android:viewportHeight="13">
-    <path
-        android:pathData="m6.875 6.5v6.125l1.885-0.32356z"
-        android:fillColor="@color/marker_rating_0" />
-</vector>


### PR DESCRIPTION
Alternative approach to fixing #16613
Changes Geocache class to not differentiate between connectors supporting D/T ratings but always return the default rating (0) and move the differentation into MapMarkerUtils

fixes #16613