### PR TITLE
#16882: Add snackbar for log visit with share option

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -199,6 +199,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
     private static final int MESSAGE_FAILED = -1;
     private static final int MESSAGE_SUCCEEDED = 1;
+    private static final int REQUEST_CODE_LOG = 1001;
 
     private static final String EXTRA_FORCE_WAYPOINTSPAGE = "cgeo.geocaching.extra.cachedetail.forceWaypointsPage";
     private static final String EXTRA_EDIT_PERSONALNOTE = "cgeo.geocaching.extra.cachedetail.editPersonalNote";
@@ -2485,6 +2486,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             imageGalleryResultRequestCode = requestCode;
             imageGalleryResultResultCode = resultCode;
             imageGalleryData = data;
+        }
+        if (requestCode == REQUEST_CODE_LOG && resultCode == Activity.RESULT_OK && data != null) {
+            ShareUtils.showLogPostedSnackbar(this, data, findViewById(R.id.tab_layout));
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -89,6 +89,7 @@ import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.MenuUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.annotation.SuppressLint;
@@ -144,6 +145,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     private static final int REFRESH_WARNING_THRESHOLD = 100;
 
+    private static final int REQUEST_CODE_LOG = 1001;
     private static final int REQUEST_CODE_IMPORT_PQ = 10003;
     private static final int REQUEST_CODE_IMPORT_BOOKMARK = 10004;
 
@@ -1241,6 +1243,11 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             }
         } else if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             setAndRefreshFilterForOnlineSearch(data.getParcelableExtra(GeocacheFilterActivity.EXTRA_FILTER_CONTEXT));
