### PR TITLE
(Temporarily) remove 'Hide ActionBar on tap' in map

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -2561,10 +2561,6 @@ public class Settings {
         putBoolean(R.string.pref_mapbackgroundmap_show_layer, show);
     }
 
-    public static boolean getMapActionbarAutohide() {
-        return getBoolean(R.string.pref_mapActionbarAutohide, false);
-    }
-
     public static boolean extendedSettingsAreEnabled() {
         return getBoolean(R.string.pref_extended_settings_enabled, false);
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -62,7 +62,6 @@ import cgeo.geocaching.unifiedmap.layers.TracksLayer;
 import cgeo.geocaching.unifiedmap.layers.WherigoLayer;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
-import cgeo.geocaching.utils.ActionBarUtils;
 import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.CommonUtils;
 import cgeo.geocaching.utils.CompactIconModeUtils;
@@ -186,7 +185,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         super.onCreate(savedInstanceState);
         acquireUnifiedMap(this);
 
-        ActionBarUtils.setContentView(this, R.layout.unifiedmap_activity, true);
+        setContentView(R.layout.unifiedmap_activity);
         if (null != findViewById(R.id.live_map_status)) {
             findViewById(R.id.live_map_status).getBackground().mutate();
         }
@@ -1232,7 +1231,6 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 if (sheetRemoveFragment()) {
                     return;
                 }
-                ActionBarUtils.toggleActionBar(this);
                 GeoItemTestLayer.handleTapTest(clickableItemsLayer, this, touchedPoint, "", isLongTap);
             }
         } else if (result.size() == 1) {

--- a/main/src/main/java/cgeo/geocaching/utils/ActionBarUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ActionBarUtils.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
 import cgeo.geocaching.activity.AbstractNavigationBarActivity;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.ui.ViewUtils;
 
 import android.app.Activity;
 import android.text.SpannableString;
@@ -26,50 +25,6 @@ public class ActionBarUtils {
 
     private ActionBarUtils() {
         // utility class
-    }
-
-    /** use this instead of AbstractBottomNavigationActivity.setContentView for being able to use a action bar toogle */
-    public static void setContentView(@NonNull final AbstractNavigationBarActivity activity, final View contentView, final boolean showSpacer) {
-        activity.setContentView(contentView);
-        showActionBarSpacer(activity, showSpacer);
-    }
-
-    /** use this instead of AbstractBottomNavigationActivity.setContentView for being able to use a action bar toogle */
-    public static void setContentView(@NonNull final AbstractNavigationBarActivity activity, @LayoutRes final int layoutResID, final boolean showSpacer) {
-        activity.setContentView(layoutResID);
-        showActionBarSpacer(activity, showSpacer);
-    }
-
-    public static boolean toggleActionBar(@NonNull final AbstractActionBarActivity activity) {
-        if (!Settings.getMapActionbarAutohide()) {
-            return true;
-        }
-        final View actionBar = activity.getActionBarView();
-        if (actionBar == null) {
-            return true;
-        }
-        final boolean isShown = activity.actionBarIsShowing();
-
-        if (!isShown) {
-            activity.showActionBar();
-        } else {
-            activity.hideActionBar();
-        }
-
-        // adjust system bars appearance, depending on action bar color and visibility
-        ActionBarUtils.setSystemBarAppearance(activity, !isShown);
-
-        final View spacer = activity.findViewById(R.id.actionBarSpacer);
-        final int height = !isShown ? 0 : -spacer.getHeight();
-        ViewUtils.applyToView(activity.findViewById(R.id.filterbar), view -> view.animate().translationY(height).start());
-        ViewUtils.applyToView(activity.findViewById(R.id.distanceinfo), view -> view.animate().translationY(height).start());
-        ViewUtils.applyToView(activity.findViewById(R.id.map_progressbar), view -> view.animate().translationY(height).start());
-
-        return !isShown;
-    }
-
-    private static void showActionBarSpacer(@NonNull final Activity activity, final boolean showSpacer) {
-        activity.findViewById(R.id.actionBarSpacer).setVisibility(showSpacer ? View.VISIBLE : View.GONE);
     }
 
     public static void setSystemBarAppearance(@NonNull final Activity activity, final boolean isActionBarShown) {

--- a/main/src/main/res/layout/filter_sort_bar.xml
+++ b/main/src/main/res/layout/filter_sort_bar.xml
@@ -11,8 +11,7 @@
     <Space
         android:id="@+id/actionBarSpacer"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:visibility="gone"/>
+        android:layout_height="?attr/actionBarSize"/>
 
     <cgeo.geocaching.wherigo.WherigoInfoBarView
         android:id="@+id/wherigo_info_bar"

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -260,7 +260,6 @@
     <string translatable="false" name="pref_longTapOnMap">pref_longTapOnMap</string>
     <string translatable="false" name="pref_showRouteMenu">showRouteMenu</string>
     <string translatable="false" name="pref_mapRotation">mapRotation</string>
-    <string translatable="false" name="pref_mapActionbarAutohide">mapActionbarAutohide</string>
 
     <!-- category proximity notfication -->
     <string translatable="false" name="pref_proximityDistanceFar">pref_proximityDistanceFar</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1873,8 +1873,6 @@
     <string name="init_summary_longtap_map">Activate long tap on map icon (create an individual route) or on free map space (create a user-defined cache / waypoint)</string>
     <string name="init_show_routing_menu">Show routing menu</string>
     <string name="init_summary_show_routing_menu">Long tap on a cache shows a menu with advanced options to add/remove the cache to/from a route. If disabled the cache is just added/removed to/from the route.</string>
-    <string name="init_ActionbarAutohide">Hide toolbar on tap</string>
-    <string name="init_summary_ActionbarAutohide">Tap on free map space to hide/show the toolbar</string>
     <string name="init_autozoom_consider_lastcenter">Restore map position on mapping a list</string>
     <string name="init_summary_autozoom_consider_lastcenter_on">When a list of caches is mapped and map was previously left inside the list boundaries restore preview position, otherwise zoom to fit all caches.</string>
     <string name="init_summary_autozoom_consider_lastcenter_off">When a list of caches is mapped set map zoom and boundaries to fit all caches.</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -105,12 +105,6 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="@string/pref_mapActionbarAutohide"
-            android:summary="@string/init_summary_ActionbarAutohide"
-            android:title="@string/init_ActionbarAutohide"
-            app:iconSpaceReserved="false" />
-        <CheckBoxPreference
-            android:defaultValue="false"
             android:key="@string/pref_autozoom_consider_lastcenter"
             android:summary="@string/init_summary_autozoom_consider_lastcenter_on"
             android:title="@string/init_autozoom_consider_lastcenter"


### PR DESCRIPTION
## Description
As discussed in yesterday's dev meeting: Temporarily removing the "hide ActionBar on tap" functionality from map might make migration to a clean `Toolbar` / `MaterialToolbar` and (hopefully) resolving some edge2edge issues on the map easier.