### PR TITLE
Prevent crash on custom map uri without host name (fix #17518)

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/downloader/DownloaderTest.java
@@ -172,8 +172,8 @@ public void testOpenAndroMaps() {
         // check one named entry
         final Download d = findByName(list, "E5_N50.rd5");
         assertThat(d).isNotNull();
-        final String sizeInfoString = d.getSizeInfo(); // 154.8 MB as of 2023-06-05
+        final String sizeInfoString = d.getSizeInfo(); // 174.1 MB as of 2025-10-06
         final float sizeInfoFloat = Float.parseFloat(sizeInfoString.substring(0, sizeInfoString.length() - 3));
-        assertThat(sizeInfoFloat).isBetween(120.0F, 170.0F);
+        assertThat(sizeInfoFloat).isBetween(120.0F, 190.0F);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
@@ -31,7 +31,8 @@ public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTil
     }
 
     public static boolean isConfigured() {
-        return StringUtils.isNotBlank(Settings.getUserDefinedTileProviderUri());
+        final String uri = Settings.getUserDefinedTileProviderUri();
+        return StringUtils.isNotBlank(uri) && StringUtils.isNotBlank(Uri.parse(uri).getHost());
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
@@ -33,6 +33,7 @@ public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnl
     }
 
     public static boolean isConfigured() {
-        return StringUtils.isNotBlank(Settings.getUserDefinedTileProviderUri());
+        final String uri = Settings.getUserDefinedTileProviderUri();
+        return StringUtils.isNotBlank(uri) && StringUtils.isNotBlank(Uri.parse(uri).getHost());
     }
 }


### PR DESCRIPTION
## Description
Initializing settings retrieves a list of tile providers, among other things. This initializes the tile providers, which will fail for custom map provider, if its uri is non-empty, but does not contain a host part.

Sadly, the user has no way to fix this easily if the user has not configured a "view settings" quick launch button on the home screen. (It might be possible by performing a backup, manually deleting the key `userDefinedTileProviderUri` from `cgeo-settings.xml`, and then restoring this settings file - haven't tested this, though.)