### PR TITLE
fix #17731: make link clickable by use jsoup parseBodyFragment 

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/html/HtmlUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/html/HtmlUtils.java
@@ -237,9 +237,31 @@ public final class HtmlUtils {
         replaceSpans(spannable, BackgroundColorSpan.class, null);
     }
 
+    /**
+     * Prepares HTML for further processing by parsing it with Jsoup and returning the HTML content.
+     * Simply parsing with Jsoup already removes problematic zero-width spans, such as those created by HtmlCompat.fromHtml() for empty anchor tags.
+     *
+     * @param html the HTML string to process
+     * @return the Jsoup-parsed and cleaned HTML (without <body> tag)
+     */
+    @NonNull
+    private static String prepareParseBody(@Nullable final String html) {
+        if (StringUtils.isBlank(html)) {
+            return StringUtils.EMPTY;
+        }
+        try {
+            final Document doc = Jsoup.parseBodyFragment(html);
+            // Return the body HTML (without the wrapping <body> tag)
+            return doc.body().html();
+        } catch (Exception e) {
+            return html;
+        }
+    }
+
     public static Pair<Spannable, Boolean> renderHtml(final String html, final Function<String, Drawable> imageGetter) {
+        final String preparedHtml = prepareParseBody(html);
         final UnknownTagsHandler unknownTagsHandler = new UnknownTagsHandler();
-        final SpannableStringBuilder description = new SpannableStringBuilder(HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY, imageGetter::apply, unknownTagsHandler));
+        final SpannableStringBuilder description = new SpannableStringBuilder(HtmlCompat.fromHtml(preparedHtml, HtmlCompat.FROM_HTML_MODE_LEGACY, imageGetter::apply, unknownTagsHandler));
         return new Pair<>(description, unknownTagsHandler.isProblematicDetected());
 
     }
@@ -436,3 +458,4 @@ public final class HtmlUtils {
     }
 
 }
+


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
It seems, that parsing the html-text with jsoup parseBodyFragment before parsing it with HtmlCompat.fromHtml fixes the problem. It removes problematic html content (see [documentation for jsoup](https://jsoup.org/cookbook/input/parse-body-fragment))

They recommend to use a [safelist](https://jsoup.org/apidocs/org/jsoup/safety/Safelist.html) and clean the input with [clean(String bodyHtml, Safelist safelist)](https://jsoup.org/apidocs/org/jsoup/Jsoup.html#clean(java.lang.String,org.jsoup.safety.Safelist)) to avoid cross-site scripting attacks.
But that will be a separate PR if wanted.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #17731

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Copilot suggested to replace the anchor text with the url itself by using jsoup parseBodyFragment. But it seems, already the parsing alone works to fix the issue