### PR TITLE
fix #17291: Use unixepoch and service_log_id for sorting logs

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -3774,7 +3774,7 @@ public class DataStore {
                         //                     0           1               2     3       4            5    6     7      8                                       9                10      11     12   13           14
                         "SELECT cg_logs._id AS cg_logs_id, service_log_id, type, author, author_guid, log, date, found, friend, " + dbTableLogImages + "._id as cg_logImages_id, log_id, title, url, description, service_image_id"
                                 + " FROM " + dbTableLogs + " LEFT OUTER JOIN " + dbTableLogImages
-                                + " ON ( cg_logs._id = log_id ) WHERE geocode = ?  " + " AND author LIKE ? " + whereFriendSql + " ORDER BY Date(date) DESC, cg_logs._id ASC", new String[]{geocode, StringUtils.isEmpty(authorName) ? "%" : authorName});
+                                + " ON ( cg_logs._id = log_id ) WHERE geocode = ?  " + " AND author LIKE ? " + whereFriendSql + " ORDER BY Date(date / 1000, 'unixepoch') DESC, service_log_id DESC, cg_logs._id ASC ", new String[]{geocode, StringUtils.isEmpty(authorName) ? "%" : authorName});
 
                 LogEntry.Builder log = null;
                 int cnt = 0;


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Used Date(date) did not work, so use option unixepoch and service_log_id for sorting logs

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #17291
