### PR TITLE
Fix mocked cache with HTML at beginning of description

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/test/mock/GC40.java
+++ b/main/src/androidTest/java/cgeo/geocaching/test/mock/GC40.java
@@ -77,7 +77,7 @@ public class GC40 extends MockedCache {
     @NonNull
     @Override
     public String getDescription() {
-        return "<br> <br> This is the oldest cache that you can log on continental Europe.<br>";
+        return "This is the oldest cache that you can log on continental Europe.<br>";
     }
 
     @NonNull

--- a/main/src/androidTest/res/raw/mock/GC40.html
+++ b/main/src/androidTest/res/raw/mock/GC40.html
@@ -11,7 +11,7 @@
 <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700&amp;subset=latin,latin-ext" rel="stylesheet" type="text/css" /><link href="/content/coreCSS?v=BG33cbunKJDzOj2zx7feuGxtxCy2UsGNvo5MqNRzHLw1" rel="stylesheet"/>
 <link rel="stylesheet" type="text/css" media="print" href="../css/tlnMasterPrint.css" /><script src="/bundle/modernizer?v=HfmUMlIbhuybNYbtsV4gvygQU2XxNXFZuOsLOTe8PBo1"></script>
 
-                
+
         <script type="text/javascript" src="/play/dataparameters/datalayer"></script>
 
         <!-- Google Tag Manager -->
@@ -37,15 +37,15 @@
             })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
 
-            
+
             ga('create', 'UA-2020240-1', 'auto', {userId: 25174446});
-            
+
             ga('require', 'linkid');
         </script>
-        
-         
+
+
             <!-- google adsense + tag services -->
-            <script type="text/javascript">               
+            <script type="text/javascript">
                 (function () {
                     var gads = document.createElement('script');
                     gads.async = true;
@@ -56,7 +56,7 @@
                     node.parentNode.insertBefore(gads, node);
                 })();
             </script>
-        
+
     <script type="text/javascript">
         ga('set', 'page', '/geocache/cache_details.aspx');
         ga('set', 'title', 'Geocaching Detail Page');
@@ -69,7 +69,7 @@
 
     <script type="text/javascript" src="/play/serverparameters/params"></script>
 