+        } else if (requestCode == REQUEST_CODE_LOG && resultCode == Activity.RESULT_OK && data != null) {
+            final View navBar = findViewById(R.id.activity_navigationBar);
+            final boolean isNavBarVisible = navBar != null && navBar.getVisibility() == View.VISIBLE && navBar.getHeight() > 0;
+
+            ShareUtils.showLogPostedSnackbar(this, data, isNavBarVisible ? navBar : null);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/CompassActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CompassActivity.java
@@ -26,8 +26,10 @@ import cgeo.geocaching.ui.WaypointSelectionActionProvider;
 import cgeo.geocaching.utils.AngleUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.Log;
+import cgeo.geocaching.utils.ShareUtils;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -43,6 +45,7 @@ import androidx.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Locale;
+
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.functions.Consumer;
@@ -66,6 +69,8 @@ public class CompassActivity extends AbstractActionBarActivity {
     private CompassActivityBinding binding;
 
     private final PermissionAction<Void> askLocationPermissionAction = PermissionAction.register(this, PermissionContext.LOCATION, b -> binding.hint.locationStatus.updatePermissions());
+
+    private static final int REQUEST_CODE_LOG = 1001;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -254,6 +259,17 @@ public class CompassActivity extends AbstractActionBarActivity {
         }
         return true;
     }
+
+    @Override
+    protected void onActivityResult(final int requestCode, final int resultCode, @Nullable final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == REQUEST_CODE_LOG && resultCode == Activity.RESULT_OK && data != null) {
+            ShareUtils.showLogPostedSnackbar(this, data, findViewById(R.id.location_status));
+        }
+    }
+
+
 
     private void setTarget(@NonNull final Geopoint coords, final String newDescription) {
         setDestCoords(coords);

--- a/main/src/main/java/cgeo/geocaching/log/LoggingUI.java
+++ b/main/src/main/java/cgeo/geocaching/log/LoggingUI.java
@@ -22,6 +22,7 @@ import java.util.Calendar;
 import java.util.List;
 
 public final class LoggingUI extends AbstractUIFactory {
+    public static final int REQUEST_CODE_LOG = 1001;
 
     private LoggingUI() {
         // utility class
@@ -74,7 +75,7 @@ public final class LoggingUI extends AbstractUIFactory {
     public static boolean onMenuItemSelected(final MenuItem item, final Activity activity, final Geocache cache, final DialogInterface.OnDismissListener listener) {
         final int itemId = item.getItemId();
         if (itemId == R.id.menu_log_visit) {
-            cache.logVisit(activity);
+            cache.logVisitForResult(activity, REQUEST_CODE_LOG);
         } else if (itemId == R.id.menu_log_visit_offline) {
             showOfflineMenu(cache, activity, listener);
         } else {

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -563,6 +563,19 @@ public class Geocache implements INamedGeoCoordinate {
         LogCacheActivity.startForCreate(fromActivity, geocode);
     }
 
+    public void logVisitForResult(@NonNull final Activity fromActivity, final int requestCode) {
+        if (!getConnector().canLog(this)) {
+            ActivityMixin.showToast(fromActivity, fromActivity.getString(R.string.err_cannot_log_visit));
+            return;
+        }
+        String geocode = this.geocode;
+        if (StringUtils.isBlank(geocode)) {
+            geocode = DataStore.getGeocodeForGuid(this.cacheId);
+        }
+        LogCacheActivity.startForCreateForResult(fromActivity, geocode, requestCode);
+    }
+
+
     public boolean hasLogOffline() {
         return BooleanUtils.isTrue(hasLogOffline);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -74,6 +74,7 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.MenuUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.utils.functions.Func1;
 import cgeo.geocaching.wherigo.WherigoGame;
@@ -141,6 +142,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     private static final String STATE_ROUTETRACKUTILS = "routetrackutils";
     private static final String ROUTING_SERVICE_KEY = "UnifiedMap";
+    private static final int REQUEST_CODE_LOG = 1001;
 
     private UnifiedMapViewModel viewModel = null;
     private AbstractTileProvider tileProvider = null;
@@ -1056,6 +1058,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
             viewModel.mapType.filterContext = data.getParcelableExtra(EXTRA_FILTER_CONTEXT);
             refreshMapData(true);
+        } else if (requestCode == REQUEST_CODE_LOG && resultCode == Activity.RESULT_OK && data != null) {
+            ShareUtils.showLogPostedSnackbar(this, data, findViewById(R.id.activity_navigationBar));
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/ShareUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ShareUtils.java
@@ -22,6 +22,7 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Parcelable;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -33,6 +34,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.android.material.snackbar.Snackbar;
 import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -263,5 +265,23 @@ public class ShareUtils {
         // custom tabs API was restricted to chrome as other browsers like firefox may loop back to c:geo (as of September 2020)
         customTabsIntent.intent.setPackage(CHROME_PACKAGE_NAME);
         customTabsIntent.launchUrl(context, Uri.parse(url));
+    }
+
+    public static void showLogPostedSnackbar(@NonNull final Activity activity, @Nullable final Intent data, final View anchor) {
+        if (data == null) {
+            return;
+        }
+        final String shareText = data.getStringExtra("EXTRA_SHARE_TEXT");
+        if (!StringUtils.isBlank(shareText)) {
+            Snackbar.make(activity.findViewById(android.R.id.content), activity.getString(R.string.info_log_posted), Snackbar.LENGTH_LONG)
+                    .setAnchorView(anchor)
+                    .setAction(R.string.snackbar_action_share, v -> {
+                        final Intent shareIntent = new Intent(Intent.ACTION_SEND);
+                        shareIntent.setType("text/plain");
+                        shareIntent.putExtra(Intent.EXTRA_TEXT, shareText);
+                        activity.startActivity(Intent.createChooser(shareIntent, null));
+                    })
+                    .show();
+        }
     }
 }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -232,6 +232,13 @@
     <string name="log_delete_confirm">Do you really want to delete log of type \'%1$s\' by author \'%2$s\' with log date \'%3$s\'?</string>
     <string name="log_offline_delete_confirm">Do you really want to delete your stored offline log of type \'%1$s\' with log date \'%2$s\'?</string>
 
+    <string name="log_share_prefix_found">I found %1$s (%2$s):\n\n</string>
+    <string name="log_share_prefix_dnf">I couldn\'t find %1$s (%2$s):\n\n</string>
+    <string name="log_share_prefix_note">I left a note on %1$s (%2$s):\n\n</string>
+    <string name="log_share_prefix_maintenance">I reported maintenance needed for %1$s (%2$s):\n\n</string>
+    <string name="log_share_prefix_archive">I think %1$s (%2$s) should be archived:\n\n</string>
+    <string name="log_share_prefix_default">My log for %1$s (%2$s):\n\n</string>
+
     <string name="datetime_nodateset_display">No date set</string>
 
     <!-- Contacts -->
@@ -355,6 +362,7 @@
     <string name="dont_show_again">Don\'t show again</string>
     <string name="tap_icon_more_info">Tap on icon for more info</string>
     <string name="use_slider_adjust_value">Use slider to adjust value</string>
+    <string name="snackbar_action_share">Share</string>
 
     <string name="warn_gm_not_available">Google Maps not available.</string>
     <string name="switch_to_mf">Your Google Play Service is outdated. Do you want to switch to Mapsforge map provider instead?</string>


### PR DESCRIPTION
## Description
- Add share intent in `LogCacheActivity`.
- Add `startForCreateForResult()` in `LogCacheActivity` to support request code.
- The share text prefix changes based on the log type (e.g., `FOUND_IT`, `DIDNT_FIND_IT`, `NOTE`, `NEEDS_MAINTENANCE`, and `NEEDS_ARCHIVE`) to provide more meaningful context for social media sharing.
- Add snackbar confirmation in `CacheDetailActivity`, `CacheListActivity`, `CompassActivity`, and `UnifiedMapActivity` after the user posts a log.
- Add `logVisitForResult()` in `Geocache` to launch the log activity with a result callback.
- Update `LoggingUI` to use `logVisitForResult()`.

From `CacheListActivity`:
![Screenshot_20250526_003455_cgeo](https://github.com/user-attachments/assets/e78ac14e-f43a-4364-9132-78df6ba169e7)

From `CacheDetailActivity`:
![Screenshot_20250526_002031_cgeo](https://github.com/user-attachments/assets/3b37ec83-56bf-4f5c-a673-86517d3148de)

From `CompassActivity`:
![Screenshot_20250526_003336_cgeo](https://github.com/user-attachments/assets/4f13eea6-3d57-4aa0-b053-c3b568aa0077)

From `UnifiedMapActivity`:
![Screenshot_20250526_003111_cgeo (1)](https://github.com/user-attachments/assets/58a64aaa-6445-4558-8a25-bc8366e5a955)

Sharesheet:
![Screenshot_20250526_002706_IntentResolver (4)](https://github.com/user-attachments/assets/25095467-44ec-4726-9b19-53e90cd4facf)

## Related issues
#16882 