### PR TITLE
Support tb parameter when opening trackable links (fix #17914)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/TrackableActivity.java
+++ b/main/src/main/java/cgeo/geocaching/TrackableActivity.java
@@ -151,6 +151,9 @@ public class TrackableActivity extends TabbedViewPagerActivity {
                 if (StringUtils.isBlank(geocode)) {
                     geocode = uri.getQueryParameter("TB");
                 }
+                if (StringUtils.isBlank(geocode)) {
+                    geocode = uri.getQueryParameter("tb");
+                }
                 guid = uri.getQueryParameter("guid");
                 id = uri.getQueryParameter("id");
 


### PR DESCRIPTION
## Description
Try to read "tb" parameter, if "TB" has failed