### PR TITLE
fix #16280: mapsforge, manually accomodate for rotation in coord projection

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/geoitem/ToScreenProjector.java
+++ b/main/src/main/java/cgeo/geocaching/models/geoitem/ToScreenProjector.java
@@ -2,7 +2,14 @@ package cgeo.geocaching.models.geoitem;
 
 import cgeo.geocaching.location.Geopoint;
 
+/** Projects lat/lon-coordinates to screen coordinates for a concrete map */
 public interface ToScreenProjector {
 
+    /**
+     * for a given geopoint, returns an int array of size 2 (x, y) containing the
+     * screen coordinate for the given lat/lon for a currently displayed map. Any visualization
+     * details of the map (e.g. rotating, tilting, zooming, ...) should be accomodated for by the
+     * implementor.
+     */
     int[] project(Geopoint t);
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
@@ -493,7 +493,8 @@ public class GeoItemLayer<K> {
             final IProviderGeoItemLayer<?> pl = this.providerLayer;
             if (pl != null) {
                 toCoordFct = pl.getScreenCoordCalculator();
-                Log.d("Touched: " + tapped + " at " + (toCoordFct == null ? "-" : toCoordFct.project(tapped)));
+                final int[] projCoord = toCoordFct == null ? new int[]{-1, -1} : toCoordFct.project(tapped);
+                Log.d("Touched: " + tapped + " at [" + projCoord[0] + ", " + projCoord[1] + "]");
             } else {
                 toCoordFct = null;
             }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -229,7 +229,7 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
     @Override
     public IProviderGeoItemLayer<?> createGeoItemProviderLayer() {
-        return new MapsforgeV6GeoItemLayer(mMapView.getLayerManager(), mMapView.getMapViewProjection());
+        return new MapsforgeV6GeoItemLayer(mMapView);
     }
 
 


### PR DESCRIPTION
fix #16280: mapsforge, manually accomodate for rotation in coord projection