### PR TITLE
Update Mapsforge/VTM to current 0.27 releases

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -385,7 +385,7 @@ dependencies {
 
     // Mapsforge official version
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = '0.26.1'
+    String mapsforgeVersion = '0.27.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     // String mapsforgeSource = 'com.github.mapsforge.mapsforge'
@@ -404,12 +404,12 @@ dependencies {
     // -- Mapsforge / VTM --
 
     // Mapsforge VTM implementation (official version)
-    // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    // String mapsforgeVTMVersion = '0.26.1'
+    String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
+    String mapsforgeVTMVersion = '0.27.0'
 
     // Mapsforge VTM Snapshot from official master branch (via https://jitpack.io/#mapsforge/vtm)
-    String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
-    String mapsforgeVTMVersion = '3a15669' // Closed circles fix
+    // String mapsforgeVTMSource = 'com.github.mapsforge.vtm'
+    // String mapsforgeVTMVersion = '3a15669' // Closed circles fix
 
     // Mapsforge VTM Snapshots (created by project itself)
     // See https://github.com/mapsforge/vtm/blob/master/docs/Integration.md#snapshots


### PR DESCRIPTION
## Description
Updates both Mapsforge and VTM to current 0.27 releases (also bringing VTM back to regular release track)

Supersedes #17756
