### PR TITLE
Add GC Live API integration with OAuth2 authentication

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -121,6 +121,15 @@
             android:windowSoftInputMode="adjustNothing" >
             <!-- 'adjustNothing' fixes the issue described in #11610 -->
             <!-- don't add configChanges="orientation|screenSize" as we use different base layouts depending on the device orientation -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="${gcLiveRedirectScheme}"
+                    android:host="oauth2.callback"
+                    android:path="/callback" />
+            </intent-filter>
         </activity>
         <activity android:name=".DBInspectionActivity"
             android:exported="false"
@@ -882,6 +891,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
 
         <activity
             android:name=".connector.su.SuAuthorizationActivity"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -30,6 +30,19 @@ plugins {
 Provider<String> gitCommitIdProvider = providers.of(GitCommitIdValueSource.class) {}
 String commitIdShort = gitCommitIdProvider.get()
 
+// extract GC Live OAuth redirect scheme from private.properties for manifest placeholder
+String gcLiveRedirectScheme = ''
+File ppFile = rootProject.file('private.properties')
+if (ppFile.exists()) {
+    Properties pp = new Properties()
+    ppFile.withInputStream { pp.load(it) }
+    String redirectUri = pp.getProperty('gc.live.redirect.uri', '')
+    int idx = redirectUri.indexOf('://')
+    if (idx > 0) {
+        gcLiveRedirectScheme = redirectUri.substring(0, idx)
+    }
+}
+
 android {
     namespace = 'cgeo.geocaching'
     compileSdk = 36
@@ -82,6 +95,9 @@ android {
         buildConfigField "String[]", "TRANSLATION_ARRAY", "new String[]{\""+locales.join("\",\"")+"\"}"
 
         resourceConfigurations += locales
+
+        // GC Live OAuth redirect scheme (parsed from private.properties)
+        manifestPlaceholders = [gcLiveRedirectScheme: gcLiveRedirectScheme]
     }
 
     // signing is handled via private.properties

--- a/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
+++ b/main/src/main/java/cgeo/geocaching/AbstractDialogFragment.java
@@ -142,10 +142,13 @@ public abstract class AbstractDialogFragment extends Fragment implements CacheMe
             details.addRating(cache);
         }
 
-        // favorite count
+        // finds and favorite counts
         final int favCount = cache.getFavoritePoints();
+        final int findsCount = cache.getFindsCount();
+        if (findsCount > 0) {
+            details.add(R.string.caches_sort_finds, String.valueOf(findsCount));
+        }
         if (favCount >= 0) {
-            final int findsCount = cache.getFindsCount();
             if (findsCount > 0) {
                 details.add(R.string.cache_favorite, LocalizationUtils.getPlainString(R.string.favorite_count_percent, favCount, (float) (favCount * 100) / findsCount));
             } else if (!cache.isEventCache()) {

--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1309,6 +1309,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
     public static class DetailsViewCreator extends TabbedViewPagerFragment<CachedetailDetailsPageBinding> {
         private static final String STATE_COORDINATE_FORMAT_POSITION = "coordinateFormatPosition";
         private CacheDetailsCreator.NameValueLine favoriteLine;
+        private CacheDetailsCreator.NameValueLine findsLine;
         private Geocache cache;
         private int coordinateFormatPosition = 0;
 
@@ -1380,6 +1381,9 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             details.addDifficulty(cache);
             details.addTerrain(cache);
             details.addRating(cache);
+
+            // finds count
+            findsLine = details.add(R.string.caches_sort_finds, "");
 
             // favorite count
             favoriteLine = details.add(R.string.cache_favorite, "");
@@ -1721,10 +1725,10 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         private void updateFavPointBox(final CacheDetailActivity activity) {
             // Favorite counts
             final int favCount = cache.getFavoritePoints();
+            final int findsCount = cache.getFindsCount();
             if (favCount >= 0 && !cache.isEventCache()) {
                 favoriteLine.layout.setVisibility(View.VISIBLE);
 
-                final int findsCount = cache.getFindsCount();
                 if (findsCount > 0) {
                     favoriteLine.valueView.setText(LocalizationUtils.getPlainString(R.string.favorite_count_percent, favCount, Math.min((float) (favCount * 100) / findsCount, 100.0f)));
                 } else {
@@ -1732,6 +1736,14 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 }
             } else {
                 favoriteLine.layout.setVisibility(View.GONE);
+            }
+
+            // Finds count
+            if (findsCount > 0) {
+                findsLine.layout.setVisibility(View.VISIBLE);
+                findsLine.valueView.setText(String.valueOf(findsCount));
+            } else {
+                findsLine.layout.setVisibility(View.GONE);
             }
             final boolean supportsFavoritePoints = cache.supportsFavoritePoints();
             binding.favpointBox.setVisibility(supportsFavoritePoints ? View.VISIBLE : View.GONE);

--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -8,6 +8,8 @@ import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.BookmarkListActivity;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.gc.GCConstants;
+import cgeo.geocaching.connector.gc.GCLiveAPI;
+import cgeo.geocaching.connector.gc.GCLiveOAuth;
 import cgeo.geocaching.connector.gc.PocketQueryListActivity;
 import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.databinding.MainActivityBinding;
@@ -57,6 +59,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.app.SearchManager;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -239,6 +242,30 @@ public class MainActivity extends AbstractNavigationBarActivity {
                             } else {
                                 userAvatar.setVisibility(View.GONE);
                             }
+
+                            // GC Live API status line
+                            final TextView liveApiStatus = connectorInfo.findViewById(R.id.item_live_api_status);
+                            if (conn instanceof GCConnector && Settings.useGCLiveAPI()) {
+                                liveApiStatus.setVisibility(View.VISIBLE);
+                                if (!Settings.hasGCLiveAuthorization()) {
+                                    liveApiStatus.setText(R.string.gc_live_status_not_authorized);
+                                } else {
+                                    final long issuedAt = Settings.getGCLiveTokenIssuedAt();
+                                    final long age = System.currentTimeMillis() / 1000 - issuedAt;
+                                    if (age < 3600) {
+                                        liveApiStatus.setText(R.string.gc_live_status_token_valid);
+                                    } else {
+                                        liveApiStatus.setText(R.string.gc_live_status_refreshing_token);
+                                        AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> GCLiveAPI.ensureTokenValid(), () -> {
+                                            final long newAge = System.currentTimeMillis() / 1000 - Settings.getGCLiveTokenIssuedAt();
+                                            liveApiStatus.setText(newAge < 3600 ? R.string.gc_live_status_token_valid : R.string.gc_live_status_token_refresh_failed);
+                                        });
+                                    }
+                                }
+                                liveApiStatus.setOnClickListener(connectorConfig);
+                            } else {
+                                liveApiStatus.setVisibility(View.GONE);
+                            }
                         }
                     });
                 }
