### PR TITLE
Fix track detection for tracks/route menu

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -435,6 +435,6 @@ public class RouteTrackUtils {
     }
 
     public static boolean isIndividualRoute(final IGeoItemSupplier route) {
-        return (route instanceof Route && ((Route) route).getName().isEmpty());
+        return route instanceof IndividualRoute;
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an error reported by a user on support (477952).

The user has loaded some tracks on the map. Opening the track/routes bottom sheet listed the tracks, but with the wrong action buttons. Being shown were the action buttons for an individual route, not for a track, and tapping on one of the buttons did not work. - This was caused by wrongly detecting tracks as individual routes.