### PR TITLE
rel to #10927: Live Map Status updates on found, disabled and archived

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -251,7 +251,6 @@ public class Geocache implements INamedGeoCoordinate {
         }
 
         updated = System.currentTimeMillis();
-        //storageLocation.addAll(other.getStorageLocation()); // seems correct but has side effects / failing tests
 
         // if parsed cache is not yet detailed and stored is, the information of
         // the parsed cache will be overwritten
@@ -402,7 +401,7 @@ public class Geocache implements INamedGeoCoordinate {
             setCoords(other.getCoords());
         } else {
             if (coords == null) {
-                coords = other.coords;
+                setCoords(other.coords);
             }
         }
         // if cache has ORIGINAL type waypoint ... it is considered that it has modified coordinates, otherwise not
@@ -1162,6 +1161,9 @@ public class Geocache implements INamedGeoCoordinate {
      * Set reliable coordinates
      */
     public void setCoords(final Geopoint coords) {
+        if (this.coords != null && coords == null) {
+            Log.w("Geocache: setting non-null-coordinates to null for cache´" + geocode + " (was: " + coords + ")");
+        }
         this.coords = coords;
     }
 

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2322,7 +2322,7 @@ public class DataStore {
 
                 cLog.add("gc" + cLog.toStringLimited(caches, 10, c -> c == null ? "-" : c.getGeocode()));
 
-                final List<String> cachesFromDatabase = new ArrayList<>();
+                final List<String> cachesToLoadFromDatabase = new ArrayList<>();
                 final Map<String, Geocache> existingCaches = new HashMap<>();
 
                 // first check which caches are in the memory cache
@@ -2330,14 +2330,14 @@ public class DataStore {
                     final String geocode = cache.getGeocode();
                     final Geocache cacheFromCache = cacheCache.getCacheFromCache(geocode);
                     if (cacheFromCache == null) {
-                        cachesFromDatabase.add(geocode);
+                        cachesToLoadFromDatabase.add(geocode);
                     } else {
                         existingCaches.put(geocode, cacheFromCache);
                     }
                 }
 
                 // then load all remaining caches from the database in one step
-                for (final Geocache cacheFromDatabase : loadCaches(cachesFromDatabase, LoadFlags.LOAD_ALL_DB_ONLY)) {
+                for (final Geocache cacheFromDatabase : loadCaches(cachesToLoadFromDatabase, LoadFlags.LOAD_ALL_DB_ONLY)) {
                     existingCaches.put(cacheFromDatabase.getGeocode(), cacheFromDatabase);
                 }
 
@@ -2366,8 +2366,8 @@ public class DataStore {
                     // the cache contains detailed information.
                     if (saveFlags.contains(SaveFlag.DB) && dbUpdateRequired) {
                         toBeStored.add(cache);
-                    } else if (existingCache != null && existingCache.isDisabled() != cache.isDisabled()) {
-                        // Update the disabled status in the database if it changed
+                    } else if (existingCache != null && needsStatusUpdate(existingCache, cache)) {
+                        // Update the status in the database if it changed
                         toBeUpdated.add(cache);
                     }
                 }
@@ -2377,26 +2377,34 @@ public class DataStore {
                 }
 
                 for (final Geocache geocache : toBeUpdated) {
-                    updateDisabledStatus(geocache);
+                    updateCacheStatus(geocache);
                 }
             }
         });
-
     }
 
-    private static boolean updateDisabledStatus(final Geocache cache) {
-        cache.addStorageLocation(StorageLocation.DATABASE);
+    private static boolean needsStatusUpdate(final Geocache existingCache, final Geocache newCache) {
+        return existingCache.isDisabled() != newCache.isDisabled() ||
+            existingCache.isArchived() != newCache.isArchived() ||
+            existingCache.isFound() != newCache.isFound() ||
+            existingCache.isDNF() != newCache.isDNF();
+    }
+
+    private static boolean updateCacheStatus(final Geocache cache) {
         cacheCache.putCacheInCache(cache);
-        Log.d("Updating disabled status of " + cache + " in DB");
+        Log.d("Updating status of " + cache + " in DB");
 
         final ContentValues values = new ContentValues();
         values.put("disabled", cache.isDisabled() ? 1 : 0);
+        values.put("archived", cache.isArchived() ? 1 : 0);
+        values.put("found", cache.isFound() ? 1 : cache.isDNF() ? -1 : 0);
 
         init();
         try {
             database.beginTransaction();
             final int rows = database.update(dbTableCaches, values, "geocode = ?", new String[]{cache.getGeocode()});
             if (rows == 1) {
+                cache.addStorageLocation(StorageLocation.DATABASE);
                 database.setTransactionSuccessful();
                 return true;
             }
@@ -5096,7 +5104,7 @@ public class DataStore {
     }
 
     public static void saveChangedCache(final Geocache cache) {
-        saveCache(cache, cache.inDatabase() ? LoadFlags.SAVE_ALL : EnumSet.of(SaveFlag.CACHE));
+        saveCache(cache, cache.getLists().isEmpty() ? EnumSet.of(SaveFlag.CACHE) : LoadFlags.SAVE_ALL);
     }
 
     private enum PreparedStatement {


### PR DESCRIPTION
rel to #10927: Live Map Status updates on found, disabled and archived

This PR serves three different purposes which however are interconnected code-wise:
* Issue #10927: fixes status update from live data for stored caches not only for disabled but also for archived and found caches
* A bug I noticed myself: when a stored cache is logged from c:geo, database is now updated too
* #17358: Sometimes cache items become "unclickable" on map. Analysis shows that this might be related to caches sometimes "loosing" their coordinates (for yet unknown reasons). This PR adds logging to analyze this case further.