### PR TITLE
ci: Fix check-website PR task when run from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
+          # On push, use the push commit sha. On PR from cgeo/cgeo use the PR commit sha; on forks fall back to master
+          ref: ${{ !github.event.pull_request && github.sha || github.event.pull_request && github.event.pull_request.head.repo.full_name == 'cgeo/cgeo' && github.event.pull_request.head.sha || 'master' }}
       - name: Check websites status
         uses: ./.github/actions/check-websites
 
@@ -200,7 +200,7 @@ jobs:
     # > are 2-3 times faster than the macOS ones which are also a lot more expensive.
     # https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners
     runs-on: ubuntu-latest
-    needs: check-secrets
+    needs: [check-secrets, check-websites]
     strategy:
       fail-fast: false
       matrix:
@@ -210,12 +210,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fail early if OC.de is not reachable
-        uses: ./.github/actions/check-websites
-        with:
-          URLS: https://www.opencaching.de/
-          with_error: "true"
 
       # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
       - name: Enable KVM group perms
@@ -315,12 +309,6 @@ jobs:
           while [ "$i" -lt $(( 6 * $TIMEOUT_MINUTES )) ] && ! curl -X POST -qSs "https://mutex.kumy.org/api/client/${{ secrets.MUTEX_SECRET }}/mutex/unit-test?lock&waitTimeoutMs=10000" --fail
             do ((i+=1))
           done && locked=true
-
-      - name: Check websites status
-        uses: ./.github/actions/check-websites
-        continue-on-error: true
-        with:
-          with_error: "true"
 
       - name: Run Unit Tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
- removed `actions/check-websites` calls from job `integration-tests` and used a dependency (they were here to try diagnose https://github.com/cgeo/cgeo/issues/15608#issuecomment-3014185955)
- updated the `actions/checkout` branch ref based on `github.event.pull_request.head.repo.full_name`
- ~also fixed some pre-existing to this PR lint blocking issues~ (In fact there are 9 of them, will move that to a dedicated PR... EDIT: https://github.com/cgeo/cgeo/pull/17622 exists, but I don't plan to fix them myself)

## Related issues
Closes #17620


## Additional context
Raised from https://github.com/cgeo/cgeo/pull/17618

New chain become
<img width="894" height="559" alt="image" src="https://github.com/user-attachments/assets/8f52d164-7530-4515-9a49-7e49307a8420" />

Previous was:
<img width="896" height="626" alt="image" src="https://github.com/user-attachments/assets/f082a1d7-ca3c-4054-8b62-341c85985627" />