@@ -318,6 +345,18 @@ public class MainActivity extends AbstractNavigationBarActivity {
     @NonNull
     protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
         return calculateInsetsWithToolbarInPortrait(def);
+    }
+
+    @Override
+    protected void onNewIntent(final Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        // Handle GC Live OAuth callback immediately for singleTop launch mode,
+        // since onResume() may not always be called after onNewIntent()
+        final android.net.Uri oauthData = intent.getData();
+        if (GCLiveOAuth.handleCallback(this, oauthData)) {
+            setIntent(new Intent());
+        }
     }
 
     private void configureMessageCenterPolling() {
@@ -427,6 +466,12 @@ public class MainActivity extends AbstractNavigationBarActivity {
 
     @Override
     public void onResume() {
+        // Handle GC Live OAuth callback (browser redirects here via intent filter)
+        final android.net.Uri oauthData = getIntent().getData();
+        if (GCLiveOAuth.handleCallback(this, oauthData)) {
+            setIntent(new Intent()); // clear so we don't re-handle on next resume
+        }
+
         try (ContextLogger cLog = new ContextLogger(Log.LogLevel.DEBUG, "MainActivity.onResume")) {
 
             super.onResume();
@@ -475,7 +520,8 @@ public class MainActivity extends AbstractNavigationBarActivity {
             final SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
             searchItem = menu.findItem(R.id.menu_gosearch);
             searchView = (SearchView) searchItem.getActionView();
-            searchView.setSearchableInfo(searchManager.getSearchableInfo(getComponentName()));
+            searchView.setSearchableInfo(searchManager.getSearchableInfo(
+                    new ComponentName(this, SearchActivity.class)));
             searchView.setSuggestionsAdapter(new GeocacheSuggestionsAdapter(this));
             SearchUtils.setSearchViewColor(searchView);
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkListActivity.java
@@ -29,6 +29,9 @@ public class BookmarkListActivity extends AbstractListActivity {
 
     @Override
     protected List<GCList> getList() {
+        if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+            return GCLiveAPI.searchBookmarkLists();
+        }
         return GCParser.searchBookmarkLists();
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/BookmarkUtils.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.list.PseudoList;
 import cgeo.geocaching.models.GCList;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.ui.SimpleItemListModel;
 import cgeo.geocaching.ui.TextParam;
 import cgeo.geocaching.ui.dialog.SimpleDialog;
@@ -41,7 +42,12 @@ public class BookmarkUtils {
 
         AndroidRxUtils.andThenOnUi(AndroidRxUtils.networkScheduler, () -> {
 
-            final List<GCList> bmLists = GCParser.searchBookmarkLists();
+            final List<GCList> bmLists;
+            if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+                bmLists = GCLiveAPI.searchBookmarkLists();
+            } else {
+                bmLists = GCParser.searchBookmarkLists();
+            }
             if (bmLists == null) {
                 ActivityMixin.showToast(context, LocalizationUtils.getString(R.string.err_read_bookmark_list));
                 return;
@@ -75,20 +81,33 @@ public class BookmarkUtils {
     }
 
     private static void processSelection(final Context context, final List<Geocache> geocaches, final GCList selection) {
+        final boolean useLiveApi = Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization();
         if (selection.getGuid().equals(NEW_LIST_GUID)) {
             SimpleDialog.ofContext(context).setTitle(R.string.search_bookmark_new).input(null,
                     name -> AndroidRxUtils.networkScheduler.scheduleDirect(() -> {
-                        final String guid = GCParser.createBookmarkList(name, geocaches.get(0));
+                        final String guid;
+                        if (useLiveApi) {
+                            guid = GCLiveAPI.createBookmarkList(name);
+                        } else {
+                            guid = GCParser.createBookmarkList(name, geocaches.get(0));
+                        }
                         if (guid == null) {
                             ActivityMixin.showToast(context, LocalizationUtils.getString(R.string.search_bookmark_create_new_failed));
                             return;
                         }
-                        showResult(context, GCParser.addCachesToBookmarkList(guid, geocaches).blockingGet());
+                        showResult(context, addCachesToList(useLiveApi, guid, geocaches));
                     }));
         } else {
             AndroidRxUtils.networkScheduler.scheduleDirect(
-                    () -> showResult(context, GCParser.addCachesToBookmarkList(selection.getGuid(), geocaches).blockingGet()));
+                    () -> showResult(context, addCachesToList(useLiveApi, selection.getGuid(), geocaches)));
         }
+    }
+
+    private static boolean addCachesToList(final boolean useLiveApi, final String listGuid, final List<Geocache> geocaches) {
+        if (useLiveApi) {
+            return GCLiveAPI.addCachesToBookmarkList(listGuid, geocaches);
+        }
+        return GCParser.addCachesToBookmarkList(listGuid, geocaches).blockingGet();
     }
 
     private static void showResult(final Context context, final boolean success) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLiveAPI.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLiveAPI.java
@@ -1,0 +1,1789 @@
+package cgeo.geocaching.connector.gc;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.trackable.TrackableBrand;
+import cgeo.geocaching.enumerations.CacheAttribute;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
+import cgeo.geocaching.enumerations.StatusCode;
+import cgeo.geocaching.enumerations.WaypointType;
+import cgeo.geocaching.filters.core.BaseGeocacheFilter;
+import cgeo.geocaching.filters.core.DifficultyAndTerrainGeocacheFilter;
+import cgeo.geocaching.filters.core.DifficultyGeocacheFilter;
+import cgeo.geocaching.filters.core.DistanceGeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.HiddenGeocacheFilter;
+import cgeo.geocaching.filters.core.LogEntryGeocacheFilter;
+import cgeo.geocaching.filters.core.NameGeocacheFilter;
+import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
+import cgeo.geocaching.filters.core.SizeGeocacheFilter;
+import cgeo.geocaching.filters.core.StatusGeocacheFilter;
+import cgeo.geocaching.filters.core.TerrainGeocacheFilter;
+import cgeo.geocaching.filters.core.TypeGeocacheFilter;
+import cgeo.geocaching.location.Geopoint;
+import cgeo.geocaching.location.Viewport;
+import cgeo.geocaching.log.LogEntry;
+import cgeo.geocaching.log.LogType;
+import cgeo.geocaching.models.GCList;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.models.Image;
+import cgeo.geocaching.models.Trackable;
+import cgeo.geocaching.models.Waypoint;
+import cgeo.geocaching.network.HttpRequest;
+import cgeo.geocaching.network.HttpResponse;
+import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.sorting.GeocacheSort;
+import cgeo.geocaching.storage.DataStore;
+import cgeo.geocaching.utils.DisposableHandler;
+import cgeo.geocaching.utils.JsonUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+import cgeo.geocaching.utils.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
+
+import java.io.File;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.reactivex.rxjava3.core.Single;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+/**
+ * Handles requests against the official GC Live API at https://api.groundspeak.com/v1.
+ * Uses OAuth2 Bearer tokens (separate from GCAuthAPI's session-based tokens).
+ */
+public final class GCLiveAPI {
+
+    private static final String API_BASE_URL = "https://api.groundspeak.com/v1";
+    private static final String TOKEN_ENDPOINT = "https://oauth.geocaching.com/token";
+
+    /** Maximum number of geocaches per batch request */
+    private static final int BATCH_SIZE = 50;
+
+    /** Access token TTL in seconds — refresh before expiry (GC tokens last ~3600s) */
+    private static final long TOKEN_TTL_SECONDS = 3400;
+
+    /** Maximum retry attempts for rate-limited or server-error requests */
+    private static final int MAX_RETRIES = 2;
+
+    /** Delay in ms before retrying after a 5xx server error */
+    private static final long SERVER_ERROR_DELAY_MS = 1000;
+
+    /** Callback interface for rate limit countdown notifications. */
+    public interface RateLimitCallback {
+        void onRateLimited(int secondsRemaining);
+    }
+
+    /** Callback interface for batch fetch progress notifications. */
+    public interface BatchProgressCallback {
+        void onProgress(int fetched, int total);
+    }
+
+    /**
+     * Callback references are updated from the main/UI thread (typically via {@link Settings})
+     * and read/invoked from worker threads (e.g. network scheduler threads).
+     * <p>
+     * Access is intentionally lock-free; the {@code volatile} keyword provides visibility
+     * guarantees only. Implementations must be thread-safe and tolerate being invoked
+     * concurrently with {@code set*Callback} updates.
+     */
+    private static volatile RateLimitCallback rateLimitCallback;
+    private static volatile BatchProgressCallback batchProgressCallback;
+
+    /**
+     * Sets a callback to be notified during rate limit waits.
+     * The callback may be invoked from background threads. Pass {@code null} to clear.
+     */
+    public static void setRateLimitCallback(@Nullable final RateLimitCallback callback) {
+        rateLimitCallback = callback;
+    }
+
+    /**
+     * Sets a callback to be notified of batch fetch progress.
+     * The callback may be invoked from background threads. Pass {@code null} to clear.
+     */
+    public static void setBatchProgressCallback(@Nullable final BatchProgressCallback callback) {
+        batchProgressCallback = callback;
+    }
+
+    private static final Object TOKEN_LOCK = new Object();
+    private static String cachedAccessToken;
+    private static long cachedTokenExpires;
+
+    // Fields to request from the Live API — never include owner.profileText
+    private static final String FIELDS_DETAIL = "referenceCode,name,difficulty,terrain,"
+            + "favoritePoints,trackableCount,placedDate,geocacheType,geocacheSize,"
+            + "status,location,postedCoordinates,lastVisitedDate,ownerCode,"
+            + "owner[referenceCode,username],ownerAlias,isPremiumOnly,"
+            + "shortDescription,longDescription,hints,attributes,"
+            + "additionalWaypoints,findCount,hasSolutionChecker,userData,containsHtml";
+
+    private GCLiveAPI() {
+        // utility class
+    }
+
+    // ---- Token Management ----
+
+    /**
+     * Ensures a valid access token is available, refreshing if necessary.
+     * Intended for pre-warming from the UI (e.g. home screen status check).
+     * Blocks the calling thread — call from a background scheduler.
+     */
+    @WorkerThread
+    public static void ensureTokenValid() {
+        getAccessToken();
+    }
+
+    /**
+     * Returns a valid access token, refreshing if necessary.
+     * Blocks the calling thread.
+     */
+    @WorkerThread
+    @Nullable
+    private static String getAccessToken() {
+        synchronized (TOKEN_LOCK) {
+            final long now = System.currentTimeMillis() / 1000;
+            if (cachedAccessToken != null && now < cachedTokenExpires) {
+                return cachedAccessToken;
+            }
+
+            // Try from settings
+            final String storedToken = Settings.getGCLiveAccessToken();
+            final long issuedAt = Settings.getGCLiveTokenIssuedAt();
+            if (storedToken != null && issuedAt + TOKEN_TTL_SECONDS > now) {
+                cachedAccessToken = storedToken;
+                cachedTokenExpires = issuedAt + TOKEN_TTL_SECONDS;
+                return cachedAccessToken;
+            }
+
+            // Need to refresh
+            final String refreshToken = Settings.getGCLiveRefreshToken();
+            if (StringUtils.isBlank(refreshToken)) {
+                Log.w("GCLiveAPI: No refresh token available");
+                return null;
+            }
+
+            return refreshAccessToken(refreshToken);
+        }
+    }
+
+    /**
+     * Refreshes the access token using the refresh token.
+     * Must be called within TOKEN_LOCK.
+     */
+    @Nullable
+    private static String refreshAccessToken(final String refreshToken) {
+        try {
+            final String clientId = LocalizationUtils.getString(R.string.gc_live_client_id);
+            final String clientSecret = LocalizationUtils.getString(R.string.gc_live_client_secret);
+
+            final Parameters body = new Parameters();
+            body.put("grant_type", "refresh_token");
+            body.put("client_id", clientId);
+            body.put("client_secret", clientSecret);
+            body.put("refresh_token", refreshToken);
+
+            final HttpResponse response = new HttpRequest()
+                    .uriBase(TOKEN_ENDPOINT)
+                    .uri("")
+                    .bodyForm(body)
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.e("GCLiveAPI: Token refresh HTTP " + status);
+                return null;
+            }
+
+            final TokenResponse token = response.parseJson(TokenResponse.class, null);
+            if (token == null || StringUtils.isBlank(token.accessToken)) {
+                Log.e("GCLiveAPI: Token refresh returned empty access token");
+                return null;
+            }
+
+            final long now = System.currentTimeMillis() / 1000;
+            Settings.setGCLiveAccessToken(token.accessToken);
+            Settings.setGCLiveTokenIssuedAt(now);
+            if (StringUtils.isNotBlank(token.refreshToken)) {
+                Settings.setGCLiveRefreshToken(token.refreshToken);
+            }
+
+            cachedAccessToken = token.accessToken;
+            cachedTokenExpires = now + TOKEN_TTL_SECONDS;
+            Log.i("GCLiveAPI: Token refreshed successfully");
+            return cachedAccessToken;
+        } catch (final Exception e) {
+            Log.e("GCLiveAPI: Token refresh failed", e);
+            return null;
+        }
+    }
+
+    /** Creates an HttpRequest with Bearer auth targeting the Live API base URL. */
+    static HttpRequest apiReq() {
+        return new HttpRequest().requestPreparer(reqBuilder -> {
+            final String token = getAccessToken();
+            if (token != null) {
+                reqBuilder.addHeader("Authorization", "Bearer " + token);
+            } else {
+                Log.w("GCLiveAPI: No access token available");
+            }
+            return Single.just(reqBuilder);
+        }).uriBase(API_BASE_URL);
+    }
+
+    // ---- Single Cache Fetch ----
+
+    @WorkerThread
+    @Nullable
+    static SearchResult searchByGeocode(@NonNull final String geocode, @Nullable final DisposableHandler handler) {
+        DisposableHandler.sendLoadProgressDetail(handler, R.string.cache_dialog_loading_details_status_loadpage);
+
+        final LiveApiGeocache apiCache = fetchGeocacheWithRetry(geocode);
+        if (apiCache == null) {
+            Log.e("GCLiveAPI.searchByGeocode: No data for " + geocode);
+            final SearchResult search = new SearchResult();
+            search.setError(GCConnector.getInstance(), StatusCode.COMMUNICATION_ERROR);
+            return search;
+        }
+
+        final Geocache cache = mapToGeocache(apiCache);
+        DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
+
+        // Fetch logs and spoiler images via API
+        fetchAndSaveLogs(geocode);
+        fetchAndSaveSpoilers(cache);
+
+        final SearchResult result = new SearchResult();
+        result.addGeocode(cache.getGeocode());
+        return result;
+    }
+
+    // ---- Search ----
+
+    /** Max results per search API call (Live API maximum is 100) */
+    private static final int SEARCH_PAGE_SIZE = 100;
+
+    /** Lightweight fields for search results (no descriptions, hints, etc.) */
+    private static final String FIELDS_SEARCH = "referenceCode,name,difficulty,terrain,"
+            + "favoritePoints,trackableCount,placedDate,geocacheType,geocacheSize,"
+            + "status,postedCoordinates,lastVisitedDate,ownerCode,"
+            + "owner[referenceCode,username],ownerAlias,isPremiumOnly,"
+            + "location,userData,findCount,attributes";
+
+    /**
+     * Searches for geocaches using the Live API search endpoint.
+     *
+     * @param filter   the filter to apply
+     * @param sort     the sort order
+     * @param take     max results to return (will be capped to {@link #SEARCH_PAGE_SIZE})
+     * @param skip     number of results to skip (for pagination)
+     * @return search result with geocodes
+     */
+    @WorkerThread
+    @NonNull
+    static SearchResult searchByFilter(@NonNull final GeocacheFilter filter, @NonNull final GeocacheSort sort,
+                                       final int take, final int skip) {
+        final SearchResult result = new SearchResult();
+
+        try {
+            final String q = buildSearchQuery(filter);
+            if (q == null) {
+                return result;
+            }
+
+            final int effectiveTake = Math.min(take, SEARCH_PAGE_SIZE);
+            final String sortField = mapSortType(sort.getEffectiveType());
+            final boolean sortAsc = sort.isEffectiveAscending();
+
+            final HttpResponse response = apiReq()
+                    .uri("/geocaches/search")
+                    .uriParams("q", q, "sort", sortField, "asc", String.valueOf(sortAsc),
+                            "skip", String.valueOf(skip), "take", String.valueOf(effectiveTake),
+                            "fields", FIELDS_SEARCH, "lite", "true")
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.w("GCLiveAPI: search HTTP " + status + ": " + response.getBodyString());
+                result.setError(GCConnector.getInstance(), StatusCode.COMMUNICATION_ERROR);
+                return result;
+            }
+
+            // Parse total count from header for pagination
+            final String totalHeader = response.getResponse() != null
+                    ? response.getResponse().header("x-total-count") : null;
+            int totalCount = 0;
+            if (StringUtils.isNotBlank(totalHeader)) {
+                try {
+                    totalCount = Integer.parseInt(totalHeader);
+                } catch (final NumberFormatException ignored) {
+                    // ignore
+                }
+            }
+
+            final LiveApiGeocache[] apiCaches = response.parseJson(LiveApiGeocache[].class, null);
+            if (apiCaches == null || apiCaches.length == 0) {
+                return result;
+            }
+
+            final List<Geocache> caches = new ArrayList<>(apiCaches.length);
+            for (final LiveApiGeocache apiCache : apiCaches) {
+                final Geocache cache = mapToGeocache(apiCache);
+                cache.setDetailed(false);  // search results are not fully detailed
+                caches.add(cache);
+            }
+
+            result.addAndPutInCache(caches);
+
+            // Pagination info
+            final int leftToFetch = Math.max(0, totalCount - skip - effectiveTake);
+            result.setLeftToFetch(GCConnector.getInstance(), leftToFetch);
+            result.setPartialResult(GCConnector.getInstance(), apiCaches.length == effectiveTake && leftToFetch > 0);
+
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: search failed", e);
+            result.setError(GCConnector.getInstance(), StatusCode.COMMUNICATION_ERROR);
+        }
+
+        return result;
+    }
+
+    /**
+     * Builds the 'q' query parameter for the Live API search from a GeocacheFilter.
+     * Returns null if no valid location/origin filter is present.
+     */
+    @Nullable
+    private static String buildSearchQuery(@NonNull final GeocacheFilter filter) {
+        final List<String> parts = new ArrayList<>();
+
+        for (final BaseGeocacheFilter bf : filter.getAndChainIfPossible()) {
+            if (bf.getType() == GeocacheFilterType.DISTANCE) {
+                // Handle DISTANCE specially — it produces location/box
+                final DistanceGeocacheFilter df = (DistanceGeocacheFilter) bf;
+                final Geopoint coord = df.getEffectiveCoordinate();
+                if (coord != null) {
+                    if (df.getMaxRangeValue() != null) {
+                        final Viewport box = new Viewport(coord, df.getMaxRangeValue());
+                        parts.add("box:[[" + box.getLatitudeMax() + "," + box.getLongitudeMin()
+                                + "],[" + box.getLatitudeMin() + "," + box.getLongitudeMax() + "]]");
+                    } else {
+                        parts.add("location:[" + coord.getLatitude() + "," + coord.getLongitude() + "]");
+                    }
+                }
+            } else {
+                addFilterToParts(bf, parts);
+            }
+        }
+
+        // Must have at least a location/box in the query
+        if (parts.isEmpty()) {
+            final Geopoint currentPos = cgeo.geocaching.sensors.LocationDataProvider.getInstance().currentGeo().getCoords();
+            if (currentPos != null) {
+                parts.add(0, "location:[" + currentPos.getLatitude() + "," + currentPos.getLongitude() + "]");
+            } else {
+                return null;
+            }
+        }
+
+        return StringUtils.join(parts, '+');
+    }
+
+    @Nullable
+    private static String formatRange(@Nullable final Float min, @Nullable final Float max,
+                                       final float defaultMin, final float defaultMax) {
+        if (min == null && max == null) {
+            return null;
+        }
+        final float rawFrom = min != null ? Math.round(Math.max(defaultMin, Math.min(defaultMax, min)) * 2f) / 2f : defaultMin;
+        final float rawTo = max != null ? Math.round(Math.max(defaultMin, Math.min(defaultMax, max)) * 2f) / 2f : defaultMax;
+        return Math.min(rawFrom, rawTo) + "-" + Math.max(rawFrom, rawTo);
+    }
+
+    private static final ThreadLocal<SimpleDateFormat> DATE_PARAM_FORMAT = ThreadLocal.withInitial(() -> {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf;
+    });
+
+    private static String formatDateParam(final long millis) {
+        return DATE_PARAM_FORMAT.get().format(new Date(millis));
+    }
+
+    /** Maps cgeo sort type to Live API sort field name. */
+    @NonNull
+    private static String mapSortType(@NonNull final GeocacheSort.SortType sortType) {
+        switch (sortType) {
+            case NAME:
+                return "name";
+            case FAVORITES:
+            case FAVORITES_RATIO:
+                return "favoritepoints";
+            case DIFFICULTY:
+                return "difficulty";
+            case TERRAIN:
+                return "terrain";
+            case HIDDEN_DATE:
+                return "placeddate";
+            case LAST_FOUND:
+                return "founddate";
+            case DISTANCE:
+            default:
+                return "distance";
+        }
+    }
+
+    // ---- Viewport Search (Map) ----
+
+    /** Max caches to load for a viewport search */
+    private static final int VIEWPORT_MAX_CACHES = 500;
+
+    /** Page size for viewport search (Live API max is 100) */
+    private static final int VIEWPORT_PAGE_SIZE = 100;
+
+    /**
+     * Searches for geocaches within a viewport bounding box via the Live API.
+     * Fires all page requests in parallel for minimal latency.
+     */
+    @WorkerThread
+    @NonNull
+    static SearchResult searchByViewport(@NonNull final Viewport viewport, @Nullable final GeocacheFilter filter) {
+        final SearchResult result = new SearchResult();
+
+        try {
+            // Build query: box + optional filter operators
+            final List<String> parts = new ArrayList<>();
+            parts.add("box:[[" + viewport.getLatitudeMax() + "," + viewport.getLongitudeMin()
+                    + "],[" + viewport.getLatitudeMin() + "," + viewport.getLongitudeMax() + "]]");
+
+            if (filter != null) {
+                for (final BaseGeocacheFilter bf : filter.getAndChainIfPossible()) {
+                    addFilterToParts(bf, parts);
+                }
+            }
+
+            final String q = StringUtils.join(parts, '+');
+            final int numPages = (VIEWPORT_MAX_CACHES + VIEWPORT_PAGE_SIZE - 1) / VIEWPORT_PAGE_SIZE;
+
+            // Fetch all pages sequentially to avoid concurrent rate-limit issues
+            final List<Geocache> allCaches = new ArrayList<>();
+
+            for (int page = 0; page < numPages; page++) {
+                final int skip = page * VIEWPORT_PAGE_SIZE;
+                try {
+                    final HttpResponse response = apiReq()
+                            .uri("/geocaches/search")
+                            .uriParams("q", q, "skip", String.valueOf(skip),
+                                    "take", String.valueOf(VIEWPORT_PAGE_SIZE),
+                                    "fields", FIELDS_SEARCH, "lite", "true")
+                            .request()
+                            .blockingGet();
+
+                    final int status = response.getStatusCode();
+                    if (status == 200) {
+                        final LiveApiGeocache[] apiCaches = response.parseJson(LiveApiGeocache[].class, null);
+                        if (apiCaches != null) {
+                            for (final LiveApiGeocache apiCache : apiCaches) {
+                                final Geocache cache = mapToGeocache(apiCache);
+                                cache.setDetailed(false);
+                                allCaches.add(cache);
+                            }
+                        }
+                    } else if (status == 429) {
+                        waitForRateLimit(response);
+                        // retry this page after rate limit wait
+                        page--;
+                    } else {
+                        Log.w("GCLiveAPI: viewport page skip=" + skip + " HTTP " + status);
+                    }
+                } catch (final Exception e) {
+                    Log.w("GCLiveAPI: viewport page skip=" + skip + " failed", e);
+                }
+            }
+
+            result.addAndPutInCache(allCaches);
+
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: viewport search failed", e);
+            result.setError(GCConnector.getInstance(), StatusCode.COMMUNICATION_ERROR);
+        }
+
+        return result;
+    }
+
+    /**
+     * Adds filter operators to the query parts list (shared by searchByFilter and searchByViewport).
+     * Only adds operators for filter types supported by the Live API.
+     */
+    private static void addFilterToParts(@NonNull final BaseGeocacheFilter bf, @NonNull final List<String> parts) {
+        switch (bf.getType()) {
+            case TYPE: {
+                final TypeGeocacheFilter tf = (TypeGeocacheFilter) bf;
+                final List<String> ids = new ArrayList<>();
+                for (final CacheType ct : tf.getRawValues()) {
+                    if (ct != CacheType.ALL) {
+                        ids.add(ct.wptTypeId);
+                    }
+                }
+                if (!ids.isEmpty()) {
+                    parts.add("type:" + StringUtils.join(ids, ','));
+                }
+                break;
+            }
+            case SIZE: {
+                final SizeGeocacheFilter sf = (SizeGeocacheFilter) bf;
+                final List<String> ids = new ArrayList<>();
+                for (final CacheSize cs : sf.getValues()) {
+                    for (final int gcId : CacheSize.getGcIdsForSize(cs)) {
+                        ids.add(String.valueOf(gcId));
+                    }
+                }
+                if (!ids.isEmpty()) {
+                    parts.add("size:" + StringUtils.join(ids, ','));
+                }
+                break;
+            }
+            case DIFFICULTY: {
+                final DifficultyGeocacheFilter df = (DifficultyGeocacheFilter) bf;
+                final String range = formatRange(df.getMinRangeValue(), df.getMaxRangeValue(), 1f, 5f);
+                if (range != null) {
+                    parts.add("diff:" + range);
+                }
+                break;
+            }
+            case TERRAIN: {
+                final TerrainGeocacheFilter tf = (TerrainGeocacheFilter) bf;
+                final String range = formatRange(tf.getMinRangeValue(), tf.getMaxRangeValue(), 1f, 5f);
+                if (range != null) {
+                    parts.add("terr:" + range);
+                }
+                break;
+            }
+            case DIFFICULTY_TERRAIN: {
+                final DifficultyAndTerrainGeocacheFilter dtf = (DifficultyAndTerrainGeocacheFilter) bf;
+                final String dr = formatRange(dtf.difficultyGeocacheFilter.getMinRangeValue(),
+                        dtf.difficultyGeocacheFilter.getMaxRangeValue(), 1f, 5f);
+                if (dr != null) {
+                    parts.add("diff:" + dr);
+                }
+                final String tr = formatRange(dtf.terrainGeocacheFilter.getMinRangeValue(),
+                        dtf.terrainGeocacheFilter.getMaxRangeValue(), 1f, 5f);
+                if (tr != null) {
+                    parts.add("terr:" + tr);
+                }
+                break;
+            }
+            case NAME: {
+                final NameGeocacheFilter nf = (NameGeocacheFilter) bf;
+                final String text = nf.getStringFilter().getTextValue();
+                if (StringUtils.isNotBlank(text)) {
+                    parts.add("name:" + text);
+                }
+                break;
+            }
+            case OWNER: {
+                final OwnerGeocacheFilter of = (OwnerGeocacheFilter) bf;
+                final String owner = of.getStringFilter().getTextValue();
+                if (StringUtils.isNotBlank(owner)) {
+                    parts.add("hby:" + owner);
+                }
+                break;
+            }
+            case STATUS: {
+                final StatusGeocacheFilter stf = (StatusGeocacheFilter) bf;
+                if (stf.getStatusFound() != null) {
+                    final String user = Settings.getUserName();
+                    if (StringUtils.isNotBlank(user)) {
+                        parts.add(stf.getStatusFound() ? "fby:" + user : "fby:not(" + user + ")");
+                    }
+                }
+                if (stf.getStatusOwned() != null) {
+                    final String user = Settings.getUserName();
+                    if (StringUtils.isNotBlank(user)) {
+                        parts.add(stf.getStatusOwned() ? "hby:" + user : "hby:not(" + user + ")");
+                    }
+                }
+                if (!stf.isExcludeArchived()) {
+                    parts.add("ia:true");
+                }
+                break;
+            }
+            case HIDDEN:
+            case EVENT_DATE: {
+                final HiddenGeocacheFilter hf = (HiddenGeocacheFilter) bf;
+                final String from = hf.getMinDate() != null ? formatDateParam(hf.getMinDate().getTime()) : null;
+                final String to = hf.getMaxDate() != null ? formatDateParam(hf.getMaxDate().getTime()) : null;
+                if (from != null || to != null) {
+                    parts.add("pd:[" + (from != null ? from : "") + "," + (to != null ? to : "") + "]");
+                }
+                break;
+            }
+            case LOG_ENTRY: {
+                final LogEntryGeocacheFilter lf = (LogEntryGeocacheFilter) bf;
+                final String logUser = lf.getFoundByUser();
+                if (StringUtils.isNotBlank(logUser)) {
+                    parts.add(lf.isInverse() ? "fby:not(" + logUser + ")" : "fby:" + logUser);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    // ---- Cache Actions (watchlist, favorites, coords, notes) ----
+
+    /** Adds a cache to the user's watchlist. */
+    @WorkerThread
+    static boolean addToWatchlist(@NonNull final String geocode) {
+        return simpleApiCall(HttpRequest.Method.PUT, "/geocaches/" + geocode + "/watchlist");
+    }
+
+    /** Removes a cache from the user's watchlist. */
+    @WorkerThread
+    static boolean removeFromWatchlist(@NonNull final String geocode) {
+        return simpleApiCall(HttpRequest.Method.DELETE, "/geocaches/" + geocode + "/watchlist");
+    }
+
+    /** Adds a cache to the user's favorites. */
+    @WorkerThread
+    static boolean addToFavorites(@NonNull final String geocode) {
+        return simpleApiCall(HttpRequest.Method.PUT, "/geocaches/" + geocode + "/favoritedby");
+    }
+
+    /** Removes a cache from the user's favorites. */
+    @WorkerThread
+    static boolean removeFromFavorites(@NonNull final String geocode) {
+        return simpleApiCall(HttpRequest.Method.DELETE, "/geocaches/" + geocode + "/favoritedby");
+    }
+
+    /** Uploads corrected coordinates for a cache. */
+    @WorkerThread
+    static boolean uploadModifiedCoordinates(@NonNull final String geocode, @NonNull final Geopoint coords) {
+        try {
+            final ObjectNode bodyNode = JsonUtils.createObjectNode();
+            bodyNode.put("latitude", coords.getLatitude());
+            bodyNode.put("longitude", coords.getLongitude());
+            final String body = bodyNode.toString();
+            final HttpResponse response = apiReq()
+                    .uri("/geocaches/" + geocode + "/correctedcoordinates")
+                    .bodyJson(body)
+                    .method(HttpRequest.Method.PUT)
+                    .request()
+                    .blockingGet();
+            final int status = response.getStatusCode();
+            if (status >= 200 && status < 300) {
+                Log.i("GCLiveAPI: uploaded corrected coords for " + geocode);
+                return true;
+            }
+            Log.w("GCLiveAPI: uploadModifiedCoordinates " + geocode + " HTTP " + status);
+            return false;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: uploadModifiedCoordinates failed for " + geocode, e);
+            return false;
+        }
+    }
+
+    /** Deletes corrected coordinates for a cache. */
+    @WorkerThread
+    static boolean deleteModifiedCoordinates(@NonNull final String geocode) {
+        return simpleApiCall(HttpRequest.Method.DELETE, "/geocaches/" + geocode + "/correctedcoordinates");
+    }
+
+    /** Uploads a personal note for a cache. */
+    @WorkerThread
+    static boolean uploadPersonalNote(@NonNull final String geocode, @NonNull final String note) {
+        try {
+            final ObjectNode bodyNode = JsonUtils.createObjectNode();
+            bodyNode.put("note", note);
+            final String body = bodyNode.toString();
+            final HttpResponse response = apiReq()
+                    .uri("/geocaches/" + geocode + "/notes")
+                    .bodyJson(body)
+                    .method(HttpRequest.Method.PUT)
+                    .request()
+                    .blockingGet();
+            final int status = response.getStatusCode();
+            if (status >= 200 && status < 300) {
+                Log.i("GCLiveAPI: uploaded personal note for " + geocode);
+                return true;
+            }
+            Log.w("GCLiveAPI: uploadPersonalNote " + geocode + " HTTP " + status);
+            return false;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: uploadPersonalNote failed for " + geocode, e);
+            return false;
+        }
+    }
+
+    /** Adds a cache to the user's ignore list. */
+    @WorkerThread
+    static boolean ignoreCache(@NonNull final String geocode) {
+        return simpleApiCall(HttpRequest.Method.PUT, "/geocaches/" + geocode + "/ignorelist");
+    }
+
+    // ---- Trackable Search ----
+
+    private static final String TRACKABLE_FIELDS = "referenceCode,trackingNumber,name,goal,description,"
+            + "releasedDate,originCountry,ownerCode,owner[referenceCode,username],"
+            + "holder[referenceCode,username],currentGeocacheCode,currentGeocacheName,"
+            + "trackableType[id,name,imageUrl],isMissing,isLocked,kilometersTraveled,"
+            + "images[url,name,description]";
+
+    /** Searches for a trackable via the Live API. */
+    @WorkerThread
+    @Nullable
+    public static Trackable searchTrackable(@Nullable final String geocode, @Nullable final String guid, @Nullable final String id) {
+        if (StringUtils.isBlank(geocode) && StringUtils.isBlank(guid) && StringUtils.isBlank(id)) {
+            return null;
+        }
+
+        try {
+            final HttpResponse response;
+            if (StringUtils.isNotBlank(geocode) && StringUtils.startsWithIgnoreCase(geocode, "TB")) {
+                // Reference code lookup
+                response = apiReq()
+                        .uri("/trackables/" + geocode)
+                        .uriParams("fields", TRACKABLE_FIELDS)
+                        .request()
+                        .blockingGet();
+            } else {
+                // Tracking number lookup (6-char codes, numeric IDs, etc.)
+                final String trackingNumber = StringUtils.isNotBlank(geocode) ? geocode : id;
+                if (StringUtils.isBlank(trackingNumber)) {
+                    return null;
+                }
+                response = apiReq()
+                        .uri("/trackables")
+                        .uriParams("trackingNumber", trackingNumber, "fields", TRACKABLE_FIELDS)
+                        .request()
+                        .blockingGet();
+            }
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.w("GCLiveAPI: searchTrackable HTTP " + status);
+                return null;
+            }
+
+            final JsonNode json = JsonUtils.reader.readTree(response.getBodyString());
+            // Tracking number endpoint returns an array; reference code endpoint returns a single object
+            final JsonNode tb = json.isArray() ? (json.size() > 0 ? json.get(0) : null) : json;
+            if (tb == null) {
+                return null;
+            }
+
+            return mapToTrackable(tb);
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: searchTrackable failed", e);
+            return null;
+        }
+    }
+
+    @NonNull
+    private static Trackable mapToTrackable(@NonNull final JsonNode tb) {
+        final Trackable trackable = new Trackable();
+        trackable.forceSetBrand(TrackableBrand.TRAVELBUG);
+
+        trackable.setGeocode(tb.path("referenceCode").asText());
+        trackable.setTrackingcode(tb.path("trackingNumber").asText(null));
+        trackable.setName(tb.path("name").asText());
+        trackable.setGoal(tb.path("goal").asText(null));
+        trackable.setDetails(tb.path("description").asText(null));
+        trackable.setReleased(parseDate(tb.path("releasedDate").asText(null)));
+        trackable.setOrigin(tb.path("originCountry").asText(null));
+
+        // Owner
+        final JsonNode owner = tb.path("owner");
+        if (owner.has("username")) {
+            trackable.setOwner(owner.path("username").asText());
+            trackable.setOwnerGuid(owner.path("referenceCode").asText(null));
+        }
+
+        // Holder / spotted location
+        final JsonNode holder = tb.path("holder");
+        final String currentGeocacheCode = tb.path("currentGeocacheCode").asText(null);
+        if (StringUtils.isNotBlank(currentGeocacheCode)) {
+            trackable.setSpottedCacheGeocode(currentGeocacheCode);
+            trackable.setSpottedName(tb.path("currentGeocacheName").asText(null));
+            trackable.setSpottedType(Trackable.SPOTTED_CACHE);
+        } else if (holder.has("username")) {
+            trackable.setSpottedName(holder.path("username").asText());
+            trackable.setSpottedGuid(holder.path("referenceCode").asText(null));
+            // Check if holder is the owner
+            final String ownerCode = tb.path("ownerCode").asText(null);
+            final String holderCode = holder.path("referenceCode").asText(null);
+            if (StringUtils.isNotBlank(ownerCode) && ownerCode.equals(holderCode)) {
+                trackable.setSpottedType(Trackable.SPOTTED_OWNER);
+            } else {
+                trackable.setSpottedType(Trackable.SPOTTED_USER);
+            }
+        }
+
+        // Type
+        final JsonNode tbType = tb.path("trackableType");
+        if (tbType.has("name")) {
+            trackable.setType(tbType.path("name").asText());
+        }
+        if (tbType.has("imageUrl")) {
+            trackable.setIconUrl(tbType.path("imageUrl").asText());
+        }
+
+        // Status
+        trackable.setMissing(tb.path("isMissing").asBoolean(false));
+        if (tb.path("isLocked").asBoolean(false)) {
+            trackable.setIsLocked();
+        }
+
+        // Distance
+        final double km = tb.path("kilometersTraveled").asDouble(0);
+        if (km > 0) {
+            trackable.setDistance((float) km);
+        }
+
+        // Image
+        final JsonNode images = tb.path("images");
+        if (images.isArray() && images.size() > 0) {
+            trackable.setImage(images.get(0).path("url").asText(null));
+        }
+
+        return trackable;
+    }
+
+    /**
+     * Returns the D/T combinations still needed for the 81 matrix.
+     * Uses GET /v1/statistics/difficultyterrain which returns all 81 combos with counts.
+     * We filter for count == 0 to get the needed ones.
+     */
+    @WorkerThread
+    @NonNull
+    static Collection<ImmutablePair<Float, Float>> getNeededDifficultyTerrainCombisFor81Matrix() {
+        try {
+            final HttpResponse response = apiReq()
+                    .uri("/statistics/difficultyterrain")
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.w("GCLiveAPI: getDTmatrix HTTP " + status);
+                return Collections.emptyList();
+            }
+
+            final JsonNode json = JsonUtils.reader.readTree(response.getBodyString());
+            final JsonNode counts = json.path("difficultyTerrainCounts");
+            if (!counts.isArray()) {
+                return Collections.emptyList();
+            }
+
+            final List<ImmutablePair<Float, Float>> needed = new ArrayList<>();
+            // Build set of found combos
+            final float[] levels = {1f, 1.5f, 2f, 2.5f, 3f, 3.5f, 4f, 4.5f, 5f};
+            final java.util.Set<String> found = new java.util.HashSet<>();
+            for (final JsonNode entry : counts) {
+                if (entry.path("count").asInt(0) > 0) {
+                    found.add(entry.path("difficulty").asDouble() + "-" + entry.path("terrain").asDouble());
+                }
+            }
+            // Anything not found is needed
+            for (final float d : levels) {
+                for (final float t : levels) {
+                    if (!found.contains((double) d + "-" + (double) t)) {
+                        needed.add(new ImmutablePair<>(d, t));
+                    }
+                }
+            }
+            return needed;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: getDTmatrix failed", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /** Uploads a field notes file via the Live API. */
+    @WorkerThread
+    static boolean uploadFieldNotes(@NonNull final File exportFile) {
+        try {
+            final HttpResponse response = apiReq()
+                    .uri("/logdrafts/upload")
+                    .method(HttpRequest.Method.POST)
+                    .bodyForm(null, "file", "text/plain", exportFile)
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status >= 200 && status < 300) {
+                Log.i("GCLiveAPI: field notes uploaded successfully");
+                return true;
+            }
+            Log.w("GCLiveAPI: uploadFieldNotes HTTP " + status);
+            return false;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: uploadFieldNotes failed", e);
+            return false;
+        }
+    }
+
+    // ---- Bookmark List Operations ----
+
+    /** Fetches the user's bookmark lists via the Live API. */
+    @WorkerThread
+    @Nullable
+    static List<GCList> searchBookmarkLists() {
+        try {
+            final HttpResponse response = apiReq()
+                    .uri("/lists")
+                    .uriParams("types", "bm", "skip", "0", "take", "100")
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.w("GCLiveAPI: searchBookmarkLists HTTP " + status);
+                return null;
+            }
+
+            final JsonNode json = JsonUtils.reader.readTree(response.getBodyString());
+            final List<GCList> list = new ArrayList<>();
+            for (final JsonNode row : json) {
+                final String referenceCode = row.path("referenceCode").asText();
+                final String name = row.path("name").asText();
+                final int count = row.path("count").asInt();
+                final Date date = parseDate(row.path("lastUpdatedDateUtc").asText());
+                final long dateMs = date != null ? date.getTime() : 0;
+                list.add(new GCList(referenceCode, name, count, true, dateMs, -1, true, null, null));
+            }
+            return list;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: searchBookmarkLists failed", e);
+            return null;
+        }
+    }
+
+    /** Fetches the user's pocket queries via the Live API. */
+    @WorkerThread
+    @Nullable
+    static List<GCList> searchPocketQueries() {
+        try {
+            final HttpResponse response = apiReq()
+                    .uri("/users/me/lists")
+                    .uriParams("types", "pq", "skip", "0", "take", "100",
+                            "fields", "referenceCode,name,count,lastUpdatedDateUtc")
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.w("GCLiveAPI: searchPocketQueries HTTP " + status);
+                return null;
+            }
+
+            final JsonNode json = JsonUtils.reader.readTree(response.getBodyString());
+            final List<GCList> list = new ArrayList<>();
+            for (final JsonNode row : json) {
+                final String referenceCode = row.path("referenceCode").asText();
+                final String name = row.path("name").asText();
+                final int count = row.path("count").asInt();
+                final Date date = parseDate(row.path("lastUpdatedDateUtc").asText());
+                final long dateMs = date != null ? date.getTime() : 0;
+                // Store referenceCode as guid; PQs are always downloadable; not a bookmark list
+                list.add(new GCList(referenceCode, name, count, true, dateMs, -1, false, null, null));
+            }
+            return list;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: searchPocketQueries failed", e);
+            return null;
+        }
+    }
+
+    /** Fetches geocaches from a bookmark list. */
+    @WorkerThread
+    @Nullable
+    public static SearchResult searchByBookmarkList(@NonNull final IConnector con, @NonNull final String listReferenceCode, final int alreadyTaken) {
+        try {
+            final HttpResponse response = apiReq()
+                    .uri("/lists/" + listReferenceCode + "/geocaches")
+                    .uriParams("skip", String.valueOf(alreadyTaken), "take", "100",
+                            "lite", "true", "fields", "referenceCode,name,difficulty,terrain,geocacheType,geocacheSize,postedCoordinates,status,isPremiumOnly,owner[username]")
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.w("GCLiveAPI: searchByBookmarkList HTTP " + status);
+                return null;
+            }
+
+            final String totalHeader = response.getResponse() != null
+                    ? response.getResponse().header("x-total-count") : null;
+            int totalCount = 0;
+            if (totalHeader != null) {
+                try {
+                    totalCount = Integer.parseInt(totalHeader);
+                } catch (final NumberFormatException e) {
+                    Log.w("GCLiveAPI: invalid x-total-count header: " + totalHeader);
+                }
+            }
+
+            final JsonNode json = JsonUtils.reader.readTree(response.getBodyString());
+            final List<Geocache> caches = new ArrayList<>();
+            for (final JsonNode node : json) {
+                final Geocache cache = new Geocache();
+                cache.setGeocode(node.path("referenceCode").asText());
+                cache.setName(node.path("name").asText());
+                cache.setDifficulty((float) node.path("difficulty").asDouble());
+                cache.setTerrain((float) node.path("terrain").asDouble());
+                cache.setType(CacheType.getByWaypointType(String.valueOf(node.path("geocacheType").path("id").asInt())));
+                cache.setSize(CacheSize.getByGcId(node.path("geocacheSize").path("id").asInt()));
+                final JsonNode owner = node.path("owner");
+                if (owner.has("username")) {
+                    cache.setOwnerDisplayName(owner.path("username").asText());
+                }
+                final JsonNode coords = node.path("postedCoordinates");
+                if (coords.has("latitude") && coords.has("longitude")) {
+                    cache.setCoords(new Geopoint(coords.path("latitude").asDouble(), coords.path("longitude").asDouble()));
+                }
+                final String cacheStatus = node.path("status").asText();
+                cache.setDisabled("Disabled".equals(cacheStatus));
+                cache.setArchived("Archived".equals(cacheStatus) || "Locked".equals(cacheStatus));
+                cache.setPremiumMembersOnly(node.path("isPremiumOnly").asBoolean());
+                caches.add(cache);
+            }
+
+            final int currentFetched = alreadyTaken + caches.size();
+            final SearchResult searchResult = new SearchResult(caches);
+            searchResult.setLeftToFetch(con, totalCount - currentFetched);
+            searchResult.setToContext(con, b -> {
+                b.putInt(GCConnector.SEARCH_CONTEXT_TOOK_TOTAL, currentFetched);
+                b.putString(GCConnector.SEARCH_CONTEXT_BOOKMARK, listReferenceCode);
+            });
+
+            return searchResult;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: searchByBookmarkList failed", e);
+            return null;
+        }
+    }
+
+    /** Creates a new bookmark list via the Live API. Returns the reference code or null. */
+    @WorkerThread
+    @Nullable
+    static String createBookmarkList(@NonNull final String name) {
+        try {
+            final ObjectNode typeNode = JsonUtils.createObjectNode();
+            typeNode.put("code", "bm");
+            final ObjectNode bodyNode = JsonUtils.createObjectNode();
+            bodyNode.put("name", name);
+            bodyNode.set("type", typeNode);
+            final String body = bodyNode.toString();
+            final HttpResponse response = apiReq()
+                    .uri("/lists")
+                    .method(HttpRequest.Method.POST)
+                    .bodyJson(body)
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status < 200 || status >= 300) {
+                Log.w("GCLiveAPI: createBookmarkList HTTP " + status);
+                return null;
+            }
+
+            final JsonNode json = JsonUtils.reader.readTree(response.getBodyString());
+            return json.path("referenceCode").asText(null);
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: createBookmarkList failed", e);
+            return null;
+        }
+    }
+
+    /** Adds geocaches to a bookmark list via the Live API. */
+    @WorkerThread
+    static boolean addCachesToBookmarkList(@NonNull final String listReferenceCode, @NonNull final List<Geocache> geocaches) {
+        try {
+            final ArrayNode arrayNode = JsonUtils.createArrayNode();
+            for (final Geocache geocache : geocaches) {
+                if (ConnectorFactory.getConnector(geocache) instanceof GCConnector) {
+                    arrayNode.add(new ObjectNode(JsonUtils.factory).put("referenceCode", geocache.getGeocode()));
+                }
+            }
+
+            final HttpResponse response = apiReq()
+                    .uri("/lists/" + listReferenceCode + "/geocaches")
+                    .method(HttpRequest.Method.PUT)
+                    .bodyJson(arrayNode.toString())
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status >= 200 && status < 300) {
+                Log.i("GCLiveAPI: added " + arrayNode.size() + " caches to list " + listReferenceCode);
+                return true;
+            }
+            Log.w("GCLiveAPI: addCachesToBookmarkList HTTP " + status);
+            return false;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: addCachesToBookmarkList failed", e);
+            return false;
+        }
+    }
+
+    /**
+     * Helper for simple PUT/DELETE API calls that expect a 2xx response with no body parsing.
+     */
+    private static boolean simpleApiCall(@NonNull final HttpRequest.Method method, @NonNull final String uri) {
+        try {
+            final HttpResponse response = apiReq()
+                    .uri(uri)
+                    .method(method)
+                    .request()
+                    .blockingGet();
+            final int status = response.getStatusCode();
+            if (status >= 200 && status < 300) {
+                Log.i("GCLiveAPI: " + method + " " + uri + " OK");
+                return true;
+            }
+            Log.w("GCLiveAPI: " + method + " " + uri + " HTTP " + status);
+            return false;
+        } catch (final Exception e) {
+            Log.w("GCLiveAPI: " + method + " " + uri + " failed", e);
+            return false;
+        }
+    }
+
+    // ---- Log Fetching ----
+
+    private static final String LOG_FIELDS = "referenceCode,text,loggedDate,type,owner[username,referenceCode],"
+            + "images[url,name,description]";
+
+    /** Fetches logs for a geocache via the Live API and saves them to DB. */
+    @WorkerThread
+    public static void fetchAndSaveLogs(@NonNull final String geocode) {
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                final HttpResponse response = apiReq()
+                        .uri("/geocaches/" + geocode + "/geocachelogs")
+                        .uriParams("fields", LOG_FIELDS, "take", "35")
+                        .request()
+                        .blockingGet();
+
+                final int status = response.getStatusCode();
+                if (status == 429) {
+                    waitForRateLimit(response);
+                    continue;
+                }
+                if (status >= 500) {
+                    TimeUnit.MILLISECONDS.sleep(SERVER_ERROR_DELAY_MS);
+                    continue;
+                }
+                if (status != 200) {
+                    Log.w("GCLiveAPI: fetchLogs " + geocode + " HTTP " + status);
+                    return;
+                }
+
+                final LiveApiLog[] apiLogs = response.parseJson(LiveApiLog[].class, null);
+                if (apiLogs == null || apiLogs.length == 0) {
+                    return;
+                }
+
+                final List<LogEntry> logs = new ArrayList<>(apiLogs.length);
+                for (final LiveApiLog apiLog : apiLogs) {
+                    logs.add(mapToLogEntry(apiLog));
+                }
+
+                DataStore.saveLogs(geocode, logs, true);
+                Log.i("GCLiveAPI: Saved " + logs.size() + " logs for " + geocode);
+                return;
+            } catch (final Exception e) {
+                Log.w("GCLiveAPI: fetchLogs attempt " + attempt + " failed for " + geocode, e);
+            }
+        }
+    }
+
+    @NonNull
+    private static LogEntry mapToLogEntry(@NonNull final LiveApiLog apiLog) {
+        final LogEntry.Builder builder = new LogEntry.Builder();
+
+        if (StringUtils.isNotBlank(apiLog.referenceCode)) {
+            builder.setServiceLogId(apiLog.referenceCode);
+        }
+        if (StringUtils.isNotBlank(apiLog.type)) {
+            builder.setLogType(LogType.getByType(apiLog.type));
+        }
+        if (apiLog.owner != null) {
+            builder.setAuthor(StringUtils.defaultString(apiLog.owner.username));
+        }
+        builder.setLog(StringUtils.defaultString(apiLog.text));
+
+        final Date logDate = parseDate(apiLog.loggedDate);
+        if (logDate != null) {
+            builder.setDate(logDate.getTime());
+        }
+
+        return builder.build();
+    }
+
+    // ---- Spoiler / Gallery Image Fetching ----
+
+    /** Fetches spoiler/gallery images for a geocache via the Live API and saves them on the cache. */
+    @WorkerThread
+    public static void fetchAndSaveSpoilers(@NonNull final Geocache cache) {
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                final HttpResponse response = apiReq()
+                        .uri("/geocaches/" + cache.getGeocode() + "/images")
+                        .uriParams("fields", "url,name,description")
+                        .request()
+                        .blockingGet();
+
+                final int status = response.getStatusCode();
+                if (status == 429) {
+                    waitForRateLimit(response);
+                    continue;
+                }
+                if (status >= 500) {
+                    TimeUnit.MILLISECONDS.sleep(SERVER_ERROR_DELAY_MS);
+                    continue;
+                }
+                if (status != 200) {
+                    Log.w("GCLiveAPI: fetchImages " + cache.getGeocode() + " HTTP " + status);
+                    return;
+                }
+
+                final LiveApiImage[] apiImages = response.parseJson(LiveApiImage[].class, null);
+                if (apiImages == null || apiImages.length == 0) {
+                    return;
+                }
+
+                final List<Image> spoilers = new ArrayList<>(apiImages.length);
+                for (final LiveApiImage apiImg : apiImages) {
+                    if (StringUtils.isNotBlank(apiImg.url)) {
+                        spoilers.add(new Image.Builder()
+                                .setUrl(apiImg.url)
+                                .setTitle(StringUtils.defaultString(apiImg.name))
+                                .setDescription(apiImg.description)
+                                .build());
+                    }
+                }
+
+                cache.setSpoilers(spoilers);
+                DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
+                Log.i("GCLiveAPI: Saved " + spoilers.size() + " spoiler images for " + cache.getGeocode());
+                return;
+            } catch (final Exception e) {
+                Log.w("GCLiveAPI: fetchImages attempt " + attempt + " failed for " + cache.getGeocode(), e);
+            }
+        }
+    }
+
+    @WorkerThread
+    @Nullable
+    private static LiveApiGeocache fetchGeocacheWithRetry(final String geocode) {
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                final HttpResponse response = apiReq()
+                        .uri("/geocaches/" + geocode)
+                        .uriParams("lite", "false", "fields", FIELDS_DETAIL)
+                        .request()
+                        .blockingGet();
+
+                final int status = response.getStatusCode();
+                if (status == 200) {
+                    final LiveApiGeocache result = response.parseJson(LiveApiGeocache.class, null);
+                    if (result == null) {
+                        Log.w("GCLiveAPI: parseJson returned null for " + geocode);
+                    }
+                    return result;
+                }
+                Log.w("GCLiveAPI: fetch " + geocode + " HTTP " + status);
+                if (status == 429) {
+                    waitForRateLimit(response);
+                    continue;
+                }
+                if (status >= 500) {
+                    TimeUnit.MILLISECONDS.sleep(SERVER_ERROR_DELAY_MS);
+                    continue;
+                }
+                Log.w("GCLiveAPI: fetch " + geocode + " returned HTTP " + status);
+                return null;
+            } catch (final Exception e) {
+                Log.w("GCLiveAPI: fetch " + geocode + " attempt " + attempt + " failed", e);
+            }
+        }
+        return null;
+    }
+
+    // ---- Batch Fetch ----
+
+    /**
+     * Fetches multiple geocaches in chunks of {@link #BATCH_SIZE}.
+     * Returns list of mapped Geocache objects, already saved to DB.
+     */
+    @WorkerThread
+    @NonNull
+    public static List<Geocache> fetchGeocachesBatch(@NonNull final List<String> geocodes) {
+        final List<Geocache> result = new ArrayList<>();
+        final int total = geocodes.size();
+        final BatchProgressCallback progressCallback = batchProgressCallback;
+
+        if (progressCallback != null) {
+            progressCallback.onProgress(0, total);
+        }
+
+        for (int offset = 0; offset < total; offset += BATCH_SIZE) {
+            final int end = Math.min(offset + BATCH_SIZE, total);
+            final List<String> chunk = geocodes.subList(offset, end);
+            final String codes = StringUtils.join(chunk, ',');
+
+            final LiveApiGeocache[] apiCaches = fetchBatchWithRetry(codes);
+            if (apiCaches != null) {
+                final List<Geocache> mapped = new ArrayList<>(apiCaches.length);
+                for (final LiveApiGeocache apiCache : apiCaches) {
+                    mapped.add(mapToGeocache(apiCache));
+                }
+                DataStore.saveCaches(mapped, EnumSet.of(SaveFlag.DB));
+                result.addAll(mapped);
+            }
+
+            if (progressCallback != null) {
+                progressCallback.onProgress(Math.min(end, total), total);
+            }
+        }
+
+        return result;
+    }
+
+    @WorkerThread
+    @Nullable
+    private static LiveApiGeocache[] fetchBatchWithRetry(final String referenceCodes) {
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                final HttpResponse response = apiReq()
+                        .uri("/geocaches")
+                        .uriParams("referenceCodes", referenceCodes,
+                                "fields", FIELDS_DETAIL)
+                        .request()
+                        .blockingGet();
+
+                final int status = response.getStatusCode();
+                if (status == 200) {
+                    return response.parseJson(LiveApiGeocache[].class, null);
+                }
+                if (status == 429) {
+                    waitForRateLimit(response);
+                    continue;
+                }
+                if (status >= 500) {
+                    TimeUnit.MILLISECONDS.sleep(SERVER_ERROR_DELAY_MS);
+                    continue;
+                }
+                Log.w("GCLiveAPI: batch fetch returned HTTP " + status);
+                return null;
+            } catch (final Exception e) {
+                Log.w("GCLiveAPI: batch fetch attempt " + attempt + " failed", e);
+            }
+        }
+        return null;
+    }
+
+    // ---- Rate Limit Handling ----
+
+    private static void waitForRateLimit(final HttpResponse response) {
+        int waitSeconds = 1;
+        final String resetHeader = response.getResponse() != null
+                ? response.getResponse().header("x-rate-limit-reset") : null;
+        if (StringUtils.isNotBlank(resetHeader)) {
+            try {
+                waitSeconds = Integer.parseInt(resetHeader);
+            } catch (final NumberFormatException ignored) {
+                // use default
+            }
+        }
+        Log.i("GCLiveAPI: Rate limited, waiting " + waitSeconds + "s");
+        final RateLimitCallback callback = rateLimitCallback;
+        try {
+            for (int remaining = waitSeconds; remaining > 0; remaining--) {
+                if (callback != null) {
+                    callback.onRateLimited(remaining);
+                }
+                TimeUnit.SECONDS.sleep(1);
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (callback != null) {
+            callback.onRateLimited(0);
+        }
+    }
+
+    // ---- JSON to Geocache Mapper ----
+
+    @NonNull
+    static Geocache mapToGeocache(@NonNull final LiveApiGeocache api) {
+        final Geocache cache = new Geocache();
+        cache.setGeocode(api.referenceCode);
+        cache.setName(api.name);
+        cache.setType(api.geocacheType != null
+                ? CacheType.getByWaypointType(String.valueOf(api.geocacheType.id))
+                : CacheType.UNKNOWN);
+        cache.setSize(api.geocacheSize != null
+                ? CacheSize.getByGcId(api.geocacheSize.id)
+                : CacheSize.UNKNOWN);
+        cache.setDifficulty(api.difficulty);
+        cache.setTerrain(api.terrain);
+        cache.setFavoritePoints(api.favoritePoints);
+        cache.setInventoryItems(api.trackableCount);
+        cache.setPremiumMembersOnly(api.isPremiumOnly);
+        cache.setHidden(parseDate(api.placedDate));
+        cache.setLastFound(parseDate(api.lastVisitedDate));
+
+        // Owner
+        if (api.owner != null) {
+            cache.setOwnerDisplayName(api.owner.username);
+            cache.setOwnerUserId(api.owner.username);
+        } else if (StringUtils.isNotBlank(api.ownerAlias)) {
+            cache.setOwnerDisplayName(api.ownerAlias);
+            cache.setOwnerUserId(api.ownerAlias);
+        }
+
+        // Status
+        if ("Disabled".equalsIgnoreCase(api.status)) {
+            cache.setDisabled(true);
+            cache.setArchived(false);
+        } else if ("Archived".equalsIgnoreCase(api.status)) {
+            cache.setDisabled(false);
+            cache.setArchived(true);
+        } else {
+            cache.setDisabled(false);
+            cache.setArchived(false);
+        }
+
+        // Coordinates
+        if (api.userData != null && api.userData.correctedCoordinates != null) {
+            cache.setCoords(new Geopoint(api.userData.correctedCoordinates.latitude,
+                    api.userData.correctedCoordinates.longitude));
+            cache.setUserModifiedCoords(true);
+        } else if (api.postedCoordinates != null) {
+            cache.setCoords(new Geopoint(api.postedCoordinates.latitude,
+                    api.postedCoordinates.longitude));
+            cache.setUserModifiedCoords(false);
+        }
+
+        // Location
+        if (api.location != null) {
+            final String loc = StringUtils.isNotBlank(api.location.state)
+                    ? api.location.state + ", " + api.location.country
+                    : api.location.country;
+            cache.setLocation(loc);
+        }
+
+        // Text fields
+        cache.setShortDescription(StringUtils.defaultString(api.shortDescription));
+        cache.setDescription(StringUtils.defaultString(api.longDescription));
+        cache.setHint(StringUtils.defaultString(api.hints));
+
+        // User data
+        if (api.userData != null) {
+            if (StringUtils.isNotBlank(api.userData.foundDate)) {
+                cache.setFound(true);
+            } else if (StringUtils.isNotBlank(api.userData.dnfDate)) {
+                cache.setDNF(true);
+            }
+            if (StringUtils.isNotBlank(api.userData.note)) {
+                cache.setPersonalNote(api.userData.note);
+            }
+        }
+
+        // Attributes
+        if (api.attributes != null) {
+            final List<String> attrs = new ArrayList<>(api.attributes.length);
+            for (final LiveApiAttribute attr : api.attributes) {
+                final CacheAttribute cacheAttribute = CacheAttribute.getById(attr.id);
+                if (cacheAttribute != null) {
+                    attrs.add(cacheAttribute.getValue(attr.isOn));
+                } else {
+                    Log.w("GCLiveAPI: unknown cache attribute id from API: " + attr.id);
+                }
+            }
+            cache.setAttributes(attrs);
+        }
+
+        // Additional waypoints
+        if (api.additionalWaypoints != null) {
+            for (final LiveApiWaypoint apiWp : api.additionalWaypoints) {
+                final WaypointType wpType = mapWaypointType(apiWp.typeId);
+                final Waypoint wp = new Waypoint(
+                        StringUtils.defaultString(apiWp.name, "Waypoint"),
+                        wpType,
+                        false);
+                wp.setPrefix(StringUtils.defaultString(apiWp.prefix));
+                if (apiWp.coordinates != null) {
+                    wp.setCoords(new Geopoint(apiWp.coordinates.latitude,
+                            apiWp.coordinates.longitude));
+                } else {
+                    wp.setOriginalCoordsEmpty(true);
+                }
+                if (StringUtils.isNotBlank(apiWp.description)) {
+                    wp.setNote(apiWp.description);
+                }
+                cache.addOrChangeWaypoint(wp, false);
+            }
+        }
+
+        // Log counts — the API gives us findCount directly
+        if (api.findCount > 0) {
+            final Map<LogType, Integer> logCounts = new EnumMap<>(LogType.class);
+            logCounts.put(LogType.FOUND_IT, api.findCount);
+            cache.setLogCounts(logCounts);
+        }
+
+        cache.setDetailed(true);
+        cache.setDetailedUpdatedNow();
+        return cache;
+    }
+
+    private static final ThreadLocal<SimpleDateFormat> DATE_PARSE_FORMAT = ThreadLocal.withInitial(() -> {
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf;
+    });
+
+    /** Parses ISO-8601 date strings from the GC Live API (e.g. "2024-12-13T00:00:00" or "2024-12-13T00:00:00.000"). */
+    @Nullable
+    private static Date parseDate(@Nullable final String dateStr) {
+        if (StringUtils.isBlank(dateStr)) {
+            return null;
+        }
+        try {
+            // Strip fractional seconds if present
+            final String normalized = dateStr.contains(".") ? dateStr.substring(0, dateStr.indexOf('.')) : dateStr;
+            return DATE_PARSE_FORMAT.get().parse(normalized);
+        } catch (final ParseException e) {
+            Log.w("GCLiveAPI: Failed to parse date: " + dateStr);
+            return null;
+        }
+    }
+
+    /**
+     * Maps GC Live API waypoint type IDs to cgeo WaypointType.
+     * GC API type IDs: 217=Parking, 218=Final, 219=Virtual Stage (Puzzle/Question),
+     * 220=Physical Stage, 221=Trailhead, 452=Reference Point
+     */
+    @NonNull
+    private static WaypointType mapWaypointType(final int typeId) {
+        switch (typeId) {
+            case 217:
+                return WaypointType.PARKING;
+            case 218:
+                return WaypointType.FINAL;
+            case 219:
+                return WaypointType.PUZZLE;
+            case 220:
+                return WaypointType.STAGE;
+            case 221:
+                return WaypointType.TRAILHEAD;
+            case 452:
+                return WaypointType.WAYPOINT;
+            default:
+                return WaypointType.WAYPOINT;
+        }
+    }
+
+    // ---- Jackson Model Classes ----
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class TokenResponse {
+        @JsonProperty("access_token")
+        String accessToken;
+        @JsonProperty("refresh_token")
+        String refreshToken;
+        @JsonProperty("token_type")
+        String tokenType;
+        @JsonProperty("expires_in")
+        long expiresIn;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiGeocache {
+        @JsonProperty("referenceCode")
+        String referenceCode;
+        @JsonProperty("name")
+        String name;
+        @JsonProperty("difficulty")
+        float difficulty;
+        @JsonProperty("terrain")
+        float terrain;
+        @JsonProperty("favoritePoints")
+        int favoritePoints;
+        @JsonProperty("trackableCount")
+        int trackableCount;
+        @JsonProperty("placedDate")
+        String placedDate;
+        @JsonProperty("geocacheType")
+        LiveApiType geocacheType;
+        @JsonProperty("geocacheSize")
+        LiveApiSize geocacheSize;
+        @JsonProperty("status")
+        String status;
+        @JsonProperty("location")
+        LiveApiLocation location;
+        @JsonProperty("postedCoordinates")
+        LiveApiCoordinates postedCoordinates;
+        @JsonProperty("lastVisitedDate")
+        String lastVisitedDate;
+        @JsonProperty("ownerCode")
+        String ownerCode;
+        @JsonProperty("owner")
+        LiveApiOwner owner;
+        @JsonProperty("ownerAlias")
+        String ownerAlias;
+        @JsonProperty("isPremiumOnly")
+        boolean isPremiumOnly;
+        @JsonProperty("shortDescription")
+        String shortDescription;
+        @JsonProperty("longDescription")
+        String longDescription;
+        @JsonProperty("hints")
+        String hints;
+        @JsonProperty("attributes")
+        LiveApiAttribute[] attributes;
+        @JsonProperty("additionalWaypoints")
+        LiveApiWaypoint[] additionalWaypoints;
+        @JsonProperty("findCount")
+        int findCount;
+        @JsonProperty("hasSolutionChecker")
+        boolean hasSolutionChecker;
+        @JsonProperty("userData")
+        LiveApiUserData userData;
+        @JsonProperty("containsHtml")
+        boolean containsHtml;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiOwner {
+        @JsonProperty("referenceCode")
+        String referenceCode;
+        @JsonProperty("username")
+        String username;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiLocation {
+        @JsonProperty("state")
+        String state;
+        @JsonProperty("country")
+        String country;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiCoordinates {
+        @JsonProperty("latitude")
+        double latitude;
+        @JsonProperty("longitude")
+        double longitude;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiType {
+        @JsonProperty("id")
+        int id;
+        @JsonProperty("name")
+        String name;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiSize {
+        @JsonProperty("id")
+        int id;
+        @JsonProperty("name")
+        String name;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiAttribute {
+        @JsonProperty("id")
+        int id;
+        @JsonProperty("name")
+        String name;
+        @JsonProperty("isOn")
+        boolean isOn;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiWaypoint {
+        @JsonProperty("prefix")
+        String prefix;
+        @JsonProperty("name")
+        String name;
+        @JsonProperty("type")
+        int typeId;
+        @JsonProperty("coordinates")
+        LiveApiCoordinates coordinates;
+        @JsonProperty("description")
+        String description;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiUserData {
+        @JsonProperty("foundDate")
+        String foundDate;
+        @JsonProperty("dnfDate")
+        String dnfDate;
+        @JsonProperty("correctedCoordinates")
+        LiveApiCoordinates correctedCoordinates;
+        @JsonProperty("note")
+        String note;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiLog {
+        @JsonProperty("referenceCode")
+        String referenceCode;
+        @JsonProperty("text")
+        String text;
+        @JsonProperty("loggedDate")
+        String loggedDate;
+        @JsonProperty("type")
+        String type;
+        @JsonProperty("owner")
+        LiveApiOwner owner;
+        // images is omitted — the API returns an object (not array) when empty,
+        // which causes Jackson type mismatch. Log images are fetched via description images instead.
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class LiveApiImage {
+        @JsonProperty("url")
+        String url;
+        @JsonProperty("name")
+        String name;
+        @JsonProperty("description")
+        String description;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLiveOAuth.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLiveOAuth.java
@@ -1,0 +1,204 @@
+package cgeo.geocaching.connector.gc;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.network.HttpRequest;
+import cgeo.geocaching.network.HttpResponse;
+import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+import cgeo.geocaching.utils.Log;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Base64;
+import android.widget.Toast;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * OAuth2 + PKCE authorization helper for the GC Live API.
+ *
+ * Usage:
+ * 1. Call {@link #startAuthorization(Context)} — stores PKCE verifier, opens browser
+ * 2. Browser redirects to gcdroid://oauth2.callback/callback?code=...
+ * 3. MainActivity receives the callback, calls {@link #handleCallback(Context, Uri)}
+ * 4. Tokens are exchanged and stored in Settings
+ */
+public final class GCLiveOAuth {
+
+    private static final String AUTH_URL = "https://www.geocaching.com/oauth/authorize.aspx";
+    private static final String TOKEN_URL = "https://oauth.geocaching.com/token";
+
+    private GCLiveOAuth() {
+        // utility class
+    }
+
+    /**
+     * Start the OAuth2 authorization flow: generate PKCE verifier, persist it,
+     * and open the browser to the GC authorize page.
+     */
+    public static void startAuthorization(final Context context) {
+        final String clientId = LocalizationUtils.getString(R.string.gc_live_client_id);
+        final String redirectUri = LocalizationUtils.getString(R.string.gc_live_redirect_uri);
+
+        final String codeVerifier = generateCodeVerifier();
+        Settings.setGCLiveCodeVerifier(codeVerifier);
+
+        final String codeChallenge = generateCodeChallenge(codeVerifier);
+
+        final Uri uri = Uri.parse(AUTH_URL).buildUpon()
+                .appendQueryParameter("client_id", clientId)
+                .appendQueryParameter("response_type", "code")
+                .appendQueryParameter("scope", "*")
+                .appendQueryParameter("redirect_uri", redirectUri)
+                .appendQueryParameter("code_challenge", codeChallenge)
+                .appendQueryParameter("code_challenge_method", "S256")
+                .build();
+
+        Log.i("GCLiveOAuth: Opening browser for authorization");
+        final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        context.startActivity(intent);
+    }
+
+    /**
+     * Check whether the given URI is a GC Live OAuth callback and handle it.
+     *
+     * @return true if the URI was an OAuth callback (handled or error), false otherwise
+     */
+    public static boolean handleCallback(final Context context, final Uri uri) {
+        if (uri == null) {
+            return false;
+        }
+
+        final String redirectUri = LocalizationUtils.getString(R.string.gc_live_redirect_uri);
+        if (StringUtils.isBlank(redirectUri)) {
+            return false;
+        }
+
+        final Uri redirect = Uri.parse(redirectUri);
+        if (!StringUtils.equals(uri.getScheme(), redirect.getScheme())
+                || !StringUtils.equals(uri.getAuthority(), redirect.getAuthority())
+                || !StringUtils.equals(uri.getPath(), redirect.getPath())) {
+            return false;
+        }
+
+        Log.i("GCLiveOAuth: Received OAuth callback");
+
+        final String code = uri.getQueryParameter("code");
+        if (StringUtils.isBlank(code)) {
+            final String error = uri.getQueryParameter("error");
+            Log.e("GCLiveOAuth: No code in callback: " + (error != null ? error : "unknown"));
+            final String msg = error != null
+                    ? context.getString(R.string.gc_live_auth_failed, error)
+                    : context.getString(R.string.gc_live_auth_failed_no_code);
+            Toast.makeText(context, msg, Toast.LENGTH_LONG).show();
+            return true;
+        }
+
+        final String codeVerifier = Settings.getGCLiveCodeVerifier();
+        // Clear it immediately so it can't be reused
+        Settings.setGCLiveCodeVerifier(null);
+
+        if (StringUtils.isBlank(codeVerifier)) {
+            Log.e("GCLiveOAuth: No code verifier found in Settings");
+            Toast.makeText(context, R.string.gc_live_auth_failed_no_verifier, Toast.LENGTH_LONG).show();
+            return true;
+        }
+
+        Log.i("GCLiveOAuth: Got authorization code, exchanging for tokens...");
+        AndroidRxUtils.networkScheduler.scheduleDirect(() -> exchangeCodeForTokens(context, code, codeVerifier));
+        return true;
+    }
+
+    private static void exchangeCodeForTokens(final Context context, final String code, final String codeVerifier) {
+        try {
+            final String clientId = LocalizationUtils.getString(R.string.gc_live_client_id);
+            final String clientSecret = LocalizationUtils.getString(R.string.gc_live_client_secret);
+            final String redirectUri = LocalizationUtils.getString(R.string.gc_live_redirect_uri);
+
+            final Parameters body = new Parameters();
+            body.put("client_id", clientId);
+            body.put("client_secret", clientSecret);
+            body.put("grant_type", "authorization_code");
+            body.put("redirect_uri", redirectUri);
+            body.put("code", code);
+            body.put("code_verifier", codeVerifier);
+
+            final HttpResponse response = new HttpRequest()
+                    .uriBase(TOKEN_URL)
+                    .uri("")
+                    .bodyForm(body)
+                    .request()
+                    .blockingGet();
+
+            final int status = response.getStatusCode();
+            if (status != 200) {
+                Log.e("GCLiveOAuth: Token exchange HTTP " + status);
+                showToast(context, context.getString(R.string.gc_live_auth_failed_http, status));
+                return;
+            }
+
+            final TokenResponse token = response.parseJson(TokenResponse.class, null);
+            if (token == null || StringUtils.isBlank(token.accessToken)) {
+                Log.e("GCLiveOAuth: Empty token response");
+                showToast(context, context.getString(R.string.gc_live_auth_failed_empty_token));
+                return;
+            }
+
+            final long now = System.currentTimeMillis() / 1000;
+            Settings.setGCLiveAccessToken(token.accessToken);
+            Settings.setGCLiveTokenIssuedAt(now);
+            if (StringUtils.isNotBlank(token.refreshToken)) {
+                Settings.setGCLiveRefreshToken(token.refreshToken);
+            }
+
+            Log.i("GCLiveOAuth: Tokens stored successfully");
+            showToast(context, context.getString(R.string.gc_live_auth_success));
+
+        } catch (final Exception e) {
+            Log.e("GCLiveOAuth: Token exchange failed", e);
+            showToast(context, context.getString(R.string.gc_live_auth_failed, e.getMessage()));
+        }
+    }
+
+    private static void showToast(final Context context, final String msg) {
+        AndroidRxUtils.runOnUi(() -> Toast.makeText(context.getApplicationContext(), msg, Toast.LENGTH_LONG).show());
+    }
+
+    private static String generateCodeVerifier() {
+        final byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.encodeToString(bytes, Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+    }
+
+    private static String generateCodeChallenge(final String verifier) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            final byte[] hash = digest.digest(verifier.getBytes(StandardCharsets.US_ASCII));
+            return Base64.encodeToString(hash, Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+        } catch (final Exception e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class TokenResponse {
+        @JsonProperty("access_token")
+        String accessToken;
+        @JsonProperty("refresh_token")
+        String refreshToken;
+        @JsonProperty("token_type")
+        String tokenType;
+        @JsonProperty("expires_in")
+        long expiresIn;
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/PocketQueryListActivity.java
@@ -28,6 +28,9 @@ public class PocketQueryListActivity extends AbstractListActivity {
 
     @Override
     protected List<GCList> getList() {
+        if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+            return GCLiveAPI.searchPocketQueries();
+        }
         return GCParser.searchPocketQueries();
     }
 

--- a/main/src/main/java/cgeo/geocaching/connector/trackable/TravelBugConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/trackable/TravelBugConnector.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.connector.trackable;
 import cgeo.geocaching.R;
 import cgeo.geocaching.connector.UserAction;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCLiveAPI;
 import cgeo.geocaching.connector.gc.GCParser;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.models.Trackable;
@@ -70,6 +71,9 @@ public class TravelBugConnector extends AbstractTrackableConnector {
     @Override
     @Nullable
     public Trackable searchTrackable(final String geocode, final String guid, final String id) {
+        if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+            return GCLiveAPI.searchTrackable(geocode, guid, id);
+        }
         return GCParser.searchTrackable(geocode, guid, id);
     }
 

--- a/main/src/main/java/cgeo/geocaching/loaders/GCListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/GCListLoader.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.loaders;
 
 import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.gc.GCLiveAPI;
 import cgeo.geocaching.connector.gc.GCParser;
 import cgeo.geocaching.models.GCList;
 import cgeo.geocaching.settings.Settings;
@@ -24,10 +25,21 @@ public class GCListLoader extends AbstractSearchLoader {
             final SearchResult combinedResult = new SearchResult();
             for (final GCList gcList : gcLists) {
                 if (gcList.isBookmarkList()) {
-                    final SearchResult bmResult = GCParser.searchByBookmarkList(GCConnector.getInstance(), gcList.getGuid(), 0);
+                    final SearchResult bmResult;
+                    if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+                        bmResult = GCLiveAPI.searchByBookmarkList(GCConnector.getInstance(), gcList.getGuid(), 0);
+                    } else {
+                        bmResult = GCParser.searchByBookmarkList(GCConnector.getInstance(), gcList.getGuid(), 0);
+                    }
                     combinedResult.addSearchResult(bmResult);
                 } else {
-                    final SearchResult pqResult = GCParser.searchByPocketQuery(GCConnector.getInstance(), gcList.getShortGuid(), gcList.getPqHash());
+                    final SearchResult pqResult;
+                    if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+                        // Live API uses same /lists/{ref}/geocaches endpoint for PQs
+                        pqResult = GCLiveAPI.searchByBookmarkList(GCConnector.getInstance(), gcList.getGuid(), 0);
+                    } else {
+                        pqResult = GCParser.searchByPocketQuery(GCConnector.getInstance(), gcList.getShortGuid(), gcList.getPqHash());
+                    }
                     combinedResult.addSearchResult(pqResult);
                 }
             }

--- a/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
+++ b/main/src/main/java/cgeo/geocaching/network/HttpRequest.java
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
  */
 public class HttpRequest {
 
-    public enum Method { GET, POST, PATCH, PUT }
+    public enum Method { GET, POST, PATCH, PUT, DELETE }
 
     private static final ObjectMapper JSON_MAPPER = JsonUtils.mapper;
 
@@ -219,6 +219,13 @@ public class HttpRequest {
                 break;
             case PUT:
                 builder.put(rbs.get());
+                break;
+            case DELETE:
+                if (requestBodySupplier != null) {
+                    builder.delete(rbs.get());
+                } else {
+                    builder.delete();
+                }
                 break;
             case GET:
             default:

--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -2,9 +2,11 @@ package cgeo.geocaching.service;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.gc.GCLiveAPI;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.network.HtmlImage;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.ViewUtils;
@@ -25,12 +27,14 @@ import android.widget.RadioGroup;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -183,20 +187,71 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
             return;
         }
 
-        // schedule download on multiple threads...
-
         Log.d("Download task started");
 
-        final Observable<String> geocodes = Observable.fromIterable(intent.getStringArrayListExtra(EXTRA_GEOCODES));
+        final ArrayList<String> allGeocodes = intent.getStringArrayListExtra(EXTRA_GEOCODES);
+        if (allGeocodes == null || allGeocodes.isEmpty()) {
+            return;
+        }
+
+        // Set rate limit callback for the entire download operation
+        GCLiveAPI.setRateLimitCallback(secondsRemaining -> {
+            if (secondsRemaining > 0) {
+                notification.setContentText(getString(R.string.gc_live_rate_limited, secondsRemaining));
+            } else {
+                notification.setContentText("");
+            }
+            updateForegroundNotification();
+        });
+
+        try {
+        // Batch pre-fetch GC caches via Live API if enabled
+        final Set<String> batchFetched = new HashSet<>();
+        if (Settings.useGCLiveAPI() && Settings.hasGCLiveAuthorization()) {
+            final ArrayList<String> gcGeocodes = new ArrayList<>();
+            for (final String geocode : allGeocodes) {
+                if (geocode != null && geocode.startsWith("GC")) {
+                    gcGeocodes.add(geocode);
+                }
+            }
+            if (!gcGeocodes.isEmpty()) {
+                // Phase 1: Batch fetch cache details (chunks of 50)
+                Log.i("GCLiveAPI: Batch pre-fetching " + gcGeocodes.size() + " GC caches");
+                GCLiveAPI.setBatchProgressCallback((fetched, total) -> {
+                    notification.setContentText(getString(R.string.gc_live_batch_progress, fetched, total));
+                    notification.setProgress(total, fetched, false);
+                    updateForegroundNotification();
+                });
+                try {
+                    final List<Geocache> fetched = GCLiveAPI.fetchGeocachesBatch(gcGeocodes);
+                    for (final Geocache c : fetched) {
+                        batchFetched.add(c.getGeocode());
+                    }
+                } finally {
+                    GCLiveAPI.setBatchProgressCallback(null);
+                }
+                Log.i("GCLiveAPI: Batch pre-fetched " + batchFetched.size() + " caches successfully");
+
+                // Logs and spoilers are fetched on-demand when opening individual caches
+                // (via searchByGeocode → fetchAndSaveLogs/fetchAndSaveSpoilers).
+                // Bulk fetching them here would hit API rate limits heavily.
+            }
+        }
+
+        // Per-cache processing (list management, image download, notifications)
+        final Observable<String> geocodes = Observable.fromIterable(allGeocodes);
         geocodes.flatMap((Function<String, Observable<String>>) geocode -> Observable.create((ObservableOnSubscribe<String>) emitter -> {
-            handleDownload(geocode);
+            handleDownload(geocode, batchFetched);
             emitter.onComplete();
         }).subscribeOn(AndroidRxUtils.refreshScheduler)).blockingSubscribe();
 
         Log.d("Download task completed");
+        } finally {
+            GCLiveAPI.setRateLimitCallback(null);
+        }
     }
 
-    private void handleDownload(final String geocode) {
+    private void handleDownload(final String geocode, final Set<String> batchFetched) {
         try {
             if (shouldStop) {
                 Log.i("download canceled");
@@ -229,8 +284,43 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
                 combinedListIds.addAll(cache.getLists());
             }
 
-            // download...
-            if (Geocache.storeCache(null, geocode, combinedListIds, properties.forceDownload, null)) {
+            // Batch-fetched path: cache data already in DB from Live API batch fetch.
+            // Skip re-fetching via searchByGeocode — just download images and set lists.
+            if (batchFetched.contains(geocode)) {
+                final Geocache batchCache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
+                if (batchCache != null) {
+                    // Download description images
+                    final HtmlImage imgGetter = new HtmlImage(batchCache.getGeocode(), false, true, false);
+                    if (org.apache.commons.lang3.StringUtils.isNotBlank(batchCache.getDescription())) {
+                        HtmlCompat.fromHtml(batchCache.getDescription(), HtmlCompat.FROM_HTML_MODE_LEGACY, imgGetter, null);
+                    }
+                    // Download spoiler images
+                    if (batchCache.getSpoilers() != null) {
+                        for (final cgeo.geocaching.models.Image spoiler : batchCache.getSpoilers()) {
+                            imgGetter.getDrawable(spoiler.getUrl());
+                        }
+                    }
+                    imgGetter.waitForEndCompletable(null).blockingAwait();
+
+                    batchCache.setLists(combinedListIds);
+                    DataStore.saveCache(batchCache, java.util.EnumSet.of(LoadFlags.SaveFlag.DB));
+
+                    GeocacheChangedBroadcastReceiver.sendBroadcast(this, geocode);
+                    synchronized (downloadQuery) {
+                        if (downloadQuery.get(geocode) == null) {
+                            downloadQuery.remove(geocode);
+                        }
+                    }
+                    Log.d("Download #" + cachesDownloaded.get() + " " + geocode + " completed (batch)");
+                    cachesDownloaded.incrementAndGet();
+                    return;
+                }
+                // fall through to normal path if cache not found in DB
+            }
+
+            // Normal path: fetch + download images
+            final boolean forceDownload = properties.forceDownload;
+            if (Geocache.storeCache(null, geocode, combinedListIds, forceDownload, null)) {
                 // send a broadcast so that foreground activities know that they might need to update their content
                 GeocacheChangedBroadcastReceiver.sendBroadcast(this, geocode);
                 // check whether the download properties are still null,

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -820,6 +820,71 @@ public class Settings {
         putString(R.string.pref_memberstatus, memberStatus.id);
     }
 
+    // GC Live API OAuth2 tokens
+
+    public static String getGCLiveAccessToken() {
+        return getString(R.string.pref_gc_live_access_token, null);
+    }
+
+    public static void setGCLiveAccessToken(final String token) {
+        if (token == null) {
+            remove(R.string.pref_gc_live_access_token);
+        } else {
+            putString(R.string.pref_gc_live_access_token, token);
+        }
+    }
+
+    public static String getGCLiveRefreshToken() {
+        return getString(R.string.pref_gc_live_refresh_token, null);
+    }
+
+    public static void setGCLiveRefreshToken(final String token) {
+        if (token == null) {
+            remove(R.string.pref_gc_live_refresh_token);
+        } else {
+            putString(R.string.pref_gc_live_refresh_token, token);
+        }
+    }
+
+    public static long getGCLiveTokenIssuedAt() {
+        return getLong(R.string.pref_gc_live_token_issued_at, 0);
+    }
+
+    public static void setGCLiveTokenIssuedAt(final long issuedAt) {
+        putLong(R.string.pref_gc_live_token_issued_at, issuedAt);
+    }
+
+    public static String getGCLiveCodeVerifier() {
+        return getString(R.string.pref_gc_live_code_verifier, null);
+    }
+
+    public static void setGCLiveCodeVerifier(final String verifier) {
+        if (verifier == null) {
+            remove(R.string.pref_gc_live_code_verifier);
+        } else {
+            putString(R.string.pref_gc_live_code_verifier, verifier);
+        }
+    }
+
+    public static boolean hasGCLiveAuthorization() {
+        return StringUtils.isNotBlank(getGCLiveRefreshToken());
+    }
+
+    public static void clearGCLiveTokens() {
+        remove(R.string.pref_gc_live_access_token);
+        remove(R.string.pref_gc_live_refresh_token);
+        remove(R.string.pref_gc_live_token_issued_at);
+        remove(R.string.pref_gc_live_code_verifier);
+    }
+
+    public static boolean useGCLiveAPI() {
+        return getBoolean(R.string.pref_gc_use_live_api, false);
+    }
+
+    public static void setUseGCLiveAPI(final boolean value) {
+        putBoolean(R.string.pref_gc_use_live_api, value);
+    }
+
     //solely to be used by class Cookies
     public static String getPersistentCookies() {
         return getString(R.string.pref_cookiejar, "");

--- a/main/src/main/res/layout/main_activity_connectorstatus.xml
+++ b/main/src/main/res/layout/main_activity_connectorstatus.xml
@@ -60,6 +60,18 @@
             android:textIsSelectable="false"
             android:textSize="@dimen/textSize_headingSecondary" />
 
+        <TextView
+            android:id="@+id/item_live_api_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:scrollHorizontally="true"
+            android:textIsSelectable="false"
+            android:textSize="@dimen/textSize_headingSecondary"
+            android:visibility="gone" />
+
         <Button
             android:id="@+id/manual_login"
             android:visibility="gone"

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -66,6 +66,7 @@
     <string translatable="false" name="pref_loaddirectionimg">loaddirectionimg</string>
     <string translatable="false" name="pref_gc_fb_login_hint">gc_fb_login_hint</string>
     <string translatable="false" name="pref_fakekey_gc_website">fakekey_gc_website</string>
+    <string translatable="false" name="pref_fakekey_gc_live_authorization">fakekey_gc_live_authorization</string>
 
     <!-- settings for geocaching.com lab adventures screen -->
     <string translatable="false" name="preference_screen_al">preference_screen_al</string>
@@ -516,6 +517,12 @@
     <string translatable="false" name="pref_gcLastLoginErrorStatus">gcLastLoginErrorStatus</string>
     <string translatable="false" name="pref_gcLastLoginError">gcLastLoginError</string>
     <string translatable="false" name="pref_gcLastLoginSuccess">gcLastLoginSuccess</string>
+
+    <string translatable="false" name="pref_gc_live_access_token">gc_live_access_token</string>
+    <string translatable="false" name="pref_gc_live_refresh_token">gc_live_refresh_token</string>
+    <string translatable="false" name="pref_gc_live_token_issued_at">gc_live_token_issued_at</string>
+    <string translatable="false" name="pref_gc_live_code_verifier">gc_live_code_verifier</string>
+    <string translatable="false" name="pref_gc_use_live_api">gc_use_live_api</string>
 
     <string translatable="false" name="pref_ocde_tokensecret">ocde_tokensecret</string>
     <string translatable="false" name="pref_ocde_tokenpublic">ocde_tokenpublic</string>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3195,6 +3195,25 @@
         <item quantity="other">%d unread messages in message center</item>
     </plurals>
 
+    <!-- GC Live API -->
+    <string name="settings_gc_live_api_title">Use GC Live API</string>
+    <string name="settings_gc_live_api_summary">Use the official Geocaching API instead of web scraping. Faster, especially for bulk operations.</string>
+    <string name="settings_gc_live_auth_title">Authorize GC Live API</string>
+    <string name="settings_gc_live_auth_connected">Authorized</string>
+    <string name="settings_gc_live_auth_not_connected">Not authorized. Tap to authorize.</string>
+    <string name="gc_live_auth_failed">GC Live auth failed: %s</string>
+    <string name="gc_live_auth_failed_no_code">GC Live auth failed: no code</string>
+    <string name="gc_live_auth_failed_no_verifier">GC Live auth failed: no code verifier. Please try again.</string>
+    <string name="gc_live_auth_failed_http">GC Live auth failed (HTTP %d)</string>
+    <string name="gc_live_auth_failed_empty_token">GC Live auth failed: empty token</string>
+    <string name="gc_live_auth_success">GC Live API authorized!</string>
+    <string name="gc_live_status_not_authorized">Live API: not authorized</string>
+    <string name="gc_live_status_token_valid">Live API: token valid</string>
+    <string name="gc_live_status_refreshing_token">Live API: refreshing token\u2026</string>
+    <string name="gc_live_status_token_refresh_failed">Live API: token refresh failed</string>
+    <string name="gc_live_rate_limited">Rate limited, retrying in %ds\u2026</string>
+    <string name="gc_live_batch_progress">Fetching cache data: %1$d/%2$d\u2026</string>
+
     <!-- GC image size conversion -->
     <string name="settings_gc_imagesize_title">Preferred Image Size</string>
     <string name="settings_gc_imagesize_summary">Images from Geocaching.com in listing, logs and trackables are available in different sizes. Select the size to be loaded when loading and storing a cache. "Unchanged" will load the version the listing/log author included in the page.</string>

--- a/main/src/main/res/xml/preferences_services_geocaching_com.xml
+++ b/main/src/main/res/xml/preferences_services_geocaching_com.xml
@@ -29,6 +29,21 @@
 
         <CheckBoxPreference
             android:dependency="@string/pref_connectorGCActive"
+            android:defaultValue="false"
+            android:key="@string/pref_gc_use_live_api"
+            android:title="@string/settings_gc_live_api_title"
+            android:summary="@string/settings_gc_live_api_summary"
+            app:iconSpaceReserved="false" />
+
+        <Preference
+            android:dependency="@string/pref_connectorGCActive"
+            android:key="@string/pref_fakekey_gc_live_authorization"
+            android:title="@string/settings_gc_live_auth_title"
+            app:summary="@string/settings_gc_live_auth_not_connected"
+            app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:dependency="@string/pref_connectorGCActive"
             android:key="@string/pref_pollMessageCenter"
             android:title="@string/mcpolling_title"
             android:summary="@string/mcpolling_summary"

--- a/main/templates/keys.xml
+++ b/main/templates/keys.xml
@@ -33,4 +33,9 @@
 
     <!-- Geocaching.com public ALC API -->
     <string name="alc_consumer_key" translatable="false">@alc.consumer.key@</string>
+
+    <!-- Geocaching.com Live API (OAuth2) -->
+    <string name="gc_live_client_id" translatable="false">@gc.live.client.id@</string>
+    <string name="gc_live_client_secret" translatable="false">@gc.live.client.secret@</string>
+    <string name="gc_live_redirect_uri" translatable="false">@gc.live.redirect.uri@</string>
 </resources>

--- a/templates/private.properties
+++ b/templates/private.properties
@@ -37,3 +37,8 @@ su.consumer.secret=
 
 # Geocaching.com public API for Adventure Labs
 alc.consumer.key=
+
+# Geocaching.com Live API (OAuth2)
+gc.live.client.id=
+gc.live.client.secret=
+gc.live.redirect.uri=


### PR DESCRIPTION
Route all geocaching.com operations through the official Live API (api.groundspeak.com/v1) instead of HTML scraping, with a toggle in Settings to switch between API and scraping. Includes OAuth2 + PKCE authorization flow, batch cache retrieval, parallel log/spoiler fetching, and finds count display in cache details.

This is a PoC, do not merge.