### PR TITLE
fix #17115: Wherigo, consider html symbols when showing author and cartridge name in cartridge selector

### DIFF
--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoViewUtils.java
@@ -314,8 +314,9 @@ public final class WherigoViewUtils {
         final ImageParam icon = iconData == null ? ImageParam.id(R.drawable.ic_menu_wherigo) :
                 ImageParam.drawable(getDrawableForImageData(null, iconData));
 
-        binding.name.setText(name);
-        binding.description.setText(description);
+        //using "markdown" replaces HTML chars (like eg &amp;) with corresponding text symbols
+        TextParam.text(name).setMarkdown(true).applyTo(binding.name);
+        TextParam.text(description).setMarkdown(true).applyTo(binding.description);
         icon.applyTo(binding.icon);
     }
 


### PR DESCRIPTION
fix #17115: Wherigo, consider html symbols when showing author and cartridge name in cartridge selector