-    
+
     <script>
         var linkResources = {
             "youAreAboutToLeave": 'You\'re about to leave Geocaching.com.',
@@ -224,47 +224,47 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
 
         <a id="ctl00_hlSkipLinksContent" class="visually-hidden" href="#Content">Skip to content</a>
 
-        
 
-        
+
+
         <div class="PrintOnly">
-            
+
             <svg viewBox="0 0 196 29" height="29" width="196" role="img" aria-label="Geocaching">
                 <use xlink:href="/images/branding/logo-geocaching.svg#gcLogo"></use>
             </svg>
             <hr />
-            
+
         </div>
-        
+
         <div id="gc-header-root" style="background-color: #02874D; min-height: 80px;"></div>
 
         <main id="Content">
-            
-    
 
-            
-            
+
+
+
+
             <div class="container">
-                
+
 
                 <div id="divContentMain" class="span-24&#32;last">
-	
-                    
-    <h1 class="visually-hidden">Geocache Traditional Geocache</h1>
-    
 
-    
-    
-    
-    
-    
-    
-    
-    
+
+    <h1 class="visually-hidden">Geocache Traditional Geocache</h1>
+
+
+
+
+
+
+
+
+
+
     <input type="hidden" name="ctl00$ContentBody$LastSynced" id="LastSynced" />
 
     <div id="ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoLinkPanel" class="CoordInfoLinkWidget&#32;FloatRight">
-		
+
     <p>
         <a href="https://coord.info/GC40" id="coordinate-link-control" class="CoordInfoLink" aria-expanded="false" aria-controls="coordinate-info-link" tabindex="0">
             <span id="ctl00_ContentBody_CoordInfoLinkControl1_uxCoordInfoCode" class="CoordInfoCode">GC40</span>
@@ -275,35 +275,35 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
 
 	</div>
 
-    
+
     <div class="span-17">
-        
+
         <div class="span-17 last BottomSpacing" id="cacheDetails">
             <div class="cacheDetailsTitle">
-               
+
                 <a href="/about/cache_types.aspx" target="_blank" title="Traditional Geocache" aria-label="About geocache types" class="cacheImage">
                     <div id="uxCacheImage">
-		
+
                         <div class="activity-type-icon">
                                 <svg class="icon cache-icon" role="presentation">
                                     <use xlink:href="/app/ui-icons/sprites/cache-types.svg#icon-2" />
                                 </svg>
-                                 
+
                         </div>
-                    
+
 	</div>
                 </a>
-                
-                
+
+
                 <span class="NoBottomSpacing h2" aria-hidden="true">
-                    
+
                     <span id="ctl00_ContentBody_CacheName" class="tex2jax_ignore">Geocache</span>
                 </span>
             </div>
             <div class="minorCacheDetails Clear">
                 <div id="ctl00_ContentBody_mcd1">
                     A cache by <a href="https://www.geocaching.com/p/?guid=ed08266d-d7f6-408f-88a9-8f0d2631b61c&wid=e10600a4-fd99-474d-aa0d-34a96672906a&ds=2">Pierre Cao, Speerpunt, adopted by Grokky</a>
-                    <span id="ctl00_ContentBody_MessageLink" class="message__owner">                        
+                    <span id="ctl00_ContentBody_MessageLink" class="message__owner">
                         <svg width="25px" height="12px" viewBox="0 0 25 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true">
                             <defs>
                                 <path d="M1.98946751,1.37469233 L15.0220577,1.37469233 L8.61273139,7.72639296 C8.55386063,7.78494241 8.4576646,7.78494241 8.39849038,7.72639296 L1.98946751,1.37469233 L1.98946751,1.37469233 Z M12.4435791,8.38476934 L14.966525,10.8853188 L1.964584,10.8853188 L4.48783329,8.38476934 C4.65170035,8.22253857 4.65170035,7.95937098 4.48783329,7.79714021 C4.32396623,7.63460449 4.05874436,7.63460449 3.89487729,7.79714021 L1.40956019,10.2598765 L1.40956019,1.97543409 L7.80553438,8.31402209 C7.99853336,8.50552758 8.25222385,8.60128033 8.50561088,8.60128033 C8.75930137,8.60128033 9.0126884,8.50552758 9.20568739,8.31402209 L15.6016616,1.97543409 L15.6022685,10.3397721 L13.0365351,7.79714021 C12.8726681,7.63460449 12.6074462,7.63460449 12.4435791,7.79714021 C12.2797121,7.95937098 12.2797121,8.22253857 12.4435791,8.38476934 L12.4435791,8.38476934 Z M15.6016616,0.266521981 L1.40956019,0.266521981 C0.792934505,0.266521981 0.291319221,0.763582427 0.291319221,1.37469233 L0.291319221,10.8853188 C0.291319221,11.4964287 0.792934505,11.9934892 1.40956019,11.9934892 L15.6016616,11.9934892 C16.2185907,11.9934892 16.720206,11.4964287 16.720206,10.8853188 L16.720206,1.37469233 C16.720206,0.763582427 16.2185907,0.266521981 15.6016616,0.266521981 L15.6016616,0.266521981 Z" id="path-1"></path>
@@ -334,24 +334,24 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                     Hidden
                     :
                     2000-07-07
-                    
-                    
+
+
                 </div>
             </div>
             <div class="minorCacheDetails&#32;Clear">
                 <div id="mcd3">
-                    
-                    
+
+
                 </div>
 
                 <div id="mcd4">
-                    
-                    
+
+
                 </div>
             </div>
         </div>
         <div id="ctl00_ContentBody_diffTerr" class="CacheStarLabels&#32;span-6&#32;BottomSpacing">
-            
+
             <dl>
                 <dt>
                     Difficulty:</dt>
@@ -361,34 +361,34 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
             </dl>
             <dl>
                 <dt>
-                    Terrain:</dt> 
+                    Terrain:</dt>
                 <dd>
                     <span id="ctl00_ContentBody_Localize12" title="(1&#32;is&#32;easiest,&#32;5&#32;is&#32;hardest)"><img src="/images/stars/stars1_5.gif" alt="1.5 out of 5" /></span>
                 </dd>
             </dl>
-            
+
         </div>
         <div id="ctl00_ContentBody_size" class="CacheSize&#32;span-5">
-            
+
             <p class="AlignCenter">
                 Size:&nbsp;<span class="minorCacheDetails"><img src="/images/icons/container/regular.gif" alt="Size:   regular" title="Size: regular" />&nbsp<small>(regular)</small></span>
             </p>
-            
+
         </div>
         <div class="span-6 right last">
-            
-            
+
+
                 <div class="favorite right">
                     <a id="uxFavContainerLink" href="javascript:void(0);">
                         <div class="favorite-container"><!-- TODO! -->
                             <span class="favorite-value">
-                                5829 
+                                5829
                             </span>
                             Favorites
                         </div>
                     </a>
                     <div class="favorite-dropdown">
-                        
+
                         <ul>
                             <li class="favorite-score">
                             </li>
@@ -401,22 +401,22 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                         </ul>
                     </div>
                 </div>
-            
-            
+
+
 
         </div>
         <div class="span-6 right last">
-            
-            
-            
+
+
+
         </div>
-        
+
         <p class="Clear">
 
             <a id="ctl00_ContentBody_uxCacheUrl" title="Related&#32;Web&#32;Page" href="http://users.swing.be/geocache/redu.htm">Related Web Page</a>
 
         </p>
-        
+
 
         <div id="ctl00_ContentBody_CacheInformationTable" class="CacheInformationTable">
             <div class="LocationData FloatContainer">
@@ -443,7 +443,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                     <dt class="label">
                         <span id="ctl00_ContentBody_uxPrintHeader">Print</span>:
                     </dt>
-                    <dd>              
+                    <dd>
                         <a id="ctl00_ContentBody_lnkPrintFriendly" href="../seek/cdpf.aspx?guid=e10600a4-fd99-474d-aa0d-34a96672906a" target="_blank">No Logs</a>
                         <a id="ctl00_ContentBody_lnkPrintFriendly5Logs" href="../seek/cdpf.aspx?guid=e10600a4-fd99-474d-aa0d-34a96672906a&amp;lc=5" target="_blank">5 Logs</a>
                         <a id="ctl00_ContentBody_lnkPrintFriendly10Logs" href="../seek/cdpf.aspx?guid=e10600a4-fd99-474d-aa0d-34a96672906a&amp;lc=10" target="_blank">10 Logs</a>
@@ -459,29 +459,27 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnet
                 </dl>
             </div>
         </div>
-        
+
             <div class="Note Disclaimer">
                 <strong>Please note</strong> Use of geocaching.com services is subject to the terms and conditions <a href="http://www.geocaching.com/about/disclaimer.aspx" title="Read our disclaimer">in our disclaimer</a>.
             </div>
-        
-        
-        
-        
-            <h2 class="h3 CacheDescriptionHeader">Geocache Description:</h2>        
-        
+
+
+
+
+            <h2 class="h3 CacheDescriptionHeader">Geocache Description:</h2>
+
         <div class="UserSuppliedContent">
-            
+
             <span id="ctl00_ContentBody_ShortDescription">
 </span>
-            
+
         </div>
-        
+
         <br />
         <div class="UserSuppliedContent">
-            
-            <span id="ctl00_ContentBody_LongDescription"><br>
-<br>
-This is the oldest cache that you can log on continental Europe.<br>
+
+            <span id="ctl00_ContentBody_LongDescription">This is the oldest cache that you can log on continental Europe.<br>
 <br>
 It is one of the first caches ever in Europe and was placed 7/7/2000 by Pierre Cao.<br>
 It was transferred to Speerpunt in 2003 and he maintained it for 13 years.<br>
@@ -551,11 +549,11 @@ You are visiting a part of geocaching history, so please take good care of the c
 </td>
 </tr>
 </table></span>
-            
+
         </div>
-        
-        
-        
+
+
+
         <p id="ctl00_ContentBody_hints">
             <strong>
                 Additional Hints</strong>
@@ -565,15 +563,15 @@ You are visiting a part of geocaching history, so please take good care of the c
         </div>
         <div class="Clear">
         </div><br /><br />
-        
+
     </div>
-    
-    
+
+
     <div class="span-6 prepend-1 last sidebar">
-        
-        
+
+
 <div class="CacheDetailNavigation NoPrint">
-    
+
     <a href="/seek/log.aspx?ID=64&lcn=1" id="ctl00_ContentBody_GeoNav_logButton" class="btn&#32;btn-primary">Log geocache</a>
     <ul>
         <li><a href="/seek/geocache_logs.aspx?guid=e10600a4-fd99-474d-aa0d-34a96672906a">View all logs (13464)</a></li>
@@ -582,8 +580,8 @@ You are visiting a part of geocaching history, so please take good care of the c
         <li id="ctl00_ContentBody_GeoNav_uxAddToListBtn"><span class="add-to-list" data-gcRefCode="GC40" data-href="/bookmarks/mark.aspx?view=legacy&guid=e10600a4-fd99-474d-aa0d-34a96672906a&amp;WptTypeID=2">Add to List</span></li>
         <li id="ctl00_ContentBody_GeoNav_uxIgnoreBtn"><a href="/bookmarks/ignore.aspx?guid=e10600a4-fd99-474d-aa0d-34a96672906a&amp;WptTypeID=2">Ignore</a></li>
     </ul>
-    
-    
+
+
 </div>
 
 <script type="text/javascript">
@@ -618,24 +616,24 @@ You are visiting a part of geocaching history, so please take good care of the c
         "removeFromWatchlistError": "Unable to remove cache from Watchlist. Please try again later."
     }
 </script>
