### PR TITLE
Set targetSDK to 35

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         minSdk 21
-        targetSdk 34
+        targetSdk 35
 
         versionName versionNameFromDate()
         versionCode versionCodeFromDate(0)

--- a/main/src/main/res/values-v35/themes.xml
+++ b/main/src/main/res/values-v35/themes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="cgeo_base" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="android:fitsSystemWindows">true</item>
+        <item name="android:enforceNavigationBarContrast">true</item>
+        <item name="android:enforceStatusBarContrast">true</item>
+    </style>
+
+</resources>

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -2,8 +2,8 @@
 <resources>
 
     <!-- theme for (nearly) all activities -->
-
-    <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="cgeo_base" parent="Theme.MaterialComponents.DayNight.DarkActionBar" />
+    <style name="cgeo" parent="cgeo_base">
         <!-- Action bar theming -->
         <item name="actionBarStyle">@style/actionBarStyle</item>
         <item name="android:actionOverflowButtonStyle">@style/actionBarActionOverflow</item>


### PR DESCRIPTION
## Description
As discussed in our last dev meeting: Let's try targetSDK 35 early in the current dev cycle, as some breaking changes are to be expected from reading the docs.

~One is already very visible directly after start: The new edge-to-edge mode hides UI elements under the topbar (eg: in settings), therefore setting WIP label for now.~ (that seems to be fixed as of Jul 5th)