### PR TITLE
fix #17518: Prevent crash on custom map uri without host name

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
@@ -31,7 +31,8 @@ public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTil
     }
 
     public static boolean isConfigured() {
-        return StringUtils.isNotBlank(Settings.getUserDefinedTileProviderUri());
+        final String uri = Settings.getUserDefinedTileProviderUri();
+        return StringUtils.isNotBlank(uri) && StringUtils.isNotBlank(Uri.parse(uri).getHost());
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
@@ -33,6 +33,7 @@ public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnl
     }
 
     public static boolean isConfigured() {
-        return StringUtils.isNotBlank(Settings.getUserDefinedTileProviderUri());
+        final String uri = Settings.getUserDefinedTileProviderUri();
+        return StringUtils.isNotBlank(uri) && StringUtils.isNotBlank(Uri.parse(uri).getHost());
     }
 }


### PR DESCRIPTION
fix #17518: Prevent crash on custom map uri without host name

I believe I accidentally messed up @moving-bits s PR #17519 by trying to resolve a conflict online. Sorry for that. 
This is a replacement for the original PR.