### PR TITLE
Collapse long log entries per default (fix #16789)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
@@ -172,6 +172,11 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
 
             }
 
+            // expand/collapse
+            if (holder.binding.log.isCollapsible()) {
+                ctxMenu.addItem(holder.binding.log.isCollapsed() ? R.string.menu_expand_log : R.string.menu_collapse_log, holder.binding.log.isCollapsed() ? R.drawable.expand_less : R.drawable.expand_more, it -> holder.binding.log.setCollapse(!holder.binding.log.isCollapsed()));
+            }
+
             //Copy to clipboard
             ctxMenu.addItem(LocalizationUtils.getString(R.string.copy_to_clipboard), R.drawable.ic_menu_copy, i -> {
                 ClipboardUtils.copyToClipboard(holder.binding.log.getText().toString());

--- a/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
@@ -7,6 +7,7 @@ import android.util.AttributeSet;
 
 public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextView {
     private static final int MAX_LINES = 5;
+    private boolean isCollapsible = false;
 
     public ExpandableTextView(final Context context) {
         this(context, null);
@@ -18,12 +19,11 @@ public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextV
 
     public ExpandableTextView(final Context context, final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
-        setMaxLines(MAX_LINES);
+        setCollapse(true);
         this.setOnLongClickListener(v -> {
-            final boolean isCollapsed = (getMaxLines() != Integer.MAX_VALUE);
+            final boolean isCollapsed = isCollapsed();
             if (isCollapsed) {
-                setMaxLines(Integer.MAX_VALUE);
-                setImage(false);
+                setCollapse(false);
             }
             return isCollapsed;
         });
@@ -31,10 +31,22 @@ public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextV
 
     @Override
     protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
-        post(() -> setImage(getLineCount() > MAX_LINES));
+        post(() -> {
+            isCollapsible = getLineCount() > MAX_LINES;
+            setCollapse(isCollapsible);
+        });
     }
 
-    private void setImage(final boolean show) {
-        setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, show ? R.drawable.ic_menu_more : 0);
+    public boolean isCollapsible() {
+        return isCollapsible;
+    }
+
+    public boolean isCollapsed() {
+        return (getMaxLines() != Integer.MAX_VALUE);
+    }
+
+    public void setCollapse(final boolean collapse) {
+        setMaxLines(collapse ? MAX_LINES : Integer.MAX_VALUE);
+        setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, collapse ? R.drawable.ic_menu_more : 0);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
@@ -4,10 +4,14 @@ import cgeo.geocaching.R;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.View;
+
+import androidx.annotation.Nullable;
 
 public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextView {
-    private static final int MAX_LINES = 5;
+    private static final int MAX_LINES = 15;
     private boolean isCollapsible = false;
+    private View.OnClickListener stackedOnClickListener = null;
 
     public ExpandableTextView(final Context context) {
         this(context, null);
@@ -20,12 +24,12 @@ public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextV
     public ExpandableTextView(final Context context, final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
         setCollapse(true);
-        this.setOnLongClickListener(v -> {
-            final boolean isCollapsed = isCollapsed();
-            if (isCollapsed) {
+        super.setOnClickListener(v -> {
+            if (isCollapsed()) {
                 setCollapse(false);
+            } else if (stackedOnClickListener != null) {
+                stackedOnClickListener.onClick(this);
             }
-            return isCollapsed;
         });
     }
 
@@ -48,5 +52,10 @@ public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextV
     public void setCollapse(final boolean collapse) {
         setMaxLines(collapse ? MAX_LINES : Integer.MAX_VALUE);
         setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, collapse ? R.drawable.ic_menu_more : 0);
+    }
+
+    @Override
+    public void setOnClickListener(@Nullable final OnClickListener l) {
+        stackedOnClickListener = l;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
@@ -1,0 +1,40 @@
+package cgeo.geocaching.ui;
+
+import cgeo.geocaching.R;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextView {
+    private static final int MAX_LINES = 5;
+
+    public ExpandableTextView(final Context context) {
+        this(context, null);
+    }
+
+    public ExpandableTextView(final Context context, final AttributeSet attrs) {
+        this(context, attrs, android.R.attr.textViewStyle);
+    }
+
+    public ExpandableTextView(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        setMaxLines(MAX_LINES);
+        this.setOnLongClickListener(v -> {
+            final boolean isCollapsed = (getMaxLines() != Integer.MAX_VALUE);
+            if (isCollapsed) {
+                setMaxLines(Integer.MAX_VALUE);
+                setImage(false);
+            }
+            return isCollapsed;
+        });
+    }
+
+    @Override
+    protected void onTextChanged(final CharSequence text, final int start, final int lengthBefore, final int lengthAfter) {
+        post(() -> setImage(getLineCount() > MAX_LINES));
+    }
+
+    private void setImage(final boolean show) {
+        setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, show ? R.drawable.ic_menu_more : 0);
+    }
+}

--- a/main/src/main/res/layout/logs_item.xml
+++ b/main/src/main/res/layout/logs_item.xml
@@ -64,7 +64,7 @@
                 android:layout_gravity="left"
                 android:textSize="@dimen/textSize_detailsPrimary" />
 
-            <TextView
+            <cgeo.geocaching.ui.ExpandableTextView
                 android:id="@+id/log"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1692,6 +1692,8 @@
     <string name="cache_menu_ignore">Ignore cache</string>
     <string name="cache_log_menu_decrypt">Decrypt/Encrypt</string>
     <string name="cache_log_menu_edit">Edit Log</string>
+    <string name="menu_expand_log">Expand log</string>
+    <string name="menu_collapse_log">Collapse log</string>
     <string name="cache_log_menu_delete">Delete Log</string>
     <string name="cache_log_menu_popup_title">Log of %s</string>
     <string name="cache_log_delete_reason_default">Log was deleted using c:geo</string>


### PR DESCRIPTION
## Description
Per default show log entries with a maximum of 5 lines. If a log entry is longer, a vertical ellipsis symbol is being displayed. Long-tapping on the log entry will expand the view.

|collapsed state|expanded state|
|---|---|
|![image](https://github.com/user-attachments/assets/3a28b4f8-dec5-430e-917c-24ccb7c19445)|![image](https://github.com/user-attachments/assets/a9238a0d-5fe9-49ab-83b5-ca86c68b69c8)|

Edit: If a log item is collapsible, a menu item will be added to the log entry's context menu to either collapse or expand the log item:

|non collapsible|collapsed|expanded|
|---|---|---|
|![image](https://github.com/user-attachments/assets/8dc747e3-f078-45ed-af62-5a1338de63e3)|![image](https://github.com/user-attachments/assets/d5593165-ca63-473b-be14-b3a8a5e1761f)|![image](https://github.com/user-attachments/assets/e5deefe6-a88a-4c39-9b64-5f00951c202c)|


