### PR TITLE
rel to #17987: add DavidV Offline Translator as external translator

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/TranslationUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/TranslationUtils.java
@@ -34,7 +34,8 @@ public final class TranslationUtils {
         NONE(R.string.translate_external_none, null, null),
         EXTERNAL_APP(R.string.translate_external_app, APP_PACKAGE_ANYAPP, null),
         GOOGLE(R.string.translate_external_google, "com.google.android.apps.translate", WEB_GOOGLE_URL),
-        DEEPL(R.string.translate_external_deepl, "com.deepl.mobiletranslator", WEB_DEEPL_URL);
+        DEEPL(R.string.translate_external_deepl, "com.deepl.mobiletranslator", WEB_DEEPL_URL),
+        DAVIDV(R.string.translate_external_davidv, "dev.davidv.translator", null);
 
         private final int nameId;
         public final String appPackageName;
@@ -51,7 +52,8 @@ public final class TranslationUtils {
             if (this.appPackageName != null && !APP_PACKAGE_ANYAPP.equals(this.appPackageName)) {
                 sb
                     .append(" (")
-                    .append(LocalizationUtils.getString(appIsAvailable(this.appPackageName) ? R.string.translate_external_variant_app : R.string.translate_external_variant_web))
+                    .append(LocalizationUtils.getString(appIsAvailable(this.appPackageName) ? R.string.translate_external_variant_app :
+                        (this.urlPattern != null ? R.string.translate_external_variant_web : R.string.translate_external_variant_unavailable)))
                     .append(")");
             }
             return sb.toString();
@@ -114,8 +116,11 @@ public final class TranslationUtils {
         final Translator translator = getTranslator();
         if (APP_PACKAGE_ANYAPP.equals(translator.appPackageName) || appIsAvailable(translator.appPackageName)) {
             startTranslateViaApp(activity, translator.appPackageName, text);
-        } else {
+        } else if (translator.urlPattern != null) {
             startTranslateViaUrl(activity, translator.urlPattern, text);
+        } else {
+            //just open app selector
+            startTranslateViaApp(activity, null, text);
         }
     }
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -253,10 +253,12 @@
     <string name="translate_external_label">Translate with %s</string>
     <string name="translate_external_variant_app">App</string>
     <string name="translate_external_variant_web">Website</string>
+    <string name="translate_external_variant_unavailable">Unavailable</string>
     <string name="translate_external_none">&lt;None&gt;</string>
     <string name="translate_external_app">External App</string>
     <string name="translate_external_google">Google Translate</string>
     <string name="translate_external_deepl">DeepL</string>
+    <string name="translate_external_davidv">DavidV Offline Translate</string>
     <string name="translate_length_warning">Translation via Website may fail with a large amount of text.</string>
 
     <!-- errors, warnings, info toasts -->


### PR DESCRIPTION
rel to #17987: add DavidV Offline Translator as external translator

Translator as of now only available via F-Droid. Still it seems worth including because it seems to be the only current purely offline translator accessible via standard Android integration (using Intent.PROCESS_TEXT).

F-Droid: https://f-droid.org/packages/dev.davidv.translator/
Source: https://github.com/DavidVentura/offline-translator