### PR TITLE
Fix toolbar insets in landscape mode (fix #17892)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActionBarActivity.java
@@ -140,7 +140,7 @@ public class AbstractActionBarActivity extends AbstractActivity {
         if (t != null) {
             actionBarHeightWithStatusBar = (int) (getResources().getDimension(R.dimen.actionbar_height) + statusBarHeight);
             // add statusbar height (= def.top) as padding to appBar, increasing its size accordingly, and set inset.top = 0
-            t.setPadding(t.getPaddingLeft(), statusBarHeight, t.getPaddingRight(), t.getPaddingBottom());
+            t.setPadding(currentWindowInsets.left, statusBarHeight, currentWindowInsets.right, t.getPaddingBottom());
             final ViewGroup.LayoutParams params = t.getLayoutParams();
             params.height = actionBarHeightWithStatusBar;
             t.setLayoutParams(params);

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActivity.java
@@ -56,7 +56,7 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
 
     private final String logToken = "[" + this.getClass().getName() + "]";
 
-    private Insets currentWindowInsets;
+    protected Insets currentWindowInsets;
 
     private static final String ACTION_CLEAR_BACKSTACK = "cgeo.geocaching.ACTION_CLEAR_BACKSTACK";
 

--- a/main/src/main/res/layout-h390dp-land/activity_navigationbar.xml
+++ b/main/src/main/res/layout-h390dp-land/activity_navigationbar.xml
@@ -15,13 +15,14 @@
     <com.google.android.material.navigationrail.NavigationRailView
         android:id="@+id/activity_navigationBar"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_below="@id/appToolbar"
         app:labelVisibilityMode="labeled"
         android:background="@color/colorBackgroundTabBar"
         app:itemIconTint="@color/bottom_bar_selector"
         app:itemTextColor="@color/bottom_bar_selector"
+        app:paddingTopSystemWindowInsets="false"
         app:menu="@menu/activity_navigationbar_menu" />
 
     <!-- make sure toolbar is placed above navigation rail -->

--- a/main/src/main/res/layout-h390dp-land/activity_navigationbar.xml
+++ b/main/src/main/res/layout-h390dp-land/activity_navigationbar.xml
@@ -11,6 +11,20 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
+    <!-- Show a navigation rail on landscape devices instead. -->
+    <com.google.android.material.navigationrail.NavigationRailView
+        android:id="@+id/activity_navigationBar"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/appToolbar"
+        app:labelVisibilityMode="labeled"
+        android:background="@color/colorBackgroundTabBar"
+        app:itemIconTint="@color/bottom_bar_selector"
+        app:itemTextColor="@color/bottom_bar_selector"
+        app:menu="@menu/activity_navigationbar_menu" />
+
+    <!-- make sure toolbar is placed above navigation rail -->
     <include
         android:id="@+id/appToolbar"
         layout="@layout/toolbar"
@@ -26,16 +40,4 @@
         android:layout_alignParentEnd="true"
         android:layout_toEndOf="@id/activity_navigationBar" /><!-- android:layout_below="@id/appToolbar" -->
 
-    <!-- Show a navigation rail on landscape devices instead. -->
-    <com.google.android.material.navigationrail.NavigationRailView
-        android:id="@+id/activity_navigationBar"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_alignParentStart="true"
-        android:layout_below="@id/appToolbar"
-        app:labelVisibilityMode="labeled"
-        android:background="@color/colorBackgroundTabBar"
-        app:itemIconTint="@color/bottom_bar_selector"
-        app:itemTextColor="@color/bottom_bar_selector"
-        app:menu="@menu/activity_navigationbar_menu" />
 </cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>

--- a/main/src/main/res/layout-land/activity_navigationbar.xml
+++ b/main/src/main/res/layout-land/activity_navigationbar.xml
@@ -16,13 +16,14 @@
         android:id="@+id/activity_navigationBar"
         style="@style/Widget.MaterialComponents.NavigationRailView.Compact"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_below="@id/appToolbar"
         app:labelVisibilityMode="unlabeled"
         android:background="@color/colorBackgroundTabBar"
         app:itemIconTint="@color/bottom_bar_selector"
         app:itemTextColor="@color/bottom_bar_selector"
+        app:paddingTopSystemWindowInsets="false"
         app:menu="@menu/activity_navigationbar_menu" />
 
     <!-- make sure toolbar is placed above navigation rail -->

--- a/main/src/main/res/layout-land/activity_navigationbar.xml
+++ b/main/src/main/res/layout-land/activity_navigationbar.xml
@@ -11,6 +11,21 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop" />
 
+    <!-- Show a navigation rail on landscape devices instead. On rather small screens, don't show labels to save some space -->
+    <com.google.android.material.navigationrail.NavigationRailView
+        android:id="@+id/activity_navigationBar"
+        style="@style/Widget.MaterialComponents.NavigationRailView.Compact"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentStart="true"
+        android:layout_below="@id/appToolbar"
+        app:labelVisibilityMode="unlabeled"
+        android:background="@color/colorBackgroundTabBar"
+        app:itemIconTint="@color/bottom_bar_selector"
+        app:itemTextColor="@color/bottom_bar_selector"
+        app:menu="@menu/activity_navigationbar_menu" />
+
+    <!-- make sure toolbar is placed above navigation rail -->
     <include
         android:id="@+id/appToolbar"
         layout="@layout/toolbar"
@@ -25,18 +40,4 @@
         android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
         android:layout_toEndOf="@id/activity_navigationBar" /><!-- android:layout_below="@id/appToolbar" -->
-
-    <!-- Show a navigation rail on landscape devices instead. On rather small screens, don't show labels to save some space -->
-    <com.google.android.material.navigationrail.NavigationRailView
-        android:id="@+id/activity_navigationBar"
-        style="@style/Widget.MaterialComponents.NavigationRailView.Compact"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_alignParentStart="true"
-        android:layout_below="@id/appToolbar"
-        app:labelVisibilityMode="unlabeled"
-        android:background="@color/colorBackgroundTabBar"
-        app:itemIconTint="@color/bottom_bar_selector"
-        app:itemTextColor="@color/bottom_bar_selector"
-        app:menu="@menu/activity_navigationbar_menu" />
 </cgeo.geocaching.ui.RelativeLayoutWithInterceptTouchEventPossibility>


### PR DESCRIPTION
## Description
- Fix toolbar insets in landscape mode (fix #17892)
- Fix z-order for toolbar and navigation rail (landscape mode, mitigation for #17893)
- Fix additional top spacing in navigation rail

<img width="606" height="270" alt="image" src="https://github.com/user-attachments/assets/10787b72-8b03-40bf-b696-d00af08af975" />
