### PR TITLE
don't show NA/NM logtypes for own caches (fixes #16969)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/main/java/cgeo/geocaching/log/LoggingUI.java
@@ -89,7 +89,7 @@ public final class LoggingUI extends AbstractUIFactory {
 
         final List<LogType> logTypes = cache.getPossibleLogTypes();
         // manually add NM/NA log types for GC connector, as those are no longer part of default log types, but need to be selectable for quick offline log
-        if (GCConnector.getInstance().canHandle(cache.getGeocode())) {
+        if (GCConnector.getInstance().canHandle(cache.getGeocode()) && !cache.isOwner()) {
             logTypes.add(LogType.NEEDS_MAINTENANCE);
             logTypes.add(LogType.NEEDS_ARCHIVE);
         }


### PR DESCRIPTION
fixes #16969 by showing NA/NM logtypes only for caches from GC + not owned