-        
-        
+
+
         <div id="ctl00_ContentBody_detailWidget" class="CacheDetailNavigationWidget&#32;TopSpacing&#32;BottomSpacing">
-            
+
             <h3 class="WidgetHeader">
                 Attributes
             </h3>
             <div class="WidgetBody">
                 <img src="/images/attributes/available-yes.png" alt="Available 24/7" title="Available 24/7" width="30" height="30" /> <img src="/images/attributes/onehour-yes.png" alt="Takes less than one hour" title="Takes less than one hour" width="30" height="30" /> <img src="/images/attributes/attribute-blank.png" alt="blank" title="blank" width="30" height="30" /> <img src="/images/attributes/attribute-blank.png" alt="blank" title="blank" width="30" height="30" /> <img src="/images/attributes/attribute-blank.png" alt="blank" title="blank" width="30" height="30" /> <img src="/images/attributes/attribute-blank.png" alt="blank" title="blank" width="30" height="30" /> <p class="NoBottomSpacing"><small><a href="/about/icons.aspx" title="What are Attributes?">What are Attributes?</a></small></p>
             </div>
-            
+
         </div>
 
-        
+
             <div id="ctl00_ContentBody_uxBanManWidget" class="InlinePageAds">
-		
-            
-            
+
+
+
             <script type="text/javascript" src="https://1666210260.rsc.cdn77.org/geocaching/prebid.js"></script>
             <script type="text/javascript">
                 const premium = 'false';
