### PR TITLE
add swiperefreshlayout

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -488,11 +488,14 @@ dependencies {
     // Support Library constraintlayout
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    // Support Library ExifInterface
-    implementation 'androidx.exifinterface:exifinterface:1.4.0'
-
     // Support Library GridLayout used by the coordinate calculator
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
+
+    // Support Library swiperefreshlayout
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+
+    // Support Library ExifInterface
+    implementation 'androidx.exifinterface:exifinterface:1.4.0'
 
     // Support Library RecyclerView
     implementation 'androidx.recyclerview:recyclerview:1.3.2'


### PR DESCRIPTION
After updating `gridlayout` (https://github.com/cgeo/cgeo/pull/16834), the statement
` import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;` is not more valid. ("error: package androidx.swiperefreshlayout.widget does not exist" in lint check)

see https://ci.cgeo.org/job/cgeo-CI_PR-build/12029/console
