### PR TITLE
Bump com.github.AppDevNext:AndroidChart from 3.1.0.27 to 3.1.0.31

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -524,7 +524,7 @@ dependencies {
 
     // charting, based on com.github.PhilJay:MPAndroidChart
     // for detailed docs for the base library see https://weeklycoding.com/mpandroidchart/
-    implementation 'com.github.AppDevNext:AndroidChart:3.1.0.27'
+    implementation 'com.github.AppDevNext:AndroidChart:3.1.0.31'
 
     // For Wherigos: GIF support
     // ani gif support

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -154,3 +154,10 @@
 # jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
 # See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
 -dontwarn com.google.re2j.**
+
+# Whitelist MPAndroidChart
+# Preserve all public classes and methods
+-keep class com.github.mikephil.charting.** { *; }
+-keep public class com.github.mikephil.charting.animation.* {
+    public protected *;
+}


### PR DESCRIPTION
replaces #17457

for release notes see https://github.com/AppDevNext/AndroidChart/releases.


