### PR TITLE
Revert updates for AGP & Mapsforge to be Java 11-compatbile for testing purposes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,12 +27,3 @@ systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 
 # AndroidX configuration
 android.useAndroidX=true
-
-# Enable buildConfig build feature
-android.defaults.buildfeatures.buildconfig=true
-
-# Preserve transitive R classes
-android.nonTransitiveRClass=false
-
-# Preserve constant R class values
-android.nonFinalResIds=false

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -372,7 +372,7 @@ dependencies {
 
     // Mapsforge official version
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = '0.24.0'
+    String mapsforgeVersion = '0.23.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     // String mapsforgeSource = 'com.github.mapsforge.mapsforge'
@@ -392,7 +392,7 @@ dependencies {
 
     // Mapsforge VTM implementation (official version)
     String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '0.24.0'
+    String mapsforgeVTMVersion = '0.22.0'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
     // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
@@ -408,7 +408,7 @@ dependencies {
     implementation "$mapsforgeVTMSource:vtm:$mapsforgeVTMVersion"
     implementation "$mapsforgeVTMSource:vtm-themes:$mapsforgeVTMVersion"
     implementation "$mapsforgeVTMSource:vtm-jts:$mapsforgeVTMVersion"
-    implementation "org.locationtech.jts:jts-core:1.20.0"
+    implementation "org.locationtech.jts:jts-core:1.16.1"
 
     runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-armeabi-v7a"
     runtimeOnly "$mapsforgeVTMSource:vtm-android:$mapsforgeVTMVersion:natives-arm64-v8a"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -66,8 +66,6 @@ android {
 
     buildFeatures {
         viewBinding true
-        // Enable aidl, some modules in this project appear to be using AIDL
-        aidl true
     }
 
     buildTypes {
@@ -81,10 +79,7 @@ android {
             testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt', '../tests/proguard-project.txt'
 
             // code coverage
-            if (isContinuousIntegrationServer()) {
-                enableAndroidTestCoverage true
-                enableUnitTestCoverage true
-            }
+            testCoverageEnabled isContinuousIntegrationServer()
 
             // replace in AndroidManifest.xml
             manifestPlaceholders = [


### PR DESCRIPTION
## Description
As discussed in today's dev meeting: 
Temporarily revert AGP & MF updates to become Java 11-compatible again to test next nightly with Java 11.