### PR TITLE
Wherigo: Display EULA error message (fix #16772)

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3003,6 +3003,7 @@
     <string name="wherigo_download_progress_login">Logging in…</string>
     <string name="wherigo_download_progress_started">Download started</string>
     <string name="wherigo_download_progress_download_status">Downloaded %1$s / %2$s (%3$s %%)</string>
+    <string name="wherigo_download_accept_eula">Please log in to www.wherigo.com and accept their terms and conditions first</string>
 
     <string name="wherigo_error_title">Wherigo Problem report</string>
     <string name="wherigo_error_game_noerror">No error reported by Wherigo Engine.</string>


### PR DESCRIPTION
## Description
Displays an error message on Wherigo download if website reports "EULA not set":

![image](https://github.com/user-attachments/assets/417c4c62-0ce6-4ad0-a4c6-121e5428f246)
