### PR TITLE
Fix crash on lab stageNum == 0

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -749,7 +749,7 @@ public final class MapMarkerUtils {
 
     @SuppressWarnings("DiscouragedApi")
     private static Drawable getStageNumberMarker(final Resources res, final int stageNum, final float scaling) {
-        int counter = stageNum;
+        int counter = Math.max(stageNum, 1); // safeguard for stageNum == 0
         while (counter > 10) {
             counter = counter - 10;
         }


### PR DESCRIPTION
## Description
`getStageNumberMarker()` sometimes fails with `ResourceNotFoundException`, which can happen if given stage number is 0 somehow (imported lab stage?). PR adds a safeguard for this.