### PR TITLE
add proguard rules for re2j

### DIFF
--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -149,3 +149,8 @@
 
 # keep classes of metadata libaray (this lib heavily uses reflection)
 -keep class com.drew.** { *; }
+
+# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
+# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
+# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
+-dontwarn com.google.re2j.**


### PR DESCRIPTION
which is transitive, but optional in jsoup 1.22.1.

See https://github.com/jhy/jsoup/releases/tag/jsoup-1.22.1 
See https://github.com/jhy/jsoup/issues/2459

In CI we see 
~~~
> Task :main:minifyBasicNightlyWithR8
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /srv/jenkins/jobs/cgeo nightly/workspace/main/build/outputs/mapping/basicNightly/missing_rules.txt.
ERROR: R8: Missing class com.google.re2j.Matcher (referenced from: com.google.re2j.Matcher org.jsoup.helper.Re2jRegex$Re2jMatcher.delegate and 3 other contexts)
Missing class com.google.re2j.Pattern (referenced from: com.google.re2j.Pattern org.jsoup.helper.Re2jRegex.re2jPattern and 4 other contexts)
> Task :main:minifyBasicNightlyWithR8 FAILED
~~~