### PR TITLE
Fix crash on loading a broken track (rel. to #17026)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -165,7 +165,7 @@ public class RouteTrackUtils {
         configureMenuItem(menu.findItem(R.id.indivroute_export_route), isIndividualRoute, null);
         configureMenuItem(menu.findItem(R.id.indivroute_export_track), isIndividualRoute, null);
         configureMenuItem(menu.findItem(R.id.indivroute_load), isIndividualRoute, null);
-        configureVisibility(menu.findItem(R.id.menu_visibility), route.isHidden());
+        configureVisibility(menu.findItem(R.id.menu_visibility), route != null && route.isHidden());
     }
 
     private static void configureMenuItem(final MenuItem item, final boolean visible, final Boolean hidePerDefault) {


### PR DESCRIPTION
## Description
Don't break toolbar creation for track/route popup if a given track is null due to a loading error