### PR TITLE
Keep parameters for user-defined tile providers

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeOnlineSource.java
@@ -26,7 +26,8 @@ public class UserDefinedMapsforgeOnlineSource extends AbstractMapsforgeOnlineTil
                 }
                 tilePath += "{Z}/{X}/{Y}.png";
             }
-            setTilePath(tilePath);
+            final String query = fullUri.getQuery();
+            setTilePath(tilePath + (StringUtils.isNotBlank(query) ? "?" + query : ""));
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/UserDefinedMapsforgeVTMOnlineSource.java
@@ -27,6 +27,8 @@ public class UserDefinedMapsforgeVTMOnlineSource extends AbstractMapsforgeVTMOnl
                 }
                 tilePath += "{Z}/{X}/{Y}.png";
             }
+            final String query = fullUri.getQuery();
+            setTilePath(tilePath + (StringUtils.isNotBlank(query) ? "?" + query : ""));
             setTilePath(tilePath);
         }
         supportsHillshading = true;


### PR DESCRIPTION
## Description
A user on support wants to use a user-defined tile provider that requires additional URL parameters (like API key and language selection), which is currently not supported by c:geo.

This PR extends user-defined tile providers to keep query parameters in the configured tileprovider string.