### PR TITLE
Fix lint: Add missing calls to super.onBackPressed() (fix #16978)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
@@ -316,7 +316,9 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
 
     @Override
     public void onBackPressed() {
+        // @todo should be replaced by setting a OnBackPressedDispatcher
         finishConfirmDiscard();
+        super.onBackPressed();
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -368,6 +368,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     @Override
     public void onBackPressed() {
+        // @todo should be replaced by setting a OnBackPressedDispatcher
         final GeocacheFilter newFilter = getFilterFromView();
         final boolean filterWasChanged = !originalFilterConfig.equals(newFilter.toConfig());
         if (filterWasChanged) {
@@ -375,6 +376,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         } else {
             finish();
         }
+        super.onBackPressed();
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/maps/routing/RouteSortActivity.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/RouteSortActivity.java
@@ -214,10 +214,12 @@ public class RouteSortActivity extends AbstractActionBarActivity {
 
     @Override
     public void onBackPressed() {
+        // @todo should be replaced by setting a OnBackPressedDispatcher
         if (!originalRouteItems.equals(routeItemAdapter.getItems())) {
             SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes).confirm(this::finish);
         } else {
             finish();
         }
+        super.onBackPressed();
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/CheckableItemSelectActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CheckableItemSelectActivity.java
@@ -135,6 +135,7 @@ public class CheckableItemSelectActivity extends AbstractActionBarActivity {
 
     @Override
     public void onBackPressed() {
+        // @todo should be replaced by setting a OnBackPressedDispatcher
         final ArrayList<Integer> selected = new ArrayList<>();
         for (InfoItem item : infoItemListAdapter.getItems()) {
             if (item == null) {
@@ -144,5 +145,6 @@ public class CheckableItemSelectActivity extends AbstractActionBarActivity {
         }
         Settings.setInfoItems(prefKey, selected);
         finish();
+        super.onBackPressed();
     }
 }


### PR DESCRIPTION
## Description
Adds the missing super calls as a quick mitigation for the lint errors to unblock upgrading other libs.

As using `onBackPressed` is deprecated meanwhile, we should switch to setting an `OnBackPressedDispatcher` in the long run.