### PR TITLE
Migrate ActionBar to MaterialToolbar

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -119,6 +119,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.core.graphics.Insets;
 import androidx.core.util.Consumer;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -440,6 +441,12 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                 }
             }
         });
+    }
+
+    @Override
+    @NonNull
+    protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
+        return calculateInsetsWithToolbarInPortrait(def);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/ImageViewActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ImageViewActivity.java
@@ -229,7 +229,6 @@ public class ImageViewActivity extends AbstractActionBarActivity {
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setFixedActionBar(false);
-        getSupportActionBar().hide(); //do not use normal Action Bar
         setThemeAndContentView(R.layout.imageview_activity);
         enableViewTransitions(this);
         postponeEnterTransition();

--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -80,6 +80,7 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.graphics.Insets;
 import androidx.core.util.Pair;
 import androidx.core.view.MenuCompat;
 
@@ -309,6 +310,12 @@ public class MainActivity extends AbstractNavigationBarActivity {
             binding.getRoot().post(() -> Log.d("Post after MainActivity.onCreate"));
         }
 
+    }
+
+    @Override
+    @NonNull
+    protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
+        return calculateInsetsWithToolbarInPortrait(def);
     }
 
     private void configureMessageCenterPolling() {

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -57,6 +57,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.cardview.widget.CardView;
+import androidx.core.graphics.Insets;
 
 import java.util.Locale;
 import java.util.function.Consumer;
@@ -147,6 +148,12 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         // set title in code, as the activity needs a hard coded title due to the intent filters
         setTitle(res.getString(R.string.search));
         init();
+    }
+
+    @Override
+    @NonNull
+    protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
+        return calculateInsetsWithToolbarInPortrait(def);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -115,10 +115,19 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
         binding.activityContent.addView(contentView);
         super.setContentView(binding.getRoot());
 
+        // Set up the toolbar
+        setSupportActionBar(binding.appToolbar.getRoot());
+
         // --- other initialization --- //
         updateSelectedBottomNavItemId();
         // will be called if c:geo cannot log in
         startLoginIssueHandler();
+    }
+
+    @Override
+    @Nullable
+    public View getActionBarView() {
+        return binding == null ? null : binding.appToolbar.getRoot();
     }
 
     @Nullable
@@ -230,6 +239,7 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
     @Override
     protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
         final Insets insets = super.calculateInsetsForActivityContent(def);
+        Log.e("insets.top=" + insets.top + ", left=" + insets.left + ", right=" + insets.right + ", bottom=" + insets.bottom + ", ab=" + getResources().getDimension(R.dimen.actionbar_height));
         if (hideNavigationBar || getSelectedBottomItemId() == MENU_HIDE_NAVIGATIONBAR) {
             //-> navbar is NOT shown, we have to handle all insets (including bottom)
             return insets;
@@ -238,6 +248,13 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
             return Insets.of(0, insets.top, insets.right, insets.bottom);
         }
         return Insets.of(insets.left, insets.top, insets.right, 0);
