### PR TITLE
Support coloring statusbar (rel. to #17775)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/TabbedViewPagerActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/TabbedViewPagerActivity.java
@@ -91,14 +91,6 @@ public abstract class TabbedViewPagerActivity extends AbstractActionBarActivity 
         }).attach();
     }
 
-    @NonNull
-    @Override
-    protected Insets calculateInsetsForActivityContent(@NonNull final Insets def) {
-        final Insets skip = super.calculateInsetsForActivityContent(def); // only to trigger toolbar adjustment
-        Log.e("TabbedViewPagerActivity(given): left=" + def.left + ", top=" + def.top + ", right=" + def.right + ", bottom=" + def.bottom);
-        return def;
-    }
-
     private final ViewPager2.OnPageChangeCallback pageChangeCallback = new ViewPager2.OnPageChangeCallback() {
 
         @Override

--- a/main/src/main/java/cgeo/geocaching/utils/ActionBarUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ActionBarUtils.java
@@ -44,9 +44,8 @@ public class ActionBarUtils {
         final Window currentWindow = activity.getWindow();
         final WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(currentWindow, currentWindow.getDecorView());
 
-        // TODO: set light/dark system bars depending on action bar colors
         final boolean isLightSkin = Settings.isLightSkin(activity);
-        windowInsetsController.setAppearanceLightStatusBars(isLightSkin);
+        windowInsetsController.setAppearanceLightStatusBars(false);
         windowInsetsController.setAppearanceLightNavigationBars(isLightSkin);
     }
 


### PR DESCRIPTION
## Description
Colors statusbar the same color as actionbar.
(For CacheDetailActivity, this will be a color depending on cache type, if enabled in settings.)
Fixes the remaining open issue of #17775.

This is achieved by:
- using inset.top as additional padding to toolbar, which needs to be increased in height accordingly
- by this, toolbar's background color will be used for top padding (= statusbar area) as well
- finally, set inset.top=0, as the added padding will fill the space
- spacer will get a similar adjustment
