### PR TITLE
Allow creation of new parent list in new list dialog (fix #17190)

### DIFF
--- a/main/src/main/res/layout/createlist.xml
+++ b/main/src/main/res/layout/createlist.xml
@@ -21,6 +21,20 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/newParentWrapper"
+        style="@style/textinput_edittext_singleline"
+        android:visibility="gone">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/newParent"
+            android:inputType="textPersonName"
+            style="@style/textinput_embedded_singleline"
+            android:hint="@string/list_parent_list"
+            android:importantForAutofill="yes"
+            android:autofillHints="@string/list_parent_list" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/titleWrapper"
         style="@style/textinput_edittext_singleline">
 
@@ -32,5 +46,4 @@
             android:importantForAutofill="yes"
             android:autofillHints="@string/list_name" />
     </com.google.android.material.textfield.TextInputLayout>
-
 </LinearLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -612,6 +612,7 @@
     <string name="list_dialog_rename">Rename</string>
     <string name="list_not_available">List no longer available, switching to standard list</string>
     <string name="list_parent_list">Parent list</string>
+    <string name="list_create_parent">&lt;Create new parent list&gt;</string>
     <string name="list_name">List name</string>
     <string name="list_confirm_rename">Renaming from \"%1$s\" to \"%2$s\"\n%3$s\nThis action cannot be undone!</string>
     <string name="list_confirm_no_hierarchy">\nNo \":\" found - all matching lists will be transformed to top-level lists\n</string>


### PR DESCRIPTION
## Description
Allow creation of a new parent list in "New list" / "Rename list" dialogs:

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/0b999a35-403f-4df1-b152-9f5c0f24cbe0" />.<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/e8b6766b-1ded-4639-afae-72520525a573" />.<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/f5f81e1e-a0a4-4d20-921b-116242449398" />.<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/2311290a-87e4-4c01-91f2-8365a4cc9f2c" />
