### PR TITLE
UnifiedMap, GeoItemLayer: add better logging to analyze problems with nonclickable items

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -139,6 +139,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     // Activity should only contain display logic, everything else goes into the ViewModel
 
+    private static final String LOGPRAEFIX = "UnifiedMapActivity:";
+
     private static final String STATE_ROUTETRACKUTILS = "routetrackutils";
     private static final String ROUTING_SERVICE_KEY = "UnifiedMap";
 
@@ -548,7 +550,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     private LiveMapGeocacheLoader.LoadState oldStatus;
 
     public void setLiveLoadStatus(final LiveMapGeocacheLoader.LiveDataState observedStatus) {
-        Log.iForce("UnifiedMap:set progress to " + observedStatus);
+        Log.d(LOGPRAEFIX + "set progress to " + observedStatus.loadState);
         refreshLiveStatusView();
     }
 
@@ -682,7 +684,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
 
     public void replaceSearchResultByGeocaches(final SearchResult searchResult) {
-        Log.d("replace " + searchResult.getGeocodes());
+        Log.d(LOGPRAEFIX + "replace " + searchResult.getGeocodes());
         viewModel.caches.write(true, Set::clear);
         final Set<Geocache> geocaches = DataStore.loadCaches(searchResult.getGeocodes(), LoadFlags.LOAD_CACHE_OR_DB);
         CommonUtils.filterCollection(geocaches, cache -> cache != null && cache.getCoords() != null);
@@ -1122,8 +1124,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         // lookup elements touched by this
         final LinkedList<MapSelectableItem> result = new LinkedList<>();
+        final Set<String> touchedKeys = clickableItemsLayer.getTouched(Geopoint.forE6(latitudeE6, longitudeE6));
+        final Set<String> missedKeys = new HashSet<>();
 
-        for (String key : clickableItemsLayer.getTouched(Geopoint.forE6(latitudeE6, longitudeE6))) {
+        for (String key : touchedKeys) {
 
             if (key.startsWith(UnifiedMapViewModel.CACHE_KEY_PREFIX)) {
                 final String geocode = key.substring(UnifiedMapViewModel.CACHE_KEY_PREFIX.length());
@@ -1132,9 +1136,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 if (temp != null && temp.getCoords() != null) {
                     result.add(new MapSelectableItem(new RouteItem(temp)));
                 }
-            }
-
-            if (key.startsWith(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX) && isLongTap) { // only consider when tap was a longTap
+            } else if (key.startsWith(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX) && isLongTap) { // only consider when tap was a longTap
                 final String identifier = key.substring(UnifiedMapViewModel.COORDSPOINT_KEY_PREFIX.length());
 
                 for (RouteItem item : viewModel.individualRoute.getValue().getRouteItems()) {
@@ -1143,9 +1145,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                         break;
                     }
                 }
-            }
-
-            if (key.startsWith(UnifiedMapViewModel.WAYPOINT_KEY_PREFIX)) {
+            } else if (key.startsWith(UnifiedMapViewModel.WAYPOINT_KEY_PREFIX)) {
                 final String fullGpxId = key.substring(UnifiedMapViewModel.WAYPOINT_KEY_PREFIX.length());
                 viewModel.waypoints.read(wps -> {
                     for (Waypoint waypoint : wps) {
@@ -1155,29 +1155,23 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                         }
                     }
                 });
-            }
-
-            if (key.startsWith(IndividualRouteLayer.KEY_INDIVIDUAL_ROUTE) && isLongTap) {
+            } else if (key.startsWith(IndividualRouteLayer.KEY_INDIVIDUAL_ROUTE) && isLongTap) {
                 result.add(new MapSelectableItem(viewModel.individualRoute.getValue()));
-            }
-            if (key.startsWith(TracksLayer.TRACK_KEY_PREFIX) && viewModel.getTracks().getTrack(key.substring(TracksLayer.TRACK_KEY_PREFIX.length())).getRoute() instanceof Route && isLongTap) {
+            } else if (key.startsWith(TracksLayer.TRACK_KEY_PREFIX) && viewModel.getTracks().getTrack(key.substring(TracksLayer.TRACK_KEY_PREFIX.length())).getRoute() instanceof Route && isLongTap) {
                 result.add(new MapSelectableItem((Route) viewModel.getTracks().getTrack(key.substring(TracksLayer.TRACK_KEY_PREFIX.length())).getRoute()));
-            }
-            if (key.startsWith(WherigoLayer.WHERIGO_KEY_PRAEFIX) && !isLongTap) {
+            } else if (key.startsWith(WherigoLayer.WHERIGO_KEY_PRAEFIX) && !isLongTap) {
                 result.add(new MapSelectableItem(WherigoGame.get().getZone(key.substring(WherigoLayer.WHERIGO_KEY_PRAEFIX.length())),
                         key.substring(WherigoLayer.WHERIGO_KEY_PRAEFIX.length()), // Zone name
                         WherigoGame.get().getCartridgeName(), // Wherigo
                         WherigoThingType.LOCATION.getIconId()));
-            }
-
-            if (key.startsWith(GeoItemTestLayer.TESTLAYER_KEY_PREFIX)) {
+            } else if (key.startsWith(GeoItemTestLayer.TESTLAYER_KEY_PREFIX)) {
                 result.add(new MapSelectableItem(key, "Test item: " + key.substring(GeoItemTestLayer.TESTLAYER_KEY_PREFIX.length()), clickableItemsLayer.get(key).getType().toString(), -1));
+            } else {
+                missedKeys.add(key);
             }
-
-
-
         }
