### PR TITLE
Update jackson (release)

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -379,7 +379,7 @@ dependencies {
     //noinspection GradleDependency
     String jacksonVersion = '2.12.7'
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion.2"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
 
     // Jsoup HTML parsing


### PR DESCRIPTION
Update at least jackson-databind with a micro patch, see https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12
