### PR TITLE
Ask for Wherigo credentials if necessary

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -67,6 +67,7 @@ import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.service.GeocacheChangedBroadcastReceiver;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.speech.SpeechService;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
@@ -1656,8 +1657,15 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private void updateWherigoBox(final CacheDetailActivity activity) {
             final List<String> wherigoGuis = WherigoUtils.getWherigoGuids(cache);
             binding.wherigoBox.setVisibility(!wherigoGuis.isEmpty() ? View.VISIBLE : View.GONE);
-            binding.playInCgeo.setOnClickListener(v -> WherigoViewUtils.executeForOneCartridge(activity, wherigoGuis, guid ->
-                WherigoActivity.startForGuid(activity, guid, cache.getGeocode(), true)));
+            binding.wherigoText.setText(wherigoGuis.isEmpty() || Settings.hasGCCredentials() ? R.string.cache_wherigo_start : R.string.cache_wherigo_credentials);
+            binding.playInCgeo.setOnClickListener(v -> {
+                    if (Settings.hasGCCredentials()) {
+                        WherigoViewUtils.executeForOneCartridge(activity, wherigoGuis, guid ->
+                                WherigoActivity.startForGuid(activity, guid, cache.getGeocode(), true));
+                    } else {
+                        SettingsActivity.openForScreen(R.string.preference_screen_gc, activity);
+                    }
+            });
         }
 
         private void updateChirpWolfBox(final CacheDetailActivity activity) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1775,6 +1775,7 @@
     <string name="cache_multiple_wherigo_cartridges_message">Consult cache listing for further information about the cartridges.</string>
     <string name="cache_wherigo_cartridge_not_downloaded">%s - not downloaded</string>
     <string name="cache_wherigo_start">Download and play this Wherigo using c:geo\'s internal player</string>
+    <string name="cache_wherigo_credentials">In order to play this Wherigo using c:geo\'s internal player you need to authorize against geocaching.com service first. Tap on the button on the right to go to configuration.</string>
     <string name="cache_whereyougo_start">Open WhereYouGo to download and start this cartridge</string>
     <string name="cache_whereyougo_install">Install WhereYouGo player to download and start this cartridge</string>
     <string name="cache_chirpwolf_start">This cache might use either a chirp transmitter or another kind of wireless beacon. For reading chirp data you can open Chirp Wolf.</string>


### PR DESCRIPTION
## Description
As discussed in the last dev meeting: Do not offer c:geo's internal Wherigo player on cache details page if no credentials for gc service are configured. Instead show an info message + forward to connector's settings page:

![image](https://github.com/user-attachments/assets/cd580ae1-85eb-48e7-b42f-6d8b3f130884).![image](https://github.com/user-attachments/assets/f459674f-3e12-4d37-b2bf-5b615a082065)
