### PR TITLE
rel to #17375: move legacy compassrose movement from HideActionBarUtils to GoogleMapView

### DIFF
--- a/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
+++ b/main/src/main/java/cgeo/geocaching/maps/google/v2/GoogleMapView.java
@@ -45,6 +45,7 @@ import android.view.MotionEvent;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.res.ResourcesCompat;
@@ -257,11 +258,45 @@ public class GoogleMapView extends MapView implements MapViewImpl<GoogleCacheOve
             try {
                 final View mapView = findViewById(R.id.map);
                 final View compass = mapView.findViewWithTag("GoogleMapCompass");
-                HideActionBarUtils.adaptLayoutForActionBarHelper(activity, actionBarShowing, compass);
+                adaptLayoutForActionBarHelper(activity, actionBarShowing, compass);
             } catch (Exception ignore) {
             }
         }
     }
+
+    private static void adaptLayoutForActionBarHelper(final AppCompatActivity activity, @androidx.annotation.Nullable final Boolean actionBarShowing, @androidx.annotation.Nullable final View compassRose) {
+        if (compassRose == null) {
+            return;
+        }
+
+        int minHeight = 0;
+
+        Boolean abs = actionBarShowing;
+        if (actionBarShowing == null) {
+            final ActionBar actionBar = activity.getSupportActionBar();
+            abs = actionBar != null && actionBar.isShowing();
+        }
+        if (abs) {
+            minHeight = activity.findViewById(R.id.actionBarSpacer).getHeight();
+        }
+
+        final View filterbar = activity.findViewById(R.id.filter_bar);
+        if (filterbar != null) {
+            minHeight += filterbar.getHeight();
+        }
+
+        View v = activity.findViewById(R.id.distanceinfo);
+        if (v.getVisibility() != View.VISIBLE) {
+            v = activity.findViewById(R.id.target);
+        }
+        if (v.getVisibility() == View.VISIBLE) {
+            minHeight += v.getHeight();
+        }
+
+        final int finalMinHeight = minHeight;
+        activity.runOnUiThread(() -> compassRose.animate().translationY(finalMinHeight).start());
+    }
+
 
     @Override
     public void setCoordsMarker(@Nullable final Geopoint coords) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
@@ -10,7 +10,6 @@ import cgeo.geocaching.unifiedmap.geoitemlayer.GeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
-import cgeo.geocaching.utils.HideActionBarUtils;
 import cgeo.geocaching.utils.Log;
 import static cgeo.geocaching.storage.extension.OneTimeDialogs.DialogType.MAP_AUTOROTATION_DISABLE;
 
@@ -22,7 +21,6 @@ import android.widget.ImageView;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.util.Consumer;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
@@ -289,13 +287,6 @@ public abstract class AbstractMapFragment extends Fragment {
     protected void onTapCallback(final int latitudeE6, final int longitudeE6, final int x, final int y, final boolean isLongTap) {
         Log.d("registered " + (isLongTap ? "long " : "") + " tap on map @ (" + latitudeE6 + ", " + longitudeE6 + ")");
         ((UnifiedMapActivity) requireActivity()).onTap(latitudeE6, longitudeE6, x, y, isLongTap);
-    }
-
-    public void adaptLayoutForActionBar(final @Nullable Boolean actionBarShowing) {
-        final AppCompatActivity activity = (AppCompatActivity) getActivity();
-        if (activity != null) {
-            HideActionBarUtils.adaptLayoutForActionBarHelper(activity, actionBarShowing, null);
-        }
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1223,7 +1223,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 if (sheetRemoveFragment()) {
                     return;
                 }
-                mapFragment.adaptLayoutForActionBar(HideActionBarUtils.toggleActionBar(this));
+                HideActionBarUtils.toggleActionBar(this);
                 GeoItemTestLayer.handleTapTest(clickableItemsLayer, this, touchedPoint, "", isLongTap);
             }
         } else if (result.size() == 1) {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/googlemaps/GoogleMapsFragment.java
@@ -136,8 +136,6 @@ public class GoogleMapsFragment extends AbstractMapFragment implements OnMapRead
             scaleDrawer.drawScale(lastBounds);
         });
 
