### PR TITLE
Fix translation box missing after translation

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1903,12 +1903,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                         binding.descriptionTranslateButton.setEnabled(false);
                     };
                     reloadDescription(cda, cache, true, 0, cda.descriptionStyle, translator, cda.translationStatus, errorConsumer);
-        /*
-                    OfflineTranslateUtils.translateParagraph(translator, cda.translationStatus, binding.description.getText().toString(), translatedText -> {
-                        displayDescription(getActivity(), cache, translatedText, binding.description);
-                        binding.descriptionTranslateNote.setText(String.format(getString(R.string.translator_translation_success), sourceLng));
-                    }, errorConsumer);
-        */
                     OfflineTranslateUtils.translateParagraph(translator, cda.translationStatus, binding.hint.getText().toString(), binding.hint::setText, errorConsumer);
                 });
         }
@@ -1955,12 +1949,12 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                     createDescriptionContent(activity, cache, restrictLength, binding.description, descriptionStyle, translator, status, p -> {
                         displayDescription(activity, cache, p.first, binding.description);
                         if (translator != null) {
-                            // @todo: Box does not come up again after successful translation
                             binding.descriptionTranslateNote.setText(String.format(getString(R.string.translator_translation_success), status.getSourceLanguage()));
-                            binding.descriptionTranslate.setVisibility(View.VISIBLE);
                         }
 
-                        OfflineTranslateUtils.initializeListingTranslatorInTabbedViewPagerActivity((CacheDetailActivity) getActivity(), binding.descriptionTranslate, binding.description.getText().toString(), this::translateListing);
+                        if (status == null || StringUtils.equals(status.getSourceLanguage().getCode(), OfflineTranslateUtils.LANGUAGE_INVALID)) {
+                            OfflineTranslateUtils.initializeListingTranslatorInTabbedViewPagerActivity((CacheDetailActivity) getActivity(), binding.descriptionTranslate, binding.description.getText().toString(), this::translateListing);
+                        }
 
                         // we need to use post, so that the textview is layouted before scrolling gets called
                         if (((CacheDetailActivity) activity).lastActionWasEditNote) {

--- a/main/src/main/java/cgeo/geocaching/utils/OfflineTranslateUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/OfflineTranslateUtils.java
@@ -133,21 +133,26 @@ public class OfflineTranslateUtils {
         final Document document = Jsoup.parseBodyFragment(text);
         final List<TextNode> elements = document.children().select("*").textNodes();
         final AtomicInteger remaining = new AtomicInteger(elements.size());
-        for (TextNode textNode : elements) {
-            translator.translate(textNode.text())
-                    .addOnSuccessListener(translation -> {
-                        textNode.text(translation);
-                        // check if all done
-                        if (remaining.decrementAndGet() == 0) {
-                            consumer.accept(document.body().html());
-                            status.updateProgress();
-                        }
-                    })
-                    .addOnFailureListener(e -> {
-                        Log.e("err: " + e.getMessage());
-                        status.abortTranslation();
-                        errorConsumer.accept(e);
-                    });
+        if (remaining.get() == 0) {
+            consumer.accept("");
+            status.updateProgress();
+        } else {
+            for (TextNode textNode : elements) {
+                translator.translate(textNode.text())
+                        .addOnSuccessListener(translation -> {
+                            textNode.text(translation);
+                            // check if all done
+                            if (remaining.decrementAndGet() == 0) {
+                                consumer.accept(document.body().html());
+                                status.updateProgress();
+                            }
+                        })
+                        .addOnFailureListener(e -> {
+                            Log.e("err: " + e.getMessage());
+                            status.abortTranslation();
+                            errorConsumer.accept(e);
+                        });
+            }
         }
     }
 


### PR DESCRIPTION
## Description
#16910 introduced two bugs that the translation box did not become visible again after successful translation (+ even if it would have come, the spinner would have been spinning endlessly when there was no hint in the cache to be translated). This PR fixes both issues.