### PR TITLE
rel #17995: serialize SAF subdir creation and use case-insensitive lookup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
@@ -367,9 +367,18 @@ class DocumentContentAccessor extends AbstractContentAccessor {
 
     private Uri findCreateSubdirectory(final Uri dirUri, final String dirName, final boolean createIfNotExisting) throws IOException {
         synchronized (subdirCreationLock) {
-            final Uri existing = findSubdirectoryByName(dirUri, dirName);
+            final Uri existing = findDocumentByName(dirUri, dirName);
             if (existing != null) {
-                return existing;
+                // Check whether the existing document is actually a directory
+                final ContentStorage.FileInformation info = getFileInfo(existing, null);
+                if (info != null && info.isDirectory) {
+                    return existing;
+                }
+
+                // A non-directory document with the same name exists – creating a directory would
+                // cause the provider to auto-rename it (e.g. "wherigo (1)"). Bail out instead.
+                Log.w("Cannot create dir '" + dirName + "' in '" + dirUri + "': a non-directory document with that name already exists");
+                return null;
             }
 
             if (!createIfNotExisting) {
@@ -381,26 +390,26 @@ class DocumentContentAccessor extends AbstractContentAccessor {
                 if (created != null) {
                     Log.d("Create dir '" + dirName + "' in '" + dirUri + "': " + created);
                 } else {
-                    Log.d("Failed to create dir '" + dirName + "' in '" + dirUri + "'");
+                    Log.w("Cannot create dir '" + dirName + "' in '" + dirUri + "': DocumentsContract.createDocument returned null");
                 }
                 return created;
             } catch (RuntimeException re) {
-                Log.e("Could not create dir '" + dirName + "' in '" + dirUri + "'", re);
+                Log.e("Cannot create dir '" + dirName + "' in '" + dirUri + "'", re);
             }
             return null;
         }
     }
 
     /**
-     * Returns the URI of the first child directory of {@code dirUri} whose display name matches
-     * {@code dirName} case-insensitively, or {@code null} if no such child exists.
+     * Returns the URI of the first child document (file or directory) of {@code dirUri} whose
+     * display name matches {@code name} case-insensitively, or {@code null} if no such child exists.
      */
-    private Uri findSubdirectoryByName(final Uri dirUri, final String dirName) throws IOException {
+    private Uri findDocumentByName(final Uri dirUri, final String name) throws IOException {
         final List<Uri> result = queryDir(dirUri,
-                new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME, DocumentsContract.Document.COLUMN_MIME_TYPE},
+                new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME},
                 c -> {
                     // lookup – case-insensitive to cope with SAF provider quirks
-                    if (dirName.equalsIgnoreCase(c.getString(1)) && DocumentsContract.Document.MIME_TYPE_DIR.equals(c.getString(2))) {
+                    if (name.equalsIgnoreCase(c.getString(1))) {
                         return DocumentsContract.buildDocumentUriUsingTree(dirUri, c.getString(0));
                     }
                     return null;

--- a/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
@@ -379,7 +379,7 @@ class DocumentContentAccessor extends AbstractContentAccessor {
             try {
                 final Uri created = DocumentsContract.createDocument(getContext().getContentResolver(), dirUri, DocumentsContract.Document.MIME_TYPE_DIR, dirName);
                 if (created != null) {
-                    Log.d("Create dir '" + dirName + "' in '" + dirUri + "': " + created.getPath());
+                    Log.d("Create dir '" + dirName + "' in '" + dirUri + "': " + created);
                 } else {
                     Log.d("Failed to create dir '" + dirName + "' in '" + dirUri + "'");
                 }

--- a/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
@@ -62,6 +62,11 @@ class DocumentContentAccessor extends AbstractContentAccessor {
             DocumentsContract.Document.COLUMN_SIZE
     };
 
+    /**
+     * Lock object used to serialize directory creation operations and avoid duplicate directories
+     * when multiple threads attempt to create the same subdirectory concurrently (e.g. parallel Wherigo downloads).
+     */
+    private final Object subdirCreationLock = new Object();
 
     /**
      * cache for Uri permissions
@@ -361,23 +366,49 @@ class DocumentContentAccessor extends AbstractContentAccessor {
     }
 
     private Uri findCreateSubdirectory(final Uri dirUri, final String dirName, final boolean createIfNotExisting) throws IOException {
-        final List<Uri> result = queryDir(dirUri, new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME, DocumentsContract.Document.COLUMN_MIME_TYPE}, c -> {
-            if (dirName.equals(c.getString(1)) && DocumentsContract.Document.MIME_TYPE_DIR.equals(c.getString(2))) {
-                return DocumentsContract.buildDocumentUriUsingTree(dirUri, c.getString(0));
+        synchronized (subdirCreationLock) {
+            final Uri existing = findSubdirectoryByName(dirUri, dirName);
+            if (existing != null) {
+                return existing;
             }
-            return null;
 
-        });
-        for (Uri uri : result) {
-            if (uri != null) {
-                return uri;
+            if (!createIfNotExisting) {
+                return null;
             }
-        }
-        if (createIfNotExisting) {
+
             try {
-                return DocumentsContract.createDocument(getContext().getContentResolver(), dirUri, DocumentsContract.Document.MIME_TYPE_DIR, dirName);
+                final Uri created = DocumentsContract.createDocument(getContext().getContentResolver(), dirUri, DocumentsContract.Document.MIME_TYPE_DIR, dirName);
+                if (created != null) {
+                    Log.d("Create dir '" + dirName + "' in '" + dirUri + "': " + created.getPath());
+                } else {
+                    Log.d("Failed to create dir '" + dirName + "' in '" + dirUri + "'");
+                }
+                return created;
             } catch (RuntimeException re) {
                 Log.e("Could not create dir '" + dirName + "' in '" + dirUri + "'", re);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Returns the URI of the first child directory of {@code dirUri} whose display name matches
+     * {@code dirName} case-insensitively, or {@code null} if no such child exists.
+     */
+    private Uri findSubdirectoryByName(final Uri dirUri, final String dirName) throws IOException {
+        final List<Uri> result = queryDir(dirUri,
+                new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME, DocumentsContract.Document.COLUMN_MIME_TYPE},
+                c -> {
+                    // lookup – case-insensitive to cope with SAF provider quirks
+                    if (dirName.equalsIgnoreCase(c.getString(1)) && DocumentsContract.Document.MIME_TYPE_DIR.equals(c.getString(2))) {
+                        return DocumentsContract.buildDocumentUriUsingTree(dirUri, c.getString(0));
+                    }
+                    return null;
+                });
+
+        for (final Uri uri : result) {
+            if (uri != null) {
+                return uri;
             }
         }
         return null;


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Serialize subdirectory creation in DocumentContentAccessor with subdirCreationLock to make check-and-create atomic.
Also use case-insensitive directory name lookup to handle SAF provider quirks and avoid duplicate folders during concurrent writes.

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #17995

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Suggestion from copilot
implementation of lock-mechanism 