### PR TITLE
Mark log dates as wrappable in certain places (fix #17826)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/Formatter.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Formatter.java
@@ -173,7 +173,7 @@ public final class Formatter {
         if (verbally != null) {
             return verbally;
         }
-        return formatShortDate(date);
+        return formatShortDate(date).replace("/", "/\u200B");
     }
 
     private static String formatDateVerbally(final long date) {

--- a/main/src/main/res/layout/logs_item.xml
+++ b/main/src/main/res/layout/logs_item.xml
@@ -30,7 +30,8 @@
 
                 <TextView
                     android:id="@+id/added"
-                    style="@style/logitem_property"/>
+                    style="@style/logitem_property"
+                    android:maxLines="2" />
 
                 <TextView
                     android:id="@+id/type"


### PR DESCRIPTION
## Description
Supports wrapping of log view dates in certain places to better support larger font sizes

\u200B is a Unicode "zero width space", allowing text to wrap in that place, but without the visual spacing of a regular whitespace character.