### PR TITLE
Fix #16625: Move upload entries and update labels

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -616,9 +616,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
             MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_bookmarklist, isGcPremiumMember, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_upload_bookmarklist, R.string.caches_upload_bookmarklist_selected, R.string.caches_upload_bookmarklist_all, checkedCount);
-            MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_modifiedcoords, isGcConnectorActive, !isEmpty);
-            MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_allcoords, isGcConnectorActive, !isEmpty);
-            setMenuItemLabel(menu, R.id.menu_upload_allcoords, R.string.caches_upload_allcoords, R.string.caches_upload_allcoords, checkedCount);
             MenuUtils.setEnabled(menu, R.id.menu_show_attributes, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_show_attributes, R.string.caches_show_attributes_selected, R.string.caches_show_attributes_all, checkedCount);
             MenuUtils.setEnabled(menu, R.id.menu_set_cache_icon, !isEmpty);
@@ -645,6 +642,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             setMenuItemLabel(menu, R.id.menu_export_gpx, R.string.export_gpx, R.string.export_gpx, checkedCount);
             setMenuItemLabel(menu, R.id.menu_export_fieldnotes, R.string.export_fieldnotes, R.string.export_fieldnotes, checkedCount);
             setMenuItemLabel(menu, R.id.menu_export_persnotes, R.string.export_persnotes, R.string.export_persnotes, checkedCount);
+            MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_modifiedcoords, isGcConnectorActive, !isEmpty);
+            MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_allcoords, isGcConnectorActive, !isEmpty);
+            setMenuItemLabel(menu, R.id.menu_upload_allcoords, R.string.caches_upload_allcoords, R.string.caches_upload_allcoords, checkedCount);
 
         } catch (final RuntimeException e) {
             Log.e("CacheListActivity.onPrepareOptionsMenu", e);

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -90,14 +90,6 @@
                 android:title="@string/caches_upload_bookmarklist_all"
                 app:showAsAction="ifRoom|withText"/>
             <item
-                android:id="@+id/menu_upload_modifiedcoords"
-                android:title="@string/caches_upload_modifiedcoords"
-                app:showAsAction="ifRoom|withText"/>
-            <item
-                android:id="@+id/menu_upload_allcoords"
-                android:title="@string/caches_upload_allcoords"
-                app:showAsAction="ifRoom|withText"/>
-            <item
                 android:id="@+id/menu_clear_offline_logs"
                 android:title="@string/caches_clear_offlinelogs"
                 android:enabled="true"
@@ -198,6 +190,16 @@
                 android:id="@+id/menu_export_persnotes"
                 android:title="@string/export_persnotes"
                 android:icon="@drawable/ic_menu_note"/>
+            <item
+                android:id="@+id/menu_upload_modifiedcoords"
+                android:icon="@drawable/ic_menu_upload"
+                android:title="@string/caches_upload_modifiedcoords"
+                app:showAsAction="ifRoom|withText" />
+            <item
+                android:id="@+id/menu_upload_allcoords"
+                android:icon="@drawable/ic_menu_upload"
+                android:title="@string/caches_upload_allcoords"
+                app:showAsAction="ifRoom|withText" />
         </menu>
     </item>
     <item

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2198,11 +2198,11 @@
 
     <!-- export -->
     <string name="share_export">Share / Export</string>
-    <string name="export">Export</string>
+    <string name="export">Export / Upload</string>
     <string name="export_progress">Export: %1$s</string>
     <string name="export_exportedto">exported to</string>
     <string name="export_failed">Export failed</string>
-    <string name="export_fieldnotes">Field Notes</string>
+    <string name="export_fieldnotes">Export field notes</string>
     <string name="export_fieldnotes_info">Field Notes will be exported to /sdcard/field-notes with the current date and time as their file name.</string>
     <string name="export_fieldnotes_upload">Upload to geocaching.com</string>
     <string name="export_fieldnotes_uploading">Uploading…</string>
@@ -2212,7 +2212,7 @@
     <string name="export_gpx_info">The GPX file will be exported to %1$s with the current date and time as its file name.</string>
     <string name="export_confirm_title">Exporting %1$s</string>
     <string name="export_confirm_message">To Path: %1$s\nFile Name: %2$s</string>
-    <string name="export_persnotes">Personal notes</string>
+    <string name="export_persnotes">Upload personal notes</string>
     <string name="export_persnotes_uploading">Uploading personal note %1$d</string>
     <plurals name="export_persnotes_upload_success">
         <item quantity="zero">Uploaded %1$d notes successfully</item>

--- a/main/src/main/res/values/strings_not_translatable.xml
+++ b/main/src/main/res/values/strings_not_translatable.xml
@@ -50,7 +50,7 @@
     <string translatable="false"  name="persistablefolder_wherigo">Wherigo</string>
 
     <!-- export -->
-    <string translatable="false" name="export_gpx">GPX</string>
+    <string translatable="false" name="export_gpx">Export GPX</string>
 
     <!-- map sources -->
     <string translatable="false" name="map_source_osm_mapnik">OpenStreetMap.org</string>


### PR DESCRIPTION
## Description
- Fixes a UI inconsistency by moving "Upload modified coordinates" and "Upload coordinates for all caches" into the "Export" submenu.
- Renames the submenu to "Export / Upload" to better reflect its contents.
- Updates string labels of existing export actions to begin with "Export" for clarity and consistency.
- Adds icons to the new upload entries to match the visual style of other items.

## Related issues
Fixes #16625

## Additional context
![image](https://github.com/user-attachments/assets/8a3a4bc3-f63d-4523-b5e0-23494bfd8fc7)
![image](https://github.com/user-attachments/assets/5ae12b22-24d9-43f0-9747-81e8bc5b9565)
