### PR TITLE
Put refreshing waypoints into background

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -662,27 +662,28 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             return;
         }
 
-        final Set<Waypoint> waypoints;
-
         //show all waypoints be displayed or just the ones from visible caches?
-        final boolean showAll = viewModel.mapType.enableLiveMap();
-        if (showAll) {
-            waypoints = DataStore.loadWaypoints(viewport);
-        } else {
-            waypoints = viewModel.caches.readWithResult(caches -> {
-                final Set<Waypoint> wpSet = new HashSet<>();
-                for (final Geocache c : caches) {
-                    wpSet.addAll(c.getWaypoints());
-                }
-                return wpSet;
-            });
-        }
+        Schedulers.io().scheduleDirect(() -> {
+            final Set<Waypoint> waypoints;
+            final boolean showAll = viewModel.mapType.enableLiveMap();
+            if (showAll) {
+                waypoints = DataStore.loadWaypoints(viewport);
+            } else {
+                waypoints = viewModel.caches.readWithResult(caches -> {
+                    final Set<Waypoint> wpSet = new HashSet<>();
+                    for (final Geocache c : caches) {
+                        wpSet.addAll(c.getWaypoints());
+                    }
+                    return wpSet;
+                });
+            }
 
-        //filter waypoints
-        MapUtils.filter(waypoints, filter);
-        viewModel.waypoints.write(wps -> {
+            //filter waypoints
+            MapUtils.filter(waypoints, filter);
+            viewModel.waypoints.write(wps -> {
                 wps.clear();
                 wps.addAll(waypoints);
+            });
         });
     }
 


### PR DESCRIPTION
## Description
Puts refreshing waypoints into a background thread to avoid the crash listed below (copied from Play Store logs)

## Additional context
Play Store error log:

```
at jdk.internal.misc.Unsafe.park (Native method)
      at java.util.concurrent.locks.LockSupport.parkNanos (LockSupport.java:269)
      at android.database.sqlite.SQLiteConnectionPool.waitForConnection (SQLiteConnectionPool.java:787)
      at android.database.sqlite.SQLiteConnectionPool.acquireConnection (SQLiteConnectionPool.java:399)

Durch diesen Funktionsaufruf werden E/A-Abläufe mit unvorhersehbarem zeitlichen Verlauf ausgeführt. [Weitere Informationen](https://developer.android.com/topic/performance/anrs/find-unresponsive-thread#blocking-io)

      at android.database.sqlite.SQLiteSession.acquireConnection (SQLiteSession.java:920)
      at android.database.sqlite.SQLiteSession.prepare (SQLiteSession.java:612)
      at android.database.sqlite.SQLiteProgram.<init> (SQLiteProgram.java:62)
      at android.database.sqlite.SQLiteQuery.<init> (SQLiteQuery.java:37)
      at android.database.sqlite.SQLiteDirectCursorDriver.query (SQLiteDirectCursorDriver.java:46)
      at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory (SQLiteDatabase.java:1823)
      at android.database.sqlite.SQLiteDatabase.rawQuery (SQLiteDatabase.java:1755)
      at cgeo.geocaching.storage.DataStore.$r8$lambda$MGege7EI4jQ78TSpWaiOr1zVpg0 (SourceFile:5102)
      at cgeo.geocaching.storage.DataStore$$ExternalSyntheticLambda78.get (SourceFile)
      at cgeo.geocaching.storage.DataStore.withAccessLock (SourceFile:1011)
      at cgeo.geocaching.storage.DataStore.loadWaypoints (SourceFile:5090)
**>      at cgeo.geocaching.unifiedmap.UnifiedMapActivity.refreshWaypoints (SourceFile:670) **
      at cgeo.geocaching.unifiedmap.UnifiedMapActivity.$r8$lambda$8TvIQmhUcrIuu23GcyBtNukqmSc (SourceFile:271)
      at cgeo.geocaching.unifiedmap.UnifiedMapActivity$$ExternalSyntheticLambda45.run (SourceFile)
      at cgeo.geocaching.utils.livedata.CollectionLiveData.$r8$lambda$_6RzvcZKvFhgkWRqmY5kWF89MP0 (SourceFile:104)
      at cgeo.geocaching.utils.livedata.CollectionLiveData$$ExternalSyntheticLambda4.onChanged (SourceFile)
      at androidx.lifecycle.LiveData.considerNotify (SourceFile:133)
      at androidx.lifecycle.LiveData.dispatchingValue (SourceFile:151)
      at androidx.lifecycle.LiveData.setValue (SourceFile:309)
      at androidx.lifecycle.MutableLiveData.setValue (SourceFile:50)
      at androidx.lifecycle.LiveData$1.run (SourceFile:93)
      at android.os.Handler.handleCallback (Handler.java:973)
      at android.os.Handler.dispatchMessage (Handler.java:100)
      at android.os.Looper.loopOnce (Looper.java:282)
      at android.os.Looper.loop (Looper.java:387)
      at android.app.ActivityThread.main (ActivityThread.java:9500)
      at java.lang.reflect.Method.invoke (Native method)
      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:600)
      at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1005)
```
