### PR TITLE
add an option to not change the size of images loaded from GC

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/GCParserTest.java
@@ -83,7 +83,7 @@ public class GCParserTest {
         assertThat(cache).isNotNull();
         assertThat(cache.getSpoilers()).as("spoilers").hasSize(2);
         final Image spoiler = cache.getSpoilers().get(1);
-        assertThat(spoiler.getUrl()).as("First spoiler image url wrong").isEqualTo("https://img.geocaching.com/6ddbbe82-8762-46ad-8f4c-57d03f4b0564.jpeg");
+        assertThat(spoiler.getUrl()).as("First spoiler image url wrong").isEqualTo("http://imgcdn.geocaching.com/cache/large/6ddbbe82-8762-46ad-8f4c-57d03f4b0564.jpeg");
         assertThat(spoiler.getTitle()).as("First spoiler image text wrong").isEqualTo("SPOILER");
         assertThat(spoiler.getDescription()).as("First spoiler image description").isEqualTo("Spoiler");
     }
@@ -327,7 +327,7 @@ public class GCParserTest {
         final Image spoiler = spoilers.get(0);
         assertThat(spoiler.getTitle()).isEqualTo("");
         assertThat(spoiler.getDescription()).isEqualTo("Spoiler: FOTO SPOILER");
-        assertThat(spoiler.getUrl()).isEqualTo("https://img.geocaching.com/124a14b5-87dd-42c6-8c83-52c184e07389.jpg");
+        assertThat(spoiler.getUrl()).isEqualTo("https://img.geocaching.com/cache/large/124a14b5-87dd-42c6-8c83-52c184e07389.jpg");
     }
 
     @MediumTest
@@ -350,7 +350,7 @@ public class GCParserTest {
 
         final List<Image> images = GCParser.parseSpoiler(html);
         assertThat(images).hasSize(2);
-        assertThat(images.get(0).getUrl()).isEqualTo("https://img.geocaching.com/baf98e07-b431-4fbf-920d-0df4346c2847.JPG");
+        assertThat(images.get(0).getUrl()).isEqualTo("https://img.geocaching.com/cache/large/baf98e07-b431-4fbf-920d-0df4346c2847.JPG");
         assertThat(images.get(0).getTitle()).isEqualTo("Blick vom Weg");
         assertThat(images.get(0).getDescription()).isEqualTo("Spoiler");
     }
@@ -391,17 +391,32 @@ public class GCParserTest {
                 "\t</table>\n";
         final List<Image> images = GCParser.parseGalleryImages(html, url -> true);
         assertThat(images).hasSize(3);
-        assertThat(images.get(0).getUrl()).isEqualTo("https://img.geocaching.com/93cc7be4-0515-4364-9d9a-be9336f279c7.jpg");
+        assertThat(images.get(0).getUrl()).isEqualTo("https://img.geocaching.com/cache/log/large/93cc7be4-0515-4364-9d9a-be9336f279c7.jpg");
         assertThat(images.get(0).getTitle()).isEqualTo("Bild ");
         assertThat(images.get(0).getDescription()).isEqualTo("Gallery: 09.02.2025");    }
 
     @MediumTest
     @Test
