### PR TITLE
Remove automatic replacement of x while scanning coordinates in formula

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/utils/InstrumentedFormulaUtilsTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/utils/InstrumentedFormulaUtilsTest.java
@@ -113,12 +113,13 @@ public class InstrumentedFormulaUtilsTest {
         //from Issue #12867
         assertScanCoordinates("N 49° 53.(H+1) (H-A) (B-2) \nE 008° 37. (B) (C) (H-1)", "N 49° 53.(H+1) (H-A) (B-2)|E 008° 37. (B) (C) (H-1)");
         assertScanCoordinates("N 49° (A + 42).0(B + 10)\nE 008° (C*6 + 2).(D + 256)", "N 49° (A + 42).0(B + 10)|E 008° (C*6 + 2).(D + 256)");
-        assertScanCoordinates("N AB CD.EFG E HI JK.LMN", "N AB CD.EFG|E HI JK.LMN");
+        assertScanCoordinates("N AB CD.EFG E 00U VW.XYZ", "N AB CD.EFG|E 00U VW.XYZ");
+        assertScanCoordinates("N ab cd.efg E 00u vw.xyz", "N ab cd.efg|E 00u vw.xyz");
 
         assertScanCoordinates("[N 49° 4(A-1).(B*50+85)]\n[E 008° (B+C+A).(D+45)]", "N 49° 4(A-1).(B*50+85)]|E 008° (B+C+A).(D+45)]");
         //from https://coord.info/GCW1GJ
         assertScanCoordinates("N 48° 04.ABE,\n E 11° 56.DEB.", "N 48° 04.ABE|E 11° 56.DEB");
-        assertScanCoordinates("N 48° 0B.(2x C)(2x C)(2x C),\n  E 11° BB.(G+H)DF", "N 48° 0B.(2* C)(2* C)(2* C)|E 11° BB.(G+H)DF");
+        assertScanCoordinates("N 48° 0B.(2x C)(2x C)(2x C),\n  E 11° BB.(G+H)DF", "N 48° 0B.(2x C)(2x C)(2x C)|E 11° BB.(G+H)DF");
         assertScanCoordinates("N 48° 0B.0[I+J*D],\nE 11° BB.D(J/4)D", "N 48° 0B.0[I+J*D]|E 11° BB.D(J/4)D");
 
         assertScanCoordinates("N 45° A.B(C+D)'  E 9° (A-B).(2*D)EF\n", "N 45° A.B(C+D)'|E 9° (A-B).(2*D)EF");

--- a/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/formulas/FormulaUtils.java
@@ -325,7 +325,7 @@ public class FormulaUtils {
             d = d.substring(0, d.length() - group.length()).trim();
             m = DEGREE_TRAILINGSTUFF_REMOVER.matcher(d);
         }
-        return d.replace('x', '*');
+        return d;
     }
 
     private static String processFoundText(final String text) {

--- a/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/formulas/FormulaUtilsTest.java
@@ -410,12 +410,13 @@ public class FormulaUtilsTest {
         //from Issue #12867
         assertScanCoordinates("N 49° 53.(H+1) (H-A) (B-2) \nE 008° 37. (B) (C) (H-1)", "N 49° 53.(H+1) (H-A) (B-2)|E 008° 37. (B) (C) (H-1)");
         assertScanCoordinates("N 49° (A + 42).0(B + 10)\nE 008° (C*6 + 2).(D + 256)", "N 49° (A + 42).0(B + 10)|E 008° (C*6 + 2).(D + 256)");
-        assertScanCoordinates("N AB CD.EFG E HI JK.LMN", "N AB CD.EFG|E HI JK.LMN");
+        assertScanCoordinates("N AB CD.EFG E 00U VW.XYZ", "N AB CD.EFG|E 00U VW.XYZ");
+        assertScanCoordinates("N ab cd.efg E 00u vw.xyz", "N ab cd.efg|E 00u vw.xyz");
 
         assertScanCoordinates("[N 49° 4(A-1).(B*50+85)]\n[E 008° (B+C+A).(D+45)]", "N 49° 4(A-1).(B*50+85)]|E 008° (B+C+A).(D+45)]");
         //from https://coord.info/GCW1GJ
         assertScanCoordinates("N 48° 04.ABE,\n E 11° 56.DEB.", "N 48° 04.ABE|E 11° 56.DEB");
-        assertScanCoordinates("N 48° 0B.(2x C)(2x C)(2x C),\n  E 11° BB.(G+H)DF", "N 48° 0B.(2* C)(2* C)(2* C)|E 11° BB.(G+H)DF");
+        assertScanCoordinates("N 48° 0B.(2x C)(2x C)(2x C),\n  E 11° BB.(G+H)DF", "N 48° 0B.(2x C)(2x C)(2x C)|E 11° BB.(G+H)DF");
         assertScanCoordinates("N 48° 0B.0[I+J*D],\nE 11° BB.D(J/4)D", "N 48° 0B.0[I+J*D]|E 11° BB.D(J/4)D");
 
         assertScanCoordinates("N 45° A.B(C+D)'  E 9° (A-B).(2*D)EF\n", "N 45° A.B(C+D)'|E 9° (A-B).(2*D)EF");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. --> <!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Copy/Paste of formula in GC53XAF `N ab cd.efg E 00u vw.xyz` leads in current implementation to `N ab cd.efg E 00u vw.*yz`

A new function was introduced to replace the letter x with the multiply-sign. So the automatic replacement in scanning the coordinates is not necessary anymore.

This PR removes the automatic replacement of `x`

## Related issues
<!-- List the related issues fixed or improved by this PR --> 
rel #13844
rel PR #16692

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->