### PR TITLE
fix #13683: Show generated waypoints on map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -424,7 +424,10 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                         if (null != currentCoordinates) {
                             viewModel.caches.write(false, c -> {
                                 c.clear();
-                                c.add(cache);
+                                // we can only display the cache if it has coordinates
+                                if (null != cacheCoordinates) {
+                                    c.add(cache);
+                                }
                             });
 
                             viewModel.waypoints.write(wps -> {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Remove the restriction on showing only caches with valid coordinates on the map.
Now caches with valid coordinates or having at least one waypoint with valid coordinates are shown.
So generated waypoints are shown on the map (their cache doesn't have a coordinate)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #13683


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Implementing  a function to the map to display multiple waypoints as mentioned from @eddiemuc  in https://github.com/cgeo/cgeo/issues/13683#issuecomment-1321104426 was not necessary IMHO, since that implementation is already contained in displaying a single cache. 
So that means a more complex refactoring of displaying only waypoints on the map....

So for displaying a single waypoint there is already a cache for that purpose, which contains the waypoint.
