### PR TITLE
rel to #16779: wherigo zone: add compass and copy coordinate

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
+++ b/main/src/main/java/cgeo/geocaching/maps/DefaultMap.java
@@ -153,7 +153,7 @@ public final class DefaultMap {
         }
     }
 
-    public static void startActivityWherigoMap(final Activity fromActivity, final Viewport viewport, final String mapTitle) {
+    public static void startActivityWherigoMap(final Activity fromActivity, final Viewport viewport, final String mapTitle, final Geopoint coords) {
         if (Settings.useLegacyMaps()) {
             final String unifiedMapCategory = LocalizationUtils.getString(R.string.category_unifiedMap);
             SimpleDialog.of(fromActivity)
@@ -163,6 +163,7 @@ public final class DefaultMap {
         } else {
             Log.d("Launching UnifiedMap in viewport mode, viewport=" + viewport + ")");
             final UnifiedMapType mapType = viewport == null ? new UnifiedMapType() : new UnifiedMapType(viewport, mapTitle);
+            mapType.coords = coords;
             mapType.launchMap(fromActivity);
         }
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -388,6 +388,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                     mapFragment.setCenter(mapType.viewport.getCenter());
                     mapFragment.zoomToBounds(mapType.viewport);
                 }
+                if (!isTargetSet() && mapType.coords != null && mapType.viewport.contains(mapType.coords)) {
+                    onReceiveTargetUpdate(new AbstractDialogFragment.TargetInfo(mapType.coords,
+                            StringUtils.isNotBlank(mapType.title) ? mapType.title : "---"));
+                }
                 break;
             case UMTT_TargetGeocode: // can be either a cache or a waypoint
                 // load cache/waypoint, focus map on it, and set it as target
@@ -1152,7 +1156,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             if (key.startsWith(TracksLayer.TRACK_KEY_PREFIX) && viewModel.getTracks().getTrack(key.substring(TracksLayer.TRACK_KEY_PREFIX.length())).getRoute() instanceof Route && isLongTap) {
                 result.add(new MapSelectableItem((Route) viewModel.getTracks().getTrack(key.substring(TracksLayer.TRACK_KEY_PREFIX.length())).getRoute()));
             }
-            if (key.startsWith(WherigoLayer.WHERIGO_KEY_PRAEFIX)) {
+            if (key.startsWith(WherigoLayer.WHERIGO_KEY_PRAEFIX) && !isLongTap) {
                 result.add(new MapSelectableItem(WherigoGame.get().getZone(key.substring(WherigoLayer.WHERIGO_KEY_PRAEFIX.length())),
                         key.substring(WherigoLayer.WHERIGO_KEY_PRAEFIX.length()), // Zone name
                         WherigoGame.get().getCartridgeName(), // Wherigo

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
@@ -201,7 +201,7 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         final List<Zone> zones = WherigoThingType.LOCATION.getThingsForUserDisplay(Zone.class);
         final Viewport viewport = WherigoUtils.getZonesViewport(zones);
         if (viewport != null && !viewport.isJustADot()) {
-            DefaultMap.startActivityWherigoMap(this, viewport, WherigoGame.get().getCartridgeName());
+            DefaultMap.startActivityWherigoMap(this, viewport, WherigoGame.get().getCartridgeName(), null);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingDialogProvider.java
@@ -1,11 +1,15 @@
 package cgeo.geocaching.wherigo;
 
+import cgeo.geocaching.CompassActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.databinding.WherigoThingDetailsBinding;
 import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.maps.DefaultMap;
 import cgeo.geocaching.ui.ImageParam;
 import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.utils.ClipboardUtils;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -29,6 +33,8 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
 
     private enum ThingAction {
         DISPLAY_ON_MAP(TextParam.id(R.string.caches_on_map).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_mapmode))),
+        COMPASS(TextParam.id(R.string.wherigo_zone_navigate_compass).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_compass))),
+        COPY_CENTER(TextParam.id(R.string.wherigo_zone_copy_coordinates).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_copy))),
         LOCATE_ON_CENTER(TextParam.id(R.string.wherigo_locate_on_center).setAllCaps(true).setImage(ImageParam.id(R.drawable.map_followmylocation_btn))),
         CLOSE(WherigoUtils.TP_CLOSE_BUTTON);
 
@@ -85,6 +91,8 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
         }
         if (eventTable instanceof Zone) {
             actions.add(ThingAction.DISPLAY_ON_MAP);
+            actions.add(ThingAction.COMPASS);
+            actions.add(ThingAction.COPY_CENTER);
             if (WherigoGame.get().isDebugModeForCartridge()) {
                 actions.add(ThingAction.LOCATE_ON_CENTER);
             }
@@ -105,7 +113,15 @@ public class WherigoThingDialogProvider implements IWherigoDialogProvider {
                     switch (thingAction) {
                         case DISPLAY_ON_MAP:
                             control.dismiss();
-                            DefaultMap.startActivityWherigoMap(activity, WherigoUtils.getZonesViewport(Collections.singleton((Zone) eventTable)), eventTable.name);
+                            DefaultMap.startActivityWherigoMap(activity, WherigoUtils.getZonesViewport(Collections.singleton((Zone) eventTable)), eventTable.name, WherigoUtils.getZoneCenter((Zone) eventTable));
+                            break;
+                        case COMPASS:
+                            control.dismiss();
+                            CompassActivity.startActivityPoint(activity, WherigoUtils.getNearestPointTo((Zone) eventTable), eventTable.name);
+                            break;
+                        case COPY_CENTER:
+                            ClipboardUtils.copyToClipboard(GeopointFormatter.reformatForClipboard(WherigoUtils.getZoneCenter((Zone) eventTable).toString()));
+                            ViewUtils.showShortToast(activity, R.string.clipboard_copy_ok);
                             break;
                         case LOCATE_ON_CENTER:
                             control.dismiss();

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
@@ -260,6 +260,13 @@ public final class WherigoUtils {
         return distance + " " + direction;
     }
 
+    public static Geopoint getNearestPointTo(final Zone zone) {
+        if (zone == null) {
+            return Geopoint.ZERO;
+        }
+        return zone.nearestPoint != null ? GP_CONVERTER.from(zone.nearestPoint) : getZoneCenter(zone);
+    }
+
     public static String getDisplayableDistanceTo(final Zone zone) {
         if (zone == null) {
             return "?";
@@ -268,7 +275,7 @@ public final class WherigoUtils {
             return LocalizationUtils.getString(R.string.wherigo_zone_inside);
         }
         if (zone.nearestPoint != null) {
-            final Geopoint current = new Geopoint(WherigoLocationProvider.get().getLatitude(), WherigoLocationProvider.get().getLongitude());
+            final Geopoint current = WherigoLocationProvider.get().getLocation();
             return getDisplayableDistance(current, GP_CONVERTER.from(zone.nearestPoint)) + (zone.contain == Zone.PROXIMITY ? " (" + LocalizationUtils.getString(R.string.wherigo_zone_near) + ")" : "");
         }
         final Geopoint center = getZoneCenter(zone);

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2980,6 +2980,8 @@
     <string name="wherigo_author">Author</string>
     <string name="wherigo_zone_inside">inside</string>
     <string name="wherigo_zone_near">near</string>
+    <string name="wherigo_zone_navigate_compass">Compass to center</string>
+    <string name="wherigo_zone_copy_coordinates">Copy center coordinates</string>
 
     <string name="wherigo_choose_cartridge">Choose cartridge</string>
     <string name="wherigo_choose_new_loadgame">Choose new game or game to load</string>


### PR DESCRIPTION
rel to #16779: wherigo zone: add compass and copy coordinate

Adds to Wherigo Player:
* ability to navigate to a zone using compass
* ability to copy zone center coordinates to clipboard
* long-tap on a zone on map is no longer recognized. This allows users to do other stuff in map zone area available on long-tap eg create user-defined cache
* set zone center as target when opening map (to get routing and distance info for it)