### PR TITLE
Set colors for disabled menu state (fix #17958)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -768,7 +768,7 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
         }
 
         MenuUtils.enableIconsInOverflowMenu(menu);
-        MenuUtils.tintToolbarAndOverflowIcons(menu);
+        MenuUtils.tintToolbarAndOverflowIconsAndTitles(menu);
 
         return super.onPrepareOptionsMenu(menu);
     }

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -545,7 +545,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         ListNavigationSelectionActionProvider.initialize(menu.findItem(R.id.menu_cache_list_app_provider), app -> app.invoke(CacheListAppUtils.filterCoords(adapter.getList()), CacheListActivity.this, getFilteredSearch()));
         FilterUtils.initializeFilterMenu(this, this);
         MenuUtils.enableIconsInOverflowMenu(menu);
-        MenuUtils.tintToolbarAndOverflowIcons(menu);
+        MenuUtils.tintToolbarAndOverflowIconsAndTitles(menu);
 
         return true;
     }
@@ -666,7 +666,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         } catch (final RuntimeException e) {
             Log.e("CacheListActivity.onPrepareOptionsMenu", e);
         }
-        MenuUtils.tintToolbarAndOverflowIcons(menu);
+        MenuUtils.tintToolbarAndOverflowIconsAndTitles(menu);
 
         return true;
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -918,7 +918,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
         menu.findItem(R.id.menu_as_list).setVisible(true);
 
-        MenuUtils.tintToolbarAndOverflowIcons(menu);
+        MenuUtils.tintToolbarAndOverflowIconsAndTitles(menu);
 
         return result;
     }
@@ -1037,7 +1037,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 return super.onOptionsItemSelected(item);
             }
         }
-        MenuUtils.tintToolbarAndOverflowIcons(toolbarMenu);
+        MenuUtils.tintToolbarAndOverflowIconsAndTitles(toolbarMenu);
         return true;
     }
 

--- a/main/src/main/java/cgeo/geocaching/utils/ColorUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/ColorUtils.java
@@ -86,4 +86,8 @@ public class ColorUtils {
         return androidx.core.graphics.ColorUtils.HSLToColor(hslValues);
 
     }
+
+    public static int setAlpha(final int color, final int alpha) {
+        return ((alpha & 0xFF) << 24) + (color & 0xFFFFFF);
+    }
 }

--- a/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MenuUtils.java
@@ -1,10 +1,13 @@
 package cgeo.geocaching.utils;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.activity.ActivityMixin;
 
 import android.annotation.SuppressLint;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -61,34 +64,46 @@ public class MenuUtils {
     }
 
     @SuppressLint("RestrictedApi")
-    public static void tintToolbarAndOverflowIcons(@Nullable final Menu menu) {
+    public static void tintToolbarAndOverflowIconsAndTitles(@Nullable final Menu menu) {
         if (null == menu) {
             return;
         }
-        // Menu might not yet have been initialized due to timing issues, only run if there's at least 1 toolbar item
-        boolean anyMenuItemVisible = false;
-        for (int i = 0; i < menu.size(); i++) {
-            final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
-            anyMenuItemVisible = anyMenuItemVisible || item.isActionButton();
-        }
-        if (!anyMenuItemVisible) {
-            return;
-        }
-        final Resources res = ColorUtils.getThemedContext().getResources();
-        tintMenuIcons(menu, res.getColor(R.color.colorTextActionBar), res.getColor(R.color.colorIconMenu));
+        // slight delay
+        ActivityMixin.postDelayed(() -> {
+            // Menu might not yet have been initialized due to timing issues, only run if there's at least 1 toolbar item
+            boolean anyMenuItemVisible = false;
+            for (int i = 0; i < menu.size(); i++) {
+                final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
+                anyMenuItemVisible = anyMenuItemVisible || item.isActionButton();
+            }
+            if (!anyMenuItemVisible) {
+                return;
+            }
+            final Resources res = ColorUtils.getThemedContext().getResources();
+            tintMenuIconsAndTitles(menu, res.getColor(R.color.colorTextActionBar), res.getColor(R.color.colorIconMenu));
+        }, 100);
     }
 
     @SuppressLint("RestrictedApi")
-    private static void tintMenuIcons(final Menu menu, final int actionBarColor, final int menuColor) {
+    private static void tintMenuIconsAndTitles(final Menu menu, final int actionBarColor, final int menuColor) {
         for (int i = 0; i < menu.size(); i++) {
             final MenuItemImpl item = (MenuItemImpl) menu.getItem(i);
+            // choose color depending on state
+            final int color = ColorUtils.setAlpha(item.isActionButton() ? actionBarColor : menuColor, item.isEnabled() ? 255 : 128);
+
+            // color menu item title
+            final SpannableString s = new SpannableString(item.getTitle());
+            s.setSpan(new ForegroundColorSpan(color), 0, s.length(), 0);
+            item.setTitle(s);
+
+            // color icon, if present
             final Drawable drw = item.getIcon();
             if (null != drw) {
-                drw.mutate().setTint(item.isActionButton() ? actionBarColor :  menuColor);
+                drw.mutate().setTint(color);
                 item.setIcon(drw);
             }
             if (null != item.getSubMenu()) {
-                tintMenuIcons(item.getSubMenu(), actionBarColor, menuColor);
+                tintMenuIconsAndTitles(item.getSubMenu(), actionBarColor, menuColor);
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes coloring of disabled menu items.

light mode:
<img width="270" height="555" alt="image" src="https://github.com/user-attachments/assets/c64732e8-f118-49b9-8c46-5b1ec0ebc7fd" />.<img width="270" height="555" alt="image" src="https://github.com/user-attachments/assets/c03e4570-24d1-45cf-a421-6993bad3766b" />

dark mode:
<img width="270" height="555" alt="image" src="https://github.com/user-attachments/assets/c56bcef7-c88a-4367-9e37-d89439b16a40" />.<img width="270" height="555" alt="image" src="https://github.com/user-attachments/assets/062fa022-a2a0-4a9c-abea-102724be8e43" />
