### PR TITLE
Restore hint hightling functionality (fix #17399)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -144,6 +144,7 @@ import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
@@ -1733,6 +1734,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             return Page.DESCRIPTION.id;
         }
 
+        @SuppressLint("ClickableViewAccessibility") // for binding.hint onTouchListener
         @Override
         // splitting up that method would not help improve readability
         @SuppressWarnings({"PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
@@ -1821,13 +1823,16 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 if (Settings.getHintAsRot13()) {
                     binding.hint.setText(CryptUtils.rot13((Spannable) binding.hint.getText()));
                 }
+                // see #17399 and https://stackoverflow.com/questions/22653641/using-onclick-on-textview-with-selectable-text-how-to-avoid-double-click
+                binding.hint.setOnTouchListener((v, event) -> {
+                    if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                        v.requestFocus();
+                    }
+                    return false;
+                });
                 final DecryptTextClickListener decryptListener = new DecryptTextClickListener(binding.hint);
                 binding.hint.setOnClickListener(decryptListener);
                 binding.hint.setClickable(true);
-                binding.hint.setOnLongClickListener(v -> {
-                    ShareUtils.sharePlainText(activity, binding.hint.getText().toString());
-                    return true;
-                });
                 binding.hintBox.setOnClickListener(decryptListener);
                 binding.hintBox.setClickable(true);
                 binding.hintBox.setOnLongClickListener(v -> {

--- a/main/src/main/res/layout/cachedetail_description_page.xml
+++ b/main/src/main/res/layout/cachedetail_description_page.xml
@@ -177,7 +177,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="left"
                 android:linksClickable="true"
-                android:focusable="false"
+                android:focusable="true"
                 android:textIsSelectable="true"
                 android:textSize="@dimen/textSize_detailsPrimary"
                 android:textColor="@color/colorText"


### PR DESCRIPTION
## Description
- Restores functionality to use long-tap to select text blocks from hint while avoiding having to tap twice initially for encrypting/decrypting text
- Removes "long tap to start share action" hotfix from #17404

Implements the approach pointed to in https://github.com/cgeo/cgeo/issues/17399#issuecomment-3261668079
