### PR TITLE
fix #17609: Wherigo, trigger autosave from c:geo side on save-worthy actions

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/geoitemlayer/GeoItemLayer.java
@@ -7,7 +7,6 @@ import cgeo.geocaching.models.geoitem.GeoItem;
 import cgeo.geocaching.models.geoitem.GeoPrimitive;
 import cgeo.geocaching.models.geoitem.ToScreenProjector;
 import cgeo.geocaching.utils.AsynchronousMapWrapper;
-import cgeo.geocaching.utils.CommonUtils;
 import cgeo.geocaching.utils.ContextLogger;
 import cgeo.geocaching.utils.Log;
 

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoGame.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoGame.java
@@ -110,7 +110,6 @@ public class WherigoGame implements UI {
             // not really important
             Log.d(LOG_PRAEFIX + "unable to set name/platform for OpenWIG", e);
         }
-
     }
 
     public int addListener(final Consumer<NotifyType> listener) {
@@ -337,7 +336,7 @@ public class WherigoGame implements UI {
         isPlaying = true;
         Log.iForce(LOG_PRAEFIX + "pos: " + GP_CONVERTER.from(cartridge.position));
         notifyListeners(NotifyType.START);
-        WherigoSaveFileHandler.get().loadSaveFinished(); // ends a probable LOAD
+        WherigoSaveFileHandler.get().reset(); // ends a probable LOAD
         WherigoLocationProvider.get().connect();
         WherigoGameService.startService();
     }
@@ -484,7 +483,7 @@ public class WherigoGame implements UI {
 
     @Override
     public void unblock() {
-        WherigoSaveFileHandler.get().loadSaveFinished(); // Ends a running SAVE
+        WherigoSaveFileHandler.get().saveFinished(); // Ends a running SAVE
     }
 
     /**
@@ -529,4 +528,5 @@ public class WherigoGame implements UI {
     public String toString() {
         return "isPlaying:" + isPlaying + ", name:" + getCartridgeName() + ", cguid:" + getCGuid() + ", context: " + getContextGeocacheName();
     }
+
 }

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoInputDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoInputDialogProvider.java
@@ -93,6 +93,7 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
                     control.setPauseOnDismiss(false);
                     control.dismiss();
                     Engine.callEvent(input, "OnGetInput", String.valueOf(binding.dialogInputEdittext.getText()));
+                    WherigoSaveFileHandler.get().markSafeWorthyAction();
                 } else {
                     control.dismiss();
                 }
@@ -101,6 +102,7 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
                 control.setPauseOnDismiss(false);
                 control.dismiss();
                 Engine.callEvent(input, "OnGetInput", String.valueOf(binding.dialogInputEdittext.getText()));
+                WherigoSaveFileHandler.get().markSafeWorthyAction();
             });
             Keyboard.show(activity, binding.dialogInputEdittext);
 
@@ -130,6 +132,7 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
                         if (item) {
                             control.setPauseOnDismiss(false);
                             control.dismiss();
+                            WherigoSaveFileHandler.get().markSafeWorthyAction();
                             Engine.callEvent(input, "OnGetInput", CommonUtils.first(choiceModel.getSelectedItems()));
                         } else {
                             control.dismiss();
@@ -144,6 +147,7 @@ public class WherigoInputDialogProvider implements IWherigoDialogProvider {
             WherigoViewUtils.setViewActions(Collections.singleton("ok"), binding.dialogActionlist, 1, item -> WherigoUtils.TP_OK_BUTTON, item -> {
                 control.setPauseOnDismiss(false);
                 control.dismiss();
+                WherigoSaveFileHandler.get().markSafeWorthyAction();
                 Engine.callEvent(input, "OnGetInput", null);
             });
         }

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoPushDialogProvider.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoPushDialogProvider.java
@@ -118,12 +118,14 @@ public class WherigoPushDialogProvider implements IWherigoDialogProvider {
                         if (callback != null) {
                             Engine.invokeCallback(callback, "Button2");
                         }
+                        WherigoSaveFileHandler.get().markSafeWorthyAction();
                     } else if (pageDisplayed + 1 < texts.length) {
                         pageDisplayed ++;
                         refreshGui(binding, control);
                     } else {
                         control.setPauseOnDismiss(false);
                         control.dismiss();
+                        WherigoSaveFileHandler.get().markSafeWorthyAction();
                         if (callback != null) {
                             Engine.invokeCallback(callback, "Button1");
                         }

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingType.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoThingType.java
@@ -102,4 +102,11 @@ public enum WherigoThingType {
         return result;
     }
 
+    public static String getVisibleThingState() {
+        return getEverything().stream()
+            .filter(WherigoUtils::isVisibleToPlayer)
+            .map(et -> et.getClass().getSimpleName() + ":" + et.name)
+            .sorted().collect(Collectors.joining(","));
+    }
+
 }


### PR DESCRIPTION
fix #17609: Wherigo, trigger autosave from c:geo side on save-worthy actions

Save-worthy is:
* a change of visibility for a zone, task, inventory or item
* a finished push dialog or input dialog

Auto-safe files are only created if at least 30 seconds no safe was done and (in case of push/input dialog) action was at least 10 seconds ago. Both restrictions should prevent double-safes in case the cartridge saves automatically or the player saves manually.