### PR TITLE
replace testInstrumentationRunnerArguments comand line parameter by property

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -48,6 +48,8 @@ android {
 
         // set the default test runner to be used by IDE and command line
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // add Parameter
+        testInstrumentationRunnerArguments.put("notAnnotation", "cgeo.geocaching.test.NotForIntegrationTests")
 
         // by convention, the folder name "main" is used for the APK file name. we want cgeo instead
         base.archivesName = "cgeo"


### PR DESCRIPTION
see eg. CI/GHWorkflow message
"Passing custom test runner argument android.testInstrumentationRunnerArguments.notAnnotation from gradle.properties or command line is not compatible with configuration caching. Please specify this argument using android gradle dsl."

After merge on `release` and `master` we can remove the commandline parameter from the CI script and GH workflow configuration.