### PR TITLE
UnifiedMap VTM: Add background map capability

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -83,6 +83,11 @@ public class DownloaderUtils {
         if (id == R.id.menu_download_offlinemap) {
             activity.startActivity(new Intent(activity, DownloadSelectorActivity.class));
             return true;
+        } else if (id == R.id.menu_download_backgroundmap) {
+            final Intent intent = new Intent(activity, DownloadSelectorActivity.class);
+            intent.putExtra(DownloadSelectorActivity.INTENT_FIXED_DOWNLOADTYPE, Download.DownloadType.DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS.id);
+            activity.startActivity(intent);
+            return true;
         } else if (id == R.id.menu_delete_offline_data) {
             deleteOfflineData(activity);
             return true;

--- a/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsBackgroundMaps.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/MapDownloaderOpenAndroMapsBackgroundMaps.java
@@ -1,0 +1,56 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.models.Download;
+import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.utils.CalendarUtils;
+import cgeo.geocaching.utils.Formatter;
+import cgeo.geocaching.utils.MatcherWrapper;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class MapDownloaderOpenAndroMapsBackgroundMaps extends AbstractDownloader {
+    private static final Pattern PATTERN_MAP = Pattern.compile("<a href=\"([A-Za-z0-9_-]+\\.mbtiles)\">(OAM-World-[A-Za-z0-9_-]+)\\.mbtiles<\\/a>[ ]*([0-9]{2}-[A-Za-z]{3}-[0-9]{4}) [0-9]{2}:[0-9]{2}[ ]*([0-9]+)"); // 1:file name, 2:display name, 3:date DD-MMM-YYYY, 4:size (bytes)
+    private static final MapDownloaderOpenAndroMapsBackgroundMaps INSTANCE = new MapDownloaderOpenAndroMapsBackgroundMaps();
+
+    private MapDownloaderOpenAndroMapsBackgroundMaps() {
+        super(Download.DownloadType.DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS, R.string.mapserver_openandromaps_backgroundmaps, R.string.mapserver_openandromaps_name, R.string.mapserver_openandromaps_info, R.string.mapserver_openandromaps_projecturl, R.string.mapserver_openandromaps_likeiturl, PersistableFolder.BACKGROUND_MAPS);
+        this.iconRes = AbstractMapDownloader.ICONRES_MAP;
+        this.forceExtension = ".mbtiles";
+        companionType = null;
+        downloadHasExtraContents = true;
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<Download> list, final @NonNull String page) {
+        final MatcherWrapper matchMap = new MatcherWrapper(PATTERN_MAP, page);
+        while (matchMap.find()) {
+            final Download offlineMap = new Download(matchMap.group(2), Uri.parse(uri + matchMap.group(1)), false, CalendarUtils.yearMonthDay(CalendarUtils.parseDayMonthYearUS(matchMap.group(3))), Formatter.formatBytes(Long.parseLong(matchMap.group(4))), offlineMapType, iconRes);
+            list.add(offlineMap);
+        }
+    }
+
+    @Nullable
+    @Override
+    protected Download checkUpdateFor(final @NonNull String page, final String remoteUrl, final String remoteFilename) {
+        final MatcherWrapper matchMap = new MatcherWrapper(PATTERN_MAP, page);
+        while (matchMap.find()) {
+            final String filename = matchMap.group(1);
+            if (filename.equals(remoteFilename)) {
+                return new Download(matchMap.group(2), Uri.parse(remoteUrl + "/" + filename), false, CalendarUtils.yearMonthDay(CalendarUtils.parseDayMonthYearUS(matchMap.group(3))), Formatter.formatBytes(Long.parseLong(matchMap.group(4))), offlineMapType, iconRes);
+            }
+        }
+        return null;
+    }
+
+    @NonNull
+    public static MapDownloaderOpenAndroMapsBackgroundMaps getInstance() {
+        return INSTANCE;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/models/Download.java
+++ b/main/src/main/java/cgeo/geocaching/models/Download.java
@@ -16,6 +16,7 @@ import cgeo.geocaching.downloader.MapDownloaderMapsforge;
 import cgeo.geocaching.downloader.MapDownloaderOSMPaws;
 import cgeo.geocaching.downloader.MapDownloaderOSMPawsThemes;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMaps;
+import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsBackgroundMaps;
 import cgeo.geocaching.downloader.MapDownloaderOpenAndroMapsThemes;
 import cgeo.geocaching.storage.extension.PendingDownload;
 import cgeo.geocaching.utils.CalendarUtils;
@@ -156,7 +157,8 @@ public class Download {
 
         DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile, R.drawable.ic_menu_route),
         DOWNLOADTYPE_HILLSHADING_TILES(91, R.string.downloadmap_hillshadingfile, R.drawable.ic_menu_hills),
-        DOWNLOADTYPE_LANGUAGE_MODEL(92, R.string.translator_model, R.drawable.ic_menu_translate);
+        DOWNLOADTYPE_LANGUAGE_MODEL(92, R.string.translator_model, R.drawable.ic_menu_translate),
+        DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS(93, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode);
 
         public final int id;
         @StringRes final int typeNameResId;
@@ -187,6 +189,18 @@ public class Download {
             final ArrayList<DownloadTypeDescriptor> mapRelatedTypes = new ArrayList<>(offlineMapTypes);
             mapRelatedTypes.addAll(offlineMapThemeTypes);
             return mapRelatedTypes;
+        }
+
+        public static ArrayList<DownloadTypeDescriptor> get(final int typeId) {
+            buildTypelist();
+            final ArrayList<DownloadTypeDescriptor> result = new ArrayList<>();
+            for (DownloadTypeDescriptor descriptor : downloadTypes) {
+                if (descriptor.type.id == typeId) {
+                    result.add(descriptor);
+                    break;
+                }
+            }
+            return result;
         }
 
         @Nullable
@@ -239,6 +253,7 @@ public class Download {
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_THEME_JUSTDOWNLOAD, MapDownloaderJustDownloadThemes.getInstance(), R.string.downloadmap_themefile));
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_HILLSHADING_TILES, HillshadingTileDownloader.getInstance(), R.string.hillshading_name));
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_BROUTER_TILES, BRouterTileDownloader.getInstance(), R.string.brouter_name));
+                downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS, MapDownloaderOpenAndroMapsBackgroundMaps.getInstance(), R.string.persistablefolder_backgroundmaps));
 
                 // adding maps and map themes to download types for completeness
                 downloadTypes.addAll(offlineMapTypes);

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2524,6 +2524,14 @@ public class Settings {
         putBoolean(R.string.pref_maphillshading_show_layer, show);
     }
 
