### PR TITLE
Use new coordinate entry dialog in all places except waypoint page

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -82,7 +82,6 @@ import cgeo.geocaching.ui.ToggleItemType;
 import cgeo.geocaching.ui.TrackableListAdapter;
 import cgeo.geocaching.ui.UserClickListener;
 import cgeo.geocaching.ui.ViewUtils;
-import cgeo.geocaching.ui.dialog.CoordinatesInputDialog;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.EditNoteDialog;
 import cgeo.geocaching.ui.dialog.EditNoteDialog.EditNoteDialogListener;

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -845,9 +845,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         });
     }
 
-    private void setCoordinates(Activity activity) {
+    private void setCoordinates(final Activity activity) {
         ensureSaved();
-        NewCoordinateInputDialog.show(activity,this::onCoordinatesUpdated, cache.getCoords());
+        NewCoordinateInputDialog.show(activity, this::onCoordinatesUpdated, cache.getCoords());
     }
 
     public void onCoordinatesUpdated(final Geopoint input) {

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -462,8 +462,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         }
     }
 
-    private void onClickCoordinates()
-    {
+    private void onClickCoordinates() {
         NewCoordinateInputDialog.show(this, this::onUpdateCoordinates, LocationDataProvider.getInstance().currentGeo().getCoords());
     }
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -17,12 +17,13 @@ import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.search.GeocacheAutoCompleteAdapter;
 import cgeo.geocaching.search.SearchAutoCompleteAdapter;
+import cgeo.geocaching.sensors.LocationDataProvider;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.SearchCardView;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
-import cgeo.geocaching.ui.dialog.CoordinatesInputDialog;
+import cgeo.geocaching.ui.dialog.NewCoordinateInputDialog;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.Log;
@@ -62,7 +63,7 @@ import de.k3b.geo.api.IGeoPointInfo;
 import de.k3b.geo.io.GeoUri;
 import org.apache.commons.lang3.StringUtils;
 
-public class SearchActivity extends AbstractNavigationBarActivity implements CoordinatesInputDialog.CoordinateUpdate {
+public class SearchActivity extends AbstractNavigationBarActivity {
     private SearchActivityBinding binding;
 
     private static final String GOOGLE_NOW_SEARCH_ACTION = "com.google.android.gms.actions.SEARCH_ACTION";
@@ -424,7 +425,7 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
         }
 
         addSearchCard(R.string.search_coordinates, R.drawable.ic_menu_mylocation)
-                .addOnClickListener(() -> CoordinatesInputDialog.show(getSupportFragmentManager(), null, null)); // callback method is updateCoordinates()
+                .addOnClickListener(this::onClickCoordinates);
 
         addSearchCardWithField(R.string.search_address, R.drawable.ic_menu_home, this::findByAddressFn, null, () -> Settings.getHistoryList(R.string.pref_search_history_address), null);
 
@@ -461,21 +462,19 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
         }
     }
 
