### PR TITLE
ci: add trigger on pull_request_target: opened/reopened

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
   pull_request_target:
-    types: [labeled, synchronize]
+    types: [opened, labeled, synchronize, reopened]
   workflow_dispatch:
     inputs:
       JDK_VERSION:
@@ -51,6 +51,7 @@ jobs:
       (
         github.event.pull_request.head.repo.full_name != github.repository &&
         (
+          github.event.action == 'opened' || github.event.action == 'reopened' ||
           (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
           (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
         )


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->

Add trigger on PR open/reopen so the task to add the label if the user is authorized is triggered

## Related issues
<!-- List the related issues fixed or improved by this PR -->
#17928 #17905 #17904 

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Due to the `pull_request_target` the code need to land in `master` to be tested :/