### PR TITLE
set minimal AGP version for kotlin 2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // these dependencies are used by gradle plugins, not by our projects
 
         // Android gradle plugin
-        classpath 'com.android.tools.build:gradle:8.9.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.9.0'
@@ -67,7 +67,7 @@ tasks.register('cgeoHelp') {
         println '    gradlew dependencies main:dependencies'
         println ''
         println 'check gradle dependencies for updates:'
-        println '    gradlew dependencyUpdates'
+        println '    gradlew dependencyUpdates --no-parallel'
         println ''
         println 'Use "gradlew tasks" for more available tasks.'
         println ''


### PR DESCRIPTION
see https://developer.android.com/build/kotlin-support

related to #17561
