### PR TITLE
Add some missing OC cache types

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -1193,6 +1193,18 @@ final class OkapiClient {
         if ("Webcam".equalsIgnoreCase(cacheType)) {
             return CacheType.WEBCAM;
         }
+        if ("Moving".equalsIgnoreCase(cacheType)) {
+            return CacheType.LOCATIONLESS;
+        }
+        if ("Other".equalsIgnoreCase(cacheType)) {
+            return CacheType.UNKNOWN;
+        }
+        if ("Podcast".equalsIgnoreCase(cacheType)) {
+            return CacheType.VIRTUAL;
+        }
+        if ("Own".equalsIgnoreCase(cacheType)) {
+            return CacheType.LOCATIONLESS;
+        }
         if ("Math/Physics".equalsIgnoreCase(cacheType)) {
             return CacheType.MYSTERY;
         }


### PR DESCRIPTION
Define the open Caches at OCPL as follow:

~~~
        'Moving'   =>  CacheType.LOCATIONLESS
        'Other'    =>  CacheType.UNKNOWN
        'Podcast'  =>  CacheType.VIRTUAL
        'Own'      =>  CacheType.LOCATIONLESS
~~~
fixes #16992
see https://github.com/opencaching/opencaching-pl/issues/2520

@andrixnet OK?