### PR TITLE
fix #16822: wherigo, add possibility to contact cartridge author via wherigo.com

### DIFF
--- a/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/cache/WhereYouGoApp.java
@@ -30,7 +30,7 @@ public class WhereYouGoApp extends AbstractGeneralApp {
     public void navigate(@NonNull final Context context, @NonNull final Geocache cache) {
         final List<String> guids = WherigoUtils.getWherigoGuids(cache);
         if (!guids.isEmpty()) {
-            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(WherigoUtils.getWherigoUrl(guids.get(0)))));
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(WherigoUtils.getWherigoDownloadUrl(guids.get(0)))));
         }
     }
 
@@ -41,7 +41,7 @@ public class WhereYouGoApp extends AbstractGeneralApp {
     public static void openWherigo(@NonNull final Activity activity, @NonNull final String guid) {
         // re-check installation state, might have changed since creating the view
         if (isWhereYouGoInstalled()) {
-            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(WherigoUtils.getWherigoUrl(guid)));
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(WherigoUtils.getWherigoDownloadUrl(guid)));
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             activity.startActivity(intent);
         } else {

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoCartridgeDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoCartridgeDialogProvider.java
@@ -90,8 +90,10 @@ public class WherigoCartridgeDialogProvider implements IWherigoDialogProvider {
     }
 
     private void refreshGui(final WherigoCartridgeDetailsBinding binding) {
+        final String link = WherigoUtils.getWherigoDetailsUrl(cartridgeInfo.getCGuid());
         TextParam.text("**CGUID:** " + cartridgeInfo.getCGuid() + "  \n" +
             "**" + LocalizationUtils.getString(R.string.wherigo_author) + ":** " + cartridgeFile.author + "  \n" +
+            "**[" + LocalizationUtils.getString(R.string.cache_menu_browser) + "](" + link + ")**  \n" +
             "**" + LocalizationUtils.getString(R.string.cache_location) + ":** " + cartridgeInfo.getCartridgeLocation() + "  \n" +
             "**" + LocalizationUtils.getString(R.string.distance) + ":** " + WherigoUtils.getDisplayableDistance(WherigoLocationProvider.get().getLocation(), cartridgeInfo.getCartridgeLocation())
             ).setMarkdown(true).applyTo(binding.headerInformation);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoGame.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoGame.java
@@ -78,6 +78,7 @@ public class WherigoGame implements UI {
     private File cartridgeCacheDir;
     private HtmlImage htmlImageGetter;
     private String lastError;
+    private String lastErrorCGuid;
     private boolean lastErrorNotSeen = false;
     private String contextGeocode;
     private String contextGeocacheName;
@@ -150,6 +151,7 @@ public class WherigoGame implements UI {
             this.cartridgeInfo = new WherigoCartridgeInfo(cartridgeFileInfo, true, false);
             setCGuidAndDependentThings(this.cartridgeInfo.getCGuid());
             this.lastError = null;
+            this.lastErrorCGuid = null;
             this.lastErrorNotSeen = false;
 
             //try to restore context geocache
@@ -217,8 +219,14 @@ public class WherigoGame implements UI {
         return lastError;
     }
 
+    @Nullable
+    public String getLastErrorCGuid() {
+        return lastErrorCGuid;
+    }
+
     public void clearLastError() {
         lastError = null;
+        lastErrorCGuid = null;
         notifyListeners(NotifyType.REFRESH);
     }
 
@@ -365,6 +373,7 @@ public class WherigoGame implements UI {
             this.lastError = errorMessage +
                 " (Cartridge: " + getCartridgeName() + ", cguid: " + getCGuid() +
                 ", timestamp: " + Formatter.formatDateTime(System.currentTimeMillis()) + ")";
+            this.lastErrorCGuid = getCGuid();
             this.lastErrorNotSeen = true;
         }
         ViewUtils.showToast(null, R.string.wherigo_error_toast);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoUtils.java
@@ -71,7 +71,8 @@ public final class WherigoUtils {
     public static final TextParam TP_CANCEL_BUTTON = TextParam.id(R.string.cancel).setAllCaps(true).setImage(ImageParam.id(R.drawable.ic_menu_cancel));
 
     private static final Pattern PATTERN_CARTRIDGE_LINK = Pattern.compile("https?" + Pattern.quote("://") + "(?:www\\.)?" + Pattern.quote("wherigo.com/cartridge/") + "(?:details|download)" + Pattern.quote(".aspx?") + "[Cc][Gg][Uu][Ii][Dd]=([-0-9a-zA-Z]*)");
-    private static final String WHERIGO_URL_BASE = "https://www.wherigo.com/cartridge/download.aspx?CGUID=";
+    private static final String WHERIGO_DOWNLOAD_URL_BASE = "https://www.wherigo.com/cartridge/download.aspx?CGUID=";
+    private static final String WHERIGO_DETAILS_URL_BASE = "https://wherigo.com/cartridge/details.aspx?CGUID=";
 
     public static final GeopointConverter<ZonePoint> GP_CONVERTER = new GeopointConverter<>(
         gc -> new ZonePoint(gc.getLatitude(), gc.getLongitude(), 0),
@@ -363,8 +364,14 @@ public final class WherigoUtils {
     }
 
     @Nullable
-    public static String getWherigoUrl(@Nullable final String guid) {
-        return guid == null ? null : WHERIGO_URL_BASE + guid;
+    public static String getWherigoDetailsUrl(@Nullable final String guid) {
+        return guid == null ? null : WHERIGO_DETAILS_URL_BASE + guid;
+    }
+
+
+    @Nullable
+    public static String getWherigoDownloadUrl(@Nullable final String guid) {
+        return guid == null ? null : WHERIGO_DOWNLOAD_URL_BASE + guid;
     }
 
     @NonNull

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
@@ -218,13 +218,14 @@ public final class WherigoViewUtils {
 
     public static void showErrorDialog(final Activity activity) {
         final String lastError = WherigoGame.get().getLastError();
+        final String lastErrorCartridgeLink = WherigoUtils.getWherigoDetailsUrl(WherigoGame.get().getLastErrorCGuid());
         final String dialogErrorMessage = (lastError == null ? LocalizationUtils.getString(R.string.wherigo_error_game_noerror) :
-                LocalizationUtils.getString(R.string.wherigo_error_game_error, lastError));
+                LocalizationUtils.getString(R.string.wherigo_error_game_error, lastError, lastErrorCartridgeLink));
 
         final SimpleDialog dialog = SimpleDialog.of(activity)
                 .setTitle(TextParam.id(R.string.wherigo_error_title))
                 .setMessage(TextParam.text(dialogErrorMessage).setMarkdown(true))
-                .setPositiveButton(TextParam.id(R.string.copy));
+                .setPositiveButton(lastError == null ? TextParam.id(R.string.ok) : TextParam.id(R.string.copy));
 
         if (lastError != null) {
             dialog
@@ -232,8 +233,10 @@ public final class WherigoViewUtils {
                 .setNeutralAction(() -> WherigoGame.get().clearLastError());
         }
         dialog.show(() -> {
-            ClipboardUtils.copyToClipboard(lastError);
-            ActivityMixin.showToast(activity, R.string.copied_to_clipboard);
+            if (lastError != null) {
+                ClipboardUtils.copyToClipboard(lastError);
+                ActivityMixin.showToast(activity, R.string.copied_to_clipboard);
+            }
         });
         WherigoGame.get().clearLastErrorNotSeen();
     }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3009,7 +3009,7 @@
 
     <string name="wherigo_error_title">Wherigo Problem report</string>
     <string name="wherigo_error_game_noerror">No error reported by Wherigo Engine.</string>
-    <string name="wherigo_error_game_error">Error reported by Wherigo Engine:\n\n```\n%1$s\n```</string>
+    <string name="wherigo_error_game_error">Error reported by Wherigo Engine:\n\n```\n%1$s\n```\nYou may contact the author of the cartridge [here](%2$s)</string>
     <string name="wherigo_error_email">Wherigo Problem report\n\nEngine Error: %1$s\n\nWherigo Info: %2$s</string>
     <string name="wherigo_error_toast">Wherigo Engine reported an error. Open bug dialog for details.</string>
 

--- a/main/src/test/java/cgeo/geocaching/wherigo/WherigoUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/wherigo/WherigoUtilsTest.java
@@ -27,7 +27,7 @@ public class WherigoUtilsTest {
 
     // from GC7K2KZ
     @Test
-    public void testGetWherIGoURLHttps() {
+    public void testGetWherIGoDownloadURLHttps() {
         final String description = "Da kannsch da die Cartridge oaladn:<br>\n<br>\n<a target=\"_blank\" href=\"https://www.wherigo.com/cartridge/details.aspx?CGUID=a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6\"><img src=\"https://imgproxy.geocaching.com/5e0c76c4b8cccbb11eecc36b322a9177d6820421?url=https%3A%2F%2Fwww.muggelfrei.at%2Fcaches%2Fi-heart-innsbruck%2Fcartridge.png\"></a><br>";
         assertThat(WherigoUtils.scanWherigoGuids(description)).containsExactly("a482bfed-47f0-4b2c-a9f9-c1e3c4ef48c6");
     }


### PR DESCRIPTION
fix #16822: wherigo, add possibility to contact cartridge author via wherigo.com

Allows user to navigate to cartridge detail page on wherigo.com in both the cardtridge info dialog and the error dialog. The later is meant so the user may contact the cartridge author (via wherigo.com) if he/she wants to report an error to him/her.

![image](https://github.com/user-attachments/assets/713d6032-5813-462b-8a1a-24bfc8a115cf)