@@ -653,169 +651,169 @@ You are visiting a part of geocaching history, so please take good care of the c
             <p>
                 <small><a href="../about/advertising.aspx" id="ctl00_ContentBody_advertisingWithUs">Advertising with Us</a></small>
             </p>
-            
-        
+
+
 	</div>
-        
-        
+
+
         <div class="clear">
         </div>
-        
+
         <span id="ctl00_ContentBody_lnkTravelBugs"></span>
-        
-        
+
+
 <div class="CacheDetailNavigationWidget">
-    
+
     <h3 class="WidgetHeader">
         <span id="ctl00_ContentBody_uxTravelBugList_uxInventoryLabel">Inventory</span>
     </h3>
     <div class="WidgetBody">
-        
-        
+
+
                 <ul>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=38376f81-6353-465a-a390-cbe0f3d613eb" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Actuator with 2 discs</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=99774b34-d23d-4b0d-9a64-5e164d0026ad" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Eye 2 Eye</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=aa502693-f512-429c-88e7-d74315d6d1ff" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>FUSSBALL IST UNSER LEBEN</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=6afc1332-d31c-4615-b17c-20ce18e7bff1" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Hamburger Royal TS</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=7b1de782-87c6-4a05-9a43-23877057e05d" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Hand of Fatima</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=9b18a85e-df73-43da-95b4-94cfc6e05fdf" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Mais Oui, Paris!</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=e1c0c48c-ef80-4c0e-8f39-be54f9dfb0d7" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Mike the Explorer</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=a0ba889f-b1d2-4ca6-94fa-2a2728750851" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Nightbug</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=72675b2f-c5f0-4880-a801-b28ea663cd52" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Nilos` Bicycle TB</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=d453f5b8-7953-4257-aec2-73ba94659dde" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Pixelhaschers Käfer</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=6e25c5ee-3048-4925-a980-8e9495b4e451" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Puch&#8217;en Gertrud</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=33ed4522-6cf8-44de-a9e2-91447e7822aa" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Rollercacher&#39;s Klapperkiste</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=8c1ee1f4-3e13-4070-96a9-53aa303c4a40" class="lnk">
                         <img src="/images/WptTypes/sm/21.gif" width="16" alt="" /><span>Travel Bug Challenge de Bikette059</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=4e3816bd-3b3e-4e3b-9b7f-462e6f38bba3" class="lnk">
                         <img src="/images/WptTypes/sm/1179.gif" width="16" alt="" /><span>Mons</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=e734f74b-ecfe-48ed-a510-198522f9bb02" class="lnk">
                         <img src="/images/WptTypes/sm/1696.gif" width="16" alt="" /><span>We love geocaching and have Joy ;-)</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=18ef4f28-f2ca-43d0-9ac8-2c8e01518b48" class="lnk">
                         <img src="/images/WptTypes/sm/1736.gif" width="16" alt="" /><span>Wingst 2011</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=31dd3f39-5cef-4044-825b-3c77f6074e90" class="lnk">
                         <img src="/images/WptTypes/sm/2020.gif" width="16" alt="" /><span>AlMa-Erzgebirgscoin</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=926106d4-4f98-4c89-9a6d-1b6983d42ee4" class="lnk">
                         <img src="/images/WptTypes/sm/2304.gif" width="16" alt="" /><span>Hoera ik ben &quot;65 jaar&quot; geworden</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=42e66bd4-edc0-44a3-bb9f-9a12ae1fe8b0" class="lnk">
                         <img src="/images/WptTypes/sm/2518.gif" width="16" alt="" /><span>U.S. Flag Micro #9</span></a>
                 </li>
