### PR TITLE
Fix short date formatting (fix #16925)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -274,7 +274,7 @@ public class Settings {
     }
 
     public static int getExpectedVersion() {
-        return 9;
+        return 10;
     }
 
     private static void migrateSettings() {
@@ -478,6 +478,19 @@ public class Settings {
 
             e.apply();
             setActualVersion(9);
+        }
+
+        if (currentVersion < 10) {
+            final Editor e = sharedPrefs.edit();
+
+            final String dateFormatString = getShortDateFormat();
+            if (!dateFormatString.isEmpty()) {
+                // fix short date formatting: "week date" => "date", see #16925
+                e.putString(getKey(R.string.pref_short_date_format), dateFormatString.replace("Y", "y"));
+            }
+
+            e.apply();
+            setActualVersion(10);
         }
     }
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -639,14 +639,14 @@
     <!-- appearance => short date format -->
     <string translatable="false" name="pref_short_date_format">short_date_format</string>
     <string translatable="false" name="pref_value_short_date_format_default" />
-    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYYYY">dd.MM.YYYY</string>
-    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYY">dd.MM.YY</string>
-    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYYYY">MM/dd/YYYY</string>
-    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYY">MM/dd/YY</string>
-    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYYYY">dd/MM/YYYY</string>
-    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYY">dd/MM/YY</string>
-    <string translatable="false" name="pref_value_short_date_format_YYYYdashMMdashDD">YYYY-MM-dd</string>
-    <string translatable="false" name="pref_value_short_date_format_YYdashMMdashDD">YY-MM-dd</string>
+    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYYYY">dd.MM.yyyy</string>
+    <string translatable="false" name="pref_value_short_date_format_DDdotMMdotYY">dd.MM.yy</string>
+    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYYYY">MM/dd/yyyy</string>
+    <string translatable="false" name="pref_value_short_date_format_MMslashDDslashYY">MM/dd/yy</string>
+    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYYYY">dd/MM/yyyy</string>
+    <string translatable="false" name="pref_value_short_date_format_DDslashMMslashYY">dd/MM/yy</string>
+    <string translatable="false" name="pref_value_short_date_format_YYYYdashMMdashDD">yyyy-MM-dd</string>
+    <string translatable="false" name="pref_value_short_date_format_YYdashMMdashDD">yy-MM-dd</string>
     <string-array name="pref_values_short_date_format">
         <item>@string/pref_value_short_date_format_default</item>
         <item>@string/pref_value_short_date_format_DDdotMMdotYYYY</item>


### PR DESCRIPTION
## Description
Date formatter "Y" uses "week years" in contrast to "y" using "years" (which is what we need here)
(https://docs.oracle.com/javase/8/docs/api/java/util/GregorianCalendar.html#week_year)

![image](https://github.com/user-attachments/assets/a9f29d09-7fd2-4df4-bee2-68fc78270bfd)
