### PR TITLE
Revert "replace testInstrumentationRunnerArguments commandline parameter …

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -48,8 +48,6 @@ android {
 
         // set the default test runner to be used by IDE and command line
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        // add Parameter
-        testInstrumentationRunnerArguments.put("notAnnotation", "cgeo.geocaching.test.NotForIntegrationTests")
 
         // by convention, the folder name "main" is used for the APK file name. we want cgeo instead
         base.archivesName = "cgeo"


### PR DESCRIPTION
… by a property"

This reverts commit aeb02bb538a7be41ed0d18dbc2afb8617d876d41.

The watchdog tests are not compatible with this change, so we need another solution.