-        Log.d("touched elements on " + touchedPoint + " (" + result.size() + "): " + result);
+        Log.iForce(LOGPRAEFIX + "TOUCHED [" + touchedPoint + "/" + isLongTap + "] (identified " + result.size() + " of " + touchedKeys.size() + ", missed: " + missedKeys + ")");
+        Log.d(LOGPRAEFIX + "TOUCHED DETAILS: " + result);
 
         if (result.isEmpty()) {
             if (isLongTap) {
@@ -1210,7 +1204,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 SimpleDialog.of(this).setTitle(R.string.map_select_multiple_items).selectSingle(model, item -> handleTap(item, touchedPoint, isLongTap, x, y));
 
             } catch (final Resources.NotFoundException e) {
-                Log.e("UnifiedMapActivity.showSelection", e);
+                Log.e(LOGPRAEFIX + "showSelection", e);
             }
         }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
@@ -127,7 +127,8 @@ public class GeoItemLayer<K> {
         @SuppressWarnings("unchecked")
         MapWriter(final String logPraefix, final IProviderGeoItemLayer<?> providerLayer) {
             this.providerLayer = (IProviderGeoItemLayer<Object>) providerLayer;
-            this.logPraefix = logPraefix;
+            this.logPraefix = logPraefix + "[" + System.identityHashCode(this) + "] ";
+            Log.iForce(this.logPraefix + " CREATE ");
         }
 
         @Override
@@ -195,7 +196,8 @@ public class GeoItemLayer<K> {
 
         @Override
         public void destroy(final Collection<Pair<GeoPrimitive, Object>> values) {
-            Log.i(this.logPraefix + "DESTROY " + values.size() + " values");
+            Log.iForce(this.logPraefix + " DESTROY " + values.size() + " values" +
+                    " (after a total of " + addProcessed + " ADDs, " + removeProcessed + " REMOVES, " + replaceProcessed + " REPLACES)");
 
             if (providerLayer != null) {
                 providerLayer.destroy(values);
@@ -260,7 +262,7 @@ public class GeoItemLayer<K> {
 
         final IProviderGeoItemLayer<?>  providerLayer = newProviderLayer == null ? NOOP_GEOITEM_LAYER : newProviderLayer;
         final String logPraefix = "GeoItemLayer:" + getId() + "(" + providerLayer.getClass().getSimpleName() + "):";
-        Log.d(logPraefix + " init " + zLevel);
+        Log.d(logPraefix + " setProvider " + zLevel);
         providerLayer.init(zLevel);
         this.providerLayer = providerLayer;
         this.mapWriter = new AsynchronousMapWrapper<>(new MapWriter(logPraefix, providerLayer));


### PR DESCRIPTION
UnifiedMap, GeoItemLayer: add better logging to analyze problems with nonclickable items

This PR improves logging inside UnifiedMapActivity and GeoItemLayer. It is designed to analyze the problem with non-clickable items which @murggel was experiencing. It is at the same time designed in a way that it can stay in the code permanently (and might be useful to analyze future, not-yet-known problems).