-            
+
                 <li>
                     <a href="https://www.geocaching.com/track/details.aspx?guid=7906097e-2a27-480d-86a5-6590aaacfea4" class="lnk">
                         <img src="/images/WptTypes/sm/2636.gif" width="16" alt="" /><span>crocalien</span></a>
                 </li>
-            
+
                 </ul>
-            
-            
+
+
             <div class="TopSpacing">
                 <div id="ctl00_ContentBody_uxTravelBugList_uxTrackableItemsLinks">
-		
+
                     <p class="NoBottomSpacing"><a id="ctl00_ContentBody_uxTravelBugList_uxViewAllTrackableItems" href="../track/search.aspx?wid=e10600a4-fd99-474d-aa0d-34a96672906a&amp;ccid=64">View all 37 Trackables...</a></p>
-                
+
 	</div>
                 <p class="NoBottomSpacing"><a id="ctl00_ContentBody_uxTravelBugList_uxTrackableItemsHistory" href="../track/search.aspx?wid=e10600a4-fd99-474d-aa0d-34a96672906a">View past Trackables</a></p>
                 <p class="NoBottomSpacing"><a id="ctl00_ContentBody_uxTravelBugList_uxWhatAreTrackables" title="What&#32;are&#32;Trackable&#32;Items?" href="../track/default.aspx">What are Trackable Items?</a></p>
             </div>
 
-        
+
     </div>
