### PR TITLE
fix lint string multiple parameters

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1933,7 +1933,7 @@
     <string name="waypoint_edit_title">Edit waypoint</string>
     <string name="waypoint_add_title">Add waypoint</string>
     <string name="waypoint_added">Waypoint added</string>
-    <string name="waypoint_added_current_location">Waypoint (%s) added (±%s)</string>
+    <string name="waypoint_added_current_location">Waypoint (%1s) added (±%2s)</string>
     <string name="waypoint_note">Note</string>
     <string name="waypoint_user_note">User note</string>
     <string name="waypoint_visited">Visited</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1933,7 +1933,7 @@
     <string name="waypoint_edit_title">Edit waypoint</string>
     <string name="waypoint_add_title">Add waypoint</string>
     <string name="waypoint_added">Waypoint added</string>
-    <string name="waypoint_added_current_location">Waypoint (%1s) added (±%2s)</string>
+    <string name="waypoint_added_current_location">Waypoint (%1$s) added (±%2$s)</string>
     <string name="waypoint_note">Note</string>
     <string name="waypoint_user_note">User note</string>
     <string name="waypoint_visited">Visited</string>


### PR DESCRIPTION
Info: Multiple substitutions specified in non-positional format of string resource string/waypoint_added_current_location.

See eg. https://ci.cgeo.org/job/cgeo-CI_PR-build/12850/console