### PR TITLE
Enable move-to / copy-to for all lists (fix #15733)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -582,8 +582,12 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             if (!isOffline && !isHistory) {
                 menu.findItem(R.id.menu_refresh_stored).setTitle(R.string.caches_store_offline);
             }
-            MenuUtils.setVisibleEnabled(menu, R.id.menu_move_to_list, isHistory || isOffline, !isEmpty);
-            MenuUtils.setVisibleEnabled(menu, R.id.menu_copy_to_list, isHistory || isOffline, !isEmpty);
+
+            MenuUtils.setVisible(menu, R.id.menu_move_to_list, containsStoredCaches());
+            setMenuItemLabel(menu, R.id.menu_move_to_list, R.string.caches_move_selected, R.string.caches_move_all);
+            MenuUtils.setVisible(menu, R.id.menu_copy_to_list, containsStoredCaches());
+            setMenuItemLabel(menu, R.id.menu_copy_to_list, R.string.caches_copy_selected, R.string.caches_copy_all);
+
             MenuUtils.setEnabled(menu, R.id.menu_add_to_route, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_add_to_route, R.string.caches_append_to_route_selected, R.string.caches_append_to_route_all);
             MenuUtils.setVisibleEnabled(menu, R.id.menu_delete_events, isConcrete, !isEmpty && containsPastEvents());
@@ -599,8 +603,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
             if (isOffline || type == CacheListType.HISTORY) { // only offline list
                 setMenuItemLabel(menu, R.id.menu_refresh_stored, R.string.caches_refresh_selected, R.string.caches_refresh_all);
-                setMenuItemLabel(menu, R.id.menu_move_to_list, R.string.caches_move_selected, R.string.caches_move_all);
-                setMenuItemLabel(menu, R.id.menu_copy_to_list, R.string.caches_copy_selected, R.string.caches_copy_all);
             } else { // search and global list (all other than offline and history)
                 setMenuItemLabel(menu, R.id.menu_refresh_stored, R.string.caches_store_selected, R.string.caches_store_offline);
             }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Adds "move multiple caches to another list" function to list opened by "show as list" 

Behavior will be:
Move: remove from existing list-assignment and add only to the new one
Copy: keep existing list assignment and add to the new list


The entries are only shown, if there are stored caches in the list.
If no stored caches are in the list, the entries for storing the caches offline should be used instead.
In case of mixed caches (stored and unstored caches), the unstored caches will be downloaded and stored in the selected list.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #15733

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->