### PR TITLE
Improve cache list menu (rel #16195)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -815,7 +815,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             clearOfflineLogs(adapter.getCheckedOrAllCaches());
             invalidateOptionsMenuCompatible();
         } else if (menuItem == R.id.menu_show_attributes) {
-            adapter.showAttributes();
+            adapter.showAttributes(adapter.getCheckedOrAllCaches());
         } else if (menuItem == R.id.menu_make_list_unique) {
             new MakeListUniqueCommand(this, listId) {
 

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -623,6 +623,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setMenuItemLabel(menu, R.id.menu_show_attributes, R.string.caches_show_attributes_selected, R.string.caches_show_attributes_all, checkedCount);
             MenuUtils.setEnabled(menu, R.id.menu_set_cache_icon, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_set_cache_icon, R.string.caches_set_cache_icon_selected, R.string.caches_set_cache_icon_all, checkedCount);
+            MenuUtils.setVisibleEnabled(menu, R.id.menu_remove_from_other_lists, isOffline && listId != PseudoList.ALL_LIST.id, !isEmpty);
+            setMenuItemLabel(menu, R.id.menu_remove_from_other_lists, R.string.caches_remove_from_other_lists_selected, R.string.caches_remove_from_other_lists_all, checkedCount);
 
             // Manage Lists submenu
             MenuUtils.setVisibleEnabled(menu, R.id.menu_lists, isOffline, !isSelectMode);
@@ -816,8 +818,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             invalidateOptionsMenuCompatible();
         } else if (menuItem == R.id.menu_show_attributes) {
             adapter.showAttributes(adapter.getCheckedOrAllCaches());
-        } else if (menuItem == R.id.menu_make_list_unique) {
-            new MakeListUniqueCommand(this, listId) {
+        } else if (menuItem == R.id.menu_make_list_unique || menuItem == R.id.menu_remove_from_other_lists) {
+            new MakeListUniqueCommand(this, listId, Geocache.getGeocodes(menuItem == R.id.menu_remove_from_other_lists ? adapter.getCheckedOrAllCaches() : new ArrayList<>())) {
 
                 @Override
                 protected void onFinished() {

--- a/main/src/main/java/cgeo/geocaching/command/MakeListUniqueCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/MakeListUniqueCommand.java
@@ -1,7 +1,6 @@
 package cgeo.geocaching.command;
 
 import cgeo.geocaching.R;
-import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.models.Geocache;
@@ -24,18 +23,21 @@ import java.util.Set;
 public abstract class MakeListUniqueCommand extends AbstractCommand {
 
     private final int listId;
+    private final Set<String> cacheList;
     @NonNull
     private final Map<String, Set<Integer>> oldLists = new HashMap<>();
 
-    public MakeListUniqueCommand(@NonNull final Activity context, final int listId) {
+    public MakeListUniqueCommand(@NonNull final Activity context, final int listId, final Set<String> cacheList) {
         super(context);
         this.listId = listId;
+        this.cacheList = cacheList;
     }
 
     @Override
     protected void doCommand() {
-        final SearchResult search = DataStore.getBatchOfStoredCaches(null, listId);
-        final Set<Geocache> caches = DataStore.loadCaches(search.getGeocodes(), LoadFlags.LOAD_CACHE_OR_DB);
+        final Set<String> geocodesList = cacheList.isEmpty() ? DataStore.getBatchOfStoredCaches(null, listId).getGeocodes() : cacheList;
+
+        final Set<Geocache> caches = DataStore.loadCaches(geocodesList, LoadFlags.LOAD_CACHE_OR_DB);
 
         for (final Geocache geocache : caches) {
             final HashSet<Integer> backupOfLists = new HashSet<>(geocache.getLists());

--- a/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
@@ -229,13 +229,17 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
     }
 
     public int getCheckedCount() {
-        int checked = 0;
+        if (!isSelectMode()) {
+            return 0;
+        }
+
+        int checkedCount = 0;
         for (final Geocache cache : list) {
             if (cache.isStatusChecked()) {
-                checked++;
+                checkedCount++;
             }
         }
-        return checked;
+        return checkedCount;
     }
 
     public int getOriginalListCount() {
@@ -442,7 +446,7 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
 
         holder.binding.checkbox.setVisibility(selectMode ? View.VISIBLE : View.GONE);
         holder.binding.checkbox.setChecked(cache.isStatusChecked());
-        holder.binding.checkbox.setOnClickListener(new SelectionCheckBoxListener(cache));
+        holder.binding.checkbox.setOnClickListener(new SelectionCheckBoxListener(cache, this));
 
         distances.add(holder.binding.distance);
         holder.binding.distance.setCacheData(cache.getCoords(), cache.getDistance());
@@ -524,15 +528,21 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
     private static class SelectionCheckBoxListener implements View.OnClickListener {
 
         private final Geocache cache;
+        @NonNull private final WeakReference<CacheListAdapter> adapterRef;
 
-        SelectionCheckBoxListener(final Geocache cache) {
+        SelectionCheckBoxListener(final Geocache cache, @NonNull final CacheListAdapter adapter) {
             this.cache = cache;
+            adapterRef = new WeakReference<>(adapter);
         }
 
         @Override
         public void onClick(final View view) {
             final boolean checkNow = ((CheckBox) view).isChecked();
             cache.setStatusChecked(checkNow);
+            final CacheListAdapter adapter = adapterRef.get();
+            if (adapter == null) {
+                return;
+            }
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheListAdapter.java
@@ -285,15 +285,14 @@ public class CacheListAdapter extends ArrayAdapter<Geocache> implements SectionI
         notifyDataSetChanged();
     }
 
-    public void showAttributes() {
+    public void showAttributes(final Collection<Geocache> caches) {
         final Context context = getContext();
 
         // collect attributes and counters
         final Map<String, Integer> attributes = new HashMap<>();
         CacheAttribute ca;
-        final int max = list.size();
-        for (int i = 0; i < max; i++) {
-            for (String attr : list.get(i).getAttributes()) {
+        for (final Geocache cache : caches) {
+            for (String attr : cache.getAttributes()) {
                 // OC attributes are always positive, to count them with GC attributes append "_yes"
                 final String attrVal;
                 ca = CacheAttribute.getByName(attr);

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -68,6 +68,11 @@
                 android:title="@string/caches_remove_all"
                 app:showAsAction="ifRoom|withText"/>
             <item
+                android:id="@+id/menu_remove_from_other_lists"
+                android:title="@string/caches_remove_from_other_lists_all"
+                android:enabled="true"
+                app:showAsAction="never|withText"/>
+            <item
                 android:id="@+id/menu_drop_caches_all_lists"
                 android:title="@string/caches_remove_all_completely"
                 app:showAsAction="ifRoom|withText"/>

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -82,7 +82,7 @@
                 app:showAsAction="never|withText"/>
             <item
                 android:id="@+id/menu_upload_bookmarklist"
-                android:title="@string/caches_upload_bookmarklist"
+                android:title="@string/caches_upload_bookmarklist_all"
                 app:showAsAction="ifRoom|withText"/>
             <item
                 android:id="@+id/menu_upload_modifiedcoords"
@@ -95,15 +95,15 @@
             <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"
-                android:enabled="false"
+                android:enabled="true"
                 app:showAsAction="never|withText"/>
             <item
                 android:id="@+id/menu_show_attributes"
-                android:title="@string/caches_show_attributes"
+                android:title="@string/caches_show_attributes_all"
                 app:showAsAction="never"/>
             <item
                 android:id="@+id/menu_set_cache_icon"
-                android:title="@string/caches_set_cache_icon"
+                android:title="@string/caches_set_cache_icon_all"
                 android:enabled="false"
                 app:showAsAction="never"/>
             <item

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -500,6 +500,8 @@
     <string name="waypoints_appended_to_route">Waypoints appended to route</string>
     <string name="caches_delete_events">Delete past events</string>
     <string name="caches_upload_bookmarklist">Add to bookmark list</string>
+    <string name="caches_upload_bookmarklist_all">Add all to bookmark list</string>
+    <string name="caches_upload_bookmarklist_selected">Add selected to bookmark list</string>
     <string name="caches_upload_modifiedcoords">Upload modified coordinates</string>
     <string name="caches_upload_modifiedcoords_warning">Do you want to upload modified coordinates for all (selected) caches and overwrite the existing coordinates on the server? This cannot be undone.</string>
     <string name="caches_upload_allcoords">Upload coordinates for all caches</string>
@@ -521,8 +523,11 @@
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
     <string name="caches_overwrite_offline_log">Overwrite offline log</string>
     <string name="caches_overwrite_offline_log_question">Cache has existing offline log of type "%1$s" with a log text. Do you want to overwrite this log?</string>
-    <string name="caches_show_attributes">Show attribute overview</string>
+    <string name="caches_show_attributes_all">Show attribute overview for all caches</string>
+    <string name="caches_show_attributes_selected">Show attribute overview for selected caches</string>
     <string name="caches_set_cache_icon">Set cache icon</string>
+    <string name="caches_set_cache_icon_all">Set cache icon for all caches</string>
+    <string name="caches_set_cache_icon_selected">Set cache icon for selected caches</string>
     <string name="caches_reset_cache_icons_title">Reset cache icon</string>
     <string name="caches_make_list_unique">Make list unique</string>
     <string name="caches_set_listmarker">Set list marker</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -494,6 +494,8 @@
     <string name="caches_remove_selected">Remove selected from list</string>
     <string name="caches_remove_all_completely">Delete all from device</string>
     <string name="caches_remove_selected_completely">Delete selected from device</string>
+    <string name="caches_remove_from_other_lists_selected">Remove selected from other lists</string>
+    <string name="caches_remove_from_other_lists_all">Remove all from other lists</string>
     <string name="caches_append_to_route_selected">Append selected to individual route</string>
     <string name="caches_append_to_route_all">Append all to individual route</string>
     <string name="caches_appended_to_route">Caches appended to route</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
New entry "Remove from other lists" in "Manage caches"-menu  works for all caches in list and for selection (menu"Manage list" is now disabled for select-mode)
Existing entry  "Show Attribute Overview" in "Manage caches"-menu works now on selected caches


## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #16195 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Some more GUI-improvements

Avoid unnecessary calls:
* Get upfront necessary options
* Get list of selected or all caches only once
* Count checked caches only if select-mode is active
* Handover checkedCount

Improve Labels:
* No count for delete past events
* No count for clear offline logs
* No count for upload modified coordinates
* Add count for export-entries in select-mode

Improve Visibility:
* Disable "Manage list"-menu  in select-mode
* Disable "Import"-menu in select-mode
* Hide "Clear offline log", if no caches with offline logs are in the list / selected