### PR TITLE
Revert "Bump androidx.constraintlayout:constraintlayout ...

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -479,7 +479,7 @@ dependencies {
     implementation 'androidx.core:core:1.8.0'
 
     // Support Library constraintlayout
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // Support Library ExifInterface
     implementation 'androidx.exifinterface:exifinterface:1.3.7'


### PR DESCRIPTION
from 2.1.4 to 2.2.1"

This reverts commit b831885564dee978d076dab98a7813eb17d85f4d.

The build fails with:
~~~
00:06:25  ERROR:/home/jenkins/.gradle/caches/transforms-3/24a6b705f49afbf44645d391c7b69293/transformed/instrumented_constraintlayout-2.2.1-runtime.jar: D8: java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null 
00:06:25  ERROR:/home/jenkins/.gradle/caches/transforms-3/9eb1cc3a4aea1f6cee6c6f73b7cac628/transformed/instrumented_profileinstaller-1.4.0-runtime.jar: D8: java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null 
00:06:25  ERROR:/home/jenkins/.gradle/caches/transforms-3/9e479a912ef56592ad7a7b4055c57ed9/transformed/instrumented_constraintlayout-core-1.1.1.jar: D8: java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null
~~~
