### PR TITLE
Do not load broken tracks (fix #17053)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -110,10 +110,12 @@ public class RouteTrackUtils {
                 Log.d("[RouteTrackDebug] Start import of track " + uri);
                 GPXTrackOrRouteImporter.doImport(activity, uri, UriUtils.getLastPathSegment(uri), (route) -> {
                     Log.d("[RouteTrackDebug] Finished import of track " + uri + ": " + (route == null ? "null returned" : "updating map"));
-                    final String key = tracks.add(activity, uri, updateTrack);
-                    tracks.setRoute(key, route);
-                    updateTrack.updateRoute(key, route, tracks.getColor(key), tracks.getWidth(key));
-                    updateDialogTracks(popup, tracks, null);
+                    if (route != null) {
+                        final String key = tracks.add(activity, uri, updateTrack);
+                        tracks.setRoute(key, route);
+                        updateTrack.updateRoute(key, route, tracks.getColor(key), tracks.getWidth(key));
+                        updateDialogTracks(popup, tracks, null);
+                    }
                 });
             }
         }


### PR DESCRIPTION
## Description
Do not import broken tracks (returning `null` as route) to internal storage.