### PR TITLE
Add long-tap action to cache infosheet (fix #17003)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
@@ -136,6 +136,7 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
         }
 
         details.addBetterCacher(cache);
+        details.addCoordinates(cache.getCoords());
 
         // Latest logs
         details.addLatestLogs(cache);

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -72,7 +72,6 @@ import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.AnchorAwareLinkMovementMethod;
 import cgeo.geocaching.ui.CacheDetailsCreator;
-import cgeo.geocaching.ui.CoordinatesFormatSwitcher;
 import cgeo.geocaching.ui.DecryptTextClickListener;
 import cgeo.geocaching.ui.FastScrollListener;
 import cgeo.geocaching.ui.ImageGalleryView;
@@ -1262,7 +1261,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             // cache name (full name), may be editable
             // Not using colored cache names at this place to have at least one place without any formatting to support visually impaired users
             final TextView cachename = details.add(R.string.cache_name, cache.getName()).valueView;
-            activity.addShareAction(cachename);
+            details.addShareAction(cachename);
             if (cache.supportsNamechange()) {
                 cachename.setOnClickListener(v -> Dialogs.input(activity, activity.getString(R.string.cache_name_set), cache.getName(), activity.getString(R.string.caches_sort_name), name -> {
                     cachename.setText(name);
@@ -1277,7 +1276,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 details.addAlcMode(cache);
             }
             details.addSize(cache);
-            activity.addShareAction(details.add(R.string.cache_geocode, cache.getShortGeocode()).valueView);
+            details.addShareAction(details.add(R.string.cache_geocode, cache.getShortGeocode()).valueView);
             details.addCacheState(cache);
 
             activity.cacheDistanceView = details.addDistance(cache, activity.cacheDistanceView);
@@ -1310,7 +1309,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             // hidden or event date
             final TextView hiddenView = details.addHiddenDate(cache);
             if (hiddenView != null) {
-                activity.addShareAction(hiddenView);
+                details.addShareAction(hiddenView);
                 if (cache.isEventCache()) {
                     hiddenView.setOnClickListener(v -> CalendarUtils.openCalendar(activity, cache.getHiddenDate()));
                 }
@@ -1322,11 +1321,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             }
 
             // cache coordinates
-            if (cache.getCoords() != null) {
-                final TextView valueView = details.add(R.string.cache_coordinates, cache.getCoords().toString()).valueView;
-                new CoordinatesFormatSwitcher().setView(valueView).setCoordinate(cache.getCoords());
-                activity.addShareAction(valueView, s -> GeopointFormatter.reformatForClipboard(s).toString());
-            }
+            details.addCoordinates(cache.getCoords());
 
             // Latest logs
             details.addLatestLogs(cache);
@@ -1781,7 +1776,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             // cache personal note
             setPersonalNote(binding.personalnote, binding.personalnoteButtonSeparator, cache.getPersonalNote());
             binding.personalnote.setMovementMethod(AnchorAwareLinkMovementMethod.getInstance());
-            activity.addShareAction(binding.personalnote);
+            CacheDetailsCreator.addShareAction(activity, binding.personalnote);
             TooltipCompat.setTooltipText(binding.editPersonalnote, getString(R.string.cache_personal_note_edit));
             binding.editPersonalnote.setOnClickListener(v -> editPersonalNote(cache, activity));
             binding.personalnote.setOnClickListener(v -> editPersonalNote(cache, activity));
@@ -2303,7 +2298,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
             // coordinates
             holder.setCoordinate(coordinates);
-            activity.addShareAction(coordinatesView, s -> GeopointFormatter.reformatForClipboard(s).toString());
+            CacheDetailsCreator.addShareAction(activity, coordinatesView, s -> GeopointFormatter.reformatForClipboard(s).toString());
             coordinatesView.setVisibility(null != coordinates ? View.VISIBLE : View.GONE);
             calculatedCoordinatesView.setVisibility(null != calcStateJson ? View.VISIBLE : View.GONE);
             final CalculatedCoordinate cc = CalculatedCoordinate.createFromConfig(calcStateJson);
@@ -2492,17 +2487,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     public void onActivityReenter(final int resultCode, final Intent data) {
         super.onActivityReenter(resultCode, data);
         this.imageGalleryPos = ImageGalleryView.onActivityReenter(this, this.imageGallery, data);
-    }
-
-    public void addShareAction(final TextView view) {
-        addShareAction(view, s -> s);
-    }
-
-    public void addShareAction(final TextView view, final androidx.arch.core.util.Function<String, String> formatter) {
-        view.setOnLongClickListener(v -> {
-            ShareUtils.sharePlainText(this, formatter.apply(view.getText().toString()));
-            return true;
-        });
     }
 
     public static void startActivityGuid(final Context context, final String guid, final String cacheName) {

--- a/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/CachePopupFragment.java
@@ -23,6 +23,7 @@ import cgeo.geocaching.utils.DisposableHandler;
 import cgeo.geocaching.utils.EmojiUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.TextUtils;
 import cgeo.geocaching.wherigo.WherigoActivity;
 import cgeo.geocaching.wherigo.WherigoUtils;
@@ -67,7 +68,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
 
         return f;
     }
- 
+
     private static class StoreCacheHandler extends DisposableHandler {
         private final int progressMessage;
         private final WeakReference<CachePopupFragment> popupRef;
@@ -136,22 +137,25 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
             toolbar.setTitle(geocode);
             toolbar.setLogo(MapMarkerUtils.getCacheMarker(getResources(), cache, CacheListType.MAP, Settings.getIconScaleEverywhere()).getDrawable());
             toolbar.setLongClickable(true);
-            toolbar.setOnLongClickListener(v -> {
+            toolbar.setOnClickListener(v -> {
                 if (cache.isOffline()) {
                     EmojiUtils.selectEmojiPopup(CachePopupFragment.this.requireContext(), cache.getAssignedEmoji(), cache, newCacheIcon -> {
                         cache.setAssignedEmoji(newCacheIcon);
                         toolbar.setLogo(MapMarkerUtils.getCacheMarker(getResources(), cache, CacheListType.MAP, Settings.getIconScaleEverywhere()).getDrawable());
                         DataStore.saveCache(cache, LoadFlags.SAVE_ALL);
                     });
-                    return true;
                 }
-                return false;
+            });
+            toolbar.setOnLongClickListener(v -> {
+                ShareUtils.sharePlainText(v.getContext(), geocode);
+                return true;
             });
             onCreatePopupOptionsMenu(toolbar, this, cache);
             toolbar.setOnMenuItemClickListener(this::onPopupOptionsItemSelected);
 
-            binding.title.setText(TextUtils.coloredCacheText(getActivity(), cache, StringUtils.defaultIfBlank(cache.getName(), "")));
             details = new CacheDetailsCreator(requireActivity(), binding.detailsList);
+            binding.title.setText(TextUtils.coloredCacheText(getActivity(), cache, StringUtils.defaultIfBlank(cache.getName(), "")));
+            details.addShareAction(binding.title);
 
             addCacheDetails(false);
 
@@ -352,6 +356,7 @@ public class CachePopupFragment extends AbstractDialogFragmentWithProximityNotif
             } else {
                 offlineHintText.setVisibility(View.VISIBLE);
                 offlineHintSeparator.setVisibility(View.VISIBLE);
+                CacheDetailsCreator.addShareAction(offlineHintText.getContext(), offlineHintText);
             }
         }
     }

--- a/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
@@ -3,6 +3,8 @@ package cgeo.geocaching.ui;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.bettercacher.BetterCacherConnector;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.GeopointFormatter;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
@@ -35,6 +37,7 @@ import android.widget.TextView;
 import static android.view.View.GONE;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.text.HtmlCompat;
 
 import java.util.ArrayList;
@@ -336,6 +339,17 @@ public final class CacheDetailsCreator {
         return add(R.string.cache_distance, text).valueView;
     }
 
+    public TextView addCoordinates(@Nullable final Geopoint coords) {
+        if (coords == null) {
+            return null;
+        }
+        final TextView valueView = add(R.string.cache_coordinates, coords.toString()).valueView;
+        new CoordinatesFormatSwitcher().setView(valueView).setCoordinate(coords);
+        CacheDetailsCreator.addShareAction(activity, valueView, s -> GeopointFormatter.reformatForClipboard(s).toString());
+        return valueView;
+    }
+
+
     public void addEventDate(@NonNull final Geocache cache) {
         if (!cache.isEventCache()) {
             return;
@@ -375,4 +389,20 @@ public final class CacheDetailsCreator {
             markers.addView(logIcon);
         }
     }
+
+    public void addShareAction(final TextView view) {
+        addShareAction(activity, view, s -> s);
+    }
+
+    public static void addShareAction(final Context context, final TextView view) {
+        addShareAction(context, view, s -> s);
+    }
+
+    public static void addShareAction(final Context context, final TextView view, final androidx.arch.core.util.Function<String, String> formatter) {
+        view.setOnLongClickListener(v -> {
+            ShareUtils.sharePlainText(context, formatter.apply(view.getText().toString()));
+            return true;
+        });
+    }
+
 }


### PR DESCRIPTION
## Description
- Adds long-tap actions to cache infosheet: GC code, cache title, coordinates, personal note/hint
- Switches long-tap for emoji selector to short tap to resolve the collision
