### PR TITLE
Allow running Unit Tests on PR from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ concurrency:
 
 on:
   push:
-  pull_request:
-    types: [labeled]
+  pull_request_target:
+    types: [labeled, opened, synchronize]
   workflow_dispatch:
     inputs:
       JDK_VERSION:
@@ -24,9 +24,34 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    steps:
+      - name: Check secrets
+        run: |
+          if [ -z "${{ secrets.KEY_STORE }}" ]; then
+            echo "::error::No secret defined or no access to secrets"
+            exit 1
+          fi
+          echo "::notice::Secrets seems available"
+
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "::error::${{ github.triggering_actor }} does not have permissions on this repo.\nCurrent permission level is ${{ steps.checkAccess.outputs.user-permission }}\nJob originally triggered by ${{ github.actor }}"
+          exit 1
 
   checkstyle:
     runs-on: ubuntu-latest
+    needs: check-secrets
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
 
@@ -90,6 +115,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    needs: check-secrets
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Checkout the latest code
@@ -157,6 +183,7 @@ jobs:
     # > are 2-3 times faster than the macOS ones which are also a lot more expensive.
     # https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners
     runs-on: ubuntu-latest
+    needs: check-secrets
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     strategy:
       fail-fast: false

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -19,9 +19,21 @@ env:
   API_LEVEL: ${{ inputs.API_LEVEL || '26' }}
 
 jobs:
-  watchdog-tests:
+  check-secrets:
     runs-on: ubuntu-latest
     if: github.repository == 'cgeo/cgeo'
+    steps:
+      - name: Check secrets
+        run: |
+          if [ -z "${{ secrets.KEY_STORE }}" ]; then
+            echo "::error::No secret defined or no access to secrets"
+            exit 1
+          fi
+          echo "::notice::Secrets seems available"
+
+  watchdog-tests:
+    runs-on: ubuntu-latest
+    needs: check-secrets
     strategy:
       matrix:
         branch: [ "master", "release" ]


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
- check access to secrets explicitly
- use trigger `pull_request_target` and add safety guards on user permission over cgeo repo.

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#16804

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->