### PR TITLE
fix #17311: Show waypoints for mapType which enableLiveMap, not only for visible caches.

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -663,7 +663,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         final Set<Waypoint> waypoints;
 
         //show all waypoints be displayed or just the ones from visible caches?
-        final boolean showAll = TRUE.equals(viewModel.transientIsLiveEnabled.getValue());
+        final boolean showAll = viewModel.mapType.enableLiveMap();
         if (showAll) {
             waypoints = DataStore.loadWaypoints(viewport);
         } else {
@@ -675,6 +675,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 return wpSet;
             });
         }
+
         //filter waypoints
         MapUtils.filter(waypoints, filter);
         viewModel.waypoints.write(wps -> {


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Show waypoints for mapType which enableLiveMap, not only for visible caches.
So waypoints in the visible area are shown, even if the cache-coordinates are outside of the considered viewport

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #17311

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->