### PR TITLE
Add additional logging to DownloadManager

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -137,7 +137,7 @@ public class DownloaderUtils {
                     final boolean allowMeteredNetwork = binding.allowMeteredNetwork.isChecked();
                     final DownloadManager downloadManager = (DownloadManager) activity.getSystemService(DOWNLOAD_SERVICE);
                     if (null != downloadManager) {
-                        final long id = addDownload(activity, downloadManager, type, uri, filename, allowMeteredNetwork);
+                        final long id = addDownload(activity, downloadManager, type, uri, filename, allowMeteredNetwork, System.currentTimeMillis());
                         if (id != -1) {
                             if (downloadStartedCallback != null) {
                                 downloadStartedCallback.accept(id);
@@ -148,7 +148,7 @@ public class DownloaderUtils {
                             if (downloader != null) {
                                 final DownloadDescriptor extraFile = downloader.getExtrafile(activity, uri);
                                 if (extraFile != null) {
-                                    addDownload(activity, downloadManager, extraFile.type, extraFile.uri, extraFile.filename, allowMeteredNetwork);
+                                    addDownload(activity, downloadManager, extraFile.type, extraFile.uri, extraFile.filename, allowMeteredNetwork, System.currentTimeMillis());
                                 }
                             }
                             ActivityMixin.showShortToast(activity, R.string.download_started);
@@ -207,15 +207,7 @@ public class DownloaderUtils {
                         for (Download download : downloads) {
                             if (download.customMarker) {
                                 numFiles++;
-                                final DownloadManager.Request request = new DownloadManager.Request(download.getUri())
-                                        .setTitle(download.getName())
-                                        .setDescription(String.format(activity.getString(R.string.downloadmap_filename), download.getName()))
-                                        .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                                        .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, download.getName())
-                                        .setAllowedOverMetered(allowMeteredNetwork)
-                                        .setAllowedOverRoaming(allowMeteredNetwork);
-                                Log.i("Download enqueued: " + Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/" + download.getName());
-                                AndroidRxUtils.networkScheduler.scheduleDirect(() -> PendingDownload.add(downloadManager.enqueue(request), download.getName(), download.getUri().toString(), download.getDateInfo(), download.getType().id));
+                                addDownload(activity, downloadManager, download.getType().id, download.getUri(), download.getName(), allowMeteredNetwork, download.getDateInfo());
                             }
                         }
                         ActivityMixin.showShortToast(activity, numFiles > 0 ? R.string.download_started : R.string.no_files_selected);
@@ -237,23 +229,30 @@ public class DownloaderUtils {
                 .show();
     }
 
-    private static long addDownload(final Activity activity, final DownloadManager downloadManager, final int type, final Uri uri, final String filename, final boolean allowMeteredNetwork) {
+    private static long addDownload(final Activity activity, final DownloadManager downloadManager, final int type, final Uri uri, final String filename, final boolean allowMeteredNetwork, final long timestamp) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P && !PermissionContext.LEGACY_WRITE_EXTERNAL_STORAGE.hasAllPermissions()) {
             // those versions still need WRITE_EXTERNAL_STORAGE permission to enqueue a download
             SimpleDialog.ofContext(activity).setTitle(TextParam.id(R.string.permission_missing)).setMessage(TextParam.id(R.string.storage_permission_needed)).show();
             return -1;
         }
-        final DownloadManager.Request request = new DownloadManager.Request(uri)
-                .setTitle(filename)
-                .setDescription(String.format(activity.getString(R.string.downloadmap_filename), filename))
-                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
-                .setAllowedOverMetered(allowMeteredNetwork)
-                .setAllowedOverRoaming(allowMeteredNetwork);
-        Log.i("Download enqueued: " + Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/" + filename);
-        final long id = downloadManager.enqueue(request);
-        PendingDownload.add(id, filename, uri.toString(), System.currentTimeMillis(), type);
-        return id;
+        try {
+            Log.i("Enqueuing download: '" + filename + "' from '" + uri + "' to '" + Environment.DIRECTORY_DOWNLOADS + "/" + filename + "'");
+            final DownloadManager.Request request = new DownloadManager.Request(uri)
+                    .setTitle(filename)
+                    .setDescription(String.format(activity.getString(R.string.downloadmap_filename), filename))
+                    .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                    .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
+                    .setAllowedOverMetered(allowMeteredNetwork)
+                    .setAllowedOverRoaming(allowMeteredNetwork);
+            final long id = downloadManager.enqueue(request);
+            AndroidRxUtils.networkScheduler.scheduleDirect(() -> PendingDownload.add(id, filename, uri.toString(), timestamp, type));
+            Log.i("Download #" + id + " enqueued successfully ('" + uri + "')");
+            return id;
+        } catch (SecurityException | IllegalStateException e) {
+            Log.e("Error adding download of '" + filename + "' from '" + uri + "' to '" + Environment.DIRECTORY_DOWNLOADS + "/" + filename + "':\n" + e.getClass() + ", " + e.getMessage());
+            ActivityMixin.showToast(activity, R.string.download_enqueing_error);
+        }
+        return -1;
     }
 
     public static class DownloadDescriptor {


### PR DESCRIPTION
## Description
While debugging for some support issue I noticed that we don't catch and don't log exceptions while enqueing new downloads. This PR adds catching & logging those exceptions.