### PR TITLE
Make popup background transparent (rel. to #17950)

### DIFF
--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -53,7 +53,7 @@
     <!-- ensures correct color for headings of submenus in appToolbar -->
     <style name="appToolbarPopup" parent="ThemeOverlay.MaterialComponents">
         <item name="colorControlNormal">@color/colorText</item>
-        <item name="android:background">@color/colorBackground</item>
+        <item name="android:background">@android:color/transparent</item>
         <item name="android:textColor">@color/colorAccent</item>
         <item name="android:minHeight">0dp</item>
     </style>


### PR DESCRIPTION
## Description
Replaces default popup background with a transparent color, avoiding the "black box" effect described in #17950.