### PR TITLE
Fix 'too much space in menus' (rel. to #17929)

### DIFF
--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -55,6 +55,7 @@
         <item name="colorControlNormal">@color/colorText</item>
         <item name="android:background">@color/colorBackground</item>
         <item name="android:textColor">@color/colorText</item>
+        <item name="android:minHeight">0dp</item>
     </style>
 
     <!-- theme for alert dialogs -->


### PR DESCRIPTION
Popups seem to inherit minHeight / layoutHeight from new toolbar, so set a minHeight of `0dp` for popup elements.