### PR TITLE
Fix #17768 - Add GSAK corrected lat and long

### DIFF
--- a/main/src/main/java/cgeo/geocaching/export/GpxSerializer.java
+++ b/main/src/main/java/cgeo/geocaching/export/GpxSerializer.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.connector.gc.GCUtils;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.enumerations.CacheAttribute;
 import cgeo.geocaching.enumerations.LoadFlags;
-import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.models.Geocache;


### PR DESCRIPTION
## Description
Adds two missing fields to the GSAK section of an exported GPX file containing the original coordinates


## Related issues
Bug #17768  (though actually a feature request as it was missing functionality)


## Additional context
Tested locally by importing a new GPX file to GSAK and checking that the user corrected flag is set where appropriate

No unit tests have been changed (or hopefully affected) 