### PR TITLE
Same padding in variables, waypoint and logs-view

### DIFF
--- a/main/src/main/res/layout/cachedetail_imagegallery_page.xml
+++ b/main/src/main/res/layout/cachedetail_imagegallery_page.xml
@@ -4,7 +4,6 @@
     android:id="@+id/image_gallery"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:padding="4dip"
     tools:context=".CacheDetailActivity$ImageGalleryCreator">
 
 </cgeo.geocaching.ui.ImageGalleryView>

--- a/main/src/main/res/layout/cachedetail_variables_page.xml
+++ b/main/src/main/res/layout/cachedetail_variables_page.xml
@@ -18,7 +18,6 @@
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="4sp"
         android:orientation="horizontal">
 
         <Button
@@ -63,6 +62,7 @@
         android:id="@+id/chip_completed_variables"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="7sp"
         style="@style/chip_choice"
         android:text="@string/cache_variables_chip_completed_variables"
         tools:context=".VariablesViewPageFragment" />
@@ -70,6 +70,7 @@
     <View
         android:id="@+id/variable_header_line"
         style="@style/separator_horizontal"
+        android:paddingHorizontal="@dimen/paddingRight_fastscroll"
         android:layout_marginTop="3dp" />
 
     <ScrollView

--- a/main/src/main/res/layout/cachedetail_waypoints_page.xml
+++ b/main/src/main/res/layout/cachedetail_waypoints_page.xml
@@ -18,6 +18,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4sp"
             android:orientation="horizontal">
 
             <Button
@@ -28,8 +29,7 @@
                 android:focusable="true"
                 android:text="@string/cache_waypoints_add"
                 app:icon="@drawable/ic_menu_add"
-                tools:context=".CacheDetailActivity$WaypointsViewCreator"
-                android:layout_width="0dp" />
+                tools:context=".CacheDetailActivity$WaypointsViewCreator" />
 
             <Button
                 android:id="@+id/add_waypoint_fromclipboard"
@@ -46,7 +46,6 @@
                 android:focusable="true"
                 app:icon="@drawable/ic_menu_mylocation" />
 
-
         </LinearLayout>
 
         <com.google.android.material.chip.Chip
@@ -54,6 +53,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/chip_choice"
+            android:layout_marginHorizontal="7sp"
             android:text="@string/waypoint_visited"
             tools:context=".CacheDetailActivity$WaypointsViewCreator" />
     </LinearLayout>
@@ -61,6 +61,7 @@
     <View
         android:id="@+id/waypoint_header_line"
         style="@style/separator_horizontal"
+        android:paddingHorizontal="@dimen/paddingRight_fastscroll"
         android:layout_marginTop="3dp" />
 
     <ListView

--- a/main/src/main/res/layout/logs_page.xml
+++ b/main/src/main/res/layout/logs_page.xml
@@ -10,6 +10,7 @@
     <com.google.android.material.chip.ChipGroup
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="4sp"
         android:id="@+id/filter_chips">
         <com.google.android.material.chip.Chip
             android:id="@+id/chip_own"
@@ -50,6 +51,7 @@
         android:headerDividersEnabled="false"
         android:nestedScrollingEnabled="true"
         android:scrollbarStyle="outsideOverlay"
+        android:paddingHorizontal="@dimen/paddingRight_fastscroll"
         tools:context=".log.LogsViewCreator"
         tools:listitem="@layout/logs_item" />
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Adds consistent padding for variable, waypoint and logs-tab

## Related issues
<!-- List the related issues fixed or improved by this PR -->

https://github.com/cgeo/cgeo/pull/17290#issuecomment-3192881612

| Original | Padding for whole layout | Padding for button-groups |
| --- | --- | --- |
| <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/d38a9e5c-089f-4c37-8fe6-0f29496eb91e" /> | <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/492fe823-bb5b-4d50-8eb2-38bad253afdf" /> | <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/e107b69f-4150-4d9e-b384-89f49207f207" /> |
| <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/e94d7b52-772c-48d9-b9fb-253472629c73" /> | <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/8813bb21-0674-4b7f-8b41-a3cf842eb04f" /> | <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/f3f8ad15-e415-46b5-b881-bcd08f68d96d" /> |
| <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/5d765771-8d04-4424-86c0-1f678500cd1b" /> | <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/e8eca530-5b72-480b-9fa7-5f82b591f5d6" /> | <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/80feb228-6481-4981-82e1-87d911c56fe9" />

