### PR TITLE
Revert "modify import icon"

### DIFF
--- a/main/src/main/res/drawable/ic_menu_import.xml
+++ b/main/src/main/res/drawable/ic_menu_import.xml
@@ -5,7 +5,6 @@
     android:viewportHeight="24"
     android:tint="?android:textColorPrimary">
     <path
-        android:pathData="M6,2C4.89,2 4,2.9 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,3.5L18.5,9H13M15.67,20.5L12.84,17.67L10.72,19.79V12.72H17.79L15.67,14.85L18.5,17.68
-"
+        android:pathData="M6,2C4.89,2 4,2.9 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,3.5L18.5,9H13M10.05,11.22L12.88,14.05L15,11.93V19H7.93L10.05,16.88L7.22,14.05"
         android:fillColor="#000"/>
 </vector>


### PR DESCRIPTION
Reverts cgeo/cgeo#17159

The merged icon is "wrong" as it shows a "INTO file" symbol for a "FROM file" action.

See https://github.com/cgeo/cgeo/issues/17204