### PR TITLE
Add delete all pending downloads button (fix #17174)

### DIFF
--- a/main/src/main/res/layout/pending_downloads_activity.xml
+++ b/main/src/main/res/layout/pending_downloads_activity.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/delete_all_button"
+        style="@style/button_icon_with_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/downloader_delete_all_pending"
+        app:icon="@drawable/ic_menu_delete"
+        app:iconGravity="start" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_margin="0dip"
+        android:clipToPadding="false"
+        android:dividerHeight="1dip"
+        android:padding="0dip"
+        android:scrollbarStyle="outsideOverlay" />
+
+</LinearLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -920,6 +920,10 @@
     <string name="downloader_pending_info">There is at least one pausing or failed download. Do you want to open the list of pending downloads?</string>
     <string name="downloader_retry_download">Retry download</string>
     <string name="downloader_retry_download_details">Do you want to retry the download of the following file?</string>
+    <string name="downloader_delete_all_pending">Delete all</string>
+    <string name="downloader_delete_all_confirmation">Delete all pending downloads?</string>
+    <string name="downloader_delete_all_message">This will cancel all %d pending downloads and remove the downloaded parts. This action cannot be undone.</string>
+    <string name="downloader_deleted_all">Deleted all pending downloads</string>
 
     <!-- Android system download manager status messages -->
     <string name="asdm_status_failed">Download has failed (and will not be retried)</string>


### PR DESCRIPTION
Since it can happen that very many downloads stall/fail and it is a pain to remove them all manually, I added a button for removing all of them at once.

Fixes #17174