### PR TITLE
fix #17935: Fix Dropbox images not displayed in cache descriptions

### DIFF
--- a/main/src/main/java/cgeo/geocaching/network/HtmlImage.java
+++ b/main/src/main/java/cgeo/geocaching/network/HtmlImage.java
@@ -80,6 +80,8 @@ public class HtmlImage implements Html.ImageGetter {
 
     public static final ImageData IMAGE_ERROR_DATA = new ImageData(null, null, null);
 
+    private static final String IMAGE_ACCEPT_HEADER = "image/webp,image/png,image/jpeg,image/gif,*/*;q=0.8";
+
     @NonNull private final String geocode;
     /**
      * on error: return large error image, if {@code true}, otherwise empty 1x1 image
@@ -375,7 +377,8 @@ public class HtmlImage implements Html.ImageGetter {
 
         if (absoluteURL != null) {
             try {
-                final Response httpResponse = Network.getRequest(absoluteURL, null, file).blockingGet();
+                final Parameters imageHeaders = new Parameters("Accept", IMAGE_ACCEPT_HEADER);
+                final Response httpResponse = Network.getRequest(absoluteURL, null, imageHeaders, file).blockingGet();
                 if (httpResponse.isSuccessful()) {
                     FileUtils.saveEntityToFile(httpResponse, file);
                 } else if (httpResponse.code() == 304) {
@@ -436,7 +439,7 @@ public class HtmlImage implements Html.ImageGetter {
     private String makeAbsoluteURL(@NonNull final String url) {
         // Check if uri is absolute or not, if not attach the connector hostname
         if (Uri.parse(url).isAbsolute()) {
-            return url;
+            return ImageUtils.fixDropboxImageUrl(url);
         }
 
         final String hostUrl = ConnectorFactory.getConnector(geocode).getHostUrl();

--- a/main/src/main/java/cgeo/geocaching/network/Network.java
+++ b/main/src/main/java/cgeo/geocaching/network/Network.java
@@ -477,6 +477,20 @@ public final class Network {
     /**
      * GET HTTP request
      *
+     * @param uri       the URI to request
+     * @param params    the parameters to add to the GET request
+     * @param headers   the headers to add to the GET request
+     * @param cacheFile the name of the file storing the cached resource, or null not to use one
+     * @return a single with the HTTP response, or an IOException
+     */
+    @NonNull
+    public static Single<Response> getRequest(final String uri, @Nullable final Parameters params, @Nullable final Parameters headers, @Nullable final File cacheFile) {
+        return request("GET", uri, params, headers, cacheFile);
+    }
+
+    /**
+     * GET HTTP request
+     *
      * @param uri     the URI to request
      * @param params  the parameters to add to the GET request
      * @param headers the headers to add to the GET request

--- a/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ImageUtils.java
@@ -99,6 +99,7 @@ public final class ImageUtils {
     private static final Pattern IMG_URL = Pattern.compile("(https?://\\S*\\.(jpeg|jpe|jpg|png|webp|gif|svg)((\\?|#|$|\\)|])\\S*)?)");
     static final Pattern PATTERN_GC_HOSTED_IMAGE = Pattern.compile("^https?://img(?:cdn)?\\.geocaching\\.com(?::443)?(?:/[a-z/]*)?/([^/]*)");
     static final Pattern PATTERN_GC_HOSTED_IMAGE_S3 = Pattern.compile("^https?://s3\\.amazonaws\\.com(?::443)?/gs-geo-images/(.*?)(?:_l|_d|_sm|_t)?(\\.jpg|jpeg|png|gif|bmp|JPG|JPEG|PNG|GIF|BMP)");
+    private static final Pattern PATTERN_DROPBOX_DL_PARAM = Pattern.compile("([?&])dl=\\d+");
 
     public static class ImageFolderCategoryHandler implements ImageGalleryView.EditableCategoryHandler {
 
@@ -550,6 +551,35 @@ public final class ImageUtils {
             //return "https://s3.amazonaws.com/gs-geo-images/" + matcherViewstates.group(1) + preferredSize.getSuffix() + matcherViewstates.group(2);
         }
         return imageUrl;
+    }
+
+    /**
+     * Fix Dropbox image URLs to ensure they return the raw image content.
+     *
+     * Dropbox shared links (www.dropbox.com) return an HTML viewer page by default.
+     * Adding the {@code dl=1} query parameter forces a direct download of the file.
+     * This handles both the old format ({@code /s/}) and the new format ({@code /scl/fi/}).
+     *
+     * @param imageUrl the URL to potentially fix
+     * @return the URL with {@code dl=1} set, or the original URL if no fix is needed
+     */
+    @NonNull
+    public static String fixDropboxImageUrl(@NonNull final String imageUrl) {
+        // Only transform www.dropbox.com URLs; dl.dropboxusercontent.com and dl.dropbox.com
+        // already serve raw content and don't need this transformation.
+        if (!imageUrl.contains("://www.dropbox.com/")) {
+            return imageUrl;
+        }
+
+        // Replace existing dl parameter with dl=1 using regex to avoid replacing
+        // occurrences elsewhere in the URL (e.g., in a filename).
+        final Matcher matcher = PATTERN_DROPBOX_DL_PARAM.matcher(imageUrl);
+        if (matcher.find()) {
+            return matcher.replaceFirst("$1dl=1");
+        }
+
+        // No dl parameter present, append dl=1
+        return imageUrl + (imageUrl.contains("?") ? "&dl=1" : "?dl=1");
     }
 
     public enum GCImageSize {

--- a/main/src/test/java/cgeo/geocaching/utils/ImageUtilsTest.java
+++ b/main/src/test/java/cgeo/geocaching/utils/ImageUtilsTest.java
@@ -1,0 +1,69 @@
+package cgeo.geocaching.utils;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ImageUtilsTest {
+
+    @Test
+    public void fixDropboxImageUrlOldFormatWithDl0() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/s/abc123/photo.jpg?dl=0"))
+                .isEqualTo("https://www.dropbox.com/s/abc123/photo.jpg?dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlOldFormatWithDl1() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/s/abc123/photo.jpg?dl=1"))
+                .isEqualTo("https://www.dropbox.com/s/abc123/photo.jpg?dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlOldFormatWithoutDlParam() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/s/abc123/photo.jpg"))
+                .isEqualTo("https://www.dropbox.com/s/abc123/photo.jpg?dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlNewSclFormatWithDl0() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/scl/fi/abc123/photo.jpg?rlkey=xyz&dl=0"))
+                .isEqualTo("https://www.dropbox.com/scl/fi/abc123/photo.jpg?rlkey=xyz&dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlNewSclFormatWithDl1() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/scl/fi/abc123/photo.jpg?rlkey=xyz&dl=1"))
+                .isEqualTo("https://www.dropbox.com/scl/fi/abc123/photo.jpg?rlkey=xyz&dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlNewSclFormatWithoutDlParam() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/scl/fi/abc123/photo.jpg?rlkey=xyz"))
+                .isEqualTo("https://www.dropbox.com/scl/fi/abc123/photo.jpg?rlkey=xyz&dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlDlDropboxUsercontentUnchanged() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://dl.dropboxusercontent.com/s/abc123/photo.jpg"))
+                .isEqualTo("https://dl.dropboxusercontent.com/s/abc123/photo.jpg");
+    }
+
+    @Test
+    public void fixDropboxImageUrlDlDropboxComUnchanged() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://dl.dropbox.com/s/abc123/photo.jpg?dl=1"))
+                .isEqualTo("https://dl.dropbox.com/s/abc123/photo.jpg?dl=1");
+    }
+
+    @Test
+    public void fixDropboxImageUrlNonDropboxUrlUnchanged() {
+        assertThat(ImageUtils.fixDropboxImageUrl("https://img.geocaching.com/cache/abc123.jpg"))
+                .isEqualTo("https://img.geocaching.com/cache/abc123.jpg");
+    }
+
+    @Test
+    public void fixDropboxImageUrlDlParamInFilenameNotAffected() {
+        // dl=0 in a filename path segment should not be mistakenly replaced
+        assertThat(ImageUtils.fixDropboxImageUrl("https://www.dropbox.com/s/abc123/photo_dl=0.jpg?rlkey=xyz"))
+                .isEqualTo("https://www.dropbox.com/s/abc123/photo_dl=0.jpg?rlkey=xyz&dl=1");
+    }
+
+}


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
Fix Dropbox images without dl=1 parameter

See JakeDot#214