### PR TITLE
modify import icon

### DIFF
--- a/main/src/main/res/drawable/ic_menu_import.xml
+++ b/main/src/main/res/drawable/ic_menu_import.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="24"
     android:tint="?android:textColorPrimary">
     <path
-        android:pathData="M6,2C4.89,2 4,2.9 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,3.5L18.5,9H13M10.05,11.22L12.88,14.05L15,11.93V19H7.93L10.05,16.88L7.22,14.05"
+        android:pathData="M6,2C4.89,2,4,2.9,4,4V20A2,2,0,0,0,6,22H18A2,2,0,0,0,20,20V8L14,2,M13,3.5L18.5,9H13M13.95,18.99L11.12,16.16L9,18.28V11.21H16.07L13.95,13.34L16.78,16.17"
         android:fillColor="#000"/>
 </vector>


### PR DESCRIPTION
The arrow in the import icon was pointing downwards, which I personally believe is pretty confusing. Rotate it by 180°.


<img height="200" alt="Screenshot_20250721-144436" src="https://github.com/user-attachments/assets/d0f05cf3-5951-47cd-9f52-91688008bcb6" />


<img width="98" height="109" alt="grafik" src="https://github.com/user-attachments/assets/af12dcad-1bd8-4b2e-83d1-bc99ab8765e5" />
