### PR TITLE
ci: Don't cancel workflows for master/release branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,6 @@ jobs:
           # concurrency:
           #   group: ci-tests-${{ github.event.pull_request.head.label || github.ref }}
           #   cancel-in-progress: true
-          #
 
       - name: Debug
         uses: raven-actions/debug@v1
@@ -123,7 +122,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     needs: check-secrets
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v4
@@ -191,7 +189,6 @@ jobs:
     # https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners
     runs-on: ubuntu-latest
     needs: check-secrets
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'safe to test')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Unit tests
 
 concurrency:
   group: ci-tests-${{ github.event.pull_request.head.label || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !((github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release') && github.event_name == 'push') }}
 
 on:
   push:
@@ -31,7 +31,7 @@ jobs:
         run: |
           # concurrency:
           #   group: ci-tests-${{ github.event.pull_request.head.label || github.ref }}
-          #   cancel-in-progress: true
+          #   cancel-in-progress: ${{ !((github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release') && github.event_name == 'push') }}
 
       - name: Debug
         uses: raven-actions/debug@v1


### PR DESCRIPTION
Should not cancel jobs for branches master and release