### PR TITLE
Remove 'Send email' option for Wherigo problem reports

### DIFF
--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.wherigo;
 
 import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.databinding.WherigoDialogTitleViewBinding;
 import cgeo.geocaching.databinding.WherigoMapQuickinfosBinding;
 import cgeo.geocaching.databinding.WherigolistItemBinding;
@@ -16,7 +17,7 @@ import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
-import cgeo.geocaching.utils.DebugUtils;
+import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.TextUtils;
@@ -221,27 +222,21 @@ public final class WherigoViewUtils {
     public static void showErrorDialog(final Activity activity) {
         final String lastError = WherigoGame.get().getLastError();
         final String dialogErrorMessage = (lastError == null ? LocalizationUtils.getString(R.string.wherigo_error_game_noerror) :
-                LocalizationUtils.getString(R.string.wherigo_error_game_error, lastError)) +
-                        "\n\n" + LocalizationUtils.getString(R.string.wherigo_error_game_error_addinfo);
-        final String errorMessageEmail = lastError == null ? "-" : lastError;
+                LocalizationUtils.getString(R.string.wherigo_error_game_error, lastError));
 
         final SimpleDialog dialog = SimpleDialog.of(activity)
                 .setTitle(TextParam.id(R.string.wherigo_error_title))
                 .setMessage(TextParam.text(dialogErrorMessage).setMarkdown(true))
-                .setPositiveButton(TextParam.id(R.string.about_system_info_send_button))
-                .setNegativeButton(TextParam.id(R.string.close));
+                .setPositiveButton(TextParam.id(R.string.copy));
 
         if (lastError != null) {
             dialog
                 .setNeutralButton(TextParam.id(R.string.log_clear))
                 .setNeutralAction(() -> WherigoGame.get().clearLastError());
         }
-
-        dialog.confirm(() -> {
-            final String emailMessage = LocalizationUtils.getString(R.string.wherigo_error_email,
-                    errorMessageEmail,
-                    WherigoGame.get().getCartridgeName() + " (" + WherigoGame.get().getCGuid() + ")´");
-            DebugUtils.createLogcatHelper(activity, false, true, emailMessage);
+        dialog.show(() -> {
+            ClipboardUtils.copyToClipboard(lastError);
+            ActivityMixin.showToast(activity, R.string.copied_to_clipboard);
         });
         WherigoGame.get().clearLastErrorNotSeen();
     }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1924,6 +1924,7 @@
     <string name="waypoint_coordinate_formats_plain">Plain</string>
     <string name="from_clipboard">From clipboard</string>
     <string name="copy_to_clipboard">Copy to clipboard</string>
+    <string name="copied_to_clipboard">Copied to clipboard</string>
 
     <!-- Projection -->
     <string name="projection_type_none">No projection</string>
@@ -2950,7 +2951,7 @@
     <string name="wherigo_controls_stopgame_hint">Stop a runninggame</string>
     <string name="wherigo_controls_mapzones_hint">Show zones of a running game on map</string>
     <string name="wherigo_controls_downloadcartridge_hint">Download a cartridge (cguid needed)</string>
-    <string name="wherigo_controls_reportproblem_hint">Report a problem with the wherigo player</string>
+    <string name="wherigo_controls_reportproblem_hint">Show last Wherigo problem</string>
     <string name="wherigo_controls_cache_context">Cache Context</string>
     <string name="wherigo_controls_cache_link">Go to cache details</string>
 
@@ -3003,7 +3004,6 @@
     <string name="wherigo_error_title">Wherigo Problem report</string>
     <string name="wherigo_error_game_noerror">No error reported by Wherigo Engine.</string>
     <string name="wherigo_error_game_error">Error reported by Wherigo Engine:\n\n```\n%1$s\n```</string>
-    <string name="wherigo_error_game_error_addinfo">Use \'Send by email\' to report a wherigo related problem to our support team.</string>
     <string name="wherigo_error_email">Wherigo Problem report\n\nEngine Error: %1$s\n\nWherigo Info: %2$s</string>
     <string name="wherigo_error_toast">Wherigo Engine reported an error. Open bug dialog for details.</string>
 
@@ -3049,6 +3049,7 @@
     <string name="close">Close</string>
     <string name="delete">Delete</string>
     <string name="play">Play</string>
+    <string name="copy">Copy</string>
 
     <!-- Multi-Selections -->
     <string name="multiselect_selectall">Select All</string>


### PR DESCRIPTION
## Description
Replaces Wherigo "Send error report by email" option by "Copy error message to clipboard":

![image](https://github.com/user-attachments/assets/2cbb7707-74e8-4859-89de-4d158ab1cde9)
