### PR TITLE
Lower max distance for history track (fix #17690)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1143,6 +1143,10 @@ public class Settings {
         return getInt(R.string.pref_maptrail_length, getKeyInt(R.integer.historytrack_length_default));
     }
 
+    public static int getMaximumMapTrailDistance() {
+        return getInt(R.string.pref_maptrail_maxdistance, getKeyInt(R.integer.historytrack_mindistance_default));
+    }
+
     public static int getMapLineValue(final int prefKeyId, final int defaultValueKeyId) {
         return getInt(prefKeyId, getKeyInt(defaultValueKeyId));
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionHistoryLayer.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/layers/PositionHistoryLayer.java
@@ -29,7 +29,7 @@ public class PositionHistoryLayer {
     /**
      * maximum distance (in meters) up to which two points in the trail get connected by a drawn line
      */
-    private static final float LINE_MAXIMUM_DISTANCE_METERS = 10000;
+    private static final float LINE_MAXIMUM_DISTANCE_METERS = Settings.getMaximumMapTrailDistance();
 
     private static final String KEY_HISTORY_LINE = "historyLine";
 

--- a/main/src/main/res/values/numbers.xml
+++ b/main/src/main/res/values/numbers.xml
@@ -31,5 +31,7 @@
     <!-- history track -->
     <integer name="historytrack_length_default">700</integer>
     <integer name="historytrack_length_max">60000</integer>
+    <integer name="historytrack_mindistance_default">500</integer>
+    <integer name="historytrack_mindistance_max">20000</integer>
 
 </resources>

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -247,6 +247,7 @@
     <!-- category map content -->
     <string translatable="false" name="pref_maptrail">maptrail</string>
     <string translatable="false" name="pref_maptrail_length">maptrail_length</string>
+    <string translatable="false" name="pref_maptrail_maxdistance">maptrail_maxdistance</string>
     <string translatable="false" name="pref_bigSmileysOnMap">pref_bigSmileysOnMap</string>
     <string translatable="false" name="pref_dtMarkerOnCacheIcon">pref_dtMarkerOnCacheIcon</string>
     <string translatable="false" name="pref_showElevation">showElevation</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -965,6 +965,7 @@
     <string name="settings_summary_offline_routing">Offline routing is available if either helper app \"BRouter\" is installed and configured or internal routing is enabled.</string>
     <string name="settings_title_waypoints">Waypoints</string>
     <string name="settings_title_map_content">Map Content</string>
+    <string name="settings_title_maptrail">History track</string>
     <string name="settings_title_map_behavior">Map behavior</string>
     <string name="settings_title_map_style">Map style</string>
     <string name="settings_hide_tileproviders_title">Hide Map Sources</string>
@@ -1277,8 +1278,10 @@
     <string name="init_dataDir">Select data folder</string>
     <string name="init_dataDir_note">You may choose to store the additional data for geocaches (spoilers, log images, …) on your external storage (emulated or real external SD card depending on your device).</string>
     <string name="init_maptrail">Show history track</string>
-    <string name="init_maptrail_length">History track max. length</string>
+    <string name="init_maptrail_length">Maximum length</string>
     <string name="init_maptrail_length_summary">Set maximum length of history track (enforced on each startup of c:geo). Default value is 700 points - adjust according to available memory.</string>
+    <string name="init_maptrail_maxdistance">Maximum distance</string>
+    <string name="init_maptrail_maxdistance_summary">Maximum distance until which two consecutive points of the history track get connected on the map</string>
     <string name="init_summary_maptrail">When activated (and GPS is on) c:geo saves the history of your movements as a track and displays it on the map.</string>
     <string name="init_trailappearance">History track appearance</string>
     <string name="init_trailappearance_summary">Select color, opaqueness and line width for history track line</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -11,22 +11,6 @@
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="@string/pref_maptrail"
-            android:summary="@string/init_summary_maptrail"
-            android:title="@string/init_maptrail"
-            app:iconSpaceReserved="false" />
-        <cgeo.geocaching.settings.SeekbarPreference
-            android:key="@string/pref_maptrail_length"
-            android:title="@string/init_maptrail_length"
-            android:summary="@string/init_maptrail_length_summary"
-            android:defaultValue="@integer/historytrack_length_default"
-            app:min="100"
-            app:max="@integer/historytrack_length_max"
-            app:stepSize="100"
-            app:logScaling="true"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
             android:key="@string/pref_bigSmileysOnMap"
             android:summary="@string/init_summary_bigSmileysOnMap"
             android:title="@string/init_bigSmileysOnMap"
@@ -42,6 +26,39 @@
             android:key="@string/pref_showElevation"
             android:title="@string/init_showElevation"
             android:summary="@string/init_summary_showElevation"
+            app:iconSpaceReserved="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/settings_title_maptrail"
+        app:iconSpaceReserved="false">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_maptrail"
+            android:summary="@string/init_summary_maptrail"
+            android:title="@string/init_maptrail"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_maptrail_length"
+            android:title="@string/init_maptrail_length"
+            android:summary="@string/init_maptrail_length_summary"
+            android:defaultValue="@integer/historytrack_length_default"
+            android:dependency="@string/pref_maptrail"
+            app:min="100"
+            app:max="@integer/historytrack_length_max"
+            app:stepSize="100"
+            app:logScaling="true"
+            app:iconSpaceReserved="false" />
+        <cgeo.geocaching.settings.SeekbarPreference
+            android:key="@string/pref_maptrail_maxdistance"
+            android:title="@string/init_maptrail_maxdistance"
+            android:summary="@string/init_maptrail_maxdistance_summary"
+            android:defaultValue="@integer/historytrack_mindistance_default"
+            android:dependency="@string/pref_maptrail"
+            app:min="10"
+            app:max="@integer/historytrack_mindistance_max"
+            app:stepSize="100"
+            app:logScaling="true"
             app:iconSpaceReserved="false" />
     </PreferenceCategory>
 


### PR DESCRIPTION
## Description
- Lowers the maximum distance up to which two points of a history track get drawn connected from 10,000 m to 500 m (default)
- Adds a config option to set this value in the range 10 .. 20,000 m
- Puts the three history track-related config options into their own category

<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/bd838e87-643a-40a9-81d3-7eaf2892a9dd" />

This is for testing purposes currently, default value of 500 m needs to be cross-checked "in real life". Also imperial units need to be taken into consideration in the UI.