### PR TITLE
#431: Add CompassMiniView in cache detail view

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1055,6 +1055,10 @@ public class Settings {
         return getBoolean(R.string.pref_livelist, true);
     }
 
+    public static boolean useLiveCompassInNavigationAction() {
+        return getBoolean(R.string.pref_live_compass_in_navigation_action, false);
+    }
+
     public static boolean isTrackableAutoVisit() {
         return getBoolean(R.string.pref_trackautovisit, false);
     }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -47,6 +47,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             // cache details
             R.string.pref_friendlogswanted,
             R.string.pref_livelist,
+            R.string.pref_live_compass_in_navigation_action,
             R.string.pref_rot13_hint,
             // map sources
             R.string.pref_mapsource, R.string.pref_fakekey_info_offline_maps, R.string.pref_fakekey_start_downloader,

--- a/main/src/main/java/cgeo/geocaching/ui/CompassMiniView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CompassMiniView.java
@@ -88,7 +88,7 @@ public final class CompassMiniView extends View {
         targetCoords = point;
     }
 
-    void updateAzimuth(final float azimuth) {
+    public void updateAzimuth(final float azimuth) {
         this.azimuth = azimuth;
         updateDirection();
     }
@@ -98,7 +98,7 @@ public final class CompassMiniView extends View {
         updateDirection();
     }
 
-    void updateCurrentCoords(@NonNull final Geopoint currentCoords) {
+    public void updateCurrentCoords(@NonNull final Geopoint currentCoords) {
         if (targetCoords == null) {
             return;
         }

--- a/main/src/main/java/cgeo/geocaching/ui/NavigationActionProvider.java
+++ b/main/src/main/java/cgeo/geocaching/ui/NavigationActionProvider.java
@@ -1,7 +1,9 @@
 package cgeo.geocaching.ui;
 
+import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.INavigationSource;
+import cgeo.geocaching.settings.Settings;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -43,9 +45,14 @@ public class NavigationActionProvider extends ActionProvider {
         if (navigationSource != null) {
 
             final LayoutInflater layoutInflater = LayoutInflater.from(context);
-            view = layoutInflater.inflate(R.layout.navigation_action, null);
-
-            final View navItem = view.findViewById(R.id.default_navigation_action);
+            View navItem = null;
+            if (Settings.useLiveCompassInNavigationAction() && navigationSource instanceof CacheDetailActivity) {
+                view = layoutInflater.inflate(R.layout.compass_action_view, null);
+                navItem = view.findViewById(R.id.compass_action);
+            } else {
+                view = layoutInflater.inflate(R.layout.navigation_action, null);
+                navItem = view.findViewById(R.id.default_navigation_action);
+            }
 
             navItem.setOnClickListener(v -> navigationSource.startDefaultNavigation());
 

--- a/main/src/main/res/layout/compass_action_view.xml
+++ b/main/src/main/res/layout/compass_action_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:foreground="?attr/selectableItemBackgroundBorderless"
+    android:clickable="true"
+    android:focusable="true"
+    android:minWidth="48dp"
+    android:minHeight="48dp"
+    android:layout_gravity="center">
+
+    <cgeo.geocaching.ui.CompassMiniView
+        android:id="@+id/compass_action"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_gravity="center"/>
+
+</FrameLayout>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -197,6 +197,7 @@
     <string translatable="false" name="pref_personal_cache_note_merge_disable">personalCacheNoteMergeDisable</string>
     <string translatable="false" name="pref_customtabs_as_browser">customtabs_as_browser</string>
     <string translatable="false" name="pref_rot13_hint">pref_scramble_hint</string>
+    <string translatable="false" name="pref_live_compass_in_navigation_action">live_compass_in_navigation_action</string>
     <string translatable="false" name="pref_collapse_log_limit">pref_collapse_log_limit</string>
 
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1128,6 +1128,8 @@
     <string name="init_summary_cacheListInfo">Select the additional information to be shown for each cache in cache lists</string>
     <string name="init_livelist">Show Direction</string>
     <string name="init_summary_livelist">Show an arrow with compass direction for caches in a list</string>
+    <string name="init_live_compass_in_navigation_action">Show direction in cache detail view</string>
+    <string name="init_summary_live_compass_in_navigation_action">Show an arrow with compass direction for caches in their detail view</string>
     <string name="init_quicklaunchitems">Quick launch buttons</string>
     <string name="init_summary_quicklaunchitems">Select one or more items as quick launch buttons on home screen</string>
     <string name="init_custombnitem">Custom Menu Item</string>

--- a/main/src/main/res/xml/preferences_cachedetails.xml
+++ b/main/src/main/res/xml/preferences_cachedetails.xml
@@ -28,6 +28,12 @@
             android:title="@string/init_customtabs_as_browser"
             android:summary="@string/init_summary_customtabs_as_browser"
             app:iconSpaceReserved="false" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_live_compass_in_navigation_action"
+            android:title="@string/init_live_compass_in_navigation_action"
+            android:summary="@string/init_summary_live_compass_in_navigation_action"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Description
- Replace the static compass icon in the action bar of `CacheDetailActivity` with a dynamic, rotating `CompassMiniView` with the same behavior seen in the cache list view. The click and long click actions on the compass icon still work, triggering default and secondary navigation as before.

- Add a user setting: "Show direction in cache detail view"
  The user can toggle whether the dynamic compass arrow appears in the detail view. If disabled, the original compass icon will appear instead. It is enabled by default.

## Related issues
#431 


## Additional context
![AISelect_20250607_113400_cgeo](https://github.com/user-attachments/assets/ac022cca-a6f9-4df0-973a-460841c0c7e9)
![Screenshot_20250607_113528_cgeo (1)](https://github.com/user-attachments/assets/3cbc4166-1fbb-4df3-96f1-fb924ae643a6)
