### PR TITLE
DO NOT MERGE, rel to #17065: Demo on how to add images of new category (waypoint) to image gallery

### DIFF
--- a/main/src/main/java/cgeo/geocaching/models/Geocache.java
+++ b/main/src/main/java/cgeo/geocaching/models/Geocache.java
@@ -2303,6 +2303,13 @@ public class Geocache implements INamedGeoCoordinate {
         images.addAll(getSpoilers()); //for gc.com this includes gallery images, spoilers and background
         addLocalSpoilersTo(images);
 
+        //For Demonstration purposes: add a fake "WAYPOINT" image
+        images.add(new Image.Builder()
+                .setTitle("cgeo Logo")
+                .setCategory(Image.ImageCategory.WAYPOINT)
+                .setUrl("https://www.cgeo.org/images/logo.png")
+                .build());
+
         // Deduplicate images and return them in requested size
         ImageUtils.deduplicateImageList(images);
 

--- a/main/src/main/java/cgeo/geocaching/models/Image.java
+++ b/main/src/main/java/cgeo/geocaching/models/Image.java
@@ -33,6 +33,7 @@ public class Image implements Parcelable {
         OWN(R.string.image_category_own),
         LISTING(R.string.image_category_listing),
         LOG(R.string.image_category_log),
+        WAYPOINT(R.string.waypoint),
         NOTE(R.string.cache_personal_note);
 
         @StringRes


### PR DESCRIPTION
DO NOT MERGE, rel to #17065: Demo on how to add images of new category (waypoint) to image gallery

If this code would be merged, it would add a fake cgeo logo as waypoint image to each geocache's image gallery:

<img width="477" height="482" alt="image" src="https://github.com/user-attachments/assets/596109a1-3015-4f58-a553-c86c6da1344e" />
