### PR TITLE
Show internal connector as active in filter and add display name (fix #14832)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
@@ -423,5 +423,9 @@ public abstract class AbstractConnector implements IConnector {
         return getName().hashCode();
     }
 
-
+    @Override
+    @NonNull
+    public String getDisplayName() {
+        return getName();
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/IConnector.java
@@ -23,6 +23,10 @@ public interface IConnector {
     @NonNull
     String getName();
 
+    @NonNull
+    String getDisplayName();
+
+
     /**
      * Check if this connector is responsible for the given geocode.
      *

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -87,6 +87,11 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
     @Nullable
     public String getCacheUrl(@NonNull final Geocache cache) {
         return null;

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -22,6 +22,7 @@ import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.EmojiUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 
@@ -78,6 +79,12 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     @NonNull
     public String getName() {
         return "Internal";
+    }
+
+    @Override
+    @NonNull
+    public String getDisplayName() {
+        return LocalizationUtils.getStringWithFallback(R.string.internal_connector_name, "User Defined Caches");
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/core/OriginGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/OriginGeocacheFilter.java
@@ -24,7 +24,7 @@ public class OriginGeocacheFilter extends ValueGroupGeocacheFilter<IConnector, I
     }
 
     public String valueToUserDisplayableValue(final IConnector value) {
-        return value.getName();
+        return value.getDisplayName();
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/FilterViewHolderCreator.java
@@ -147,7 +147,7 @@ public class FilterViewHolderCreator {
                 result = new CheckboxFilterViewHolder<>(
                         ValueGroupFilterAccessor.<IConnector, OriginGeocacheFilter>createForValueGroupFilter()
                                 .setSelectableValues(ConnectorFactory.getConnectors())
-                                .setValueDisplayTextGetter(IConnector::getName)
+                                .setValueDisplayTextGetter(IConnector::getDisplayName)
                                 .setValueDrawableGetter(ct -> ImageParam.id(R.drawable.ic_menu_upload)), 1,
                         new HashSet<>(ConnectorFactory.getActiveConnectors()));
                 break;

--- a/main/src/main/res/values-ca/strings.xml
+++ b/main/src/main/res/values-ca/strings.xml
@@ -1608,6 +1608,7 @@
     <string name="goto_targets_list">Catxé definit per l\'usuari</string>
     <string name="clear_goto_history_title">Esborreu l\'historial de destinacions</string>
     <string name="clear_goto_history">Això suprimirà tots el historial de punts de ruta, excepte els cinc més recents</string>
+    <string name="internal_connector_name">Catxé definit per l\'usuari</string>
     <!-- html styles -->
     <string name="html_style_default">Per defecte</string>
     <string name="html_style_default_no_contrast_fix">Per defecte sense correcció de contrast</string>

--- a/main/src/main/res/values-cs/strings.xml
+++ b/main/src/main/res/values-cs/strings.xml
@@ -1635,6 +1635,7 @@
     <string name="goto_targets_list">Uživatelem definované kešky</string>
     <string name="clear_goto_history_title">Vymazat historii Jít na</string>
     <string name="clear_goto_history">Tímto se odstraní všechny historické trasové body kromě pěti posledních</string>
+    <string name="internal_connector_name">Uživatelem definované kešky</string>
     <!-- html styles -->
     <string name="html_style_default">Výchozí</string>
     <string name="html_style_default_no_contrast_fix">Výchozí bez opravy kontrastu</string>

--- a/main/src/main/res/values-da/strings.xml
+++ b/main/src/main/res/values-da/strings.xml
@@ -1016,6 +1016,7 @@
     <string name="init_longtap_map">Tryk-og-hold på kortet</string>
     <string name="goto_targets_list">Brugerdefinerede caches</string>
     <string name="clear_goto_history">Dette vil slette alle historiske rutepunkter undtagen de fem seneste</string>
+    <string name="internal_connector_name">Brugerdefinerede caches</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">grader</string>

--- a/main/src/main/res/values-de/strings.xml
+++ b/main/src/main/res/values-de/strings.xml
@@ -1603,6 +1603,7 @@
     <string name="goto_targets_list">Benutzerdefinierte Caches</string>
     <string name="clear_goto_history_title">\"Gehe Zu\"-Verlauf löschen</string>
     <string name="clear_goto_history">Lösche alle historischen Wegpunkte außer den fünf neuesten</string>
+    <string name="internal_connector_name">Benutzerdefinierte Caches</string>
     <!-- html styles -->
     <string name="html_style_default">Standard</string>
     <string name="html_style_default_no_contrast_fix">Standard ohne Kontrastkorrektur</string>

--- a/main/src/main/res/values-el/strings.xml
+++ b/main/src/main/res/values-el/strings.xml
@@ -1296,6 +1296,7 @@
     <string name="goto_targets_list">Κρύπτες ορισμένες από τον χρήστη</string>
     <string name="clear_goto_history_title">Εκκαθάριση ιστορικού σημείων \"Πήγαινε σε\"</string>
     <string name="clear_goto_history">Αυτή η ενέργεια θα διαγράψει όλο το ιστορικό των ενδιάμεσων σημείων εκτός των πέντε πιο πρόσφατων</string>
+    <string name="internal_connector_name">Κρύπτες ορισμένες από τον χρήστη</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">Μοίρες</string>

--- a/main/src/main/res/values-es/strings.xml
+++ b/main/src/main/res/values-es/strings.xml
@@ -1227,6 +1227,7 @@
     <string name="goto_targets_list">Cachés definidos por el usuario</string>
     <string name="clear_goto_history_title">Borrar historial de destinos</string>
     <string name="clear_goto_history">Esto eliminará todos los waypoints históricos excepto los cinco más recientes</string>
+    <string name="internal_connector_name">Cachés definidos por el usuario</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">grados</string>

--- a/main/src/main/res/values-fi/strings.xml
+++ b/main/src/main/res/values-fi/strings.xml
@@ -1485,6 +1485,7 @@
     <string name="goto_targets_list">Sisäiset kätköt</string>
     <string name="clear_goto_history_title">Poista Siirry-historia</string>
     <string name="clear_goto_history">Tämä poistaa historiasta kaikki paitsi 5 viimeisintä reittipistettä</string>
+    <string name="internal_connector_name">Sisäiset kätköt</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">astetta</string>

--- a/main/src/main/res/values-fr/strings.xml
+++ b/main/src/main/res/values-fr/strings.xml
@@ -1535,6 +1535,7 @@
     <string name="goto_targets_list">Caches personnalisées</string>
     <string name="clear_goto_history_title">Effacer l\'historique des destinations</string>
     <string name="clear_goto_history">Vous allez supprimer l\'historique des points de passage hormis les cinq plus récents</string>
+    <string name="internal_connector_name">Caches personnalisées</string>
     <!-- html styles -->
     <string name="html_style_default">Par défaut</string>
     <string name="html_style_monochrome">Monochrome</string>

--- a/main/src/main/res/values-it/strings.xml
+++ b/main/src/main/res/values-it/strings.xml
@@ -1552,6 +1552,7 @@
     <string name="goto_targets_list">Cache definiti dall\'utente</string>
     <string name="clear_goto_history_title">Cancella cronologia dei percorsi</string>
     <string name="clear_goto_history">Questo eliminerà tutti i waypoint storici eccetto i cinque più recenti</string>
+    <string name="internal_connector_name">Cache definiti dall\'utente</string>
     <!-- html styles -->
     <string name="html_style_default">Predefinito</string>
     <string name="html_style_monochrome">Monocromatico</string>

--- a/main/src/main/res/values-ja/strings.xml
+++ b/main/src/main/res/values-ja/strings.xml
@@ -1207,6 +1207,7 @@
     <string name="goto_targets_list">ユーザー定義キャッシュ</string>
     <string name="clear_goto_history_title">移動の履歴を削除</string>
     <string name="clear_goto_history">最近5つを除いて過去のウェイポイントがすべて削除されます</string>
+    <string name="internal_connector_name">ユーザー定義キャッシュ</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">度</string>

--- a/main/src/main/res/values-ko/strings.xml
+++ b/main/src/main/res/values-ko/strings.xml
@@ -1508,6 +1508,7 @@
     <string name="goto_targets_list">사용자 정의 캐시</string>
     <string name="clear_goto_history_title">\"이동으로\" 역사 지우기</string>
     <string name="clear_goto_history">가장 최근 5 개를 제외한 모든 역사적인 지점이 삭제하겠습니다</string>
+    <string name="internal_connector_name">사용자 정의 캐시</string>
     <!-- html styles -->
     <string name="html_style_default">기본</string>
     <string name="html_style_monochrome">흑백크롬</string>

--- a/main/src/main/res/values-lt/strings.xml
+++ b/main/src/main/res/values-lt/strings.xml
@@ -1474,6 +1474,7 @@
     <string name="goto_targets_list">Vartotojo nustatytos slėptuvės</string>
     <string name="clear_goto_history_title">Išvalyti \"Eiti į\" istoriją</string>
     <string name="clear_goto_history">Tai iš istorijos ištrins visus maršruto taškus, išskyrus penkis naujausius</string>
+    <string name="internal_connector_name">Vartotojo nustatytos slėptuvės</string>
     <!-- html styles -->
     <string name="html_style_default">Numatytas</string>
     <string name="html_style_monochrome">Vienspalvė</string>

--- a/main/src/main/res/values-lv/strings.xml
+++ b/main/src/main/res/values-lv/strings.xml
@@ -761,6 +761,7 @@
     <string name="goto_targets_list">Lietotāja definēti slēpņi</string>
     <string name="clear_goto_history_title">Dzēst \"iet uz\" (goto) vēsturi</string>
     <string name="clear_goto_history">Šis izdzēsīs visus vēsturiskos starpposmus, izņemot pēdējos piecus</string>
+    <string name="internal_connector_name">Lietotāja definēti slēpņi</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">grādi</string>

--- a/main/src/main/res/values-nb/strings.xml
+++ b/main/src/main/res/values-nb/strings.xml
@@ -1195,6 +1195,7 @@
     <string name="goto_targets_list">Interne cacher</string>
     <string name="clear_goto_history_title">Slett goto historikk</string>
     <string name="clear_goto_history">Dette vil slette alle historiske veipunkter unntatt de fem siste</string>
+    <string name="internal_connector_name">Interne cacher</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">grader</string>

--- a/main/src/main/res/values-nl/strings.xml
+++ b/main/src/main/res/values-nl/strings.xml
@@ -1607,6 +1607,7 @@
     <string name="goto_targets_list">Gebruiker gedefinieerde caches</string>
     <string name="clear_goto_history_title">Spoor geschiedenis wissen</string>
     <string name="clear_goto_history">Dit zal alle historische waypoints verwijderen behalve de vijf meest recente</string>
+    <string name="internal_connector_name">Gebruiker gedefinieerde caches</string>
     <!-- html styles -->
     <string name="html_style_default">Standaard</string>
     <string name="html_style_default_no_contrast_fix">Standaard zonder contrastcorrectie</string>

--- a/main/src/main/res/values-pl/strings.xml
+++ b/main/src/main/res/values-pl/strings.xml
@@ -1635,6 +1635,7 @@
     <string name="goto_targets_list">Skrytki zdefiniowane przez użytkownika</string>
     <string name="clear_goto_history_title">Wyczyść historię „Idź do”</string>
     <string name="clear_goto_history">Spowoduje to usunięcie wszystkich historycznych punktów nawigacji z wyjątkiem pięciu najnowszych</string>
+    <string name="internal_connector_name">Skrytki zdefiniowane przez użytkownika</string>
     <!-- html styles -->
     <string name="html_style_default">Domyślny</string>
     <string name="html_style_default_no_contrast_fix">Domyślne bez korekty kontrastu</string>

--- a/main/src/main/res/values-pt/strings.xml
+++ b/main/src/main/res/values-pt/strings.xml
@@ -1604,6 +1604,7 @@
     <string name="goto_targets_list">Caches internas</string>
     <string name="clear_goto_history_title">Limpar o histórico de \'Ir para\'</string>
     <string name="clear_goto_history">Esta acção irá eliminar os pontos adicionais antigos exceptuando os cinco mais recentes</string>
+    <string name="internal_connector_name">Caches internas</string>
     <!-- html styles -->
     <string name="html_style_default">Predefinição</string>
     <string name="html_style_default_no_contrast_fix">Padrão sem correcção de contraste</string>

--- a/main/src/main/res/values-ru/strings.xml
+++ b/main/src/main/res/values-ru/strings.xml
@@ -905,7 +905,7 @@
     <string name="init_brouterProfileCar">Профиль «Автомобиль»</string>
     <string name="init_brouterProfileUserNumber">Пользовательский профиль %d</string>
     <string name="init_removeFromRouteOnLog">Удалить из маршрута после записи в блокноте</string>
-    <string name="init_summary_removeFromRouteOnLog">При отправке или сохранении записи удалить 
+    <string name="init_summary_removeFromRouteOnLog">При отправке или сохранении записи удалить
 тайник из текущего маршрута.</string>
     <string name="brouter_recalculating">Пересчет маршрута в фоновом режиме…</string>
     <string name="brouter_missing_data">Откройте BRouter для загрузки недостающих данных маршрутизации (%s)</string>
@@ -1560,6 +1560,7 @@
     <string name="goto_targets_list">Внутренние тайники</string>
     <string name="clear_goto_history_title">Очистить историю \"перейти к\"</string>
     <string name="clear_goto_history">Это удалит все путевые точки, кроме пяти последних</string>
+    <string name="internal_connector_name">Внутренние тайники</string>
     <!-- html styles -->
     <string name="html_style_default">По умолчанию</string>
     <string name="html_style_monochrome">Монохромный</string>

--- a/main/src/main/res/values-sk/strings.xml
+++ b/main/src/main/res/values-sk/strings.xml
@@ -1395,6 +1395,7 @@
     <string name="goto_targets_list">Interné kešky</string>
     <string name="clear_goto_history_title">Vymazať históriu Choď k</string>
     <string name="clear_goto_history">Týmto sa odstránia všetky historické body trasy okrem piatich posledných</string>
+    <string name="internal_connector_name">Interné kešky</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">stupne</string>

--- a/main/src/main/res/values-sv/strings.xml
+++ b/main/src/main/res/values-sv/strings.xml
@@ -1604,6 +1604,7 @@
     <string name="goto_targets_list">Interna cacher</string>
     <string name="clear_goto_history_title">Rensa \"gå till\" historik</string>
     <string name="clear_goto_history">Detta kommer att ta bort alla historiska vägpunkter utom de fem senaste</string>
+    <string name="internal_connector_name">Interna cacher</string>
     <!-- html styles -->
     <string name="html_style_default">Standard</string>
     <string name="html_style_default_no_contrast_fix">Standard utan kontrast-fix</string>

--- a/main/src/main/res/values-tr/strings.xml
+++ b/main/src/main/res/values-tr/strings.xml
@@ -1295,6 +1295,7 @@
     <string name="goto_targets_list">Kullanıcı tarafından belirlenen Cache\'ler</string>
     <string name="clear_goto_history_title">Konuma git geçmişini temizle</string>
     <string name="clear_goto_history">Bu işlem en yeni 5 yol noktası hariç eski tüm yol noktalarını silecektir.</string>
+    <string name="internal_connector_name">Kullanıcı tarafından belirlenen Cache\'ler</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">derece</string>

--- a/main/src/main/res/values-uk/strings.xml
+++ b/main/src/main/res/values-uk/strings.xml
@@ -796,6 +796,7 @@
     <string name="goto_targets_list">Визначений користувачем кеш</string>
     <string name="clear_goto_history_title">Очистити історію Goto</string>
     <string name="clear_goto_history">Це видалить всі історичні шляхові точки, окрім п\'яти останніх</string>
+    <string name="internal_connector_name">Визначений користувачем кеш</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">градуси</string>

--- a/main/src/main/res/values-zh-rTW/strings.xml
+++ b/main/src/main/res/values-zh-rTW/strings.xml
@@ -1017,6 +1017,7 @@
     <string name="goto_targets_list">玩家自訂cache</string>
     <string name="clear_goto_history_title">清除記錄</string>
     <string name="clear_goto_history">除了五個最近的航點外，其他航點將被刪除。</string>
+    <string name="internal_connector_name">玩家自訂cache</string>
     <!-- html styles -->
     <!-- coordinate calculator hints -->
     <string name="cc_hint_degrees">角度</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1818,6 +1818,7 @@
     <string name="goto_targets_list">User-defined caches</string>
     <string name="clear_goto_history_title">Clear goto history</string>
     <string name="clear_goto_history">This will delete all historical waypoints except the five most recent</string>
+    <string name="internal_connector_name">User-defined caches</string>
 
     <!-- html styles -->
     <string name="html_style_default">Default</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
* Show internal connector per default for selectable connectors in filter. `isActive()` method returns true as @eddiemuc suggested.
* Add displayName to IConnector to make connector-name translatable as @fm-sys suggested

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #14832

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
I use already existing translation for "User defined caches" (goto_targets_list), but I did not reuse the key, I introduced a new key to be independent.