### PR TITLE
Preserve time-stamp of own log on refreshing the cache (fix #9653)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/log/LogEntryTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/log/LogEntryTest.java
@@ -222,6 +222,20 @@ public class LogEntryTest {
 
     }
 
+    @Test
+    public void testIsMatchingLog() {
+        final LogEntry logEntry = new LogEntry.Builder().setAuthor("testUser").setDate(178672529).setLogType(LogType.FOUND_IT).setLog("LOGENTRY").build();
+        final OfflineLogEntry offlineLogEntry = new OfflineLogEntry.Builder().setAuthor("testUser").setDate(178672000).setLogType(LogType.FOUND_IT).setLog("LOGENTRY").build();
+        final LogEntry logEntryEmpty = new LogEntry.Builder().setAuthor("testUser").setDate(178672000).setLogType(LogType.FOUND_IT).setLog("").build();
+        final LogEntry logEntryUser = new LogEntry.Builder().setAuthor("testUserDifferent").setDate(178672529).setLogType(LogType.FOUND_IT).setLog("LOGENTRY").build();
+        final LogEntry logEntryDate = new LogEntry.Builder().setAuthor("testUser").setDate(718867252).setLogType(LogType.FOUND_IT).setLog("LOGENTRY").build();
+
+        assertThat(logEntry.isMatchingLog(offlineLogEntry)).isTrue();
+        assertThat(logEntry.isMatchingLog(logEntryUser)).isFalse();
+        assertThat(logEntry.isMatchingLog(logEntryDate)).isFalse();
+        assertThat(logEntry.isMatchingLog(logEntryEmpty)).isTrue();
+    }
+
     public static byte[] marshall(final Parcelable parceable) {
         final Parcel parcel = Parcel.obtain();
         parceable.writeToParcel(parcel, 0);

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1720,12 +1720,13 @@ public final class GCParser {
      */
     private static void mergeFriendsLogs(final List<LogEntry> mergedLogs, final Iterable<LogEntry> logsToMerge) {
         for (final LogEntry log : logsToMerge) {
-            if (mergedLogs.contains(log)) {
-                final LogEntry friendLog = mergedLogs.get(mergedLogs.indexOf(log));
-                final LogEntry updatedFriendLog = friendLog.buildUpon().setFriend(true).build();
-                mergedLogs.set(mergedLogs.indexOf(log), updatedFriendLog);
-            } else {
+            final int logIndex = mergedLogs.indexOf(log);
+            if (logIndex < 0) {
                 mergedLogs.add(log);
+            } else {
+                final LogEntry friendLog = mergedLogs.get(logIndex);
+                final LogEntry updatedFriendLog = friendLog.buildUpon().setFriend(true).build();
+                mergedLogs.set(logIndex, updatedFriendLog);
             }
         }
     }
@@ -1736,15 +1737,15 @@ public final class GCParser {
             logTimesToMergeMap.put(logToMerge.serviceLogId, logToMerge);
         }
 
-        for (final LogEntry mergedLog : mergedLogTimes) {
+        for (int i = 0; i < mergedLogTimes.size(); i++) {
+            final LogEntry mergedLog = mergedLogTimes.get(i);
             final LogEntry logToMerge = logTimesToMergeMap.get(mergedLog.serviceLogId);
             if (logToMerge != null) {
                 final Date dateTimeLogTime = new Date(mergedLog.date);
                 final Date logTime = new Date(logToMerge.date);
                 if (!logTime.equals(dateTimeLogTime) && DateUtils.isSameDay(dateTimeLogTime, logTime)) {
                     final LogEntry updatedTimeLog = mergedLog.buildUpon().setDate(logToMerge.date).build();
-                    final int logIndex = mergedLogTimes.indexOf(mergedLog);
-                    mergedLogTimes.set(logIndex, updatedTimeLog);
+                    mergedLogTimes.set(i, updatedTimeLog);
                 }
             }
         }
@@ -1755,12 +1756,11 @@ public final class GCParser {
             return;
         }
 
-        // TODO iterate via index to avoid indexOf
-        for (final LogEntry mergedLog : mergedLogTimes) {
+        for (int i = 0; i < mergedLogTimes.size(); i++) {
+            final LogEntry mergedLog = mergedLogTimes.get(i);
             if (logToMerge.isMatchingLog(mergedLog)) {
                 final LogEntry updatedTimeLog = mergedLog.buildUpon().setDate(logToMerge.date).build();
-                final int logIndex = mergedLogTimes.indexOf(mergedLog);
-                mergedLogTimes.set(logIndex, updatedTimeLog);
+                mergedLogTimes.set(i, updatedTimeLog);
 
                 break;
             }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1725,8 +1725,10 @@ public final class GCParser {
                 mergedLogs.add(log);
             } else {
                 final LogEntry friendLog = mergedLogs.get(logIndex);
-                final LogEntry updatedFriendLog = friendLog.buildUpon().setFriend(true).build();
-                mergedLogs.set(logIndex, updatedFriendLog);
+                if (!friendLog.friend) {
+                    final LogEntry updatedFriendLog = friendLog.buildUpon().setFriend(true).build();
+                    mergedLogs.set(logIndex, updatedFriendLog);
+                }
             }
         }
     }

--- a/main/src/main/java/cgeo/geocaching/log/LogEntry.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogEntry.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.utils.CommonUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.MatcherWrapper;
+import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.html.HtmlUtils;
 
 import android.os.Parcel;
@@ -26,6 +27,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.time.DateUtils;
 
 /**
  * Entry in a log book.
@@ -57,7 +59,7 @@ public class LogEntry implements Parcelable {
     /** The log message */
     @NonNull public final String log;
     /** The log date */
-    public final long date;
+    public long date;
     /** Is a found log */
     public final int found;
     /** Own's or Friend's log entry indicator. */
@@ -76,6 +78,10 @@ public class LogEntry implements Parcelable {
     @NonNull
     public Date getDate() {
         return new Date(date);
+    }
+
+    public void setDate(final long date) {
+        this.date = date;
     }
 
     @NonNull
@@ -511,5 +517,16 @@ public class LogEntry implements Parcelable {
      */
     public boolean isOwn() {
         return author.equalsIgnoreCase(Settings.getUserName());
+    }
+
+    /**
+     * Checks, if the logs are representing the same log-entry.
+     * Log-text can be empty (to deal with field-notes)
+     */
+    public boolean isMatchingLog(final LogEntry log) {
+        return this.logType == log.logType &&
+                this.author.compareTo(log.author) == 0 &&
+                DateUtils.isSameDay(new Date(this.date), new Date(log.date)) &&
+                (this.log.isEmpty() || log.log.isEmpty() || TextUtils.isEqualStripHtmlIgnoreSpaces(this.log, log.log));
     }
 }

--- a/main/src/main/java/cgeo/geocaching/log/LogEntry.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogEntry.java
@@ -59,7 +59,7 @@ public class LogEntry implements Parcelable {
     /** The log message */
     @NonNull public final String log;
     /** The log date */
-    public long date;
+    public final long date;
     /** Is a found log */
     public final int found;
     /** Own's or Friend's log entry indicator. */
@@ -78,10 +78,6 @@ public class LogEntry implements Parcelable {
     @NonNull
     public Date getDate() {
         return new Date(date);
-    }
-
-    public void setDate(final long date) {
-        this.date = date;
     }
 
     @NonNull

--- a/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/TextUtils.java
@@ -519,6 +519,24 @@ public final class TextUtils {
         return PATTERN_REMOVE_SPECIAL.matcher(value.toLowerCase(Locale.US)).replaceAll("");
     }
 
+
+    public static boolean isEqualStripHtmlIgnoreSpaces(final @Nullable String s1, final String s2) {
+        if (Objects.equals(s1, s2)) {
+            return true;
+        }
+        if (s1 == null || s2 == null) {
+            return false;
+        }
+
+        final String s1Stripped = TextUtils.stripHtml(s1);
+        final String s2Stripped = TextUtils.stripHtml(s2);
+        if (s1Stripped == null || s2Stripped == null) {
+            return false;
+        }
+
+        return StringUtils.compare(TextUtils.replaceWhitespace(s1Stripped), TextUtils.replaceWhitespace(s2Stripped)) == 0;
+    }
+
     public static <E extends Enum<E>> E getEnumIgnoreCaseAndSpecialChars(final Class<E> enumClass, final String enumName, final E defaultEnum) {
         if (enumName == null || !enumClass.isEnum()) {
             return defaultEnum;

--- a/main/src/test/java/cgeo/geocaching/utils/TextUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/TextUtilsTest.java
@@ -270,6 +270,12 @@ public class TextUtilsTest {
     }
 
     @Test
+    public void isEqualStripHtmlIgnoreSpaces() {
+        assertThat(TextUtils.isEqualStripHtmlIgnoreSpaces("This is a test \n with linebreak", "This is a test <br> with linebreak")).isTrue();
+        assertThat(TextUtils.isEqualStripHtmlIgnoreSpaces("<p>This is a test with html", "This is a test with html")).isTrue();
+    }
+
+    @Test
     public void pattern() {
         final String text = "abc\"logTypes\":[{\"value\":2},{\"value\":3},{\"value\":4},{\"value\":45},{\"value\":7}]def";
         final Pattern p = Pattern.compile("\"logTypes\":\\[([^]]+)]");


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Keep time of time-stamp of stored own logs, if online log has same date.

Also for offline log, if the log-text is empty (to support keeping time-stamp for logging via field-notes)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #9653
fix #16898

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
