### PR TITLE
fix #15412: avoid doubled route items

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
+++ b/main/src/main/java/cgeo/geocaching/models/IndividualRoute.java
@@ -82,8 +82,8 @@ public class IndividualRoute extends Route implements Parcelable {
     }
 
     public void reloadRoute(final UpdateIndividualRoute updateRoute) {
-        clearRouteInternal(null, false);
-        AndroidRxUtils.andThenOnUi(Schedulers.io(), this::loadRouteInternal, () -> updateRoute(updateRoute));
+        AndroidRxUtils.andThenOnUi(Schedulers.io(), this::loadRouteInternal,
+                () -> updateRoute(updateRoute));
     }
 
     public void updateRoute(final UpdateIndividualRoute routeUpdater) {
@@ -97,6 +97,10 @@ public class IndividualRoute extends Route implements Parcelable {
     }
 
     public void clearRoute(final UpdateIndividualRoute routeUpdater) {
+        if (loadingRoute) {
+            return;
+        }
+
         clearRouteInternal(routeUpdater, true);
     }
 
@@ -121,6 +125,12 @@ public class IndividualRoute extends Route implements Parcelable {
     }
 
     private synchronized void loadRouteInternal() {
+        if (loadingRoute) {
+            return;
+        }
+
+        clearRouteInternal(null, false);
+        
         loadingRoute = true;
         Log.d("[RouteTrackDebug] Individual route: Start loading from database");
         final ArrayList<RouteItem> routeItems = DataStore.loadIndividualRoute();

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1450,12 +1450,14 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             recreate(); // restart with a fresh MapView
         }
 
-        if (Settings.removeFromRouteOnLog()) {
-            viewModel.reloadIndividualRoute();
-        }
         super.onResume();
         reloadCachesAndWaypoints();
         MapUtils.updateFilterBar(this, viewModel.mapType.filterContext);
+        
+        if (Settings.removeFromRouteOnLog()) {
+            viewModel.reloadIndividualRoute();
+        }
+
         if (tileProvider != null) {
             tileProvider.onResume();
         }


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Avoid clearing / updating route, if it is already loading / updating from database
(but I don't know yet, why / how that happens, has something to do with AndroidRxUtils.andThenOnUi in IndividualRoute::reloadRoute

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #15412

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->