### PR TITLE
Merge alc waypoints with already stored ones

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -208,7 +208,7 @@ public class GCParserTest {
 
     private void assertWaypointsFromNote(final Geocache cache, final Geopoint[] expected, final String note) {
         cache.setPersonalNote(note);
-        cache.setWaypoints(new ArrayList<>(), false);
+        cache.setWaypoints(new ArrayList<>());
         cache.addCacheArtefactsFromNotes();
         final List<Waypoint> waypoints = cache.getWaypoints();
         assertThat(waypoints).hasSize(expected.length);
@@ -248,7 +248,7 @@ public class GCParserTest {
     @Test
     public void testNoteParsingWaypointTypes() {
         final Geocache cache = new Geocache();
-        cache.setWaypoints(new ArrayList<>(), false);
+        cache.setWaypoints(new ArrayList<>());
         cache.setPersonalNote("\"Parking area at PARKING=N 50° 40.666E 006° 58.222\n" + "My calculated final coordinates: FINAL=N 50° 40.777E 006° 58.111\n" + "Get some ice cream at N 50° 40.555E 006° 58.000\"");
 
         cache.addCacheArtefactsFromNotes();

--- a/main/src/androidTest/java/cgeo/geocaching/models/GeocacheTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/models/GeocacheTest.java
@@ -468,7 +468,7 @@ public class GeocacheTest {
         final Geocache cache = new Geocache();
         final String geocode = "Test" + System.nanoTime();
         cache.setGeocode(geocode);
-        cache.setWaypoints(new ArrayList<>(), false);
+        cache.setWaypoints(new ArrayList<>());
         assertWaypointsParsed(cache, note, expectedWaypoints);
         cache.store(Collections.singleton(StoredList.TEMPORARY_LIST.id), null);
         removeCacheCompletely(geocode);

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -383,7 +383,7 @@ final class ALApi {
             cache.setDisabled(false);
             cache.setHidden(parseDate(response.get("PublishedUtc").asText()));
             cache.setOwnerDisplayName(response.get("OwnerUsername").asText());
-            cache.setWaypoints(parseWaypoints((ArrayNode) response.path("GeocacheSummaries"), geocode), true);
+            cache.setWaypoints(parseWaypoints((ArrayNode) response.path("GeocacheSummaries"), geocode), false);
             final boolean isLinear = response.get("IsLinear").asBoolean();
             if (isLinear) {
                 cache.setAlcMode(1);

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -383,7 +383,7 @@ final class ALApi {
             cache.setDisabled(false);
             cache.setHidden(parseDate(response.get("PublishedUtc").asText()));
             cache.setOwnerDisplayName(response.get("OwnerUsername").asText());
-            cache.setWaypoints(parseWaypoints((ArrayNode) response.path("GeocacheSummaries"), geocode), false);
+            cache.setWaypoints(parseWaypoints((ArrayNode) response.path("GeocacheSummaries"), geocode));
             final boolean isLinear = response.get("IsLinear").asBoolean();
             if (isLinear) {
                 cache.setAlcMode(1);

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -521,7 +521,7 @@ public final class GCParser {
         }
 
         // waypoints - reset collection
-        cache.setWaypoints(Collections.emptyList(), false);
+        cache.setWaypoints(Collections.emptyList());
 
         // add waypoint for original coordinates in case of user-modified listing-coordinates
         try {

--- a/main/src/main/java/cgeo/geocaching/connector/su/SuParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/su/SuParser.java
@@ -165,7 +165,7 @@ public class SuParser {
 
 
         if (data.has(CACHE_WPTS)) {
-            cache.setWaypoints(parseWaypoints((ArrayNode) data.path(CACHE_WPTS)), false);
+            cache.setWaypoints(parseWaypoints((ArrayNode) data.path(CACHE_WPTS)));
         }
 
         // TODO: Maybe put smth in Hint?

--- a/main/src/main/java/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXParser.java
@@ -349,7 +349,7 @@ abstract class GPXParser extends FileParser {
                         final List<Waypoint> newPoints = new ArrayList<>();
                         newPoints.add(waypoint);
                         Waypoint.mergeWayPoints(newPoints, mergedWayPoints, true);
-                        cacheForWaypoint.setWaypoints(newPoints, false);
+                        cacheForWaypoint.setWaypoints(newPoints);
                         DataStore.saveCache(cacheForWaypoint, EnumSet.of(SaveFlag.DB));
                         showProgressMessage(progressHandler, progressStream.getProgress());
                     }
@@ -986,7 +986,7 @@ abstract class GPXParser extends FileParser {
         final Geocache newCache = new Geocache();
 
         newCache.setAttributes(Collections.emptyList()); // override the lazy initialized list
-        newCache.setWaypoints(Collections.emptyList(), false); // override the lazy initialized list
+        newCache.setWaypoints(Collections.emptyList()); // override the lazy initialized list
 
         return newCache;
     }

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -428,11 +428,11 @@ public class Geocache implements INamedGeoCoordinate {
 
     public void mergeWaypoints(final List<Waypoint> otherWaypoints, final boolean forceMerge) {
         if (waypoints.isEmpty()) {
-            this.setWaypoints(otherWaypoints, false);
+            this.setWaypoints(otherWaypoints);
         } else {
             final List<Waypoint> newPoints = new ArrayList<>(waypoints);
             Waypoint.mergeWayPoints(newPoints, otherWaypoints, forceMerge);
-            this.setWaypoints(newPoints, false);
+            this.setWaypoints(newPoints);
         }
     }
 
@@ -1366,11 +1366,8 @@ public class Geocache implements INamedGeoCoordinate {
 
     /**
      * @param waypoints      List of waypoints to set for cache
-     * @param saveToDatabase Indicates whether to add the waypoints to the database. Should be false if
-     *                       called while loading or building a cache
-     * @return {@code true} if waypoints successfully added to waypoint database
      */
-    public boolean setWaypoints(@Nullable final List<Waypoint> waypoints, final boolean saveToDatabase) {
+    public void setWaypoints(@Nullable final List<Waypoint> waypoints) {
         this.waypoints.clear();
         if (waypoints != null) {
             this.waypoints.addAll(waypoints);
@@ -1381,7 +1378,6 @@ public class Geocache implements INamedGeoCoordinate {
             }
         }
         resetFinalDefined();
-        return saveToDatabase && DataStore.saveWaypoints(this);
     }
 
     /**

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -3144,7 +3144,7 @@ public class DataStore {
                     if (loadFlags.contains(LoadFlag.WAYPOINTS)) {
                         final List<Waypoint> waypoints = loadWaypoints(cache.getGeocode());
                         if (CollectionUtils.isNotEmpty(waypoints)) {
-                            cache.setWaypoints(waypoints, false);
+                            cache.setWaypoints(waypoints);
                         }
                     }
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Don't store parsed waypoints directly in db. Otherwise the merging of already stored information gets lost.
Storing waypoints is done in saveCache after merging already stored cache anyway

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #16193 
fix #16932 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->