-    
-    
+
+
 </div>
 
-        
+
 <div class="CacheDetailNavigationWidget">
     <h3 class="WidgetHeader">
         Bookmark Lists
     </h3>
     <div class="WidgetBody">
-        
+
                 <ul class="BookmarkList">
-            
+
                 <li class=''>
                     <a href="https://www.geocaching.com/bookmarks/view.aspx?guid=c73cd4b4-8c5f-4f45-9e2a-b68999cd4414">Jiheffes&#39; Favorites</a><br />by <a href="https://www.geocaching.com/p/?guid=107e2e81-fc1a-4ca1-8b59-5f4aee312add">Jiheffe</a>
                 </li>
-            
+
                 <li class='AlternatingRow'>
                     <a href="https://www.geocaching.com/bookmarks/view.aspx?guid=7deb0d75-f9a4-47a3-adeb-ecb962ba35f3">First or oldest</a><br />by <a href="https://www.geocaching.com/p/?guid=db08f2ae-0baa-470a-bf63-e99223ee93cd">tiki-4</a>
                 </li>
-            
+
                 <li class=''>
                     <a href="https://www.geocaching.com/bookmarks/view.aspx?guid=cfe336f3-da6d-4aeb-a95e-05cefb39e60c">Grandfather caches</a><br />by <a href="https://www.geocaching.com/p/?guid=db08f2ae-0baa-470a-bf63-e99223ee93cd">tiki-4</a>
                 </li>
-            
+
                 </ul>
-            
+
         <p class="NoBottomSpacing">
             <a href="/bookmarks/default.aspx?guid=e10600a4-fd99-474d-aa0d-34a96672906a&WptTypeID=2" title="View all 343 bookmark lists...">View all 343 bookmark lists...</a>
         </p>
@@ -823,23 +821,23 @@ You are visiting a part of geocaching history, so please take good care of the c
 </div>
 
 
-        
-        
+
+
     </div>
-    
-    
+
+
     <div id="ctl00_ContentBody_bottomSection" class="span-24&#32;last">
-        
+
         <p>
             &nbsp; <br />
-            
-            
+
+
         </p>
-        
+
         <div id="uxlrgMap" class="FloatRight&#32;TopSpacing">
-		
+
             <div class="PageBreakBefore">
-                
+
             </div>
             <div class="CDMapWidget">
                 <p class="WidgetHeader NoBottomSpacing">
@@ -847,9 +845,9 @@ You are visiting a part of geocaching history, so please take good care of the c
                 </p>
                 <div id="map_canvas" style="width: 325px; height: 325px;"></div>
             </div>
-        
+
 	</div>
-        
+
         <p class="NoPrint">
             <span id="ctl00_ContentBody_uxFindLinksHeader" style="font-weight:bold;">Find...</span>
             <br />
@@ -859,7 +857,7 @@ You are visiting a part of geocaching history, so please take good care of the c
             <li>
                 ...other caches <a href="/play/search?owner[0]=Grokky%20Grokson&a=0&sort=PlaceDate&asc=False">hidden</a> by this user
             </li>
-            
+
                 <li>
                     ...nearby <a href="/play/search?types=2&origin=50.000000,5.000000">caches of this type</a>
                 </li>
@@ -869,8 +867,8 @@ You are visiting a part of geocaching history, so please take good care of the c
                 <li>
                     ...all nearby <a href="http://www.waymarking.com/directory.aspx?f=1&lat=50.000000&lon=5.000000">waymarks on Waymarking.com</a>
                 </li>
-            
-            
+
+
         </ul>
         <p class="NoPrint">
             <span id="ctl00_ContentBody_uxMapLinkHeader" style="font-weight:bold;">For online maps...</span>
@@ -882,7 +880,7 @@ You are visiting a part of geocaching history, so please take good care of the c
         <ul class="CachePageImages NoPrint">
             <li><a href="https://img.geocaching.com/cache/large/f75e2097-d1e6-4de5-ae2e-62b758a263f2.jpg" rel="lightbox">Orginele geocache</a></li><li><a href="https://img.geocaching.com/cache/large/e950f8f7-c7c7-49ab-83a9-d2e575b84d62.jpg" rel="lightbox">Spoiler</a></li>
         </ul>