-    public void testFullScaleImageUrl() {
+    public void testFullScaleImawhergeUrl() {
         assertThat(ImageUtils.getGCFullScaleImageUrl("https://www.dropbox.com/s/1kakwnpny8698hm/QR_Hintergrund.jpg?dl=1"))
                 .isEqualTo("https://www.dropbox.com/s/1kakwnpny8698hm/QR_Hintergrund.jpg?dl=1");
+        Settings.putString(cgeo.geocaching.R.string.pref_gc_imagesize, ImageUtils.GCImageSize.ORIGINAL.name());
         assertThat(ImageUtils.getGCFullScaleImageUrl("http://imgcdn.geocaching.com/track/display/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg"))
                 .isEqualTo("https://img.geocaching.com/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg");
+        Settings.putString(cgeo.geocaching.R.string.pref_gc_imagesize, ImageUtils.GCImageSize.THUMB.name());
+        assertThat(ImageUtils.getGCFullScaleImageUrl("http://imgcdn.geocaching.com/track/log/large/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg"))
+                .isEqualTo("https://img.geocaching.com/thumb/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg");
+        Settings.putString(cgeo.geocaching.R.string.pref_gc_imagesize, ImageUtils.GCImageSize.THUMB.name());
+        assertThat(ImageUtils.getGCFullScaleImageUrl("http://imgcdn.geocaching.com/track/display/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg"))
+                .isEqualTo("https://img.geocaching.com/thumb/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg");
+        Settings.putString(cgeo.geocaching.R.string.pref_gc_imagesize, ImageUtils.GCImageSize.UNCHANGED.name());
+        assertThat(ImageUtils.getGCFullScaleImageUrl("https://s3.amazonaws.com/gs-geo-images/33cee358-f692-4f90-ace0-80c5a2c60a5c_t.jpg"))
+                .isEqualTo("https://s3.amazonaws.com/gs-geo-images/33cee358-f692-4f90-ace0-80c5a2c60a5c_t.jpg");
+        Settings.putString(cgeo.geocaching.R.string.pref_gc_imagesize, ImageUtils.GCImageSize.LARGE.name());
+        assertThat(ImageUtils.getGCFullScaleImageUrl("https://s3.amazonaws.com/gs-geo-images/33cee358-f692-4f90-ace0-80c5a2c60a5c_t.jpg"))
+                .isEqualTo("https://img.geocaching.com/large/33cee358-f692-4f90-ace0-80c5a2c60a5c.jpg");
+        // return to the default UNCHANGED
+        Settings.putString(cgeo.geocaching.R.string.pref_gc_imagesize, ImageUtils.GCImageSize.UNCHANGED.name());
     }
 
     @MediumTest

--- a/main/src/androidTest/java/cgeo/geocaching/connector/gc/TrackablesTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/gc/TrackablesTest.java
@@ -42,7 +42,7 @@ public class TrackablesTest {
         final List<Image> logImages = log.get(5).logImages;
         assertThat(logImages).isNotNull();
         assertThat(logImages).hasSize(1);
-        assertThat(logImages.get(0).getUrl()).isEqualTo("https://img.geocaching.com/3dc286d2-671e-4502-937a-f1bd35a13813.jpg");
+        assertThat(logImages.get(0).getUrl()).isEqualTo("https://img.geocaching.com/track/log/large/3dc286d2-671e-4502-937a-f1bd35a13813.jpg");
         assertThat(logImages.get(0).getTitle()).isEqualTo("@Osaka");
 
         for (final LogEntry entry : log) {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceServiceGeocachingComFragment.java
@@ -6,6 +6,8 @@ import cgeo.geocaching.settings.Credentials;
 import cgeo.geocaching.settings.CredentialsPreference;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.dialog.Dialogs;
+import cgeo.geocaching.utils.ImageUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.PreferenceUtils;
 import cgeo.geocaching.utils.SettingsUtils;
 import cgeo.geocaching.utils.ShareUtils;
@@ -13,8 +15,11 @@ import cgeo.geocaching.utils.ShareUtils;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
+import java.util.Arrays;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -45,6 +50,10 @@ public class PreferenceServiceGeocachingComFragment extends PreferenceFragmentCo
             builder.create().show();
             return true;
         });
+
+        final ListPreference imageSizePref = findPreference(getString(R.string.pref_gc_imagesize));
+        imageSizePref.setEntries(Arrays.stream(ImageUtils.GCImageSize.values()).map(is -> LocalizationUtils.getString(is.getLabel())).toArray(String[]::new));
+        imageSizePref.setEntryValues(Arrays.stream(ImageUtils.GCImageSize.values()).map(Enum::name).toArray(String[]::new));
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -532,7 +532,10 @@ public final class ImageUtils {
     public static String getGCFullScaleImageUrl(@NonNull final String imageUrl) {
         // Images from geocaching.com exist in original + 4 generated sizes: large, display, small, thumb
         // Manipulate the URL to load the requested size.
-        final GCImageSize preferredSize = ImageUtils.GCImageSize.valueOf(Settings.getString(R.string.pref_gc_imagesize, "ORIGINAL"));
+        final GCImageSize preferredSize = ImageUtils.GCImageSize.valueOf(Settings.getString(R.string.pref_gc_imagesize, "UNCHANGED"));
+        if (preferredSize == GCImageSize.UNCHANGED) {
+            return imageUrl;
+        }
         MatcherWrapper matcherViewstates = new MatcherWrapper(PATTERN_GC_HOSTED_IMAGE, imageUrl);
         if (matcherViewstates.find()) {
             return "https://img.geocaching.com/" + preferredSize.getPathname() + matcherViewstates.group(1);
@@ -546,6 +549,7 @@ public final class ImageUtils {
     }
 
     public enum GCImageSize {
+        UNCHANGED("", ""),
         ORIGINAL("", ""),
         LARGE("_l", "large/"),
         DISPLAY("_d", "display/"),

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -45,6 +45,7 @@ import android.widget.TextView;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.core.content.FileProvider;
 import androidx.core.graphics.BitmapCompat;
 import androidx.core.util.Predicate;
@@ -549,19 +550,21 @@ public final class ImageUtils {
     }
 
     public enum GCImageSize {
-        UNCHANGED("", ""),
-        ORIGINAL("", ""),
-        LARGE("_l", "large/"),
-        DISPLAY("_d", "display/"),
-        SMALL("_sm", "small/"),
-        THUMB("_t", "thumb/");
+        UNCHANGED("", "", R.string.settings_gc_imagesize_entry_unchanged),
+        ORIGINAL("", "", R.string.settings_gc_imagesize_entry_original),
+        LARGE("_l", "large/", R.string.settings_gc_imagesize_entry_large),
+        DISPLAY("_d", "display/", R.string.settings_gc_imagesize_entry_diplay),
+        SMALL("_sm", "small/", R.string.settings_gc_imagesize_entry_small),
+        THUMB("_t", "thumb/", R.string.settings_gc_imagesize_entry_thumb);
 
         private final String suffix;
         private final String pathname;
+        private final int label;
 
-        GCImageSize(final String suffix, final String pathname) {
+        GCImageSize(final String suffix, final String pathname, final @StringRes int label) {
             this.suffix = suffix;
             this.pathname = pathname;
+            this.label = label;
         }
 
         public String getPathname() {
@@ -570,6 +573,10 @@ public final class ImageUtils {
 
         public String getSuffix() {
             return suffix;
+        }
+
+        public int getLabel() {
+            return label;
         }
     }
 

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -490,11 +490,13 @@
     </string-array>
 
     <!-- Geocaching.com => image size -->
+    <string translatable="false" name="pref_value_gc_imagesize_unchanged">UNCHANGED</string>
     <string translatable="false" name="pref_value_gc_imagesize_original">ORIGINAL</string>
     <string translatable="false" name="pref_value_gc_imagesize_large">LARGE</string>
     <string translatable="false" name="pref_value_gc_imagesize_display">DISPLAY</string>
     <string translatable="false" name="pref_value_gc_imagesize_small">SMALL</string>
     <string-array name="pref_gc_imagesize_values">
+        <item>@string/pref_value_gc_imagesize_unchanged</item>
         <item>@string/pref_value_gc_imagesize_original</item>
         <item>@string/pref_value_gc_imagesize_large</item>
         <item>@string/pref_value_gc_imagesize_display</item>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -491,17 +491,6 @@
 
     <!-- Geocaching.com => image size -->
     <string translatable="false" name="pref_value_gc_imagesize_unchanged">UNCHANGED</string>
-    <string translatable="false" name="pref_value_gc_imagesize_original">ORIGINAL</string>
-    <string translatable="false" name="pref_value_gc_imagesize_large">LARGE</string>
-    <string translatable="false" name="pref_value_gc_imagesize_display">DISPLAY</string>
-    <string translatable="false" name="pref_value_gc_imagesize_small">SMALL</string>
-    <string-array name="pref_gc_imagesize_values">
-        <item>@string/pref_value_gc_imagesize_unchanged</item>
-        <item>@string/pref_value_gc_imagesize_original</item>
-        <item>@string/pref_value_gc_imagesize_large</item>
-        <item>@string/pref_value_gc_imagesize_display</item>
-        <item>@string/pref_value_gc_imagesize_small</item>
-    </string-array>
 
     <!-- ============================================================================================================================================================================== -->
     <!-- other preference keys (not used directly in our preferences) -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3127,9 +3127,10 @@
 
     <!-- GC image size conversion -->
     <string name="settings_gc_imagesize_title">Preferred Image Size</string>
-    <string name="settings_gc_imagesize_summary">Images from Geocaching.com in listing, logs and trackables are available in different sizes. Select the size to be loaded when loading and storing a cache.</string>
+    <string name="settings_gc_imagesize_summary">Images from Geocaching.com in listing, logs and trackables are available in different sizes. Select the size to be loaded when loading and storing a cache. "Unchanged" will load the version the listing/log author included in the page.</string>
     <string-array name="settings_gc_imagesize_entries">
-        <item>Original</item>
+        <item>Unchanged</item>
+        <item>Maximum</item>
         <item>640px</item>
         <item>320px</item>
         <item>120px</item>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3128,13 +3128,12 @@
     <!-- GC image size conversion -->
     <string name="settings_gc_imagesize_title">Preferred Image Size</string>
     <string name="settings_gc_imagesize_summary">Images from Geocaching.com in listing, logs and trackables are available in different sizes. Select the size to be loaded when loading and storing a cache. "Unchanged" will load the version the listing/log author included in the page.</string>
-    <string-array name="settings_gc_imagesize_entries">
-        <item>Unchanged</item>
-        <item>Maximum</item>
-        <item>640px</item>
-        <item>320px</item>
-        <item>120px</item>
-    </string-array>
+    <string name="settings_gc_imagesize_entry_unchanged">Unchanged</string>
+    <string name="settings_gc_imagesize_entry_original">Maximum</string>
+    <string name="settings_gc_imagesize_entry_large">640px</string>
+    <string name="settings_gc_imagesize_entry_diplay">320px</string>
+    <string name="settings_gc_imagesize_entry_small">120px</string>
+    <string name="settings_gc_imagesize_entry_thumb">100px</string>
 
     <!-- db inspection -->
     <string name="view_database">View database</string>

--- a/main/src/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/src/main/res/xml/preferences_services_geocaching_com.xml
@@ -36,9 +36,7 @@
             app:iconSpaceReserved="false" />
 
         <ListPreference
-            android:defaultValue="@string/pref_value_gc_imagesize_original"
-            android:entries="@array/settings_gc_imagesize_entries"
-            android:entryValues="@array/pref_gc_imagesize_values"
+            android:defaultValue="@string/pref_value_gc_imagesize_unchanged"
             android:key="@string/pref_gc_imagesize"
             android:title="@string/settings_gc_imagesize_title"
             android:summary="@string/settings_gc_imagesize_summary"


### PR DESCRIPTION
GC has 5 sizes for each image and we currently have a logic for the user to select to load a specific one of those (actually not for thumb as that one is tiny and of no use). However there's currently no option to NOT rewrite the request but instead load whatever the listing owner used when creating the listing.

Also setting that new "unchanged" size as default as that's what you get with any other app.