### PR TITLE
WIP: Make offline translation preserve HTML

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1603,6 +1603,7 @@
     <string name="cache_description">Description</string>
     <string name="cache_description_table_note">Description contains table formatting which may need to be viewed at %s to be seen correctly.</string>
     <string name="cache_description_rendering">Rendering description, please wait…</string>
+    <string name="cache_description_translating_and_rendering">Translating and rendering description, please wait…</string>
     <string name="cache_description_render_restricted_warning" tools:ignore="PluralsCandidate">Warning: Description is very large (%1$d chars). Only first %2$d%% are displayed.</string>
     <string name="cache_description_render_fully">Render complete description</string>
     <string name="cache_area_description">Area Description</string>


### PR DESCRIPTION
## Description
This PR tries to preserve HTML during offline translation of a cache description.

|Original|Translated|
|---|---|
|![image](https://github.com/user-attachments/assets/c196e3e9-222d-4ba4-ab7b-7615ebfcb68f)|![image](https://github.com/user-attachments/assets/2e1afab9-2282-4539-b0fa-3504d49a05cb)| 

Partly works already, images are preserved, as well as most formatting, but only _some_ links:

|Original|Translated|
|---|---|
|![image](https://github.com/user-attachments/assets/01d91d10-23d7-4d5e-ae2c-e372da1cb895)|![image](https://github.com/user-attachments/assets/d12a729d-15dc-401e-a5e7-71406b849884)|

Also, depending on the specific source text, sometimes paragraphs are lost:

|Original|Translated|
|---|---|
|![image](https://github.com/user-attachments/assets/5b2dfb93-c922-4083-b138-72e1d0f9e2d7)|![image](https://github.com/user-attachments/assets/fb7e7924-a365-410b-b11f-c838d887475b)|

This may be some difference between `JSoup.parse()` and Android's `HTML.from()`, but I haven't cross-checked yet.

## Technical info
The old way of translating a cache listing was to get the listing text's `Spannable.getText()`, translate this string, and display the result. Due to calling `getText()` all HTML formatting gets removed.

The approach of this PR is to translate the text directly after loading it from the database, then apply `HTML.from()` and all the "magic" for loading the images etc. Google's ML translation misses some HTML attributes, though, which lead to "HTML reminders" being displayed in the translation (especially some style attributes), thus I added another step: First parse the string loaded from the database with `JSoup.parse()`, then translate all pure-text blocks (and leave the other unchanged), then apply c:geo's "magic" for images etc., then display the result.

Haven't tested yet with renderings other than "original".

Setting WIP for now.

Any input on how to fix the open issues would be highly welcomed.