### PR TITLE
UnifiedMap Mapsforge: Add background map capability

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -32,6 +32,7 @@ import cgeo.geocaching.utils.functions.Action1;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_HILLSHADING_TILES;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_LANGUAGE_MODEL;
+import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOAD_TYPE_ALL_MAPS;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOAD_TYPE_ALL_THEMES;
 
@@ -412,6 +413,11 @@ public class DownloaderUtils {
                 offlineItems.add(new Pair<>(DOWNLOAD_TYPE_ALL_THEMES.id, offlineItem.localFile));
             }
         }
+        for (ContentStorage.FileInformation fi : ContentStorage.get().list(PersistableFolder.BACKGROUND_MAPS)) {
+            if (!fi.isDirectory && StringUtils.endsWithIgnoreCase(fi.name, FileUtils.BACKGROUND_MAP_FILE_EXTENSION)) {
+                offlineItems.add(new Pair<>(DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS.id, fi.name));
+            }
+        }
         for (CompanionFileUtils.DownloadedFileData offlineItem : CompanionFileUtils.availableOfflineMaps(DOWNLOADTYPE_BROUTER_TILES)) {
             offlineItems.add(new Pair<>(DOWNLOADTYPE_BROUTER_TILES.id, offlineItem.localFile));
         }
@@ -458,6 +464,8 @@ public class DownloaderUtils {
                         folder = PersistableFolder.ROUTING_TILES;
                     } else if (offlineItem.first == DOWNLOADTYPE_HILLSHADING_TILES.id) {
                         folder = PersistableFolder.OFFLINE_MAP_SHADING;
+                    } else if (offlineItem.first == DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS.id) {
+                        folder = PersistableFolder.BACKGROUND_MAPS;
                     } else if (offlineItem.first == DOWNLOADTYPE_LANGUAGE_MODEL.id) {
                         OfflineTranslateUtils.deleteLanguageModel(offlineItem.second);
                         filesDeleted++;

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/MBTilesLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/MBTilesLayerHelper.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.unifiedmap.layers;
 
 import cgeo.geocaching.unifiedmap.layers.mbtiles.MBTilesFile;
 import cgeo.geocaching.unifiedmap.layers.mbtiles.MBTilesLayer;
+import cgeo.geocaching.utils.FileUtils;
 import cgeo.geocaching.utils.Log;
 
 import android.content.Context;
@@ -50,7 +51,7 @@ public class MBTilesLayerHelper {
 
     /** returns a list of .mbtiles files found in app-specific media folder, typically /Android/media/(app-id)/*.mbtiles */
     private static File[] getMBTilesSources(final Context context) {
-        return context.getExternalMediaDirs()[0].listFiles((dir, name) -> StringUtils.endsWith(name, ".mbtiles"));
+        return context.getExternalMediaDirs()[0].listFiles((dir, name) -> StringUtils.endsWith(name, FileUtils.BACKGROUND_MAP_FILE_EXTENSION));
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/MBTilesLayerHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/MBTilesLayerHelper.java
@@ -1,11 +1,18 @@
 package cgeo.geocaching.unifiedmap.layers;
 
+import cgeo.geocaching.unifiedmap.layers.mbtiles.MBTilesFile;
+import cgeo.geocaching.unifiedmap.layers.mbtiles.MBTilesLayer;
+import cgeo.geocaching.utils.Log;
+
 import android.content.Context;
 
 import java.io.File;
 import java.util.ArrayList;
 
 import org.apache.commons.lang3.StringUtils;
+import org.mapsforge.map.android.graphics.AndroidGraphicFactory;
+import org.mapsforge.map.layer.cache.InMemoryTileCache;
+import org.mapsforge.map.view.MapView;
 import org.oscim.android.tiling.source.mbtiles.MBTilesBitmapTileSource;
 import org.oscim.layers.tile.bitmap.BitmapTileLayer;
 import org.oscim.map.Map;
@@ -16,16 +23,34 @@ public class MBTilesLayerHelper {
         //no instance
     }
 
-    /** returns a list of BitmapTileLayes for all .mbtiles files found in app-specific media folder, typically /Android/media/(app-id)/*.mbtiles */
-    public static ArrayList<BitmapTileLayer> getBitmapTileLayers(final Context context, final Map map) {
+    /** returns a list of BitmapTileLayers for all .mbtiles used for background maps (VTM variant) */
+    public static ArrayList<BitmapTileLayer> getBitmapTileLayersVTM(final Context context, final Map map) {
         final ArrayList<BitmapTileLayer> result = new ArrayList<>();
-        final File[] files = context.getExternalMediaDirs()[0].listFiles((dir, name) -> StringUtils.endsWith(name, ".mbtiles"));
+        final File[] files = getMBTilesSources(context);
         if (files != null) {
             for (File file : files) {
                 result.add(new BitmapTileLayer(map, new MBTilesBitmapTileSource(file.getAbsolutePath(), 192, null)));
             }
         }
         return result;
+    }
+
+    /** returns a list of BitmapTileLayers for all .mbtiles used for background maps (Mapsforge variant) */
+    public static ArrayList<MBTilesLayer> getBitmapTileLayersMapsforge(final Context context, final MapView mapView) {
+        final ArrayList<MBTilesLayer> result = new ArrayList<>();
+        final File[] files = getMBTilesSources(context);
+        if (files != null) {
+            for (File file : files) {
+                Log.e("file: " + file);
+                result.add(new MBTilesLayer(new InMemoryTileCache(500), mapView.getModel().mapViewPosition, true, new MBTilesFile(file), AndroidGraphicFactory.INSTANCE));
+            }
+        }
+        return result;
+    }
+
+    /** returns a list of .mbtiles files found in app-specific media folder, typically /Android/media/(app-id)/*.mbtiles */
+    private static File[] getMBTilesSources(final Context context) {
+        return context.getExternalMediaDirs()[0].listFiles((dir, name) -> StringUtils.endsWith(name, ".mbtiles"));
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesFile.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesFile.java
@@ -1,0 +1,149 @@
+package cgeo.geocaching.unifiedmap.layers.mbtiles;
+
+/* based upon work of (c) 2023 Christian Pesch, https://github.com/cpesch */
+
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mapsforge.core.model.BoundingBox;
+
+public class MBTilesFile {
+
+    protected final SQLiteDatabase database;
+
+    private Map<String, String> metadata = null;
+
+    private static final String SELECT_METADATA = "SELECT name, value FROM metadata";
+    private static final String SELECT_TILES = "SELECT tile_data FROM tiles WHERE zoom_level=%s AND tile_column=%s AND tile_row=%s ORDER BY zoom_level DESC LIMIT 1";
+    private static final List<String> SUPPORTED_FORMATS = Arrays.asList("png", "jpg", "jpeg");
+
+    public MBTilesFile(final File file) {
+        this.database = SQLiteDatabase.openDatabase(file.getPath(), null, SQLiteDatabase.OPEN_READONLY);
+
+        final String format = getFormat();
+        if (format == null) {
+            throw new IllegalArgumentException("'metadata.format' field was not found. Is this an MBTiles database?");
+        }
+        if (!SUPPORTED_FORMATS.contains(format)) {
+            throw new IllegalArgumentException(String.format("Unsupported 'metadata.format: %s'. Supported format(s) are: %s", format, SUPPORTED_FORMATS));
+        }
+    }
+
+    public void close() {
+        try {
+            metadata = null;
+            this.database.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public BoundingBox getBoundingBox() {
+        final String bounds = getMetadata().get("bounds");
+        if (bounds == null) {
+            return null;
+        }
+        final String[] split = bounds.split(",");
+        if (split.length != 4) {
+            return null;
+        }
+        return new BoundingBox(Double.parseDouble(split[1]), Double.parseDouble(split[0]), Double.parseDouble(split[3]), Double.parseDouble(split[2]));
+    }
+
+    private String getFormat() {
+        return getMetadata().get("format");
+    }
+
+    private Integer getMetadata(final String name) {
+        final String value = getMetadata().get(name);
+        return value != null ? Integer.parseInt(value) : null;
+    }
+
+    private Map<String, String> getMetadata() {
+        if (this.metadata == null) {
+            this.metadata = new HashMap<>();
+            try (Cursor cursor = this.database.rawQuery(SELECT_METADATA, null)) {
+                while (cursor.moveToNext()) {
+                    final String key = cursor.getString(0);
+                    final String value = cursor.getString(1);
+                    this.metadata.put(key, value);
+                }
+            }
+        }
+        return this.metadata;
+    }
+
+    private Integer getZoomLevel(final String name, final String function) {
+        if (getMetadata(name) == null) {
+            final String result = getSingleValue("SELECT " + function + "(zoom_level) AS value FROM tiles");
+            if (result != null) {
+                getMetadata().put(name, result);
+            }
+        }
+        return getMetadata(name);
+    }
+
+    public Integer getZoomLevelMax() {
+        return getZoomLevel("maxzoom", "MAX");
+    }
+
+    public int getZoomLevelMin() {
+        return getZoomLevel("minzoom", "MIN");
+    }
+
+    private String getSingleValue(final String query) {
+        try (Cursor cursor = database.rawQuery(query, null)) {
+            if (cursor.moveToNext()) {
+                final int i = cursor.getColumnIndex("value");
+                return cursor.getString(i);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    /**
+     * Converts a zoom level to a scale factor.
+     *
+     * @param zoomLevel the zoom level to convert.
+     * @return the corresponding scale factor.
+     */
+    private double zoomLevelToScale(final byte zoomLevel) {
+        return 1 << zoomLevel;
+    }
+
+    /**
+     * Converts a tile Y number at a certain zoom level to TMS notation.
+     *
+     * @param tileY     the tile Y number that should be converted.
+     * @param zoomLevel the zoom level at which the number should be converted.
+     * @return the TMS value of the tile Y number.
+     */
+    private long tileYToTMS(final long tileY, final byte zoomLevel) {
+        return (long) (zoomLevelToScale(zoomLevel) - tileY - 1);
+    }
+
+    public InputStream getTileAsBytes(final int tileX, final int tileY, final byte zoomLevel) {
+        final long tmsTileY = tileYToTMS(tileY, zoomLevel);
+        try (Cursor cursor = database.rawQuery(String.format(SELECT_TILES, zoomLevel, tileX, tmsTileY), null)) {
+            if (cursor.moveToNext()) {
+                final int i = cursor.getColumnIndex("tile_data");
+                return i < 0 ? null : new ByteArrayInputStream(cursor.getBlob(i));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesLayer.java
@@ -1,0 +1,85 @@
+package cgeo.geocaching.unifiedmap.layers.mbtiles;
+
+/* based upon work of (c) 2023 Christian Pesch, https://github.com/cpesch */
+
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.model.DisplayModel;
+import org.mapsforge.map.model.MapViewPosition;
+import org.mapsforge.map.model.common.Observer;
+
+public class MBTilesLayer extends TileLayer<MBTilesRendererJob> implements Observer {
+    private final MBTilesRenderer renderer;
+    private MBTilesMapWorkerPool mapWorkerPool;
+
+    public MBTilesLayer(final TileCache tileCache, final MapViewPosition mapViewPosition, final boolean isTransparent,
+                        final MBTilesFile file, final GraphicFactory graphicFactory) {
+        super(tileCache, mapViewPosition, graphicFactory.createMatrix(), isTransparent);
+        this.renderer = new MBTilesRenderer(file, graphicFactory);
+    }
+
+    public synchronized void setDisplayModel(final DisplayModel displayModel) {
+        super.setDisplayModel(displayModel);
+        if (displayModel != null) {
+            if (this.mapWorkerPool == null) {
+                this.mapWorkerPool = new MBTilesMapWorkerPool(this.tileCache, this.jobQueue, this.renderer, this);
+            }
+            this.mapWorkerPool.start();
+        } else if (this.mapWorkerPool != null) {
+            // if we do not have a displayModel any more we can stop rendering.
+            this.mapWorkerPool.stop();
+        }
+    }
+
+    protected MBTilesRendererJob createJob(final Tile tile) {
+        return new MBTilesRendererJob(tile, renderer, this.isTransparent);
+    }
+
+    /**
+     * Whether the tile is stale and should be refreshed.
+     * <br />
+     * This method is called from {@link #draw(org.mapsforge.core.model.BoundingBox, byte, org.mapsforge.core.graphics.Canvas, org.mapsforge.core.model.Point)} to determine whether the tile needs to
+     * be refreshed.
+     * <br />
+     * A tile is considered stale if the timestamp of the layer's {@link #renderer} is more recent than the
+     * {@code bitmap}'s {@link org.mapsforge.core.graphics.TileBitmap#getTimestamp()}.
+     * <br />
+     * When a tile has become stale, the layer will first display the tile referenced by {@code bitmap} and attempt to
+     * obtain a fresh copy in the background. When a fresh copy becomes available, the layer will replace is and update
+     * the cache. If a fresh copy cannot be obtained for whatever reason, the stale tile will continue to be used until
+     * another {@code #draw(BoundingBox, byte, Canvas, Point)} operation requests it again.
+     *
+     * @param tile   A tile.
+     * @param bitmap The bitmap for {@code tile} currently held in the layer's cache.
+     */
+    @Override
+    protected boolean isTileStale(final Tile tile, final TileBitmap bitmap) {
+        return this.renderer.getDataTimestamp(tile) > bitmap.getTimestamp();
+    }
+
+    @Override
+    protected void onAdd() {
+        this.mapWorkerPool.start();
+        if (tileCache != null) {
+            tileCache.addObserver(this);
+        }
+        super.onAdd();
+    }
+
+    @Override
+    protected void onRemove() {
+        this.mapWorkerPool.stop();
+        if (tileCache != null) {
+            tileCache.removeObserver(this);
+        }
+        super.onRemove();
+    }
+
+    @Override
+    public void onChange() {
+        this.requestRedraw();
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesMapWorkerPool.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesMapWorkerPool.java
@@ -1,0 +1,133 @@
+package cgeo.geocaching.unifiedmap.layers.mbtiles;
+
+/* based upon work of (c) 2023 Christian Pesch, https://github.com/cpesch */
+
+import cgeo.geocaching.utils.Log;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.util.Parameters;
+import org.mapsforge.map.layer.Layer;
+import org.mapsforge.map.layer.cache.TileCache;
+import org.mapsforge.map.layer.queue.JobQueue;
+
+class MBTilesMapWorkerPool implements Runnable {
+    private final MBTilesRenderer renderer;
+    private boolean inShutdown, isRunning;
+    private final JobQueue<MBTilesRendererJob> jobQueue;
+    private final Layer layer;
+    private ExecutorService self, workers;
+    private final TileCache tileCache;
+
+    MBTilesMapWorkerPool(final TileCache tileCache, final JobQueue<MBTilesRendererJob> jobQueue, final MBTilesRenderer renderer, final MBTilesLayer layer) {
+        super();
+        this.tileCache = tileCache;
+        this.jobQueue = jobQueue;
+        this.renderer = renderer;
+        this.layer = layer;
+        this.inShutdown = false;
+        this.isRunning = false;
+    }
+
+    public void run() {
+        try {
+            while (!inShutdown) {
+                final MBTilesRendererJob rendererJob = this.jobQueue.get(Parameters.NUMBER_OF_THREADS);
+                if (rendererJob == null) {
+                    continue;
+                }
+                if (!this.tileCache.containsKey(rendererJob)) {
+                    workers.execute(new MapWorker(rendererJob));
+                } else {
+                    jobQueue.remove(rendererJob);
+                }
+            }
+        } catch (InterruptedException e) {
+            Log.e("MapWorkerPool interrupted", e);
+        } catch (RejectedExecutionException e) {
+            Log.e("MapWorkerPool rejected", e);
+        }
+    }
+
+    public synchronized void start() {
+        if (this.isRunning) {
+            return;
+        }
+        this.inShutdown = false;
+        this.self = Executors.newSingleThreadExecutor();
+        this.workers = Executors.newFixedThreadPool(Parameters.NUMBER_OF_THREADS);
+        this.self.execute(this);
+        this.isRunning = true;
+    }
+
+    public synchronized void stop() {
+        if (!this.isRunning) {
+            return;
+        }
+        this.inShutdown = true;
+        this.jobQueue.interrupt();
+
+        // Shutdown executors
+        this.self.shutdown();
+        this.workers.shutdown();
+
+        try {
+            if (!this.self.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                this.self.shutdownNow();
+                if (!this.self.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                    Log.w("Shutdown self executor failed");
+                }
+            }
+        } catch (InterruptedException e) {
+            Log.e("Shutdown self executor interrupted", e);
+        }
+
+        try {
+            if (!this.workers.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                this.workers.shutdownNow();
+                if (!this.workers.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                    Log.w("Shutdown workers executor failed");
+                }
+            }
+        } catch (InterruptedException e) {
+            Log.e("Shutdown workers executor interrupted", e);
+        }
+
+        this.isRunning = false;
+    }
+
+    class MapWorker implements Runnable {
+        private final MBTilesRendererJob rendererJob;
+
+        MapWorker(final MBTilesRendererJob rendererJob) {
+            this.rendererJob = rendererJob;
+        }
+
+        public void run() {
+            TileBitmap bitmap = null;
+            try {
+                if (inShutdown) {
+                    return;
+                }
+                bitmap = renderer.executeJob(rendererJob);
+                if (inShutdown) {
+                    return;
+                }
+
+                if (bitmap != null) {
+                    tileCache.put(rendererJob, bitmap);
+                }
+                layer.requestRedraw();
+            } finally {
+                jobQueue.remove(rendererJob);
+                if (bitmap != null) {
+                    bitmap.decrementRefCount();
+                }
+            }
+        }
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesRenderer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesRenderer.java
@@ -1,0 +1,54 @@
+package cgeo.geocaching.unifiedmap.layers.mbtiles;
+
+/* based upon work of (c) 2023 Christian Pesch, https://github.com/cpesch */
+
+import cgeo.geocaching.utils.Log;
+
+import java.io.InputStream;
+
+import org.mapsforge.core.graphics.GraphicFactory;
+import org.mapsforge.core.graphics.TileBitmap;
+import org.mapsforge.core.model.Tile;
+
+public class MBTilesRenderer {
+
+    private final MBTilesFile file;
+    private final GraphicFactory graphicFactory;
+    private final long timestamp;
+
+    MBTilesRenderer(final MBTilesFile file, final GraphicFactory graphicFactory) {
+        this.file = file;
+        this.graphicFactory = graphicFactory;
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * Called when a job needs to be executed.
+     *
+     * @param rendererJob the job that should be executed.
+     */
+    public TileBitmap executeJob(final MBTilesRendererJob rendererJob) {
+
+        try {
+            final InputStream inputStream = file.getTileAsBytes(rendererJob.tile.tileX, rendererJob.tile.tileY, rendererJob.tile.zoomLevel);
+
+            final TileBitmap bitmap;
+            if (inputStream == null) {
+                bitmap = graphicFactory.createTileBitmap(rendererJob.tile.tileSize, rendererJob.hasAlpha);
+            } else {
+                bitmap = graphicFactory.createTileBitmap(inputStream, rendererJob.tile.tileSize, rendererJob.hasAlpha);
+                bitmap.scaleTo(rendererJob.tile.tileSize, rendererJob.tile.tileSize);
+            }
+            bitmap.setTimestamp(rendererJob.getDatabaseRenderer().getDataTimestamp(rendererJob.tile));
+            return bitmap;
+        } catch (Exception e) {
+            Log.e("Error while rendering job " + rendererJob + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    public long getDataTimestamp(final Tile tile) {
+        return timestamp;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesRendererJob.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/mbtiles/MBTilesRendererJob.java
@@ -1,0 +1,44 @@
+package cgeo.geocaching.unifiedmap.layers.mbtiles;
+
+/* based upon work of (c) 2023 Christian Pesch, https://github.com/cpesch */
+
+import org.mapsforge.core.model.Tile;
+import org.mapsforge.map.layer.queue.Job;
+
+public class MBTilesRendererJob extends Job {
+    private final MBTilesRenderer renderer;
+    private final int hashCodeValue;
+
+    public MBTilesRendererJob(final Tile tile, final MBTilesRenderer renderer, final boolean isTransparent) {
+        super(tile, isTransparent);
+        this.renderer = renderer;
+        this.hashCodeValue = calculateHashCode();
+    }
+
+    public MBTilesRenderer getDatabaseRenderer() {
+        return renderer;
+    }
+
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!super.equals(obj)) {
+            return false;
+        } else if (!(obj instanceof MBTilesRendererJob)) {
+            return false;
+        }
+        final MBTilesRendererJob other = (MBTilesRendererJob) obj;
+        return this.getDatabaseRenderer().equals(other.getDatabaseRenderer());
+    }
+
+    public int hashCode() {
+        return this.hashCodeValue;
+    }
+
+    private int calculateHashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + this.getDatabaseRenderer().hashCode();
+        return result;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -11,6 +11,8 @@ import cgeo.geocaching.unifiedmap.AbstractMapFragment;
 import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeV6GeoItemLayer;
+import cgeo.geocaching.unifiedmap.layers.MBTilesLayerHelper;
+import cgeo.geocaching.unifiedmap.layers.mbtiles.MBTilesLayer;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
@@ -122,6 +124,12 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
         //make room for map attribution icon button
         final int mapAttPx = Math.round(this.getResources().getDisplayMetrics().density * 30);
         mMapView.getMapScaleBar().setMarginHorizontal(mapAttPx);
+
+        if (Settings.getMapBackgroundMapLayer() && currentTileProvider.supportsBackgroundMaps()) {
+            for (MBTilesLayer backgroundMap : MBTilesLayerHelper.getBitmapTileLayersMapsforge(requireActivity(), mMapView)) {
+                mMapView.getLayerManager().getLayers().add(backgroundMap);
+            }
+        }
 
         if (this.mapAttribution != null) {
             this.mapAttribution.setOnClickListener(v -> displayMapAttribution());

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeVtmFragment.java
@@ -132,7 +132,7 @@ public class MapsforgeVtmFragment extends AbstractMapFragment {
         addLayer(LayerHelper.ZINDEX_SCALEBAR, mapScaleBarLayer);
 
         if (Settings.getMapBackgroundMapLayer() && currentTileProvider.supportsBackgroundMaps()) {
-            for (BitmapTileLayer backgroundMap : MBTilesLayerHelper.getBitmapTileLayers(requireActivity(), mMap)) {
+            for (BitmapTileLayer backgroundMap : MBTilesLayerHelper.getBitmapTileLayersVTM(requireActivity(), mMap)) {
                 addLayer(LayerHelper.ZINDEX_BASEMAP, backgroundMap);
             }
         }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOfflineTileProvider.java
@@ -35,6 +35,7 @@ public class AbstractMapsforgeOfflineTileProvider extends AbstractMapsforgeTileP
         supportsThemes = true;
         supportsThemeOptions = true; // rule of thumb, not all themes support options
         supportsHillshading = true;
+        supportsBackgroundMaps = true;
         displayName = CompanionFileUtils.getDisplaynameForMap(uri);
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/FileUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FileUtils.java
@@ -40,6 +40,7 @@ public final class FileUtils {
     public static final String LOC_FILE_EXTENSION = ".loc";
     public static final String ZIP_FILE_EXTENSION = ".zip";
     public static final String MAP_FILE_EXTENSION = ".map";
+    public static final String BACKGROUND_MAP_FILE_EXTENSION = ".mbtiles";
 
     private static final String FILE_PROTOCOL = "file://";
 


### PR DESCRIPTION
## Description
Similar to #16869, but for Mapsforge. Currently implements reading capability for `.mbtiles` maps itself, but I'll try to get that part integrated into official Mapsforge library.

|zoom level 3|zoom level 4|zoom level 5|
|---|---|---|
|![image](https://github.com/user-attachments/assets/7a88ebb8-601e-45b4-acf3-7cf89ecccb2c)|![image](https://github.com/user-attachments/assets/17a17280-1bea-4baf-81dc-1adcc2500bdd)|![image](https://github.com/user-attachments/assets/b43ae860-913b-4bb0-8827-7efee6cafe7d)|

|zoom level 6|zoom level 7|zoom level 8|
|---|---|---|
|![image](https://github.com/user-attachments/assets/4869851c-7427-48cf-9ae7-dfaea94ff422)|![image](https://github.com/user-attachments/assets/e2ea1c52-d0e8-4d98-8224-9acc17e482bb)|![image](https://github.com/user-attachments/assets/00fe1c76-a3ae-4b04-92b6-993b7e8adc3a)|

finally the loaded vector map takes over (depending on which zoom levels you have downloaded for background map):
|zoom level 9|zoom level 10|zoom level 11|
|---|---|---|
|![image](https://github.com/user-attachments/assets/678ef536-63be-48e3-ad2d-6e5cfe717946)|![image](https://github.com/user-attachments/assets/2401e3e1-2cc0-4c47-9e26-ed308f1f0131)|![image](https://github.com/user-attachments/assets/3452c798-0d38-4b72-9a20-8a4a29ca0ac1)|


