### PR TITLE
fix #7936 / fix #16788: show confirmation on deleting caches with offline log / all caches

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
 import cgeo.geocaching.command.AbstractCachesCommand;
 import cgeo.geocaching.command.CopyToListCommand;
+import cgeo.geocaching.command.DeleteCachesCommand;
 import cgeo.geocaching.command.DeleteListCommand;
 import cgeo.geocaching.command.MakeListUniqueCommand;
 import cgeo.geocaching.command.MoveToListAndRemoveFromOthersCommand;
@@ -94,6 +95,7 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.MenuUtils;
+import cgeo.geocaching.utils.ProgressBarDisposableHandler;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.WatchListUtils;
 import cgeo.geocaching.utils.functions.Action1;
@@ -131,9 +133,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1333,7 +1335,11 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     }
 
     private void deleteCaches(@NonNull final Collection<Geocache> caches, final boolean removeFromAllLists) {
-        new DeleteCachesFromListCommand(this, caches, listId, removeFromAllLists).execute();
+        if (removeFromAllLists || removeWillDeleteFromDevice(listId)) {
+            new DeleteCachesCommand(this, new HashSet<>(caches), new DeleteCachesHandler(this)).execute();
+            return;
+        }
+        new DeleteCachesFromListCommand(this, caches, listId).execute();
     }
 
     private void shareGeocodes(@NonNull final Collection<Geocache> caches) {
@@ -1388,18 +1394,28 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         return listId == PseudoList.ALL_LIST.id || listId == PseudoList.HISTORY_LIST.id || listId == StoredList.TEMPORARY_LIST.id;
     }
 
