### PR TITLE
Support new Lab2gpx format

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/connector/ConnectorFactoryTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/ConnectorFactoryTest.java
@@ -134,6 +134,7 @@ public class ConnectorFactoryTest {
         geocodes.add("GE1234");
         geocodes.add("GA1234");
         geocodes.add("TP1234");
+        geocodes.add("AL1234");
 
         geocodes.add("GC5678");
         geocodes.add("OC5678");
@@ -143,6 +144,7 @@ public class ConnectorFactoryTest {
         geocodes.add("GE5678");
         geocodes.add("GA5678");
         geocodes.add("TP5678");
+        geocodes.add("AL5678");
 
         geocodes.add("ZZ1");
         return geocodes;

--- a/main/src/androidTest/java/cgeo/geocaching/connector/al/ALConnectorTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/connector/al/ALConnectorTest.java
@@ -1,0 +1,53 @@
+package cgeo.geocaching.connector.al;
+
+import cgeo.geocaching.connector.ConnectorFactoryTest;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.Geocache;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ALConnectorTest {
+
+    @Test
+    public void testCanHandle() throws Exception {
+        assertThat(ALConnector.getInstance().canHandle("AL380")).isTrue();
+        assertThat(ALConnector.getInstance().canHandle("ALc47d3f39-ac94-4c03-82bc-c6f3a611439f")).isTrue();
+        assertThat(ALConnector.getInstance().canHandle("ALC47D3F39-AC94-4C03-82BC-C6F3A611439F")).isTrue();
+        assertThat(ALConnector.getInstance().canHandle("GC380")).isFalse();
+        assertThat(ALConnector.getInstance().canHandle("GCAL380")).overridingErrorMessage("faked AL codes must be handled during the import, otherwise GCALxxxx codes belong to 2 connectors").isFalse();
+    }
+
+    @Test
+    public void testGetPossibleLogTypes() throws Exception {
+        final List<LogType> possibleLogTypes = ALConnector.getInstance().getPossibleLogTypes(createCache());
+        assertThat(possibleLogTypes).isNotNull();
+        assertThat(possibleLogTypes).isNotEmpty();
+        assertThat(possibleLogTypes).contains(LogType.FOUND_IT);
+    }
+
+    private static Geocache createCache() {
+        final Geocache geocache = new Geocache();
+        geocache.setType(CacheType.ADVLAB);
+        geocache.setGeocode("AL727");
+        return geocache;
+    }
+
+    @Test
+    public void testGetGeocodeFromUrl() throws Exception {
+        assertThat(ALConnector.getInstance().getGeocodeFromUrl("https://adventurelab.page.link/738")).isEqualTo("AL738");
+        assertThat(ALConnector.getInstance().getGeocodeFromUrl("https://labs.geocaching.com/goto/c47d3f39-ac94-4c03-82bc-c6f3a611439f")).isEqualTo("AL738");
+        assertThat(ALConnector.getInstance().getGeocodeFromUrl("ALhttps://labs.geocaching.com/goto/c47d3f39-ac94-4c03-82bc-c6f3a611439f")).isEqualTo("ALc47d3f39-ac94-4c03-82bc-c6f3a611439f");
+        assertThat(ALConnector.getInstance().getGeocodeFromUrl("ALHTTPS://LABS.GEOCACHING.COM/GOTO/C47D3F39-AC94-4C03-82BC-C6F3A611439F")).isEqualTo("ALC47D3F39-AC94-4C03-82BC-C6F3A611439F");
+    }
+
+    @Test
+    public void testHandledGeocodes() {
+        final Set<String> geocodes = ConnectorFactoryTest.getGeocodeSample();
+        assertThat(ALConnector.getInstance().handledGeocodes(geocodes)).containsOnly("AL1234", "AL5678");
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALConnector.java
@@ -212,10 +212,24 @@ public class ALConnector extends AbstractConnector implements ISearchByGeocode, 
     @Override
     @Nullable
     public String getGeocodeFromUrl(@NonNull final String url) {
-        final String geocode = "AL" + StringUtils.substringAfter(url, "https://adventurelab.page.link/");
-        if (canHandle(geocode)) {
-            return geocode;
+        // try current url
+        final String geocodeCacheUrl = "AL" + StringUtils.substringAfter(url, CACHE_URL);
+        if (canHandle(geocodeCacheUrl)) {
+            return geocodeCacheUrl;
         }
+
+        // try current url with uppercase (lab2gpx with option uppercase)
+        final String geocodeCacheUrlUppercase = "AL" + StringUtils.substringAfter(url, StringUtils.upperCase(CACHE_URL));
+        if (canHandle(geocodeCacheUrlUppercase)) {
+            return geocodeCacheUrlUppercase;
+        }
+
+        // try old firebase url
+        final String geocodeFirebase = "AL" + StringUtils.substringAfter(url, "https://adventurelab.page.link/");
+        if (canHandle(geocodeFirebase)) {
+            return geocodeFirebase;
+        }
+
         return super.getGeocodeFromUrl(url);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/files/GPXParser.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXParser.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.files;
 
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.al.ALConnector;
 import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCUtils;
@@ -722,7 +723,12 @@ abstract class GPXParser extends FileParser {
 
             gsak.getChild(gsakNamespace, "Code").setEndTextElementListener(geocode -> {
                 if (StringUtils.isNotBlank(geocode)) {
-                    cache.setGeocode(StringUtils.trim(geocode));
+                    final String alConnectorCode = ALConnector.getInstance().getGeocodeFromUrl(geocode);
+                    if (null != alConnectorCode) {
+                        cache.setGeocode(alConnectorCode);
+                    } else {
+                        cache.setGeocode(StringUtils.trim(geocode));
+                    }
                 }
             });
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
For Adventure Labs Lab2gpx already returns the guid (but in a format of `ALhttps://labs.geocaching.com/goto/guid`), since the firebase-link is no more available.

This PR adapt the recognization for the geocode.
Lab2gpx has an option to convert the code to uppercase which will lead to `ALHTTPS://LABS.GEOCACHING.COM/GOTO/GUID`

## Related issues
<!-- List the related issues fixed or improved by this PR -->


## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->