### PR TITLE
SimpleDialog: cleanup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -615,7 +615,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
             MenuUtils.setVisibleEnabled(menu, R.id.menu_drop_caches_all_lists, isHistory || containsStoredCaches, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_drop_caches_all_lists, R.string.caches_remove_selected_completely, R.string.caches_remove_all_completely, checkedCount);
 
-            MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_bookmarklist, isGcPremiumMember, !isEmpty);
+            //MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_bookmarklist, isGcPremiumMember, !isEmpty);
+            MenuUtils.setVisibleEnabled(menu, R.id.menu_upload_bookmarklist, true, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_upload_bookmarklist, R.string.caches_upload_bookmarklist_selected, R.string.caches_upload_bookmarklist_all, checkedCount);
             MenuUtils.setEnabled(menu, R.id.menu_show_attributes, !isEmpty);
             setMenuItemLabel(menu, R.id.menu_show_attributes, R.string.caches_show_attributes_selected, R.string.caches_show_attributes_all, checkedCount);

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceSystemFragment.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.ui.dialog.SimpleDialogExamples;
 import cgeo.geocaching.utils.BranchDetectionHelper;
 import cgeo.geocaching.utils.DebugUtils;
 import cgeo.geocaching.utils.Log;
@@ -42,6 +43,7 @@ public class PreferenceSystemFragment extends BasePreferenceFragment {
         setPrefClick(this, R.string.pref_fakekey_generate_logcat, () -> DebugUtils.createLogcat(activity));
         setPrefClick(this, R.string.pref_fakekey_view_settings, () -> startActivity(new Intent(activity, ViewSettingsActivity.class)));
         setPrefClick(this, R.string.pref_fakekey_view_database, () -> startActivity(new Intent(activity, DBInspectionActivity.class)));
+        setPrefClick(this, R.string.pref_fakekey_gui_testscreen, () -> SimpleDialogExamples.createTestDialog(activity));
 
         if (BranchDetectionHelper.isDeveloperBuild()) {
             Preference testDir = findPreference(getString(R.string.pref_persistablefolder_testdir));

--- a/main/src/main/java/cgeo/geocaching/ui/ContinuousRangeSlider.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ContinuousRangeSlider.java
@@ -15,7 +15,6 @@ import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.util.Consumer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -103,7 +102,7 @@ public class ContinuousRangeSlider extends LinearLayout {
                     if (slider.getValueFrom() < 0) {
                         inputType |= InputType.TYPE_NUMBER_FLAG_SIGNED;
                     }
-                    final Consumer<String> listener = input -> {
+                    final java.util.function.Consumer<String> listener = input -> {
                         try {
                             final float newValue = Dialogs.checkInputRange(getContext(), Float.parseFloat(input), slider.getValueFrom() * factor, slider.getValueTo() * factor) / factor;
                             if (lastThumb == 0) {

--- a/main/src/main/java/cgeo/geocaching/ui/SimpleItemListModel.java
+++ b/main/src/main/java/cgeo/geocaching/ui/SimpleItemListModel.java
@@ -78,7 +78,8 @@ public class SimpleItemListModel<T> {
         private Function<T, G> groupMapper = null;
         private Function<G, G> groupGroupMapper = null;
 
-        private Func5<G, ItemGroup<T, G>, Context, View, ViewGroup, View> groupDisplayViewMapper = (group, itemGroup, context, view, parent) -> null;
+        private Func5<G, ItemGroup<T, G>, Context, View, ViewGroup, View> groupDisplayViewMapper = constructGroupDisplayViewMapper((ig) -> TextParam.text(ig == null || ig.getGroup() == null ? "-" : ig.getGroup().toString()));
+            //(group, itemGroup, context, view, parent) -> null;
         private Function<ItemGroup<T, G>, ImageParam> groupDisplayIconMapper = (ig) -> null;
         private Comparator<Object> itemGroupComparator = null;
         private Comparator<G> groupComparator = null;

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -13,9 +13,6 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.ScalableDrawable;
 import cgeo.geocaching.utils.TextUtils;
-import cgeo.geocaching.utils.functions.Action1;
-import cgeo.geocaching.utils.functions.Func1;
-import cgeo.geocaching.utils.functions.Func2;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -70,13 +67,14 @@ import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.util.LinkifyCompat;
-import androidx.core.util.Consumer;
-import androidx.core.util.Predicate;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
@@ -182,7 +180,7 @@ public class ViewUtils {
      *                          May return null for some columns, in which case those are empty
      * @return new ViewGroup holding the column layout. If "root" was not null, then "root" is returned.
      */
-    public static ViewGroup createColumnView(final Context ctx, final LinearLayout root, final int columnCount, final boolean withSeparator, final Func1<Integer, View> columnViewCreator) {
+    public static ViewGroup createColumnView(final Context ctx, final LinearLayout root, final int columnCount, final boolean withSeparator, final Function<Integer, View> columnViewCreator) {
 
         final List<Float> columnWidths = new ArrayList<>();
         for (int c = 0; c < columnCount * 2 - 1; c++) {
@@ -195,13 +193,13 @@ public class ViewUtils {
                 return ViewUtils.createVerticalSeparator(ctx, !withSeparator);
             }
 
-            return columnViewCreator.call(i / 2);
+            return columnViewCreator.apply(i / 2);
         }, (i, f) -> f);
     }
 
-    public static <T> ViewGroup createHorizontallyDistributedText(final Context ctx, final LinearLayout root, final List<T> items, final Func2<Integer, T, String> itemTextMapper) {
+    public static <T> ViewGroup createHorizontallyDistributedText(final Context ctx, final LinearLayout root, final List<T> items, final BiFunction<Integer, T, String> itemTextMapper) {
         return createHorizontallyDistributedViews(ctx, root, items, (idx, item) -> {
-            final String itemText = item == null ? null : itemTextMapper.call(idx, item);
+            final String itemText = item == null ? null : itemTextMapper.apply(idx, item);
             if (itemText != null) {
                 final TextView tv = new TextView(ctx);
                 tv.setText(itemText);
@@ -216,11 +214,11 @@ public class ViewUtils {
         });
     }
 
-    public static <T> ViewGroup createHorizontallyDistributedViews(final Context ctx, final LinearLayout root, final List<T> items, final Func2<Integer, T, View> viewCreator) {
+    public static <T> ViewGroup createHorizontallyDistributedViews(final Context ctx, final LinearLayout root, final List<T> items, final BiFunction<Integer, T, View> viewCreator) {
         return createHorizontallyDistributedViews(ctx, root, items, viewCreator, null);
     }
 
-    public static <T> ViewGroup createHorizontallyDistributedViews(final Context ctx, final LinearLayout root, final List<T> items, final Func2<Integer, T, View> viewCreator, final Func2<Integer, T, Float> weightCreator) {
+    public static <T> ViewGroup createHorizontallyDistributedViews(final Context ctx, final LinearLayout root, final List<T> items, final BiFunction<Integer, T, View> viewCreator, final BiFunction<Integer, T, Float> weightCreator) {
 
         final LinearLayout viewGroup = root == null ? new LinearLayout(ctx) : root;
         viewGroup.setOrientation(LinearLayout.HORIZONTAL);
@@ -228,9 +226,9 @@ public class ViewUtils {
         int idx = 0;
         for (T item : items) {
             final LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT);
-            lp.weight = weightCreator == null ? 1 : weightCreator.call(idx, item);
+            lp.weight = weightCreator == null ? 1 : weightCreator.apply(idx, item);
 
-            View itemView = viewCreator.call(idx, item);
+            View itemView = viewCreator.apply(idx, item);
             if (itemView == null) {
                 itemView = new View(ctx);
             }
@@ -726,9 +724,9 @@ public class ViewUtils {
     }
 
     /** null-safe call to view */
-    public static void applyToView(@Nullable final View view, final Action1<View> applyMethod) {
+    public static void applyToView(@Nullable final View view, final Consumer<View> applyMethod) {
         if (view != null) {
-            applyMethod.call(view);
+            applyMethod.accept(view);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/ContextMenuDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/ContextMenuDialog.java
@@ -10,10 +10,10 @@ import android.app.Activity;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
-import androidx.core.util.Consumer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Represents a dialog usable as a context menu for various elements.
@@ -26,7 +26,7 @@ public class ContextMenuDialog {
     private String title;
 
     private final List<Item> items = new ArrayList<>();
-    private Action1<Integer> dialogClickAction;
+    private Consumer<Integer> dialogClickAction;
 
     public ContextMenuDialog setTitle(final String title) {
         this.title = title;
@@ -62,7 +62,7 @@ public class ContextMenuDialog {
         return this;
     }
 
-    public ContextMenuDialog setOnClickAction(final Action1<Integer> clickAction) {
+    public ContextMenuDialog setOnClickAction(final Consumer<Integer> clickAction) {
         this.dialogClickAction = clickAction;
         return this;
     }
@@ -78,7 +78,7 @@ public class ContextMenuDialog {
             if (dialogClickAction != null) {
                 final int pos = this.items.indexOf(it);
                 if (pos >= 0) {
-                    dialogClickAction.call(pos);
+                    dialogClickAction.accept(pos);
                 }
             }
         };

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialogExamples.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialogExamples.java
@@ -1,0 +1,131 @@
+package cgeo.geocaching.ui.dialog;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.ui.ImageParam;
+import cgeo.geocaching.ui.SimpleItemListModel;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.utils.EmojiUtils;
+import cgeo.geocaching.utils.TextUtils;
+
+import android.content.Context;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** Helper class to test real dialogs */
+public class SimpleDialogExamples {
+
+    private enum Example {
+        SELECT_SINGLE_DIRECT,
+        SEELECT_SINGLE_RADIO,
+        SELECT_MULTIPLE
+    }
+
+    private static final ImageParam[] IMAGES = new ImageParam[] {
+        ImageParam.emoji(EmojiUtils.RED_FLAG), ImageParam.id(R.drawable.ic_menu_myposition), ImageParam.id(CacheType.MULTI.iconId)
+    };
+
+    private SimpleDialogExamples() {
+        //no instances
+    }
+
+    public static void createTestDialog(final Context ctx) {
+        final SimpleDialog.ItemSelectModel<Example> model = new SimpleDialog.ItemSelectModel<>();
+        model.setItems(Arrays.asList(Example.values()));
+        SimpleDialog.ofContext(ctx)
+            .setTitle(TextParam.text("SimpleDialog Tests"))
+            .setMessage(TextParam.text("Choose your test dialog"))
+            .selectSingle(model, test -> executeTest(ctx, test));
+    }
+
+    private static void executeTest(final Context ctx, final Example test) {
+        final SimpleDialog dialog = SimpleDialog.ofContext(ctx).setTitle(TextParam.text("TEST: " + test));
+        SimpleDialog.ItemSelectModel<String> model = null;
+        switch (test) {
+            case SELECT_SINGLE_DIRECT:
+                model = createSimpleDialogModel(ctx, SimpleItemListModel.ChoiceMode.SINGLE_PLAIN);
+                dialog.selectSingle(model, item -> display(ctx, "Selected", "Selected: " + item));
+                break;
+            case SEELECT_SINGLE_RADIO:
+                model = createSimpleDialogModel(ctx, SimpleItemListModel.ChoiceMode.SINGLE_RADIO);
+                dialog.selectSingle(model, item -> display(ctx, "Selected", "Selected: " + item));
+                break;
+            case SELECT_MULTIPLE:
+            default:
+                model = createSimpleDialogModel(ctx, SimpleItemListModel.ChoiceMode.MULTI_CHECKBOX);
+                dialog.selectMultiple(model, item -> display(ctx, "Selected", "Selected: " + item));
+                break;
+        }
+    }
+
+    private static SimpleDialog.ItemSelectModel<String> createSimpleDialogModel(final Context ctx, final SimpleItemListModel.ChoiceMode choice) {
+        final SimpleDialog.ItemSelectModel<String> model = new SimpleDialog.ItemSelectModel<>();
+        model.activateGrouping(SimpleDialogExamples::getGroup)
+            .setGroupGroupMapper(SimpleDialogExamples::getGroup)
+            .setGroupPruner(gi -> gi.getSize() >= 2);
+        model.setItemActionListener(item -> display(ctx, "Action clicked", "Action clicked on: " + item));
+        model.setDisplayMapper(item -> {
+           final TextParam tp = TextParam.text(item);
+           final String id = TextUtils.getMatch(item, Pattern.compile("IMG:([0-9]+)"), null);
+           if (id != null) {
+               tp.setImage(IMAGES[Integer.parseInt(id)]);
+           }
+           return tp;
+        }).setDisplayIconMapper(item -> {
+            final String id = TextUtils.getMatch(item, Pattern.compile("ICON:([0-9]+)"), null);
+            if (id != null) {
+                return IMAGES[Integer.parseInt(id)];
+            }
+            return null;
+        });
+        model.setChoiceMode(choice);
+
+        final List<String> items = new ArrayList<>();
+        final List<String> selectedItems = new ArrayList<>();
+
+        //groups
+        for (int i = 0; i < 5; i++) {
+            items.add("Groups:5:it " + i);
+        }
+        for (int i = 0; i < 1; i++) {
+            items.add("Groups:1:it " + i);
+        }
+
+        //preselected
+        for (int i = 0; i < 6; i++) {
+            final boolean isPre = i % 2 == 0;
+            final String item = "PreSel:It " + i + "(PRE: " + isPre + ")";
+            items.add(item);
+            if (isPre) {
+                selectedItems.add(item);
+            }
+        }
+
+        //images and icons
+        for (int i = 0; i < 6; i++) {
+            items.add("Images:It " + i + " (IMG:" + (i % IMAGES.length) + ")");
+        }
+        for (int i = 0; i < 6; i++) {
+            items.add("Icons:It " + i + " (ICON:" + (i % IMAGES.length) + ")");
+        }
+
+        model.setItems(items);
+        model.setSelectedItems(selectedItems);
+        return model;
+    }
+
+    private static String getGroup(final String item) {
+        final int idx = item == null ? -1 : item.lastIndexOf(":");
+        return idx < 0 ? null : item.substring(0, idx);
+    }
+
+    private static void display(final Context ctx, final String title, final String message) {
+        SimpleDialog.ofContext(ctx)
+            .setTitle(TextParam.text(title))
+            .setMessage(TextParam.text(message)).show();
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/TranslatorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/TranslatorUtils.java
@@ -201,7 +201,7 @@ public class TranslatorUtils {
     public static Disposable initializeView(final String id, final Context context, final Translator translator,
                                             final Button button, final View box, final TextView status) {
 
-        final androidx.core.util.Consumer<Boolean> circularSetter = ViewUtils.createCircularProgressSetter(button);
+        final Consumer<Boolean> circularSetter = ViewUtils.createCircularProgressSetter(button);
 
         //changes on state
         final Disposable disposable = translator.addStateListener((s, e) -> {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -404,6 +404,7 @@
     <string translatable="false" name="pref_fakekey_reset_otm">fakekey_reset_otm</string>
     <string translatable="false" name="pref_fakekey_view_settings">fakekey_view_settings</string>
     <string translatable="false" name="pref_fakekey_view_database">fakekey_view_database</string>
+    <string translatable="false" name="pref_fakekey_gui_testscreen">fakekey_gui_testscreen</string>
 
 
     <!-- ============================================================================================================================================================================== -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1373,6 +1373,7 @@
     <string name="category_unifiedMap">Unified Map</string>
     <string name="localstorage_migrate_title">Migration of local files</string>
     <string name="localstorage_migrate_status_major">Version %1$d</string>
+    <string name="gui_test_title">GUI Test Screen</string>
 
     <!-- proximity notification -->
     <string name="settings_title_proximityNotification">Proximity notification</string>

--- a/main/src/main/res/xml/preferences_system.xml
+++ b/main/src/main/res/xml/preferences_system.xml
@@ -93,5 +93,10 @@
             android:layout="@layout/preference_button"
             android:title="@string/view_database"
             app:iconSpaceReserved="false" />
+        <Preference
+            android:key="@string/pref_fakekey_gui_testscreen"
+            android:layout="@layout/preference_button"
+            android:title="@string/gui_test_title"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
SimpleDialog: cleanup

While looking at #17264 I realized that there are some long-overdue refactorings necessary to SimpleDialog. AMong some minor cleanups, SimpleDialog still didn't use the JDK function classes (Consumer, Predicate and so on) but instead our own versions (Func1, Action1 etc). This is no longer necessary for a long time.

As part of this I created a (currently sketchy) Test Dialog class SImpleDialogTest. It helped me greatly already to identify two bugs. I would love to keep it in code for future changes to SimpleDialog to easily test them. I made this accessible through a new Button in System dialog right under "View Database". This seemed to fit since "View Database" is also a development-nrea option. Hope thats ok..