### PR TITLE
Migrate map mode to UnifiedMap

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -274,7 +274,7 @@ public class Settings {
     }
 
     public static int getExpectedVersion() {
-        return 10;
+        return 11;
     }
 
     private static void migrateSettings() {
@@ -492,6 +492,45 @@ public class Settings {
             e.apply();
             setActualVersion(10);
         }
+
+        if (currentVersion < 11) {
+            final String tileprovider = sharedPrefs.getString(getKey(R.string.pref_mapsource), "")
+                // Google Maps map sources
+                .replace("cgeo.geocaching.maps.google.v2.GoogleMapProvider$", "cgeo.geocaching.unifiedmap.tileproviders.")
+                // cgeo.geocaching.maps.google.v2.GoogleMapProvider$GoogleMapSource         => cgeo.geocaching.unifiedmap.tileproviders.GoogleMapSource
+                // cgeo.geocaching.maps.google.v2.GoogleMapProvider$GoogleSatelliteSource   => cgeo.geocaching.unifiedmap.tileproviders.GoogleSatelliteSource
+                // cgeo.geocaching.maps.google.v2.GoogleMapProvider$GoogleTerrainSource     => cgeo.geocaching.unifiedmap.tileproviders.GoogleTerrainSource
+
+                // OSM online map sources
+                .replace("cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$", "cgeo.geocaching.unifiedmap.tileproviders.")
+                // cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$OsmMapSource         => cgeo.geocaching.unifiedmap.tileproviders.OsmOrgSource:null
+                .replace(".OsmMapSource", ".OsmOrgSource:null")
+                // cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$OsmdeMapSource       => cgeo.geocaching.unifiedmap.tileproviders.OsmDeSource:null
+                .replace(".OsmdeMapSource", ".OsmDeSource:null")
+                // cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$CyclosmMapSource     => cgeo.geocaching.unifiedmap.tileproviders.CyclosmSource:null
+                .replace(".CyclosmMapSource", ".CyclosmSource:null")
+                // cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$OpenTopoMapSource    => cgeo.geocaching.unifiedmap.tileproviders.OpenTopoMapSource:null (!!!)
+                .replace(".OpenTopoMapSource", ".OpenTopoMapSource:null")
+
+                // OSM offline map sources
+                // cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$OfflineMapSource:primary:cgeo/maps/bremen.map => cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeOfflineTileProvider:primary:cgeo/maps/bremen.map
+                .replace(".OfflineMapSource:", ".AbstractMapsforgeOfflineTileProvider:")
+                // cgeo.geocaching.maps.mapsforge.MapsforgeMapProvider$OfflineMultiMapSource => cgeo.geocaching.unifiedmap.tileproviders.MapsforgeMultiOfflineTileProvider:null
+                .replace(".OfflineMultiMapSource", ".MapsforgeMultiOfflineTileProvider:null")
+            ;
+
+            if (useLegacyMaps()) {
+                final Editor e = sharedPrefs.edit();
+                e.putString(getKey(R.string.pref_tileprovider), StringUtils.isBlank(tileprovider) ? "cgeo.geocaching.unifiedmap.tileproviders.GoogleMapSource" : tileprovider);
+                e.putBoolean(getKey(R.string.pref_useLegacyMap), false);
+                e.putString(getKey(R.string.pref_unifiedMapVariants), String.valueOf(UNIFIEDMAP_VARIANT_MAPSFORGE));
+                e.apply();
+                Log.e("Migrated map mode to UnifiedMap: " + tileprovider);
+            }
+
+            setActualVersion(11);
+        }
+
     }
 
     private static String getKey(final int prefKeyId) {


### PR DESCRIPTION
## Description
In our legacy maps deprecation notice in release 2025.07.31 we shared a roadmap for removing the legacy maps. Next step is a once-only migration of selected map mode to UnifiedMap, which this PR implements:

- if current map mode is legacy map:
  - migrate mapsource to tileprovider equivalent
  - store new tileprovider value
  - set useLegacyMaps to `false`

This is implemented as a settings migration, thus it will be called only once. If a user decides to switch back to legacy maps for the time being, this decision will be honored for now.

The last step (to be executed somewhere in spring) will be to remove legacy maps completely and re-do the migration. (This step will have to be implemented in a separate PR at some point in 2026.)