### PR TITLE
fix #17135: Avoid doubled log-entries

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1719,13 +1719,17 @@ public final class GCParser {
      * @param logsToMerge the list of logs to merge
      */
     private static void mergeFriendsLogs(final List<LogEntry> mergedLogs, final Iterable<LogEntry> logsToMerge) {
+        final Map<String, LogEntry> logsToMergeMap = new HashMap<>();
+        for (final LogEntry logToMerge : mergedLogs) {
+            logsToMergeMap.put(logToMerge.serviceLogId, logToMerge);
+        }
         for (final LogEntry log : logsToMerge) {
-            final int logIndex = mergedLogs.indexOf(log);
-            if (logIndex < 0) {
+            final LogEntry friendLog = logsToMergeMap.get(log.serviceLogId);
+            if (friendLog == null) {
                 mergedLogs.add(log);
-            } else {
-                final LogEntry friendLog = mergedLogs.get(logIndex);
-                if (!friendLog.friend) {
+            } else if (!friendLog.friend) {
+                final int logIndex = mergedLogs.indexOf(friendLog);
+                if (logIndex >= 0) {
                     final LogEntry updatedFriendLog = friendLog.buildUpon().setFriend(true).build();
                     mergedLogs.set(logIndex, updatedFriendLog);
                 }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1640,7 +1640,9 @@ public final class GCParser {
         mergeOfflineLogTime(ownLogEntriesBlocked, offlineLog);
 
         // merge time from online-logs already stored in db (overrides possible offline log)
-        mergeLogTimes(ownLogEntriesBlocked, ownLogsFromDb);
+        if (!ownLogsFromDb.isEmpty()) {
+            mergeLogTimes(ownLogEntriesBlocked, ownLogsFromDb);
+        }
 
         if (cache.isFound() || cache.isDNF()) {
             for (final LogEntry logEntry : ownLogEntriesBlocked) {
@@ -1652,7 +1654,9 @@ public final class GCParser {
         }
 
         final List<LogEntry> specialLogEntries = ListUtils.union(friendLogsBlocked, ownLogEntriesBlocked);
-        mergeFriendsLogs(logsBlocked, specialLogEntries);
+        if (!specialLogEntries.isEmpty()) {
+            mergeFriendsLogs(logsBlocked, specialLogEntries);
+        }
 
         DataStore.saveLogs(cache.getGeocode(), logsBlocked, true);
     }

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1640,9 +1640,7 @@ public final class GCParser {
         mergeOfflineLogTime(ownLogEntriesBlocked, offlineLog);
 
         // merge time from online-logs already stored in db (overrides possible offline log)
-        if (!ownLogsFromDb.isEmpty()) {
-            mergeLogTimes(ownLogEntriesBlocked, ownLogsFromDb);
-        }
+        mergeLogTimes(ownLogEntriesBlocked, ownLogsFromDb);
 
         if (cache.isFound() || cache.isDNF()) {
             for (final LogEntry logEntry : ownLogEntriesBlocked) {
@@ -1654,9 +1652,7 @@ public final class GCParser {
         }
 
         final List<LogEntry> specialLogEntries = ListUtils.union(friendLogsBlocked, ownLogEntriesBlocked);
-        if (!specialLogEntries.isEmpty()) {
-            mergeFriendsLogs(logsBlocked, specialLogEntries);
-        }
+        mergeFriendsLogs(logsBlocked, specialLogEntries);
 
         DataStore.saveLogs(cache.getGeocode(), logsBlocked, true);
     }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
 Check for serviceLogId, because log was recreated and could hence not found via `contains(log)`

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fix #17135

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->