-        
+
             <div class="InformationWidget Clear">
                 <h2 class="h3">
                     13,464 Logged Visits
@@ -899,9 +897,9 @@ You are visiting a part of geocaching history, so please take good care of the c
             </div>
 
               <input name="__RequestVerificationToken" type="hidden" value="QNtkw1VnVC4KbW0zzlbn1UWVOyJ6lkukdP_x6tFDwSuHf_38avQ6_o5DCeQfG2vUiw1H_d7P3-HUYJoLfjBZdq5P1jg1" />
-            
+
             <div id="cache_logs_container" class="span-24">
-                
+
 
                 <table id="cache_logs_table" class="LogsTable NoBottomSpacing">
                     <tbody>
@@ -917,9 +915,9 @@ You are visiting a part of geocaching history, so please take good care of the c
                 </table>
             </div>
             <div id="topScroll" class="TopScroll" style="display: none;">
-                <a href="#Top" class="btn" title="Back to top"></a> 
+                <a href="#Top" class="btn" title="Back to top"></a>
             </div>
-        
+
     </div>
     <script id="tmpl_CacheLogRow" type="text/x-jquery-tmpl">
         <tr class="log-row l-${LogID}" data-encoded="${IsEncoded}">
@@ -968,16 +966,16 @@ You are visiting a part of geocaching history, so please take good care of the c
                         {{if LogType === "Found it" || LogType === "Didn't find it" || LogType === "Webcam Photo Taken" || LogType === "Attended" || LogType === "Announcement" }}
                             <div class="upvotes">
                                 <button class="great-story-btn"
-                                        type="button" 
-                                        data-log-id="${LogID}" 
-                                        data-upvoted="false" 
-                                        data-upvote-type="1" 
+                                        type="button"
+                                        data-log-id="${LogID}"
+                                        data-upvoted="false"
+                                        data-upvote-type="1"
                                         {{if userInfo.ID == AccountID}}
                                             title="You cannot vote for your own logs."
                                         {{else}}
                                             title="Was this a great story?"
                                         {{/if}}
-                                        {{if userInfo.ID == AccountID}}disabled{{/if}}>                
+                                        {{if userInfo.ID == AccountID}}disabled{{/if}}>
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
                                       <g>
                                         <g stroke-width="1.125" transform="translate(4 3)">
@@ -992,10 +990,10 @@ You are visiting a part of geocaching history, so please take good care of the c
                                 <span class="loading-container hide loading-${LogID}">
                                     <img src="/app/ui-images/branding/loading-spinner.svg"></img>
                                 </span>
-                                <button class="helpful-btn" 
+                                <button class="helpful-btn"
                                         type="button" data-log-id="${LogID}"
-                                        data-upvoted="false" 
-                                        data-upvote-type="2" 
+                                        data-upvoted="false"
+                                        data-upvote-type="2"
                                         {{if userInfo.ID == AccountID}}
                                             title="You cannot vote for your own logs."
                                         {{else}}
@@ -1016,7 +1014,7 @@ You are visiting a part of geocaching history, so please take good care of the c
                                 </button>
                             </div>
                         {{/if}}
-                        
+
                         <div class="AlignRight">
                             <small>
                                 <a title="View Log" href="/seek/log.aspx?LUID=${LogGuid}" target="_blank">
@@ -1052,7 +1050,7 @@ You are visiting a part of geocaching history, so please take good care of the c
             ').html($item.data.Name).text()).html()).html() } &lt;/span&gt;&lt;span class=&quot;LogImgLink&quot;&gt;
 
                 &lt;a target=&quot;_blank&quot; href=&quot;/seek/log.aspx?LUID=${$item.parent.parent.data.LogGuid}&IID=${ImageGuid}&quot;>View Log&lt;/a&gt;&nbsp;
-        
+
                 &lt;a href=&quot;https://img.geocaching.com/cache/log/large/${FileName}&quot;>Print Picture&lt;/a&gt;&lt;/span&gt;
 
                 {{if (Descr && Descr.length > 0) }}
