### PR TITLE
Limit gc trackable visits to 100 per log

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.connector.ILoggingManager;
 import cgeo.geocaching.connector.LogContextInfo;
 import cgeo.geocaching.connector.StatusResult;
 import cgeo.geocaching.connector.capability.IFavoriteCapability;
+import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.databinding.LogcacheActivityBinding;
 import cgeo.geocaching.databinding.LogcacheTrackableItemBinding;
@@ -79,6 +80,8 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     private static final String SAVED_STATE_LOGENTRY = "cgeo.geocaching.saved_state_logentry";
     private static final String SAVED_STATE_AVAILABLE_FAV_POINTS  = "cgeo.geocaching.saved_state_available_fav_points";
     private static final String SAVED_STATE_FAVORITE = "cgeo.geocaching.saved_state_favorite";
+
+    private static final int MAX_GC_TRACKABLE_FOUNDS = 100; // maximum number of allowed trackables visiting per cache log for geocaching.com
 
     private enum LogEditMode {
         CREATE_NEW, // create/edit a new log entry (which may be stored offline)
@@ -533,6 +536,10 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
             SimpleDialog.of(this).setMessage(R.string.log_date_future_not_allowed).show();
             return;
         }
+        if (inventoryAdapter.hastTooManyGCVisitedLogs()) {
+            SimpleDialog.of(this).setTitle(R.string.err_trackable_error).setMessage(R.string.err_trackable_too_many_visited, MAX_GC_TRACKABLE_FOUNDS).confirm(() -> { });
+            return;
+        }
         if (logType.get().mustConfirmLog()) {
             SimpleDialog.of(this).setTitle(R.string.confirm_log_title).setMessage(R.string.confirm_log_message, logType.get().getL10n()).confirm(this::sendLogInternal);
         } else if (reportProblem.get() != ReportProblemType.NO_PROBLEM) {
@@ -543,6 +550,9 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     }
 
     private void sendLogInternal() {
+        if (inventoryAdapter.hastTooManyGCVisitedLogs()) {
+            return;
+        }
         if (logEditMode == LogEditMode.EDIT_EXISTING) {
             logActivityHelper.editLog(cache, this.originalLogEntry,
                 getEntryFromView().buildUponOfflineLogEntry().setServiceLogId(this.originalLogEntry.serviceLogId).build());
@@ -739,6 +749,20 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
             this.clear();
             this.addAll(inventory);
             resortTrackables(Settings.getTrackableComparator());
+        }
+
+        public boolean hastTooManyGCVisitedLogs() {
+            int count = 0;
+            for (int i = 0; i < getCount(); i++) {
+                final Trackable t = getItem(i);
+                if (t != null && t.getBrand() == TrackableBrand.TRAVELBUG && actionLogs.get(t.getGeocode()) == LogTypeTrackable.VISITED) {
+                    count++;
+                    if (count > MAX_GC_TRACKABLE_FOUNDS) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         public void resortTrackables(final TrackableComparator comparator) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -344,6 +344,8 @@
     <string name="warn_calculator_state_save">Be sure to save waypoint if you want to keep the calculator state.</string>
     <string name="err_trackable_log_not_anonymous">Logging %1$s from c:geo cannot be done anonymously. Do you want to open the settings to fill in your credentials from %2$s?</string>
     <string name="err_trackable_no_preference_activity">Sorry, cannot find a suitable preference screen.</string>
+    <string name="err_trackable_error">Trackable error</string>
+    <string name="err_trackable_too_many_visited">Too many trackables marked as \"visit\" - maximum of %d allowed</string>
     <string name="confirm_unsaved_changes_title">Unsaved changes</string>
     <string name="confirm_discard_changes">Discard unsaved changes?</string>
     <string name="confirm_unsent_changes_title">Unsent changes</string>


### PR DESCRIPTION
## Description
Skips sending a cache log when number of GC trackable set to "visit" exceeds 100 (see https://github.com/orgs/cgeo/discussions/105)

Can someone from the team please cross-check whether this is the right way to implement this?