### PR TITLE
Adapt c:geo to edge2edge enforcement of target API 35

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -20,7 +20,7 @@ String commitIdShort = gitCommitIdProvider.get()
 
 android {
     namespace 'cgeo.geocaching'
-    compileSdk 35
+    compileSdk 36
 
     compileOptions {
         // https://developer.android.com/studio/write/java8-support
@@ -492,7 +492,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
 
     // Support Library core (used for eg. HtmlCompat)
-    implementation 'androidx.core:core:1.16.0'
+    implementation 'androidx.core:core:1.17.0'
 
     // Support Library constraintlayout
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -163,6 +163,7 @@ import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.text.HtmlCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.FragmentManager;
 
 import java.lang.ref.WeakReference;
@@ -263,6 +264,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
+        calculateInsets |= WindowInsetsCompat.Type.navigationBars(); // no bottom navigation, need to take navigation bar into account for insets calculation
         super.onCreate(savedInstanceState);
         setThemeAndContentView(R.layout.tabbed_viewpager_activity_refreshable);
 

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -163,7 +163,6 @@ import androidx.annotation.WorkerThread;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.text.HtmlCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.FragmentManager;
 
 import java.lang.ref.WeakReference;
@@ -264,7 +263,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        calculateInsets |= WindowInsetsCompat.Type.navigationBars(); // no bottom navigation, need to take navigation bar into account for insets calculation
         super.onCreate(savedInstanceState);
         setThemeAndContentView(R.layout.tabbed_viewpager_activity_refreshable);
 

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.activity;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.utils.Log;
 
 import android.os.Bundle;
 import android.view.View;
@@ -43,6 +44,9 @@ public class AbstractActionBarActivity extends AbstractActivity {
                 if (isEdgeToEdge) {
                     // make room for action bar on top + whatever other insets are requested with calculateInsets variable
                     final ViewGroup activityContent = v.findViewById(R.id.activity_content);
+                    if (activityContent == null) {
+                        Log.e("edge2edge: activityContent not found in " + this);
+                    }
                     if (activityContent != null && !skipActionBarInsetCalculation) {
                         final float actionBarHeight = getResources().getDimension(R.dimen.actionbar_height);
                         final Insets innerPadding = insets.getInsets(calculateInsets);

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -1,20 +1,57 @@
 package cgeo.geocaching.activity;
 
-import android.os.Bundle;
+import cgeo.geocaching.R;
 
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 /**
  * Classes actually having an ActionBar (as opposed to the Dialog activities)
  */
 public class AbstractActionBarActivity extends AbstractActivity {
 
+    protected int calculateInsets = WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.displayCutout();
+    boolean skipActionBarInsetCalculation = false; // for edge to edge configuration, see onCreate()
+
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         initUpAction();
-    }
 
+        // edge2edge configuration
+        final Window currentWindow = getWindow();
+        final WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(currentWindow, currentWindow.getDecorView());
+        windowInsetsController.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        ViewCompat.setOnApplyWindowInsetsListener(currentWindow.getDecorView(), new OnApplyWindowInsetsListener() {
+            @Override
+            public @NonNull WindowInsetsCompat onApplyWindowInsets(final @NonNull View v, final @NonNull WindowInsetsCompat insets) {
+                // only apply padding calculations when edge2edge is currently active
+                final Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                final boolean isEdgeToEdge = systemBars.top == systemBars.bottom; // seems to be no official API for this
+                if (isEdgeToEdge) {
+                    // make room for action bar on top + whatever other insets are requested with calculateInsets variable
+                    final ViewGroup activityContent = v.findViewById(R.id.activity_content);
+                    if (activityContent != null && !skipActionBarInsetCalculation) {
+                        final float actionBarHeight = getResources().getDimension(R.dimen.actionbar_height);
+                        final Insets innerPadding = insets.getInsets(calculateInsets);
+                        activityContent.setPadding(innerPadding.left, (int) (innerPadding.top + actionBarHeight), innerPadding.right, innerPadding.bottom);
+                    }
+                }
+                return insets;
+            }
+        });
+    }
 
     private void initUpAction() {
         final ActionBar actionBar = getSupportActionBar();

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -47,10 +47,10 @@ public class AbstractActionBarActivity extends AbstractActivity {
                     if (activityContent == null) {
                         Log.e("edge2edge: activityContent not found in " + this);
                     }
-                    if (activityContent != null && !skipActionBarInsetCalculation) {
-                        final float actionBarHeight = getResources().getDimension(R.dimen.actionbar_height);
+                    if (activityContent != null) {
+                        final float actionBarHeight = skipActionBarInsetCalculation ? 0f : ViewUtils.dpToPixelFloat(10f) + getResources().getDimension(R.dimen.actionbar_height);
                         final Insets innerPadding = insets.getInsets(calculateInsets);
-                        activityContent.setPadding(innerPadding.left, (int) (innerPadding.top + ViewUtils.dpToPixelFloat(10f) + actionBarHeight), innerPadding.right, innerPadding.bottom);
+                        activityContent.setPadding(innerPadding.left, (int) (innerPadding.top + actionBarHeight), innerPadding.right, innerPadding.bottom);
                     }
                 }
                 return insets;

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -1,61 +1,18 @@
 package cgeo.geocaching.activity;
 
-import cgeo.geocaching.R;
-import cgeo.geocaching.ui.ViewUtils;
-import cgeo.geocaching.utils.Log;
-
 import android.os.Bundle;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.Window;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 
 /**
  * Classes actually having an ActionBar (as opposed to the Dialog activities)
  */
 public class AbstractActionBarActivity extends AbstractActivity {
 
-    protected int calculateInsets = WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.displayCutout();
-    boolean skipActionBarInsetCalculation = false; // for edge to edge configuration, see onCreate()
-
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         initUpAction();
-
-        // edge2edge configuration
-        final Window currentWindow = getWindow();
-        final WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(currentWindow, currentWindow.getDecorView());
-        windowInsetsController.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
-        ViewCompat.setOnApplyWindowInsetsListener(currentWindow.getDecorView(), new OnApplyWindowInsetsListener() {
-            @Override
-            public @NonNull WindowInsetsCompat onApplyWindowInsets(final @NonNull View v, final @NonNull WindowInsetsCompat insets) {
-                // only apply padding calculations when edge2edge is currently active
-                final Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
-                final boolean isEdgeToEdge = systemBars.top == systemBars.bottom; // seems to be no official API for this
-                if (isEdgeToEdge) {
-                    // make room for action bar on top + whatever other insets are requested with calculateInsets variable
-                    final ViewGroup activityContent = v.findViewById(R.id.activity_content);
-                    if (activityContent == null) {
-                        Log.e("edge2edge: activityContent not found in " + this);
-                    }
-                    if (activityContent != null) {
-                        final float actionBarHeight = skipActionBarInsetCalculation ? 0f : ViewUtils.dpToPixelFloat(10f) + getResources().getDimension(R.dimen.actionbar_height);
-                        final Insets innerPadding = insets.getInsets(calculateInsets);
-                        activityContent.setPadding(innerPadding.left, (int) (innerPadding.top + actionBarHeight), innerPadding.right, innerPadding.bottom);
-                    }
-                }
-                return insets;
-            }
-        });
     }
 
     private void initUpAction() {

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.activity;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.ui.ViewUtils;
 
 import android.os.Bundle;
 import android.view.View;
@@ -45,7 +46,7 @@ public class AbstractActionBarActivity extends AbstractActivity {
                     if (activityContent != null && !skipActionBarInsetCalculation) {
                         final float actionBarHeight = getResources().getDimension(R.dimen.actionbar_height);
                         final Insets innerPadding = insets.getInsets(calculateInsets);
-                        activityContent.setPadding(innerPadding.left, (int) (innerPadding.top + actionBarHeight), innerPadding.right, innerPadding.bottom);
+                        activityContent.setPadding(innerPadding.left, (int) (innerPadding.top + ViewUtils.dpToPixelFloat(10f) + actionBarHeight), innerPadding.right, innerPadding.bottom);
                     }
                 }
                 return insets;

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -16,6 +16,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
@@ -43,6 +44,12 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
     private static long close429warning = 0;
 
     private final ViewTreeObserver.OnGlobalLayoutListener[] layoutListeners = new ViewTreeObserver.OnGlobalLayoutListener[1];
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        skipActionBarInsetCalculation = true; // gets calculated by map activities themselves
+        super.onCreate(savedInstanceState);
+    }
 
     @Override
     public void onBackPressed() {

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -48,7 +48,7 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        skipActionBarInsetCalculation = Settings.getMapActionbarAutohide(); // may get calculated by map HideActionBarUtils
+        configureEdge2Edge(0, Settings.getMapActionbarAutohide());
         super.onCreate(savedInstanceState);
     }
 

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -6,6 +6,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.SwipeToOpenFragment;
 import cgeo.geocaching.WaypointPopupFragment;
 import cgeo.geocaching.network.HttpRequest;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.unifiedmap.UnifiedMapViewModel;
@@ -47,7 +48,7 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        skipActionBarInsetCalculation = true; // gets calculated by map activities themselves
+        skipActionBarInsetCalculation = Settings.getMapActionbarAutohide(); // may get calculated by map HideActionBarUtils
         super.onCreate(savedInstanceState);
     }
 

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -38,6 +38,7 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.text.ParseException;
@@ -93,6 +94,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
+        configureEdge2Edge(WindowInsetsCompat.Type.navigationBars(), false);
         super.onCreate(savedInstanceState);
         setThemeAndContentView(R.layout.cache_filter_activity);
         binding = CacheFilterActivityBinding.bind(findViewById(R.id.activity_content));

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -95,7 +95,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setThemeAndContentView(R.layout.cache_filter_activity);
-        binding = CacheFilterActivityBinding.bind(findViewById(R.id.cachefilter_activity_viewroot));
+        binding = CacheFilterActivityBinding.bind(findViewById(R.id.activity_content));
 
         binding.filterPropsCheckboxes.removeAllViews();
         this.andOrFilterCheckbox = ViewUtils.addCheckboxItem(this, binding.filterPropsCheckboxes, TextParam.id(R.string.cache_filter_option_and_or), R.drawable.ic_menu_logic);

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -35,7 +35,6 @@ import cgeo.geocaching.settings.fragments.PreferencesFragmentRoot;
 import cgeo.geocaching.storage.ContentStorageActivityHelper;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.storage.PersistableUri;
-import cgeo.geocaching.utils.ApplicationSettings;
 import cgeo.geocaching.utils.BackupUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.utils.SettingsUtils.initPublicFolders;
@@ -105,8 +104,7 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        ApplicationSettings.setLocale(this);
-        calculateInsets |= WindowInsetsCompat.Type.navigationBars(); // no bottom navigation, need to take navigation bar into account for insets calculation
+        configureEdge2Edge(WindowInsetsCompat.Type.navigationBars(), false);
         super.onCreate(savedInstanceState);
 
         backupUtils = new BackupUtils(SettingsActivity.this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));

--- a/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/SettingsActivity.java
@@ -62,6 +62,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.preference.Preference;
@@ -105,6 +106,7 @@ public class SettingsActivity extends CustomMenuEntryActivity implements Prefere
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         ApplicationSettings.setLocale(this);
+        calculateInsets |= WindowInsetsCompat.Type.navigationBars(); // no bottom navigation, need to take navigation bar into account for insets calculation
         super.onCreate(savedInstanceState);
 
         backupUtils = new BackupUtils(SettingsActivity.this, savedInstanceState == null ? null : savedInstanceState.getBundle(STATE_BACKUPUTILS));

--- a/main/src/main/res/layout/cache_filter_activity.xml
+++ b/main/src/main/res/layout/cache_filter_activity.xml
@@ -2,7 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/cachefilter_activity_viewroot"
+    android:id="@+id/activity_content"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"

--- a/main/src/main/res/layout/generic_recyclerview.xml
+++ b/main/src/main/res/layout/generic_recyclerview.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/main/src/main/res/layout/tabbed_viewpager_activity.xml
+++ b/main/src/main/res/layout/tabbed_viewpager_activity.xml
@@ -1,4 +1,5 @@
 <LinearLayout
+    android:id="@+id/activity_content"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
+++ b/main/src/main/res/layout/tabbed_viewpager_activity_refreshable.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
+    android:id="@+id/activity_content"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/main/src/main/res/values-v35/themes.xml
+++ b/main/src/main/res/values-v35/themes.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <style name="cgeo_base" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-
-</resources>

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -2,8 +2,7 @@
 <resources>
 
     <!-- theme for (nearly) all activities -->
-    <style name="cgeo_base" parent="Theme.MaterialComponents.DayNight.DarkActionBar" />
-    <style name="cgeo" parent="cgeo_base">
+    <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Action bar theming -->
         <item name="actionBarStyle">@style/actionBarStyle</item>
         <item name="android:actionOverflowButtonStyle">@style/actionBarActionOverflow</item>


### PR DESCRIPTION
## Description
First steps in adapting c:geo to the new API 35 edge to edge enforcement. It mimics today's behavior, not making any actual use of edge to edge yet.

Current status (list probably to be extended):
- [x] main screen
- [x] pending downloads
- [x] map (standalone)
  - [x] general appearance
  - [x] filter bar, sort bar
  - [x] distance info
  - [x] filter edit activity
- [x] map (from cache)
  - [x] navigation bar overlap
  - [x] cache title overlap
- [x] settings screens
- [x] cache details: all sub screens

Especially for map view, edge to edge mode might be useful, see the following sample screen:

<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/080c581d-1a97-4c23-be81-d87d49f54adb" />

(~Some elements are missing yet (bug), eg. current target (for cache map etc.), distance infos and (maybe) filter bar.~ => implemented meanwhile, screenshot is outdated.)

This is a screenshot with "hide action bar on tap" active, normally the action bar would be shown as well. But IMHO the immersive effect is quite useful on map view, therefore I'd like to propose some further steps here - will create a separate issue for it for further discussion. (Edit: See #17356)