+    public static boolean getMapBackgroundMapLayer() {
+        return getBoolean(R.string.pref_mapbackgroundmap_show_layer, true);
+    }
+
+    public static void setMapBackgroundMapLayer(final boolean show) {
+        putBoolean(R.string.pref_mapbackgroundmap_show_layer, show);
+    }
+
     public static boolean getMapActionbarAutohide() {
         return getBoolean(R.string.pref_mapActionbarAutohide, false);
     }

--- a/main/src/main/java/cgeo/geocaching/storage/PersistableFolder.java
+++ b/main/src/main/java/cgeo/geocaching/storage/PersistableFolder.java
@@ -34,6 +34,8 @@ public enum PersistableFolder {
     OFFLINE_MAP_THEMES(R.string.pref_persistablefolder_offlinemapthemes, R.string.persistablefolder_offline_maps_themes, Folder.fromPersistableFolder(OFFLINE_MAPS, "_themes")),
     /** Offline Maps: optional folder for map shading files (dem) */
     OFFLINE_MAP_SHADING(R.string.pref_persistablefolder_offlinemapshading, R.string.persistablefolder_offline_maps_shading, Folder.fromPersistableFolder(OFFLINE_MAPS, "_hgt")),
+    /** Offline Maps: app-specific media folder */
+    BACKGROUND_MAPS(R.string.pref_persistablefolder_backgroundmaps, R.string.persistablefolder_backgroundmaps, Folder.fromFile(CgeoApplication.getInstance().getApplicationContext().getExternalMediaDirs()[0])),
     /** Target folder for written logfiles */
     LOGFILES(R.string.pref_persistablefolder_logfiles, R.string.persistablefolder_logfiles, Folder.fromPersistableFolder(BASE, "logfiles")),
     /** GPX Files */

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -999,6 +999,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             Settings.setMapShadingShowLayer(!Settings.getMapShadingShowLayer());
             item.setChecked(Settings.getMapShadingShowLayer());
             changeMapSource(mapFragment.currentTileProvider);
+        } else if (id == R.id.menu_backgroundmap) {
+            Settings.setMapBackgroundMapLayer(!Settings.getMapBackgroundMapLayer());
+            item.setChecked(Settings.getMapBackgroundMapLayer());
+            changeMapSource(mapFragment.currentTileProvider);
         } else { // dynamic submenus: Map language, Map source
             final String language = TileProviderFactory.getLanguage(id);
             final AbstractTileProvider tileProviderLocal = TileProviderFactory.getTileProvider(id);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/MBTilesLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/MBTilesLayerHelper.java
@@ -1,0 +1,31 @@
+package cgeo.geocaching.unifiedmap.layers;
+
+import android.content.Context;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import org.apache.commons.lang3.StringUtils;
+import org.oscim.android.tiling.source.mbtiles.MBTilesBitmapTileSource;
+import org.oscim.layers.tile.bitmap.BitmapTileLayer;
+import org.oscim.map.Map;
+
+public class MBTilesLayerHelper {
+
+    private MBTilesLayerHelper() {
+        //no instance
+    }
+
+    /** returns a list of BitmapTileLayes for all .mbtiles files found in app-specific media folder, typically /Android/media/(app-id)/*.mbtiles */
+    public static ArrayList<BitmapTileLayer> getBitmapTileLayers(final Context context, final Map map) {
+        final ArrayList<BitmapTileLayer> result = new ArrayList<>();
+        final File[] files = context.getExternalMediaDirs()[0].listFiles((dir, name) -> StringUtils.endsWith(name, ".mbtiles"));
+        if (files != null) {
+            for (File file : files) {
+                result.add(new BitmapTileLayer(map, new MBTilesBitmapTileSource(file.getAbsolutePath(), 192, null)));
+            }
+        }
+        return result;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -12,6 +12,7 @@ import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeVtmGeoItemLayer;
 import cgeo.geocaching.unifiedmap.layers.HillShadingLayerHelper;
+import cgeo.geocaching.unifiedmap.layers.MBTilesLayerHelper;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeVTMTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
@@ -45,6 +46,7 @@ import org.oscim.event.GestureListener;
 import org.oscim.event.MotionEvent;
 import org.oscim.layers.Layer;
 import org.oscim.layers.tile.TileLayer;
+import org.oscim.layers.tile.bitmap.BitmapTileLayer;
 import org.oscim.layers.tile.vector.OsmTileLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.map.Map;
@@ -128,6 +130,12 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         renderer.setPosition(GLViewport.Position.BOTTOM_LEFT);
         renderer.setOffset(30 * CanvasAdapter.getScale(), 0); // make room for attribution
         addLayer(LayerHelper.ZINDEX_SCALEBAR, mapScaleBarLayer);
+
+        if (Settings.getMapBackgroundMapLayer() && currentTileProvider.supportsBackgroundMaps()) {
+            for (BitmapTileLayer backgroundMap : MBTilesLayerHelper.getBitmapTileLayers(requireActivity(), mMap)) {
+                addLayer(LayerHelper.ZINDEX_BASEMAP, backgroundMap);
+            }
+        }
         if (Settings.getMapShadingShowLayer()) {
             addLayer(2, HillShadingLayerHelper.getBitmapTileLayer(getContext(), mMap));
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeVTMOfflineTileProvider.java
@@ -34,6 +34,7 @@ public class AbstractMapsforgeVTMOfflineTileProvider extends AbstractMapsforgeVT
         supportsThemes = true;
         supportsThemeOptions = true; // rule of thumb, not all themes support options
         supportsHillshading = true;
+        supportsBackgroundMaps = true;
         displayName = CompanionFileUtils.getDisplaynameForMap(uri);
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractTileProvider.java
@@ -13,6 +13,7 @@ public abstract class AbstractTileProvider {
     protected boolean supportsLanguages;
     protected boolean supportsThemes;
     protected boolean supportsHillshading = false;
+    protected boolean supportsBackgroundMaps = false;
     protected boolean supportsThemeOptions;
     protected String tileProviderName;
     private Integer numericId;
@@ -50,6 +51,10 @@ public abstract class AbstractTileProvider {
 
     public boolean supportsHillshading() {
         return supportsHillshading;
+    }
+
+    public boolean supportsBackgroundMaps() {
+        return supportsBackgroundMaps;
     }
 
     public String getTileProviderName() {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -70,10 +70,13 @@ public class TileProviderFactory {
             }
             i++;
         }
+        final AbstractTileProvider ctp = Settings.getTileProvider();
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_offline, true, true);
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
-        parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(MapUtils.hasHillshadingTiles() && Settings.getTileProvider().supportsHillshading());
+        parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(MapUtils.hasHillshadingTiles() && ctp.supportsHillshading());
+        parentMenu.findItem(R.id.menu_backgroundmap).setCheckable(true).setChecked(Settings.getMapBackgroundMapLayer()).setVisible(ctp.supportsBackgroundMaps());
         parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getTileProvider().supportsHillshading());
+        parentMenu.findItem(R.id.menu_download_backgroundmap).setVisible(ctp.supportsBackgroundMaps);
         parentMenu.findItem(R.id.menu_check_routingdata).setVisible(Settings.useInternalRouting() || ProcessUtils.isInstalled(CgeoApplication.getInstance().getString(R.string.package_brouter)));
     }
 

--- a/main/src/main/res/layout/downloader_activity.xml
+++ b/main/src/main/res/layout/downloader_activity.xml
@@ -17,6 +17,7 @@
         android:visibility="gone" />
 
     <RelativeLayout
+        android:id="@+id/downloader_selector"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingRight="8dip"
@@ -36,15 +37,14 @@
             android:layout_alignParentRight="true"
             android:text="@null"/>
 
+        <TextView
+            android:id="@+id/downloader_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/downloader_type"
+            android:paddingLeft="8dp"
+            android:paddingBottom="4dp" />
     </RelativeLayout>
-
-    <TextView
-        android:id="@+id/downloader_info"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingLeft="8dp"
-        android:paddingRight="8dp"
-        android:paddingBottom="4dp" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/mapdownloader_list"

--- a/main/src/main/res/menu/map_mapview.xml
+++ b/main/src/main/res/menu/map_mapview.xml
@@ -15,6 +15,13 @@
             android:checkable="true"
             android:visible="false"/>
         <item
+            android:orderInCategory="90"
+            android:id="@+id/menu_backgroundmap"
+            android:title="@string/persistablefolder_backgroundmaps"
+            android:icon="@drawable/ic_menu_mapmode"
+            android:checkable="true"
+            android:visible="false"/>
+        <item
             android:orderInCategory="91"
             android:id="@+id/menu_manage_offline_maps"
             android:icon="@drawable/wherigo_download"
@@ -24,6 +31,11 @@
                     android:id="@+id/menu_download_offlinemap"
                     android:title="@string/downloadmap_title"
                     android:icon="@drawable/ic_menu_mapmode"/>
+                <item
+                    android:id="@+id/menu_download_backgroundmap"
+                    android:title="@string/downloadbackground_title"
+                    android:icon="@drawable/ic_menu_mapmode"
+                    android:visible="false"/>
                 <item
                     android:id="@+id/menu_check_routingdata"
                     android:title="@string/check_tiles_menu"

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -233,6 +233,10 @@
     <string translatable="false" name="pref_maphillshading_hq">maphillshading_hq</string>
     <string translatable="false" name="pref_persistablefolder_offlinemapshading">persistablefolder_offlinemapshading</string>
 
+    <!-- category background maps -->
+    <string translatable="false" name="pref_mapbackgroundmap_show_layer">mapbackgroundmap_show_layer</string>
+    <string translatable="false" name="pref_persistablefolder_backgroundmaps">persistablefolder_backgroundmaps</string>
+
     <!-- category other -->
     <string translatable="false" name="pref_map_osm_multithreaded">map_osm_multithreaded</string>
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1415,6 +1415,7 @@
     <string name="persistablefolder_base">Base</string>
     <string name="persistablefolder_offline_maps">Offline Maps</string>
     <string name="persistablefolder_offline_maps_themes">Map Themes</string>
+    <string name="persistablefolder_backgroundmaps">Background Maps</string>
     <string name="persistablefolder_offline_maps_shading">Map Shading Files</string>
     <string name="persistablefolder_backup">Backup</string>
     <string name="persistablefolder_logfiles">Logfiles</string>
@@ -2816,6 +2817,7 @@
 
     <!-- Download map preference and menu entry -->
     <string name="downloadmap_title">Download offline map</string>
+    <string name="downloadbackground_title">Download background map</string>
     <string name="download_title">Download file</string>
     <string name="downloadmap_info">Select a map file for your region by tapping the \"Save\" icon.\n\nThe download is performed in the background. When the transfer is complete, the file is copied to the c:geo map folder and set as the current map.\n\nBe careful: Downloading a map can cause high network traffic!</string>
     <string name="downloadmap_filename">Downloading %s</string>

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -297,6 +297,7 @@
     <string translatable="false" name="mapserver_openandromaps_downloadurl">https://ftp.gwdg.de/pub/misc/openstreetmap/openandromaps/mapsV5/</string>
     <string translatable="false" name="mapserver_openandromaps_likeiturl">https://www.openandromaps.org/projektkosten</string>
     <string translatable="false" name="mapserver_openandromaps_projecturl">https://www.openandromaps.org/</string>
+    <string translatable="false" name="mapserver_openandromaps_backgroundmaps">https://ftp.gwdg.de/pub/misc/openstreetmap/openandromaps/world/</string>
 
     <string translatable="false" name="mapserver_openandromaps_themes_name">OpenAndroMaps Theme</string>
     <string translatable="false" name="mapserver_openandromaps_themes_downloadurl">https://ftp.gwdg.de/pub/misc/openstreetmap/openandromaps/themes/elevate/</string>


### PR DESCRIPTION
## Description
Support background maps in `.mbtiles` format for VTM (display, download, update, settings).

|Default "world.map"|background map|
|---|---|
|![image](https://github.com/user-attachments/assets/78d66a3b-2984-4179-8aa4-336f56bf7bfd)|![image](https://github.com/user-attachments/assets/07014883-128e-4c1f-9979-12340e8e91f3)|

Using regular "world.map" is fast, but has nearly no detail info. Using country-specific maps instead requires much device space + is very slow in low zoom levels. An alternative is using bitmap based overview maps like those provided by [OpenAndroMaps](https://www.openandromaps.org/downloads/ubersichts-karten). Those maps are provided in `.mbtiles` format, which is supported by VTM.

|enable/disable|start downloader|downloader|
|---|---|---|
|![image](https://github.com/user-attachments/assets/9f93a28f-0db9-4478-83e5-a97523f97410)|![image](https://github.com/user-attachments/assets/29d59790-575a-4107-895f-189ce2564428)|![image](https://github.com/user-attachments/assets/db5ee81a-ceff-42f0-9a5e-64fb520168ed)|

Users can decide which zoom levels to support with background maps by selecting the appropriate download. (Supporting more zoom levels cost more device space.)

