### PR TITLE
fix #17812: Implement multi-connector owner search support with ConnectorUsernameMap (extends #17812)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -59,6 +59,7 @@ public class Intents {
     public static final String EXTRA_SEARCH = PREFIX + "search";
     public static final String EXTRA_TRACKING_CODE = PREFIX + "tracking_code";
     public static final String EXTRA_USERNAME = PREFIX + "username";
+    public static final String EXTRA_CONNECTOR_USERNAMES = PREFIX + "connector_usernames";
     public static final String EXTRA_WAYPOINT_ID = PREFIX + "waypoint_id";
     public static final String EXTRA_POCKET_LIST = PREFIX + "pocket_list";
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.activity.Keyboard;
 import cgeo.geocaching.address.AddressListActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.ConnectorUsernameMap;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.al.ALConnector;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
@@ -535,7 +536,9 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         }
 
         Settings.addToHistoryList(R.string.pref_search_history_owner, userName);
-        CacheListActivity.startActivityOwner(this, userName);
+        final ConnectorUsernameMap map = new ConnectorUsernameMap(1);
+        map.put(null, userName);
+        CacheListActivity.startActivityOwner(this, map);
         ActivityMixin.overrideTransitionToFade(this);
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/AbstractConnector.java
@@ -363,7 +363,11 @@ public abstract class AbstractConnector implements IConnector {
         if (this instanceof ISearchByFilter) {
             final ISearchByFilter sbf = (ISearchByFilter) this;
             if (sbf.getFilterCapabilities().contains(GeocacheFilterType.OWNER)) {
-                actions.add(new UserAction(R.string.user_menu_view_hidden, R.drawable.ic_menu_owned, context -> CacheListActivity.startActivityOwner(context.getContext(), context.userName)));
+                actions.add(new UserAction(R.string.user_menu_view_hidden, R.drawable.ic_menu_owned, context -> {
+                    final ConnectorUsernameMap map = new ConnectorUsernameMap(1);
+                    map.put(null, context.userName);
+                    CacheListActivity.startActivityOwner(context.getContext(), map);
+                }));
             }
             if (sbf.getFilterCapabilities().contains(GeocacheFilterType.LOG_ENTRY)) {
                 actions.add(new UserAction(R.string.user_menu_view_found, R.drawable.ic_menu_emoticons, context -> CacheListActivity.startActivityFinder(context.getContext(), context.userName)));

--- a/main/src/main/java/cgeo/geocaching/connector/ConnectorUsernameMap.java
+++ b/main/src/main/java/cgeo/geocaching/connector/ConnectorUsernameMap.java
@@ -1,0 +1,26 @@
+package cgeo.geocaching.connector;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+
+/**
+ * A specialized HashMap for mapping connector names to usernames.
+ * Keys can be null (representing "any connector") or non-null connector names.
+ * Values are non-null usernames.
+ * 
+ * This class implements Serializable to support passing the map via Android Intent extras.
+ */
+public class ConnectorUsernameMap extends HashMap<@Nullable String, @NonNull String> {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public ConnectorUsernameMap() {
+        super();
+    }
+    
+    public ConnectorUsernameMap(final int initialCapacity) {
+        super(initialCapacity);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -1,21 +1,29 @@
 package cgeo.geocaching.loaders;
 
+import cgeo.geocaching.connector.ConnectorUsernameMap;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.sorting.GeocacheSort;
 
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Map;
 
 public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
-    @NonNull public final String username;
+    @NonNull private final ConnectorUsernameMap connectorUsernameMap;
 
-    public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final String username) {
+    public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final ConnectorUsernameMap connectorToUsername) {
         super(activity, sort);
-        this.username = username;
+        this.connectorUsernameMap = connectorToUsername;
     }
 
     @Override
@@ -25,8 +33,43 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
     @Override
     public IGeocacheFilter getAdditionalFilterParameter() {
-        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
-        ownerFilter.getStringFilter().setTextValue(username);
-        return ownerFilter;
+        final OrGeocacheFilter aggregator = new OrGeocacheFilter();
+        
+        for (final Map.Entry<String, String> entry : connectorUsernameMap.entrySet()) {
+            final String platformName = entry.getKey();
+            final String ownerName = entry.getValue();
+            
+            if (platformName == null) {
+                aggregator.addChild(createOwnerOnlyFilter(ownerName));
+                continue;
+            }
+            
+            final IConnector platform = cgeo.geocaching.connector.ConnectorFactory.getConnectorByName(platformName);
+            if (platform == null) {
+                continue;
+            }
+            
+            aggregator.addChild(createPlatformAndOwnerFilter(platform, ownerName));
+        }
+        
+        return aggregator;
+    }
+    
+    private OwnerGeocacheFilter createOwnerOnlyFilter(final String ownerName) {
+        final OwnerGeocacheFilter filter = GeocacheFilterType.OWNER.create();
+        filter.getStringFilter().setTextValue(ownerName);
+        return filter;
+    }
+    
+    private AndGeocacheFilter createPlatformAndOwnerFilter(final IConnector platform, final String ownerName) {
+        final AndGeocacheFilter combo = new AndGeocacheFilter();
+        
+        final OriginGeocacheFilter platformPart = GeocacheFilterType.ORIGIN.create();
+        platformPart.addValue(platform);
+        combo.addChild(platformPart);
+        
+        combo.addChild(createOwnerOnlyFilter(ownerName));
+        
+        return combo;
     }
 }


### PR DESCRIPTION
## Description

Refactors connector-username mapping to use a dedicated type with proper nullability annotations. Addresses review feedback from PR jakedot#197 to replace the magic string "default" with explicit `null` values and introduce a specialized HashMap class.

Addresses JakeDot's review comments on PR https://github.com/cgeo/cgeo/pull/17812. The original implementation had a critical filtering bug where OR(Owner1, Owner2) would incorrectly match any owner on any connector. For example, user "JakeDot" on geocaching.com and "JakeDotNet" on opencaching would also match JakeDotNet's caches from geocaching.com.

### Filter Logic Fix

    Changed from OR(Owner="JakeDot", Owner="JakeDotNet")
    To OR(AND(Connector=GC, Owner="JakeDot"), AND(Connector=OC, Owner="JakeDotNet"))
    Special case: null key matches owner on any connector (backward compatibility)

**Key Changes:**
- Created `ConnectorUsernameMap` class extending `HashMap<@Nullable String, @NonNull String>` where `null` keys represent "any connector"
- Replaced all `Collections.singletonMap("default", username)` usages with `null`-keyed `ConnectorUsernameMap` instances
- Updated method signatures in `CacheListActivity.startActivityOwner()`, `OwnerGeocacheListLoader` constructor, and `SearchActivity` methods
- Added `Intents.EXTRA_CONNECTOR_USERNAMES` constant for Intent serialization
- Implemented proper deserialization with type safety and error handling in `CacheListActivity`
- Simplified filter logic in `OwnerGeocacheListLoader` to check `platformName == null` directly instead of comparing to "default" string

## Related issues

rel #17812

## Additional context

The changes maintain the same functional behavior while improving type safety and code clarity. A `null` key in the map represents a username that should match any connector, while a non-null key represents a specific connector name.

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> Based on PR https://github.com/JakeDot/cgeo/pull/197: change the Connector-Username Map type to a new class extending HashMap<@Nullable String, @NonNull String>


</details>