### PR TITLE
Fix  #17007:  Move "recently used" lists in list selection dialog to the top

### DIFF
--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
@@ -131,7 +132,7 @@ public final class StoredList extends AbstractList {
             model.setButtonSelectionIsMandatory(true)
                     .setSelectAction(TextParam.id(R.string.cache_list_select_last), () -> {
                         model.setSelectedItems(lastSelectedListSet);
-                        configureListDisplay(model, lastSelectedLists);
+                        configureListDisplay(model, Stream.concat(lastSelectedLists.stream(), selectedListIds.stream()).collect(Collectors.toSet()));
                         return lastSelectedListSet;
                     })
                     .setChoiceMode(SimpleItemListModel.ChoiceMode.MULTI_CHECKBOX)

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -129,7 +129,11 @@ public final class StoredList extends AbstractList {
 
             final SimpleDialog.ItemSelectModel<AbstractList> model = new SimpleDialog.ItemSelectModel<>();
             model.setButtonSelectionIsMandatory(true)
-                    .setSelectAction(TextParam.id(R.string.cache_list_select_last), () -> lastSelectedListSet)
+                    .setSelectAction(TextParam.id(R.string.cache_list_select_last), () -> {
+                        model.setSelectedItems(lastSelectedListSet);
+                        configureListDisplay(model, lastSelectedLists);
+                        return lastSelectedListSet;
+                    })
                     .setChoiceMode(SimpleItemListModel.ChoiceMode.MULTI_CHECKBOX)
                     .setItems(lists)
                     .setSelectedItems(selectedListSet);


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Moving the lists from the "last selection" to the "top group", while current lists remain unchecked as well in the "top group" to easily "recheck" them.
(Un)checking list-entries does not move the lists to the / from the "top group"

Open "Pick the lists" 
<img src="https://github.com/user-attachments/assets/e9d2606d-4982-4406-aae0-31030cdff056" width="200">

Select "Last selection": add checked last selected list (keep original selection unchecked at top)
<img src="https://github.com/user-attachments/assets/6646a58c-c7c8-4b81-ba11-ea1d6bb0db38" width="200">

Change selection does not move 
<img src="https://github.com/user-attachments/assets/d8ec023e-4067-4d27-8d08-de2414f48d2e" width="200">

Select "Last selection" again (no more moving)
<img src="https://github.com/user-attachments/assets/28d419bb-d7f9-4335-bcf5-79b888948cb6" width="200">

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #17007

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->