### PR TITLE
Avoid NoSuchElementException in Geocache.isOffline (rel. to #17042)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -2228,7 +2228,7 @@ public class Geocache implements INamedGeoCoordinate {
     }
 
     public boolean isOffline() {
-        return !lists.isEmpty() && (lists.size() > 1 || lists.iterator().next() != StoredList.TEMPORARY_LIST.id);
+        return !lists.isEmpty() && (lists.size() > 1 || !lists.contains(StoredList.TEMPORARY_LIST.id));
     }
 
     public int getEventStartTimeInMinutes() {


### PR DESCRIPTION
## Description
Use `list.contains()` instead of `list.iterator().next()` (which may throw an exception on lists already forwarded to end)