### PR TITLE
Altitude conversion for MSL values (fix #16724)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -493,6 +493,9 @@ dependencies {
     // Settings Library
     implementation 'androidx.preference:preference:1.2.1'
 
+    // Altitude above MSL
+    implementation 'androidx.core:core-location-altitude:1.0.0-alpha03'
+
     // Support Annotations. use same version for the main app and the test app
     String annotationVersion = '1.9.0'
     implementation "androidx.annotation:annotation:$annotationVersion"

--- a/main/src/main/java/cgeo/geocaching/utils/GeoHeightUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/GeoHeightUtils.java
@@ -1,14 +1,28 @@
 package cgeo.geocaching.utils;
 
+import cgeo.geocaching.CgeoApplication;
+import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.sensors.GeoData;
 
 import android.location.Location;
 import android.os.Build;
 
+import androidx.core.location.LocationCompat;
+import androidx.core.location.altitude.AltitudeConverterCompat;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class GeoHeightUtils {
     private static final double[] altitudeReadings = {0.0d, 0.0d, 0.0d, 0.0d, 0.0d};
     private static int altitudeReadingPos = 0;
+
+    // msl correction (WGS84 model to actual form)
+    private static final float MAX_DISTANCE = 0.1f; // max allowed distance in km to accept last msl reading
+    private static double mslCorrection = Double.NaN;
+    private static Geopoint mslLastReading;
+    private static AtomicBoolean mslRetrievalOngoing = new AtomicBoolean(false);
 
     private GeoHeightUtils() {
         // utility class
@@ -36,11 +50,29 @@ public class GeoHeightUtils {
 
     /** returns altitude in meters; prefers msl altitude if available */
     public static double getAltitude(final Location geo) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            if (geo.hasMslAltitude()) {
-                return geo.getMslAltitudeMeters();
+        if (Double.isNaN(mslCorrection) || (mslLastReading != null && mslLastReading.distanceTo(new Geopoint(geo.getLatitude(), geo.getLongitude())) > MAX_DISTANCE)) {
+            if (!mslRetrievalOngoing.get()) {
+                // trigger download of msl correction, if not yet available
+                mslRetrievalOngoing.set(true);
+                final Location dummy = new Location(geo);
+                dummy.setAltitude(0d);
+                AndroidRxUtils.networkScheduler.scheduleDirect(() -> {
+                    try {
+                        AltitudeConverterCompat.addMslAltitudeToLocation(CgeoApplication.getInstance().getApplicationContext(), dummy);
+                        if (LocationCompat.hasMslAltitude(dummy)) {
+                            mslCorrection = LocationCompat.getMslAltitudeMeters(dummy);
+                            mslLastReading = new Geopoint(geo.getLatitude(), geo.getLongitude());
+                        }
+                    } catch (IOException ignore) {
+                        // ignore
+                    } finally {
+                        mslRetrievalOngoing.set(false);
+                    }
+                });
             }
+            return geo.getAltitude();
+        } else {
+            return geo.getAltitude() + mslCorrection;
         }
-        return geo.getAltitude();
     }
 }


### PR DESCRIPTION
## Description
Implements an alternative MSL altitude conversion that does not depend on API 34

Use `GeoHeightUtils.getAltitude()` to calculate the corrected value (correction will be applied automatically as soon as it is available).