### PR TITLE
Allow simple lists to become parent lists (fix #17679)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -92,7 +92,7 @@ public final class StoredList extends AbstractList {
         private final WeakReference<Activity> activityRef;
         private final Resources res;
 
-        private static final String GROUP_SEPARATOR = ":";
+        public static final String GROUP_SEPARATOR = ":";
 
         public UserInterface(@NonNull final Activity activity) {
             this.activityRef = new WeakReference<>(activity);
@@ -381,13 +381,10 @@ public final class StoredList extends AbstractList {
 
             final String current = defaultValue != null ? defaultValue.substring(defaultValue.lastIndexOf(GROUP_SEPARATOR) + 1).trim() : "";
 
-            final List<String> hierarchies = DataStore.getListHierarchy();
-            if (hierarchies.isEmpty()) {
-                hierarchies.add(0, activity.getString(R.string.init_custombnitem_none)); // overwrite empty entry
-            } else {
-                hierarchies.set(0, activity.getString(R.string.init_custombnitem_none)); // overwrite empty entry
-            }
+            final List<String> hierarchies = DataStore.getFullListHierarchy();
+            hierarchies.add(0, activity.getString(R.string.init_custombnitem_none));
             hierarchies.add(1, activity.getString(R.string.list_create_parent));
+
             listprefix.setVisibility(View.VISIBLE);
             listprefixView.setText(defaultValue != null ? defaultValue.substring(0, defaultValue.length() - current.length()) : "");
             listprefixView.setAdapter(new NewListAdapter(activity, R.layout.createlist_item , hierarchies));
@@ -404,7 +401,7 @@ public final class StoredList extends AbstractList {
                                     prefix = prefix.trim() + GROUP_SEPARATOR;
                                 }
                             } else if (!Strings.CS.equals(temp, activity.getString(R.string.init_custombnitem_none))) {
-                                prefix = temp;
+                                prefix = temp + (!Strings.CS.endsWith(prefix.trim(), GROUP_SEPARATOR) ? GROUP_SEPARATOR : "");
                             }
                             runnable.call(prefix + ((EditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.title))).getText().toString());
                         }))


### PR DESCRIPTION
## Description
Add non-parent lists to list creation dialog to enable easy creation of nested lists from existing non-parent lists.

First group is list of existing parent lists, marked by ending colon, sorted alphabetically.
Second group is list of non-parent lists, without ending colon, sorted alphabetically.

## Example
There is an existing non-parent list named "Berlin".
Let's add the cache to a newly created list "Moabit", which is a sub-list of "Berlin":

|Open list assignment|Create new list "Moabit"|
|---|---|
|<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/cebf4f9e-5e89-41c2-b745-5f72adf14317" />|<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/487538cc-beca-4cff-b6a9-655ddd45bdc4" />|

|New list is assigned|"Berlin" is now a parent list"|
|---|---|
|<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/241592a0-a986-4f6d-934a-24a9a4dd8fa4" />|<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/31246334-53b8-4e2b-9abf-b68a2a883a75" />|

