### PR TITLE
develocity Publishing buildScan only on-demand

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,5 +26,7 @@ develocity {
     buildScan {
         termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
         termsOfUseAgree = "yes"
+        // Publishing a Build only Scan on-demand (gradlew --scan)
+        publishing.onlyIf { false }
     }
 }


### PR DESCRIPTION
Publishing every build is the default state.
As we have access to our build logs, this is not necessary. 
You can use `./gradlew --scan` id you want the build scan.
