### PR TITLE
rel to #17646 ANR on Startup: dont check vallidity of default folders on startup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/ContentStorage.java
+++ b/main/src/main/java/cgeo/geocaching/storage/ContentStorage.java
@@ -619,7 +619,7 @@ public class ContentStorage {
     protected Folder getAccessibleDefaultFolder(final Folder candidate, final boolean needsWrite, final String fallbackName) {
 
         //candidate is ok if it is either directly accessible or based on another public folder (which will become accessible later)
-        if (candidate != null && ensureFolder(candidate, needsWrite, true)) {
+        if (candidate != null && ensureFolder(candidate, needsWrite, false)) {
             return candidate;
         }
 


### PR DESCRIPTION
rel to #17646 ANR on Startup: dont check vallidity of default folders on startup

This is taken from https://github.com/cgeo/cgeo/pull/17646, seemed easier to create a new PR than to tell copilot how to extract this part.