### PR TITLE
optimize GC login flow for performance

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConstants.java
@@ -103,6 +103,7 @@ public final class GCConstants {
 
     // Info box top-right
     public static final Pattern PATTERN_LOGIN_NAME2 = Pattern.compile("window(?>\\.|\\[')(?:headerSettings|chromeSettings)(?>'\\])?\\s*=\\s*\\{[\\S\\s]*\"username\":\\s*\"([^\"]*)\",?[\\S\\s]*\\}");
+    public static final Pattern PATTERN_LOGIN_NAME3 = Pattern.compile("user:info\":\\s*\\{\\s*\"username\":\\s*\"(([^\\\\\\\"]*(\\\\[a-z\\\"])*)*)\\\",");
     /**
      * Use replaceAll("[,.]","") on the resulting string before converting to an int
      */

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1800,8 +1800,14 @@ public final class GCParser {
             return username;
         }
 
-        //second try
+        // header in right top
         username = TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME2, null);
+        if (StringUtils.isNotBlank(username)) {
+            return username;
+        }
+
+        // serverparams page
+        username = TextUtils.getMatch(page, GCConstants.PATTERN_LOGIN_NAME3, null);
         if (StringUtils.isNotBlank(username)) {
             return username;
         }


### PR DESCRIPTION
optimize the GC login flow:
Calling https://www.geocaching.com/account/signin with a logged-in user redirects to https://www.geocaching.com/play/search which is quite large (and not really used for anything)
Afterwards we call https://www.geocaching.com/play/serverparameters/params to load info about the user, language, ...

This PR changes the signin-call to redirect to https://www.geocaching.com/play/serverparameters/params which a) saves 1 HTTP call, b) prevents us from receiving the large /play/search response