### PR TITLE
Fix #17958: Use color-selector for disabling actionbar-items

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -3,13 +3,15 @@ package cgeo.geocaching.utils;
 import cgeo.geocaching.R;
 
 import android.annotation.SuppressLint;
-import android.content.res.Resources;
+import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.appcompat.view.menu.MenuBuilder;
 import androidx.appcompat.view.menu.MenuItemImpl;
+import androidx.core.content.ContextCompat;
 
 import javax.annotation.Nullable;
 
@@ -30,13 +32,15 @@ public class MenuUtils {
     }
 
     /**
-     * Sets enabled state for given menu item (without crashing on null item)
+     * Sets enabled state for given menu item (without crashing on null item).
+     * Also updates icon tint immediately to reflect the new state.
      */
     public static void setEnabled(final MenuItem menuItem, final boolean enabled) {
         if (menuItem == null) {
             return;
         }
         menuItem.setEnabled(enabled);
+        tintSingleIcon(menuItem);
     }
 
     public static void setVisible(final Menu menu, final int itemId, final boolean visible) {
@@ -61,6 +65,30 @@ public class MenuUtils {
     }
 
     @SuppressLint("RestrictedApi")
+    private static void tintSingleIcon(final MenuItem menuItem) {
+        if (!(menuItem instanceof MenuItemImpl)) {
+            return;
+        }
+        final MenuItemImpl item = (MenuItemImpl) menuItem;
+        final Drawable drw = item.getIcon();
+        if (drw == null) {
+            return;
+        }
+        final Context ctx = ColorUtils.getThemedContext();
+        final boolean isActionButton = item.isActionButton();
+        final ColorStateList tint = ContextCompat.getColorStateList(ctx, isActionButton ? R.color.action_bar_item_text_selector : R.color.menu_icon_tint_selector);
+        if (tint == null) {
+            return;
+        }
+        final int[] state = item.isEnabled() ? new int[]{android.R.attr.state_enabled} : new int[]{};
+        final int baseColor = tint.getColorForState(state, tint.getDefaultColor());
+        // android:alpha in ColorStateList is not applied by getColorForState() - apply manually
+        final int color = item.isEnabled() ? baseColor : applyAlpha(baseColor, 0.6f);
+        drw.mutate().setTint(color);
+        item.setIcon(drw);
+    }
+
+    @SuppressLint("RestrictedApi")
     public static void tintToolbarAndOverflowIcons(@Nullable final Menu menu) {
         if (null == menu) {
             return;
@@ -74,22 +102,39 @@ public class MenuUtils {
         if (!anyMenuItemVisible) {
             return;
         }
-        final Resources res = ColorUtils.getThemedContext().getResources();
-        tintMenuIcons(menu, res.getColor(R.color.colorTextActionBar), res.getColor(R.color.colorIconMenu));
+        final Context ctx = ColorUtils.getThemedContext();
+        final ColorStateList actionBarTint = ContextCompat.getColorStateList(ctx, R.color.action_bar_item_text_selector);
+        final ColorStateList menuTint = ContextCompat.getColorStateList(ctx, R.color.menu_icon_tint_selector);
+        tintMenuIcons(menu, actionBarTint, menuTint);
     }
 
     @SuppressLint("RestrictedApi")
-    private static void tintMenuIcons(final Menu menu, final int actionBarColor, final int menuColor) {
+    private static void tintMenuIcons(final Menu menu, final ColorStateList actionBarTint, final ColorStateList menuTint) {
+        final int[] stateEnabled = new int[]{android.R.attr.state_enabled};
+        final int[] stateDisabled = new int[]{};
         for (int i = 0; i < menu.size(); i++) {
             final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
             final Drawable drw = item.getIcon();
             if (null != drw) {
-                drw.mutate().setTint(item.isActionButton() ? actionBarColor :  menuColor);
+                final ColorStateList tint = item.isActionButton() ? actionBarTint : menuTint;
+                final int[] state = item.isEnabled() ? stateEnabled : stateDisabled;
+                final int baseColor = tint.getColorForState(state, tint.getDefaultColor());
+                // android:alpha in ColorStateList is not applied by getColorForState() - apply manually
+                final int color = item.isEnabled() ? baseColor : applyAlpha(baseColor, 0.6f);
+                drw.mutate().setTint(color);
                 item.setIcon(drw);
             }
             if (null != item.getSubMenu()) {
-                tintMenuIcons(item.getSubMenu(), actionBarColor, menuColor);
+                tintMenuIcons(item.getSubMenu(), actionBarTint, menuTint);
             }
         }
+    }
+
+    private static int applyAlpha(final int color, final float alpha) {
+        return android.graphics.Color.argb(
+                Math.round(alpha * android.graphics.Color.alpha(color)),
+                android.graphics.Color.red(color),
+                android.graphics.Color.green(color),
+                android.graphics.Color.blue(color));
     }
 }

--- a/main/src/main/res/color/action_bar_item_text_selector.xml
+++ b/main/src/main/res/color/action_bar_item_text_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/colorTextActionBar" android:alpha="0.6" />
+    <item android:color="@color/colorTextActionBar" />
+</selector>
+

--- a/main/src/main/res/color/color_text_selector.xml
+++ b/main/src/main/res/color/color_text_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/colorText" android:alpha="0.6" />
+    <item android:color="@color/colorText" />
+</selector>

--- a/main/src/main/res/color/menu_icon_tint_selector.xml
+++ b/main/src/main/res/color/menu_icon_tint_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/colorIconMenu" android:alpha="0.6" />
+    <item android:color="@color/colorIconMenu" />
+</selector>
+

--- a/main/src/main/res/values/styles.xml
+++ b/main/src/main/res/values/styles.xml
@@ -13,7 +13,7 @@
 
     <style name="text_default" parent="@style/text">
         <item name="android:textSize">@dimen/textSize_detailsPrimary</item>
-        <item name="android:textColor">@color/colorText</item>
+        <item name="android:textColor">@color/color_text_selector</item>
     </style>
 
     <style name="text_label" parent="text">
@@ -96,6 +96,7 @@
         <item name="colorControlNormal">@color/colorTextActionBar</item>
         <item name="colorOnPrimary">@color/colorTextActionBar</item>
         <item name="android:itemTextAppearance">@style/text_default</item>
+        <item name="android:actionMenuTextColor">@color/action_bar_item_text_selector</item>
     </style>
 
     <style name="action_bar_title" parent="@style/TextAppearance.AppCompat.Widget.ActionBar.Title">
@@ -126,7 +127,7 @@
         <item name="android:ellipsize">marquee</item>
         <item name="android:textSize">@dimen/textSize_buttonsPrimary</item>
         <item name="strokeColor">@color/button_strokecolor_selector</item>
-        <item name="iconTint">@color/colorText</item>
+        <item name="iconTint">@color/color_text_selector</item>
     </style>
 
     <style name="button_full_base" parent="button_base">
@@ -247,7 +248,7 @@
 
      <style name="IconButtonThemeOverlay">
         <!-- For filled buttons, your theme's colorPrimary provides the default background color of the component -->
-        <item name="colorPrimary">@color/colorText</item>
+         <item name="colorPrimary">@color/colorText</item>
     </style>
 
     <style name="shapeRoundedCorner" parent="">

--- a/main/src/main/res/values/themes.xml
+++ b/main/src/main/res/values/themes.xml
@@ -54,7 +54,8 @@
     <style name="appToolbarPopup" parent="ThemeOverlay.MaterialComponents">
         <item name="colorControlNormal">@color/colorText</item>
         <item name="android:background">@color/colorBackground</item>
-        <item name="android:textColor">@color/colorAccent</item>
+        <item name="android:textColor">@color/color_text_selector</item>
+        <item name="android:textColorPrimary">@color/color_text_selector</item>
         <item name="android:minHeight">0dp</item>
     </style>
 


### PR DESCRIPTION
Tried to find a solution with copilot (for #17958) - but I am not convinced, but maybe as a start / discussion point, it is good / bad enough



Disabled menu items (text + icons) are now visually distinguishable from enabled ones.

Root cause: The toolbar was switched to MaterialToolbar/MaterialComponents, which no longer automatically dims disabled menu item text and icons.

Fix:
- New ColorStateList color_text_selector: uses colorText with alpha=0.6 for state_enabled=false; referenced in text_default style (via android:itemTextAppearance) and appToolbarPopup theme (android:textColor + android:textColorPrimary)
- New ColorStateList action_bar_item_text_selector / menu_icon_tint_selector: same pattern for toolbar action icons and overflow menu icons respectively
- MenuUtils.tintMenuIcons: replaced setTint(int) with getColorForState() using an empty int[] for the disabled state (not -state_enabled, which does not match ColorStateList selectors) to resolve the correct dimmed color per item.isEnabled()
- MenuUtils.setEnabled: calls tintSingleIcon() immediately after setEnabled() so that action bar icons are updated at once, without waiting for the next onPrepareOptionsMenu cycle
- New android:actionMenuTextColor in tool_bar style for action button text dimming
