### PR TITLE
Enabling flag to compress JNI Libs to reduce APK size

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -315,6 +315,16 @@ android {
     useLibrary 'android.test.base'
 }
 
+// Enabling flag to compress JNI Libs to reduce APK size Ref: https://developer.android.com/studio/releases/gradle-plugin#compress-native-libs-dsl
+androidComponents {
+    onVariants(selector().withBuildType("debug")) {
+        packaging.jniLibs.useLegacyPackaging.set(true)
+    }
+    onVariants(selector().withBuildType("nightly")) {
+        packaging.jniLibs.useLegacyPackaging.set(true)
+    }
+}
+
 dependencies {
     // desugaring of Java 8 APIs
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'


### PR DESCRIPTION
Ref: https://developer.android.com/studio/releases/gradle-plugin#compress-native-libs-dsl

Test data (cgeo-debug.apk):
 - without this flag: 90.993 kB
 - with this flag:    55.791 kB

Activated only for `debug` and `nightly` builds.

Fixes #17610
