### PR TITLE
Always show Upload personal note button (#15482)

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3132,4 +3132,15 @@
     <string name="emoji_category_people">People</string>
     <string name="emoji_category_numbers">Numbers</string>
 
+    <!-- Personal Note Upload States -->
+    <string name="personal_note_upload_unavailable_offline">
+        Currently offline – cannot upload personal notes.
+    </string>
+    <string name="personal_note_upload_unavailable_generic">
+        Personal note upload not supported on this site.
+    </string>
+    <string name="personal_note_upload_unavailable_not_pm">
+        Only Premium Members can upload personal notes.
+    </string>
+
 </resources>


### PR DESCRIPTION
- Never hide, only disable with contextual toast feedback
- Handle offline / unsupported site / non-PM cases

<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Instead of hiding the “Upload personal note” button when the feature is unavailable, this change always keeps the button visible but:

- disables it and reduces its alpha to 0.3

- provides a contextual toast on click explaining why upload is unavailable

Key changes:

- Never call setVisibility(GONE) on the upload button.

- Add a small section in DescriptionViewCreator#setContent() that:

1. Checks Network.isConnected() → shows “Currently offline – cannot upload personal notes.
2. Checks connectorPN == null → shows “Personal note upload not supported on this site.”
3. Checks !connectorPN.canAddPersonalNote(cache) → shows “Only Premium Members can upload personal notes.”
[Most common situation, most of users may get this toast notfication]
5. Otherwise enables the button and lets it call uploadPersonalNote()

Testing & Verification:

1. Offline (airplane mode) → button greyed out, toast “Currently offline – cannot upload personal notes.”

2. Unsupported site (e.g. connectorPN==null) → button greyed out, toast “Personal note upload not supported on this site.”

3. Basic user (non-PM) → button greyed out, toast “Only Premium Members can upload personal notes.”

4. Premium + online → button enabled, clicking invokes upload flow

## Related issues
<!-- List the related issues fixed or improved by this PR -->
 cgeo/cgeo#15482

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

- Retains all existing tests and layouts.

- Keys added to strings.xml for the three new messages.

- Existing checkAndUploadPersonalNote(...) call (which was hiding the button in non-PM cases) has been commented out and replaced by this uniform disable-with-toast approach.
<img width="414" alt="Screenshot 2025-05-30 at 17 50 58" src="https://github.com/user-attachments/assets/db6efe59-9764-4d4c-bd20-680c453ba02c" />
<img width="414" alt="Screenshot 2025-05-30 at 19 16 02" src="https://github.com/user-attachments/assets/74d33f2f-4c8c-4654-9919-aba4285a35ec" />
<img width="469" alt="Screenshot 2025-05-30 at 22 28 34" src="https://github.com/user-attachments/assets/0f8b7d31-b052-438a-90b2-2f72699c897a" />
<img width="414" alt="Screenshot 2025-05-30 at 21 16 52" src="https://github.com/user-attachments/assets/411bf75f-8a45-4c13-80cd-a33294512224" />
<img width="414" alt="Screenshot 2025-05-30 at 21 15 59" src="https://github.com/user-attachments/assets/43d156dc-d5f1-45e7-84c1-df20f722627c" />

