### PR TITLE
long-tap on search suggestion to prefill it as search term

### DIFF
--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -333,6 +333,12 @@ public class SearchActivity extends AbstractNavigationBarActivity implements Coo
                 final String searchTerm = (String) parent.getItemAtPosition(position);
                 searchFunction.accept(searchTerm);
             });
+            binding.suggestionList.setOnItemLongClickListener((parent, view, position, id) -> {
+                final String searchTerm = (String) parent.getItemAtPosition(position);
+                searchView.setText(searchTerm);
+                searchView.setSelection(searchView.getText().length());
+                return true;
+            });
 
             if (title == R.string.search_geo) {
                 searchView.setText("GC");


### PR DESCRIPTION
adds a long-tap action on any item in search suggestions/history to use its text as search term
fixes #16970