### PR TITLE
Fix lint PluralsCandidate

### DIFF
--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -345,7 +345,7 @@
     <string name="err_trackable_log_not_anonymous">Logging %1$s from c:geo cannot be done anonymously. Do you want to open the settings to fill in your credentials from %2$s?</string>
     <string name="err_trackable_no_preference_activity">Sorry, cannot find a suitable preference screen.</string>
     <string name="err_trackable_error">Trackable error</string>
-    <string name="err_trackable_too_many_visited">Too many trackables marked as \"visit\" - maximum of %d allowed</string>
+    <string name="err_trackable_too_many_visited" tools:ignore="PluralsCandidate">Too many trackables marked as \"visit\" - maximum of %d allowed</string>
     <string name="confirm_unsaved_changes_title">Unsaved changes</string>
     <string name="confirm_discard_changes">Discard unsaved changes?</string>
     <string name="confirm_unsent_changes_title">Unsent changes</string>


### PR DESCRIPTION
Lint suggest to have the key`err_trackable_too_many_visited` in plurals form. This is not necessary.