+    private static final class DeleteCachesHandler extends ProgressBarDisposableHandler {
+
+        DeleteCachesHandler(final CacheListActivity activity) {
+            super(activity);
+        }
+
+        @Override
+        public void handleMessage(final Message msg) {
+            new LastPositionHelper((CacheListActivity) activityRef.get()).refreshListAtLastPosition(true);
+            dismissProgress();
+        }
+    }
+
     private static final class DeleteCachesFromListCommand extends AbstractCachesCommand {
 
         private final LastPositionHelper lastPositionHelper;
         private final int listId;
-        private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
-        private final boolean removeFromAllLists;
 
-        DeleteCachesFromListCommand(@NonNull final CacheListActivity context, final Collection<Geocache> caches, final int listId, final boolean removeFromAllLists) {
+        DeleteCachesFromListCommand(@NonNull final CacheListActivity context, final Collection<Geocache> caches, final int listId) {
             super(context, caches, R.string.command_delete_caches_progress);
             this.lastPositionHelper = new LastPositionHelper(context);
             this.listId = listId;
-            this.removeFromAllLists = removeFromAllLists;
         }
 
         @Override
@@ -1409,24 +1425,12 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
         @Override
         protected void doCommand() {
-            if (appliesToAllLists()) {
-                oldCachesLists.putAll(DataStore.markDropped(getCaches()));
-            } else {
-                DataStore.removeFromList(getCaches(), listId);
-            }
-        }
-
-        public boolean appliesToAllLists() {
-            return removeFromAllLists || removeWillDeleteFromDevice(listId);
+            DataStore.removeFromList(getCaches(), listId);
         }
 
         @Override
         protected void undoCommand() {
-            if (appliesToAllLists()) {
-                DataStore.addToLists(getCaches(), oldCachesLists);
-            } else {
-                DataStore.addToList(getCaches(), listId);
-            }
+            DataStore.addToList(getCaches(), listId);
         }
 
         @Override

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -9,7 +9,6 @@ import cgeo.geocaching.apps.cachelist.CacheListAppUtils;
 import cgeo.geocaching.apps.cachelist.CacheListApps;
 import cgeo.geocaching.apps.cachelist.ListNavigationSelectionActionProvider;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
-import cgeo.geocaching.command.AbstractCachesCommand;
 import cgeo.geocaching.command.CopyToListCommand;
 import cgeo.geocaching.command.DeleteCachesCommand;
 import cgeo.geocaching.command.DeleteListCommand;
@@ -132,7 +131,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -1334,12 +1332,15 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
     }
 
     private void deleteCaches(@NonNull final Collection<Geocache> caches, final boolean removeFromAllLists) {
+        final LastPositionHelper lastPositionHelper = new LastPositionHelper(this);
+        final Runnable onFinished = () -> lastPositionHelper.refreshListAtLastPosition(true);
+        final DeleteCachesCommand deleteCachesCommand;
         if (removeFromAllLists || removeWillDeleteFromDevice(listId)) {
-            final LastPositionHelper lastPositionHelper = new LastPositionHelper(this);
-            new DeleteCachesCommand(this, new HashSet<>(caches), () -> lastPositionHelper.refreshListAtLastPosition(true)).showDeleteAllDialogsAndExecute();
-            return;
+            deleteCachesCommand = new DeleteCachesCommand(this, caches, onFinished);
+        } else {
+            deleteCachesCommand = new DeleteCachesCommand(this, caches, listId, onFinished);
         }
-        new DeleteCachesFromListCommand(this, caches, listId).execute();
+        deleteCachesCommand.showAllDialogsAndExecute();
     }
 
     private void shareGeocodes(@NonNull final Collection<Geocache> caches) {
@@ -1392,41 +1393,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     public static boolean removeWillDeleteFromDevice(final int listId) {
         return listId == PseudoList.ALL_LIST.id || listId == PseudoList.HISTORY_LIST.id || listId == StoredList.TEMPORARY_LIST.id;
-    }
-
-
-    private static final class DeleteCachesFromListCommand extends AbstractCachesCommand {
-
-        private final LastPositionHelper lastPositionHelper;
-        private final int listId;
-
-        DeleteCachesFromListCommand(@NonNull final CacheListActivity context, final Collection<Geocache> caches, final int listId) {
-            super(context, caches, R.string.command_delete_caches_progress);
-            this.lastPositionHelper = new LastPositionHelper(context);
-            this.listId = listId;
-        }
-
-        @Override
-        public void onFinished() {
-            lastPositionHelper.refreshListAtLastPosition(true);
-        }
-
-        @Override
-        protected void doCommand() {
-            DataStore.removeFromList(getCaches(), listId);
-        }
-
-        @Override
-        protected void undoCommand() {
-            DataStore.addToList(getCaches(), listId);
-        }
-
-        @Override
-        @NonNull
-        protected String getResultMessage() {
-            final int size = getCaches().size();
-            return LocalizationUtils.getPlural(R.plurals.command_delete_caches_result, size);
-        }
     }
 
     private static void clearOfflineLogs(final Handler handler, final Collection<Geocache> selectedCaches) {

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -95,7 +95,6 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.MenuUtils;
-import cgeo.geocaching.utils.ProgressBarDisposableHandler;
 import cgeo.geocaching.utils.ShareUtils;
 import cgeo.geocaching.utils.WatchListUtils;
 import cgeo.geocaching.utils.functions.Action1;
@@ -1336,7 +1335,8 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     private void deleteCaches(@NonNull final Collection<Geocache> caches, final boolean removeFromAllLists) {
         if (removeFromAllLists || removeWillDeleteFromDevice(listId)) {
-            new DeleteCachesCommand(this, new HashSet<>(caches), new DeleteCachesHandler(this)).showDeleteAllDialogsAndExecute();
+            final LastPositionHelper lastPositionHelper = new LastPositionHelper(this);
+            new DeleteCachesCommand(this, new HashSet<>(caches), () -> lastPositionHelper.refreshListAtLastPosition(true)).showDeleteAllDialogsAndExecute();
             return;
         }
         new DeleteCachesFromListCommand(this, caches, listId).execute();
@@ -1394,18 +1394,6 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         return listId == PseudoList.ALL_LIST.id || listId == PseudoList.HISTORY_LIST.id || listId == StoredList.TEMPORARY_LIST.id;
     }
 
-    private static final class DeleteCachesHandler extends ProgressBarDisposableHandler {
-
-        DeleteCachesHandler(final CacheListActivity activity) {
-            super(activity);
-        }
-
-        @Override
-        public void handleMessage(final Message msg) {
-            new LastPositionHelper((CacheListActivity) activityRef.get()).refreshListAtLastPosition(true);
-            dismissProgress();
-        }
-    }
 
     private static final class DeleteCachesFromListCommand extends AbstractCachesCommand {
 

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1336,7 +1336,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
 
     private void deleteCaches(@NonNull final Collection<Geocache> caches, final boolean removeFromAllLists) {
         if (removeFromAllLists || removeWillDeleteFromDevice(listId)) {
-            new DeleteCachesCommand(this, new HashSet<>(caches), new DeleteCachesHandler(this)).execute();
+            new DeleteCachesCommand(this, new HashSet<>(caches), new DeleteCachesHandler(this)).showDeleteAllDialogsAndExecute();
             return;
         }
         new DeleteCachesFromListCommand(this, caches, listId).execute();

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -1,0 +1,65 @@
+package cgeo.geocaching.command;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.storage.DataStore;
+
+import android.app.Activity;
+import android.os.Handler;
+import android.os.Message;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class DeleteCachesCommand extends AbstractCachesCommand {
+
+    final private Handler handler;
+    private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
+
+
+    public DeleteCachesCommand(@NonNull final Activity context, final Collection<Geocache> caches, @Nullable final Handler handler) {
+        super(context, caches, R.string.command_delete_caches_progress);
+        this.handler = handler;
+    }
+
+    @Override
+    protected void doCommand() {
+        final Set<String> geocodes = Geocache.getGeocodes(getCaches());
+        oldCachesLists.putAll(DataStore.markDropped(getCaches()));
+        DataStore.removeCaches(geocodes, EnumSet.of(LoadFlags.RemoveFlag.CACHE));
+    }
+
+    @Override
+    @SuppressWarnings("unused")
+    protected void undoCommand() {
+        DataStore.addToLists(getCaches(), oldCachesLists);
+    }
+
+    @Override
+    protected void onFinished() {
+        if (null != handler) {
+            handler.sendMessage(Message.obtain());
+        }
+    }
+
+    @Override
+    protected void onFinishedUndo() {
+        if (null != handler) {
+            handler.sendMessage(Message.obtain());
+        }
+    }
+
+    @Override
+    @NonNull
+    protected String getResultMessage() {
+        final int size = getCaches().size();
+        return getContext().getResources().getQuantityString(R.plurals.command_delete_caches_result, size, size);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -5,9 +5,11 @@ import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.log.OfflineLogEntry;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.LocalizationUtils;
 
 import android.app.Activity;
 import android.os.Handler;
@@ -19,8 +21,11 @@ import androidx.annotation.Nullable;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class DeleteCachesCommand extends AbstractCachesCommand {
 
@@ -39,28 +44,35 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         final Collection<Geocache> caches = getCaches();
 
         // Check if deleting all caches
-        if (caches.size() == PseudoList.ALL_LIST.getNumberOfCaches()) {
+        final int cacheCount = caches.size();
+        if (cacheCount == PseudoList.ALL_LIST.getNumberOfCaches()) {
             SimpleDialog.of(getContext())
                     .setTitle(R.string.command_delete_caches_progress)
-                    .setMessage(R.string.caches_warning_delete_all_caches)
-                    .setButtons(SimpleDialog.ButtonTextSet.YES_NO)
-                    .confirm(this::showOfflineLogDialogAndExecute);
+                    .setMessage(R.string.caches_warning_delete_all_caches, cacheCount)
+                    .setButtons(SimpleDialog.ButtonTextSet.OK_CANCEL)
+                    .confirm(this::showUserDataDialogAndExecute);
         } else {
-            showOfflineLogDialogAndExecute();
+            showUserDataDialogAndExecute();
         }
     }
 
-    public void showOfflineLogDialogAndExecute() {
+    public void showUserDataDialogAndExecute() {
         final Collection<Geocache> caches = getCaches();
 
-        final int count = (int) caches.stream().filter(Geocache::hasLogOffline).count();
+        final List<Geocache> cachesWithUserData = caches.stream().filter(this::hasUserData).toList();
+        final int count = cachesWithUserData.size();
         if (count > 0) {
-            final String messageText = getContext().getResources().getQuantityString(R.plurals.caches_warning_delete_offline_log, count, count);
+            final String messageText = LocalizationUtils.getString(R.string.caches_warning_delete_user_data, count);
 
             SimpleDialog.of(getContext())
                     .setTitle(R.string.command_delete_caches_progress)
                     .setMessage(TextParam.text(messageText))
                     .setButtons(SimpleDialog.ButtonTextSet.OK_CANCEL)
+                    .setNeutralButton(TextParam.id(R.string.caches_warning_delete_user_data_others))
+                    .setNeutralAction(() -> {
+                        caches.removeAll(cachesWithUserData);
+                        execute();
+                    })
                     .confirm(this::execute);
         } else {
             execute();
@@ -89,6 +101,17 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         restoreDroppedInfos(caches);
     }
 
+    private boolean hasUserData(final Geocache cache) {
+        final boolean hasOfflineLog = cache.hasLogOffline();
+        final boolean hasPersonalNote = !StringUtils.isEmpty(cache.getPersonalNote());
+        final boolean hasUserdefinedWaypoints = cache.hasUserdefinedWaypoints();
+        final boolean hasUserModifiedCoords = cache.hasUserModifiedCoords();
+        final boolean hasVariables = !cache.getVariables().isEmpty();
+        final boolean hasUserModifiedWaypoints = cache.getWaypoints().stream().anyMatch(Waypoint::isUserModified);
+        return hasOfflineLog || hasPersonalNote || hasVariables
+                || hasUserdefinedWaypoints || hasUserModifiedWaypoints || hasUserModifiedCoords;
+    }
+
     private void saveDroppedInfos(final Collection<Geocache> caches) {
         for (final Geocache cache : caches) {
             final String geocode = cache.getGeocode();
@@ -101,6 +124,9 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
             if (0 < visitedDate) {
                 oldVisitedDate.put(geocode, visitedDate);
             }
+
+            // PersonalNote, Waypoint are saved with the cache and hence restored with it
+            // Variables are not deleted yet, so no need to save
         }
     }
 
@@ -112,10 +138,14 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
             if (offlineLog != null) {
                 DataStore.saveLogOffline(geocode, offlineLog);
             }
+
             final Long visitedDate = oldVisitedDate.get(geocode);
             if (visitedDate != null) {
                 DataStore.saveVisitDate(geocode, visitedDate);
             }
+
+            // PersonalNote, Waypoint are saved with the cache and hence restored with it
+            // Variables are not deleted yet, so no need to restore
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -7,7 +7,8 @@ import cgeo.geocaching.log.OfflineLogEntry;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
-import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.storage.extension.OneTimeDialogs;
+import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.LocalizationUtils;
 
@@ -33,7 +34,6 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
     private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
     private final Map<String, OfflineLogEntry> oldOfflineLogs = new HashMap<>();
     private final Map<String, Long> oldVisitedDate = new HashMap<>();
-
 
     public DeleteCachesCommand(@NonNull final Activity context, final Collection<Geocache> caches, @Nullable final Handler handler) {
         super(context, caches, R.string.command_delete_caches_progress);
@@ -62,18 +62,15 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         final List<Geocache> cachesWithUserData = caches.stream().filter(this::hasUserData).toList();
         final int count = cachesWithUserData.size();
         if (count > 0) {
-            final String messageText = LocalizationUtils.getString(R.string.caches_warning_delete_user_data, count);
-
-            SimpleDialog.of(getContext())
-                    .setTitle(R.string.command_delete_caches_progress)
-                    .setMessage(TextParam.text(messageText))
-                    .setButtons(SimpleDialog.ButtonTextSet.OK_CANCEL)
-                    .setNeutralButton(TextParam.id(R.string.caches_warning_delete_user_data_others))
-                    .setNeutralAction(() -> {
+            Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.DELETE_CACHES_USER_DATA_WARNING,
+                    LocalizationUtils.getString(R.string.command_delete_caches_progress), LocalizationUtils.getString(R.string.caches_warning_delete_user_data, count),
+                    true, this::execute,
+                    LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others),
+                    () -> {
                         caches.removeAll(cachesWithUserData);
                         execute();
-                    })
-                    .confirm(this::execute);
+                    }
+            );
         } else {
             execute();
         }

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -96,9 +96,12 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
     private void showRemoveFromListDialogsAndExecute() {
         final int cacheCount = deleteFromDeviceAction.getCacheCount();
         if (cacheCount > 0) {
+            final int allCacheCount = getCaches().size();
             final String title = LocalizationUtils.getString(R.string.command_remove_caches_from_list_progress);
-            final String warningMessage = LocalizationUtils.getString(R.string.caches_warning_remove_caches_from_single_list, cacheCount, getCaches().size());
-            final String othersButtonText = LocalizationUtils.getString(R.string.caches_warning_remove_from_list_user_data_others);
+            final String warningMessage = LocalizationUtils.getString(R.string.caches_warning_remove_caches_from_single_list, cacheCount, allCacheCount);
+
+            final boolean hasCachesToRemoveFromListOnly = allCacheCount > cacheCount;
+            final String othersButtonText = hasCachesToRemoveFromListOnly ? LocalizationUtils.getString(R.string.caches_warning_remove_from_list_user_data_others) : null;
             Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.REMOVE_CACHES_FROM_LIST_WARNING,
                     title, warningMessage, true, this::showUserDataDialogAndExecute,
                     othersButtonText,
@@ -121,9 +124,12 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
                 cachesWithUserData -> {
                     final int count = cachesWithUserData.size();
                     if (count > 0) {
+                        final int countToDelete = deleteFromDeviceAction.getCacheCount();
                         final String title = LocalizationUtils.getString(R.string.command_delete_caches_progress);
-                        final String warningMessage = LocalizationUtils.getPlural(R.plurals.caches_warning_delete_user_data, count);
-                        final String othersButtonText = LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others);
+                        final String warningMessage = LocalizationUtils.getPlural(R.plurals.caches_warning_delete_user_data, count, count, countToDelete);
+
+                        final boolean hasCachesToRemoveFromDevice = count < countToDelete;
+                        final String othersButtonText = hasCachesToRemoveFromDevice ? LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others) : null;
 
                         Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.DELETE_CACHES_USER_DATA_WARNING,
                                 title, warningMessage, true, this::execute,

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -3,8 +3,10 @@ package cgeo.geocaching.command;
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.PseudoList;
+import cgeo.geocaching.log.OfflineLogEntry;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 
 import android.app.Activity;
@@ -22,8 +24,10 @@ import java.util.Set;
 
 public class DeleteCachesCommand extends AbstractCachesCommand {
 
-    final private Handler handler;
+    private final Handler handler;
     private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
+    private final Map<String, OfflineLogEntry> oldOfflineLogs = new HashMap<>();
+    private final Map<String, Long> oldVisitedDate = new HashMap<>();
 
 
     public DeleteCachesCommand(@NonNull final Activity context, final Collection<Geocache> caches, @Nullable final Handler handler) {
@@ -40,6 +44,23 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
                     .setTitle(R.string.command_delete_caches_progress)
                     .setMessage(R.string.caches_warning_delete_all_caches)
                     .setButtons(SimpleDialog.ButtonTextSet.YES_NO)
+                    .confirm(this::showOfflineLogDialogAndExecute);
+        } else {
+            showOfflineLogDialogAndExecute();
+        }
+    }
+
+    public void showOfflineLogDialogAndExecute() {
+        final Collection<Geocache> caches = getCaches();
+
+        final int count = (int) caches.stream().filter(Geocache::hasLogOffline).count();
+        if (count > 0) {
+            final String messageText = getContext().getResources().getQuantityString(R.plurals.caches_warning_delete_offline_log, count, count);
+
+            SimpleDialog.of(getContext())
+                    .setTitle(R.string.command_delete_caches_progress)
+                    .setMessage(TextParam.text(messageText))
+                    .setButtons(SimpleDialog.ButtonTextSet.OK_CANCEL)
                     .confirm(this::execute);
         } else {
             execute();
@@ -49,6 +70,8 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
     @Override
     protected void doCommand() {
         final Collection<Geocache> caches = getCaches();
+
+        saveDroppedInfos(caches);
 
         oldCachesLists.putAll(DataStore.markDropped(caches));
 
@@ -62,6 +85,38 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         final Collection<Geocache> caches = getCaches();
 
         DataStore.addToLists(caches, oldCachesLists);
+
+        restoreDroppedInfos(caches);
+    }
+
+    private void saveDroppedInfos(final Collection<Geocache> caches) {
+        for (final Geocache cache : caches) {
+            final String geocode = cache.getGeocode();
+            if (cache.hasLogOffline()) {
+                oldOfflineLogs.put(geocode, DataStore.loadLogOffline(geocode));
+            }
+
+            // because visited date is reset on dropping cache
+            final long visitedDate = cache.getVisitedDate();
+            if (0 < visitedDate) {
+                oldVisitedDate.put(geocode, visitedDate);
+            }
+        }
+    }
+
+    private void restoreDroppedInfos(final Collection<Geocache> caches) {
+        for (final Geocache cache : caches) {
+            final String geocode = cache.getGeocode();
+
+            final OfflineLogEntry offlineLog = oldOfflineLogs.get(geocode);
+            if (offlineLog != null) {
+                DataStore.saveLogOffline(geocode, offlineLog);
+            }
+            final Long visitedDate = oldVisitedDate.get(geocode);
+            if (visitedDate != null) {
+                DataStore.saveVisitDate(geocode, visitedDate);
+            }
+        }
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,8 +44,9 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
                                @Nullable final Runnable onFinishedCallback) {
         super(context, caches, R.string.command_delete_caches_progress);
         this.onFinishedCallback = onFinishedCallback;
-
-        deleteFromDeviceAction = new DeleteFromDeviceAction(caches);
+        
+        final List<Geocache> toDelete = new ArrayList<>(caches);
+        deleteFromDeviceAction = new DeleteFromDeviceAction(toDelete);
         removeFromListAction = null;
     }
 
@@ -115,8 +117,7 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         }
     }
 
-
-    public void showUserDataDialogAndExecute() {
+    private void showUserDataDialogAndExecute() {
         // Scanning caches for user data (notes, waypoints, variables, offline logs) can be slow
         // for large selections — run it on a background thread and show the dialog on the UI thread.
         AndroidRxUtils.andThenOnUi(AndroidRxUtils.computationScheduler,
@@ -207,7 +208,7 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         }
 
         private List<Geocache> getCachesWithUserData() {
-            return caches.stream().filter(this::hasUserData).toList();
+            return caches.stream().filter(this::hasUserData).collect(Collectors.toList());
         }
 
         private int getCacheCount() {

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -11,6 +11,7 @@ import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 
 import android.app.Activity;
@@ -113,24 +114,30 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
 
 
     public void showUserDataDialogAndExecute() {
-        final List<Geocache> cachesWithUserData = deleteFromDeviceAction.getCachesWithUserData();
-        final int count = cachesWithUserData.size();
-        if (count > 0) {
-            final String title = LocalizationUtils.getString(R.string.command_delete_caches_progress);
-            final String warningMessage = LocalizationUtils.getPlural(R.plurals.caches_warning_delete_user_data, count);
-            final String othersButtonText = LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others);
+        // Scanning caches for user data (notes, waypoints, variables, offline logs) can be slow
+        // for large selections — run it on a background thread and show the dialog on the UI thread.
+        AndroidRxUtils.andThenOnUi(AndroidRxUtils.computationScheduler,
+                deleteFromDeviceAction::getCachesWithUserData,
+                cachesWithUserData -> {
+                    final int count = cachesWithUserData.size();
+                    if (count > 0) {
+                        final String title = LocalizationUtils.getString(R.string.command_delete_caches_progress);
+                        final String warningMessage = LocalizationUtils.getPlural(R.plurals.caches_warning_delete_user_data, count);
+                        final String othersButtonText = LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others);
 
-            Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.DELETE_CACHES_USER_DATA_WARNING,
-                    title, warningMessage, true, this::execute,
-                    othersButtonText,
-                    () -> {
-                        deleteFromDeviceAction.removeCaches(cachesWithUserData);
+                        Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.DELETE_CACHES_USER_DATA_WARNING,
+                                title, warningMessage, true, this::execute,
+                                othersButtonText,
+                                () -> {
+                                    deleteFromDeviceAction.removeCaches(cachesWithUserData);
+                                    execute();
+                                }
+                        );
+                    } else {
                         execute();
                     }
-            );
-        } else {
-            execute();
-        }
+                }
+        );
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -13,8 +13,6 @@ import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.LocalizationUtils;
 
 import android.app.Activity;
-import android.os.Handler;
-import android.os.Message;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -30,14 +28,15 @@ import org.apache.commons.lang3.StringUtils;
 
 public class DeleteCachesCommand extends AbstractCachesCommand {
 
-    private final Handler handler;
+    @Nullable
+    private final Runnable onFinishedCallback;
     private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
     private final Map<String, OfflineLogEntry> oldOfflineLogs = new HashMap<>();
     private final Map<String, Long> oldVisitedDate = new HashMap<>();
 
-    public DeleteCachesCommand(@NonNull final Activity context, final Collection<Geocache> caches, @Nullable final Handler handler) {
+    public DeleteCachesCommand(@NonNull final Activity context, final Collection<Geocache> caches, @Nullable final Runnable onFinishedCallback) {
         super(context, caches, R.string.command_delete_caches_progress);
-        this.handler = handler;
+        this.onFinishedCallback = onFinishedCallback;
     }
 
     public void showDeleteAllDialogsAndExecute() {
@@ -148,15 +147,15 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
 
     @Override
     protected void onFinished() {
-        if (null != handler) {
-            handler.sendMessage(Message.obtain());
+        if (onFinishedCallback != null) {
+            onFinishedCallback.run();
         }
     }
 
     @Override
     protected void onFinishedUndo() {
-        if (null != handler) {
-            handler.sendMessage(Message.obtain());
+        if (onFinishedCallback != null) {
+            onFinishedCallback.run();
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
+++ b/main/src/main/java/cgeo/geocaching/command/DeleteCachesCommand.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
+import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.Dialogs;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.LocalizationUtils;
@@ -17,6 +18,7 @@ import android.app.Activity;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -30,24 +32,59 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
 
     @Nullable
     private final Runnable onFinishedCallback;
-    private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
-    private final Map<String, OfflineLogEntry> oldOfflineLogs = new HashMap<>();
-    private final Map<String, Long> oldVisitedDate = new HashMap<>();
 
-    public DeleteCachesCommand(@NonNull final Activity context, final Collection<Geocache> caches, @Nullable final Runnable onFinishedCallback) {
+    private final DeleteFromDeviceAction deleteFromDeviceAction;
+    @Nullable
+    private final RemoveFromListAction removeFromListAction;
+
+    public DeleteCachesCommand(@NonNull final Activity context,
+                               final Collection<Geocache> caches,
+                               @Nullable final Runnable onFinishedCallback) {
         super(context, caches, R.string.command_delete_caches_progress);
         this.onFinishedCallback = onFinishedCallback;
+
+        deleteFromDeviceAction = new DeleteFromDeviceAction(caches);
+        removeFromListAction = null;
     }
 
-    public void showDeleteAllDialogsAndExecute() {
-        final Collection<Geocache> caches = getCaches();
+    public DeleteCachesCommand(@NonNull final Activity context,
+                               final Collection<Geocache> caches,
+                               final int listId,
+                               @Nullable final Runnable onFinishedCallback) {
+        super(context, caches, R.string.command_remove_caches_from_list_progress);
+        this.onFinishedCallback = onFinishedCallback;
 
-        // Check if deleting all caches
-        final int cacheCount = caches.size();
-        if (cacheCount == PseudoList.ALL_LIST.getNumberOfCaches()) {
+        final List<Geocache> toDelete = new ArrayList<>();
+        final List<Geocache> toRemoveFromList = new ArrayList<>();
+        for (final Geocache cache : getCaches()) {
+            if (cache.getLists().size() == 1) {
+                toDelete.add(cache);
+            } else {
+                toRemoveFromList.add(cache);
+            }
+        }
+
+        deleteFromDeviceAction = new DeleteFromDeviceAction(toDelete);
+        removeFromListAction = new RemoveFromListAction(toRemoveFromList, listId);
+    }
+
+    public void showAllDialogsAndExecute() {
+        if (removeFromListAction != null) {
+            showRemoveFromListDialogsAndExecute();
+        } else {
+            showDeleteAllDialogsAndExecute();
+        }
+    }
+
+    private void showDeleteAllDialogsAndExecute() {
+        final int cacheCount = deleteFromDeviceAction.getCacheCount();
+        if (cacheCount > 0 && (cacheCount == PseudoList.ALL_LIST.getNumberOfCaches())) {
+            final String title = LocalizationUtils.getString(R.string.command_delete_caches_progress);
+            final String warningMessage = LocalizationUtils.getString(R.string.caches_warning_delete_all_caches, cacheCount);
+
             SimpleDialog.of(getContext())
-                    .setTitle(R.string.command_delete_caches_progress)
-                    .setMessage(R.string.caches_warning_delete_all_caches, cacheCount)
+                    .setTitle(TextParam.text(title))
+                    .setMessage(TextParam.text(warningMessage))
                     .setButtons(SimpleDialog.ButtonTextSet.OK_CANCEL)
                     .confirm(this::showUserDataDialogAndExecute);
         } else {
@@ -55,18 +92,39 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
         }
     }
 
-    public void showUserDataDialogAndExecute() {
-        final Collection<Geocache> caches = getCaches();
+    private void showRemoveFromListDialogsAndExecute() {
+        final int cacheCount = deleteFromDeviceAction.getCacheCount();
+        if (cacheCount > 0) {
+            final String title = LocalizationUtils.getString(R.string.command_remove_caches_from_list_progress);
+            final String warningMessage = LocalizationUtils.getString(R.string.caches_warning_remove_caches_from_single_list, cacheCount, getCaches().size());
+            final String othersButtonText = LocalizationUtils.getString(R.string.caches_warning_remove_from_list_user_data_others);
+            Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.REMOVE_CACHES_FROM_LIST_WARNING,
+                    title, warningMessage, true, this::showUserDataDialogAndExecute,
+                    othersButtonText,
+                    () -> {
+                        deleteFromDeviceAction.removeAllCaches();
+                        execute();
+                    }
+            );
+        } else {
+            execute();
+        }
+    }
 
-        final List<Geocache> cachesWithUserData = caches.stream().filter(this::hasUserData).toList();
+
+    public void showUserDataDialogAndExecute() {
+        final List<Geocache> cachesWithUserData = deleteFromDeviceAction.getCachesWithUserData();
         final int count = cachesWithUserData.size();
         if (count > 0) {
+            final String title = LocalizationUtils.getString(R.string.command_delete_caches_progress);
+            final String warningMessage = LocalizationUtils.getPlural(R.plurals.caches_warning_delete_user_data, count);
+            final String othersButtonText = LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others);
+
             Dialogs.advancedOneTimeMessage(getContext(), OneTimeDialogs.DialogType.DELETE_CACHES_USER_DATA_WARNING,
-                    LocalizationUtils.getString(R.string.command_delete_caches_progress), LocalizationUtils.getString(R.string.caches_warning_delete_user_data, count),
-                    true, this::execute,
-                    LocalizationUtils.getString(R.string.caches_warning_delete_user_data_others),
+                    title, warningMessage, true, this::execute,
+                    othersButtonText,
                     () -> {
-                        caches.removeAll(cachesWithUserData);
+                        deleteFromDeviceAction.removeCaches(cachesWithUserData);
                         execute();
                     }
             );
@@ -76,73 +134,25 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
     }
 
     @Override
+    protected boolean canExecute() {
+        return !getCaches().isEmpty();
+    }
+
+    @Override
     protected void doCommand() {
-        final Collection<Geocache> caches = getCaches();
-
-        saveDroppedInfos(caches);
-
-        oldCachesLists.putAll(DataStore.markDropped(caches));
-
-        final Set<String> geocodes = Geocache.getGeocodes(caches);
-        DataStore.removeCaches(geocodes, EnumSet.of(LoadFlags.RemoveFlag.CACHE));
+        if (removeFromListAction != null) {
+            removeFromListAction.executeAction();
+        }
+        deleteFromDeviceAction.executeAction();
     }
 
     @Override
     @SuppressWarnings("unused")
     protected void undoCommand() {
-        final Collection<Geocache> caches = getCaches();
-
-        DataStore.addToLists(caches, oldCachesLists);
-
-        restoreDroppedInfos(caches);
-    }
-
-    private boolean hasUserData(final Geocache cache) {
-        final boolean hasOfflineLog = cache.hasLogOffline();
-        final boolean hasPersonalNote = !StringUtils.isEmpty(cache.getPersonalNote());
-        final boolean hasUserdefinedWaypoints = cache.hasUserdefinedWaypoints();
-        final boolean hasUserModifiedCoords = cache.hasUserModifiedCoords();
-        final boolean hasVariables = !cache.getVariables().isEmpty();
-        final boolean hasUserModifiedWaypoints = cache.getWaypoints().stream().anyMatch(Waypoint::isUserModified);
-        return hasOfflineLog || hasPersonalNote || hasVariables
-                || hasUserdefinedWaypoints || hasUserModifiedWaypoints || hasUserModifiedCoords;
-    }
-
-    private void saveDroppedInfos(final Collection<Geocache> caches) {
-        for (final Geocache cache : caches) {
-            final String geocode = cache.getGeocode();
-            if (cache.hasLogOffline()) {
-                oldOfflineLogs.put(geocode, DataStore.loadLogOffline(geocode));
-            }
-
-            // because visited date is reset on dropping cache
-            final long visitedDate = cache.getVisitedDate();
-            if (0 < visitedDate) {
-                oldVisitedDate.put(geocode, visitedDate);
-            }
-
-            // PersonalNote, Waypoint are saved with the cache and hence restored with it
-            // Variables are not deleted yet, so no need to save
+        if (removeFromListAction != null) {
+            removeFromListAction.undoAction();
         }
-    }
-
-    private void restoreDroppedInfos(final Collection<Geocache> caches) {
-        for (final Geocache cache : caches) {
-            final String geocode = cache.getGeocode();
-
-            final OfflineLogEntry offlineLog = oldOfflineLogs.get(geocode);
-            if (offlineLog != null) {
-                DataStore.saveLogOffline(geocode, offlineLog);
-            }
-
-            final Long visitedDate = oldVisitedDate.get(geocode);
-            if (visitedDate != null) {
-                DataStore.saveVisitDate(geocode, visitedDate);
-            }
-
-            // PersonalNote, Waypoint are saved with the cache and hence restored with it
-            // Variables are not deleted yet, so no need to restore
-        }
+        deleteFromDeviceAction.undoAction();
     }
 
     @Override
@@ -162,7 +172,130 @@ public class DeleteCachesCommand extends AbstractCachesCommand {
     @Override
     @NonNull
     protected String getResultMessage() {
-        final int size = getCaches().size();
-        return getContext().getResources().getQuantityString(R.plurals.command_delete_caches_result, size, size);
+        final int deletedSize = deleteFromDeviceAction.getCacheCount();
+        final int removedSize = removeFromListAction != null ? removeFromListAction.getCacheCount() : 0;
+        return LocalizationUtils.getPlural(removeFromListAction != null ? R.plurals.command_remove_caches_result : R.plurals.command_delete_caches_result, deletedSize + removedSize);
+    }
+
+    // ---- inner action classes ----
+
+    /**
+     * Encapsulates fully deleting caches from the device, including undo data.
+     */
+    private static final class DeleteFromDeviceAction {
+
+        private final Collection<Geocache> caches;
+        private final Map<String, Set<Integer>> oldCachesLists = new HashMap<>();
+        private final Map<String, OfflineLogEntry> oldOfflineLogs = new HashMap<>();
+        private final Map<String, Long> oldVisitedDate = new HashMap<>();
+
+        private DeleteFromDeviceAction(final Collection<Geocache> caches) {
+            this.caches = caches;
+        }
+
+        private List<Geocache> getCachesWithUserData() {
+            return caches.stream().filter(this::hasUserData).toList();
+        }
+
+        private int getCacheCount() {
+            return caches.size();
+        }
+
+        private void removeAllCaches() {
+            caches.clear();
+        }
+
+        private void removeCaches(final Collection<Geocache> cachesToRemove) {
+            caches.removeAll(cachesToRemove);
+        }
+
+        private void executeAction() {
+            if (caches.isEmpty()) {
+                return;
+            }
+
+            // save dropped infos for undo:
+            // PersonalNote, Waypoint are saved with the cache and hence restored with it
+            // Variables are not deleted yet, so no need to save
+            for (final Geocache cache : caches) {
+                final String geocode = cache.getGeocode();
+                if (cache.hasLogOffline()) {
+                    oldOfflineLogs.put(geocode, DataStore.loadLogOffline(geocode));
+                }
+                // because visited date is reset on dropping cache
+                final long visitedDate = cache.getVisitedDate();
+                if (0 < visitedDate) {
+                    oldVisitedDate.put(geocode, visitedDate);
+                }
+            }
+
+            oldCachesLists.putAll(DataStore.markDropped(caches));
+
+            // remove from cache-cache
+            final Set<String> geocodes = Geocache.getGeocodes(caches);
+            DataStore.removeCaches(geocodes, EnumSet.of(LoadFlags.RemoveFlag.CACHE));
+        }
+
+        private void undoAction() {
+            if (caches.isEmpty()) {
+                return;
+            }
+
+            DataStore.addToLists(caches, oldCachesLists);
+
+            // restore dropped infos:
+            // PersonalNote, Waypoint are saved with the cache and hence restored with it
+            // Variables are not deleted yet, so no need to restore
+            for (final Geocache cache : caches) {
+                final String geocode = cache.getGeocode();
+                final OfflineLogEntry offlineLog = oldOfflineLogs.get(geocode);
+                if (offlineLog != null) {
+                    DataStore.saveLogOffline(geocode, offlineLog);
+                }
+                final Long visitedDate = oldVisitedDate.get(geocode);
+                if (visitedDate != null) {
+                    DataStore.saveVisitDate(geocode, visitedDate);
+                }
+            }
+        }
+
+        private boolean hasUserData(final Geocache cache) {
+            return cache.hasLogOffline()
+                    || !StringUtils.isEmpty(cache.getPersonalNote())
+                    || cache.hasUserdefinedWaypoints()
+                    || cache.hasUserModifiedCoords()
+                    || !cache.getVariables().isEmpty()
+                    || cache.getWaypoints().stream().anyMatch(Waypoint::isUserModified);
+        }
+    }
+
+    /**
+     * Encapsulates removing caches from a specific list (they remain on other lists).
+     */
+    private static final class RemoveFromListAction {
+
+        private final Collection<Geocache> caches;
+        private final int listId;
+
+        private RemoveFromListAction(final Collection<Geocache> caches, final int listId) {
+            this.caches = caches;
+            this.listId = listId;
+        }
+
+        private int getCacheCount() {
+            return caches.size();
+        }
+
+        private void executeAction() {
+            if (!caches.isEmpty()) {
+                DataStore.removeFromList(caches, listId);
+            }
+        }
+
+        private void undoAction() {
+            if (!caches.isEmpty()) {
+                DataStore.addToList(caches, listId);
+            }
+        }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/maps/routing/RouteOptimizationHelper.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/RouteOptimizationHelper.java
@@ -137,7 +137,7 @@ public class RouteOptimizationHelper {
             return;
         }
 
-        Dialogs.advancedOneTimeMessage(context, OneTimeDialogs.DialogType.ROUTE_OPTIMIZATION, LocalizationUtils.getString(R.string.route_optimization), LocalizationUtils.getString(R.string.route_optimization_info), "", true, null, () -> {
+        Dialogs.advancedOneTimeMessage(context, OneTimeDialogs.DialogType.ROUTE_OPTIMIZATION, LocalizationUtils.getString(R.string.route_optimization), LocalizationUtils.getString(R.string.route_optimization_info), true, () -> {
             final ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
             final TSPDialog dialog = new TSPDialog(context, executor, updateRoute);
             dialog.show();

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -804,6 +804,30 @@ public class DataStore {
             });
         }
 
+        /**
+         * Atomically replaces all entries for the given key with a single new entry.
+         * Both the removal of existing entries and the insertion of the new entry are
+         * wrapped in a single database transaction, ensuring true atomicity.
+         */
+        protected static DBExtension replaceAll(final DBExtensionType type, final String key, final long long1, final long long2, final long long3, final long long4, final String string1, final String string2, final String string3, final String string4) {
+            return withAccessLock(() -> {
+                if (!init(false)) {
+                    return null;
+                }
+                database.beginTransaction();
+                try {
+                    removeAll(database, type, key);
+                    final DBExtension result = add(database, type, key, long1, long2, long3, long4, string1, string2, string3, string4);
+                    if (result != null) {
+                        database.setTransactionSuccessful();
+                    }
+                    return result;
+                } finally {
+                    database.endTransaction();
+                }
+            });
+        }
+
         private static void checkState(final DBExtensionType type, @Nullable final String key, final boolean nullable) {
             if (type == DBEXTENSION_INVALID) {
                 throw new IllegalStateException("DBExtension: type must be set to valid type");

--- a/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -3,7 +3,10 @@ package cgeo.geocaching.storage.extension;
 import cgeo.geocaching.R;
 import cgeo.geocaching.storage.DataStore;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class OneTimeDialogs extends DataStore.DBExtension {
 
@@ -20,28 +23,31 @@ public class OneTimeDialogs extends DataStore.DBExtension {
         // names must not be changed, as there are database entries depending on it
         // title and text must be set when using the Dialogs.basicOneTimeMessage() function
 
-        DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS, 0),
-        MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0),
-        MISSING_UNICODE_CHARACTERS(R.string.select_icon, R.string.onetime_missing_unicode_info, DefaultBehavior.SHOW_ALWAYS, 0),
-        MAP_THEME_FIX_SLOWNESS(R.string.onetime_mapthemefixslow_title, R.string.onetime_mapthemefixslow_message, DefaultBehavior.SHOW_ALWAYS, R.string.faq_url_settings_themes),
-        MAP_AUTOROTATION_DISABLE(R.string.map_autorotation, R.string.map_autorotation_disable, DefaultBehavior.SHOW_ALWAYS, 0),
-        MAP_LIVE_DISABLED(R.string.map_live_disabled, R.string.map_live_disabled_hint, DefaultBehavior.SHOW_ALWAYS, 0),
-        ROUTE_OPTIMIZATION(R.string.route_optimization, R.string.route_optimization_info, DefaultBehavior.SHOW_ALWAYS, 0),
-        NOTIFICATION_PERMISSION(R.string.changed_permissions_title, R.string.changed_permissions_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0),
-        GOTO_DEPRECATION_NOTICE(R.string.goto_targets_deprecation_title, R.string.goto_targets_deprecation_notice, DefaultBehavior.SHOW_ALWAYS, 0),
-        WHERIGO_PLAYER_SHORTCUTS(R.string.wherigo_otm_shortcuts_title, R.string.wherigo_otm_shortcuts_message, DefaultBehavior.SHOW_ALWAYS, 0);
+        DATABASE_CONFIRM_OVERWRITE(null, null, DefaultBehavior.SHOW_ALWAYS, 0, 0),
+        MAP_QUICK_SETTINGS(R.string.settings_information, R.string.quick_settings_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0, R.drawable.ic_info_blue),
+        MISSING_UNICODE_CHARACTERS(R.string.select_icon, R.string.onetime_missing_unicode_info, DefaultBehavior.SHOW_ALWAYS, 0, R.drawable.ic_info_blue),
+        MAP_THEME_FIX_SLOWNESS(R.string.onetime_mapthemefixslow_title, R.string.onetime_mapthemefixslow_message, DefaultBehavior.SHOW_ALWAYS, R.string.faq_url_settings_themes, R.drawable.ic_info_blue),
+        MAP_AUTOROTATION_DISABLE(R.string.map_autorotation, R.string.map_autorotation_disable, DefaultBehavior.SHOW_ALWAYS, 0, 0),
+        MAP_LIVE_DISABLED(R.string.map_live_disabled, R.string.map_live_disabled_hint, DefaultBehavior.SHOW_ALWAYS, 0, R.drawable.ic_info_blue),
+        ROUTE_OPTIMIZATION(R.string.route_optimization, R.string.route_optimization_info, DefaultBehavior.SHOW_ALWAYS, 0, 0),
+        NOTIFICATION_PERMISSION(R.string.changed_permissions_title, R.string.changed_permissions_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0, R.drawable.ic_info_blue),
+        GOTO_DEPRECATION_NOTICE(R.string.goto_targets_deprecation_title, R.string.goto_targets_deprecation_notice, DefaultBehavior.SHOW_ALWAYS, 0, R.drawable.ic_info_blue),
+        WHERIGO_PLAYER_SHORTCUTS(R.string.wherigo_otm_shortcuts_title, R.string.wherigo_otm_shortcuts_message, DefaultBehavior.SHOW_ALWAYS, 0, R.drawable.ic_info_blue),
+        DELETE_CACHES_USER_DATA_WARNING(null, null, DefaultBehavior.SHOW_ALWAYS, 0, 0);
 
 
         public final Integer messageTitle;
         public final Integer messageText;
         public final DefaultBehavior defaultBehavior;
         public final int moreInfoURLResId;
+        public final int iconResId;
 
-        DialogType(final Integer messageTitle, final Integer messageText, final DefaultBehavior defaultBehavior, @StringRes final int moreInfoURLResId) {
+        DialogType(final Integer messageTitle, final Integer messageText, final DefaultBehavior defaultBehavior, @StringRes final int moreInfoURLResId, @DrawableRes final int iconResId) {
             this.messageTitle = messageTitle;
             this.messageText = messageText;
             this.defaultBehavior = defaultBehavior;
             this.moreInfoURLResId = moreInfoURLResId;
+            this.iconResId = iconResId;
         }
     }
 
@@ -154,5 +160,42 @@ public class OneTimeDialogs extends DataStore.DBExtension {
             removeAll(type, key.name());
         }
         initializeOnFreshInstall();
+    }
+
+    /**
+     * possible chosen actions for dialogs with "don't ask again" functionality.
+     * The chosen action is stored in string1 of the DB entry.
+     */
+    public enum ChosenAction {
+        OK,
+        NEUTRAL,
+        CANCEL
+    }
+
+    /**
+     * returns the chosen action for a specific dialog, or defaultAction if none has been stored yet
+     */
+    public static ChosenAction getChosenAction(final DialogType dialogType, final ChosenAction defaultAction) {
+        final DataStore.DBExtension temp = load(type, dialogType.name());
+        if (temp != null) {
+            final String stored = new OneTimeDialogs(temp).getString1();
+            if (StringUtils.isNotBlank(stored)) {
+                try {
+                    return ChosenAction.valueOf(stored);
+                } catch (final IllegalArgumentException e) {
+                    // stored value is not a valid ChosenAction, fall through to default
+                }
+            }
+        }
+        return defaultAction;
+    }
+
+    /**
+     * sets the chosen action for a specific dialog and simultaneously sets the dialog status to DIALOG_HIDE.
+     * This is an atomic operation - no separate setStatus call needed.
+     */
+    public static void setChosenAction(final DialogType dialogType, final ChosenAction action) {
+        removeAll(type, dialogType.name());
+        add(type, dialogType.name(), DialogStatus.DIALOG_HIDE.id, DialogStatus.NONE.id, 0, 0, action.name(), "", "", "");
     }
 }

--- a/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -33,7 +33,8 @@ public class OneTimeDialogs extends DataStore.DBExtension {
         NOTIFICATION_PERMISSION(R.string.changed_permissions_title, R.string.changed_permissions_info, DefaultBehavior.SHOW_ONLY_AFTER_UPGRADE, 0, R.drawable.ic_info_blue),
         GOTO_DEPRECATION_NOTICE(R.string.goto_targets_deprecation_title, R.string.goto_targets_deprecation_notice, DefaultBehavior.SHOW_ALWAYS, 0, R.drawable.ic_info_blue),
         WHERIGO_PLAYER_SHORTCUTS(R.string.wherigo_otm_shortcuts_title, R.string.wherigo_otm_shortcuts_message, DefaultBehavior.SHOW_ALWAYS, 0, R.drawable.ic_info_blue),
-        DELETE_CACHES_USER_DATA_WARNING(null, null, DefaultBehavior.SHOW_ALWAYS, 0, 0);
+        DELETE_CACHES_USER_DATA_WARNING(R.string.command_delete_caches_progress, R.string.caches_warning_delete_all_caches, DefaultBehavior.SHOW_ALWAYS, 0, 0),
+        REMOVE_CACHES_FROM_LIST_WARNING(R.string.command_remove_caches_from_list_progress, R.string.caches_warning_remove_caches_from_single_list, DefaultBehavior.SHOW_ALWAYS, 0, 0);
 
 
         public final Integer messageTitle;

--- a/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
+++ b/main/src/main/java/cgeo/geocaching/storage/extension/OneTimeDialogs.java
@@ -191,11 +191,10 @@ public class OneTimeDialogs extends DataStore.DBExtension {
     }
 
     /**
-     * sets the chosen action for a specific dialog and simultaneously sets the dialog status to DIALOG_HIDE.
-     * This is an atomic operation - no separate setStatus call needed.
+     * Sets the chosen action for a specific dialog and simultaneously sets the dialog status to DIALOG_HIDE.
+     * Both operations are wrapped in a single database transaction to guarantee atomicity.
      */
     public static void setChosenAction(final DialogType dialogType, final ChosenAction action) {
-        removeAll(type, dialogType.name());
-        add(type, dialogType.name(), DialogStatus.DIALOG_HIDE.id, DialogStatus.NONE.id, 0, 0, action.name(), "", "", "");
+        replaceAll(type, dialogType.name(), DialogStatus.DIALOG_HIDE.id, DialogStatus.NONE.id, 0, 0, action.name(), "", "", "");
     }
 }

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/Dialogs.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/Dialogs.java
@@ -40,7 +40,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Helper class providing methods when constructing custom Dialogs.
@@ -62,13 +61,15 @@ public final class Dialogs {
      * @param title          message dialog title
      * @param message        message dialog content
      * @param dialogType     the dialogs individual identification type
-     * @param iconObservable observable (may be <tt>null</tt>) containing the icon(s) to set
      * @param cancellable    if true, a cancel button will be displayed additionally
      * @param runAfterwards  runnable (may be <tt>null</tt>) will be executed when ok button is clicked
      */
     // method readability will not improve by splitting it up
     @SuppressWarnings("PMD.NPathComplexity")
-    private static void internalOneTimeMessage(@NonNull final Context context, @Nullable final String title, final String message, @Nullable final String moreInfoURL, final OneTimeDialogs.DialogType dialogType, @Nullable final Observable<Drawable> iconObservable, final boolean cancellable, final Runnable runAfterwards, final boolean disableCancelOnDAMA) {
+    private static void internalOneTimeMessage(@NonNull final Context context, @Nullable final String title, final String message, @Nullable final String footerUrl,
+                                               final OneTimeDialogs.DialogType dialogType,
+                                               final boolean cancellable, final Runnable runAfterwards, final boolean disableCancelOnDAMA,
+                                               @Nullable final String neutralButtonLabel, @Nullable final Runnable onNeutral) {
         final DialogTextCheckboxBinding content = DialogTextCheckboxBinding.inflate(LayoutInflater.from(context));
 
         content.message.setText(message);
@@ -81,12 +82,18 @@ public final class Dialogs {
         }
         */
 
+        if (footerUrl != null) {
+            content.footerMessage.setVisibility(View.VISIBLE);
+            content.footerMessage.setText(R.string.more_information);
+            content.footerMessage.setOnClickListener(v -> ShareUtils.openUrl(context, footerUrl));
+        }
+
         final AlertDialog.Builder builder = newBuilder(context)
                 .setView(content.getRoot())
                 .setCancelable(true)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> {
                     if (content.checkBox.isChecked()) {
-                        OneTimeDialogs.setStatus(dialogType, OneTimeDialogs.DialogStatus.DIALOG_HIDE);
+                        OneTimeDialogs.setChosenAction(dialogType, OneTimeDialogs.ChosenAction.OK);
                     }
                     if (runAfterwards != null) {
                         runAfterwards.run();
@@ -97,24 +104,33 @@ public final class Dialogs {
             builder.setTitle(title);
         }
 
-        if (StringUtils.isNotBlank(moreInfoURL)) {
-            builder.setNeutralButton(R.string.more_information, (dialog, which) -> ShareUtils.openUrl(context, moreInfoURL));
+        if (neutralButtonLabel != null) {
+            builder.setNeutralButton(neutralButtonLabel, (dialog, which) -> {
+                if (content.checkBox.isChecked()) {
+                    OneTimeDialogs.setChosenAction(dialogType, OneTimeDialogs.ChosenAction.NEUTRAL);
+                }
+                if (onNeutral != null) {
+                    onNeutral.run();
+                }
+            });
         }
 
         if (cancellable) {
             builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> {
                 // reachable only when disableCancelOnDAMA is set to false
                 if (content.checkBox.isChecked()) {
-                    OneTimeDialogs.setStatus(dialogType, OneTimeDialogs.DialogStatus.DIALOG_HIDE);
+                    OneTimeDialogs.setChosenAction(dialogType, OneTimeDialogs.ChosenAction.CANCEL);
                 }
             });
         }
-
-        builder.setIcon(ImageUtils.getTransparent1x1Drawable(context.getResources()));
+        if (dialogType.iconResId > 0) {
+            builder.setIcon(ImageUtils.getTransparent1x1Drawable(context.getResources()));
+        }
 
         final AlertDialog dialog = builder.create();
 
-        if (iconObservable != null) {
+        if (dialogType.iconResId > 0) {
+            final Observable<Drawable> iconObservable = Observable.just(Objects.requireNonNull(ResourcesCompat.getDrawable(context.getResources(), dialogType.iconResId, context.getTheme())));
             iconObservable.observeOn(AndroidSchedulers.mainThread()).subscribe(dialog::setIcon);
         }
         dialog.show();
@@ -140,8 +156,10 @@ public final class Dialogs {
 
         if (OneTimeDialogs.showDialog(dialogType)) {
             OneTimeDialogs.setStatus(dialogType, OneTimeDialogs.DialogStatus.DIALOG_HIDE, OneTimeDialogs.DialogStatus.DIALOG_SHOW);
-            internalOneTimeMessage(context, LocalizationUtils.getString(dialogType.messageTitle), LocalizationUtils.getString(dialogType.messageText), dialogType.moreInfoURLResId > 0 ? LocalizationUtils.getString(dialogType.moreInfoURLResId) : null, dialogType,
-                    Observable.just(Objects.requireNonNull(ResourcesCompat.getDrawable(context.getResources(), R.drawable.ic_info_blue, context.getTheme()))), false, null, true);
+            final String moreInfoURL = dialogType.moreInfoURLResId > 0 ? LocalizationUtils.getString(dialogType.moreInfoURLResId) : null;
+            internalOneTimeMessage(context, LocalizationUtils.getString(dialogType.messageTitle), LocalizationUtils.getString(dialogType.messageText), moreInfoURL, dialogType,
+                    false, null, true,
+                    null, null);
         }
     }
 
@@ -155,8 +173,10 @@ public final class Dialogs {
 
         if (OneTimeDialogs.showDialog(dialogType)) {
             OneTimeDialogs.setStatus(dialogType, OneTimeDialogs.DialogStatus.DIALOG_HIDE, OneTimeDialogs.DialogStatus.DIALOG_SHOW);
-            internalOneTimeMessage(context, LocalizationUtils.getString(dialogType.messageTitle), LocalizationUtils.getString(dialogType.messageText), dialogType.moreInfoURLResId > 0 ? LocalizationUtils.getString(dialogType.moreInfoURLResId) : null, dialogType,
-                    Observable.just(Objects.requireNonNull(ResourcesCompat.getDrawable(context.getResources(), R.drawable.ic_info_blue, context.getTheme()))), true, runOnOk, false);
+            final String moreInfoURL = dialogType.moreInfoURLResId > 0 ? LocalizationUtils.getString(dialogType.moreInfoURLResId) : null;
+
+            internalOneTimeMessage(context, LocalizationUtils.getString(dialogType.messageTitle), LocalizationUtils.getString(dialogType.messageText), moreInfoURL, dialogType,
+                    true, runOnOk, false, null, null);
         }
     }
 
@@ -167,11 +187,50 @@ public final class Dialogs {
      *
      * @param dialogType used for storing the dialog status in the DB, title and message defined in the dialogType are ignored
      */
-    public static void advancedOneTimeMessage(final Context context, final OneTimeDialogs.DialogType dialogType, final String title, final String message, final String moreInfoURL, final boolean cancellable, @Nullable final Observable<Drawable> iconObservable, @Nullable final Runnable runAfterwards) {
+    public static void advancedOneTimeMessage(final Context context, final OneTimeDialogs.DialogType dialogType, final String title, final String message,
+                                              final boolean cancellable, @Nullable final Runnable runAfterwards) {
         if (OneTimeDialogs.showDialog(dialogType)) {
-            internalOneTimeMessage(context, title, message, moreInfoURL, dialogType, iconObservable, cancellable, runAfterwards, true);
+            final String moreInfoURL = dialogType.moreInfoURLResId > 0 ? LocalizationUtils.getString(dialogType.moreInfoURLResId) : null;
+            internalOneTimeMessage(context, title, message, moreInfoURL, dialogType, cancellable, runAfterwards, true,
+                    null, null);
         } else if (runAfterwards != null) {
             runAfterwards.run();
+        }
+    }
+
+    /**
+     * OK / neutral / cancel dialog which is shown, until "don't ask again" is checked. Title, text, icon and actions can be set.
+     * If "don't ask again" was selected previously, the stored chosen action is executed directly without showing the dialog.
+     *
+     * @param dialogType         used for storing the dialog status and chosen action in the DB
+     * @param onPositive         runnable executed when OK is clicked (or was previously chosen with "don't ask again")
+     * @param neutralButtonLabel label for the neutral button; if null, no neutral button is shown
+     * @param onNeutral          runnable executed when neutral button is clicked (or was previously chosen with "don't ask again")
+     */
+    public static void advancedOneTimeMessage(final Context context, final OneTimeDialogs.DialogType dialogType, final String title, final String message,
+                                              final boolean cancellable, @Nullable final Runnable onPositive,
+                                              @Nullable final String neutralButtonLabel, @Nullable final Runnable onNeutral) {
+        if (OneTimeDialogs.showDialog(dialogType)) {
+            final String moreInfoURL = dialogType.moreInfoURLResId > 0 ? LocalizationUtils.getString(dialogType.moreInfoURLResId) : null;
+            internalOneTimeMessage(context, title, message, moreInfoURL, dialogType, cancellable, onPositive, true, neutralButtonLabel, onNeutral);
+        } else {
+            final OneTimeDialogs.ChosenAction chosenAction = OneTimeDialogs.getChosenAction(dialogType, OneTimeDialogs.ChosenAction.OK);
+            switch (chosenAction) {
+                case OK:
+                    if (onPositive != null) {
+                        onPositive.run();
+                    }
+                    break;
+                case NEUTRAL:
+                    if (onNeutral != null) {
+                        onNeutral.run();
+                    }
+                    break;
+                case CANCEL:
+                default:
+                    // do nothing
+                    break;
+            }
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/AbstractMapFragment.java
@@ -243,7 +243,7 @@ public abstract class AbstractMapFragment extends Fragment {
             setBearing(0.0f);
             repaintRotationIndicator(0.0f);
             if (isRotated && (Settings.getMapRotation() == Settings.MAPROTATION_AUTO_LOWPOWER || Settings.getMapRotation() == Settings.MAPROTATION_AUTO_PRECISE)) {
-                Dialogs.advancedOneTimeMessage(getActivity(), MAP_AUTOROTATION_DISABLE, LocalizationUtils.getString(MAP_AUTOROTATION_DISABLE.messageTitle), LocalizationUtils.getString(MAP_AUTOROTATION_DISABLE.messageText), "", true, null, () -> Settings.setMapRotation(Settings.MAPROTATION_MANUAL));
+                Dialogs.advancedOneTimeMessage(getActivity(), MAP_AUTOROTATION_DISABLE, LocalizationUtils.getString(MAP_AUTOROTATION_DISABLE.messageTitle), LocalizationUtils.getString(MAP_AUTOROTATION_DISABLE.messageText), true, () -> Settings.setMapRotation(Settings.MAPROTATION_MANUAL));
             }
         });
         compassrose.setOnLongClickListener(v -> {

--- a/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/BackupUtils.java
@@ -373,7 +373,7 @@ public class BackupUtils {
                 removeDirs(dirs);
                 backupInternal(runAfterwards, true);
             } else {
-                Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, LocalizationUtils.getString(R.string.init_backup_backup), LocalizationUtils.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs.get(dirs.size() - 1).dirLocation)), null, true, null, () -> {
+                Dialogs.advancedOneTimeMessage(activityContext, OneTimeDialogs.DialogType.DATABASE_CONFIRM_OVERWRITE, LocalizationUtils.getString(R.string.init_backup_backup), LocalizationUtils.getString(R.string.backup_confirm_overwrite, getBackupDateTime(dirs.get(dirs.size() - 1).dirLocation)), true, () -> {
                     removeDirs(dirs);
                     backupInternal(runAfterwards, false);
                 });

--- a/main/src/main/java/cgeo/geocaching/utils/LocalizationUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/LocalizationUtils.java
@@ -134,16 +134,20 @@ public final class LocalizationUtils {
         }
     }
 
-    public static String getPlural(@PluralsRes final int pluralId, final int quantity) {
-        return getPluralWithFallback(pluralId, quantity, "thing(s)");
+    public static String getPlural(@PluralsRes final int pluralId, final int quantity, final Object... params) {
+        return getPluralWithFallback(pluralId, quantity, "thing(s)", params);
     }
 
-    public static String getPluralWithFallback(@PluralsRes final int pluralId, final int quantity, final String fallback) {
+    public static String getPluralWithFallback(@PluralsRes final int pluralId, final int quantity, final String fallback, final Object... params) {
         final Context localizationContext = getLocalizationContext();
         if (localizationContext == null) {
             return quantity + " " + fallback;
         }
-        return localizationContext.getResources().getQuantityString(pluralId, quantity, quantity);
+        if (params != null && params.length > 0) {
+            return localizationContext.getResources().getQuantityString(pluralId, quantity, params);
+        } else {
+            return localizationContext.getResources().getQuantityString(pluralId, quantity, quantity);
+        }
     }
 
     public static String getQuantityString(@PluralsRes final int resourceId, final int quantity, final Object... params) {

--- a/main/src/main/res/layout/dialog_text_checkbox.xml
+++ b/main/src/main/res/layout/dialog_text_checkbox.xml
@@ -29,4 +29,12 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="-5dp"
         android:text="@string/dont_show_again" />
+
+    <Button
+        android:id="@+id/footer_message"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:visibility="gone" />
 </LinearLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -516,7 +516,6 @@
     <string name="caches_remove_selected">Remove selected from list</string>
     <string name="caches_remove_all_completely">Delete all from device</string>
     <string name="caches_remove_selected_completely">Delete selected from device</string>
-    <string name="caches_remove_completely_ask">Ask before deleting user data</string>
     <string name="caches_remove_from_other_lists_selected">Remove selected from other lists</string>
     <string name="caches_remove_from_other_lists_all">Remove all from other lists</string>
     <string name="caches_append_to_route_selected">Append selected to individual route</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -553,6 +553,7 @@
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
     <string name="caches_overwrite_offline_log">Overwrite offline log</string>
     <string name="caches_overwrite_offline_log_question">Cache has existing offline log of type "%1$s" with a log text. Do you want to overwrite this log?</string>
+    <string name="caches_warning_delete_all_caches">This will remove all caches from your device. Do you want to proceed?</string>
     <string name="caches_show_attributes_all">Show attribute overview for all caches</string>
     <string name="caches_show_attributes_selected">Show attribute overview for selected caches</string>
     <string name="caches_set_cache_icon">Set cache icon</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -553,14 +553,9 @@
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
     <string name="caches_overwrite_offline_log">Overwrite offline log</string>
     <string name="caches_overwrite_offline_log_question">Cache has existing offline log of type "%1$s" with a log text. Do you want to overwrite this log?</string>
-    <plurals name="caches_warning_delete_offline_log">
-        <item quantity="one">%d cache has an offline log. This will get lost on deleting the cache.</item>
-        <item quantity="two">%d caches have an offline log. Those will get lost on deleting the caches.</item>
-        <item quantity="few">%d caches have an offline log. Those will get lost on deleting the caches.</item>
-        <item quantity="many">%d caches have an offline log. Those will get lost on deleting the caches.</item>
-        <item quantity="other">%d caches have an offline log. Those will get lost on deleting the caches.</item>
-    </plurals>
-    <string name="caches_warning_delete_all_caches">This will remove all caches from your device. Do you want to proceed?</string>
+    <string name="caches_warning_delete_user_data_others">Delete others</string>
+    <string name="caches_warning_delete_user_data">%d caches have user data. Those will get lost on deleting the caches.</string>
+    <string name="caches_warning_delete_all_caches">This action will delete all caches (%d) from your device.</string>
     <string name="caches_show_attributes_all">Show attribute overview for all caches</string>
     <string name="caches_show_attributes_selected">Show attribute overview for selected caches</string>
     <string name="caches_set_cache_icon">Set cache icon</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -516,6 +516,7 @@
     <string name="caches_remove_selected">Remove selected from list</string>
     <string name="caches_remove_all_completely">Delete all from device</string>
     <string name="caches_remove_selected_completely">Delete selected from device</string>
+    <string name="caches_remove_completely_ask">Ask before deleting user data</string>
     <string name="caches_remove_from_other_lists_selected">Remove selected from other lists</string>
     <string name="caches_remove_from_other_lists_all">Remove all from other lists</string>
     <string name="caches_append_to_route_selected">Append selected to individual route</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -554,8 +554,17 @@
     <string name="caches_overwrite_offline_log">Overwrite offline log</string>
     <string name="caches_overwrite_offline_log_question">Cache has existing offline log of type "%1$s" with a log text. Do you want to overwrite this log?</string>
     <string name="caches_warning_delete_user_data_others">Delete others</string>
-    <string name="caches_warning_delete_user_data">%d caches have user data. Those will get lost on deleting the caches.</string>
+    <plurals name="caches_warning_delete_user_data">
+        <item quantity="zero">No caches have user data. All caches can be removed safely.</item>
+        <item quantity="one">%d cache has user data. The user data will get lost on deleting the cache.</item>
+        <item quantity="two">%d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="few">%d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="many">%d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="other">%d caches have user data. The user data will get lost on deleting the caches.</item>
+    </plurals>
     <string name="caches_warning_delete_all_caches">This action will delete all caches (%d) from your device.</string>
+    <string name="caches_warning_remove_from_list_user_data_others">Remove others</string>
+    <string name="caches_warning_remove_caches_from_single_list">%1$d/%2$d caches are only on this list. Removing those caches from the list will delete them from your device.</string>
     <string name="caches_show_attributes_all">Show attribute overview for all caches</string>
     <string name="caches_show_attributes_selected">Show attribute overview for selected caches</string>
     <string name="caches_set_cache_icon">Set cache icon</string>
@@ -2650,6 +2659,15 @@
     <string name="do_not_ask_me_again">Do not ask me again</string>
     <string name="geokrety_parsing_failed">Failed to parse GeoKrety response.</string>
 
+    <string name="command_remove_caches_from_list_progress">Removing caches</string>
+    <plurals name="command_remove_caches_result">
+        <item quantity="zero">Removed %d caches</item>
+        <item quantity="one">Removed %d cache</item>
+        <item quantity="two">Removed %d caches</item>
+        <item quantity="few">Removed %d caches</item>
+        <item quantity="many">Removed %d caches</item>
+        <item quantity="other">Removed %d caches</item>
+    </plurals>
     <string name="command_move_caches_progress">Moving caches to list %1s</string>
     <plurals name="command_move_caches_result">
         <item quantity="zero">Moved %d caches</item>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -556,11 +556,11 @@
     <string name="caches_warning_delete_user_data_others">Delete others</string>
     <plurals name="caches_warning_delete_user_data">
         <item quantity="zero">No caches have user data. All caches can be removed safely.</item>
-        <item quantity="one">%d cache has user data. The user data will get lost on deleting the cache.</item>
-        <item quantity="two">%d caches have user data. The user data will get lost on deleting the caches.</item>
-        <item quantity="few">%d caches have user data. The user data will get lost on deleting the caches.</item>
-        <item quantity="many">%d caches have user data. The user data will get lost on deleting the caches.</item>
-        <item quantity="other">%d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="one">%1$d/%2$d cache has user data. The user data will get lost on deleting the cache.</item>
+        <item quantity="two">%1$d/%2$d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="few">%1$d/%2$d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="many">%1$d/%2$d caches have user data. The user data will get lost on deleting the caches.</item>
+        <item quantity="other">%1$d/%2$d caches have user data. The user data will get lost on deleting the caches.</item>
     </plurals>
     <string name="caches_warning_delete_all_caches">This action will delete all caches (%d) from your device.</string>
     <string name="caches_warning_remove_from_list_user_data_others">Remove others</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -553,6 +553,13 @@
     <string name="caches_clear_offlinelogs_progress">Clearing offline logs</string>
     <string name="caches_overwrite_offline_log">Overwrite offline log</string>
     <string name="caches_overwrite_offline_log_question">Cache has existing offline log of type "%1$s" with a log text. Do you want to overwrite this log?</string>
+    <plurals name="caches_warning_delete_offline_log">
+        <item quantity="one">%d cache has an offline log. This will get lost on deleting the cache.</item>
+        <item quantity="two">%d caches have an offline log. Those will get lost on deleting the caches.</item>
+        <item quantity="few">%d caches have an offline log. Those will get lost on deleting the caches.</item>
+        <item quantity="many">%d caches have an offline log. Those will get lost on deleting the caches.</item>
+        <item quantity="other">%d caches have an offline log. Those will get lost on deleting the caches.</item>
+    </plurals>
     <string name="caches_warning_delete_all_caches">This will remove all caches from your device. Do you want to proceed?</string>
     <string name="caches_show_attributes_all">Show attribute overview for all caches</string>
     <string name="caches_show_attributes_selected">Show attribute overview for selected caches</string>


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
While deleting caches from device (not from list):
* Show confirmation, if ALL caches (really all stored caches) are getting deleted
* Show confirmation if at least one cache has an offline log
* Show snackbar for undo 
* Undo restores the offline log and the visited date


## Related issues
<!-- List the related issues fixed or improved by this PR -->
fix #7936
fix #16062
fix #16788
fix #17965

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

To discuss, if the confirmation dialogs are necessary, if an undo is available.
I prefer to have them, because sometimes one is not aware of the offline log / all caches get deleted

<img height="200" alt="grafik" src="https://github.com/user-attachments/assets/a35c10d9-baee-4bd8-ba3e-1efd9414cd36" />

<img  height="200" alt="grafik" src="https://github.com/user-attachments/assets/45f634fa-b18e-4c43-a901-7135598c7811" />

Check for "Removing from list" as well  (#17965):
<img width="271" height="188" alt="grafik" src="https://github.com/user-attachments/assets/6aa9a405-08f6-44c5-89bd-6619abe8df5b" />





