### PR TITLE
Test drive VTM transparent map background (rel. to #17322)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -405,12 +405,12 @@ dependencies {
     // -- Mapsforge / VTM --
 
     // Mapsforge VTM implementation (official version)
-    String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '0.26.1'
+    // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
+    // String mapsforgeVTMVersion = '0.26.1'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
-    // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    // String mapsforgeVTMVersion = 'b3ff48fcc6' // LineBucket: transparent lines (9d68bdb) + dropDistance (31646b3) + line transparent style option (b3ff48fcc6)
+    String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
+    String mapsforgeVTMVersion = 'd8bab9c' // ThemeCallbackAdapter
 
     // Mapsforge VTM Snapshots (created by project itself)
     // See https://github.com/mapsforge/vtm/blob/master/docs/Integration.md#snapshots

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/MapsforgeThemeHelper.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -43,7 +44,9 @@ import org.oscim.android.theme.ContentResolverResourceProvider;
 import org.oscim.map.Map;
 import org.oscim.theme.ExternalRenderTheme;
 import org.oscim.theme.IRenderTheme;
+import org.oscim.theme.ThemeCallbackAdapter;
 import org.oscim.theme.ThemeFile;
+import org.oscim.theme.ThemeLoader;
 import org.oscim.theme.XmlRenderThemeMenuCallback;
 import org.oscim.theme.XmlRenderThemeStyleLayer;
 import org.oscim.theme.XmlRenderThemeStyleMenu;
@@ -138,6 +141,19 @@ public class MapsforgeThemeHelper implements XmlRenderThemeMenuCallback {
                 rendererLayer.setXmlRenderTheme(xmlRenderTheme);
                 */
                 mTheme = map.setTheme(xmlRenderTheme);
+
+                if (Settings.getMapBackgroundMapLayer() && Settings.isFeatureEnabledDefaultFalse(R.string.pref_vtmBackgroundTransparent)) {
+                    map.setTheme(ThemeLoader.load(xmlRenderTheme, new ThemeCallbackAdapter() {
+                        @Override
+                        public int getColor(final String[] keys, final String[] values, final int color) {
+                            final List<String> k = Arrays.asList(keys);
+                            final List<String> v = Arrays.asList(values);
+//                            Log.e("keys=" + Arrays.asList(keys) + " -> " + Arrays.asList(values));
+                            return (((k.isEmpty() && v.isEmpty())) || (k.contains("natural") && (v.contains("sea") || v.contains("nosea")))) ? 0x000000ff : color;
+                        }
+                    }));
+                }
+
             } catch (final Exception e) {
                 Log.w("render theme invalid", e);
                 ActivityMixin.showApplicationToast(LocalizationUtils.getString(R.string.err_rendertheme_invalid));

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/VtmThemes.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforgevtm/VtmThemes.java
@@ -45,6 +45,7 @@ public enum VtmThemes implements ThemeFile {
 
     DEFAULT("vtm/default.xml"),
     MAPZEN("vtm/mapzen.xml"),
+    MOTORIDER("vtm/motorider.xml"),
     NEWTRON("vtm/newtron.xml"),
     OPENMAPTILES("vtm/openmaptiles.xml"),
     OSMAGRAY("vtm/osmagray.xml"),

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -601,6 +601,7 @@
     <string translatable="false" name="pref_unifiedMapVariants">unifiedMapVariants</string>
     <string translatable="false" name="pref_autorenameDownloads">autorenameDownloads</string>
     <string translatable="false" name="pref_elevationChartExpanded">elevationChartExpanded</string>
+    <string translatable="false" name="pref_vtmBackgroundTransparent">vtmBackgroundTransparent</string>
 
     <!-- pq/bookmark list: show downloadable/new only -->
     <string translatable="false" name="pref_pqShowDownloadableOnly">pqShowDownloadableOnly</string>


### PR DESCRIPTION
## Description
Renders background of VTM maps as transparent (empty tags and key=natural + value in SEA, NOSEA) to avoid the blank rectangles around vector maps when being displayed on top of a background map.

This feature only gets applied when two conditions are met:
- background maps are enabled
- you have set a preference key named `vtmBackgroundTransparent` of type `boolean` to `true`

|before|after|
|---|---|
|<img width="270" height="600" alt="Image" src="https://github.com/user-attachments/assets/cdadc19e-4457-4f79-b947-2137d920a616" />|<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/20c1eba9-72e7-48e6-bbb3-6c6f7fc96942" />|

