### PR TITLE
LAB url

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -329,8 +329,8 @@ final class ALApi {
         try {
             final Geocache cache = new Geocache();
             final JsonNode location = response.at(LOCATION);
-            final String firebaseDynamicLink = response.get("FirebaseDynamicLink").asText();
-            final String[] segments = firebaseDynamicLink.split("/");
+            final String deepLink = response.get("DeepLink").asText();
+            final String[] segments = deepLink.split("/");
             final String geocode = ALConnector.GEOCODE_PREFIX + response.get("Id").asText();
             cache.setGeocode(geocode);
             cache.setCacheId(segments[segments.length - 1]);
@@ -364,8 +364,8 @@ final class ALApi {
         try {
             final Geocache cache = new Geocache();
             final JsonNode location = response.at(LOCATION);
-            final String firebaseDynamicLink = response.get("FirebaseDynamicLink").asText();
-            final String[] segments = firebaseDynamicLink.split("/");
+            final String deepLink = response.get("DeepLink").asText();
+            final String[] segments = deepLink.split("/");
             final String geocode = ALConnector.GEOCODE_PREFIX + response.get("Id").asText();
             final String ilink = response.get("KeyImageUrl").asText();
             final String desc = response.get("Description").asText();

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.NotNull;
 public class ALConnector extends AbstractConnector implements ISearchByGeocode, ISearchByFilter, ISearchByViewPort {
 
     @NonNull
-    private static final String CACHE_URL = "https://adventurelab.page.link/";
+    private static final String CACHE_URL = "https://labs.geocaching.com/goto/";
 
     @NonNull
     protected static final String GEOCODE_PREFIX = "AL";


### PR DESCRIPTION
Lab API has changed and is no longer returning a https://adventurelab.page.link/ link but instead using https://labs.geocaching.com/goto/

From the API (not the lab one) doc: "The firebase dynamic link returned for adventures is obsolete. Deeplink is now being returned and should be used instead."

This PR changes the AL parser to use the DeepLink property as source (it's value is currently identical to FirebaseDynamicLink, so no real change, but preparing for future).
It also changes the CACHE_URL to https://labs.geocaching.com/goto/

This will (probably) break existing, offline-stored caches! The identifier for the old links was a different one than for the new ones. I can't verify this as I don't have a single lab stored.
Only chance I see to avoid this breaking would be checking whether the cacheid is a GUID (new) or not (old) and select the correct base URL. If someone wants to add that please feel free ;-)