### PR TITLE
Wherigo: change toString for EventTable back to ZObject (instead of ZTimer)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/wherigo/openwig/EventTable.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/openwig/EventTable.java
@@ -41,9 +41,7 @@ public class EventTable implements LuaTable, Serializable {
         }
     }
 
-
-    protected String luaTostring () { return "a ZTimer instance"; }
-
+    protected String luaTostring () { return "a ZObject instance"; }
 
     public EventTable() {
         metatable.rawset("__tostring", new TostringJavaFunc(this));


### PR DESCRIPTION
Wherigo: change toString for EventTable back to ZObject (instead of ZTimer)

Bug was reported via Support: https://cgeosupport.droescher.eu/scp/tickets.php?id=9797