### PR TITLE
ci: Conditionally run the PR target for external repo - prevent run job twice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
   pull_request_target:
-    types: [labeled, opened, synchronize]
+    types: [labeled, synchronize]
   workflow_dispatch:
     inputs:
       JDK_VERSION:
@@ -26,6 +26,15 @@ permissions:
 
 jobs:
   check-websites:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -37,6 +46,15 @@ jobs:
         uses: ./.github/actions/check-websites
 
   check-secrets:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Debug concurrency-group
@@ -84,6 +102,15 @@ jobs:
           exit 1
 
   checkstyle:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+        )
+      )
     runs-on: ubuntu-latest
     needs: check-secrets
     steps:
@@ -160,6 +187,15 @@ jobs:
 
 
   lint:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+        )
+      )
     runs-on: ubuntu-latest
     needs: check-secrets
     steps:
@@ -238,6 +274,15 @@ jobs:
 
 
   integration-tests:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+        )
+      )
     # > It is now recommended to use the Ubuntu (ubuntu-latest) runners which
     # > are 2-3 times faster than the macOS ones which are also a lot more expensive.
     # https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners
@@ -421,7 +466,18 @@ jobs:
 
   rerun-on-failure:
     needs: integration-tests
-    if: failure() && fromJSON(github.run_attempt) < 3
+    if: >
+      failure() && fromJSON(github.run_attempt) < 3 &&
+      (
+        github.event_name != 'pull_request_target' ||
+        (
+          github.event.pull_request.head.repo.full_name != github.repository &&
+          (
+            (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+            (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+          )
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - env:


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Prevent running the tests twice per PR
<img width="739" height="187" alt="image" src="https://github.com/user-attachments/assets/5d5ac480-80ef-4032-880a-45beec4906ec" />

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Discovered while working on #17856

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

- Run on push for internal changes
- Run on pull_request_target ONLY for external forks with the 'ok-to-test' label
- NOT run on pull_request_target for internal PRs (because they already ran on push)

Post merge test: https://github.com/cgeo/cgeo/pull/17860 :heavy_check_mark: 
