### PR TITLE
Fix #17370: skip input dialog after converting to simple coords

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinatesCalculateGlobalDialog.java
@@ -200,7 +200,19 @@ public class CoordinatesCalculateGlobalDialog extends DialogFragment {
         binding.convertToPlain.setOnClickListener(v -> {
             // When the callback is hit it will clear the calculator state associated with the waypoint
             final CoordinateInputData cid = createFromDialog();
-            callback.onDialogClosed(cid.getGeopoint());
+            final Geopoint plainGp = cid.getGeopoint();
+            if (plainGp == null) {
+                SimpleDialog.of(this.getActivity()).setTitle(R.string.calccoord_convert_to_plain)
+                        .setMessage(TextParam.id(R.string.calccoord_convert_to_plain_error))
+                        .setPositiveButton(TextParam.id(R.string.button_continue))
+                        .setNegativeButton(TextParam.id(R.string.cancel))
+                        .confirm(() -> {
+                            callback.onDialogClosed(null);
+                            dismiss();
+                        });
+                return;
+            }
+            callback.onDialogClosed(plainGp);
             dismiss();
         });
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2024,6 +2024,7 @@
     <string name="calccoord_select_variable">Select Variable</string>
     <string name="calccoord_new_variable">**%s** *(New)*</string>
     <string name="calccoord_convert_to_plain">Convert to plain Coordinate</string>
+    <string name="calccoord_convert_to_plain_error">The formula does not evaluate to valid coordinates.\nConverting to plain coordinates will reset the waypoint to empty coordinates.</string>
     <string name="calccoord_plain_tools_title">Plain Tools</string>
     <string name="calccoord_remove_spaces">Remove spaces</string>
     <string name="calccoord_replace_x_with_multiplication_symbol">Replace \'x\' with \'*\'</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
This PR dismiss the input dialog after converting calculated waypoint into simple coordinates and returns direct to the edit-waypoint-activity.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fix #17370

## Workflow
| Create waypoint with calculated coordinates | Convert to simple coordinates|Returns automatically (without any confirmation) to edit-waypoint (User can confirm or cancel the coordinates / waypoint ) | 
| --- | --- | --- |
|<img width="200" alt="image" src="https://github.com/user-attachments/assets/77d36342-ea09-4787-9ff7-2396c2419abc" /> |<img width="200" alt="image" src="https://github.com/user-attachments/assets/a7703fe9-af57-4589-8a00-c222bfdb8599" /> |<img width="200" alt="image" src="https://github.com/user-attachments/assets/0ca0504e-65c4-44d0-8d15-fd42d8004879" /> |




### to discuss
* should there be a confirmation dialog? If no, the formula would be lost, if the waypoint with formula wasn't be saved before...