### PR TITLE
remove --configuration-cache cmdline parameter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
           add-job-summary-as-pr-comment: on-failure  # Valid values are 'never' (default), 'always', and 'on-failure'
 
       - name: Run checkstyle
-        run: ./gradlew --no-configuration-cache --no-daemon --scan checkstyle
+        run: ./gradlew --no-daemon --scan checkstyle
 
       - uses: lcollins/checkstyle-github-action@v3.1.0
         with:
@@ -172,7 +172,7 @@ jobs:
           add-job-summary-as-pr-comment: on-failure  # Valid values are 'never' (default), 'always', and 'on-failure'
 
       - name: Run lintBasicDebug
-        run: ./gradlew --no-configuration-cache --no-daemon --scan lintBasicDebug
+        run: ./gradlew --no-daemon --scan lintBasicDebug
 
       - name: Check and report lint results
         uses: hidakatsuya/action-report-android-lint@v1
@@ -251,8 +251,8 @@ jobs:
 
       - name: Build binary
         run: |
-          ./gradlew --no-configuration-cache --scan packageBasicDebug
-          ./gradlew --no-configuration-cache packageBasicDebugAndroidTest
+          ./gradlew --scan packageBasicDebug
+          ./gradlew packageBasicDebugAndroidTest
 
       - name: Upload resulting APK
         uses: actions/upload-artifact@v4
@@ -309,7 +309,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            ./gradlew --no-configuration-cache --scan testDebug -Pandroid.testInstrumentationRunnerArguments.notAnnotation=cgeo.geocaching.test.NotForIntegrationTests || { killall -INT crashpad_handler; false; }
+            ./gradlew --scan testDebug -Pandroid.testInstrumentationRunnerArguments.notAnnotation=cgeo.geocaching.test.NotForIntegrationTests || { killall -INT crashpad_handler; false; }
             killall -INT crashpad_handler || true
 
       - name: Publish Test Report

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -128,7 +128,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            ./gradlew --no-configuration-cache main:connectedBasicDebugAndroidTest --no-daemon --continue -Pandroid.testInstrumentationRunnerArguments.class=cgeo.watchdog.WatchdogTest
+            ./gradlew main:connectedBasicDebugAndroidTest --no-daemon --continue -Pandroid.testInstrumentationRunnerArguments.class=cgeo.watchdog.WatchdogTest
             killall -INT crashpad_handler || true
 
       - name: Publish Test Report


### PR DESCRIPTION
After PR #17675 we don't need the parameter anymore. 

(Hint: the script on CI is already changed)
