### PR TITLE
Remember most recent search item verbatim for geocode and address

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -510,7 +510,7 @@ public class Settings {
         return sharedPrefs != null && sharedPrefs.contains(prefKey);
     }
 
-    private static String getStringDirect(final String prefKey, final String defaultValue) {
+    public static String getStringDirect(final String prefKey, final String defaultValue) {
         return sharedPrefs == null ? defaultValue : sharedPrefs.getString(prefKey, defaultValue);
     }
 
@@ -566,7 +566,7 @@ public class Settings {
         putStringDirect(getKey(prefKeyId), value);
     }
 
-    private static void putStringDirect(final String prefKey, final String value) {
+    public static void putStringDirect(final String prefKey, final String value) {
         if (sharedPrefs == null) {
             return;
         }

--- a/main/src/main/res/layout/cacheslist_item_select.xml
+++ b/main/src/main/res/layout/cacheslist_item_select.xml
@@ -13,7 +13,8 @@
         android:layout_height="wrap_content"
         android:minHeight="36dip"
         android:layout_centerVertical="true"
-        android:scaleType="fitStart"
+        android:scaleType="center"
+
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginLeft="5dp"

--- a/main/src/main/res/layout/search_activity.xml
+++ b/main/src/main/res/layout/search_activity.xml
@@ -24,6 +24,22 @@
         android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/mostRecent"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <include
+                android:layout_height="48dp"
+                android:layout_width="match_parent"
+                layout="@layout/cacheslist_item_select"
+                />
+
+            <View style="@style/separator_horizontal" />
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/clipboardGeocode"
             android:visibility="gone"
             android:layout_width="match_parent"

--- a/main/src/main/res/layout/search_suggestion.xml
+++ b/main/src/main/res/layout/search_suggestion.xml
@@ -8,7 +8,7 @@
 
     <ImageView
         android:id="@+id/icon"
-        android:layout_width="48dip"
+        android:layout_width="36dip"
         android:layout_height="wrap_content"
         android:layout_marginLeft="5dp"
         app:tint="@color/colorText"

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -653,6 +653,7 @@
     <string translatable="false" name="pref_search_history_finder">search_history_finder</string>
     <string translatable="false" name="pref_search_history_trackable">search_history_trackable</string>
     <string translatable="false" name="pref_search_history_address">search_history_address</string>
+    <string translatable="false" name="pref_search_history_geocode">search_history_geocode</string>
 
     <string translatable="false" name="pref_caches_history">caches_history</string>
     <string translatable="false" name="pref_phone_model_and_sdk">phone_model_and_sdk</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2106,6 +2106,7 @@
     <string name="search_filter">Filter</string>
     <string name="search_filter_info_message" formatted="false">**Search by filter** searches caches on all active online services (e.g. geocaching.com) using a provided filter. However, search capabilities of these services are usually more limited than filter capabilities of c:geo.\n\n- All services only support AND filters (no OR filters and no filter inversion).\n- The more basic filters like **cache type** or **cache size** are supported by all services. More complicated filters are often not supported or have some restrictions e.g. **favorites** or **hidden date**.\n- A detailed list on supported filters per service can be found [here](https://github.com/cgeo/cgeo/wiki/%22Search-by-Filter%22-support-by-c:geo-Connectors).\n\nFilters not supported by the online service will be applied by c:geo on the received results.</string>
     <string name="search_tb">Trackable</string>
+    <string name="most_recent">Most recent</string>
     <string name="search_destination">Open destination in c:geo</string>
     <string name="add_target_to">Add target to</string>
     <string name="search_address_started">Searching for places</string>


### PR DESCRIPTION
## Description
Remembers the last entered search string verbatim, for 
- geocode search (where strings currently only got stored on successful searches), and for
- address search (where only the resulting geocoded string got stored currently

Fixes #16970
