### PR TITLE
Correct color of list-icon for standard list (save) in action bar

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/ColorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ColorUtils.java
@@ -2,10 +2,14 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.CgeoApplication;
 
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Color;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.ColorRes;
+import androidx.appcompat.app.AppCompatDelegate;
 
 public class ColorUtils {
     private ColorUtils() {
@@ -50,7 +54,22 @@ public class ColorUtils {
 
     @ColorInt
     public static int colorFromResource(@ColorRes final int colorRes) {
-        return CgeoApplication.getInstance().getResources().getColor(colorRes);
+        return getThemedContext().getResources().getColor(colorRes);
+    }
+
+    public static Context getThemedContext() {
+        final Context ctx = CgeoApplication.getInstance();
+        final Resources res = ctx.getResources();
+        final Configuration configuration = new Configuration(ctx.getResources().getConfiguration());
+        final int nightNode = AppCompatDelegate.getDefaultNightMode();
+        if (nightNode == AppCompatDelegate.MODE_NIGHT_NO) {
+            configuration.uiMode = Configuration.UI_MODE_NIGHT_NO | (res.getConfiguration().uiMode & ~Configuration.UI_MODE_NIGHT_MASK);
+        } else if (nightNode == AppCompatDelegate.MODE_NIGHT_YES) {
+            configuration.uiMode = Configuration.UI_MODE_NIGHT_YES | (res.getConfiguration().uiMode & ~Configuration.UI_MODE_NIGHT_MASK);
+        } else {
+            configuration.uiMode = res.getConfiguration().uiMode;
+        }
+        return ctx.createConfigurationContext(configuration);
     }
 
     private static float[] getHslValues(@ColorInt final int colorInt) {

--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -78,23 +78,8 @@ public class MenuUtils {
         if (!anyMenuItemVisible) {
             return;
         }
-        final Resources res = getThemedContext().getResources();
+        final Resources res = ColorUtils.getThemedContext().getResources();
         tintMenuIcons(menu, res.getColor(R.color.colorTextActionBar), res.getColor(R.color.colorIconMenu));
-    }
-
-    private static Context getThemedContext() {
-        final Context ctx = CgeoApplication.getInstance();
-        final Resources res = ctx.getResources();
-        final Configuration configuration = new Configuration(ctx.getResources().getConfiguration());
-        final int nightNode = AppCompatDelegate.getDefaultNightMode();
-        if (nightNode == AppCompatDelegate.MODE_NIGHT_NO) {
-            configuration.uiMode = Configuration.UI_MODE_NIGHT_NO | (res.getConfiguration().uiMode & ~Configuration.UI_MODE_NIGHT_MASK);
-        } else if (nightNode == AppCompatDelegate.MODE_NIGHT_YES) {
-            configuration.uiMode = Configuration.UI_MODE_NIGHT_YES | (res.getConfiguration().uiMode & ~Configuration.UI_MODE_NIGHT_MASK);
-        } else {
-            configuration.uiMode = res.getConfiguration().uiMode;
-        }
-        return ctx.createConfigurationContext(configuration);
     }
 
     @SuppressLint("RestrictedApi")


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
While working on PR #17425, I had the effect, that the icon for the standard list had a wrong tint, while switching between dark and light mode

Save-icon is tinted to use in action bar - so read the tint from current theme

<img width="400"  alt="grafik" src="https://github.com/user-attachments/assets/0623d347-3898-404e-aab2-f170c728fe18" />
