### PR TITLE
vectors instead of emojis for stage numbers

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -26,7 +26,6 @@ import cgeo.geocaching.utils.builders.InsetBuilder;
 import cgeo.geocaching.utils.builders.InsetsBuilder;
 import static cgeo.geocaching.utils.DisplayUtils.SIZE_CACHE_MARKER_DP;
 import static cgeo.geocaching.utils.DisplayUtils.SIZE_LIST_MARKER_DP;
-import static cgeo.geocaching.utils.EmojiUtils.NUMBER_START;
 
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -299,16 +298,11 @@ public final class MapMarkerUtils {
         insetsBuilder.withInset(new InsetBuilder(marker));
 
         if (cache != null && cache.isLinearAlc()) {
-            int stageCounter = 0;
             try {
-                stageCounter = Integer.parseInt(waypoint.getPrefix());
+                insetsBuilder.withInset(new InsetBuilder(getStageNumberMarker(res, Integer.parseInt(waypoint.getPrefix()), getWaypointScalingFactor(applyScaling)), Gravity.CENTER));
             } catch (NumberFormatException ignore) {
-                // ignored, value defaults to 0
+                insetsBuilder.withInset(new InsetBuilder(new ScalableDrawable(ViewUtils.getDrawable(waypointType.markerId, true), getWaypointScalingFactor(applyScaling)), Gravity.CENTER));
             }
-            while (stageCounter > 9) {
-                stageCounter = stageCounter - 10;
-            }
-            insetsBuilder.withInset(new InsetBuilder(getScaledEmojiDrawable(res, NUMBER_START + stageCounter, "mainIconForWaypoint", applyScaling), Gravity.CENTER));
         } else {
             // make drawable mutatable before setting a tint, as otherwise it will change the background for all markers (on Android 7-9)!
             final Drawable waypointTypeIcon = ViewUtils.getDrawable(waypointType.markerId, true);
@@ -751,6 +745,16 @@ public final class MapMarkerUtils {
         // ensure that rating is an integer between 0 and 50 in steps of 5
         final int r = Math.max(0, Math.min(Math.round(rating * 2) * 5, 50));
         return new ScalableDrawable(ResourcesCompat.getDrawable(res, res.getIdentifier("marker_rating_" + ratingLetter + "_" + r, "drawable", packageName), null), scaling);
+    }
+
+    @SuppressWarnings("DiscouragedApi")
+    private static Drawable getStageNumberMarker(final Resources res, final int stageNum, final float scaling) {
+        int counter = stageNum;
+        while (counter > 10) {
+            counter = counter - 10;
+        }
+        final String packageName = CgeoApplication.getInstance().getPackageName();
+        return new ScalableDrawable(ResourcesCompat.getDrawable(res, res.getIdentifier("marker_stagenum_" + counter, "drawable", packageName), null), scaling);
     }
 
     private static BitmapDrawable getScaledEmojiDrawable(final Resources res, final int emoji, final String wantedSize, final boolean applyScaling) {

--- a/main/src/main/res/drawable/marker_stagenum_1.xml
+++ b/main/src/main/res/drawable/marker_stagenum_1.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10,7V9H12V17H14V7H10Z" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_10.xml
+++ b/main/src/main/res/drawable/marker_stagenum_10.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10 7H6V9H8V17H10V7M16 7H14C12.9 7 12 7.9 12 9V15C12 16.11 12.9 17 14 17H16C17.11 17 18 16.11 18 15V9C18 7.9 17.11 7 16 7M16 15H14V9H16V15Z" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_2.xml
+++ b/main/src/main/res/drawable/marker_stagenum_2.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9,7V9H13V11H11A2,2 0 0,0 9,13V17H11L15,17V15H11V13H13A2,2 0 0,0 15,11V9A2,2 0 0,0 13,7H9Z" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_3.xml
+++ b/main/src/main/res/drawable/marker_stagenum_3.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M15,15V13.5A1.5,1.5 0 0,0 13.5,12A1.5,1.5 0 0,0 15,10.5V9C15,7.89 14.1,7 13,7H9V9H13V11H11V13H13V15H9V17H13A2,2 0 0,0 15,15" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_4.xml
+++ b/main/src/main/res/drawable/marker_stagenum_4.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9,7V13H13V17H15V7H13V11H11V7H9Z" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_5.xml
+++ b/main/src/main/res/drawable/marker_stagenum_5.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9,7V13H13V15H9V17H13A2,2 0 0,0 15,15V13A2,2 0 0,0 13,11H11V9H15V7H9Z" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_6.xml
+++ b/main/src/main/res/drawable/marker_stagenum_6.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M11,7A2,2 0 0,0 9,9V15A2,2 0 0,0 11,17H13A2,2 0 0,0 15,15V13A2,2 0 0,0 13,11H11V9H15V7H11M11,13H13V15H11V13Z" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_7.xml
+++ b/main/src/main/res/drawable/marker_stagenum_7.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M11,17L15,9V7H9V9H13L9,17" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_8.xml
+++ b/main/src/main/res/drawable/marker_stagenum_8.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M11,13H13V15H11M11,9H13V11H11M11,17H13A2,2 0 0,0 15,15V13.5A1.5,1.5 0 0,0 13.5,12A1.5,1.5 0 0,0 15,10.5V9C15,7.89 14.1,7 13,7H11A2,2 0 0,0 9,9V10.5A1.5,1.5 0 0,0 10.5,12A1.5,1.5 0 0,0 9,13.5V15C9,16.11 9.9,17 11,17" />
+</vector>

--- a/main/src/main/res/drawable/marker_stagenum_9.xml
+++ b/main/src/main/res/drawable/marker_stagenum_9.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/marker_stagenumber">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M13,17A2,2 0 0,0 15,15V9A2,2 0 0,0 13,7H11A2,2 0 0,0 9,9V11A2,2 0 0,0 11,13H13V15H9V17H13M13,11H11V9H13V11Z" />
+</vector>

--- a/main/src/main/res/values/colors.xml
+++ b/main/src/main/res/values/colors.xml
@@ -69,6 +69,7 @@
     <color name="marker_rating_40">#ffef6c00</color>
     <color name="marker_rating_45">#ffe64a19</color>
     <color name="marker_rating_50">#ffd32f2f</color>
+    <color name="marker_stagenumber">#ff272727</color>
 
     <color name="attribute_category_status">#ffC62828</color>
     <color name="attribute_category_tools">#ff7f0000</color>


### PR DESCRIPTION
As some phones use a font where number emojis are white which leads to invisible numbers replace them with vector drawables that always render properly - and also add a "10"
![image](https://github.com/user-attachments/assets/9d420999-8c97-450e-a35e-10f2c6403570)
