### PR TITLE
locus-api Update

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -379,7 +379,7 @@ dependencies {
     implementation "com.squareup.leakcanary:plumber-android:$leakCanaryVersion"
 
     // Locus Maps integration
-    implementation "com.asamm:locus-api-android:0.9.64"
+    implementation 'com.github.asamm.locus-api:locus-api-android:0.9.72'
 
     // -- Mapsforge / Mapsforge --
 

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -121,6 +121,11 @@
 # used in tests
 -keepclassmembers public class * extends io.reactivex.rxjava3.core.Observable { public ** blockingFirst(); }
 
+# Locus -------------------------------------------------------------------------------------------
+
+# Keep Locus API objects
+-keep class locus.api.objects.** { *; }
+
 # Unsorted ----------------------------------------------------------------------------------------
 
 -dontwarn org.springframework.**


### PR DESCRIPTION
- move to the new base name (from `com.asamm` to `com.github.asamm.locus-api`
- Version update 0.9.64 to 0.9.72
- adding proguard rules

See
 - https://github.com/asamm/locus-api/blob/master/README.md
 - https://github.com/asamm/locus-api/blob/master/CHANGELOG.md
