### PR TITLE
config_gpx_export_details

### DIFF
--- a/main/src/main/java/cgeo/geocaching/export/GpxExport.java
+++ b/main/src/main/java/cgeo/geocaching/export/GpxExport.java
@@ -84,6 +84,12 @@ public class GpxExport extends AbstractExport {
         final CheckBox includeFoundStatus = layout.findViewById(R.id.include_found_status);
         includeFoundStatus.setChecked(Settings.getIncludeFoundStatus());
 
+        final CheckBox includeLogs = layout.findViewById(R.id.include_logs);
+        includeLogs.setChecked(Settings.getIncludeLogs());
+
+        final CheckBox includeTravelBugs = layout.findViewById(R.id.include_travelbugs);
+        includeTravelBugs.setChecked(Settings.getIncludeTravelBugs());
+
         builder.setPositiveButton(R.string.export, (dialog, which) -> {
             Settings.setIncludeFoundStatus(includeFoundStatus.isChecked());
             dialog.dismiss();

--- a/main/src/main/java/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/main/java/cgeo/geocaching/export/GpxSerializer.java
@@ -153,8 +153,12 @@ public final class GpxSerializer {
 
             XmlUtils.simpleText(gpx, NS_GROUNDSPEAK, "encoded_hints", cache.getHint());
 
-            writeLogs(cache);
-            writeTravelBugs(cache);
+            if (Settings.getIncludeLogs()) {
+                writeLogs(cache);
+            }
+            if (Settings.getIncludeTravelBugs()) {
+                writeTravelBugs(cache);
+            }
 
             gpx.endTag(NS_GROUNDSPEAK, "cache");
 

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1660,6 +1660,22 @@ public class Settings {
         putBoolean(R.string.pref_includefoundstatus, includeFoundStatus);
     }
 
+    public static boolean getIncludeLogs() {
+        return getBoolean(R.string.pref_includelogs, true);
+    }
+
+    public static void setIncludeLogs(final boolean includeLogs) {
+        putBoolean(R.string.pref_includelogs, includeLogs);
+    }
+
+    public static boolean getIncludeTravelBugs() {
+        return getBoolean(R.string.pref_includetravelbugs, true);
+    }
+
+    public static void setIncludeTravelBugs(final boolean includeTravelBugs) {
+        putBoolean(R.string.pref_includetravelbugs, includeTravelBugs);
+    }
+
     public static boolean getClearTrailAfterExportStatus() {
         return getBoolean(R.string.pref_cleartrailafterexportstatus, false);
     }

--- a/main/src/main/res/layout/gpx_export_dialog.xml
+++ b/main/src/main/res/layout/gpx_export_dialog.xml
@@ -13,4 +13,14 @@
         android:id="@+id/include_found_status"
         style="@style/checkbox_full"
         android:text="@string/init_include_found_status" />
+
+    <CheckBox
+        android:id="@+id/include_logs"
+        style="@style/checkbox_full"
+        android:text="@string/init_include_logs" />
+
+    <CheckBox
+        android:id="@+id/include_travelbugs"
+        style="@style/checkbox_full"
+        android:text="@string/init_include_travelbugs" />
 </LinearLayout>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -627,6 +627,8 @@
     <string translatable="false" name="pref_trackableaction">trackableaction</string>
     <string translatable="false" name="pref_trackable_inventory_sort">trackableComparator</string>
     <string translatable="false" name="pref_includefoundstatus">includefoundstatus</string>
+    <string translatable="false" name="pref_includelogs">includelogs</string>
+    <string translatable="false" name="pref_includetravelbugs">includetravelbugs</string>
     <string translatable="false" name="pref_cleartrailafterexportstatus">cleartrailafterexportstatus</string>
     <string translatable="false" name="pref_logImageScale">logImageScale</string>
     <string translatable="false" name="pref_fieldNoteExportDate">fieldnoteExportDate</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1247,6 +1247,8 @@
     <string name="init_accuracycirclecolor">Accuracy circle line color</string>
     <string name="init_accuracycirclecolor_summary">Select color and opaqueness for accuracy circle line. Accuracy circle is used as a visual representation for location signal accuracy.</string>
     <string name="init_include_found_status">Include \"Found\" status</string>
+    <string name="init_include_logs">Include Logs</string>
+    <string name="init_include_travelbugs">Include Travel Bugs</string>
     <string name="init_trackautovisit">Visit TBs</string>
     <string name="init_summary_trackautovisit">Set trackables to \"Visited\" by default</string>
     <string name="init_sigautoinsert">Insert automatically</string>


### PR DESCRIPTION
I have made an attempt to make the data elements that get included in a gpx export configurable. By default, the logs get included and also travel bugs. I wouldn't know what tool importing the GPX would be interested in the logs, nor the travel bugs. And if such a tool exists, well, then configure the new options accordingly.

Now there is one problem: I am on the road again with my very old and slow laptop, I have a hard time even compiling the code and running the emulator takes forever. Having said this: It seems my if-conditions don't evaluate correctly as the logs and travel bugs are always included even if I uncheck the checkboxes in the UI.

@moving-bits : Could you have a quick look at it?