### PR TITLE
fix #17487: wherigo: ignore foreground-start-exception in lack of a better way to deal with it

### DIFF
--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoGameService.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoGameService.java
@@ -47,14 +47,20 @@ public class WherigoGameService extends Service {
         Log.iForce("WherigoGameService STARTED");
         final String content = LocalizationUtils.getString(R.string.wherigo_notification_service);
         serviceDisposables.add(geoDirHandler.start(GeoDirHandler.UPDATE_GEODIR));
-        startForeground(Notifications.ID_WHERIGO_SERVICE_NOTIFICATION_ID, Notifications.newBuilder(this, NotificationChannels.WHERIGO_NOTIFICATION)
-            .setSmallIcon(R.drawable.ic_menu_wherigo)
-            .setContentTitle(content)
-            .setContentText(content)
-            .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, WherigoActivity.class), ProcessUtils.getFlagImmutable()))
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setSilent(true)
-            .setOngoing(true).build());
+        try {
+            startForeground(Notifications.ID_WHERIGO_SERVICE_NOTIFICATION_ID, Notifications.newBuilder(this, NotificationChannels.WHERIGO_NOTIFICATION)
+                    .setSmallIcon(R.drawable.ic_menu_wherigo)
+                    .setContentTitle(content)
+                    .setContentText(content)
+                    .setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, WherigoActivity.class), ProcessUtils.getFlagImmutable()))
+                    .setPriority(NotificationCompat.PRIORITY_LOW)
+                    .setSilent(true)
+                    .setOngoing(true).build());
+        } catch (IllegalStateException re) {
+            // See #17487.
+            // ForegroundServiceStartNotAllowedException extends IllegalStateException and can't be used before SDK level 31
+            Log.e("WherigoGameService: IllegalStateException on starting as foreground service", re);
+        }
     }
 
     @Override


### PR DESCRIPTION
fix #17487: wherigo: ignore foreground-start-exception in lack of a better way to deal with it