### PR TITLE
Tackle SecurityPermissions for notifications (rel. to #17565)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/ReceiveDownload.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/ReceiveDownload.java
@@ -95,9 +95,9 @@ class ReceiveDownload {
                 return handleMapFile(context, notificationManager, notification, updateForegroundNotification, false, null);
             }
         } else {
-            notificationManager.notify(Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
+            Notifications.send(context, Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
                     context, NotificationChannels.DOWNLOADER_RESULT_NOTIFICATION, R.string.receivedownload_intenttitle, String.format(context.getString(R.string.downloadmap_target_not_writable), downloader.targetFolder)
-            ).build());
+            ));
         }
         return Worker.Result.failure();
     }
@@ -176,9 +176,9 @@ class ReceiveDownload {
                 resultMsg = context.getString(R.string.receivedownload_error);
                 break;
         }
-        notificationManager.notify(Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
+        Notifications.send(context, Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
                 context, NotificationChannels.DOWNLOADER_RESULT_NOTIFICATION, R.string.receivedownload_intenttitle, resultMsg
-        ).build());
+        ));
         return resultId;
     }
 

--- a/main/src/main/java/cgeo/geocaching/downloader/ReceiveDownloadWorker.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/ReceiveDownloadWorker.java
@@ -56,7 +56,7 @@ public class ReceiveDownloadWorker extends Worker {
     }
 
     private void updateForegroundNotification() {
-        notificationManager.notify(getForegroundNotificationId(), notification.build());
+        Notifications.send(CgeoApplication.getInstance(), getForegroundNotificationId(), notification);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/location/ProximityNotification.java
+++ b/main/src/main/java/cgeo/geocaching/location/ProximityNotification.java
@@ -140,7 +140,7 @@ public class ProximityNotification implements Parcelable {
                     .setPriority(NotificationCompat.PRIORITY_HIGH)
                     .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
-            Notifications.getNotificationManager(context).notify(Notifications.ID_PROXIMITY_NOTIFICATION, builder.build());
+            Notifications.send(context, Notifications.ID_PROXIMITY_NOTIFICATION, builder);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/service/AbstractForegroundIntentService.java
+++ b/main/src/main/java/cgeo/geocaching/service/AbstractForegroundIntentService.java
@@ -55,6 +55,6 @@ public abstract class AbstractForegroundIntentService extends IntentService {
     }
 
     protected void updateForegroundNotification() {
-        notificationManager.notify(getForegroundNotificationId(), notification.build());
+        Notifications.send(this, getForegroundNotificationId(), notification);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -260,9 +260,8 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
     }
 
     private void showEndNotification(final String text) {
-        notificationManager.notify(Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
-                this, NotificationChannels.CACHES_DOWNLOADED_NOTIFICATION, R.string.caches_store_background_title, text).setSilent(true).build());
-
+        Notifications.send(this, Settings.getUniqueNotificationId(), Notifications.createTextContentNotification(
+                this, NotificationChannels.CACHES_DOWNLOADED_NOTIFICATION, R.string.caches_store_background_title, text).setSilent(true));
     }
 
     private static class DownloadTaskProperties {


### PR DESCRIPTION
## Description
Send toasts instead of notifications when notification permissions are missing