-    @Override
-    public void updateCoordinates(@NonNull final Geopoint geopoint) {
+    private void onClickCoordinates()
+    {
+        NewCoordinateInputDialog.show(this, this::onUpdateCoordinates, LocationDataProvider.getInstance().currentGeo().getCoords());
+    }
+
+    public void onUpdateCoordinates(final Geopoint input) {
         try {
-            CacheListActivity.startActivityCoordinates(this, geopoint, null);
+            CacheListActivity.startActivityCoordinates(this, input, null);
             ActivityMixin.overrideTransitionToFade(this);
         } catch (final Geopoint.ParseException e) {
             showToast(res.getString(e.resource));
         }
     }
-
-    @Override
-    public boolean supportsNullCoordinates() {
-        return false;
-    }
-
     private void findByKeywordFn(final String keyText) {
         if (StringUtils.isBlank(keyText)) {
             SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_keyword).show();

--- a/main/src/main/java/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/DistanceFilterViewHolder.java
@@ -103,8 +103,8 @@ public class DistanceFilterViewHolder extends BaseFilterViewHolder<DistanceGeoca
     }
 
     private void setCoordinates() {
-        final NewCoordinateInputDialog dialog = new NewCoordinateInputDialog(getActivity(), this::onDialogClosed);
-        dialog.show(location);
+
+        NewCoordinateInputDialog.show(getActivity(), this::onDialogClosed, location);
     }
 
     public void onDialogClosed(final Geopoint input) {

--- a/main/src/main/java/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogTrackableActivity.java
@@ -22,9 +22,8 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.DateTimeEditor;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.TextSpinner;
-import cgeo.geocaching.ui.dialog.CoordinatesInputDialog;
-import cgeo.geocaching.ui.dialog.CoordinatesInputDialog.CoordinateUpdate;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.ui.dialog.NewCoordinateInputDialog;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
@@ -54,7 +53,7 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
-public class LogTrackableActivity extends AbstractLoggingActivity implements CoordinateUpdate, LoaderManager.LoaderCallbacks<List<LogTypeTrackable>> {
+public class LogTrackableActivity extends AbstractLoggingActivity implements LoaderManager.LoaderCallbacks<List<LogTypeTrackable>> {
 
     private static final int LOADER_ID_LOGGING_INFO = 409842;
 
@@ -320,7 +319,6 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
         binding.progressBar.setVisibility(loading ? View.VISIBLE : View.GONE);
     }
 
-    @Override
     public void updateCoordinates(final Geopoint geopointIn) {
         if (geopointIn == null) {
             return;
@@ -329,16 +327,16 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Coo
         binding.coordinates.setText(geopoint.toString());
         geocache.setCoords(geopoint);
     }
-
-    @Override
-    public boolean supportsNullCoordinates() {
-        return false;
-    }
-
     private class CoordinatesListener implements View.OnClickListener {
         @Override
-        public void onClick(final View arg0) {
-            CoordinatesInputDialog.show(getSupportFragmentManager(), geocache, geopoint);
+        public void onClick(final View theView) {
+
+            NewCoordinateInputDialog.show(theView.getContext(), this::onCoordinatesUpdated, geopoint);
+        }
+
+        public void onCoordinatesUpdated(final Geopoint input) {
+
+            updateCoordinates(input);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/NewCoordinateInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/NewCoordinateInputDialog.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.android.material.textfield.TextInputLayout;
+import io.reactivex.rxjava3.disposables.Disposable;
 import org.apache.commons.lang3.StringUtils;
 
 // A recreation of the existing coordinate dialog
@@ -58,6 +59,7 @@ public class NewCoordinateInputDialog {
     private TextView lonSymbol1, lonSymbol2, lonSymbol3, lonSymbol4;
     private List<EditText> orderedInputs;
     private Geopoint gp;
+    private Disposable geoDisposable;
 
     private final GeoDirHandler geoUpdate = new GeoDirHandler() {
         @Override
@@ -109,9 +111,11 @@ public class NewCoordinateInputDialog {
         toolbar.setOnMenuItemClickListener(item -> {
             if (item.getItemId() == R.id.menu_item_save) {
                if (saveAndFinishDialog()) {
+                   geoDisposable.dispose();
                    dialog.dismiss();
                }
             } else {
+                geoDisposable.dispose();
                dialog.dismiss();
             }
             return true;
@@ -220,11 +224,8 @@ public class NewCoordinateInputDialog {
 
         dialog.show();
 
-        geoUpdate.start(GeoDirHandler.UPDATE_GEODATA);
+        geoDisposable = geoUpdate.start(GeoDirHandler.UPDATE_GEODATA);
     }
-
-
-
 
     // Close dialog and return selected coordinates to caller
     private boolean saveAndFinishDialog() {

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/NewCoordinateInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/NewCoordinateInputDialog.java
@@ -62,7 +62,7 @@ public class NewCoordinateInputDialog {
     private final GeoDirHandler geoUpdate = new GeoDirHandler() {
         @Override
         public void updateGeoData(final GeoData geo) {
-            String label = context.getString(R.string.waypoint_my_coordinates_accuracy, Units.getDistanceFromMeters(geo.getAccuracy()));
+            final String label = context.getString(R.string.waypoint_my_coordinates_accuracy, Units.getDistanceFromMeters(geo.getAccuracy()));
             binding.current.setText(label);
         }
     };


### PR DESCRIPTION
## Description
Extends the earlier work to utilise the new dialog in these additional places

- User define cache 'Set Coordinates' option
- Search card 'Coordinates'
- Logging a Geokrety TB

## Related issues
<!-- List the related issues fixed or improved by this PR -->
PR16799 
PR16889

## Additional context
Also included these improvements

- Constructor is no longer public as recommended by @eddiemuc 
- The 'My coordinates' button now shows accuracy as per the old dialog

I have tested the above use cases and replicated the same functionality as before except in these cases

1. User defined cache does not have a button to use the 'cache coordinates' - seem pointless when the purpose is to change the existing coordinates 
2. GK TB does not have the 'calculate coordinates' button. The rational here is you are dropping a TB in or visiting a cache so you must presumably already have the coordinates and do not need to compute them.


The waypoint entry page is NOT included in this change as that is more complex due to it being coupled to the calculate coordinate global dialog.  That will be done later


Note:
I replicated the usage of GeoDIrHandler from the old dialog (which was Fragment based) to show the positional accuracy by calling 

_geoUpdate.start(GeoDirHandler.UPDATE_GEODATA)_ 

when the dialog was shown but couldn't find away to stop it - the fragment dialog disposes of it when onPause is called.

Do I need to kill it also or does it get stopped automatically when _dialog.dismiss()_ is called

Tks
Dave


