### PR TITLE
Prevent downloading log images if flag not set (fix #16778)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1631,7 +1631,7 @@ public final class GCParser {
     }
 
     private static void addImagesFromGallery(@NonNull final Geocache cache, final DisposableHandler handler) {
-        if (StringUtils.isBlank(cache.getGuid())) {
+        if (StringUtils.isBlank(cache.getGuid()) || !Settings.isStoreLogImages() /* see #16778 */) {
             return;
         }
         DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_spoilers);


### PR DESCRIPTION
## Description
Prevent immediate downloading of log images on cache update if flag in settings is not set (fix #16778)

(The logs itself will still be analyzed and links to log images be stored, so if you open the image gallery for such a cache, log images start getting downloaded, even if the flag is unset. TBD if this is an intended behavior.)
