### PR TITLE
Switch Geofence UI to int (fix #17572)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Waypoint.java
+++ b/main/src/main/java/cgeo/geocaching/models/Waypoint.java
@@ -310,9 +310,8 @@ public class Waypoint implements INamedGeoCoordinate {
         return preprojectedCoords;
     }
 
-    @Nullable
-    public Float getGeofence() {
-        return geofence;
+    public int getGeofence() {
+        return geofence == null ? 0 : Math.round(geofence);
     }
 
     public boolean canChangeGeofence() {

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeofenceCirclesLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/GeofenceCirclesLayer.java
@@ -25,8 +25,8 @@ public class GeofenceCirclesLayer {
                 final GeoGroup.Builder geoGroup = GeoGroup.builder();
 
                 for (Waypoint waypoint : waypoints) {
-                    final Float geofenceInMeters = waypoint.getGeofence();
-                    if (geofenceInMeters != null && geofenceInMeters > 0f) {
+                    final int geofenceInMeters = waypoint.getGeofence();
+                    if (geofenceInMeters > 0) {
                         geoGroup.addItems(
                                 GeoPrimitive.createCircle(waypoint.getCoords(), geofenceInMeters / 1000f, GeoStyle.builder()
                                         .setStrokeWidth(2.0f)


### PR DESCRIPTION
## Description
Let's Geocache model return a geofence as `int` (instead of `Float`), which automatically leads to input box no longer displaying the ".0" suffix. (Input method was non-decimal anyway, so no need for a float.)