@@ -1098,21 +1096,21 @@ You are visiting a part of geocaching history, so please take good care of the c
         </div>
     </script>
 
-                
+
 </div>
 
-                
+
             </div>
         </main>
 
         <div id="gc-footer-root"></div>
 
-        
 
 
-<script 
-    src='https://code.jquery.com/jquery-3.5.1.min.js' 
-    integrity='sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=' 
+
+<script
+    src='https://code.jquery.com/jquery-3.5.1.min.js'
+    integrity='sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0='
     crossorigin='anonymous'></script>
 
 <script>window.jQuery || document.write('<script src="/app/dist/jquery.min.js"><\/script>')</script>
@@ -1124,7 +1122,7 @@ You are visiting a part of geocaching history, so please take good care of the c
   integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
   crossorigin="anonymous"></script>
 
-         
+
     <script>
         window.resources = {
             aboutOurMaps: 'About our maps',
@@ -1140,14 +1138,14 @@ You are visiting a part of geocaching history, so please take good care of the c
 
 
     <script src="/bundle/cachedetails-map?v=hqkL4bj89cHAnsVbCuzrafB5iWROcPC3ppCZDd1lQDo1" defer></script>
-    
+
     <script src="/bundle/synced-lists?v=16uMUGhIvZwzhCdumvFQaGSIrQBmvHJFPrg2v-qd_Ss1" defer></script>
-    
-    
-    
+
+
+
     <script src="https://www.google.com/recaptcha/api.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML" defer></script>
-    
+
     <script type="text/javascript">
         MathJax = {
             options: {
@@ -1236,7 +1234,7 @@ You are visiting a part of geocaching history, so please take good care of the c
             var upvoteType = upvoteTypeId === 1 ? "GreatStory" : "Helpful";
             var callType = "POST";
 
-            var afToken =  $('input[name=__RequestVerificationToken]').val();     
+            var afToken =  $('input[name=__RequestVerificationToken]').val();
 
             if (isRemove) {
                 callType = "DELETE";
@@ -1249,8 +1247,8 @@ You are visiting a part of geocaching history, so please take good care of the c
 
             ga('send', 'event', 'Geocache Log Upvotes', isRemove ? "Removed upvote" : "Added upvote", upvoteType);
 
-                   
-         
+
+
             $.ajax({
                 type: callType,
                 url: "/api/proxy/web/v1/geocaches/logs/" + logId + "/upvote?upvoteType=" + upvoteType,
@@ -1583,7 +1581,7 @@ You are visiting a part of geocaching history, so please take good care of the c
         Favorites/Premium Logs
     </script>
 
-    
+
 
     <script type="text/javascript">
         $(".qtip-icon-question").qtip({
@@ -1734,8 +1732,8 @@ You are visiting a part of geocaching history, so please take good care of the c
 
 
 
-        
-    
+
+
 
 <script type="text/javascript">
 //<![CDATA[
@@ -1755,7 +1753,7 @@ theForm.onsubmit = WebForm_SaveScrollPositionOnSubmit;
 //]]>
 </script>
 </form>
-    
+
 
     <form action="/account/logout" method="post" id="form-logout">
         <input type="hidden" name="returnUrl" />
@@ -1787,9 +1785,9 @@ theForm.onsubmit = WebForm_SaveScrollPositionOnSubmit;
             });
         });
     </script>
-    
+
     <script src="/bundle/reactChrome?v=k2TRTPQl6Bhq0YYBfWuQn0r8hpq8i573LIeZKKjETLk1" defer></script>
-    <!-- Server: WEB03; Build: release-20220601.1.Release_6045 
+    <!-- Server: WEB03; Build: release-20220601.1.Release_6045
  -->
 </body>
 </html>


### PR DESCRIPTION
## Description
Fixes the error found in https://ci.cgeo.org/job/cgeo-CI_PR-build/12338/testReport/cgeo.geocaching/CgeoApplicationTest/testSearchByGeocodeBasis/

(Website change, cache details seem to be stripped now, no longer returning blank lines (multiple `<br>`) at the beginning of long description)