### PR TITLE
Replace outdated parameter in GoogleNavigationApp (rel. to #15978)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
+++ b/main/src/main/java/cgeo/geocaching/apps/navi/GoogleNavigationApp.java
@@ -30,7 +30,7 @@ abstract class GoogleNavigationApp extends AbstractPointNavigationApp {
     public void navigate(@NonNull final Context context, @NonNull final Geopoint coords) {
         try {
             context.startActivity(new Intent(Intent.ACTION_VIEW, Uri
-                    .parse("google.navigation:ll=" + coords.getLatitude() + ","
+                    .parse("google.navigation:q=" + coords.getLatitude() + ","
                             + coords.getLongitude() + "&mode=" + mode)));
 
         } catch (final Exception e) {


### PR DESCRIPTION
## Description
Replaces outdated `ll` parameter for GoogleNavigationApp by `q` parameter