### PR TITLE
Disable R8 full mode optimizations (test)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,7 @@ systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 
 # AndroidX configuration
 android.useAndroidX=true
+
+# disable the more aggressive optimizations for now, see https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode
+# see #16867, #16727
+android.enableR8.fullMode=false


### PR DESCRIPTION
## Description
Test PR to check whether this avoids effects like #16727 or #16867

If this works, we can use this as a fall back and quick fix, and try to investigate further into detailed ProGuard rules.