### PR TITLE
fix lint: AppLinkWarning

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -168,7 +168,7 @@
             </intent-filter>
             <!-- "Search geocaches nearby" where location comes from click on http(s) link to internet map service
                 (google-maps, openstreetmap, yandex, here)  -->
-            <intent-filter android:label="@string/geo_search_label" android:icon="${appIcon}" android:roundIcon="${appIconRound}">
+            <intent-filter android:label="@string/geo_search_label" android:icon="${appIcon}" android:roundIcon="${appIconRound}" tools:ignore="AppLinkWarning">
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="maps.google.com" />
@@ -203,7 +203,7 @@
             android:windowSoftInputMode="stateHidden" >
 
             <!-- wherigo.com -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -371,7 +371,7 @@
             </intent-filter>
 
             <!-- intent filter for all gpx links, independent of mime types -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -408,7 +408,7 @@
             </intent-filter>
 
             <!-- intent filter for GGZ links, independent of mime types -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -478,7 +478,7 @@
             android:exported="true">
 
             <!-- GeoKrety.org QRCode-->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -507,7 +507,7 @@
             </intent-filter>
 
             <!-- extremcaching.com -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -522,7 +522,7 @@
             </intent-filter>
 
             <!-- geocaching.com URL via coord.info redirection -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -540,7 +540,7 @@
             </intent-filter>
 
             <!-- geocaching.com -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -559,7 +559,7 @@
             </intent-filter>
 
             <!-- opencaching.CZ -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -578,7 +578,7 @@
             </intent-filter>
 
             <!-- opencaching.DE -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -597,7 +597,7 @@
             </intent-filter>
 
             <!-- opencaching.NL -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -616,7 +616,7 @@
             </intent-filter>
 
             <!-- opencaching.PL -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -635,7 +635,7 @@
             </intent-filter>
 
             <!-- opencache.uk -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -654,7 +654,7 @@
             </intent-filter>
 
             <!-- opencaching.RO -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -673,7 +673,7 @@
             </intent-filter>
 
             <!-- opencaching.US -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -698,7 +698,7 @@
             android:exported="true">
 
             <!-- TravelBug URL via coord.info redirection -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -716,7 +716,7 @@
             </intent-filter>
 
             <!-- TravelBug URL tracking page -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -731,7 +731,7 @@
             </intent-filter>
 
             <!-- GeoKrety.org -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
 
@@ -757,7 +757,7 @@
             android:exported="true">
 
             <!-- geocaching.com URL via coord.info redirection -->
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -772,7 +772,7 @@
                 <data android:pathPrefix="/Bm" />
                 <data android:pathPrefix="/bM" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter tools:ignore="AppLinkWarning">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Ignore lint warnings about missing domain validation for these links, as we will never get domain attribution to c:geo for them...