### PR TITLE
fix search suggestion height (fixes #17899)

### DIFF
--- a/main/src/main/res/layout/cacheslist_item_select.xml
+++ b/main/src/main/res/layout/cacheslist_item_select.xml
@@ -40,6 +40,7 @@
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsPrimary"
         android:textColor="@color/colorText_listsPrimary"
+        android:minHeight="0dip"
         tools:text="name"
         android:maxLines="1" />
 
@@ -63,6 +64,7 @@
         android:textIsSelectable="false"
         android:textSize="@dimen/textSize_listsSecondary"
         android:textColor="@color/colorText_listsSecondary"
+        android:minHeight="0dip"
         tools:text="geocode"
         android:maxLines="3" />
 


### PR DESCRIPTION
the issue is that minHeight is somehow set to 56dp on each of the TextViews. This PR explicitly overrides that.

But I'm not sure if this is a good solution or should be solved "higher up" the chain.