### PR TITLE
Add API 31+ filtering for local file access

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -312,6 +312,19 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\.map" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.map" />
             </intent-filter>
+            <intent-filter> <!-- Android API 31+ version with better name filtering -->
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="content" />
+                <data android:pathSuffix=".map" />
+                <data android:pathSuffix=".gwc" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".CacheListActivity"
@@ -336,6 +349,18 @@
                 <data android:pathPattern=".*\\..*\\..*\\.gpx" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
+            </intent-filter>
+            <intent-filter> <!-- Android API 31+ version with better name filtering -->
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="content" />
+                <data android:pathSuffix=".gpx" />
             </intent-filter>
 
             <!-- intent filter for all gpx links, independent of mime types -->

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -303,6 +303,7 @@
                 <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
 
                 <data android:mimeType="*/*" />
+                <data android:scheme="file" />
                 <data android:host="*" />
                 <data android:pathPattern=".*\\.map" />
                 <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -291,10 +291,9 @@
         <activity android:name=".settings.ViewSettingsActivity" />
         <activity
             android:name=".HandleLocalFilesActivity"
-            android:exported="true"
-            android:label="@string/localfile_intenttitle">
+            android:exported="true">
             <!-- intent filter for local map files -->
-            <intent-filter>
+            <intent-filter android:label="c:geo local map handler">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -312,7 +311,9 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\.map" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.map" />
             </intent-filter>
-            <intent-filter> <!-- Android API 31+ version with better name filtering -->
+
+            <!-- Android API 31+ versions with better name filtering -->
+            <intent-filter android:label="c:geo local map handler">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -323,12 +324,24 @@
                 <data android:mimeType="*/*" />
                 <data android:scheme="content" />
                 <data android:pathSuffix=".map" />
+            </intent-filter>
+            <intent-filter android:label="c:geo local Wherigo cartridge handler">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="content" />
                 <data android:pathSuffix=".gwc" />
             </intent-filter>
         </activity>
         <activity
             android:name=".CacheListActivity"
-            android:exported="true">
+            android:exported="true"
+            android:label="c:geo GPX import">
             <!-- don't add configChanges="orientation|screenSize" as we use different base layouts depending on the device orientation -->
 
             <!-- intent filter for local gpx files -->

--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -293,7 +293,7 @@
             android:name=".HandleLocalFilesActivity"
             android:exported="true"
             android:label="@string/localfile_intenttitle">
-            <!-- intent filter for local map, gpx, ggz and zip files -->
+            <!-- intent filter for local map files -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -304,44 +304,38 @@
 
                 <data android:mimeType="*/*" />
                 <data android:host="*" />
-                <!-- <data android:scheme="xxx" /> neither "file" nor "content" means: both -->
-
-                <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
                 <data android:pathPattern=".*\\.map" />
+                <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
                 <data android:pathPattern=".*\\..*\\.map" />
                 <data android:pathPattern=".*\\..*\\..*\\.map" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\.map" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.map" />
-
-                <data android:pathPattern=".*\\.gpx" />
-                <data android:pathPattern=".*\\..*\\.gpx" />
-                <data android:pathPattern=".*\\..*\\..*\\.gpx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
-
-                <data android:pathPattern=".*\\.ggz" />
-                <data android:pathPattern=".*\\..*\\.ggz" />
-                <data android:pathPattern=".*\\..*\\..*\\.ggz" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.ggz" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ggz" />
-
-                <data android:pathPattern=".*\\.zip" />
-                <data android:pathPattern=".*\\..*\\.zip" />
-                <data android:pathPattern=".*\\..*\\..*\\.zip" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.zip" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.zip" />
-
-                <data android:pathPattern=".*\\.gwc" />
-                <data android:pathPattern=".*\\..*\\.gwc" />
-                <data android:pathPattern=".*\\..*\\..*\\.gwc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\.gwc" />
-                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gwc" />
             </intent-filter>
         </activity>
         <activity
             android:name=".CacheListActivity"
             android:exported="true">
             <!-- don't add configChanges="orientation|screenSize" as we use different base layouts depending on the device orientation -->
+
+            <!-- intent filter for local gpx files -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="file" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\\.gpx" />
+                <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
+                <data android:pathPattern=".*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
+            </intent-filter>
 
             <!-- intent filter for all gpx links, independent of mime types -->
             <intent-filter>
@@ -358,6 +352,26 @@
                 <data android:pathPattern=".*\\..*\\..*\\.gpx" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\.gpx" />
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.gpx" />
+            </intent-filter>
+
+            <!-- intent filter for local ggz files -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="*/*" />
+                <data android:scheme="file" />
+                <data android:host="*" />
+                <data android:pathPattern=".*\\.ggz" />
+                <!-- path pattern does not match dots correctly: http://stackoverflow.com/q/3400072/44089 -->
+                <data android:pathPattern=".*\\..*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\..*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.ggz" />
+                <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ggz" />
             </intent-filter>
 
             <!-- intent filter for GGZ links, independent of mime types -->
@@ -377,6 +391,28 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\.ggz" />
             </intent-filter>
 
+            <!-- intent filter for local ZIP / GPX files -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+
+                <data android:mimeType="text/xml" />
+                <data android:mimeType="application/xml" />
+                <data android:mimeType="application/zip" />
+                <data android:mimeType="application/x-compressed" />
+                <data android:mimeType="application/x-zip-compressed" />
+                <data android:mimeType="application/x-zip" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/gpx" />
+                <data android:mimeType="application/gpx+xml" />
+                <data android:pathPattern=".*\\.gpx" />
+                <data android:pathPattern=".*\\.zip" />
+                <data android:pathPattern=".*\\.ggz" />
+            </intent-filter>
         </activity>
         <activity
             android:exported="true"


### PR DESCRIPTION
## Description
- Reverts the changes in `AndroidManifest.xml` that came with #16593, #16600 and #16611 to get rid of the side-effects mentioned in #16777
- adds API 31+ compatible replacements for opening local gpx, gwc and map files

@Lineflyer @ztNFny 
Can you cross-check, if this version works for you and also avoids the problems you have described in #16608?