### PR TITLE
Update VTM on release

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -385,7 +385,7 @@ dependencies {
     // -- Mapsforge / Mapsforge --
 
     // Mapsforge official version
-    String mapsforgeSource = 'org.mapsforge'
+    String mapsforgeSource = 'com.github.mapsforge.mapsforge'
     String mapsforgeVersion = '0.25.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)


### PR DESCRIPTION
## Description
Update VTM on `release` to the same version as on `master` due to unrecoverable build errors when using version 25.0 - even on local builds I'm no longer able to use v25.0 (after deleting my local gradle cache) - even though this has worked in the past by re-triggering module build on jitpack.io