### PR TITLE
Share list of geocodes

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -89,6 +89,7 @@ import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.MenuUtils;
+import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.functions.Action1;
 
 import android.annotation.SuppressLint;
@@ -799,6 +800,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         } else if (menuItem == R.id.menu_upload_allcoords) {
             final Activity that2 = this;
             SimpleDialog.of(this).setTitle(R.string.caches_upload_allcoords_dialogtitle).setMessage(R.string.caches_upload_allcoords_warning).confirm(() -> new BatchUploadModifiedCoordinates(false).export(adapter.getCheckedOrAllCaches(), that2));
+        } else if (menuItem == R.id.menu_share_geocodes) {
+            shareGeocodes(adapter.getCheckedOrAllCaches());
         } else if (menuItem == R.id.menu_remove_from_history) {
             removeFromHistoryCheck();
             invalidateOptionsMenuCompatible();
@@ -1312,6 +1315,16 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     private void deleteCaches(@NonNull final Collection<Geocache> caches, final boolean removeFromAllLists) {
         new DeleteCachesFromListCommand(this, caches, listId, removeFromAllLists).execute();
+    }
+
+    private void shareGeocodes(@NonNull final Collection<Geocache> caches) {
+        final StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Geocache cache : caches) {
+            sb.append(first ? "" : ',').append(cache.getGeocode());
+            first = false;
+        }
+        ShareUtils.sharePlainText(this, sb.toString());
     }
 
     private static final class LastPositionHelper {

--- a/main/src/main/res/menu/cache_list_options.xml
+++ b/main/src/main/res/menu/cache_list_options.xml
@@ -200,6 +200,11 @@
                 android:icon="@drawable/ic_menu_upload"
                 android:title="@string/caches_upload_allcoords"
                 app:showAsAction="ifRoom|withText" />
+            <item
+                android:id="@+id/menu_share_geocodes"
+                android:icon="@drawable/ic_menu_share"
+                android:title="@string/caches_share_geocodes"
+                app:showAsAction="ifRoom|withText" />
         </menu>
     </item>
     <item

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -509,6 +509,7 @@
     <string name="caches_upload_allcoords">Upload coordinates for all caches</string>
     <string name="caches_upload_allcoords_dialogtitle">WARNING - Uploading all coordinates</string>
     <string name="caches_upload_allcoords_warning">This will overwrite the existing coordinates on the server for all (selected) caches of your list with the current listing coordinates in c:geo! This is to be used only in special cases, e. g. when you imported a GPX file which contains corrected coordinates as listing coordinates. This cannot be undone and you should only use it, if you know what you are doing. In normal cases you might rather want to use the function \"Upload modified coordinates\" in the same menu.</string>
+    <string name="caches_share_geocodes">Share list of geocodes</string>
     <string name="caches_refresh_selected">Refresh selected</string>
     <string name="caches_refresh_all">Refresh all</string>
     <string name="caches_move_selected">Move selected</string>


### PR DESCRIPTION
## Description
Triggered by a request on support: Share list of geocodes (selected or all caches in cache list)

This can be used for both sharing a list of codes with another app or person, as well as pasting it into GC's form for bulk-adding caches to a list.