### PR TITLE
increase java memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 
 # Use more memory to benefit from in-process dexing
 # Use the parallel garbage collector
-org.gradle.jvmargs = -Xmx2048m -XX:+UseParallelGC
+org.gradle.jvmargs = -Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=4g
 
 # Only configure other modules when they are actually needed for the task being executed
 org.gradle.configureondemand=true


### PR DESCRIPTION
The `gradlew check` end with an OOM error. So I increased the parameters andd added one.

For reference some messages from the tests:
~~~
An exception has occurred in the compiler (17.0.10). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.OutOfMemoryError: GC overhead limit exceeded
~~~
~~~
The Daemon will expire after the build after running out of JVM heap space.
The project memory settings are likely not configured or are configured to an insufficient value.
The daemon will restart for the next build, which may increase subsequent build times.
These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
The currently configured max heap space is '1.3 GiB' and the configured max metaspace is 'unknown'.
For more information on how to set these values, please refer to https://docs.gradle.org/8.11.1/userguide/build_environment.html#sec:configuring_jvm_memory in the Gradle documentation.
To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'.
Daemon will be stopped at the end of the build after running out of JVM heap space
~~~