### PR TITLE
fix #16984: keep metadata lib classes in proguard

### DIFF
--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -146,3 +146,6 @@
 
 # transitive needed using R8 (minifyEnabled)
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+
+# keep classes of metadata libaray (this lib heavily uses reflection)
+-keep class com.drew.** { *; }

--- a/main/src/main/java/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/main/java/cgeo/geocaching/network/HtmlImage.java
@@ -507,6 +507,7 @@ public class HtmlImage implements Html.ImageGetter {
                 return ImmutableTriple.of(image, null, true);
             }
             metadata = MetadataUtils.readImageMetadata("[HtmlImage]" + uri, imageStream, true);
+            Log.iForce("[HtmlImage] Orientation of " + uri + ": " + MetadataUtils.getOrientation(metadata));
         }
         return ImmutableTriple.of(image, metadata, freshEnough);
     }

--- a/main/src/main/java/cgeo/geocaching/utils/MetadataUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MetadataUtils.java
@@ -54,7 +54,9 @@ public final class MetadataUtils {
             return null;
         }
         try {
-            return ImageMetadataReader.readMetadata(imageStream);
+            final Metadata data = ImageMetadataReader.readMetadata(imageStream);
+            //throw new RuntimeException("test");
+            return data;
         } catch (IOException | ImageProcessingException | RuntimeException ie) {
             Log.w("[MetadataUtils] Problem reading metadata from " + description, ie);
         } finally {
@@ -84,7 +86,7 @@ public final class MetadataUtils {
     }
 
     public static int getOrientation(final Metadata metadata) {
-        return safeProcess("orientation", metadata, ExifInterface.ORIENTATION_NORMAL, () -> {
+        return safeProcess("orientation", metadata, ExifInterface.ORIENTATION_UNDEFINED, () -> {
 
             final Collection<ExifDirectoryBase> exifDirs = metadata.getDirectoriesOfType(ExifDirectoryBase.class);
             for (ExifDirectoryBase exifDir : exifDirs) {


### PR DESCRIPTION
fix #16984: keep metadata lib classes in proguard