### PR TITLE
fix #17598: preserve personal note whitespaces on refreshing/downloading cache data

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLogin.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLogin.java
@@ -571,9 +571,18 @@ public class GCLogin extends AbstractLogin {
     @Nullable
     @WorkerThread
     String getRequestLogged(@NonNull final String uri, @Nullable final Parameters params) {
+        return getRequestLogged(uri, params, null);
+    }
+
+    /**
+     * GET HTTP request. Do the request a second time if the user is not logged in
+     */
+    @Nullable
+    @WorkerThread
+    String getRequestLogged(@NonNull final String uri, @Nullable final Parameters params, @Nullable final Boolean removeWhitespace) {
         try {
             final Response response = Network.getRequest(uri, params).blockingGet();
-            final String data = Network.getResponseData(response, canRemoveWhitespace(uri));
+            final String data = Network.getResponseData(response, removeWhitespace == null ? canRemoveWhitespace(uri) : removeWhitespace);
 
             // A page not found will not be found if the user logs in either
             if (response.code() == 404 || getLoginStatus(data)) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1064,7 +1064,7 @@ public final class GCParser {
     static String requestHtmlPage(@Nullable final String geocode, @Nullable final String guid) {
         if (StringUtils.isNotBlank(geocode)) {
             final Parameters params = new Parameters("decrypt", "y");
-            return GCLogin.getInstance().getRequestLogged("https://www.geocaching.com/geocache/" + geocode, params);
+            return GCLogin.getInstance().getRequestLogged("https://www.geocaching.com/geocache/" + geocode, params, false);
         } else if (StringUtils.isNotBlank(guid)) {
             final Parameters params = new Parameters("decrypt", "y");
             params.put("guid", guid);


### PR DESCRIPTION
fix #17598: preserve personal note whitespaces on refreshing/downloading cache data