### PR TITLE
Related to #17157 - Workaround for UI glitch API35

### DIFF
--- a/main/src/main/res/values-v35/themes.xml
+++ b/main/src/main/res/values-v35/themes.xml
@@ -2,9 +2,7 @@
 <resources>
 
     <style name="cgeo_base" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <item name="android:fitsSystemWindows">true</item>
-        <item name="android:enforceNavigationBarContrast">true</item>
-        <item name="android:enforceStatusBarContrast">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Description
Found coincidentally, that the feature edge-to-edge enforcement might cause UI problems on Android 15 for some apps.
The indicated workaround was to opt out of this feature on Android 15.

This is most probably not a fix and AFAICS this will not work for Android 16 to opt out.
This means the underlying issue needs to be resolved to make c:geo compatible with this edge-to-edge feature

I did quickly run it on an emulator and the UI glitches in text field paddings are gone.
Could not check the map top padding as this problem was not visible in the emulator even before.


## Related issues
#17157 and maybe #17151


## Additional context
Did not record the precise source for this workaround, however this might be a starting point for further investigation:
https://developer.android.com/about/versions/15/behavior-changes-15?hl=de#edge-to-edge
