### PR TITLE
Consider case sensitive for some connectors (to support imported geocodes)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/files/GPXImporterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/files/GPXImporterTest.java
@@ -183,7 +183,7 @@ public class GPXImporterTest {
         runImportThread(importThread);
 
         assertImportStepMessages(GPXImporter.IMPORT_STEP_START, GPXImporter.IMPORT_STEP_READ_FILE, /*GPXImporter.IMPORT_STEP_STORE_STATIC_MAPS,*/ GPXImporter.IMPORT_STEP_FINISHED);
-        final Geocache cache = DataStore.loadCache("AID1", LoadFlags.LOAD_CACHE_OR_DB);
+        final Geocache cache = DataStore.loadCache("AId1", LoadFlags.LOAD_CACHE_OR_DB);
         assert cache != null;
         assertThat(cache).isNotNull();
         assertCacheProperties(cache);

--- a/main/src/androidTest/java/cgeo/geocaching/files/GPXParserTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/files/GPXParserTest.java
@@ -518,7 +518,7 @@ public class GPXParserTest  {
         assertThat(lab.getDifficulty()).isEqualTo(0);
 
         // geocodes are just big hashes
-        assertThat(lab.getGeocode()).isEqualTo("01_Munich Olympic Walk Of Stars_Updated-Project MUNICH2014 - Mia san Giga! Olympiapark".toUpperCase(Locale.US));
+        assertThat(lab.getGeocode()).isEqualTo("01_Munich Olympic Walk Of Stars_Updated-Project MUNICH2014 - Mia san Giga! Olympiapark");
 
         // other normal cache properties
         assertThat(lab.getName()).isEqualTo("01_Munich Olympic Walk Of Stars_Updated-Project MUNICH2014 - Mia san Giga! Olympiapark");

--- a/main/src/androidTest/java/cgeo/geocaching/models/GeocacheTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/models/GeocacheTest.java
@@ -65,9 +65,13 @@ public class GeocacheTest {
     }
 
     @Test
-    public void testGeocodeUppercase() {
+    public void testGeocodeCaseSensitive() {
         final Geocache cache = new Geocache();
-        cache.setGeocode("gc1234");
+        cache.setGeocode("gcab12");
+        assertThat(cache.getGeocode()).isEqualTo("GCab12");
+        cache.setGeocode("GCaB12");
+        assertThat(cache.getGeocode()).isEqualTo("GCaB12");
+        cache.setGeocode("Gc1234");
         assertThat(cache.getGeocode()).isEqualTo("GC1234");
     }
 

--- a/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTest.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.storage;
 
 import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.list.PseudoList;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 public class DataStoreTest {
 
     static final String ARTIFICIAL_GEOCODE = "TEST";
+    static final String ARTIFICIAL_GEOCODE_GC = "GCATEST";
 
     private static final long MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
 
@@ -144,9 +146,8 @@ public class DataStoreTest {
     // Check that loading a cache by case insensitive geo code works correctly (see #3139)
     @Test
     public void testGeocodeCaseInsensitive() {
-
-        final String upperCase = ARTIFICIAL_GEOCODE;
-        final String lowerCase = StringUtils.lowerCase(upperCase);
+        final String upperCase = ARTIFICIAL_GEOCODE_GC;
+        final String lowerCase = ConnectorFactory.normalizeGeocode(StringUtils.lowerCase(upperCase));
         assertThat(upperCase).isNotEqualTo(lowerCase);
 
         // create cache and trackable

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -239,7 +239,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
 
         // Finally if a geocache was found load it
         if (connector instanceof ISearchByGeocode && geocode != null) {
-            CacheDetailActivity.startActivity(this, geocode.toUpperCase(Locale.US));
+            CacheDetailActivity.startActivity(this, geocode);
             return true;
         }
 
@@ -283,7 +283,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         // Finally if a trackable was found load it
         if (trackableBrand != TrackableBrand.UNKNOWN && !StringUtils.isEmpty(trackableCode)) {
             final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
-            trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableCode.toUpperCase(Locale.US));
+            trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableCode);
             trackablesIntent.putExtra(Intents.EXTRA_BRAND, trackableBrand.getId());
             if (keywordSearch) { // keyword fallback, if desired by caller
                 trackablesIntent.putExtra(Intents.EXTRA_KEYWORD, query);
@@ -560,7 +560,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         }
 
         if (ConnectorFactory.anyConnectorActive()) {
-            CacheDetailActivity.startActivity(this, geocode.toUpperCase(Locale.US));
+            CacheDetailActivity.startActivity(this, geocode);
         } else {
             showToast(getString(R.string.warn_no_connector));
         }
@@ -573,7 +573,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         }
         Settings.addToHistoryList(R.string.pref_search_history_trackable, trackableText);
         final Intent trackablesIntent = new Intent(this, TrackableActivity.class);
-        trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText.toUpperCase(Locale.US));
+        trackablesIntent.putExtra(Intents.EXTRA_GEOCODE, trackableText);
         startActivity(trackablesIntent);
     }
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -227,7 +227,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
 
         // otherwise see if this is a pure geocode
         if (!(connector instanceof ISearchByGeocode)) {
-            geocode = StringUtils.upperCase(query);
+            geocode = ConnectorFactory.normalizeGeocode(query);
             connector = ConnectorFactory.getConnector(geocode);
         }
 

--- a/main/src/main/java/cgeo/geocaching/connector/ConnectorFactory.java
+++ b/main/src/main/java/cgeo/geocaching/connector/ConnectorFactory.java
@@ -372,9 +372,9 @@ public final class ConnectorFactory {
             return null;
         }
         for (final IConnector connector : CONNECTORS) {
-            final String geocode = connector.getGeocodeFromUrl(url);
+            final String geocode = normalizeGeocode(connector.getGeocodeFromUrl(url));
             if (StringUtils.isNotBlank(geocode)) {
-                return StringUtils.upperCase(geocode);
+                return geocode;
             }
         }
         return null;
@@ -386,10 +386,21 @@ public final class ConnectorFactory {
             return null;
         }
         for (final IConnector connector : CONNECTORS) {
-            final String geocode = connector.getGeocodeFromText(text);
+            final String geocode = normalizeGeocode(connector.getGeocodeFromText(text));
             if (StringUtils.isNotBlank(geocode)) {
-                return StringUtils.upperCase(geocode);
+                return geocode;
             }
+        }
+        return null;
+    }
+
+    @Nullable
+    public static String normalizeGeocode(@Nullable final String geocode) {
+        if (StringUtils.isNotBlank(geocode)) {
+            if (StringUtils.length(geocode) >= 2) {
+                return StringUtils.join(StringUtils.upperCase(geocode.substring(0, 2)), geocode.substring(2));
+            }
+            return StringUtils.upperCase(geocode);
         }
         return null;
     }

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -331,7 +331,7 @@ final class ALApi {
             final JsonNode location = response.at(LOCATION);
             final String firebaseDynamicLink = response.get("FirebaseDynamicLink").asText();
             final String[] segments = firebaseDynamicLink.split("/");
-            final String geocode = ALConnector.GEOCODE_PREFIX + response.get("Id").asText();
+            final String geocode = (ALConnector.GEOCODE_PREFIX + response.get("Id").asText()).toUpperCase();
             cache.setGeocode(geocode);
             cache.setCacheId(segments[segments.length - 1]);
             cache.setName(response.get(TITLE).asText());
@@ -366,7 +366,7 @@ final class ALApi {
             final JsonNode location = response.at(LOCATION);
             final String firebaseDynamicLink = response.get("FirebaseDynamicLink").asText();
             final String[] segments = firebaseDynamicLink.split("/");
-            final String geocode = ALConnector.GEOCODE_PREFIX + response.get("Id").asText();
+            final String geocode = (ALConnector.GEOCODE_PREFIX + response.get("Id").asText()).toUpperCase();
             final String ilink = response.get("KeyImageUrl").asText();
             final String desc = response.get("Description").asText();
             cache.setGeocode(geocode);

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -169,7 +169,7 @@ final class ALApi {
             if (!Settings.isALCfoundStateManual()) {
                 final Collection<Geocache> matchedLabCaches = search(gc.getCoords(), 1, null, 10);
                 for (Geocache matchedLabCache : matchedLabCaches) {
-                    if (matchedLabCache.getGeocode().equals(geocode)) {
+                    if (matchedLabCache.getGeocode().equalsIgnoreCase(geocode)) {
                         gc.setFound(matchedLabCache.isFound());
                     }
                 }

--- a/main/src/main/java/cgeo/geocaching/connector/bettercacher/BetterCacherAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/bettercacher/BetterCacherAPI.java
@@ -221,7 +221,7 @@ public final class BetterCacherAPI {
             }
             final Geocache cache = new Geocache();
             //set stump data
-            cache.setGeocode(gccode);
+            cache.setGeocode(gccode.toUpperCase());
             cache.setCategories(getCategories());
             cache.setTier(getTier());
 
@@ -330,7 +330,7 @@ public final class BetterCacherAPI {
             for (BetterCacherCache bcCache : caches) {
                 if (!bcCache.error && bcCache.gccode != null) {
                     bcCache.setFullData(fullData);
-                    bcCaches.put(bcCache.gccode, bcCache);
+                    bcCaches.put(bcCache.gccode.toUpperCase(), bcCache);
                 }
             }
             cLog.add(bcCaches.size() + " caches");

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -127,7 +127,7 @@ public final class GCParser {
             final JsonNode properties = features.get(i).get("properties");
             final Geocache cache = new Geocache();
             cache.setName(properties.get("name").asText());
-            cache.setGeocode(properties.get("key").asText());
+            cache.setGeocode(properties.get("key").asText().toUpperCase());
             cache.setType(CacheType.getByWaypointType(properties.get("wptid").asText()));
             cache.setArchived(properties.get("archived").asBoolean());
             cache.setDisabled(!properties.get("available").asBoolean());
@@ -267,7 +267,7 @@ public final class GCParser {
         cache.setFavorite(TextUtils.matches(page, GCConstants.PATTERN_IS_FAVORITE));
 
         // cache geocode
-        cache.setGeocode(TextUtils.getMatch(page, GCConstants.PATTERN_GEOCODE, true, cache.getGeocode()));
+        cache.setGeocode(Objects.requireNonNull(TextUtils.getMatch(page, GCConstants.PATTERN_GEOCODE, true, cache.getGeocode())).toUpperCase());
 
         // cache id
         cache.setCacheId(String.valueOf(GCUtils.gcLikeCodeToGcLikeId(cache.getGeocode())));

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCWebAPI.java
@@ -774,7 +774,7 @@ public class GCWebAPI {
 
                     final Geocache c = new Geocache();
                     c.setDetailed(false);
-                    c.setGeocode(r.code);
+                    c.setGeocode(r.code.toUpperCase());
                     c.setName(r.name);
                     if (r.userCorrectedCoordinates != null) {
                         c.setCoords(new Geopoint(r.userCorrectedCoordinates.latitude, r.userCorrectedCoordinates.longitude));

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -847,7 +847,7 @@ final class OkapiClient {
     }
 
     private static void parseCoreCache(final ObjectNode response, @NonNull final Geocache cache) {
-        cache.setGeocode(response.get(CACHE_CODE).asText());
+        cache.setGeocode(response.get(CACHE_CODE).asText().toUpperCase());
         cache.setName(response.get(CACHE_NAME).asText());
         // not used: names
         setLocation(cache, response.get(CACHE_LOCATION).asText());

--- a/main/src/main/java/cgeo/geocaching/connector/su/SuParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/su/SuParser.java
@@ -300,7 +300,7 @@ public class SuParser {
         cache.setName(data.get(CACHE_NAME).asText());
 
         cache.setType(parseType(data.get(CACHE_TYPE).asInt()));
-        cache.setGeocode(data.get(CACHE_CODE).asText());
+        cache.setGeocode(data.get(CACHE_CODE).asText().toUpperCase());
         cache.setHidden(parseDate(data.get(CACHE_HIDDEN).asText()));
 
         final double latitude = data.get(CACHE_LAT).asDouble();

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -1439,7 +1439,8 @@ public class Geocache implements INamedGeoCoordinate {
     }
 
     public void setGeocode(@NonNull final String geocode) {
-        this.geocode = StringUtils.length(geocode) >= 2 ? StringUtils.join(StringUtils.upperCase(geocode.substring(0, 2)), geocode.substring(2)) : StringUtils.upperCase(geocode);
+        final String normalizedCode = ConnectorFactory.normalizeGeocode(geocode);
+        this.geocode = StringUtils.isBlank(normalizedCode) ? "" : normalizedCode;
     }
 
     public void setCacheId(final String cacheId) {

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -466,7 +466,7 @@ public class Geocache implements INamedGeoCoordinate {
     @SuppressFBWarnings("FE_FLOATING_POINT_EQUALITY")
     private boolean isEqualTo(final Geocache other) {
         return detailed == other.detailed &&
-                StringUtils.equalsIgnoreCase(geocode, other.geocode) &&
+                StringUtils.equals(geocode, other.geocode) &&
                 StringUtils.equalsIgnoreCase(name, other.name) &&
                 cacheType.equals(other.cacheType) &&
                 size == other.size &&

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -1439,7 +1439,7 @@ public class Geocache implements INamedGeoCoordinate {
     }
 
     public void setGeocode(@NonNull final String geocode) {
-        this.geocode = geocode;
+        this.geocode = StringUtils.length(geocode) >= 2 ? StringUtils.join(StringUtils.upperCase(geocode.substring(0, 2)), geocode.substring(2)) : StringUtils.upperCase(geocode);
     }
 
     public void setCacheId(final String cacheId) {

--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -1439,7 +1439,7 @@ public class Geocache implements INamedGeoCoordinate {
     }
 
     public void setGeocode(@NonNull final String geocode) {
-        this.geocode = geocode == null ? "" : StringUtils.upperCase(geocode);
+        this.geocode = geocode;
     }
 
     public void setCacheId(final String cacheId) {

--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -275,7 +275,7 @@ public class Waypoint implements INamedGeoCoordinate {
     }
 
     public void setGeocode(final String geocode) {
-        this.geocode = geocode == null ? "" : StringUtils.upperCase(geocode);
+        this.geocode = geocode == null ? "" : geocode;
         this.parentCache = null;
     }
 

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -5099,15 +5099,14 @@ public class DataStore {
     }
 
     /**
-     * Creates the WHERE clause for matching multiple geocodes. This automatically converts all given codes to
-     * UPPERCASE.
+     * Creates the WHERE clause for matching multiple geocodes.
      */
     @NonNull
     private static StringBuilder whereGeocodeIn(final Collection<String> geocodes) {
         final StringBuilder whereExpr = new StringBuilder("geocode IN (");
         final Iterator<String> iterator = geocodes.iterator();
         while (true) {
-            DatabaseUtils.appendEscapedSQLString(whereExpr, StringUtils.upperCase(iterator.next()));
+            DatabaseUtils.appendEscapedSQLString(whereExpr, iterator.next());
             if (!iterator.hasNext()) {
                 break;
             }

--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -345,7 +345,7 @@ public final class Formatter {
     @NonNull
     public static String formatCacheInfoHistory(final Geocache cache) {
         final List<String> infos = new ArrayList<>(3);
-        infos.add(StringUtils.upperCase(cache.getShortGeocode()));
+        infos.add(cache.getShortGeocode());
         infos.add(formatDate(cache.getVisitedDate()));
         infos.add(formatTime(cache.getVisitedDate()));
         return StringUtils.join(infos, SEPARATOR);

--- a/main/src/test/java/cgeo/geocaching/models/GeocodeComparatorTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/GeocodeComparatorTest.java
@@ -19,7 +19,7 @@ public class GeocodeComparatorTest {
         caches.add(createGeocache("GC1ABCD"));
         caches.add(createGeocache("OCFBD3"));
         caches.add(createGeocache("GC2345"));
-        caches.add(createGeocache(null));
+        caches.add(createGeocache(""));
         caches.add(createGeocache("GC56EFG"));
         caches.add(createGeocache("OC117B6"));
         caches.add(createGeocache("GC77"));

--- a/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/WaypointTest.java
@@ -47,7 +47,7 @@ public class WaypointTest {
     public void testGeocode() {
         final Waypoint waypoint = new Waypoint("Test waypoint", WaypointType.PARKING, false);
         waypoint.setGeocode("p1");
-        assertThat(waypoint.getGeocode()).isEqualTo("P1");
+        assertThat(waypoint.getGeocode()).isEqualTo("p1");
     }
 
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
To consider case sensitive for imported geocodes, convert geocodes to uppercase only for some connectors.

Conditions:
Search should still work and return all possible caches.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #15916 
rel #3139

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
#3139 should still work and load the correct cache.
Unfortunately the search is converted to uppercase... so it works for GC and OC, but currently not for AL