### PR TITLE
Set Mapsforge dependencies to @jar

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -396,11 +396,11 @@ dependencies {
     // String mapsforgeSource = 'com.github.cgeo.mapsforge'
     // String mapsforgeVersion = 'fbc75a4' // fix for #12210
 
-    implementation "$mapsforgeSource:mapsforge-core:$mapsforgeVersion"
-    implementation "$mapsforgeSource:mapsforge-map:$mapsforgeVersion"
-    implementation "$mapsforgeSource:mapsforge-map-android:$mapsforgeVersion"
-    implementation "$mapsforgeSource:mapsforge-map-reader:$mapsforgeVersion"
-    implementation "$mapsforgeSource:mapsforge-themes:$mapsforgeVersion"
+    implementation "$mapsforgeSource:mapsforge-core:$mapsforgeVersion@jar"
+    implementation "$mapsforgeSource:mapsforge-map:$mapsforgeVersion@jar"
+    implementation "$mapsforgeSource:mapsforge-map-android:$mapsforgeVersion@jar"
+    implementation "$mapsforgeSource:mapsforge-map-reader:$mapsforgeVersion@jar"
+    implementation "$mapsforgeSource:mapsforge-themes:$mapsforgeVersion@jar"
 
     // -- Mapsforge / VTM --
 


### PR DESCRIPTION
## Description
As suggested in https://github.com/cgeo/cgeo/issues/17143#issuecomment-3466474380, add `@jar` to the Mapsforge dependencies to check whether Jitpack will deliver the files for the used versions again in that case