### PR TITLE
Wherigo Player: provide location accuracy/precision

### DIFF
--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoLocationProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoLocationProvider.java
@@ -145,7 +145,7 @@ public class WherigoLocationProvider extends GeoDirHandler implements LocationSe
 
     @Override
     public double getPrecision() {
-        return 0d;
+        return geoData == null || !geoData.hasAccuracy() ? 20d : Math.max(2d, geoData.getAccuracy());
     }
 
     @Override


### PR DESCRIPTION
Wherigo Player: provide location accuracy/precision

Via support I was informed that some cartridges need the location accuracy/precision to function. This PR lets the player provide this value.
