### PR TITLE
Prevent keyboard from overlapping certain fields (fix #17842)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
@@ -285,6 +285,8 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
             binding.noteLayout.setVisibility(View.GONE);
             updateCoordinates(preprojectedCoords);
         }
+
+        ViewUtils.preventKeyboardOverlap(binding.userNote);
     }
 
     private void setCoordsModificationVisibility(final IConnector con) {

--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -256,7 +256,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
             }
         }
         inventoryAdapter.putActions(lastSavedState.inventoryActions);
-
+        ViewUtils.preventKeyboardOverlap(binding.log);
         refreshGui();
 
         requestKeyboardForLogging();

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -65,8 +65,11 @@ import androidx.annotation.StyleRes;
 import androidx.annotation.StyleableRes;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.graphics.Insets;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.util.LinkifyCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -861,6 +864,14 @@ public class ViewUtils {
         final Drawable circularIcon = IndeterminateDrawable.createCircularDrawable(button.getContext(), spec);
 
         return enable -> mButton.setIcon(enable ? circularIcon : originalIcon);
+    }
+
+    public static void preventKeyboardOverlap(final View view) {
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
+            final Insets newInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime() | WindowInsetsCompat.Type.systemBars());
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), newInsets.bottom);
+            return windowInsets;
+        });
     }
 
 }


### PR DESCRIPTION
## Description
Prevents waypoint user note textedit field and cache log textfield from overlapping with keyboard by applying padding to those input fields, that take keyboard size (and system bars) into account.