### PR TITLE
configure test resultsDir

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -183,8 +183,7 @@ android {
     }
 
     testOptions {
-        Provider<Directory> output = layout.buildDirectory.dir("test-results")
-        resultsDir = output.get().asFile
+        resultsDir = layout.buildDirectory.get().toString() + '/test-results'
     }
 
     lint {


### PR DESCRIPTION
The current implementation works but there is the warning: Access to 'resultsDir' exceeds its access rights

The solution skips therefore the step with the Provider class.