+    }
+
+    @NonNull
+    protected Insets calculateInsetsWithToolbarInPortrait(@NonNull final Insets def) {
+        final Insets insets = super.calculateInsetsWithToolbarInPortrait(def);
+        final boolean isPortrait = getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+        return Insets.of(isPortrait ? insets.left : 0, insets.top, insets.right, isPortrait ? 0 : insets.bottom);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/activity/CustomMenuEntryActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/CustomMenuEntryActivity.java
@@ -6,6 +6,9 @@ import cgeo.geocaching.settings.Settings;
 import android.app.Activity;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+
 /**
  * Similar to AbstractNavigationBarActivity, but
  * - placed in custom menu slot of bottom navigation
@@ -45,5 +48,10 @@ public class CustomMenuEntryActivity extends AbstractNavigationBarActivity {
         parent.startActivity(intent);
     }
 
+    @Override
+    @NonNull
+    protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
+        return calculateInsetsWithToolbarInPortrait(def);
+    }
 
 }

--- a/main/src/main/java/cgeo/geocaching/activity/TabbedViewPagerActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/TabbedViewPagerActivity.java
@@ -10,6 +10,7 @@ import android.util.DisplayMetrics;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
 import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -59,6 +60,7 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
         this.onPageChangeListener = onPageChangeListener;
 
         setContentView(isRefreshable ? R.layout.tabbed_viewpager_activity_refreshable : R.layout.tabbed_viewpager_activity);
+        refreshActivityContentInsets();
 
         viewPager = findViewById(R.id.viewpager);
         viewPager.setAdapter(new ViewPagerAdapter(this));
@@ -89,6 +91,13 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
         }).attach();
     }
 
+    @NonNull
+    @Override
+    protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
+        final Insets skip = super.calculateInsetsForActivityContent(def); // only to trigger toolbar adjustment
+        Log.e("TabbedViewPagerActivity(given): left=" + def.left + ", top=" + def.top + ", right=" + def.right + ", bottom=" + def.bottom);
+        return def;
+    }
 
     private final ViewPager2.OnPageChangeCallback pageChangeCallback = new ViewPager2.OnPageChangeCallback() {
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -186,7 +186,8 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         super.onCreate(savedInstanceState);
         acquireUnifiedMap(this);
 
-        ActionBarUtils.setContentView(this, R.layout.unifiedmap_activity, true);
+        setContentView(R.layout.unifiedmap_activity);
+        showSpacer(true);
         if (null != findViewById(R.id.live_map_status)) {
             findViewById(R.id.live_map_status).getBackground().mutate();
         }
@@ -200,7 +201,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
             viewModel.mapType = extraMapType;
         }
 
-        // set cache reload state according to whether this is a first map initialization or a resumte
+        // set cache reload state according to whether this is a first map initialization or a resume
         this.cacheReloadState = savedInstanceState == null ? CacheReloadState.INITIALIZE : CacheReloadState.RESUME;
 
         viewModel.followMyLocation.setValue(viewModel.mapType.followMyLocation);

--- a/main/src/main/java/cgeo/geocaching/utils/ActionBarUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ActionBarUtils.java
@@ -2,9 +2,7 @@ package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
-import cgeo.geocaching.activity.AbstractNavigationBarActivity;
 import cgeo.geocaching.settings.Settings;
-import cgeo.geocaching.ui.ViewUtils;
 
 import android.app.Activity;
 import android.text.SpannableString;
@@ -14,7 +12,6 @@ import android.view.View;
 import android.view.Window;
 
 import androidx.annotation.ColorRes;
-import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.core.view.WindowCompat;
@@ -28,48 +25,19 @@ public class ActionBarUtils {
         // utility class
     }
 
-    /** use this instead of AbstractBottomNavigationActivity.setContentView for being able to use a action bar toogle */
-    public static void setContentView(@NonNull final AbstractNavigationBarActivity activity, final View contentView, final boolean showSpacer) {
-        activity.setContentView(contentView);
-        showActionBarSpacer(activity, showSpacer);
-    }
-
-    /** use this instead of AbstractBottomNavigationActivity.setContentView for being able to use a action bar toogle */
-    public static void setContentView(@NonNull final AbstractNavigationBarActivity activity, @LayoutRes final int layoutResID, final boolean showSpacer) {
-        activity.setContentView(layoutResID);
-        showActionBarSpacer(activity, showSpacer);
-    }
-
-    public static boolean toggleActionBar(@NonNull final AbstractActionBarActivity activity) {
+    public static void toggleActionBar(@NonNull final AbstractActionBarActivity activity) {
         if (!Settings.getMapActionbarAutohide()) {
-            return true;
+            return;
         }
         final View actionBar = activity.getActionBarView();
         if (actionBar == null) {
-            return true;
+            return;
         }
         final boolean isShown = activity.actionBarIsShowing();
-
-        if (!isShown) {
-            activity.showActionBar();
-        } else {
-            activity.hideActionBar();
-        }
+        activity.showActionBar(!isShown);
 
         // adjust system bars appearance, depending on action bar color and visibility
         ActionBarUtils.setSystemBarAppearance(activity, !isShown);
-
-        final View spacer = activity.findViewById(R.id.actionBarSpacer);
-        final int height = !isShown ? 0 : -spacer.getHeight();
-        ViewUtils.applyToView(activity.findViewById(R.id.filterbar), view -> view.animate().translationY(height).start());
-        ViewUtils.applyToView(activity.findViewById(R.id.distanceinfo), view -> view.animate().translationY(height).start());
-        ViewUtils.applyToView(activity.findViewById(R.id.map_progressbar), view -> view.animate().translationY(height).start());
-
-        return !isShown;
-    }
-
-    private static void showActionBarSpacer(@NonNull final Activity activity, final boolean showSpacer) {
-        activity.findViewById(R.id.actionBarSpacer).setVisibility(showSpacer ? View.VISIBLE : View.GONE);
     }
 
     public static void setSystemBarAppearance(@NonNull final Activity activity, final boolean isActionBarShown) {

--- a/main/src/main/res/layout-h390dp-land/activity_navigationbar.xml
+++ b/main/src/main/res/layout-h390dp-land/activity_navigationbar.xml
@@ -11,12 +11,20 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
+    <include
+        android:id="@+id/appToolbar"
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/actionbar_height"
+        android:layout_alignTop="@id/background"
+        android:layout_alignParentTop="true" />
+
     <FrameLayout
         android:id="@+id/activity_content"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
-        android:layout_toEndOf="@id/activity_navigationBar" />
+        android:layout_toEndOf="@id/activity_navigationBar" /><!-- android:layout_below="@id/appToolbar" -->
 
     <!-- Show a navigation rail on landscape devices instead. -->
     <com.google.android.material.navigationrail.NavigationRailView
@@ -24,7 +32,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/actionBarSpacer"
+        android:layout_below="@id/appToolbar"
         app:labelVisibilityMode="labeled"
         android:background="@color/colorBackgroundTabBar"
         app:itemIconTint="@color/bottom_bar_selector"

--- a/main/src/main/res/layout-land/activity_navigationbar.xml
+++ b/main/src/main/res/layout-land/activity_navigationbar.xml
@@ -11,12 +11,20 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
+    <include
+        android:id="@+id/appToolbar"
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/actionbar_height"
+        android:layout_alignTop="@id/background"
+        android:layout_alignParentTop="true" />
+
     <FrameLayout
         android:id="@+id/activity_content"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
-        android:layout_toEndOf="@id/activity_navigationBar" />
+        android:layout_toEndOf="@id/activity_navigationBar" /><!-- android:layout_below="@id/appToolbar" -->
 
     <!-- Show a navigation rail on landscape devices instead. On rather small screens, don't show labels to save some space -->
     <com.google.android.material.navigationrail.NavigationRailView
@@ -25,7 +33,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentStart="true"
-        android:layout_below="@id/actionBarSpacer"
+        android:layout_below="@id/appToolbar"
         app:labelVisibilityMode="unlabeled"
         android:background="@color/colorBackgroundTabBar"
         app:itemIconTint="@color/bottom_bar_selector"

--- a/main/src/main/res/layout/activity_base_with_toolbar.xml
+++ b/main/src/main/res/layout/activity_base_with_toolbar.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/appToolbar"
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/actionbar_height"
+        android:layout_alignTop="@id/background"
+        android:layout_alignParentTop="true" />
+
+    <FrameLayout
+        android:id="@+id/activity_content_wrapper"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/main/src/main/res/layout/activity_navigationbar.xml
+++ b/main/src/main/res/layout/activity_navigationbar.xml
@@ -11,12 +11,20 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
+    <include
+        android:id="@+id/appToolbar"
+        layout="@layout/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/actionbar_height"
+        android:layout_alignTop="@id/background"
+        android:layout_alignParentTop="true" />
+
     <FrameLayout
         android:id="@+id/activity_content"
         android:layout_alignParentTop="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@id/activity_navigationBar" />
+        android:layout_above="@id/activity_navigationBar" /><!-- android:layout_below="@id/appToolbar" -->
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/activity_navigationBar"

--- a/main/src/main/res/layout/filter_sort_bar.xml
+++ b/main/src/main/res/layout/filter_sort_bar.xml
@@ -9,16 +9,16 @@
     android:background="@color/colorBackgroundActionBar">
 
     <Space
-        android:id="@+id/actionBarSpacer"
+        android:id="@+id/spacer"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:visibility="gone"/>
+        android:layout_height="@dimen/actionbar_height"
+        android:visibility="gone" />
 
     <cgeo.geocaching.wherigo.WherigoInfoBarView
         android:id="@+id/wherigo_info_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/actionBarSpacer"/>
+        android:layout_below="@id/spacer"/>
 
     <LinearLayout
         android:id="@+id/filter_bar"

--- a/main/src/main/res/layout/toolbar.xml
+++ b/main/src/main/res/layout/toolbar.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.MaterialToolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/appToolbar"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/actionbar_height"
+    android:minHeight="@dimen/actionbar_height"
+    android:background="@color/colorBackgroundActionBar"
+    android:elevation="4dp"
+    android:theme="@style/tool_bar"
+    app:popupTheme="@style/appToolbarPopup"/>

--- a/main/src/main/res/values/dimens.xml
+++ b/main/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <dimen name="actionbar_height">45dip</dimen>
+    <dimen name="actionbar_height">62dip</dimen>
 
     <dimen name="radioButtonCheckboxPreferredItemHeight">32dp</dimen>
 

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -93,10 +93,9 @@
     </style>
 
     <style name="tool_bar" parent="actionBarStyle">
-        <item name="android:layout_width">fill_parent</item>
-        <item name="android:layout_height">@dimen/actionbar_height</item>
         <item name="colorControlNormal">@color/colorTextActionBar</item>
-        <item name="android:textColor">@color/colorText</item>
+        <item name="colorOnPrimary">@color/colorTextActionBar</item>
+        <item name="android:itemTextAppearance">@style/text_default</item>
     </style>
 
     <style name="action_bar_title" parent="@style/TextAppearance.AppCompat.Widget.ActionBar.Title">

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -2,12 +2,7 @@
 <resources>
 
     <!-- theme for (nearly) all activities -->
-    <style name="cgeo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Action bar theming -->
-        <item name="actionBarTheme">@style/actionBarTheme</item>
-        <item name="actionBarStyle">@style/actionBarStyle</item>
-        <item name="android:actionOverflowButtonStyle">@style/actionBarActionOverflow</item>
-
+    <style name="cgeo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- UX component styles -->
         <item name="checkboxStyle">@style/checkboxStyle</item>
         <item name="radioButtonStyle">@style/radioButtonStyle</item>
@@ -15,6 +10,7 @@
         <item name="android:textAppearanceMedium">@style/text_default</item>
         <item name="android:spinnerStyle">@style/spinnerStyle</item>
         <item name="toolbarStyle">@style/AppTheme.Toolbar</item>
+        <item name="actionBarPopupTheme">@style/appToolbarPopup</item>
 
         <!-- set Material theme colors -->
         <item name="colorOnBackground">@color/colorText</item>
@@ -37,17 +33,28 @@
 
     </style>
 
+    <style name="cgeo.withWallpaper" parent="cgeo">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowShowWallpaper">true</item>
+    </style>
+
+    <!-- toolbar formatting -->
+
     <style name="cgeo.coloredToolbar" parent="cgeo">
         <item name="android:actionOverflowButtonStyle">@style/actionBarActionOverflow2</item>
     </style>
 
     <style name="AppTheme.Toolbar" parent="Widget.MaterialComponents.Toolbar">
         <item name="contentInsetStartWithNavigation">0dp</item>
+        <item name="titleTextColor">@color/colorTextActionBar</item>
+        <item name="subtitleTextColor">@color/colorTextHintActionBar</item>
     </style>
 
-    <style name="cgeo.withWallpaper" parent="cgeo">
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowShowWallpaper">true</item>
+    <!-- ensures correct color for headings of submenus in appToolbar -->
+    <style name="appToolbarPopup" parent="ThemeOverlay.MaterialComponents">
+        <item name="colorControlNormal">@color/colorText</item>
+        <item name="android:background">@color/colorBackground</item>
+        <item name="android:textColor">@color/colorText</item>
     </style>
 
     <!-- theme for alert dialogs -->


### PR DESCRIPTION
## Description
Migrates c:geo to using `MaterialToolbar` instead of AppCompat's `SupportActionBar`

This PR is built on top of #17711 as of today, fixing a couple of it's quirks and addressing some more loose ends.

Fixes #17403

## Known issues
(not all of them are necessarily related to this PR)
- [x] Settings: Extra padding at the top after having changed one item which recreates Activity (like setting theme)
- [x] Settings: Non-active radio button indicators are missing in `ListPreference` (eg: theme or language selection)
- [x] Submenus: Titles have wrong color in light mode (Map / CacheListActivity / CacheDetailsActivity)
- [ ] Coloring of Toolbar does not color system bar area
- [x] Viewpager activities have an extra padding between toolbar and content
- [x] Crash on viewing logbook image
- [x] Some extra spacing at the top in landscape mode
- [x] CacheListActivity has extra space at the bottom
- [x] filter bar in map is placed at the top instead of below toolbar
- [x] `MainActivity`: Update notifications are placed behind toolbar
