### PR TITLE
Update jackson (master)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -357,11 +357,9 @@ dependencies {
     implementation 'com.github.moving-bits:dbinspection:v0.1.2'
 
     // Jackson XML processing
-    // Jackson 2.13++ needs minSdk 24 (see https://github.com/FasterXML/jackson-databind?tab=readme-ov-file#android)
-    //noinspection GradleDependency
-    String jacksonVersion = '2.12.7'
+    String jacksonVersion = '2.21.2'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion.2"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
 
     // Jsoup HTML parsing

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -360,7 +360,7 @@ dependencies {
     String jacksonVersion = '2.21.2'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
     // Jsoup HTML parsing
     implementation 'org.jsoup:jsoup:1.22.1'


### PR DESCRIPTION
to the latest versions in the 2.x tree.

For Release notes have a look at
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13 
to
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21

Since version 2.13 it needs minSdk 26, which we use now on master. We need to stay at 2.12.x on release.
