### PR TITLE
rel #17545: fix status message color

### DIFF
--- a/main/src/main/res/layout/status.xml
+++ b/main/src/main/res/layout/status.xml
@@ -26,7 +26,7 @@
         android:layout_toRightOf="@id/status_icon"
         android:gravity="center"
         android:padding="4dip"
-        android:textColor="@color/colorTextActionBar"
+        android:textColor="@color/colorTextMainInfo"
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_detailsPrimary"
         tools:text="status message"/>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Use `colorTextMainInfo` as status message color.

IconTint is currently not set, because it does not work for multi-color icons (e.g. used first-aid-icon)

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #17545
