### PR TITLE
Make sure super.onResume() gets called (fix #17727)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1457,12 +1457,12 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     @Override
     protected void onResume() {
+        super.onResume();
         if (mapFragment == null) {
             recreate(); // restart with a fresh MapView
             return; // prevent further execution on the old activity instance
         }
 
-        super.onResume();
         reloadCachesAndWaypoints();
         MapUtils.updateFilterBar(this, viewModel.mapType.filterContext);
 


### PR DESCRIPTION
## Description
Make sure `super.onResume()` gets called, even in case of recreating the activity