### PR TITLE
Restart UnifiedMap Mapsforge on language switch (fix #16806)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -427,6 +427,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
     @Override
     public void setPreferredLanguage(final String language) {
         currentTileProvider.setPreferredLanguage(language);
+        requireActivity().recreate();
     }
 
 


### PR DESCRIPTION
## Description
Restarts the map activity on switching language in UnifiedMap Mapsforge variant to reload data in correct language + reset caches.