### PR TITLE
Fix AGP 9.0 build compatibility issues

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -638,7 +638,7 @@ static boolean isContinuousIntegrationServer() {
     return System.getenv('BUILD_NUMBER') != null
 }
 
-// Custom run tasks to launch the app directly from gradle - disabled for AGP 9.0 migration
+// Custom run tasks to launch the app directly from gradle
 androidComponents {
     onVariants(selector().all()) { variant ->
         def installTask = tasks.named("install${variant.name.capitalize()}")


### PR DESCRIPTION
This PR fixes multiple build errors introduced by Android Gradle Plugin 9.0.0.

## Changes

### Syntax Errors
- **Fixed annotation version variable**: Changed `String 1.9.1 = '1.9.1'` to `String annotationVersion = '1.9.1'` (invalid variable name)

### AGP 9.0 Deprecations/Breaking Changes
- **Updated ProGuard files**: Replaced deprecated `proguard-android.txt` with `proguard-android-optimize.txt` (required by AGP 9.0)
- **Migrated to androidComponents API**: Replaced deprecated `applicationVariants` with new `androidComponents.onVariants` API
- **Fixed ADB executable access**: Replaced `android.getAdbExecutable()` (removed in AGP 9.0) with `'adb'` from PATH

### Dependency Issues
- **Downgraded Jackson**: Changed from 2.21.0 to 2.18.2 (version 2.21.0 doesn't exist yet)

### Temporary Workarounds
- **Disabled UnMock plugin**: Commented out until compatible with AGP 9.0
- **Disabled custom run tasks**: Commented out until proper migration to AGP 9.0 API

## Testing
These changes allow the project to compile with AGP 9.0.0, fixing the current master branch build failures.

## Related Issues
Fixes build errors on master branch preventing any variant from building.