### PR TITLE
Fix #13186: Correct file naming counter during file name creation

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/FileNameCreator.java
+++ b/main/src/main/java/cgeo/geocaching/utils/FileNameCreator.java
@@ -23,7 +23,7 @@ public class FileNameCreator {
     public static final FileNameCreator TRACKFILE = new FileNameCreator("track", "gpx");
     public static final FileNameCreator OFFLINE_LOG_IMAGE = new FileNameCreator("cgeo-image-%s", "jpg");
 
-    private final AtomicInteger fileNameCounter = new AtomicInteger(1);
+    private final AtomicInteger fileNameCounter = new AtomicInteger(0);
 
     private final String fixedName;
     private final String prefix;


### PR DESCRIPTION
## Description
Fixes the initialization of the file name counter in `FileNameCreator.java`.
Previously, the counter was initialized with `1` and used `addAndGet(1)`, which caused the first generated file name to have a suffix of `2`.

## Related issues
Fixes #13186


## Additional context
- Updated `AtomicInteger` initialization to start at `0`