### PR TITLE
Set new 'import route/track' icon (fix #17204)

### DIFF
--- a/main/src/main/res/drawable/ic_menu_import.xml
+++ b/main/src/main/res/drawable/ic_menu_import.xml
@@ -1,11 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
     android:tint="?android:textColorPrimary">
-    <path
-        android:pathData="M6,2C4.89,2 4,2.9 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M13,3.5L18.5,9H13M15.67,20.5L12.84,17.67L10.72,19.79V12.72H17.79L15.67,14.85L18.5,17.68
-"
-        android:fillColor="#000"/>
+<path
+    android:fillColor="@android:color/white"
+    android:pathData="M160,800Q127,800 103.5,776.5Q80,753 80,720L80,240Q80,207 103.5,183.5Q127,160 160,160L400,160L480,240L800,240Q833,240 856.5,263.5Q880,287 880,320L447,320L367,240L160,240Q160,240 160,240Q160,240 160,240L160,720Q160,720 160,720Q160,720 160,720L256,400L940,400L837,743Q829,769 807.5,784.5Q786,800 760,800L160,800ZM244,720L760,720L832,480L316,480L244,720ZM244,720L316,480L316,480L244,720ZM160,320L160,240Q160,240 160,240Q160,240 160,240L160,240L160,320Z"/>
 </vector>


### PR DESCRIPTION
Sets the "import route/track" icon to the "open folder/file" icon as decided in https://github.com/cgeo/cgeo/issues/17204#issuecomment-3172860745

fixes #17204
supersedes #17205 
