### PR TITLE
Fix keyword search history - remove item

### DIFF
--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -344,7 +344,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
 
             if (title == R.string.search_geo) {
                 searchView.setText("GC");
-                binding.suggestionList.setAdapter(new GeocacheAutoCompleteAdapter.GeocodeAutoCompleteAdapter(searchView.getContext(), suggestionFunction, historyFunction));
+                binding.suggestionList.setAdapter(new GeocacheAutoCompleteAdapter.GeocodeAutoCompleteAdapter(searchView.getContext(), suggestionFunction, historyFunction, deleteFunction));
                 final String clipboardGeocode = getGeocodeFromClipboard();
                 if (null != clipboardGeocode) {
                     binding.suggestionList.postDelayed(() -> {
@@ -356,7 +356,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
                     }, 0);
                 }
             } else if (title == R.string.search_kw) {
-                binding.suggestionList.setAdapter(new GeocacheAutoCompleteAdapter.KeywordAutoCompleteAdapter(searchView.getContext(), suggestionFunction, historyFunction));
+                binding.suggestionList.setAdapter(new GeocacheAutoCompleteAdapter.KeywordAutoCompleteAdapter(searchView.getContext(), suggestionFunction, historyFunction, deleteFunction));
                 binding.suggestionList.setOnItemClickListener((parent, view, position, id) -> {
                     final String searchTerm = (String) parent.getItemAtPosition(position);
                     // suggestions are a mix of geocodes and keywords, differentiate them by layout used

--- a/main/src/main/java/cgeo/geocaching/log/LogTrackableActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogTrackableActivity.java
@@ -284,7 +284,7 @@ public class LogTrackableActivity extends AbstractLoggingActivity implements Loa
      * Link the geocodeEditText to the SuggestionsGeocode.
      */
     private void initGeocodeSuggestions() {
-        binding.geocode.setAdapter(new GeocacheAutoCompleteAdapter(binding.geocode.getContext(), DataStore::getSuggestionsGeocode));
+        binding.geocode.setAdapter(new GeocacheAutoCompleteAdapter(binding.geocode.getContext(), DataStore::getSuggestionsGeocode, null));
     }
 
     public void updateForNewType() {

--- a/main/src/main/java/cgeo/geocaching/search/GeocacheAutoCompleteAdapter.java
+++ b/main/src/main/java/cgeo/geocaching/search/GeocacheAutoCompleteAdapter.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.GeoItemSelectorUtils;
+import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.functions.Func0;
 import cgeo.geocaching.utils.functions.Func1;
 
@@ -23,13 +24,13 @@ import org.apache.commons.lang3.StringUtils;
 public class GeocacheAutoCompleteAdapter extends SearchAutoCompleteAdapter {
     private final Context context;
 
-    public GeocacheAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction) {
-        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction, 0, null, null);
+    public GeocacheAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Action1<String> deleteFunction) {
+        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction, 0, null, deleteFunction);
         this.context = context;
     }
 
-    public GeocacheAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction) {
-        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction, 0, historyFunction, null);
+    public GeocacheAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction, final Action1<String> deleteFunction) {
+        super(context, R.layout.cacheslist_item_select, geocodeSuggestionFunction, 0, historyFunction, deleteFunction);
         this.context = context;
     }
 
@@ -57,8 +58,8 @@ public class GeocacheAutoCompleteAdapter extends SearchAutoCompleteAdapter {
     }
 
     public static class GeocodeAutoCompleteAdapter extends GeocacheAutoCompleteAdapter {
-        public GeocodeAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction) {
-            super(context, geocodeSuggestionFunction, historyFunction);
+        public GeocodeAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction, final Action1<String> deleteFunction) {
+            super(context, geocodeSuggestionFunction, historyFunction, deleteFunction);
         }
 
         /**
@@ -70,8 +71,8 @@ public class GeocacheAutoCompleteAdapter extends SearchAutoCompleteAdapter {
     }
 
     public static class KeywordAutoCompleteAdapter extends GeocacheAutoCompleteAdapter {
-        public KeywordAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction) {
-            super(context, geocodeSuggestionFunction, historyFunction);
+        public KeywordAutoCompleteAdapter(final Context context, final Func1<String, String[]> geocodeSuggestionFunction, final Func0<String[]> historyFunction, final Action1<String> deleteFunction) {
+            super(context, geocodeSuggestionFunction, historyFunction, deleteFunction);
         }
 
         @NonNull


### PR DESCRIPTION
## Description
Currently there are two bugs in keyword search history:
- Due to InternalConnector now defaulting to "active", GC basic member detection for keyword search history fails
- Entries cannot be removed from keyword search history

Both issues are fixed with this PR.