### PR TITLE
ci: Automatically add label ok-to-test from contributors repo fork

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,14 @@ jobs:
           echo "::error::${{ github.triggering_actor }} does not have permissions on this repo.\nCurrent permission level is ${{ steps.checkAccess.outputs.user-permission }}\nJob originally triggered by ${{ github.actor }}"
           exit 1
 
+      # Using if to restrict to pull_request_target events, as the workflow will exit with error from previous step if the user does not have permissions,
+      # so we can be sure that only users with permissions will reach this step and get the label added
+      - name: Add ok-to-test label
+        uses: actions-ecosystem/action-add-labels@v1
+        if: github.event_name == 'pull_request_target'
+        with:
+          labels: ok-to-test
+
   check-code-changed:
     if: >
       github.event_name != 'pull_request_target' ||


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
As discussed in #17904, here is a little addition that should be able to add the `ok-to-test` label for PR from c:geo contributors external repo fork.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Relates #17904

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->

x-ref: https://github.com/cgeo/cgeo/issues/17904#issuecomment-3964474059

> > For the eat your own food, really? What I propose is half the way, you need the label to be set, but the step already present to check if you really have access to the secrets will also add itself the label ok to test. It s just a few lines...

> In my experience having a normal workflow for "common" users and a special way for "core" users leads to decay of the "normal" workflow because it is seldom used. We want (need) to make our system atteactive for development by non-core-users, we depend on them

/cc @eddiemuc 

Note: this cannot be tested directly in this repo without merge first