### PR TITLE
Move background maps path to public folder with fallback

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/PersistableFolder.java
+++ b/main/src/main/java/cgeo/geocaching/storage/PersistableFolder.java
@@ -34,8 +34,8 @@ public enum PersistableFolder {
     OFFLINE_MAP_THEMES(R.string.pref_persistablefolder_offlinemapthemes, R.string.persistablefolder_offline_maps_themes, Folder.fromPersistableFolder(OFFLINE_MAPS, "_themes")),
     /** Offline Maps: optional folder for map shading files (dem) */
     OFFLINE_MAP_SHADING(R.string.pref_persistablefolder_offlinemapshading, R.string.persistablefolder_offline_maps_shading, Folder.fromPersistableFolder(OFFLINE_MAPS, "_hgt")),
-    /** Offline Maps: app-specific media folder */
-    BACKGROUND_MAPS(R.string.pref_persistablefolder_backgroundmaps, R.string.persistablefolder_backgroundmaps, Folder.fromFile(CgeoApplication.getInstance().getApplicationContext().getExternalMediaDirs()[0])),
+    /** Background Maps: stored in public offline maps folder */
+    BACKGROUND_MAPS(R.string.pref_persistablefolder_backgroundmaps, R.string.persistablefolder_backgroundmaps, Folder.fromPersistableFolder(OFFLINE_MAPS, "_mbtiles")),
     /** Target folder for written logfiles */
     LOGFILES(R.string.pref_persistablefolder_logfiles, R.string.persistablefolder_logfiles, Folder.fromPersistableFolder(BASE, "logfiles")),
     /** GPX Files */


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Makes background maps loadable from public maps directory additional to old folder in app internal directory.

See jakedot/cgeo#152