### PR TITLE
UnifiedMap: Fix rotation popup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
@@ -193,10 +193,11 @@ public abstract class AbstractMapFragment extends Fragment {
             }
         });
         compassrose.setOnLongClickListener(v -> {
-            getActivity().findViewById(R.id.container_rotationmenu).setVisibility(View.VISIBLE);
-            MapSettingsUtils.showRotationMenu(getActivity(), newRotationMode -> {
-                setMapRotation(newRotationMode);
-                getActivity().findViewById(R.id.container_rotationmenu).setVisibility(View.GONE);
+            final UnifiedMapActivity activity = (UnifiedMapActivity) getActivity();
+            activity.findViewById(R.id.container_rotationmenu).setVisibility(View.VISIBLE);
+            MapSettingsUtils.showRotationMenu(activity, newRotationMode -> {
+                activity.setMapRotation(newRotationMode);
+                activity.findViewById(R.id.container_rotationmenu).setVisibility(View.GONE);
             });
             return true;
         });

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -382,7 +382,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         // refresh options menu and routes/tracks display
         invalidateOptionsMenu();
-        setMapRotation(null, Settings.getMapRotation());
+        setMapRotation(Settings.getMapRotation());
     }
 
     private void reloadCachesAndWaypoints(final boolean setDefaultCenterAndZoom) {
@@ -822,13 +822,13 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 viewModel.coordsIndicator.setValue(coordsIndicator);
             }
         } else if (id == R.id.menu_map_rotation_off) {
-            setMapRotation(item, MAPROTATION_OFF);
+            setMapRotation(MAPROTATION_OFF);
         } else if (id == R.id.menu_map_rotation_manual) {
-            setMapRotation(item, MAPROTATION_MANUAL);
+            setMapRotation(MAPROTATION_MANUAL);
         } else if (id == R.id.menu_map_rotation_auto_lowpower) {
-            setMapRotation(item, MAPROTATION_AUTO_LOWPOWER);
+            setMapRotation(MAPROTATION_AUTO_LOWPOWER);
         } else if (id == R.id.menu_map_rotation_auto_precise) {
-            setMapRotation(item, MAPROTATION_AUTO_PRECISE);
+            setMapRotation(MAPROTATION_AUTO_PRECISE);
         } else if (id == R.id.menu_check_routingdata) {
             final BoundingBox bb = mapFragment.getBoundingBox();
             MapUtils.checkRoutingData(this, bb.getMinLatitude(), bb.getMinLongitude(), bb.getMaxLatitude(), bb.getMaxLongitude());
@@ -909,12 +909,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         Settings.setMapCenter(mapFragment.getCenter());
     }
 
-    private void setMapRotation(@Nullable final MenuItem item, final int mapRotation) {
+    void setMapRotation(final int mapRotation) {
         Settings.setMapRotation(mapRotation);
         mapFragment.setMapRotation(mapRotation);
-        if (item != null) {
-            item.setChecked(true);
-        }
+        invalidateOptionsMenu();
         ViewUtils.setVisibility(findViewById(R.id.map_compassrose), mapRotation == MAPROTATION_OFF ? View.GONE : View.VISIBLE);
         checkDrivingMode();
     }


### PR DESCRIPTION
## Description
Changing rotation mode via popup did not work, as the map fragment's `setMapRotation` method got called instead of the activity's `setMapRotation`.