### PR TITLE
set lint check UnsafeImplicitIntentLaunch to default

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -203,9 +203,6 @@ android {
         // necessary as we changing locales at runtime (CgeoApplication.initApplicationLocale())
         disable 'AppBundleLocaleChanges'
 
-        // move UnsafeImplicitIntentLaunch error to warning until fixed, see https://github.com/cgeo/cgeo/issues/16838
-        warning 'UnsafeImplicitIntentLaunch'
-
         // analyze all dependency modules in parallel and produce a single report
         // including issues from the app and all of its dependencies
         checkDependencies true


### PR DESCRIPTION
Remove the rule to set the type as warning. Now it is back to error. With PR #16904 the lint error was fixed.
