### PR TITLE
Update the gradle versions plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'idea'
 
     // check for updates of gradle plugin dependencies
-    id 'com.github.ben-manes.versions' version '0.52.0'
+    id 'com.github.ben-manes.versions' version '0.53.0'
     id 'se.ascp.gradle.gradle-versions-filter' version "0.1.16"
 
     // use SpotBugs instead of FindBugs, see https://plugins.gradle.org/plugin/com.github.spotbugs
@@ -67,7 +67,7 @@ tasks.register('cgeoHelp') {
         println '    gradlew dependencies main:dependencies'
         println ''
         println 'check gradle dependencies for updates:'
-        println '    gradlew dependencyUpdates'
+        println '    gradlew dependencyUpdates --no-parallel'
         println ''
         println 'Use "gradlew tasks" for more available tasks.'
         println ''

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,8 @@ org.gradle.caching=true
 
 # activating configuration cache, see https://docs.gradle.org/8.1/userguide/configuration_cache.html
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache.problems=warn
+# deactivated for DependencyUpdates task, see https://github.com/ben-manes/gradle-versions-plugin?tab=readme-ov-file#workarounds-for-related-gradle-issues
+#org.gradle.configuration-cache.problems=warn
 
 # Activate File system watching, see https://docs.gradle.org/6.7/userguide/gradle_daemon.html#sec:daemon_watch_fs
 org.gradle.vfs.watch=true


### PR DESCRIPTION
Additionally to the plugins update I documented the suggersted parameter "--no-parallel". 

The plugin doesn't have any results with `org.gradle.configuration-cache.problems=warn`. 
Therefore the parameter is deactivated, see https://github.com/ben-manes/gradle-versions-plugin?tab=readme-ov-file#workarounds-for-related-gradle-issues.

replaces #17494
