### PR TITLE
Encrypt/decrypt hint already on first tap (fix #17347)

### DIFF
--- a/main/src/main/res/layout/cachedetail_description_page.xml
+++ b/main/src/main/res/layout/cachedetail_description_page.xml
@@ -177,6 +177,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:linksClickable="true"
+                android:focusable="false"
                 android:textIsSelectable="true"
                 android:textSize="@dimen/textSize_detailsPrimary"
                 android:textColor="@color/colorText"


### PR DESCRIPTION
## Description
By setting `focusable="false"` for the hint text, the extra tap (for gaining focus) is no longer required, hint will be encrypted/decrypted on first tap already