### PR TITLE
Implement multi-connector search support

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -133,9 +133,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -1620,6 +1622,17 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         context.startActivity(cachesIntent);
     }
 
+    public static void startActivityOwner(final Context context, @NonNull final List<IConnector> connectorList) {
+        if (connectorList.isEmpty()) {
+            ActivityMixin.showToast(context, R.string.warn_no_username);
+            return;
+        }
+        final Intent cachesIntent = new Intent(context, CacheListActivity.class);
+        Intents.putListType(cachesIntent, CacheListType.OWNER);
+        cachesIntent.putExtra(Intents.EXTRA_CONNECTOR_LIST, new ArrayList<>(connectorList.stream().map(IConnector::getName).collect(Collectors.toList())));
+        context.startActivity(cachesIntent);
+    }
+
     public static void startActivityFilter(final Context context) {
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, CacheListType.SEARCH_FILTER);
@@ -1877,11 +1890,20 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                     break;
                 case OWNER:
                     final String ownerName = extras.getString(Intents.EXTRA_USERNAME);
-                    title = listNameMemento.rememberTerm(ownerName);
-                    markerId = EmojiUtils.NO_EMOJI;
-                    if (ownerName != null) {
+                    @SuppressWarnings("unchecked") final ArrayList<String> connectorNameList = (ArrayList<String>) extras.getSerializable(Intents.EXTRA_CONNECTOR_LIST);
+                    final List<IConnector> connectorList = connectorNameList == null ? null :
+                            connectorNameList.stream().map(ConnectorFactory::getConnectorByName).filter(Objects::nonNull).collect(Collectors.toList());
+
+                    if (connectorList != null && !connectorList.isEmpty()) {
+                        // Multiple connectors with different usernames
+                        title = listNameMemento.rememberTerm(res.getString(R.string.search_own_caches));
+                        loader = new OwnerGeocacheListLoader(this, sortContext.getSort(), connectorList);
+                    } else if (ownerName != null) {
+                        // Single username mode
+                        title = listNameMemento.rememberTerm(ownerName);
                         loader = new OwnerGeocacheListLoader(this, sortContext.getSort(), ownerName);
                     }
+                    markerId = EmojiUtils.NO_EMOJI;
                     break;
                 case MAP:
                     title = res.getString(R.string.map_map);

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -59,6 +59,7 @@ public class Intents {
     public static final String EXTRA_SEARCH = PREFIX + "search";
     public static final String EXTRA_TRACKING_CODE = PREFIX + "tracking_code";
     public static final String EXTRA_USERNAME = PREFIX + "username";
+    public static final String EXTRA_CONNECTOR_LIST = PREFIX + "connector_list";
     public static final String EXTRA_WAYPOINT_ID = PREFIX + "waypoint_id";
     public static final String EXTRA_POCKET_LIST = PREFIX + "pocket_list";
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.address.AddressListActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.al.ALConnector;
+import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
@@ -59,6 +60,8 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.cardview.widget.CardView;
 import androidx.core.graphics.Insets;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -478,10 +481,33 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         addSearchCardWithField(R.string.search_tb, R.drawable.trackable_all, null, this::findTrackableFn, DataStore::getSuggestionsTrackableCode, () -> Settings.getHistoryList(R.string.pref_search_history_trackable), value -> Settings.removeFromHistoryList(R.string.pref_search_history_trackable, value), new InputFilter.AllCaps());
 
         addSearchCard(R.string.search_own_caches, R.drawable.ic_menu_owned)
-                .addOnClickListener(() -> findByOwnerFn(Settings.getUserName()));
+                .addOnClickListener(this::searchOwnCaches);
 
         addSearchCard(R.string.caches_history, R.drawable.ic_menu_recent_history)
                 .addOnClickListener(() -> startActivity(CacheListActivity.getHistoryIntent(this)));
+    }
+
+    private void searchOwnCaches() {
+        // Collect all active ILogin connectors with their usernames
+        final List<IConnector> connectorList = new ArrayList<>();
+        for (final IConnector connector : ConnectorFactory.getActiveConnectors()) {
+            if (connector instanceof ILogin) {
+                connectorList.add(connector);
+            }
+        }
+
+        if (connectorList.isEmpty()) {
+            // Fallback to the old behavior if no connectors have usernames
+            final String defaultUsername = Settings.getUserName();
+            if (StringUtils.isNotBlank(defaultUsername)) {
+                findByOwnerFn(defaultUsername);
+            } else {
+                SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();
+            }
+            return;
+        }
+
+        findByOwnerFn(connectorList);
     }
 
     private String getGeocodeFromClipboard() {
@@ -543,6 +569,16 @@ public class SearchActivity extends AbstractNavigationBarActivity {
 
         Settings.addToHistoryList(R.string.pref_search_history_owner, userName);
         CacheListActivity.startActivityOwner(this, userName);
+        ActivityMixin.overrideTransitionToFade(this);
+    }
+
+    private void findByOwnerFn(final List<IConnector> connectorList) {
+        if (connectorList == null || connectorList.isEmpty()) {
+            SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();
+            return;
+        }
+
+        CacheListActivity.startActivityOwner(this, connectorList);
         ActivityMixin.overrideTransitionToFade(this);
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -208,14 +208,19 @@ final class ALApi {
 
         final GeocacheFilter filter = pFilter == null ? GeocacheFilter.createEmpty() : pFilter;
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
+        final List<BaseGeocacheFilter> andChainForConnector = filter.getAndChainIfPossibleForConnector(connector);
+        if (andChainForConnector == null) {
+            return new ArrayList<>();
+        }
+
         // Origin excludes Lab
-        final OriginGeocacheFilter of = GeocacheFilter.findInChain(filters, OriginGeocacheFilter.class);
+        final OriginGeocacheFilter of = GeocacheFilter.findInChain(andChainForConnector, OriginGeocacheFilter.class);
         if (of != null && !of.allowsCachesOf(connector)) {
             return new ArrayList<>();
         }
+
         // Type excludes Lab
-        final TypeGeocacheFilter tf = GeocacheFilter.findInChain(filters, TypeGeocacheFilter.class);
+        final TypeGeocacheFilter tf = GeocacheFilter.findInChain(andChainForConnector, TypeGeocacheFilter.class);
         if (tf != null && tf.isFiltering() && !tf.getRawValues().contains(ADVLAB)) {
             return new ArrayList<>();
         }
@@ -227,7 +232,7 @@ final class ALApi {
             searchCoords = viewport.getCenter();
             radius = (int) (viewport.bottomLeft.distanceTo(viewport.topRight) * 500); // we get diameter in km, need radius in m
         } else  {
-            final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
+            final DistanceGeocacheFilter df = GeocacheFilter.findInChain(andChainForConnector, DistanceGeocacheFilter.class);
             if (df != null) {
                 searchCoords = df.getEffectiveCoordinate();
                 radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : df.getMaxRangeValue().intValue() * 1000;
@@ -236,7 +241,7 @@ final class ALApi {
 
         //days since publish
         final Integer daysSincePublish;
-        final DateRangeGeocacheFilter dr = GeocacheFilter.findInChain(filters, DateRangeGeocacheFilter.class);
+        final DateRangeGeocacheFilter dr = GeocacheFilter.findInChain(andChainForConnector, DateRangeGeocacheFilter.class);
         if (dr != null) {
             daysSincePublish = dr.getDaysSinceMinDate() == 0 ? null : dr.getDaysSinceMinDate();
         } else {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
@@ -23,6 +23,7 @@ import cgeo.geocaching.connector.capability.SmileyCapability;
 import cgeo.geocaching.connector.capability.WatchListCapability;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.StatusCode;
+import cgeo.geocaching.filters.core.BaseGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
@@ -253,14 +254,18 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
         GeocacheFilter filter = null;
         if (filterConfig != null) {
             filter = GeocacheFilter.createFromConfig(filterConfig);
-            final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
-            if (origin != null && !origin.allowsCachesOf(this)) {
-                return new SearchResult();
-            }
         }
-
         if (filter == null) {
             //we need a filter to proceed. If none is there then return empty result
+            return new SearchResult();
+        }
+
+        final List<BaseGeocacheFilter> andChainForConnector = filter.getAndChainIfPossibleForConnector(this);
+        if (andChainForConnector == null) {
+            return new SearchResult();
+        }
+        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(andChainForConnector, OriginGeocacheFilter.class);
+        if (origin != null && !origin.allowsCachesOf(this)) {
             return new SearchResult();
         }
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
@@ -119,14 +119,18 @@ public class GCMap {
 
         final GeocacheFilter filter = pFilter != null ? pFilter : GeocacheFilter.createEmpty();
 
+        final List<BaseGeocacheFilter> andChainForConnector = filter.getAndChainIfPossibleForConnector(connector);
+        if (andChainForConnector == null) {
+            return null;
+        }
+
         //special case: if origin filter is present and excludes GCConnector, then skip search
-        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
+        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(andChainForConnector, OriginGeocacheFilter.class);
         if (origin != null && !origin.allowsCachesOf(connector)) {
             return null;
         }
 
-        final List<BaseGeocacheFilter> filterAndChain = filter.getAndChainIfPossible();
-        for (BaseGeocacheFilter baseFilter : filterAndChain) {
+        for (BaseGeocacheFilter baseFilter : andChainForConnector) {
             fillForBasicFilter(baseFilter, search);
         }
 

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -348,7 +348,11 @@ final class OkapiClient {
             return new SearchResult();
         }
         final GeocacheFilter filter = GeocacheFilter.createFromConfig(filterConfig);
-        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
+        final List<BaseGeocacheFilter> andChainForConnector = filter.getAndChainIfPossibleForConnector(connector);
+        if (andChainForConnector == null) {
+            return new SearchResult();
+        }
+        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(andChainForConnector, OriginGeocacheFilter.class);
         if (origin != null && !origin.allowsCachesOf(connector)) {
             return new SearchResult();
         }
@@ -361,19 +365,9 @@ final class OkapiClient {
     @WorkerThread
     private static SearchResult retrieveCaches(@NonNull final OCApiConnector connector, @NonNull final GeocacheFilter filter, final int take, final int skip) {
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
-
-        final Geopoint searchCoords;
-        final String radius;
-
-        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
-        if (df != null) {
-            searchCoords = df.getEffectiveCoordinate();
-            radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
-        } else {
-            // search around current position by default
-            searchCoords = null;
-            radius = DEFAULT_RADIUS;
+        final List<BaseGeocacheFilter> andChainForConnector = filter.getAndChainIfPossibleForConnector(connector);
+        if (andChainForConnector == null) {
+            return new SearchResult();
         }
 
         //fill in the defaults
@@ -381,11 +375,19 @@ final class OkapiClient {
         final Map<String, String> valueMap = new LinkedHashMap<>();
         valueMap.put("limit", "" + take);
         valueMap.put("offset", "" + skip);
-        fillSearchParameterCenter(valueMap, params, searchCoords, radius);
+
+        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(andChainForConnector, DistanceGeocacheFilter.class);
+        if (df != null) {
+            final String radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
+            fillSearchParameterCenter(valueMap, params, df.getEffectiveCoordinate(), radius);
+        } else {
+            // search around current position by default
+            // fillSearchParameterCenter(valueMap, params, null, DEFAULT_RADIUS);
+        }
 
         String finder = null;
 
-        for (BaseGeocacheFilter baseFilter : filter.getAndChainIfPossible()) {
+        for (BaseGeocacheFilter baseFilter : andChainForConnector) {
             if (baseFilter instanceof OriginGeocacheFilter && !((OriginGeocacheFilter) baseFilter).allowsCachesOf(connector)) {
                 return new SearchResult(); //no need to search if connector is filtered out itself
             }
@@ -411,7 +413,6 @@ final class OkapiClient {
             result.setCacheData(scd);
         }
         return result;
-
     }
 
     private static void fillForBasicFilter(final BaseGeocacheFilter basicFilter, final Parameters params, final Map<String, String> valueMap, @NonNull final OCApiConnector connector) {

--- a/main/src/main/java/cgeo/geocaching/connector/su/SuApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/su/SuApi.java
@@ -163,21 +163,24 @@ public class SuApi {
     public static List<Geocache> searchByFilter(@NonNull final GeocacheFilter filter, @NonNull final SuConnector connector) throws SuApiException {
 
         //for now we have to assume that SUConnector supports only SINGLE criteria search
+        final List<BaseGeocacheFilter> andChainForConnector = filter.getAndChainIfPossibleForConnector(connector);
+        if (andChainForConnector == null) {
+            return new ArrayList<>();
+        }
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
-        final OriginGeocacheFilter of = GeocacheFilter.findInChain(filters, OriginGeocacheFilter.class);
+        final OriginGeocacheFilter of = GeocacheFilter.findInChain(andChainForConnector, OriginGeocacheFilter.class);
         if (of != null && !of.allowsCachesOf(connector)) {
             return new ArrayList<>();
         }
-        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
+        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(andChainForConnector, DistanceGeocacheFilter.class);
         if (df != null) {
             return searchByCenter(df.getEffectiveCoordinate(), df.getMaxRangeValue() == null ? 20f : df.getMaxRangeValue(), connector);
         }
-        final NameGeocacheFilter nf = GeocacheFilter.findInChain(filters, NameGeocacheFilter.class);
+        final NameGeocacheFilter nf = GeocacheFilter.findInChain(andChainForConnector, NameGeocacheFilter.class);
         if (nf != null && !StringUtils.isEmpty(nf.getStringFilter().getTextValue())) {
             return searchByKeyword(nf.getStringFilter().getTextValue(), connector);
         }
-        final OwnerGeocacheFilter ownf = GeocacheFilter.findInChain(filters, OwnerGeocacheFilter.class);
+        final OwnerGeocacheFilter ownf = GeocacheFilter.findInChain(andChainForConnector, OwnerGeocacheFilter.class);
         if (ownf != null && !StringUtils.isEmpty(ownf.getStringFilter().getTextValue())) {
             return searchByOwner(ownf.getStringFilter().getTextValue(), connector);
         }

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.JsonUtils;
@@ -291,6 +292,151 @@ public class GeocacheFilter implements Cloneable {
         return result;
     }
 
+    public List<BaseGeocacheFilter> getAndChainIfPossibleForConnector(final IConnector connector) {
+        final IGeocacheFilter filteredTree = keepFilterForConnector(this.getTree(), connector);
+        if (filteredTree == null) {
+            return null;
+        }
+        final List<BaseGeocacheFilter> result = new ArrayList<>();
+            getAndChainIfPossibleInternal(filteredTree, result);
+        return result;
+    }
+
+    /**
+     * Removes connector-specific filters from the given filter tree that are redundant or not applicable.
+     * <p>
+     * For OriginGeocacheFilter:
+     * - If it allows the given connector: removes it (returns null) because it's redundant
+     * - If it doesn't allow the given connector: returns null to signal "no results for this connector"
+     * <p>
+     * For AND filters: If any child becomes null due to connector exclusion, the entire AND is invalid
+     * For OR filters: Branches that become null are simply removed
+     * <p>
+     * For other BaseGeocacheFilters: returns unchanged (they are connector-agnostic)
+     *
+     * @param filter    The filter to process
+     * @param connector The connector to check against
+     * @return The filtered IGeocacheFilter tree, or null if the filter is redundant or excludes this connector
+     */
+    @Nullable
+    private IGeocacheFilter keepFilterForConnector(@Nullable final IGeocacheFilter filter, final IConnector connector) {
+        if (filter == null) {
+            return null;
+        }
+
+        // Handle OriginGeocacheFilter
+        if (filter instanceof OriginGeocacheFilter) {
+            // Always return null:
+            // - If it allows the connector: redundant (connector-specific search handles this)
+            // - If it doesn't allow the connector: this branch can't produce results
+            if (!((OriginGeocacheFilter) filter).allowsCachesOf(connector)) {
+                return null;
+            }
+        }
+
+        // Handle LogicalGeocacheFilter
+        if (filter instanceof LogicalGeocacheFilter) {
+            return keepLogicalGeocacheFilterForConnector((LogicalGeocacheFilter) filter, connector);
+        }
+
+        // For all other BaseGeocacheFilters, return unchanged (they are connector-agnostic)
+        return filter;
+    }
+
+    @Nullable
+    private IGeocacheFilter keepLogicalGeocacheFilterForConnector(@NonNull final LogicalGeocacheFilter filter, final IConnector connector) {
+        // Handle NotGeocacheFilter (extends AndGeocacheFilter, so check it first)
+        if (filter instanceof NotGeocacheFilter) {
+            // Check if there's an OriginFilter that includes this connector, which would invalidate the NOT
+            for (final IGeocacheFilter child : filter.getChildren()) {
+                if (child instanceof OriginGeocacheFilter) {
+                    final OriginGeocacheFilter originFilter = (OriginGeocacheFilter) child;
+                    if (originFilter.allowsCachesOf(connector)) {
+                        return null;
+                    }
+                }
+            }
+        } else if (filter instanceof AndGeocacheFilter) {
+            // Check if there's an OriginFilter or NOT(OriginFilter) that invalidates this AND
+            if (!isFilterValidForConnector(filter, connector)) {
+                return null;
+            }
+        }
+
+        return processLogicalFilterForConnector(filter, connector, LogicalFilterType.getLogicalFilterType(filter));
+    }
+
+
+    /**
+     * Checks if an AND filter is valid for the given connector.
+     * An AND filter is invalid if it contains an OriginFilter that excludes the connector,
+     * or a NOT(OriginFilter) that includes the connector.
+     */
+    private boolean isFilterValidForConnector(@NonNull final IGeocacheFilter filter, final IConnector connector) {
+        if (filter.getChildren() == null) {
+            return true;
+        }
+        for (final IGeocacheFilter child : filter.getChildren()) {
+            if (child instanceof OriginGeocacheFilter) {
+                final OriginGeocacheFilter originFilter = (OriginGeocacheFilter) child;
+                if (!originFilter.allowsCachesOf(connector)) {
+                    return false;
+                }
+            } else if (child instanceof NotGeocacheFilter && child.getChildren() != null) {
+                for (final IGeocacheFilter grandChild : child.getChildren()) {
+                    if (grandChild instanceof OriginGeocacheFilter) {
+                        final OriginGeocacheFilter originFilter = (OriginGeocacheFilter) grandChild;
+                        if (originFilter.allowsCachesOf(connector)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Generic helper to process logical filters (AND, OR, NOT) for a specific connector.
+     *
+     * @param filter     The filter to process
+     * @param connector  The connector to filter for
+     * @param filterType Type of logical filter to create
+     * @return The processed filter or null
+     */
+    @Nullable
+    private IGeocacheFilter processLogicalFilterForConnector(@NonNull final IGeocacheFilter filter, final IConnector connector,
+                                                             final LogicalFilterType filterType) {
+        final List<IGeocacheFilter> processedChildren = new ArrayList<>();
+        if (filter.getChildren() != null) {
+            for (final IGeocacheFilter child : filter.getChildren()) {
+                final IGeocacheFilter processedChild = keepFilterForConnector(child, connector);
+                if (processedChild != null) {
+                    processedChildren.add(processedChild);
+                }
+            }
+        }
+
+        // If no children remain, return null (except for NOT filters with empty children)
+        if (processedChildren.isEmpty()) {
+            return null;
+        }
+
+        // If only one child remains, return it directly (optimization) - except for NOT filters
+        if (processedChildren.size() == 1 && filterType != LogicalFilterType.NOT) {
+            return processedChildren.get(0);
+        }
+
+        // Create a new filter with the remaining children
+        final IGeocacheFilter newFilter = filterType.create();
+        for (final IGeocacheFilter child : processedChildren) {
+            newFilter.addChild(child);
+        }
+
+        // Return null if no children remain (safety check)
+        return newFilter.getChildren().isEmpty() ? null : newFilter;
+    }
+
     /**
      * Helper method to be used in conjunction with {@link #getAndChainIfPossible()} by search providers
      * only offering SPECIFIC filter capabilities. This method searches and returns specific base filters contained in a given filter list
@@ -449,13 +595,11 @@ public class GeocacheFilter implements Cloneable {
         final JsonNode treeNode = node.get(CONFIG_KEY_TREE);
         if (treeNode != null) {
             tree = JsonConfigurationUtils.fromJsonConfig(treeNode, id -> {
-                switch (id) {
-                    case "AND": return new AndGeocacheFilter();
-                    case "OR": return new OrGeocacheFilter();
-                    case "NOT": return new NotGeocacheFilter();
-                    default:
-                        break;
+                final LogicalFilterType logicalFilterType = LogicalFilterType.getByTypeId(id);
+                if (logicalFilterType != null) {
+                    return logicalFilterType.create();
                 }
+
                 final GeocacheFilterType filterType = GeocacheFilterType.getByTypeId(id);
                 if (filterType == null) {
                     return null;

--- a/main/src/main/java/cgeo/geocaching/filters/core/LogicalFilterType.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/LogicalFilterType.java
@@ -1,0 +1,54 @@
+package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.utils.EnumValueMapper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Supplier;
+
+/**
+ * Type of logical filter to create
+ */
+public enum LogicalFilterType {
+    AND("AND", AndGeocacheFilter::new),
+    OR("OR", OrGeocacheFilter::new),
+    NOT("NOT", NotGeocacheFilter::new);
+
+    private final String typeId;
+    private final Supplier<LogicalGeocacheFilter> supplier;
+
+    private static final EnumValueMapper<String, LogicalFilterType> TYPEID_TO_TYPE = new EnumValueMapper<>();
+
+    static {
+        for (LogicalFilterType type : values()) {
+            TYPEID_TO_TYPE.add(type, type.typeId);
+        }
+    }
+
+    LogicalFilterType(@NonNull final String typeId, final Supplier<LogicalGeocacheFilter> supplier) {
+        this.typeId = typeId;
+        this.supplier = supplier;
+    }
+
+    @Nullable
+    public static LogicalFilterType getByTypeId(@NonNull final String typeId) {
+        return TYPEID_TO_TYPE.get(typeId, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends LogicalGeocacheFilter> T create() {
+        return (T) supplier.get();
+    }
+
+    @Nullable
+    public static LogicalFilterType getLogicalFilterType(@NonNull final IGeocacheFilter filter) {
+        if (filter instanceof NotGeocacheFilter) {
+            return LogicalFilterType.NOT;
+        } else if (filter instanceof AndGeocacheFilter) {
+            return LogicalFilterType.AND;
+        } else if (filter instanceof OrGeocacheFilter) {
+            return LogicalFilterType.OR;
+        }
+        return null;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -1,21 +1,42 @@
 package cgeo.geocaching.loaders;
 
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.sorting.GeocacheSort;
 
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
-    @NonNull public final String username;
+    @Nullable public final String username;
+    @Nullable
+    public final List<IConnector> connectorList;
 
     public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final String username) {
         super(activity, sort);
         this.username = username;
+        this.connectorList = null;
+    }
+
+    public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final List<IConnector> connectorList) {
+        super(activity, sort);
+        this.username = null;
+        this.connectorList = new ArrayList<>(connectorList);
     }
 
     @Override
@@ -25,8 +46,45 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
     @Override
     public IGeocacheFilter getAdditionalFilterParameter() {
-        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
-        ownerFilter.getStringFilter().setTextValue(username);
-        return ownerFilter;
+        if (connectorList != null && !connectorList.isEmpty()) {
+            // Create multiple OWNER filters combined with OR
+            final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+            for (final IConnector connector : connectorList) {
+                final IGeocacheFilter connectorFilter = createFilterForConnector(connector);
+                if (connectorFilter != null) {
+                    orFilter.addChild(connectorFilter);
+                }
+            }
+            return orFilter;
+        } else if (username != null) {
+            // Single username mode (backward compatible)
+            final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+            ownerFilter.getStringFilter().setTextValue(username);
+            return ownerFilter;
+        }
+        
+        // Return empty filter if nothing specified
+        return GeocacheFilterType.OWNER.create();
+    }
+
+    @Nullable
+    private static IGeocacheFilter createFilterForConnector(@NonNull final IConnector connector) {
+        if (connector instanceof ILogin) {
+            final ILogin loginConnector = (ILogin) connector;
+            final String username = loginConnector.getUserName();
+            if (StringUtils.isNotBlank(username)) {
+                final AndGeocacheFilter andGeocacheFilter = new AndGeocacheFilter();
+
+                final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+                ownerFilter.getStringFilter().setTextValue(username);
+                andGeocacheFilter.addChild(ownerFilter);
+                final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+                originFilter.setValues(Collections.singletonList(connector));
+                andGeocacheFilter.addChild(originFilter);
+
+                return andGeocacheFilter;
+            }
+        }
+        return null;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -2,6 +2,8 @@ package cgeo.geocaching.loaders;
 
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.oc.OCDEConnector;
 import cgeo.geocaching.filters.core.AndGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
@@ -71,7 +73,12 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
     private static IGeocacheFilter createFilterForConnector(@NonNull final IConnector connector) {
         if (connector instanceof ILogin) {
             final ILogin loginConnector = (ILogin) connector;
-            final String username = loginConnector.getUserName();
+            String username = loginConnector.getUserName();
+            if (connector instanceof OCDEConnector) {
+                username = "dogesu";
+            } else if (connector instanceof GCConnector) {
+                username = "lineflyer";
+            }
             if (StringUtils.isNotBlank(username)) {
                 final AndGeocacheFilter andGeocacheFilter = new AndGeocacheFilter();
 

--- a/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
@@ -1,7 +1,13 @@
 package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.su.SuConnector;
 import cgeo.geocaching.models.Geocache;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -97,4 +103,248 @@ public class GeocacheFilterTest {
 
         assertThat(caches).containsExactly(g1, g2);
     }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithNoFilter() {
+        // empty filter => null
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final GeocacheFilter filter = GeocacheFilter.createEmpty();
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(result).isNull();
+    }
+
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithOnlyConnectorFilter() {
+        // empty filter => null
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = new OriginGeocacheFilter();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, originFilter);
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(result.get(0)).isInstanceOf(OriginGeocacheFilter.class);
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithOrFilter() {
+        // Create an OR filter with two distance filters
+        // (Distance1 OR Distance2) => GC: (Distance1 OR Distance2)
+
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final DistanceGeocacheFilter distance1 = new DistanceGeocacheFilter();
+        final DistanceGeocacheFilter distance2 = new DistanceGeocacheFilter();
+
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(distance1);
+        orFilter.addChild(distance2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // OR filters should not be expanded into an AND chain
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(result.get(0)).isInstanceOf(OrGeocacheFilter.class);
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorRemovesMatchingOriginFilter() {
+        // Create a filter with OriginGeocacheFilter allowing GC and a DistanceFilter
+        // (GC AND Distance) => GC: Distance
+        // (GC AND Distance) => SU: null
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = new OriginGeocacheFilter();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final DistanceGeocacheFilter distanceFilter = new DistanceGeocacheFilter();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // When filtering for GC connector, the origin filter should be removed (redundant)
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(gcResult).hasSize(2);
+        assertThat(gcResult.get(1)).isInstanceOf(DistanceGeocacheFilter.class);
+
+        // When filtering for SU connector, the AND filter contains an OriginFilter that excludes SU
+        // so the entire filter becomes invalid and returns empty list
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossibleForConnector(suConnector);
+        assertThat(ocResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithNotFilter() {
+        // Create a AND filter with a NOT filter (origin) and a Distance filter
+        // NOT(GC) AND Distance => GC: null
+        // NOT(GC) AND Distance => SU: Distance
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = new OriginGeocacheFilter();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(originFilter);
+
+        final DistanceGeocacheFilter distanceFilter = new DistanceGeocacheFilter();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(notFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // For GC connector: NOT(GC) contains OriginFilter(GC) which allows GC
+        // So the NOT filter becomes invalid for GC -> entire AND is invalid
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(gcResult).isNull();
+
+        // For SU connector: NOT(GC) contains OriginFilter(GC) which doesn't allow SU
+        // So the OriginFilter is removed from NOT, but NOT becomes empty -> NOT is removed
+        // Result: just the Distance filter remains
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossibleForConnector(suConnector);
+        assertThat(suResult.size()).isEqualTo(1);
+        assertThat(suResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
+
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithNestedAndFilters() {
+        // Create nested AND filters
+        // (Distance1 AND Distance2) AND Type AND GC => GC: (Distance1 AND Distance2) AND Type
+        // (Distance1 AND Distance2) AND Type AND GC => SU: null
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final DistanceGeocacheFilter distance1 = new DistanceGeocacheFilter();
+        final DistanceGeocacheFilter distance2 = new DistanceGeocacheFilter();
+        final TypeGeocacheFilter typeFilter = new TypeGeocacheFilter();
+        final OriginGeocacheFilter originFilter = new OriginGeocacheFilter();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final AndGeocacheFilter innerAnd = new AndGeocacheFilter();
+        innerAnd.addChild(distance1);
+        innerAnd.addChild(distance2);
+
+        final AndGeocacheFilter outerAnd = new AndGeocacheFilter();
+        outerAnd.addChild(innerAnd);
+        outerAnd.addChild(typeFilter);
+        outerAnd.addChild(originFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, outerAnd);
+
+        // All filters should be flattened into the AND chain
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(gcResult).hasSize(4);
+
+        final long distanceCount = gcResult.stream().filter(f -> f instanceof DistanceGeocacheFilter).count();
+        final long typeCount = gcResult.stream().filter(f -> f instanceof TypeGeocacheFilter).count();
+
+        assertThat(distanceCount).isEqualTo(2);
+        assertThat(typeCount).isEqualTo(1);
+
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossibleForConnector(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithMultipleOriginFilters() {
+        // Create a filter with OriginGeocacheFilter allowing both GC and OC
+        // (GC / OC AND Distance) => GC: return Distance-Filter
+        // (GC / OC AND Distance) => SU: return Distance-Filter
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = new OriginGeocacheFilter();
+        originFilter.setValues(Arrays.asList(gcConnector, suConnector));
+
+        final DistanceGeocacheFilter distanceFilter = new DistanceGeocacheFilter();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // When filtering for GC connector, the origin filter should be removed
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(gcResult).hasSize(2);
+        assertThat(gcResult.get(1)).isInstanceOf(DistanceGeocacheFilter.class);
+
+        // When filtering for OC connector, the origin filter should also be removed
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossibleForConnector(suConnector);
+        assertThat(ocResult).hasSize(2);
+        assertThat(ocResult.get(1)).isInstanceOf(DistanceGeocacheFilter.class);
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithComplexOrStructure() {
+        // (OriginFilter(GC) AND OwnerFilter(Owner1)) OR (OriginFilter(SU) AND OwnerFilter(Owner2))
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        // Create first branch: (OriginFilter(GC) AND OwnerFilter(Owner1))
+        final OriginGeocacheFilter originFilter1 = new OriginGeocacheFilter();
+        originFilter1.setValues(Collections.singleton(gcConnector));
+
+        final OwnerGeocacheFilter ownerFilter1 = new OwnerGeocacheFilter();
+        ownerFilter1.getStringFilter().setTextValue("Owner1");
+
+        final AndGeocacheFilter andBranch1 = new AndGeocacheFilter();
+        andBranch1.addChild(originFilter1);
+        andBranch1.addChild(ownerFilter1);
+
+        // Create second branch: (OriginFilter(SU) AND OwnerFilter(Owner2))
+        final OriginGeocacheFilter originFilter2 = new OriginGeocacheFilter();
+        originFilter2.setValues(Collections.singleton(suConnector));
+
+        final OwnerGeocacheFilter ownerFilter2 = new OwnerGeocacheFilter();
+        ownerFilter2.getStringFilter().setTextValue("Owner2");
+
+        final AndGeocacheFilter andBranch2 = new AndGeocacheFilter();
+        andBranch2.addChild(originFilter2);
+        andBranch2.addChild(ownerFilter2);
+
+        // Combine with OR: (Branch1 OR Branch2)
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(andBranch1);
+        orFilter.addChild(andBranch2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // When filtering for GC connector:
+        // - Branch1: OriginFilter(GC) is removed (redundant), OwnerFilter(Owner1) remains
+        // - Branch2: OriginFilter(SU) doesn't allow GC, so entire branch is kept with OriginFilter
+        // Result: OR filter with one AND branch and one OriginFilter -> no AND chain possible
+        // BUT: if Branch2 contains an OriginFilter that doesn't allow GC, the entire branch
+        // should be removed because it can't produce results for GC
+        // So we should get: just OwnerFilter(Owner1) from Branch1
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossibleForConnector(gcConnector);
+        assertThat(gcResult).hasSize(2);
+        assertThat(gcResult.get(1)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) gcResult.get(1)).getStringFilter().getTextValue()).isEqualTo("Owner1");
+
+        // When filtering for SU connector:
+        // - Branch1: OriginFilter(GC) doesn't allow OC, so entire branch should be removed
+        // - Branch2: OriginFilter(SU) is removed (redundant), OwnerFilter(Owner2) remains
+        // Result: just OwnerFilter(Owner2) from Branch2
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossibleForConnector(suConnector);
+        assertThat(ocResult).hasSize(2);
+        assertThat(ocResult.get(1)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) ocResult.get(1)).getStringFilter().getTextValue()).isEqualTo("Owner2");
+    }
 }
+
+


### PR DESCRIPTION
## Summary 

Support connector-specific filter tree splitting for multi-connector searches with different owner/login names.

## Problem

When searching across multiple geocaching connectors, each connector may have a different login name for the user. Filter trees containing owner/origin filters need to be evaluated per-connector, as a filter like "owned by me" must resolve to the correct login name for each connector. Previously, the filter tree was applied uniformly, which led to incorrect results when different connectors use different account names.

## Solution

### `OwnerGeocacheListLoader`

A second constructor is added that accepts a **list of connectors** instead of a single username. In this mode, `getAdditionalFilterParameter()` builds a combined `OR` filter: for each connector in the list, it creates an `AND(OwnerFilter[username], OriginFilter[connector])` branch using the connector's own login name (via `ILogin.getUserName()`). This allows each connector to be queried with its specific owner name. The original single-username constructor remains for backward compatibility.

### `GeocacheFilter`

The `GeocacheFilter` class is extended with logic to split and adapt the filter tree per connector:

- **`getAndChainIfPossibleForConnector(IConnector)`**: New public entry point that returns the AND-chain of base filters relevant for a specific connector.
- **`keepFilterForConnector()`**: Recursively strips or adapts connector-specific filter nodes (especially `OriginGeocacheFilter`) from the filter tree. Redundant or inapplicable branches are pruned.
- **`keepLogicalGeocacheFilterForConnector()`**: Handles logical combinators (AND, OR, NOT) — invalidates branches where origin constraints exclude the given connector.
- **`isFilterValidForConnector()`**: Checks whether an AND filter is compatible with the given connector, considering nested `OriginGeocacheFilter` and `NOT(OriginGeocacheFilter)` nodes.
- **`processLogicalFilterForConnector()`**: Generic helper that rebuilds logical filter nodes with only the children remaining after connector-specific pruning.

## Impact

- No breaking changes to existing filter behavior
- Improves correctness of connector-specific searches (e.g. owner name searches on opencaching vs. geocaching.com)
- The `OR(AND(owner, origin), ...)` structure built by `OwnerGeocacheListLoader` is correctly split per connector by `GeocacheFilter`, so each connector's search backend receives only its relevant filter branch
- Filter tree splitting is purely in-memory; no storage or serialization changes


**_implemented and summary-creation with support of copilot_**
