### PR TITLE
Fix #17418: Persist coordinate format selection across fragment recreation (by copilot)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.sensors.GeoData;
 import cgeo.geocaching.sensors.GeoDirHandler;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.CacheDetailsCreator;
+import cgeo.geocaching.ui.CoordinatesFormatSwitcher;
 import cgeo.geocaching.ui.ViewUtils;
 import cgeo.geocaching.utils.Log;
 
@@ -38,12 +39,14 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
     public static final int REQUEST_CODE_TARGET_INFO = 1;
     protected static final String GEOCODE_ARG = "GEOCODE";
     protected static final String WAYPOINT_ARG = "WAYPOINT";
+    private static final String STATE_COORDINATE_FORMAT_POSITION = "coordinateFormatPosition";
     private final CompositeDisposable resumeDisposables = new CompositeDisposable();
     protected Resources res = null;
     protected String geocode;
     protected CacheDetailsCreator details;
     protected Geocache cache;
     private TextView cacheDistance = null;
+    private int coordinateFormatPosition = 0;
     private final GeoDirHandler geoUpdate = new GeoDirHandler() {
 
         @Override
@@ -65,6 +68,15 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
         super.onCreate(savedInstanceState);
         res = getResources();
         setHasOptionsMenu(true);
+        if (savedInstanceState != null) {
+            coordinateFormatPosition = savedInstanceState.getInt(STATE_COORDINATE_FORMAT_POSITION, 0);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(STATE_COORDINATE_FORMAT_POSITION, coordinateFormatPosition);
     }
 
     @Override
@@ -136,7 +148,10 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
         }
 
         details.addBetterCacher(cache);
-        details.addCoordinates(cache.getCoords());
+        final CoordinatesFormatSwitcher coordinateSwitcher = details.addCoordinates(cache.getCoords(), coordinateFormatPosition);
+        if (coordinateSwitcher != null) {
+            coordinateSwitcher.setOnPositionChangedListener(position -> coordinateFormatPosition = position);
+        }
 
         // Latest logs
         details.addLatestLogs(cache);

--- a/main/src/main/java/cgeo/geocaching/WaypointViewHolder.java
+++ b/main/src/main/java/cgeo/geocaching/WaypointViewHolder.java
@@ -21,4 +21,12 @@ public class WaypointViewHolder extends AbstractViewHolder {
         this.coordinateFormatSwitcher.setCoordinate(coordinate);
     }
 
+    public void setCoordinateFormatPosition(final int position) {
+        this.coordinateFormatSwitcher.setPosition(position);
+    }
+
+    public void setOnCoordinateFormatChangedListener(final CoordinatesFormatSwitcher.OnPositionChangedListener listener) {
+        this.coordinateFormatSwitcher.setOnPositionChangedListener(listener);
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CacheDetailsCreator.java
@@ -339,14 +339,36 @@ public final class CacheDetailsCreator {
         return add(R.string.cache_distance, text).valueView;
     }
 
-    public TextView addCoordinates(@Nullable final Geopoint coords) {
+    /**
+     * Add coordinates line with default format.
+     * <p>
+     * <strong>API Note:</strong> Return type changed from TextView to CoordinatesFormatSwitcher
+     * to support format persistence (see issue #17418). Existing callers that don't use the
+     * return value are unaffected.
+     *
+     * @param coords the coordinates to display
+     * @return the CoordinatesFormatSwitcher instance, or null if coords is null
+     */
+    public CoordinatesFormatSwitcher addCoordinates(@Nullable final Geopoint coords) {
+        return addCoordinates(coords, 0);
+    }
+
+    /**
+     * Add coordinates line with specified format position.
+     *
+     * @param coords the coordinates to display
+     * @param formatPosition the initial format position (negative values default to 0; non-negative values are normalized to valid range using modulo)
+     * @return the CoordinatesFormatSwitcher instance, or null if coords is null
+     */
+    public CoordinatesFormatSwitcher addCoordinates(@Nullable final Geopoint coords, final int formatPosition) {
         if (coords == null) {
             return null;
         }
         final TextView valueView = add(R.string.cache_coordinates, coords.toString()).valueView;
-        new CoordinatesFormatSwitcher().setView(valueView).setCoordinate(coords);
+        final CoordinatesFormatSwitcher switcher = new CoordinatesFormatSwitcher();
+        switcher.setView(valueView).setCoordinate(coords).setPosition(formatPosition);
         CacheDetailsCreator.addShareAction(activity, valueView, s -> GeopointFormatter.reformatForClipboard(s).toString());
-        return valueView;
+        return switcher;
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/ui/CoordinatesFormatSwitcher.java
+++ b/main/src/main/java/cgeo/geocaching/ui/CoordinatesFormatSwitcher.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.ui;
 
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.GeopointFormatter;
+import cgeo.geocaching.utils.Log;
 
 import android.widget.TextView;
 
@@ -9,6 +10,13 @@ import android.widget.TextView;
  * view click listener to automatically switch different coordinate formats
  */
 public class CoordinatesFormatSwitcher {
+
+    /**
+     * Callback interface for position changes
+     */
+    public interface OnPositionChangedListener {
+        void onPositionChanged(int position);
+    }
 
     private static final GeopointFormatter.Format[] availableFormats = {
             GeopointFormatter.Format.LAT_LON_DECMINUTE,
@@ -20,12 +28,16 @@ public class CoordinatesFormatSwitcher {
     private int position = 0;
     private Geopoint coordinates;
     private TextView view;
+    private OnPositionChangedListener positionChangedListener;
 
     public CoordinatesFormatSwitcher setView(final TextView view) {
         this.view = view;
         this.view.setOnClickListener(v -> {
             position = (position + 1) % availableFormats.length;
             renderView();
+            if (positionChangedListener != null) {
+                positionChangedListener.onPositionChanged(position);
+            }
         });
         renderView();
         return this;
@@ -35,6 +47,26 @@ public class CoordinatesFormatSwitcher {
         this.coordinates = coordinate;
         renderView();
         return this;
+    }
+
+    public CoordinatesFormatSwitcher setPosition(final int position) {
+        if (position < 0) {
+            Log.w("CoordinatesFormatSwitcher: Invalid negative position " + position + ", defaulting to 0");
+            this.position = 0;
+        } else {
+            this.position = position % availableFormats.length;
+        }
+        renderView();
+        return this;
+    }
+
+    public CoordinatesFormatSwitcher setOnPositionChangedListener(final OnPositionChangedListener listener) {
+        this.positionChangedListener = listener;
+        return this;
+    }
+
+    public int getPosition() {
+        return position;
     }
 
     private void renderView() {


### PR DESCRIPTION
Squashed and rebased to release from PR #17725 (created by / with copilot)

Superseded PR #17725

rel to #17418 : Store coordinate format position in bundle to survive fragment recreation
rel to #17418: Add callback to CoordinatesFormatSwitcher to update position on user click
rel to #17418: Add validation for negative position values in setPosition()
rel to #17418: Add logging for invalid position values and document API changes
rel to #17418: Improve JavaDoc to clarify API changes and parameter validation
rel to #17418: Add coordinate format persistence to CacheDetailActivity
rel to #17418: Add coordinate format persistence for waypoints in CacheDetailActivity
rel to #17418: Extract magic string suffixes to constants in WaypointsViewCreator
rel to #17418: Simplify state key constants by using direct strings instead of concatenation
rel to #17418: Use Serializable HashMap to save waypoint format positions directly
rel to #17418: Remove @SuppressWarnings by using runtime type checking