-        adaptLayoutForActionBar(true);
-
         initLayers();
         onMapReadyTasks.run();
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/NavigationTargetLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/NavigationTargetLayer.java
@@ -37,11 +37,7 @@ public class NavigationTargetLayer {
     private final boolean showBothDistances = Settings.isBrouterShowBothDistances();
 
     public NavigationTargetLayer(final UnifiedMapActivity activity, final GeoItemLayer<String> layer) {
-        mapDistanceDrawer = new UnifiedTargetAndDistancesHandler(activity.findViewById(R.id.distanceinfo), () -> {
-            if (activity.getMapFragment() != null) {
-                activity.getMapFragment().adaptLayoutForActionBar(null);
-            }
-        });
+        mapDistanceDrawer = new UnifiedTargetAndDistancesHandler(activity.findViewById(R.id.distanceinfo));
         viewModel = new ViewModelProvider(activity).get(UnifiedMapViewModel.class);
         this.layer = layer;
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/UnifiedTargetAndDistancesHandler.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/UnifiedTargetAndDistancesHandler.java
@@ -47,11 +47,10 @@ public class UnifiedTargetAndDistancesHandler {
     private float distance = 0.0f;
     private float realDistance = 0.0f;
     private float routeDistance = 0.0f;
-    private final Runnable handleSwapNotification;
 
     private static final float MIN_DISTANCE = 0.0005f;
 
-    UnifiedTargetAndDistancesHandler(final View root, final Runnable handleSwapNotification) {
+    UnifiedTargetAndDistancesHandler(final View root) {
         distanceStraight = root.findViewById(R.id.distanceStraight);
         distanceRouted = root.findViewById(R.id.distanceRouted);
         distanceIndividualRoute = root.findViewById(R.id.distanceIndividualRoute);
@@ -62,8 +61,6 @@ public class UnifiedTargetAndDistancesHandler {
         distanceRouted.setOnClickListener(v -> swap());
         distanceIndividualRoute.setOnClickListener(v -> swap());
         distanceSupersizeView.setOnClickListener(v -> swap());
-
-        this.handleSwapNotification = handleSwapNotification;
     }
 
     // distances handling -------------------------------------------------------------------------------------------
@@ -88,9 +85,6 @@ public class UnifiedTargetAndDistancesHandler {
 
     private void updateDistanceViews() {
         updateDistanceViews(distance, realDistance, routeDistance, showBothDistances, distanceStraight, distanceRouted, distanceIndividualRoute, distanceSupersizeView, targetView, bvn -> bothViewsNeeded = bvn);
-        if (handleSwapNotification != null) {
-            handleSwapNotification.run();
-        }
     }
 
     @SuppressWarnings("PMD.NPathComplexity") // split up would not help readability

--- a/main/src/main/java/cgeo/geocaching/utils/HideActionBarUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/HideActionBarUtils.java
@@ -11,9 +11,6 @@ import android.view.View;
 
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 
 public class HideActionBarUtils {
 
@@ -68,38 +65,5 @@ public class HideActionBarUtils {
         if (showSpacer) {
             activity.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
         }
-    }
-
-    public static void adaptLayoutForActionBarHelper(final AppCompatActivity activity, @Nullable final Boolean actionBarShowing, @Nullable final View compassRose) {
-        if (compassRose == null) {
-            return;
-        }
-
-        int minHeight = 0;
-
-        Boolean abs = actionBarShowing;
-        if (actionBarShowing == null) {
-            final ActionBar actionBar = activity.getSupportActionBar();
-            abs = actionBar != null && actionBar.isShowing();
-        }
-        if (abs) {
-            minHeight = activity.findViewById(R.id.actionBarSpacer).getHeight();
-        }
-
-        final View filterbar = activity.findViewById(R.id.filter_bar);
-        if (filterbar != null) {
-            minHeight += filterbar.getHeight();
-        }
-
-        View v = activity.findViewById(R.id.distanceinfo);
-        if (v.getVisibility() != View.VISIBLE) {
-            v = activity.findViewById(R.id.target);
-        }
-        if (v.getVisibility() == View.VISIBLE) {
-            minHeight += v.getHeight();
-        }
-
-        final int finalMinHeight = minHeight;
-        activity.runOnUiThread(() -> compassRose.animate().translationY(finalMinHeight).start());
     }
 }


### PR DESCRIPTION
rel to #17375: move legacy compassrose movement from HideActionBarUtils to GoogleMapView

While working on #17375 and trying to refactor showing/hiding ActionBar fpr edge-2-edge, I noticed method `HideActionBarUtils.adaptLayoutForActionBarHelper`. Apparently this method is used to adjust position of compassrose in case of actionbar showing/hiding.

I also noticed however that this method is only effective in used for legacy GoogleMapView class. It was still called from unifiedmap but with no effect (because compassrose field passed was null). 

This PR moves said method to legacy GoogleMapView in order to refactor unifiedmap further. @moving-bits I would appreciate a review before merge. Are my thoughts correct?