### PR TITLE
Catch links to c:geo settings in Markdown (fix #16838)

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -281,12 +281,6 @@
                 <action android:name="android.intent.action.APPLICATION_PREFERENCES" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="@string/settings_scheme" />
-            </intent-filter>
         </activity>
         <activity android:name=".settings.ViewSettingsActivity" />
         <activity

--- a/main/src/main/java/cgeo/geocaching/AboutActivity.java
+++ b/main/src/main/java/cgeo/geocaching/AboutActivity.java
@@ -15,6 +15,7 @@ import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.MarkdownUtils;
 import cgeo.geocaching.utils.ProcessUtils;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.Version;
@@ -226,7 +227,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
                 return;
             }
             binding.getRoot().setVisibility(View.VISIBLE);
-            final Markwon markwon = Markwon.create(activity);
+            final Markwon markwon = MarkdownUtils.create(activity);
 
             final String changelogBase = FileUtils.getChangelogMaster(activity).trim();
             final String changelogBugfix = prepareChangelogBugfix(activity);
@@ -277,7 +278,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
 
             viewModel.getSystemInformation().observe(getViewLifecycleOwner(), (si -> {
                 if (si != null) {
-                    final Markwon markwon = Markwon.create(activity);
+                    final Markwon markwon = MarkdownUtils.create(activity);
                     markwon.setMarkdown(binding.system, si);
                     binding.copy.setEnabled(true);
                     binding.copy.setOnClickListener(view -> {
@@ -336,7 +337,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
 
             binding.getRoot().setVisibility(View.VISIBLE);
             setClickListener(binding.license, "https://www.apache.org/licenses/LICENSE-2.0.html");
-            final Markwon markwon = Markwon.create(getActivity());
+            final Markwon markwon = MarkdownUtils.create(getActivity());
             markwon.setMarkdown(binding.licenseText, getRawResourceString(R.raw.license));
         }
 
@@ -377,7 +378,7 @@ public class AboutActivity extends TabbedViewPagerActivity {
             }
             binding.getRoot().setVisibility(View.VISIBLE);
 
-            final Markwon markwon = Markwon.create(activity);
+            final Markwon markwon = MarkdownUtils.create(activity);
 
             markwon.setMarkdown(binding.aboutContributorsRecent, formatContributors(R.string.contributors_recent));
             markwon.setMarkdown(binding.aboutContributorsOthers, formatContributors(R.string.contributors_other));

--- a/main/src/main/java/cgeo/geocaching/downloader/PendingDownloadsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/PendingDownloadsActivity.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.storage.extension.PendingDownload;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.MarkdownUtils;
 import cgeo.geocaching.utils.functions.Func1;
 import static cgeo.geocaching.utils.Formatter.formatBytes;
 import static cgeo.geocaching.utils.Formatter.formatDateForFilename;
@@ -216,7 +217,7 @@ public class PendingDownloadsActivity extends AbstractActionBarActivity {
             this.activity = activity;
             this.downloadManager = downloadManager;
             this.pendingDownloads = pendingDownloads;
-            this.markwon = Markwon.create(activity);
+            this.markwon = MarkdownUtils.create(activity);
         }
 
         @Override

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -349,6 +349,11 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
         return intent;
     }
 
+    public static void openForSettingsLink(final Uri uri, final Context fromActivity) {
+        final Intent intent = new Intent(Intent.ACTION_VIEW, uri, fromActivity, SettingsActivity.class);
+        fromActivity.startActivity(intent);
+    }
+
     @Override
     public boolean onSupportNavigateUp() {
         if (getSupportFragmentManager().popBackStackImmediate()) {

--- a/main/src/main/java/cgeo/geocaching/ui/TextParam.java
+++ b/main/src/main/java/cgeo/geocaching/ui/TextParam.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.ui;
 
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.utils.LocalizationUtils;
+import cgeo.geocaching.utils.MarkdownUtils;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
@@ -242,7 +243,7 @@ public class TextParam {
 
         //markdown
         if (this.useMarkdown && context != null) {
-            final Markwon markwon = Markwon.create(context);
+            final Markwon markwon = MarkdownUtils.create(context);
             text = markwon.toMarkdown(text.toString());
         }
 

--- a/main/src/main/java/cgeo/geocaching/utils/MarkdownUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MarkdownUtils.java
@@ -1,0 +1,44 @@
+package cgeo.geocaching.utils;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.settings.SettingsActivity;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import io.noties.markwon.AbstractMarkwonPlugin;
+import io.noties.markwon.LinkResolverDef;
+import io.noties.markwon.Markwon;
+import io.noties.markwon.MarkwonConfiguration;
+import org.apache.commons.lang3.StringUtils;
+
+public class MarkdownUtils {
+
+    private MarkdownUtils() {
+        // utility class
+    }
+
+    public static Markwon create(final Context context) {
+        return Markwon.builder(context)
+                .usePlugin(new AbstractMarkwonPlugin() {
+                    @Override
+                    public void configureConfiguration(@NonNull final MarkwonConfiguration.Builder builder) {
+                        builder.linkResolver((view, link) -> {
+                            final Uri uri = Uri.parse(link);
+                            if (uri != null) {
+                                // filter links to c:geo-internal settings
+                                if (StringUtils.equals(uri.getScheme(), context.getString(R.string.settings_scheme))) {
+                                    SettingsActivity.openForSettingsLink(uri, context);
+                                } else {
+                                    new LinkResolverDef().resolve(view, link);
+                                }
+                            }
+                        });
+                    }
+                })
+                .build();
+    }
+
+}


### PR DESCRIPTION
## Description
Filter links starting with `cgeo-setting://` in markdown texts (like our changelog) and use an explicit intent for it, which avoids the overlapping implicit intent definitions in `AndroidManifest.xml` leading to the lint errors described in #16838.