### PR TITLE
Implement connector aware filter chain 

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
@@ -1,178 +1,109 @@
 package cgeo.geocaching.filters;
 
+import cgeo.geocaching.SearchResult;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
-import cgeo.geocaching.connector.su.SuConnector;
+import cgeo.geocaching.connector.oc.OCDEConnector;
 import cgeo.geocaching.filters.core.AndGeocacheFilter;
-import cgeo.geocaching.filters.core.BaseGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
-import cgeo.geocaching.filters.core.NameGeocacheFilter;
+import cgeo.geocaching.filters.core.IGeocacheFilter;
 import cgeo.geocaching.filters.core.NotGeocacheFilter;
 import cgeo.geocaching.filters.core.OrGeocacheFilter;
 import cgeo.geocaching.filters.core.OriginGeocacheFilter;
+import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.sorting.GeocacheSort;
 
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 
 import org.junit.Test;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 /**
- * Tests for {@link GeocacheFilter#getConnectorRelevantFilter(IConnector)} and
- * {@link GeocacheFilter#getAndChainIfPossible(IConnector)}.
+ * Instrumented API test for the combination of OriginGeocacheFilter and OwnerGeocacheFilter.
+ * Tests OR(AND(Origin=GC, Owner="lineflyer"), AND(Origin=OC, Owner="mic@")) against the
+ * real geocaching.com and opencaching.de APIs.
+ * <p>
+ * Requires configured accounts for geocaching.com and opencaching.de on the emulator/device.
  */
 public class ConnectorRelevantFilterTest {
-
-    private static final IConnector GC = GCConnector.getInstance();
-    private static final IConnector SU = SuConnector.getInstance();
-
-    // --- Tests ---
+    private static final GCConnector GC = GCConnector.getInstance();
+    private static final OCDEConnector OC = new OCDEConnector();
+    private static final String GC_TEST_OWNER = "Grokky Grokson";
+    private static final String OC_TEST_OWNER = "lineflyer";
 
     @Test
-    public void nullTreeReturnsEmptyFilter() {
-        final GeocacheFilter empty = GeocacheFilter.createEmpty();
-        final GeocacheFilter result = empty.getConnectorRelevantFilter(GC);
-        assertThat(result).isNotNull();
-        assertThat(result.getTree()).isNull();
-        assertThat(result.isFiltering()).isFalse();
+    public void searchGCOrOCFilter() {
+        // OR(AND(Origin=GC, Owner=GC_TEST_OWNER), AND(Origin=OC, Owner=OC_TEST_OWNER))
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, createGCOrOCFilter());
+
+        // Sent to GC API: only GC branch is relevant → Owner=GC_TEST_OWNER
+        final SearchResult gcSearch = GC.searchByFilter(filter, new GeocacheSort());
+        assertThat(gcSearch).isNotNull();
+        assertThat(gcSearch.getGeocodes()).isNotEmpty();
+        assertOwner(gcSearch, GC_TEST_OWNER);
+
+        // Sent to OC API: only OC branch is relevant → Owner=OC_TEST_OWNER
+        final SearchResult ocSearch = OC.searchByFilter(filter, new GeocacheSort());
+        assertThat(ocSearch).isNotNull();
+        assertThat(ocSearch.getGeocodes()).isNotEmpty();
+        assertOwner(ocSearch, OC_TEST_OWNER);
     }
 
     @Test
-    public void simpleAndWithMatchingOriginReturnsFilterWithoutOrigin() {
-        // AND(Origin=GC, Name="test")
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
-                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+    public void searchIgnoreOCFilter() {
+        // AND(NOT(Origin=OC), Owner=OC_TEST_OWNER))
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, createIgnoreOCFilter());
 
-        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
-        assertThat(result).isNotNull();
-        // Origin was removed, only NameFilter remains
-        assertThat(result.getTree()).isInstanceOf(NameGeocacheFilter.class);
+        // Sent to GC API: only GC branch is relevant → Owner=OC_TEST_OWNER
+        final SearchResult gcSearch = GC.searchByFilter(filter, new GeocacheSort());
+        assertThat(gcSearch).isNotNull();
+        assertThat(gcSearch.getGeocodes()).isNotEmpty();
+        assertOwner(gcSearch, OC_TEST_OWNER);
+
+        // Sent to OC API: OC branch is not relevant → empty SearchResult
+        final SearchResult ocSearch = OC.searchByFilter(filter, new GeocacheSort());
+        assertThat(ocSearch).isNotNull();
+        assertThat(ocSearch.getGeocodes()).isEmpty();
     }
 
-    @Test
-    public void simpleAndWithNonMatchingOriginReturnsNull() {
-        // AND(Origin=GC, Name="test")
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
-                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
-
-        final GeocacheFilter result = filter.getConnectorRelevantFilter(SU);
-        assertThat(result).isNull();
+    private static void assertOwner(SearchResult search, final String expectedOwner) {
+        // Verify all caches belong to the expected owner
+        final Set<Geocache> caches = search.getCachesFromSearchResult();
+        assertThat(caches).isNotEmpty();
+        for (final Geocache cache : caches) {
+            assertThat(cache.getOwnerDisplayName())
+                    .as("Owner of cache " + cache.getGeocode())
+                    .isEqualToIgnoringCase(expectedOwner);
+        }
     }
 
-    @Test
-    public void orWithDifferentOriginBranches() {
-        // OR(AND(Origin=GC, Name="gc-test"), AND(Origin=SU, Name="su-test"))
-        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
-        final AndGeocacheFilter suBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
-        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
-        orFilter.addChild(gcBranch);
-        orFilter.addChild(suBranch);
-
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
-
-        // For GC: only gc-branch should remain
-        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
-        assertThat(gcResult).isNotNull();
-        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
-
-        // For SU: only su-branch should remain
-        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
-        assertThat(suResult).isNotNull();
-        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    private static IGeocacheFilter createGCOrOCFilter() {
+        // OR(AND(Origin=GC, Owner=GC_TEST_OWNER), AND(Origin=OC, Owner=OC_TEST_OWNER))
+        return OrGeocacheFilter.create(createOwnerBranch(GC, GC_TEST_OWNER), createOwnerBranch(OC, OC_TEST_OWNER));
     }
 
-    @Test
-    public void noOriginFilterReturnsFullTree() {
-        // AND(Name="test")
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, NameGeocacheFilter.create("test"));
-
-        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
-        assertThat(gcResult).isNotNull();
-        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
-
-        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
-        assertThat(suResult).isNotNull();
-        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    private static IGeocacheFilter createIgnoreOCFilter() {
+        // AND(NOT(Origin=OC), Owner=OC_TEST_OWNER))
+        return AndGeocacheFilter.create(NotGeocacheFilter.create(createOriginFilter(OC)), createOwnerFilter(OC_TEST_OWNER));
     }
 
-    @Test
-    public void notOriginExcludesMatchingConnector() {
-        // NOT(Origin=GC) means: exclude GC caches
-        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
-        notFilter.addChild(OriginGeocacheFilter.create(GC));
-
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, notFilter);
-
-        // GC should be excluded (NOT(always-true-for-GC) = false)
-        assertThat(filter.getConnectorRelevantFilter(GC)).isNull();
-
-        // SU should NOT be excluded (NOT(false-for-SU) = true → always true)
-        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
-        assertThat(suResult).isNotNull();
-        assertThat(suResult.getTree()).isNull(); // simplified to always-true
+    private static IGeocacheFilter createOwnerBranch(final IConnector connector, final String owner) {
+        return AndGeocacheFilter.create(createOriginFilter(connector), createOwnerFilter(owner));
     }
 
-    @Test
-    public void nonFilteringOriginIsAlwaysTrue() {
-        // empty OriginFilter (isFiltering() == false) → always true
-        final OriginGeocacheFilter emptyOrigin = GeocacheFilterType.ORIGIN.create();
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, emptyOrigin);
-
-        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
-        assertThat(result).isNotNull();
-        assertThat(result.getTree()).isNull(); // simplified to always-true
+    private static IGeocacheFilter createOriginFilter(final IConnector connector) {
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singletonList(connector));
+        return originFilter;
     }
 
-    @Test
-    public void getAndChainIfPossibleWithConnectorReturnsNullForExcluded() {
-        // AND(Origin=GC, Name="test")
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
-                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
-
-        final List<BaseGeocacheFilter> gcChain = filter.getAndChainIfPossible(GC);
-        assertThat(gcChain).isNotNull();
-        assertThat(gcChain).hasSize(1);
-        assertThat(gcChain.get(0)).isInstanceOf(NameGeocacheFilter.class);
-
-        final List<BaseGeocacheFilter> suChain = filter.getAndChainIfPossible(SU);
-        assertThat(suChain).isNull();
+    private static IGeocacheFilter createOwnerFilter(final String owner) {
+        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+        ownerFilter.getStringFilter().setTextValue(owner);
+        return ownerFilter;
     }
 
-    @Test
-    public void orWithMixedBranchesPartiallyRelevant() {
-        // OR(AND(Origin=GC, Name="gc-test"), Name="general")
-        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
-        final NameGeocacheFilter generalBranch = NameGeocacheFilter.create("general");
-        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
-        orFilter.addChild(gcBranch);
-        orFilter.addChild(generalBranch);
-
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
-
-        // For GC: both branches are relevant → OR(Name="gc-test", Name="general")
-        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
-        assertThat(gcResult).isNotNull();
-        assertThat(gcResult.getTree()).isInstanceOf(OrGeocacheFilter.class);
-        assertThat(((OrGeocacheFilter) gcResult.getTree()).getChildren()).hasSize(2);
-
-        // For SU: only the general branch is relevant → Name="general"
-        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
-        assertThat(suResult).isNotNull();
-        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
-    }
-
-    @Test
-    public void preservesNameAndFlags() {
-        final GeocacheFilter filter = GeocacheFilter.create("myFilter", true, true,
-                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
-
-        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
-        assertThat(result).isNotNull();
-        assertThat(result.getName()).isEqualTo("myFilter");
-        assertThat(result.isOpenInAdvancedMode()).isTrue();
-        assertThat(result.isIncludeInconclusive()).isTrue();
-    }
 }
-
-
-

--- a/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
@@ -41,10 +41,11 @@ public class ConnectorRelevantFilterTest {
 
         final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible();
         assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
         // NOT, OR
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0)).isInstanceOf(NotGeocacheFilter.class);
-        assertThat(result.get(1)).isInstanceOf(OrGeocacheFilter.class);
+        // assertThat(result).hasSize(2);
+        // assertThat(result.get(0)).isInstanceOf(NotGeocacheFilter.class);
+        // assertThat(result.get(1)).isInstanceOf(OrGeocacheFilter.class);
 
         final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(GC);
         assertThat(gcResult).isNull();

--- a/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
@@ -2,7 +2,6 @@ package cgeo.geocaching.filters;
 
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
-import cgeo.geocaching.connector.oc.OCDEConnector;
 import cgeo.geocaching.connector.su.SuConnector;
 import cgeo.geocaching.filters.core.AndGeocacheFilter;
 import cgeo.geocaching.filters.core.BaseGeocacheFilter;
@@ -26,39 +25,8 @@ public class ConnectorRelevantFilterTest {
 
     private static final IConnector GC = GCConnector.getInstance();
     private static final IConnector SU = SuConnector.getInstance();
-    private static final IConnector OC = new OCDEConnector();
 
     // --- Tests ---
-
-    @Test
-    public void getAndChainIfPossible() {
-        //AND(NOT(Origin=GC), OR(Origin=SU, Name="su-test"))
-        final NotGeocacheFilter gcBranch = NotGeocacheFilter.create(OriginGeocacheFilter.create(GC));
-        final OrGeocacheFilter suBranch = OrGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
-        final AndGeocacheFilter andBranch = AndGeocacheFilter.create(gcBranch, suBranch);
-
-        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, andBranch);
-
-        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible();
-        assertThat(result).isNotNull();
-        assertThat(result).isEmpty();
-        // NOT, OR
-        // assertThat(result).hasSize(2);
-        // assertThat(result.get(0)).isInstanceOf(NotGeocacheFilter.class);
-        // assertThat(result.get(1)).isInstanceOf(OrGeocacheFilter.class);
-
-        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(GC);
-        assertThat(gcResult).isNull();
-
-        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(SU);
-        assertThat(suResult).isNotNull();
-        assertThat(suResult).isEmpty();
-
-        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(OC);
-        assertThat(ocResult).isNotNull();
-        assertThat(ocResult).hasSize(1);
-        assertThat(ocResult.get(0).getType()).isEqualTo(GeocacheFilterType.NAME);
-    }
 
     @Test
     public void nullTreeReturnsEmptyFilter() {

--- a/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
@@ -1,0 +1,209 @@
+package cgeo.geocaching.filters;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.oc.OCDEConnector;
+import cgeo.geocaching.connector.su.SuConnector;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
+import cgeo.geocaching.filters.core.BaseGeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.NameGeocacheFilter;
+import cgeo.geocaching.filters.core.NotGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
+
+import java.util.List;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+/**
+ * Tests for {@link GeocacheFilter#getConnectorRelevantFilter(IConnector)} and
+ * {@link GeocacheFilter#getAndChainIfPossible(IConnector)}.
+ */
+public class ConnectorRelevantFilterTest {
+
+    private static final IConnector GC = GCConnector.getInstance();
+    private static final IConnector SU = SuConnector.getInstance();
+    private static final IConnector OC = new OCDEConnector();
+
+    // --- Tests ---
+
+    @Test
+    public void getAndChainIfPossible() {
+        //AND(NOT(Origin=GC), OR(Origin=SU, Name="su-test"))
+        final NotGeocacheFilter gcBranch = NotGeocacheFilter.create(OriginGeocacheFilter.create(GC));
+        final OrGeocacheFilter suBranch = OrGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
+        final AndGeocacheFilter andBranch = AndGeocacheFilter.create(gcBranch, suBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, andBranch);
+
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible();
+        assertThat(result).isNotNull();
+        // NOT, OR
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isInstanceOf(NotGeocacheFilter.class);
+        assertThat(result.get(1)).isInstanceOf(OrGeocacheFilter.class);
+
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(GC);
+        assertThat(gcResult).isNull();
+
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult).isEmpty();
+
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(OC);
+        assertThat(ocResult).isNotNull();
+        assertThat(ocResult).hasSize(1);
+        assertThat(ocResult.get(0).getType()).isEqualTo(GeocacheFilterType.NAME);
+    }
+
+    @Test
+    public void nullTreeReturnsEmptyFilter() {
+        final GeocacheFilter empty = GeocacheFilter.createEmpty();
+        final GeocacheFilter result = empty.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getTree()).isNull();
+        assertThat(result.isFiltering()).isFalse();
+    }
+
+    @Test
+    public void simpleAndWithMatchingOriginReturnsFilterWithoutOrigin() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        // Origin was removed, only NameFilter remains
+        assertThat(result.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void simpleAndWithNonMatchingOriginReturnsNull() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(SU);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void orWithDifferentOriginBranches() {
+        // OR(AND(Origin=GC, Name="gc-test"), AND(Origin=SU, Name="su-test"))
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final AndGeocacheFilter suBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(suBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
+
+        // For GC: only gc-branch should remain
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+
+        // For SU: only su-branch should remain
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void noOriginFilterReturnsFullTree() {
+        // AND(Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, NameGeocacheFilter.create("test"));
+
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void notOriginExcludesMatchingConnector() {
+        // NOT(Origin=GC) means: exclude GC caches
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(OriginGeocacheFilter.create(GC));
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, notFilter);
+
+        // GC should be excluded (NOT(always-true-for-GC) = false)
+        assertThat(filter.getConnectorRelevantFilter(GC)).isNull();
+
+        // SU should NOT be excluded (NOT(false-for-SU) = true → always true)
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isNull(); // simplified to always-true
+    }
+
+    @Test
+    public void nonFilteringOriginIsAlwaysTrue() {
+        // empty OriginFilter (isFiltering() == false) → always true
+        final OriginGeocacheFilter emptyOrigin = GeocacheFilterType.ORIGIN.create();
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, emptyOrigin);
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getTree()).isNull(); // simplified to always-true
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithConnectorReturnsNullForExcluded() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final List<BaseGeocacheFilter> gcChain = filter.getAndChainIfPossible(GC);
+        assertThat(gcChain).isNotNull();
+        assertThat(gcChain).hasSize(1);
+        assertThat(gcChain.get(0)).isInstanceOf(NameGeocacheFilter.class);
+
+        final List<BaseGeocacheFilter> suChain = filter.getAndChainIfPossible(SU);
+        assertThat(suChain).isNull();
+    }
+
+    @Test
+    public void orWithMixedBranchesPartiallyRelevant() {
+        // OR(AND(Origin=GC, Name="gc-test"), Name="general")
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final NameGeocacheFilter generalBranch = NameGeocacheFilter.create("general");
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(generalBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
+
+        // For GC: both branches are relevant → OR(Name="gc-test", Name="general")
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(OrGeocacheFilter.class);
+        assertThat(((OrGeocacheFilter) gcResult.getTree()).getChildren()).hasSize(2);
+
+        // For SU: only the general branch is relevant → Name="general"
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void preservesNameAndFlags() {
+        final GeocacheFilter filter = GeocacheFilter.create("myFilter", true, true,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("myFilter");
+        assertThat(result.isOpenInAdvancedMode()).isTrue();
+        assertThat(result.isIncludeInconclusive()).isTrue();
+    }
+}
+
+
+

--- a/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/ConnectorRelevantFilterTest.java
@@ -1,0 +1,160 @@
+package cgeo.geocaching.filters;
+
+import cgeo.geocaching.SearchResult;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.oc.OCDEConnector;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.filters.core.NotGeocacheFilter;
+import cgeo.geocaching.filters.core.OfflineLogGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
+import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
+import cgeo.geocaching.filters.core.StatusGeocacheFilter;
+import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.sorting.GeocacheSort;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+/**
+ * Instrumented API test for the combination of OriginGeocacheFilter and OwnerGeocacheFilter.
+ * Tests OR(AND(Origin=GC, Owner="eddiemuc"), AND(Origin=OC, Owner="lineflyer")) against the
+ * real geocaching.com and opencaching.de APIs.
+ * <p>
+ * Requires configured accounts for geocaching.com and opencaching.de on the emulator/device.
+ */
+public class ConnectorRelevantFilterTest {
+    private static final GCConnector GC = GCConnector.getInstance();
+    private static final OCDEConnector OC = new OCDEConnector();
+    private static final String GC_TEST_OWNER = "eddiemuc";
+    private static final String OC_TEST_OWNER = "lineflyer";
+
+    @Test
+    public void searchGCOrOCFilter() {
+        // OR(AND(Origin=GC, Owner=GC_TEST_OWNER), AND(Origin=OC, Owner=OC_TEST_OWNER))
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, createGCOrOCFilter());
+
+        // Sent to GC API: only GC branch is relevant → Owner=GC_TEST_OWNER
+        final SearchResult gcSearch = GC.searchByFilter(filter, new GeocacheSort());
+        assertThat(gcSearch).isNotNull();
+        assertThat(gcSearch.getCount()).isNotEqualTo(0);
+        assertOwner(gcSearch, GC_TEST_OWNER);
+
+        // Sent to OC API: only OC branch is relevant → Owner=OC_TEST_OWNER
+        final SearchResult ocSearch = OC.searchByFilter(filter, new GeocacheSort());
+        assertThat(ocSearch).isNotNull();
+        assertThat(ocSearch.getCount()).isNotEqualTo(0);
+        assertOwner(ocSearch, OC_TEST_OWNER);
+    }
+
+    @Test
+    public void searchIgnoreOCFilter() {
+        // AND(NOT(Origin=OC), Owner=OC_TEST_OWNER))
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, createIgnoreOCFilter());
+
+        // Sent to GC API: only GC branch is relevant → Owner=OC_TEST_OWNER
+        final SearchResult gcSearch = GC.searchByFilter(filter, new GeocacheSort());
+        assertThat(gcSearch).isNotNull();
+        assertThat(gcSearch.getCount()).isNotEqualTo(0);
+        assertOwner(gcSearch, OC_TEST_OWNER);
+
+        // Sent to OC API: OC branch is not relevant → empty SearchResult
+        final SearchResult ocSearch = OC.searchByFilter(filter, new GeocacheSort());
+        assertThat(ocSearch).isNotNull();
+        assertThat(ocSearch.getGeocodes()).isEmpty();
+    }
+
+    private static void assertOwner(final SearchResult search, final String expectedOwner) {
+        // Verify all caches belong to the expected owner
+        final Set<Geocache> caches = search.getCachesFromSearchResult();
+        assertThat(caches).isNotEmpty();
+        for (final Geocache cache : caches) {
+            assertThat(cache.getOwnerDisplayName())
+                    .as("Owner of cache " + cache.getGeocode())
+                    .isEqualToIgnoringCase(expectedOwner);
+        }
+    }
+
+    private static IGeocacheFilter createGCOrOCFilter() {
+        // OR(AND(Origin=GC, Owner=GC_TEST_OWNER), AND(Origin=OC, Owner=OC_TEST_OWNER))
+        return OrGeocacheFilter.create(createOwnerBranch(GC, GC_TEST_OWNER), createOwnerBranch(OC, OC_TEST_OWNER));
+    }
+
+    private static IGeocacheFilter createIgnoreOCFilter() {
+        // AND(NOT(Origin=OC), Owner=OC_TEST_OWNER))
+        return AndGeocacheFilter.create(NotGeocacheFilter.create(createOriginFilter(OC)), createOwnerFilter(OC_TEST_OWNER));
+    }
+
+    @Test
+    public void searchGCWithOfflineOnlyStatusInAndChain() {
+        // AND(Origin=GC, Owner=GC_TEST_OWNER, Status(hasOfflineFoundLog=true))
+        // The offline-only status sub-criterion must not prevent the GC API call from succeeding.
+        // GC API uses only the Owner filter (STATUS with hasOfflineFoundLog is not in GC capabilities).
+        final IGeocacheFilter filter = AndGeocacheFilter.create(
+                createOriginFilter(GC),
+                createOwnerFilter(GC_TEST_OWNER),
+                createStatusWithOfflineFoundLog());
+        final GeocacheFilter geocacheFilter = GeocacheFilter.create(null, false, false, filter);
+
+        final SearchResult gcSearch = GC.searchByFilter(geocacheFilter, new GeocacheSort());
+        assertThat(gcSearch).isNotNull();
+        assertThat(gcSearch.getCount()).isNotEqualTo(0);
+        assertOwner(gcSearch, GC_TEST_OWNER);
+    }
+
+    @Test
+    public void searchGCOrOCFilterWithOfflineOnlyBranch() {
+        // OR(AND(Origin=GC, Owner=GC_TEST_OWNER), AND(Origin=OC, OfflineLog="draft"))
+        // GC: OC branch (with offline-only OfflineLog filter) is removed → only Owner=GC_TEST_OWNER remains
+        // OC: GC branch removed; OfflineLog filter is not in OC capabilities → OC returns result without error
+        final IGeocacheFilter filter = OrGeocacheFilter.create(
+                createOwnerBranch(GC, GC_TEST_OWNER),
+                createOfflineLogBranch(OC, "draft"));
+        final GeocacheFilter geocacheFilter = GeocacheFilter.create(null, false, false, filter);
+
+        // GC: offline-only OC branch must not interfere → normal owner result
+        final SearchResult gcSearch = GC.searchByFilter(geocacheFilter, new GeocacheSort());
+        assertThat(gcSearch).isNotNull();
+        assertThat(gcSearch.getCount()).isNotEqualTo(0);
+        assertOwner(gcSearch, GC_TEST_OWNER);
+
+        // OC: must not throw; offline-only filter not pushed to API
+        final SearchResult ocSearch = OC.searchByFilter(geocacheFilter, new GeocacheSort());
+        assertThat(ocSearch).isNotNull();
+    }
+
+    private static IGeocacheFilter createOwnerBranch(final IConnector connector, final String owner) {
+        return AndGeocacheFilter.create(createOriginFilter(connector), createOwnerFilter(owner));
+    }
+
+    private static IGeocacheFilter createOriginFilter(final IConnector connector) {
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singletonList(connector));
+        return originFilter;
+    }
+
+    private static IGeocacheFilter createOwnerFilter(final String owner) {
+        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+        ownerFilter.getStringFilter().setTextValue(owner);
+        return ownerFilter;
+    }
+
+    private static IGeocacheFilter createStatusWithOfflineFoundLog() {
+        final StatusGeocacheFilter statusFilter = GeocacheFilterType.STATUS.create();
+        statusFilter.setStatusHasOfflineFoundLog(true);
+        return statusFilter;
+    }
+
+    private static IGeocacheFilter createOfflineLogBranch(final IConnector connector, final String logText) {
+        final OfflineLogGeocacheFilter offlineLogFilter = GeocacheFilterType.OFFLINE_LOG.create();
+        offlineLogFilter.getStringFilter().setTextValue(logText);
+        return AndGeocacheFilter.create(createOriginFilter(connector), offlineLogFilter);
+    }
+}

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -133,9 +133,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -1620,6 +1622,17 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         context.startActivity(cachesIntent);
     }
 
+    public static void startActivityOwner(final Context context, @NonNull final List<IConnector> connectorList) {
+        if (connectorList.isEmpty()) {
+            ActivityMixin.showToast(context, R.string.warn_no_username);
+            return;
+        }
+        final Intent cachesIntent = new Intent(context, CacheListActivity.class);
+        Intents.putListType(cachesIntent, CacheListType.OWNER);
+        cachesIntent.putExtra(Intents.EXTRA_CONNECTOR_LIST, new ArrayList<>(connectorList.stream().map(IConnector::getName).collect(Collectors.toList())));
+        context.startActivity(cachesIntent);
+    }
+
     public static void startActivityFilter(final Context context) {
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, CacheListType.SEARCH_FILTER);
@@ -1877,11 +1890,20 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                     break;
                 case OWNER:
                     final String ownerName = extras.getString(Intents.EXTRA_USERNAME);
-                    title = listNameMemento.rememberTerm(ownerName);
-                    markerId = EmojiUtils.NO_EMOJI;
-                    if (ownerName != null) {
+                    @SuppressWarnings("unchecked") final ArrayList<String> connectorNameList = (ArrayList<String>) extras.getSerializable(Intents.EXTRA_CONNECTOR_LIST);
+                    final List<IConnector> connectorList = connectorNameList == null ? null :
+                            connectorNameList.stream().map(ConnectorFactory::getConnectorByName).filter(Objects::nonNull).collect(Collectors.toList());
+
+                    if (connectorList != null && !connectorList.isEmpty()) {
+                        // Multiple connectors with different usernames
+                        title = listNameMemento.rememberTerm(res.getString(R.string.search_own_caches));
+                        loader = new OwnerGeocacheListLoader(this, sortContext.getSort(), connectorList);
+                    } else if (ownerName != null) {
+                        // Single username mode
+                        title = listNameMemento.rememberTerm(ownerName);
                         loader = new OwnerGeocacheListLoader(this, sortContext.getSort(), ownerName);
                     }
+                    markerId = EmojiUtils.NO_EMOJI;
                     break;
                 case MAP:
                     title = res.getString(R.string.map_map);

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -133,7 +133,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1629,7 +1628,7 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         }
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, CacheListType.OWNER);
-        cachesIntent.putExtra(Intents.EXTRA_CONNECTOR_LIST, new ArrayList<>(connectorList.stream().map(IConnector::getName).collect(Collectors.toList())));
+        cachesIntent.putStringArrayListExtra(Intents.EXTRA_CONNECTOR_LIST, new ArrayList<>(connectorList.stream().map(IConnector::getName).collect(Collectors.toList())));
         context.startActivity(cachesIntent);
     }
 
@@ -1890,9 +1889,9 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                     break;
                 case OWNER:
                     final String ownerName = extras.getString(Intents.EXTRA_USERNAME);
-                    @SuppressWarnings("unchecked") final ArrayList<String> connectorNameList = (ArrayList<String>) extras.getSerializable(Intents.EXTRA_CONNECTOR_LIST);
+                    final ArrayList<String> connectorNameList = extras.getStringArrayList(Intents.EXTRA_CONNECTOR_LIST);
                     final List<IConnector> connectorList = connectorNameList == null ? null :
-                            connectorNameList.stream().map(ConnectorFactory::getConnectorByName).filter(Objects::nonNull).collect(Collectors.toList());
+                            connectorNameList.stream().map(ConnectorFactory::getConnectorByName).collect(Collectors.toList());
 
                     if (connectorList != null && !connectorList.isEmpty()) {
                         // Multiple connectors with different usernames

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -133,9 +133,11 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -1589,6 +1591,20 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         context.startActivity(cachesIntent);
     }
 
+    public static void startActivityOwner(final Context context, @NonNull final List<IConnector> connectorList, @Nullable final GeocacheFilterContext filterContext) {
+        if (connectorList.isEmpty()) {
+            ActivityMixin.showToast(context, R.string.warn_no_username);
+            return;
+        }
+        final Intent cachesIntent = new Intent(context, CacheListActivity.class);
+        Intents.putListType(cachesIntent, CacheListType.OWNER);
+        cachesIntent.putStringArrayListExtra(Intents.EXTRA_CONNECTOR_LIST, new ArrayList<>(connectorList.stream().map(IConnector::getName).collect(Collectors.toList())));
+        if (filterContext != null) {
+            cachesIntent.putExtra(Intents.EXTRA_FILTER_CONTEXT, filterContext);
+        }
+        context.startActivity(cachesIntent);
+    }
+
     public static void startActivityFilter(final Context context) {
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, CacheListType.SEARCH_FILTER);
@@ -1845,11 +1861,20 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
                     break;
                 case OWNER:
                     final String ownerName = extras.getString(Intents.EXTRA_USERNAME);
-                    title = listNameMemento.rememberTerm(ownerName);
-                    markerId = EmojiUtils.NO_EMOJI;
-                    if (ownerName != null) {
+                    @SuppressWarnings("unchecked") final ArrayList<String> connectorNameList = (ArrayList<String>) extras.getSerializable(Intents.EXTRA_CONNECTOR_LIST);
+                    final List<IConnector> connectorList = connectorNameList == null ? null :
+                            connectorNameList.stream().map(ConnectorFactory::getConnectorByName).filter(Objects::nonNull).collect(Collectors.toList());
+
+                    if (connectorList != null && !connectorList.isEmpty()) {
+                        // Multiple connectors with different usernames
+                        title = listNameMemento.rememberTerm(LocalizationUtils.getString(R.string.search_own_caches));
+                        loader = new OwnerGeocacheListLoader(this, sortContext.getSort(), connectorList, currentCacheFilterContext);
+                    } else if (ownerName != null) {
+                        // Single username mode
+                        title = listNameMemento.rememberTerm(ownerName);
                         loader = new OwnerGeocacheListLoader(this, sortContext.getSort(), ownerName, currentCacheFilterContext);
                     }
+                    markerId = EmojiUtils.NO_EMOJI;
                     break;
                 case MAP:
                     title = LocalizationUtils.getString(R.string.map_map);

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -61,6 +61,7 @@ public class Intents {
     public static final String EXTRA_SEARCH = PREFIX + "search";
     public static final String EXTRA_TRACKING_CODE = PREFIX + "tracking_code";
     public static final String EXTRA_USERNAME = PREFIX + "username";
+    public static final String EXTRA_CONNECTOR_LIST = PREFIX + "connector_list";
     public static final String EXTRA_WAYPOINT_ID = PREFIX + "waypoint_id";
     public static final String EXTRA_POCKET_LIST = PREFIX + "pocket_list";
 

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -59,6 +59,7 @@ public class Intents {
     public static final String EXTRA_SEARCH = PREFIX + "search";
     public static final String EXTRA_TRACKING_CODE = PREFIX + "tracking_code";
     public static final String EXTRA_USERNAME = PREFIX + "username";
+    public static final String EXTRA_CONNECTOR_LIST = PREFIX + "connector_list";
     public static final String EXTRA_WAYPOINT_ID = PREFIX + "waypoint_id";
     public static final String EXTRA_POCKET_LIST = PREFIX + "pocket_list";
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -491,7 +491,12 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         // Collect all active ILogin connectors with their usernames
         final List<IConnector> connectorList = new ArrayList<>();
         for (final IConnector connector : ConnectorFactory.getActiveConnectors()) {
-            if (connector instanceof ILogin) {
+            if (!(connector instanceof ILogin)) {
+                continue;
+            }
+
+            final ILogin loginConnector = (ILogin) connector;
+            if (StringUtils.isNotEmpty(loginConnector.getUserName())) {
                 connectorList.add(connector);
             }
         }
@@ -499,7 +504,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         if (connectorList.isEmpty()) {
             // Fallback to the old behavior if no connectors have usernames
             final String defaultUsername = Settings.getUserName();
-            if (StringUtils.isNotBlank(defaultUsername)) {
+            if (StringUtils.isNotEmpty(defaultUsername)) {
                 findByOwnerFn(defaultUsername);
             } else {
                 SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.address.AddressListActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.al.ALConnector;
+import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
@@ -59,6 +60,8 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.cardview.widget.CardView;
 import androidx.core.graphics.Insets;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -478,10 +481,33 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         addSearchCardWithField(R.string.search_tb, R.drawable.trackable_all, null, this::findTrackableFn, DataStore::getSuggestionsTrackableCode, () -> Settings.getHistoryList(R.string.pref_search_history_trackable), value -> Settings.removeFromHistoryList(R.string.pref_search_history_trackable, value), new InputFilter.AllCaps());
 
         addSearchCard(R.string.search_own_caches, R.drawable.ic_menu_owned)
-                .addOnClickListener(() -> findByOwnerFn(Settings.getUserName()));
+                .addOnClickListener(this::searchOwnCaches);
 
         addSearchCard(R.string.caches_history, R.drawable.ic_menu_recent_history)
                 .addOnClickListener(() -> startActivity(CacheListActivity.getHistoryIntent(this)));
+    }
+
+    private void searchOwnCaches() {
+        // Collect all active ILogin connectors with their usernames
+        final List<IConnector> connectorList = new ArrayList<>();
+        for (final IConnector connector : ConnectorFactory.getActiveConnectors()) {
+            if (connector instanceof ILogin) {
+                connectorList.add(connector);
+            }
+        }
+
+        if (connectorList.isEmpty()) {
+            // Fallback to the old behavior if no connectors have usernames
+            final String defaultUsername = Settings.getUserName();
+            if (StringUtils.isNotBlank(defaultUsername)) {
+                findByOwnerFn(defaultUsername);
+            } else {
+                SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();
+            }
+            return;
+        }
+
+        findByOwnerFn(connectorList);
     }
 
     private String getGeocodeFromClipboard() {
@@ -543,6 +569,16 @@ public class SearchActivity extends AbstractNavigationBarActivity {
 
         Settings.addToHistoryList(R.string.pref_search_history_owner, userName);
         CacheListActivity.startActivityOwner(this, userName);
+        ActivityMixin.overrideTransitionToFade(this);
+    }
+
+    private void findByOwnerFn(final List<IConnector> connectorList) {
+        if (connectorList == null || connectorList.isEmpty()) {
+            SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();
+            return;
+        }
+
+        CacheListActivity.startActivityOwner(this, connectorList);
         ActivityMixin.overrideTransitionToFade(this);
     }
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.address.AddressListActivity;
 import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.al.ALConnector;
+import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.internal.InternalConnector;
@@ -60,6 +61,8 @@ import androidx.appcompat.content.res.AppCompatResources;
 import androidx.cardview.widget.CardView;
 import androidx.core.graphics.Insets;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
@@ -479,10 +482,33 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         addSearchCardWithField(R.string.search_tb, R.drawable.trackable_all, null, this::findTrackableFn, DataStore::getSuggestionsTrackableCode, () -> Settings.getHistoryList(R.string.pref_search_history_trackable), value -> Settings.removeFromHistoryList(R.string.pref_search_history_trackable, value), new InputFilter.AllCaps());
 
         addSearchCard(R.string.search_own_caches, R.drawable.ic_menu_owned)
-                .addOnClickListener(this::findOwnFn);
+                .addOnClickListener(this::searchOwnCaches);
 
         addSearchCard(R.string.caches_history, R.drawable.ic_menu_recent_history)
                 .addOnClickListener(() -> startActivity(CacheListActivity.getHistoryIntent(this)));
+    }
+
+    private void searchOwnCaches() {
+        // Collect all active ILogin connectors with their usernames
+        final List<IConnector> connectorList = new ArrayList<>();
+        for (final IConnector connector : ConnectorFactory.getActiveConnectors()) {
+            if (connector instanceof ILogin) {
+                connectorList.add(connector);
+            }
+        }
+
+        if (connectorList.isEmpty()) {
+            // Fallback to the old behavior if no connectors have usernames
+            final String defaultUsername = Settings.getUserName();
+            if (StringUtils.isNotBlank(defaultUsername)) {
+                findByOwnerFn(defaultUsername);
+            } else {
+                SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();
+            }
+            return;
+        }
+
+        findByOwnerFn(connectorList);
     }
 
     private String getGeocodeFromClipboard() {
@@ -547,10 +573,16 @@ public class SearchActivity extends AbstractNavigationBarActivity {
         ActivityMixin.overrideTransitionToFade(this);
     }
 
-    private void findOwnFn() {
-        CacheListActivity.startActivityOwner(this, Settings.getUserName(), new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT));
+    private void findByOwnerFn(final List<IConnector> connectorList) {
+        if (connectorList == null || connectorList.isEmpty()) {
+            SimpleDialog.of(this).setTitle(R.string.warn_search_help_title).setMessage(R.string.warn_search_help_user).show();
+            return;
+        }
+
+        CacheListActivity.startActivityOwner(this, connectorList, new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT));
         ActivityMixin.overrideTransitionToFade(this);
     }
+
 
     private void findByFinderFn(final String usernameText) {
         if (StringUtils.isBlank(usernameText)) {

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -11,7 +11,6 @@ import cgeo.geocaching.filters.core.BaseGeocacheFilter;
 import cgeo.geocaching.filters.core.DateRangeGeocacheFilter;
 import cgeo.geocaching.filters.core.DistanceGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.TypeGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
@@ -208,10 +207,9 @@ final class ALApi {
 
         final GeocacheFilter filter = pFilter == null ? GeocacheFilter.createEmpty() : pFilter;
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
-        // Origin excludes Lab
-        final OriginGeocacheFilter of = GeocacheFilter.findInChain(filters, OriginGeocacheFilter.class);
-        if (of != null && !of.allowsCachesOf(connector)) {
+        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible(connector);
+        // Connector excluded by Origin filter
+        if (filters == null) {
             return new ArrayList<>();
         }
         // Type excludes Lab

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -10,7 +10,6 @@ import cgeo.geocaching.filters.core.BaseGeocacheFilter;
 import cgeo.geocaching.filters.core.DateRangeGeocacheFilter;
 import cgeo.geocaching.filters.core.DistanceGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.TypeGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
@@ -207,10 +206,9 @@ final class ALApi {
 
         final GeocacheFilter filter = pFilter == null ? GeocacheFilter.createEmpty() : pFilter;
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
-        // Origin excludes Lab
-        final OriginGeocacheFilter of = GeocacheFilter.findInChain(filters, OriginGeocacheFilter.class);
-        if (of != null && !of.allowsCachesOf(connector)) {
+        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible(connector);
+        // Connector excluded by Origin filter
+        if (filters == null) {
             return new ArrayList<>();
         }
         // Type excludes Lab

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCConnector.java
@@ -26,7 +26,6 @@ import cgeo.geocaching.enumerations.StatusCode;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.log.LogEntry;
@@ -253,10 +252,6 @@ public class GCConnector extends AbstractConnector implements ISearchByGeocode, 
         GeocacheFilter filter = null;
         if (filterConfig != null) {
             filter = GeocacheFilter.createFromConfig(filterConfig);
-            final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
-            if (origin != null && !origin.allowsCachesOf(this)) {
-                return new SearchResult();
-            }
         }
 
         if (filter == null) {

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCMap.java
@@ -14,7 +14,6 @@ import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.HiddenGeocacheFilter;
 import cgeo.geocaching.filters.core.LogEntryGeocacheFilter;
 import cgeo.geocaching.filters.core.NameGeocacheFilter;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.filters.core.SizeGeocacheFilter;
 import cgeo.geocaching.filters.core.StatusGeocacheFilter;
@@ -118,14 +117,11 @@ public class GCMap {
         search.setPage(take, skip);
 
         final GeocacheFilter filter = pFilter != null ? pFilter : GeocacheFilter.createEmpty();
-
-        //special case: if origin filter is present and excludes GCConnector, then skip search
-        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
-        if (origin != null && !origin.allowsCachesOf(connector)) {
+        final List<BaseGeocacheFilter> filterAndChain = filter.getAndChainIfPossible(connector);
+        if (filterAndChain == null) {
             return null;
         }
 
-        final List<BaseGeocacheFilter> filterAndChain = filter.getAndChainIfPossible();
         for (BaseGeocacheFilter baseFilter : filterAndChain) {
             fillForBasicFilter(baseFilter, search);
         }
@@ -133,7 +129,6 @@ public class GCMap {
         search.setSort(GCWebAPI.WebApiSearch.SortType.getByCGeoSortType(sort.getEffectiveType()), sort.isEffectiveAscending());
 
         return search;
-
     }
 
     private static void fillForBasicFilter(@NonNull final BaseGeocacheFilter basicFilter, final GCWebAPI.WebApiSearch search) {

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -361,28 +361,22 @@ final class OkapiClient {
             return new SearchResult(); //connector is excluded by origin filter
         }
 
-        final Geopoint searchCoords;
-        final String radius;
-
-        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
-        if (df != null) {
-            searchCoords = df.getEffectiveCoordinate();
-            radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
-        } else {
-            // search around current position by default
-            searchCoords = null;
-            radius = DEFAULT_RADIUS;
-        }
-
-        //fill in the defaults
+        // fill in the defaults
         final Parameters params = new Parameters("search_method", METHOD_SEARCH_ALL);
         final Map<String, String> valueMap = new LinkedHashMap<>();
         valueMap.put("limit", "" + take);
         valueMap.put("offset", "" + skip);
-        fillSearchParameterCenter(valueMap, params, searchCoords, radius);
+
+        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
+        if (df != null) {
+            final String radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
+            fillSearchParameterCenter(valueMap, params, df.getEffectiveCoordinate(), radius);
+        } else {
+            // search around current position by default
+            //fillSearchParameterCenter(valueMap, params, null, DEFAULT_RADIUS);
+        }
 
         String finder = null;
-
         for (final BaseGeocacheFilter baseFilter : filters) {
             if (baseFilter instanceof LogEntryGeocacheFilter) {
                 finder = ((LogEntryGeocacheFilter) baseFilter).getFoundByUser();

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -28,7 +28,6 @@ import cgeo.geocaching.filters.core.LogEntryGeocacheFilter;
 import cgeo.geocaching.filters.core.LogsCountGeocacheFilter;
 import cgeo.geocaching.filters.core.NameGeocacheFilter;
 import cgeo.geocaching.filters.core.NumberRangeGeocacheFilter;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.filters.core.RatingGeocacheFilter;
 import cgeo.geocaching.filters.core.SizeGeocacheFilter;
@@ -349,12 +348,7 @@ final class OkapiClient {
             return new SearchResult();
         }
         final GeocacheFilter filter = GeocacheFilter.createFromConfig(filterConfig);
-        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
-        if (origin != null && !origin.allowsCachesOf(connector)) {
-            return new SearchResult();
-        }
         final int alreadyTook = context.getInt(SEARCH_CONTEXT_TOOK_TOTAL, 0);
-
         return retrieveCaches(connector, filter, SEARCH_LOAD_NEXTPAGE, alreadyTook);
     }
 
@@ -362,7 +356,10 @@ final class OkapiClient {
     @WorkerThread
     private static SearchResult retrieveCaches(@NonNull final OCApiConnector connector, @NonNull final GeocacheFilter filter, final int take, final int skip) {
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
+        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible(connector);
+        if (filters == null) {
+            return new SearchResult(); //connector is excluded by origin filter
+        }
 
         final Geopoint searchCoords;
         final String radius;
@@ -386,10 +383,7 @@ final class OkapiClient {
 
         String finder = null;
 
-        for (BaseGeocacheFilter baseFilter : filter.getAndChainIfPossible()) {
-            if (baseFilter instanceof OriginGeocacheFilter && !((OriginGeocacheFilter) baseFilter).allowsCachesOf(connector)) {
-                return new SearchResult(); //no need to search if connector is filtered out itself
-            }
+        for (final BaseGeocacheFilter baseFilter : filters) {
             if (baseFilter instanceof LogEntryGeocacheFilter) {
                 finder = ((LogEntryGeocacheFilter) baseFilter).getFoundByUser();
             }

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -28,7 +28,6 @@ import cgeo.geocaching.filters.core.LogEntryGeocacheFilter;
 import cgeo.geocaching.filters.core.LogsCountGeocacheFilter;
 import cgeo.geocaching.filters.core.NameGeocacheFilter;
 import cgeo.geocaching.filters.core.NumberRangeGeocacheFilter;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.filters.core.RatingGeocacheFilter;
 import cgeo.geocaching.filters.core.SizeGeocacheFilter;
@@ -349,12 +348,7 @@ final class OkapiClient {
             return new SearchResult();
         }
         final GeocacheFilter filter = GeocacheFilter.createFromConfig(filterConfig);
-        final OriginGeocacheFilter origin = GeocacheFilter.findInChain(filter.getAndChainIfPossible(), OriginGeocacheFilter.class);
-        if (origin != null && !origin.allowsCachesOf(connector)) {
-            return new SearchResult();
-        }
         final int alreadyTook = context.getInt(SEARCH_CONTEXT_TOOK_TOTAL, 0);
-
         return retrieveCaches(connector, filter, SEARCH_LOAD_NEXTPAGE, alreadyTook);
     }
 
@@ -362,7 +356,10 @@ final class OkapiClient {
     @WorkerThread
     private static SearchResult retrieveCaches(@NonNull final OCApiConnector connector, @NonNull final GeocacheFilter filter, final int take, final int skip) {
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
+        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible(connector);
+        if (filters == null) {
+            return new SearchResult(); //connector is excluded by origin filter
+        }
 
         final Geopoint searchCoords;
         final String radius;
@@ -385,11 +382,7 @@ final class OkapiClient {
         fillSearchParameterCenter(valueMap, params, searchCoords, radius);
 
         String finder = null;
-
-        for (BaseGeocacheFilter baseFilter : filter.getAndChainIfPossible()) {
-            if (baseFilter instanceof OriginGeocacheFilter && !((OriginGeocacheFilter) baseFilter).allowsCachesOf(connector)) {
-                return new SearchResult(); //no need to search if connector is filtered out itself
-            }
+        for (final BaseGeocacheFilter baseFilter : filters) {
             if (baseFilter instanceof LogEntryGeocacheFilter) {
                 finder = ((LogEntryGeocacheFilter) baseFilter).getFoundByUser();
             }

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -361,25 +361,21 @@ final class OkapiClient {
             return new SearchResult(); //connector is excluded by origin filter
         }
 
-        final Geopoint searchCoords;
-        final String radius;
-
-        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
-        if (df != null) {
-            searchCoords = df.getEffectiveCoordinate();
-            radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
-        } else {
-            // search around current position by default
-            searchCoords = null;
-            radius = DEFAULT_RADIUS;
-        }
-
-        //fill in the defaults
+        // fill in the defaults
         final Parameters params = new Parameters("search_method", METHOD_SEARCH_ALL);
         final Map<String, String> valueMap = new LinkedHashMap<>();
         valueMap.put("limit", "" + take);
         valueMap.put("offset", "" + skip);
-        fillSearchParameterCenter(valueMap, params, searchCoords, radius);
+
+        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
+        if (df != null) {
+            final String radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
+            fillSearchParameterCenter(valueMap, params, df.getEffectiveCoordinate(), radius);
+        } else {
+            // search around current position by default
+            // (but limit only the number of retrieved caches, not the search radius)
+            fillSearchParameterCenter(valueMap, params, null, null);
+        }
 
         String finder = null;
         for (final BaseGeocacheFilter baseFilter : filters) {
@@ -516,11 +512,13 @@ final class OkapiClient {
 
     }
 
-    public static void fillSearchParameterCenter(@NonNull final Map<String, String> valueMap, @NonNull final Parameters params, @Nullable final Geopoint center, final String radius) {
+    public static void fillSearchParameterCenter(@NonNull final Map<String, String> valueMap, @NonNull final Parameters params, @Nullable final Geopoint center, @Nullable final String radius) {
         final Geopoint usedCenter = center != null ? center : LocationDataProvider.getInstance().currentGeo().getCoords();
         final String centerString = GeopointFormatter.format(GeopointFormatter.Format.LAT_DECDEGREE_RAW, usedCenter) + SEPARATOR + GeopointFormatter.format(GeopointFormatter.Format.LON_DECDEGREE_RAW, usedCenter);
         valueMap.put("center", centerString);
-        valueMap.put("radius", radius);
+        if (radius != null) {
+            valueMap.put("radius", radius);
+        }
         params.removeKey("search_method");
         params.put("search_method", METHOD_SEARCH_NEAREST);
     }

--- a/main/src/main/java/cgeo/geocaching/connector/su/SuApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/su/SuApi.java
@@ -11,7 +11,6 @@ import cgeo.geocaching.filters.core.BaseGeocacheFilter;
 import cgeo.geocaching.filters.core.DistanceGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.NameGeocacheFilter;
-import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
@@ -164,9 +163,8 @@ public class SuApi {
 
         //for now we have to assume that SUConnector supports only SINGLE criteria search
 
-        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
-        final OriginGeocacheFilter of = GeocacheFilter.findInChain(filters, OriginGeocacheFilter.class);
-        if (of != null && !of.allowsCachesOf(connector)) {
+        final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible(connector);
+        if (filters == null) {
             return new ArrayList<>();
         }
         final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);

--- a/main/src/main/java/cgeo/geocaching/filters/core/AndGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/AndGeocacheFilter.java
@@ -5,6 +5,14 @@ import cgeo.geocaching.storage.SqlBuilder;
 
 public class AndGeocacheFilter extends LogicalGeocacheFilter {
 
+    public static AndGeocacheFilter create(final IGeocacheFilter... children) {
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        for (final IGeocacheFilter child : children) {
+            andFilter.addChild(child);
+        }
+        return andFilter;
+    }
+
     @Override
     public String getId() {
         return "AND";

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.JsonUtils;
@@ -398,6 +399,163 @@ public class GeocacheFilter implements Cloneable {
 
     private static boolean isAndFilter(final IGeocacheFilter filter) {
         return filter instanceof AndGeocacheFilter && !(filter instanceof NotGeocacheFilter);
+    }
+
+    // Sentinel value used internally by simplifyTreeForConnector to signal "always true" (no filtering needed)
+    private static final Object SENTINEL_ALWAYS_TRUE = new Object();
+
+    /**
+     * Returns a new GeocacheFilter with the filter tree simplified for a specific connector.
+     * OriginGeocacheFilter nodes that match the connector are removed (they are always true for this connector).
+     * OR branches that exclude the connector are pruned.
+     * Returns null if the connector is completely excluded by origin filters in this filter.
+     * Returns an empty (non-filtering) GeocacheFilter if the entire tree simplifies to "always true".
+     */
+    @Nullable
+    public GeocacheFilter getConnectorRelevantFilter(@NonNull final IConnector connector) {
+        if (this.tree == null) {
+            return new GeocacheFilter(this.name, this.openInAdvancedMode, this.includeInconclusive, null);
+        }
+        final Object simplified = simplifyTreeForConnector(this.tree, connector);
+        if (simplified == null) {
+            // connector is completely excluded
+            return null;
+        }
+        if (simplified == SENTINEL_ALWAYS_TRUE) {
+            // entire tree simplifies to "always true"
+            return new GeocacheFilter(this.name, this.openInAdvancedMode, this.includeInconclusive, null);
+        }
+        return new GeocacheFilter(this.name, this.openInAdvancedMode, this.includeInconclusive, (IGeocacheFilter) simplified);
+    }
+
+    /**
+     * Convenience method: first simplifies this filter for the given connector, then extracts the AND chain.
+     * Returns null if the connector is completely excluded by origin filters.
+     */
+    @Nullable
+    public List<BaseGeocacheFilter> getAndChainIfPossible(@NonNull final IConnector connector) {
+        final GeocacheFilter connectorFilter = getConnectorRelevantFilter(connector);
+        if (connectorFilter == null) {
+            return null;
+        }
+        return connectorFilter.getAndChainIfPossible();
+    }
+
+    /**
+     * Recursively simplifies a filter tree for a specific connector.
+     * Returns:
+     * - null if the connector is excluded (this subtree always evaluates to false for the connector)
+     * - SENTINEL_ALWAYS_TRUE if the subtree always evaluates to true (e.g., matching OriginFilter removed)
+     * - a simplified IGeocacheFilter otherwise
+     */
+    private static Object simplifyTreeForConnector(final IGeocacheFilter node, final IConnector connector) {
+        if (node == null) {
+            return SENTINEL_ALWAYS_TRUE;
+        }
+
+        // Handle OriginGeocacheFilter leaf nodes
+        if (node instanceof OriginGeocacheFilter) {
+            final OriginGeocacheFilter origin = (OriginGeocacheFilter) node;
+            if (!origin.isFiltering()) {
+                return SENTINEL_ALWAYS_TRUE;
+            }
+            return origin.allowsCachesOf(connector) ? SENTINEL_ALWAYS_TRUE : null;
+        }
+
+        // Handle NOT filter (extends AndGeocacheFilter)
+        if (node instanceof NotGeocacheFilter) {
+            return simplifyNotForConnector((NotGeocacheFilter) node, connector);
+        }
+
+        // Handle AND filter
+        if (isAndFilter(node)) {
+            return simplifyAndForConnector(node, connector);
+        }
+
+        // Handle OR filter
+        if (node instanceof OrGeocacheFilter) {
+            return simplifyOrForConnector(node, connector);
+        }
+
+        // All other BaseGeocacheFilter nodes: keep as-is
+        return node;
+    }
+
+    private static Object simplifyAndForConnector(final IGeocacheFilter andNode, final IConnector connector) {
+        final List<IGeocacheFilter> simplifiedChildren = new ArrayList<>();
+        for (final IGeocacheFilter child : andNode.getChildren()) {
+            final Object simplified = simplifyTreeForConnector(child, connector);
+            if (simplified == null) {
+                // one AND child is false → entire AND is false
+                return null;
+            }
+            if (simplified != SENTINEL_ALWAYS_TRUE) {
+                simplifiedChildren.add((IGeocacheFilter) simplified);
+            }
+            // SENTINEL_ALWAYS_TRUE children are dropped (they don't constrain anything)
+        }
+        if (simplifiedChildren.isEmpty()) {
+            return SENTINEL_ALWAYS_TRUE;
+        }
+        if (simplifiedChildren.size() == 1) {
+            return simplifiedChildren.get(0);
+        }
+        final AndGeocacheFilter newAnd = new AndGeocacheFilter();
+        for (final IGeocacheFilter child : simplifiedChildren) {
+            newAnd.addChild(child);
+        }
+        return newAnd;
+    }
+
+    private static Object simplifyOrForConnector(final IGeocacheFilter orNode, final IConnector connector) {
+        final List<IGeocacheFilter> simplifiedChildren = new ArrayList<>();
+        for (final IGeocacheFilter child : orNode.getChildren()) {
+            final Object simplified = simplifyTreeForConnector(child, connector);
+            if (simplified == SENTINEL_ALWAYS_TRUE) {
+                // one OR child is always true → entire OR is always true
+                return SENTINEL_ALWAYS_TRUE;
+            }
+            if (simplified != null) {
+                simplifiedChildren.add((IGeocacheFilter) simplified);
+            }
+            // null children are dropped (they are false for this connector)
+        }
+        if (simplifiedChildren.isEmpty()) {
+            // all OR branches excluded this connector
+            return null;
+        }
+        if (simplifiedChildren.size() == 1) {
+            return simplifiedChildren.get(0);
+        }
+        final OrGeocacheFilter newOr = new OrGeocacheFilter();
+        for (final IGeocacheFilter child : simplifiedChildren) {
+            newOr.addChild(child);
+        }
+        return newOr;
+    }
+
+    private static Object simplifyNotForConnector(final NotGeocacheFilter notNode, final IConnector connector) {
+        // NOT wraps an AND of its children, then negates the result.
+        // Simplify the inner AND first.
+        final Object innerSimplified = simplifyAndForConnector(notNode, connector);
+        if (innerSimplified == null) {
+            // inner is false → NOT(false) = true
+            return SENTINEL_ALWAYS_TRUE;
+        }
+        if (innerSimplified == SENTINEL_ALWAYS_TRUE) {
+            // inner is true → NOT(true) = false → connector excluded
+            return null;
+        }
+        // Wrap the simplified inner in a new NOT
+        final NotGeocacheFilter newNot = new NotGeocacheFilter();
+        if (innerSimplified instanceof AndGeocacheFilter) {
+            for (final IGeocacheFilter child : ((AndGeocacheFilter) innerSimplified).getChildren()) {
+                newNot.addChild(child);
+            }
+        } else {
+            newNot.addChild((IGeocacheFilter) innerSimplified);
+        }
+        return newNot;
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -550,7 +550,7 @@ public class GeocacheFilter implements Cloneable {
         }
         // Wrap the simplified inner in a new NOT
         final NotGeocacheFilter newNot = new NotGeocacheFilter();
-        if (innerSimplified instanceof AndGeocacheFilter) {
+        if (innerSimplified instanceof AndGeocacheFilter && !(innerSimplified instanceof NotGeocacheFilter)) {
             for (final IGeocacheFilter child : ((AndGeocacheFilter) innerSimplified).getChildren()) {
                 newNot.addChild(child);
             }

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -312,6 +312,8 @@ public class GeocacheFilter implements Cloneable {
             for (IGeocacheFilter fChild : filterToCheck.getChildren()) {
                 getAndChainIfPossibleInternal(fChild, chain);
             }
+        } else if (filterToCheck instanceof LogicalGeocacheFilter) {
+            return;
         } else if (filterToCheck instanceof BaseGeocacheFilter) {
             chain.add((BaseGeocacheFilter) filterToCheck);
         }

--- a/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/GeocacheFilter.java
@@ -1,6 +1,7 @@
 package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.utils.JsonUtils;
@@ -13,6 +14,7 @@ import cgeo.geocaching.utils.functions.Func1;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Pair;
 import androidx.core.util.Predicate;
 
 import java.text.ParseException;
@@ -311,6 +313,8 @@ public class GeocacheFilter implements Cloneable {
             for (IGeocacheFilter fChild : filterToCheck.getChildren()) {
                 getAndChainIfPossibleInternal(fChild, chain);
             }
+        } else if (filterToCheck instanceof LogicalGeocacheFilter) {
+            return;
         } else if (filterToCheck instanceof BaseGeocacheFilter) {
             chain.add((BaseGeocacheFilter) filterToCheck);
         }
@@ -398,6 +402,163 @@ public class GeocacheFilter implements Cloneable {
 
     private static boolean isAndFilter(final IGeocacheFilter filter) {
         return filter instanceof AndGeocacheFilter && !(filter instanceof NotGeocacheFilter);
+    }
+
+    /**
+     * Returns a new GeocacheFilter with the filter tree simplified for a specific connector.
+     * OriginGeocacheFilter nodes that match the connector are removed (they are always true for this connector).
+     * OR branches that exclude the connector are pruned.
+     * Returns null if the connector is completely excluded by origin filters in this filter.
+     * Returns an empty (non-filtering) GeocacheFilter if the entire tree simplifies to "always true".
+     */
+    @Nullable
+    public GeocacheFilter getConnectorRelevantFilter(@NonNull final IConnector connector) {
+        if (this.tree == null) {
+            return new GeocacheFilter(this.name, this.openInAdvancedMode, this.includeInconclusive, null);
+        }
+        final Pair<IGeocacheFilter, Boolean> simplified = simplifyTreeForConnector(this.tree, connector);
+        if (!simplified.second) {
+            // connector is completely excluded
+            return null;
+        }
+        if (simplified.first == null) {
+            // entire tree simplifies to "always true"
+            return new GeocacheFilter(this.name, this.openInAdvancedMode, this.includeInconclusive, null);
+        }
+        return new GeocacheFilter(this.name, this.openInAdvancedMode, this.includeInconclusive, (IGeocacheFilter) simplified.first);
+    }
+
+    /**
+     * Convenience method: first simplifies this filter for the given connector, then extracts the AND chain.
+     * Returns null if the connector is completely excluded by origin filters.
+     */
+    @Nullable
+    public List<BaseGeocacheFilter> getAndChainIfPossible(@NonNull final IConnector connector) {
+        final GeocacheFilter connectorFilter = getConnectorRelevantFilter(connector);
+        if (connectorFilter == null) {
+            return null;
+        }
+        return connectorFilter.getAndChainIfPossible();
+    }
+
+    /**
+     * Recursively simplifies a filter tree for a specific connector.
+     * Returns:
+     * - null if the connector is excluded (this subtree always evaluates to false for the connector)
+     * - if the subtree always evaluates to true (e.g., matching OriginFilter removed)
+     * - a simplified IGeocacheFilter otherwise
+     */
+    private static Pair<IGeocacheFilter, Boolean> simplifyTreeForConnector(final IGeocacheFilter node, final IConnector connector) {
+        if (node == null) {
+            return Pair.create(null, true);
+        }
+
+        // Handle OriginGeocacheFilter leaf nodes
+        if (node instanceof OriginGeocacheFilter) {
+            final OriginGeocacheFilter origin = (OriginGeocacheFilter) node;
+            if (!origin.isFiltering()) {
+                return Pair.create(null, true);
+            }
+            return Pair.create(null, origin.allowsCachesOf(connector));
+        }
+
+        // Handle NOT filter (extends AndGeocacheFilter)
+        if (node instanceof NotGeocacheFilter) {
+            return simplifyNotForConnector((NotGeocacheFilter) node, connector);
+        }
+
+        // Handle AND filter
+        if (isAndFilter(node)) {
+            return simplifyAndForConnector(node, connector);
+        }
+
+        // Handle OR filter
+        if (node instanceof OrGeocacheFilter) {
+            return simplifyOrForConnector(node, connector);
+        }
+
+        // All other BaseGeocacheFilter nodes: keep as-is
+        return Pair.create(node, true);
+    }
+
+    private static Pair<IGeocacheFilter, Boolean> simplifyAndForConnector(final IGeocacheFilter andNode, final IConnector connector) {
+        final List<IGeocacheFilter> simplifiedChildren = new ArrayList<>();
+        for (final IGeocacheFilter child : andNode.getChildren()) {
+            final Pair<IGeocacheFilter, Boolean> simplified = simplifyTreeForConnector(child, connector);
+            if (!simplified.second) {
+                // one AND child is false → entire AND is false
+                return simplified;
+            }
+            if (simplified.first != null) {
+                simplifiedChildren.add(simplified.first);
+            }
+            // Filter doesn't filter anything -> children are dropped (they don't constrain anything)
+        }
+        if (simplifiedChildren.isEmpty()) {
+            return Pair.create(null, true);
+        }
+        if (simplifiedChildren.size() == 1) {
+            return Pair.create(simplifiedChildren.get(0), true);
+        }
+        final AndGeocacheFilter newAnd = new AndGeocacheFilter();
+        for (final IGeocacheFilter child : simplifiedChildren) {
+            newAnd.addChild(child);
+        }
+        return Pair.create(newAnd, true);
+    }
+
+    private static Pair<IGeocacheFilter, Boolean> simplifyOrForConnector(final IGeocacheFilter orNode, final IConnector connector) {
+        final List<IGeocacheFilter> simplifiedChildren = new ArrayList<>();
+        for (final IGeocacheFilter child : orNode.getChildren()) {
+            final Pair<IGeocacheFilter, Boolean> simplified = simplifyTreeForConnector(child, connector);
+
+            if (simplified.first == null) {
+                if (simplified.second) {
+                    // one OR child is always true → entire OR is always true
+                    return simplified;
+                }
+                // null children are dropped (they are false for this connector)
+            } else {
+                simplifiedChildren.add(simplified.first);
+            }
+        }
+        if (simplifiedChildren.isEmpty()) {
+            // all OR branches excluded this connector
+            return Pair.create(null, false);
+        }
+        if (simplifiedChildren.size() == 1) {
+            return Pair.create(simplifiedChildren.get(0), true);
+        }
+        final OrGeocacheFilter newOr = new OrGeocacheFilter();
+        for (final IGeocacheFilter child : simplifiedChildren) {
+            newOr.addChild(child);
+        }
+        return Pair.create(newOr, true);
+    }
+
+    private static Pair<IGeocacheFilter, Boolean> simplifyNotForConnector(final NotGeocacheFilter notNode, final IConnector connector) {
+        // NOT wraps an AND of its children, then negates the result.
+        // Simplify the inner AND first.
+        final Pair<IGeocacheFilter, Boolean> innerSimplified = simplifyAndForConnector(notNode, connector);
+        if (!innerSimplified.second) {
+            // inner is false → NOT(false) = true
+            return Pair.create(null, true);
+        }
+        final IGeocacheFilter innerFilter = innerSimplified.first;
+        if (innerFilter == null) {
+            // inner is true → NOT(true) = false → connector excluded
+            return Pair.create(null, false);
+        }
+        // Wrap the simplified inner in a new NOT
+        final NotGeocacheFilter newNot = new NotGeocacheFilter();
+        if (innerFilter instanceof AndGeocacheFilter && !(innerFilter instanceof NotGeocacheFilter)) {
+            for (final IGeocacheFilter child : innerFilter.getChildren()) {
+                newNot.addChild(child);
+            }
+        } else {
+            newNot.addChild((IGeocacheFilter) innerFilter);
+        }
+        return Pair.create(newNot, true);
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/filters/core/NameGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/NameGeocacheFilter.java
@@ -4,6 +4,12 @@ import cgeo.geocaching.models.Geocache;
 
 public class NameGeocacheFilter extends StringGeocacheFilter {
 
+    public static NameGeocacheFilter create(final String text) {
+        final NameGeocacheFilter nf = GeocacheFilterType.NAME.create();
+        nf.getStringFilter().setTextValue(text);
+        return nf;
+    }
+
     public String getValue(final Geocache cache) {
         return cache.getName();
     }

--- a/main/src/main/java/cgeo/geocaching/filters/core/NotGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/NotGeocacheFilter.java
@@ -7,6 +7,12 @@ import cgeo.geocaching.utils.LocalizationUtils;
 
 public class NotGeocacheFilter extends AndGeocacheFilter {
 
+    public static NotGeocacheFilter create(final IGeocacheFilter child) {
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(child);
+        return notFilter;
+    }
+
     @Override
     public String getId() {
         return "NOT";

--- a/main/src/main/java/cgeo/geocaching/filters/core/OrGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/OrGeocacheFilter.java
@@ -5,6 +5,14 @@ import cgeo.geocaching.storage.SqlBuilder;
 
 public class OrGeocacheFilter extends LogicalGeocacheFilter {
 
+    public static OrGeocacheFilter create(final IGeocacheFilter... children) {
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        for (final IGeocacheFilter child : children) {
+            orFilter.addChild(child);
+        }
+        return orFilter;
+    }
+
     @Override
     public String getId() {
         return "OR";
@@ -42,4 +50,6 @@ public class OrGeocacheFilter extends LogicalGeocacheFilter {
     public String getUserDisplayableType() {
         return " OR ";
     }
+
+
 }

--- a/main/src/main/java/cgeo/geocaching/filters/core/OriginGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/OriginGeocacheFilter.java
@@ -5,8 +5,17 @@ import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.SqlBuilder;
 
+import java.util.Collections;
+
 public class OriginGeocacheFilter extends ValueGroupGeocacheFilter<IConnector, IConnector> {
 
+    public static OriginGeocacheFilter create(final IConnector... connectors) {
+        final OriginGeocacheFilter origin = GeocacheFilterType.ORIGIN.create();
+        for (final IConnector c : connectors) {
+            origin.setValues(Collections.singletonList(c));
+        }
+        return origin;
+    }
 
     @Override
     public IConnector getRawCacheValue(final Geocache cache) {

--- a/main/src/main/java/cgeo/geocaching/filters/core/OriginGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/OriginGeocacheFilter.java
@@ -4,9 +4,15 @@ import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.storage.SqlBuilder;
+import cgeo.geocaching.utils.CollectionStream;
 
 public class OriginGeocacheFilter extends ValueGroupGeocacheFilter<IConnector, IConnector> {
 
+    public static OriginGeocacheFilter create(final IConnector... connectors) {
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(CollectionStream.of(connectors).toSet());
+        return originFilter;
+    }
 
     @Override
     public IConnector getRawCacheValue(final Geocache cache) {

--- a/main/src/main/java/cgeo/geocaching/filters/core/TypeGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/TypeGeocacheFilter.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.filters.core;
 import cgeo.geocaching.R;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.utils.CollectionStream;
 import cgeo.geocaching.utils.LocalizationUtils;
 
 import org.apache.commons.lang3.EnumUtils;
@@ -17,6 +18,12 @@ public class TypeGeocacheFilter extends ValueGroupGeocacheFilter<CacheType, Cach
         addDisplayValues(CacheType.COMMUN_CELEBRATION, CacheType.MEGA_EVENT, CacheType.GIGA_EVENT, CacheType.COMMUN_CELEBRATION,
                 CacheType.GCHQ_CELEBRATION, CacheType.GPS_EXHIBIT, CacheType.BLOCK_PARTY);
         addDisplayValues(CacheType.VIRTUAL, CacheType.VIRTUAL, CacheType.LOCATIONLESS);
+    }
+
+    public static TypeGeocacheFilter create(final CacheType... types) {
+        final TypeGeocacheFilter typeFilter = GeocacheFilterType.TYPE.create();
+        typeFilter.setValues(CollectionStream.of(types).toSet());
+        return typeFilter;
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -1,21 +1,43 @@
 package cgeo.geocaching.loaders;
 
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.sorting.GeocacheSort;
 
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
-    @NonNull public final String username;
+    @Nullable
+    public final String username;
+    @Nullable
+    public final List<IConnector> connectorList;
 
     public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final String username) {
         super(activity, sort);
         this.username = username;
+        this.connectorList = null;
+    }
+
+    public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final List<IConnector> connectorList) {
+        super(activity, sort);
+        this.username = null;
+        this.connectorList = new ArrayList<>(connectorList);
     }
 
     @Override
@@ -25,8 +47,45 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
     @Override
     public IGeocacheFilter getAdditionalFilterParameter() {
-        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
-        ownerFilter.getStringFilter().setTextValue(username);
-        return ownerFilter;
+        if (connectorList != null && !connectorList.isEmpty()) {
+            // Create multiple OWNER filters combined with OR
+            final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+            for (final IConnector connector : connectorList) {
+                final IGeocacheFilter connectorFilter = createFilterForConnector(connector);
+                if (connectorFilter != null) {
+                    orFilter.addChild(connectorFilter);
+                }
+            }
+            return orFilter;
+        } else if (username != null) {
+            // Single username mode (backward compatible)
+            final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+            ownerFilter.getStringFilter().setTextValue(username);
+            return ownerFilter;
+        }
+
+        // Return empty filter if nothing specified
+        return GeocacheFilterType.OWNER.create();
+    }
+
+    @Nullable
+    private static IGeocacheFilter createFilterForConnector(@NonNull final IConnector connector) {
+        if (connector instanceof ILogin) {
+            final ILogin loginConnector = (ILogin) connector;
+            final String username = loginConnector.getUserName();
+            if (StringUtils.isNotBlank(username)) {
+                final AndGeocacheFilter andGeocacheFilter = new AndGeocacheFilter();
+
+                final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+                ownerFilter.getStringFilter().setTextValue(username);
+                andGeocacheFilter.addChild(ownerFilter);
+                final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+                originFilter.setValues(Collections.singletonList(connector));
+                andGeocacheFilter.addChild(originFilter);
+
+                return andGeocacheFilter;
+            }
+        }
+        return null;
     }
 }

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -56,7 +56,7 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
                     orFilter.addChild(connectorFilter);
                 }
             }
-            return orFilter;
+            return orFilter.isFiltering() ? orFilter : GeocacheFilterType.OWNER.create();
         } else if (username != null) {
             // Single username mode (backward compatible)
             final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
@@ -73,7 +73,7 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
         if (connector instanceof ILogin) {
             final ILogin loginConnector = (ILogin) connector;
             final String username = loginConnector.getUserName();
-            if (StringUtils.isNotBlank(username)) {
+            if (StringUtils.isNotEmpty(username)) {
                 final AndGeocacheFilter andGeocacheFilter = new AndGeocacheFilter();
 
                 final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();

--- a/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
+++ b/main/src/main/java/cgeo/geocaching/loaders/OwnerGeocacheListLoader.java
@@ -1,27 +1,46 @@
 package cgeo.geocaching.loaders;
 
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
 import cgeo.geocaching.sorting.GeocacheSort;
 
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
-    @NonNull public final String username;
+    @Nullable public final String username;
+    @Nullable public final List<IConnector> connectorList;
     @Nullable public final GeocacheFilterContext filterContext;
 
     public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final String username, @Nullable final GeocacheFilterContext filterContext) {
         super(activity, sort);
         this.username = username;
         this.filterContext = filterContext;
+        this.connectorList = null;
+    }
+
+    public OwnerGeocacheListLoader(final Activity activity, final GeocacheSort sort, @NonNull final List<IConnector> connectorList, @Nullable final GeocacheFilterContext filterContext) {
+        super(activity, sort);
+        this.username = null;
+        this.filterContext = filterContext;
+        this.connectorList = new ArrayList<>(connectorList);
     }
 
     @Override
@@ -31,9 +50,25 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
 
     @Override
     public IGeocacheFilter getAdditionalFilterParameter() {
-        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
-        ownerFilter.getStringFilter().setTextValue(username);
-        return ownerFilter;
+        if (connectorList != null && !connectorList.isEmpty()) {
+            // Create multiple OWNER filters combined with OR
+            final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+            for (final IConnector connector : connectorList) {
+                final IGeocacheFilter connectorFilter = createFilterForConnector(connector);
+                if (connectorFilter != null) {
+                    orFilter.addChild(connectorFilter);
+                }
+            }
+            return orFilter;
+        } else if (username != null) {
+            // Single username mode (backward compatible)
+            final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+            ownerFilter.getStringFilter().setTextValue(username);
+            return ownerFilter;
+        }
+
+        // Return empty filter if nothing specified
+        return GeocacheFilterType.OWNER.create();
     }
 
     @Override
@@ -43,5 +78,26 @@ public class OwnerGeocacheListLoader extends LiveFilterGeocacheListLoader {
             return filterContext.get();
         }
         return super.getBaseFilter();
+    }
+
+    @Nullable
+    private static IGeocacheFilter createFilterForConnector(@NonNull final IConnector connector) {
+        if (connector instanceof ILogin) {
+            final ILogin loginConnector = (ILogin) connector;
+            final String username = loginConnector.getUserName();
+            if (StringUtils.isNotBlank(username)) {
+                final AndGeocacheFilter andGeocacheFilter = new AndGeocacheFilter();
+
+                final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+                ownerFilter.getStringFilter().setTextValue(username);
+                andGeocacheFilter.addChild(ownerFilter);
+                final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+                originFilter.setValues(Collections.singletonList(connector));
+                andGeocacheFilter.addChild(originFilter);
+
+                return andGeocacheFilter;
+            }
+        }
+        return null;
     }
 }

--- a/main/src/test/java/cgeo/geocaching/filters/ConnectorRelevantFilterUnitTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/ConnectorRelevantFilterUnitTest.java
@@ -1,0 +1,178 @@
+package cgeo.geocaching.filters;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.su.SuConnector;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
+import cgeo.geocaching.filters.core.BaseGeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.NameGeocacheFilter;
+import cgeo.geocaching.filters.core.NotGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
+
+import java.util.List;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+/**
+ * Tests for {@link GeocacheFilter#getConnectorRelevantFilter(IConnector)} and
+ * {@link GeocacheFilter#getAndChainIfPossible(IConnector)}.
+ */
+public class ConnectorRelevantFilterUnitTest {
+
+    private static final IConnector GC = GCConnector.getInstance();
+    private static final IConnector SU = SuConnector.getInstance();
+
+    // --- Tests ---
+
+    @Test
+    public void nullTreeReturnsEmptyFilter() {
+        final GeocacheFilter empty = GeocacheFilter.createEmpty();
+        final GeocacheFilter result = empty.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getTree()).isNull();
+        assertThat(result.isFiltering()).isFalse();
+    }
+
+    @Test
+    public void simpleAndWithMatchingOriginReturnsFilterWithoutOrigin() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        // Origin was removed, only NameFilter remains
+        assertThat(result.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void simpleAndWithNonMatchingOriginReturnsNull() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(SU);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void orWithDifferentOriginBranches() {
+        // OR(AND(Origin=GC, Name="gc-test"), AND(Origin=SU, Name="su-test"))
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final AndGeocacheFilter suBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(suBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
+
+        // For GC: only gc-branch should remain
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+
+        // For SU: only su-branch should remain
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void noOriginFilterReturnsFullTree() {
+        // AND(Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, NameGeocacheFilter.create("test"));
+
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void notOriginExcludesMatchingConnector() {
+        // NOT(Origin=GC) means: exclude GC caches
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(OriginGeocacheFilter.create(GC));
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, notFilter);
+
+        // GC should be excluded (NOT(always-true-for-GC) = false)
+        assertThat(filter.getConnectorRelevantFilter(GC)).isNull();
+
+        // SU should NOT be excluded (NOT(false-for-SU) = true → always true)
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isNull(); // simplified to always-true
+    }
+
+    @Test
+    public void nonFilteringOriginIsAlwaysTrue() {
+        // empty OriginFilter (isFiltering() == false) → always true
+        final OriginGeocacheFilter emptyOrigin = GeocacheFilterType.ORIGIN.create();
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, emptyOrigin);
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getTree()).isNull(); // simplified to always-true
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithConnectorReturnsNullForExcluded() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final List<BaseGeocacheFilter> gcChain = filter.getAndChainIfPossible(GC);
+        assertThat(gcChain).isNotNull();
+        assertThat(gcChain).hasSize(1);
+        assertThat(gcChain.get(0)).isInstanceOf(NameGeocacheFilter.class);
+
+        final List<BaseGeocacheFilter> suChain = filter.getAndChainIfPossible(SU);
+        assertThat(suChain).isNull();
+    }
+
+    @Test
+    public void orWithMixedBranchesPartiallyRelevant() {
+        // OR(AND(Origin=GC, Name="gc-test"), Name="general")
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final NameGeocacheFilter generalBranch = NameGeocacheFilter.create("general");
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(generalBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
+
+        // For GC: both branches are relevant → OR(Name="gc-test", Name="general")
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(OrGeocacheFilter.class);
+        assertThat(((OrGeocacheFilter) gcResult.getTree()).getChildren()).hasSize(2);
+
+        // For SU: only the general branch is relevant → Name="general"
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void preservesNameAndFlags() {
+        final GeocacheFilter filter = GeocacheFilter.create("myFilter", true, true,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("myFilter");
+        assertThat(result.isOpenInAdvancedMode()).isTrue();
+        assertThat(result.isIncludeInconclusive()).isTrue();
+    }
+}
+
+
+

--- a/main/src/test/java/cgeo/geocaching/filters/ConnectorRelevantFilterUnitTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/ConnectorRelevantFilterUnitTest.java
@@ -1,0 +1,237 @@
+package cgeo.geocaching.filters;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.su.SuConnector;
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.filters.core.AndGeocacheFilter;
+import cgeo.geocaching.filters.core.BaseGeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.IGeocacheFilter;
+import cgeo.geocaching.filters.core.NameGeocacheFilter;
+import cgeo.geocaching.filters.core.NotGeocacheFilter;
+import cgeo.geocaching.filters.core.OrGeocacheFilter;
+import cgeo.geocaching.filters.core.OriginGeocacheFilter;
+import cgeo.geocaching.filters.core.TypeGeocacheFilter;
+
+import java.util.List;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+/**
+ * Tests for {@link GeocacheFilter#getConnectorRelevantFilter(IConnector)} and
+ * {@link GeocacheFilter#getAndChainIfPossible(IConnector)}.
+ */
+public class ConnectorRelevantFilterUnitTest {
+
+    private static final IConnector GC = GCConnector.getInstance();
+    private static final IConnector SU = SuConnector.getInstance();
+
+    // --- Tests ---
+
+    @Test
+    public void nullTreeReturnsEmptyFilter() {
+        final GeocacheFilter empty = GeocacheFilter.createEmpty();
+        final GeocacheFilter gcResult = empty.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isNull();
+        assertThat(gcResult.isFiltering()).isFalse();
+    }
+
+    @Test
+    public void simpleAndWithMatchingOriginReturnsFilterWithoutOrigin() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        // Origin was removed, only NameFilter remains
+        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void simpleAndWithNonMatchingOriginReturnsNull() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void orWithDifferentOriginBranches() {
+        // OR(AND(Origin=GC, Name="gc-test"), AND(Origin=SU, Name="su-test"))
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final AndGeocacheFilter suBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(suBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
+
+        // For GC: only gc-branch should remain
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        final IGeocacheFilter gcTree = gcResult.getTree();
+        assertThat(gcTree).isInstanceOf(NameGeocacheFilter.class);
+        assertThat(((NameGeocacheFilter) gcTree).getStringFilter().getTextValue()).isEqualTo("gc-test");
+
+        // For SU: only su-branch should remain
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        final IGeocacheFilter suTree = suResult.getTree();
+        assertThat(suTree).isInstanceOf(NameGeocacheFilter.class);
+        assertThat(((NameGeocacheFilter) suTree).getStringFilter().getTextValue()).isEqualTo("su-test");
+    }
+
+    @Test
+    public void noOriginFilterReturnsFullTree() {
+        // AND(Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, NameGeocacheFilter.create("test"));
+
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isInstanceOf(NameGeocacheFilter.class);
+    }
+
+    @Test
+    public void notOriginExcludesMatchingConnector() {
+        // NOT(Origin=GC) means: exclude GC caches
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(OriginGeocacheFilter.create(GC));
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, notFilter);
+
+        // GC should be excluded (NOT(always-true-for-GC) = false)
+        assertThat(filter.getConnectorRelevantFilter(GC)).isNull();
+
+        // SU should NOT be excluded (NOT(false-for-SU) = true → always true)
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult.getTree()).isNull(); // simplified to always-true
+    }
+
+    @Test
+    public void nonFilteringOriginIsAlwaysTrue() {
+        // empty OriginFilter (isFiltering() == false) → always true
+        final OriginGeocacheFilter emptyOrigin = GeocacheFilterType.ORIGIN.create();
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, emptyOrigin);
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getTree()).isNull(); // simplified to always-true
+    }
+
+    @Test
+    public void orWithMixedBranchesPartiallyRelevant() {
+        // OR(AND(Origin=GC, Name="gc-test"), Name="general")
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final NameGeocacheFilter generalBranch = NameGeocacheFilter.create("general");
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(generalBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, orFilter);
+
+        // For GC: both branches are relevant → OR(Name="gc-test", Name="general")
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        final IGeocacheFilter gcTree = gcResult.getTree();
+        assertThat(gcTree).isInstanceOf(OrGeocacheFilter.class);
+        final List<IGeocacheFilter> gcChildren = gcTree.getChildren();
+        assertThat(gcChildren).hasSize(2);
+        final IGeocacheFilter gcChild1 = gcChildren.get(0);
+        final IGeocacheFilter gcChild2 = gcChildren.get(1);
+        assertThat(((NameGeocacheFilter) gcChild1).getStringFilter().getTextValue()).isEqualTo("gc-test");
+        assertThat(((NameGeocacheFilter) gcChild2).getStringFilter().getTextValue()).isEqualTo("general");
+
+        // For SU: only the general branch is relevant → Name="general"
+        final GeocacheFilter suResult = filter.getConnectorRelevantFilter(SU);
+        assertThat(suResult).isNotNull();
+        final IGeocacheFilter suTree = suResult.getTree();
+        assertThat(suTree).isInstanceOf(NameGeocacheFilter.class);
+        assertThat(((NameGeocacheFilter) suTree).getStringFilter().getTextValue()).isEqualTo("general");
+    }
+
+    @Test
+    public void preservesNameAndFlags() {
+        final GeocacheFilter filter = GeocacheFilter.create("myFilter", true, true,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("test")));
+
+        final GeocacheFilter gcResult = filter.getConnectorRelevantFilter(GC);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult.getName()).isEqualTo("myFilter");
+        assertThat(gcResult.isOpenInAdvancedMode()).isTrue();
+        assertThat(gcResult.isIncludeInconclusive()).isTrue();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithConnectorReturnsNullForExcluded() {
+        // AND(Origin=GC, Name="test")
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false,
+                AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test")));
+
+        final List<BaseGeocacheFilter> gcChain = filter.getAndChainIfPossible(GC);
+        assertThat(gcChain).isNotNull();
+        assertThat(gcChain).hasSize(1);
+        assertThat(gcChain.get(0)).isInstanceOf(NameGeocacheFilter.class);
+
+        final List<BaseGeocacheFilter> suChain = filter.getAndChainIfPossible(SU);
+        assertThat(suChain).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithComplexFilter() {
+        // AND(OR(AND(Origin=GC, Name="gc-test"), AND(Origin=SU, Name="su-test")), Type=TRADITIONAL)
+        final AndGeocacheFilter gcBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(GC), NameGeocacheFilter.create("gc-test"));
+        final AndGeocacheFilter suBranch = AndGeocacheFilter.create(OriginGeocacheFilter.create(SU), NameGeocacheFilter.create("su-test"));
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(suBranch);
+
+        final TypeGeocacheFilter typeFilter = TypeGeocacheFilter.create(CacheType.TRADITIONAL);
+        final AndGeocacheFilter complexFilter = AndGeocacheFilter.create(orFilter, typeFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, complexFilter);
+
+        // For GC: only gc-branch and type should remain
+        final List<BaseGeocacheFilter> gcChain = filter.getAndChainIfPossible(GC);
+        assertThat(gcChain).hasSize(2);
+        final IGeocacheFilter gcChild1 = gcChain.get(0);
+        final IGeocacheFilter gcChild2 = gcChain.get(1);
+        assertThat(((NameGeocacheFilter) gcChild1).getStringFilter().getTextValue()).isEqualTo("gc-test");
+        assertThat(((TypeGeocacheFilter) gcChild2).getValues()).contains(CacheType.TRADITIONAL);
+
+        // For SU: only su-branch should remain
+        final List<BaseGeocacheFilter> suChain = filter.getAndChainIfPossible(SU);
+        assertThat(suChain).hasSize(2);
+        final IGeocacheFilter suChild1 = suChain.get(0);
+        final IGeocacheFilter suChild2 = suChain.get(1);
+        assertThat(((NameGeocacheFilter) suChild1).getStringFilter().getTextValue()).isEqualTo("su-test");
+        assertThat(((TypeGeocacheFilter) suChild2).getValues()).contains(CacheType.TRADITIONAL);
+    }
+
+    @Test
+    public void notWithNonAndInnerFilterIsPreserved() {
+        // NOT(Name="test")
+        // Expected: the NOT filter is preserved as-is for any connector.
+        final NotGeocacheFilter notFilter = NotGeocacheFilter.create(NameGeocacheFilter.create("test"));
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, notFilter);
+
+        final GeocacheFilter result = filter.getConnectorRelevantFilter(GC);
+        assertThat(result).isNotNull();
+        assertThat(result.getTree()).isInstanceOf(NotGeocacheFilter.class);
+        final IGeocacheFilter child = result.getTree().getChildren().get(0);
+        assertThat(child).isInstanceOf(NameGeocacheFilter.class);
+        assertThat(((NameGeocacheFilter) child).getStringFilter().getTextValue()).isEqualTo("test");
+    }
+
+}

--- a/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.oc.OCDEConnector;
 import cgeo.geocaching.connector.su.SuConnector;
 import cgeo.geocaching.enumerations.CacheSize;
 import cgeo.geocaching.enumerations.CacheType;
@@ -108,7 +109,7 @@ public class GeocacheFilterTest {
 
     @Test
     public void getAndChainIfPossibleForConnectorWithNoFilter() {
-        // empty filter => null
+        // empty filter => empty list (not null, but no filters to chain)
         final IConnector gcConnector = GCConnector.getInstance();
 
         final GeocacheFilter filter = GeocacheFilter.createEmpty();
@@ -120,7 +121,7 @@ public class GeocacheFilterTest {
 
     @Test
     public void getAndChainIfPossibleForConnectorWithOnlyConnectorFilter() {
-        // empty filter => null
+        // only matching connector filter => empty list
         final IConnector gcConnector = GCConnector.getInstance();
 
         final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
@@ -180,9 +181,9 @@ public class GeocacheFilterTest {
         assertThat(gcResult.get(0).getType()).isEqualTo(GeocacheFilterType.DISTANCE);
 
         // When filtering for SU connector, the AND filter contains an OriginFilter that excludes SU
-        // so the entire filter becomes invalid and returns empty list
-        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(suConnector);
-        assertThat(ocResult).isNull();
+        // so the entire filter becomes invalid and returns null
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
     }
 
     @Test
@@ -264,9 +265,9 @@ public class GeocacheFilterTest {
 
     @Test
     public void getAndChainIfPossibleWithMultipleOriginFilters() {
-        // Create a filter with OriginGeocacheFilter allowing both GC and OC
-        // (GC / OC AND Distance) => GC: return Distance-Filter
-        // (GC / OC AND Distance) => SU: return Distance-Filter
+        // Create a filter with OriginGeocacheFilter allowing both GC and SU
+        // (GC / SU AND Distance) => GC: return Distance-Filter
+        // (GC / SU AND Distance) => SU: return Distance-Filter
 
         final IConnector gcConnector = GCConnector.getInstance();
         final IConnector suConnector = SuConnector.getInstance();
@@ -287,10 +288,10 @@ public class GeocacheFilterTest {
         assertThat(gcResult).hasSize(1);
         assertThat(gcResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
 
-        // When filtering for OC connector, the origin filter should also be removed
-        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(suConnector);
-        assertThat(ocResult).hasSize(1);
-        assertThat(ocResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
+        // When filtering for SU connector, the origin filter should also be removed
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).hasSize(1);
+        assertThat(suResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
     }
 
     @Test
@@ -332,23 +333,22 @@ public class GeocacheFilterTest {
         // When filtering for GC connector:
         // - Branch1: OriginFilter(GC) is removed (redundant), OwnerFilter(Owner1) remains
         // - Branch2: OriginFilter(SU) doesn't allow GC, so entire branch is kept with OriginFilter
-        // Result: OR filter with one AND branch and one OriginFilter -> no AND chain possible
-        // BUT: if Branch2 contains an OriginFilter that doesn't allow GC, the entire branch
-        // should be removed because it can't produce results for GC
-        // So we should get: just OwnerFilter(Owner1) from Branch1
+        // Old behavior: OR filter with one AND branch and one OriginFilter -> no AND chain possible
+        // New behavior: if Branch2 contains an OriginFilter that doesn't allow GC,
+        // the entire branch is removed. So we get just OwnerFilter(Owner1) from Branch1
         final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
         assertThat(gcResult).hasSize(1);
         assertThat(gcResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
         assertThat(((OwnerGeocacheFilter) gcResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner1");
 
         // When filtering for SU connector:
-        // - Branch1: OriginFilter(GC) doesn't allow OC, so entire branch should be removed
+        // - Branch1: OriginFilter(GC) doesn't allow SU, so entire branch should be removed
         // - Branch2: OriginFilter(SU) is removed (redundant), OwnerFilter(Owner2) remains
         // Result: just OwnerFilter(Owner2) from Branch2
-        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(suConnector);
-        assertThat(ocResult).hasSize(1);
-        assertThat(ocResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
-        assertThat(((OwnerGeocacheFilter) ocResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner2");
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).hasSize(1);
+        assertThat(suResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) suResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner2");
     }
 
     @Test
@@ -387,16 +387,47 @@ public class GeocacheFilterTest {
         assertThat(relevantFilter.getTree()).isNotNull();
         assertThat(relevantFilter.getTree()).isInstanceOf(OrGeocacheFilter.class);
 
+        // Old behavior: The OR filter was flattened.
+        // New behavior: The OR filter should not be flattened, but the OriginFilter should be removed from both branches
         final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
         assertThat(gcResult).isNotNull();
         assertThat(gcResult).isEmpty();
-        // assertThat(gcResult).isNotNull();
-        // assertThat(gcResult).hasSize(1);
-        // final List<IGeocacheFilter> orResultFilter = gcResult.get(0).getChildren();
-        // assertThat(orResultFilter).hasSize(2);
-        // assertThat(orResultFilter.get(0).getType()).isEqualTo(GeocacheFilterType.TYPE);
-        // assertThat(orResultFilter.get(1).getType()).isEqualTo(GeocacheFilterType.SIZE);
     }
+
+
+    @Test
+    public void getAndChainIfPossible() {
+        //AND(NOT(Origin=GC), OR(Origin=SU, Name="su-test"))
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+        final IConnector ocConnector = new OCDEConnector();
+
+        final NotGeocacheFilter gcBranch = NotGeocacheFilter.create(OriginGeocacheFilter.create(gcConnector));
+        final OrGeocacheFilter suBranch = OrGeocacheFilter.create(OriginGeocacheFilter.create(suConnector), NameGeocacheFilter.create("su-test"));
+        final AndGeocacheFilter andBranch = AndGeocacheFilter.create(gcBranch, suBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, andBranch);
+
+        // Old behavior: The OR- and NOT-filter was flattened.
+        // New behavior: The OR- and NOT-filter should not be flattened, but the OriginFilter should be removed from both branches
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible();
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNull();
+
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult).isEmpty();
+
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(ocConnector);
+        assertThat(ocResult).isNotNull();
+        assertThat(ocResult).hasSize(1);
+        assertThat(ocResult.get(0).getType()).isEqualTo(GeocacheFilterType.NAME);
+    }
+
 }
 
 

--- a/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
@@ -150,7 +150,8 @@ public class GeocacheFilterTest {
 
         // OR filters should not be expanded into an AND chain
         final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
-        assertThat(result.get(0)).isInstanceOf(OrGeocacheFilter.class);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -388,11 +389,13 @@ public class GeocacheFilterTest {
 
         final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
         assertThat(gcResult).isNotNull();
-        assertThat(gcResult).hasSize(1);
-        final List<IGeocacheFilter> orResultFilter = gcResult.get(0).getChildren();
-        assertThat(orResultFilter).hasSize(2);
-        assertThat(orResultFilter.get(0).getType()).isEqualTo(GeocacheFilterType.TYPE);
-        assertThat(orResultFilter.get(1).getType()).isEqualTo(GeocacheFilterType.SIZE);
+        assertThat(gcResult).isEmpty();
+        // assertThat(gcResult).isNotNull();
+        // assertThat(gcResult).hasSize(1);
+        // final List<IGeocacheFilter> orResultFilter = gcResult.get(0).getChildren();
+        // assertThat(orResultFilter).hasSize(2);
+        // assertThat(orResultFilter.get(0).getType()).isEqualTo(GeocacheFilterType.TYPE);
+        // assertThat(orResultFilter.get(1).getType()).isEqualTo(GeocacheFilterType.SIZE);
     }
 }
 

--- a/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
@@ -1,7 +1,15 @@
 package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.su.SuConnector;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.models.Geocache;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -97,4 +105,295 @@ public class GeocacheFilterTest {
 
         assertThat(caches).containsExactly(g1, g2);
     }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithNoFilter() {
+        // empty filter => null
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final GeocacheFilter filter = GeocacheFilter.createEmpty();
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithOnlyConnectorFilter() {
+        // empty filter => null
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, originFilter);
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithOrFilter() {
+        // Create an OR filter with two distance filters
+        // (Distance1 OR Distance2) => GC: (Distance1 OR Distance2)
+
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final DistanceGeocacheFilter distance1 = GeocacheFilterType.DISTANCE.create();
+        final DistanceGeocacheFilter distance2 = GeocacheFilterType.DISTANCE.create();
+
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(distance1);
+        orFilter.addChild(distance2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // OR filters should not be expanded into an AND chain
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
+        assertThat(result.get(0)).isInstanceOf(OrGeocacheFilter.class);
+    }
+
+    @Test
+    public void getAndChainIfPossibleRemovesMatchingOriginFilter() {
+        // Create a filter with OriginGeocacheFilter allowing GC and a DistanceFilter
+        // (GC AND Distance) => GC: Distance
+        // (GC AND Distance) => SU: null
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // When filtering for GC connector, the origin filter should be removed (redundant)
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0).getType()).isEqualTo(GeocacheFilterType.DISTANCE);
+
+        // When filtering for SU connector, the AND filter contains an OriginFilter that excludes SU
+        // so the entire filter becomes invalid and returns empty list
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(ocResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithNotFilter() {
+        // Create a AND filter with a NOT filter (origin) and a Distance filter
+        // NOT(GC) AND Distance => GC: null
+        // NOT(GC) AND Distance => SU: Distance
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(originFilter);
+
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(notFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // For GC connector: NOT(GC) contains OriginFilter(GC) which allows GC
+        // So the NOT filter becomes invalid for GC -> entire AND is invalid
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNull();
+
+        // For SU connector: NOT(GC) contains OriginFilter(GC) which doesn't allow SU
+        // So the OriginFilter is removed from NOT, but NOT becomes empty -> NOT is removed
+        // Result: just the Distance filter remains
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).hasSize(1);
+        assertThat(suResult.get(0).getType()).isEqualTo(GeocacheFilterType.DISTANCE);
+
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithNestedAndFilters() {
+        // Create nested AND filters
+        // (Distance1 AND Distance2) AND Type AND GC => GC: (Distance1 AND Distance2) AND Type
+        // (Distance1 AND Distance2) AND Type AND GC => SU: null
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final DistanceGeocacheFilter distance1 = GeocacheFilterType.DISTANCE.create();
+        final DistanceGeocacheFilter distance2 = GeocacheFilterType.DISTANCE.create();
+        final TypeGeocacheFilter typeFilter = GeocacheFilterType.TYPE.create();
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final AndGeocacheFilter innerAnd = new AndGeocacheFilter();
+        innerAnd.addChild(distance1);
+        innerAnd.addChild(distance2);
+
+        final AndGeocacheFilter outerAnd = new AndGeocacheFilter();
+        outerAnd.addChild(innerAnd);
+        outerAnd.addChild(typeFilter);
+        outerAnd.addChild(originFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, outerAnd);
+
+        // All filters should be flattened into the AND chain
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(3);
+
+        final long distanceCount = gcResult.stream().filter(f -> f.getType() == GeocacheFilterType.DISTANCE).count();
+        final long typeCount = gcResult.stream().filter(f -> f.getType() == GeocacheFilterType.TYPE).count();
+
+        assertThat(distanceCount).isEqualTo(2);
+        assertThat(typeCount).isEqualTo(1);
+
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithMultipleOriginFilters() {
+        // Create a filter with OriginGeocacheFilter allowing both GC and OC
+        // (GC / OC AND Distance) => GC: return Distance-Filter
+        // (GC / OC AND Distance) => SU: return Distance-Filter
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Arrays.asList(gcConnector, suConnector));
+
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // When filtering for GC connector, the origin filter should be removed
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
+
+        // When filtering for OC connector, the origin filter should also be removed
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(ocResult).hasSize(1);
+        assertThat(ocResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithComplexOrStructure() {
+        // (OriginFilter(GC) AND OwnerFilter(Owner1)) OR (OriginFilter(SU) AND OwnerFilter(Owner2))
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        // Create first branch: (OriginFilter(GC) AND OwnerFilter(Owner1))
+        final OriginGeocacheFilter originFilter1 = GeocacheFilterType.ORIGIN.create();
+        originFilter1.setValues(Collections.singleton(gcConnector));
+
+        final OwnerGeocacheFilter ownerFilter1 = GeocacheFilterType.OWNER.create();
+        ownerFilter1.getStringFilter().setTextValue("Owner1");
+
+        final AndGeocacheFilter andBranch1 = new AndGeocacheFilter();
+        andBranch1.addChild(originFilter1);
+        andBranch1.addChild(ownerFilter1);
+
+        // Create second branch: (OriginFilter(SU) AND OwnerFilter(Owner2))
+        final OriginGeocacheFilter originFilter2 = GeocacheFilterType.ORIGIN.create();
+        originFilter2.setValues(Collections.singleton(suConnector));
+
+        final OwnerGeocacheFilter ownerFilter2 = GeocacheFilterType.OWNER.create();
+        ownerFilter2.getStringFilter().setTextValue("Owner2");
+
+        final AndGeocacheFilter andBranch2 = new AndGeocacheFilter();
+        andBranch2.addChild(originFilter2);
+        andBranch2.addChild(ownerFilter2);
+
+        // Combine with OR: (Branch1 OR Branch2)
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(andBranch1);
+        orFilter.addChild(andBranch2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // When filtering for GC connector:
+        // - Branch1: OriginFilter(GC) is removed (redundant), OwnerFilter(Owner1) remains
+        // - Branch2: OriginFilter(SU) doesn't allow GC, so entire branch is kept with OriginFilter
+        // Result: OR filter with one AND branch and one OriginFilter -> no AND chain possible
+        // BUT: if Branch2 contains an OriginFilter that doesn't allow GC, the entire branch
+        // should be removed because it can't produce results for GC
+        // So we should get: just OwnerFilter(Owner1) from Branch1
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) gcResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner1");
+
+        // When filtering for SU connector:
+        // - Branch1: OriginFilter(GC) doesn't allow OC, so entire branch should be removed
+        // - Branch2: OriginFilter(SU) is removed (redundant), OwnerFilter(Owner2) remains
+        // Result: just OwnerFilter(Owner2) from Branch2
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(ocResult).hasSize(1);
+        assertThat(ocResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) ocResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner2");
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithOR() {
+        // OR(AND(Origin=GC, Type=Tradi), AND(Origin=GC, Size=Micro))
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        // Create first branch: (OriginFilter(GC) AND TypeGeocacheFilter(TRADITIONAL))
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final TypeGeocacheFilter tradiFilter = GeocacheFilterType.TYPE.create();
+        tradiFilter.setValues(Collections.singleton(CacheType.TRADITIONAL));
+
+        final AndGeocacheFilter andBranch1 = new AndGeocacheFilter();
+        andBranch1.addChild(originFilter);
+        andBranch1.addChild(tradiFilter);
+
+        // Create second branch: (OriginFilter(GC) AND SizeFilter(Micro))
+        final SizeGeocacheFilter sizeFilter = GeocacheFilterType.SIZE.create();
+        sizeFilter.setValues(Collections.singleton(CacheSize.MICRO));
+
+        final AndGeocacheFilter andBranch2 = new AndGeocacheFilter();
+        andBranch2.addChild(originFilter);
+        andBranch2.addChild(sizeFilter);
+
+        // Combine with OR: (Branch1 OR Branch2)
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(andBranch1);
+        orFilter.addChild(andBranch2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        final GeocacheFilter relevantFilter = filter.getConnectorRelevantFilter(gcConnector);
+        assertThat(relevantFilter).isNotNull();
+        assertThat(relevantFilter.getTree()).isNotNull();
+        assertThat(relevantFilter.getTree()).isInstanceOf(OrGeocacheFilter.class);
+
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult).hasSize(1);
+        final List<IGeocacheFilter> orResultFilter = gcResult.get(0).getChildren();
+        assertThat(orResultFilter).hasSize(2);
+        assertThat(orResultFilter.get(0).getType()).isEqualTo(GeocacheFilterType.TYPE);
+        assertThat(orResultFilter.get(1).getType()).isEqualTo(GeocacheFilterType.SIZE);
+    }
 }
+
+

--- a/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
+++ b/main/src/test/java/cgeo/geocaching/filters/core/GeocacheFilterTest.java
@@ -1,7 +1,16 @@
 package cgeo.geocaching.filters.core;
+
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.gc.GCConnector;
+import cgeo.geocaching.connector.oc.OCDEConnector;
+import cgeo.geocaching.connector.su.SuConnector;
+import cgeo.geocaching.enumerations.CacheSize;
+import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.models.Geocache;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -97,4 +106,473 @@ public class GeocacheFilterTest {
 
         assertThat(caches).containsExactly(g1, g2);
     }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithNoFilter() {
+        // empty filter => empty list (not null, but no filters to chain)
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final GeocacheFilter filter = GeocacheFilter.createEmpty();
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithOnlyConnectorFilter() {
+        // only matching connector filter => empty list
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, originFilter);
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getAndChainIfPossibleForConnectorWithOrFilter() {
+        // Create an OR filter with two distance filters
+        // (Distance1 OR Distance2) => GC: (Distance1 OR Distance2)
+
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        final DistanceGeocacheFilter distance1 = GeocacheFilterType.DISTANCE.create();
+        final DistanceGeocacheFilter distance2 = GeocacheFilterType.DISTANCE.create();
+
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(distance1);
+        orFilter.addChild(distance2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // OR filters should not be expanded into an AND chain
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible(gcConnector);
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getAndChainIfPossibleRemovesMatchingOriginFilter() {
+        // Create a filter with OriginGeocacheFilter allowing GC and a DistanceFilter
+        // (GC AND Distance) => GC: Distance
+        // (GC AND Distance) => SU: null
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // When filtering for GC connector, the origin filter should be removed (redundant)
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0).getType()).isEqualTo(GeocacheFilterType.DISTANCE);
+
+        // When filtering for SU connector, the AND filter contains an OriginFilter that excludes SU
+        // so the entire filter becomes invalid and returns null
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithNotFilter() {
+        // Create a AND filter with a NOT filter (origin) and a Distance filter
+        // NOT(GC) AND Distance => GC: null
+        // NOT(GC) AND Distance => SU: Distance
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final NotGeocacheFilter notFilter = new NotGeocacheFilter();
+        notFilter.addChild(originFilter);
+
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(notFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // For GC connector: NOT(GC) contains OriginFilter(GC) which allows GC
+        // So the NOT filter becomes invalid for GC -> entire AND is invalid
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNull();
+
+        // For SU connector: NOT(GC) contains OriginFilter(GC) which doesn't allow SU
+        // So the OriginFilter is removed from NOT, but NOT becomes empty -> NOT is removed
+        // Result: just the Distance filter remains
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).hasSize(1);
+        assertThat(suResult.get(0).getType()).isEqualTo(GeocacheFilterType.DISTANCE);
+
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithNestedAndFilters() {
+        // Create nested AND filters
+        // (Distance1 AND Distance2) AND Type AND GC => GC: (Distance1 AND Distance2) AND Type
+        // (Distance1 AND Distance2) AND Type AND GC => SU: null
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final DistanceGeocacheFilter distance1 = GeocacheFilterType.DISTANCE.create();
+        final DistanceGeocacheFilter distance2 = GeocacheFilterType.DISTANCE.create();
+        final TypeGeocacheFilter typeFilter = GeocacheFilterType.TYPE.create();
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final AndGeocacheFilter innerAnd = new AndGeocacheFilter();
+        innerAnd.addChild(distance1);
+        innerAnd.addChild(distance2);
+
+        final AndGeocacheFilter outerAnd = new AndGeocacheFilter();
+        outerAnd.addChild(innerAnd);
+        outerAnd.addChild(typeFilter);
+        outerAnd.addChild(originFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, outerAnd);
+
+        // All filters should be flattened into the AND chain
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(3);
+
+        final long distanceCount = gcResult.stream().filter(f -> f.getType() == GeocacheFilterType.DISTANCE).count();
+        final long typeCount = gcResult.stream().filter(f -> f.getType() == GeocacheFilterType.TYPE).count();
+
+        assertThat(distanceCount).isEqualTo(2);
+        assertThat(typeCount).isEqualTo(1);
+
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithMultipleOriginFilters() {
+        // Create a filter with OriginGeocacheFilter allowing both GC and SU
+        // (GC / SU AND Distance) => GC: return Distance-Filter
+        // (GC / SU AND Distance) => SU: return Distance-Filter
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Arrays.asList(gcConnector, suConnector));
+
+        final DistanceGeocacheFilter distanceFilter = GeocacheFilterType.DISTANCE.create();
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(distanceFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // When filtering for GC connector, the origin filter should be removed
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
+
+        // When filtering for SU connector, the origin filter should also be removed
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).hasSize(1);
+        assertThat(suResult.get(0)).isInstanceOf(DistanceGeocacheFilter.class);
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithComplexOrStructure() {
+        // (OriginFilter(GC) AND OwnerFilter(Owner1)) OR (OriginFilter(SU) AND OwnerFilter(Owner2))
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        // Create first branch: (OriginFilter(GC) AND OwnerFilter(Owner1))
+        final OriginGeocacheFilter originFilter1 = GeocacheFilterType.ORIGIN.create();
+        originFilter1.setValues(Collections.singleton(gcConnector));
+
+        final OwnerGeocacheFilter ownerFilter1 = GeocacheFilterType.OWNER.create();
+        ownerFilter1.getStringFilter().setTextValue("Owner1");
+
+        final AndGeocacheFilter andBranch1 = new AndGeocacheFilter();
+        andBranch1.addChild(originFilter1);
+        andBranch1.addChild(ownerFilter1);
+
+        // Create second branch: (OriginFilter(SU) AND OwnerFilter(Owner2))
+        final OriginGeocacheFilter originFilter2 = GeocacheFilterType.ORIGIN.create();
+        originFilter2.setValues(Collections.singleton(suConnector));
+
+        final OwnerGeocacheFilter ownerFilter2 = GeocacheFilterType.OWNER.create();
+        ownerFilter2.getStringFilter().setTextValue("Owner2");
+
+        final AndGeocacheFilter andBranch2 = new AndGeocacheFilter();
+        andBranch2.addChild(originFilter2);
+        andBranch2.addChild(ownerFilter2);
+
+        // Combine with OR: (Branch1 OR Branch2)
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(andBranch1);
+        orFilter.addChild(andBranch2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // When filtering for GC connector:
+        // - Branch1: OriginFilter(GC) is removed (redundant), OwnerFilter(Owner1) remains
+        // - Branch2: OriginFilter(SU) doesn't allow GC, so entire branch is kept with OriginFilter
+        // Old behavior: OR filter with one AND branch and one OriginFilter -> no AND chain possible
+        // New behavior: if Branch2 contains an OriginFilter that doesn't allow GC,
+        // the entire branch is removed. So we get just OwnerFilter(Owner1) from Branch1
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) gcResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner1");
+
+        // When filtering for SU connector:
+        // - Branch1: OriginFilter(GC) doesn't allow SU, so entire branch should be removed
+        // - Branch2: OriginFilter(SU) is removed (redundant), OwnerFilter(Owner2) remains
+        // Result: just OwnerFilter(Owner2) from Branch2
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).hasSize(1);
+        assertThat(suResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
+        assertThat(((OwnerGeocacheFilter) suResult.get(0)).getStringFilter().getTextValue()).isEqualTo("Owner2");
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithOR() {
+        // OR(AND(Origin=GC, Type=Tradi), AND(Origin=GC, Size=Micro))
+        final IConnector gcConnector = GCConnector.getInstance();
+
+        // Create first branch: (OriginFilter(GC) AND TypeGeocacheFilter(TRADITIONAL))
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final TypeGeocacheFilter tradiFilter = GeocacheFilterType.TYPE.create();
+        tradiFilter.setValues(Collections.singleton(CacheType.TRADITIONAL));
+
+        final AndGeocacheFilter andBranch1 = new AndGeocacheFilter();
+        andBranch1.addChild(originFilter);
+        andBranch1.addChild(tradiFilter);
+
+        // Create second branch: (OriginFilter(GC) AND SizeFilter(Micro))
+        final SizeGeocacheFilter sizeFilter = GeocacheFilterType.SIZE.create();
+        sizeFilter.setValues(Collections.singleton(CacheSize.MICRO));
+
+        final AndGeocacheFilter andBranch2 = new AndGeocacheFilter();
+        andBranch2.addChild(originFilter);
+        andBranch2.addChild(sizeFilter);
+
+        // Combine with OR: (Branch1 OR Branch2)
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(andBranch1);
+        orFilter.addChild(andBranch2);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        final GeocacheFilter relevantFilter = filter.getConnectorRelevantFilter(gcConnector);
+        assertThat(relevantFilter).isNotNull();
+        assertThat(relevantFilter.getTree()).isNotNull();
+        assertThat(relevantFilter.getTree()).isInstanceOf(OrGeocacheFilter.class);
+
+        // Old behavior: The OR filter was flattened.
+        // New behavior: The OR filter should not be flattened, but the OriginFilter should be removed from both branches
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult).isEmpty();
+    }
+
+
+    @Test
+    public void getAndChainIfPossible() {
+        //AND(NOT(Origin=GC), OR(Origin=SU, Name="su-test"))
+
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+        final IConnector ocConnector = new OCDEConnector();
+
+        final NotGeocacheFilter gcBranch = NotGeocacheFilter.create(OriginGeocacheFilter.create(gcConnector));
+        final OrGeocacheFilter suBranch = OrGeocacheFilter.create(OriginGeocacheFilter.create(suConnector), NameGeocacheFilter.create("su-test"));
+        final AndGeocacheFilter andBranch = AndGeocacheFilter.create(gcBranch, suBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, andBranch);
+
+        // Old behavior: The OR- and NOT-filter was flattened.
+        // New behavior: The OR- and NOT-filter should not be flattened, but the OriginFilter should be removed from both branches
+        final List<BaseGeocacheFilter> result = filter.getAndChainIfPossible();
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNull();
+
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNotNull();
+        assertThat(suResult).isEmpty();
+
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(ocConnector);
+        assertThat(ocResult).isNotNull();
+        assertThat(ocResult).hasSize(1);
+        assertThat(ocResult.get(0).getType()).isEqualTo(GeocacheFilterType.NAME);
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithOfflineOnlyFilter() {
+        // AND(Origin=GC, OfflineLog="draft") => GC: [OfflineLogFilter] (not null!)
+        // AND(Origin=GC, OfflineLog="draft") => SU: null
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final OfflineLogGeocacheFilter offlineLogFilter = GeocacheFilterType.OFFLINE_LOG.create();
+        offlineLogFilter.getStringFilter().setTextValue("draft");
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(offlineLogFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // For GC: OriginFilter removed (redundant), OfflineLogFilter must be preserved
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0).getType()).isEqualTo(GeocacheFilterType.OFFLINE_LOG);
+
+        // For SU: Origin excludes SU → null
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithMixedOnlineAndOfflineOnlyFilters() {
+        // AND(Origin=GC, Owner="testuser", OfflineLog="draft") => GC: [OwnerFilter, OfflineLogFilter]
+        // AND(Origin=GC, Owner="testuser", OfflineLog="draft") => SU: null
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+        ownerFilter.getStringFilter().setTextValue("testuser");
+
+        final OfflineLogGeocacheFilter offlineLogFilter = GeocacheFilterType.OFFLINE_LOG.create();
+        offlineLogFilter.getStringFilter().setTextValue("draft");
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(ownerFilter);
+        andFilter.addChild(offlineLogFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // For GC: both online-capable and offline-only filter must be in chain
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult).hasSize(2);
+        final long ownerCount = gcResult.stream().filter(f -> f.getType() == GeocacheFilterType.OWNER).count();
+        final long offlineLogCount = gcResult.stream().filter(f -> f.getType() == GeocacheFilterType.OFFLINE_LOG).count();
+        assertThat(ownerCount).isEqualTo(1);
+        assertThat(offlineLogCount).isEqualTo(1);
+
+        // For SU: null
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getAndChainIfPossibleWithOfflineOnlyStatusSubCriteria() {
+        // AND(Origin=GC, Status(hasOfflineFoundLog=true)) => GC: [StatusFilter with hasOfflineFoundLog=true]
+        // AND(Origin=GC, Status(hasOfflineFoundLog=true)) => SU: null
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector suConnector = SuConnector.getInstance();
+
+        final OriginGeocacheFilter originFilter = GeocacheFilterType.ORIGIN.create();
+        originFilter.setValues(Collections.singleton(gcConnector));
+
+        final StatusGeocacheFilter statusFilter = GeocacheFilterType.STATUS.create();
+        statusFilter.setStatusHasOfflineFoundLog(true);
+
+        final AndGeocacheFilter andFilter = new AndGeocacheFilter();
+        andFilter.addChild(originFilter);
+        andFilter.addChild(statusFilter);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, andFilter);
+
+        // For GC: StatusFilter with offline-only sub-criterion must be preserved in chain
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0).getType()).isEqualTo(GeocacheFilterType.STATUS);
+        assertThat(((StatusGeocacheFilter) gcResult.get(0)).getStatusHasOfflineFoundLog()).isTrue();
+
+        // For SU: null
+        final List<BaseGeocacheFilter> suResult = filter.getAndChainIfPossible(suConnector);
+        assertThat(suResult).isNull();
+    }
+
+    @Test
+    public void getConnectorRelevantFilterWithOfflineOnlyFilterInOrBranch() {
+        // OR(AND(Origin=GC, Owner="gcuser"), AND(Origin=OC, OfflineLog="draft"))
+        // For GC: OC branch removed → relevant filter contains only OwnerFilter
+        // For OC: GC branch removed → relevant filter contains only OfflineLogFilter
+        final IConnector gcConnector = GCConnector.getInstance();
+        final IConnector ocConnector = new OCDEConnector();
+
+        final OriginGeocacheFilter gcOrigin = GeocacheFilterType.ORIGIN.create();
+        gcOrigin.setValues(Collections.singleton(gcConnector));
+
+        final OwnerGeocacheFilter ownerFilter = GeocacheFilterType.OWNER.create();
+        ownerFilter.getStringFilter().setTextValue("gcuser");
+
+        final AndGeocacheFilter gcBranch = new AndGeocacheFilter();
+        gcBranch.addChild(gcOrigin);
+        gcBranch.addChild(ownerFilter);
+
+        final OriginGeocacheFilter ocOrigin = GeocacheFilterType.ORIGIN.create();
+        ocOrigin.setValues(Collections.singleton(ocConnector));
+
+        final OfflineLogGeocacheFilter offlineLogFilter = GeocacheFilterType.OFFLINE_LOG.create();
+        offlineLogFilter.getStringFilter().setTextValue("draft");
+
+        final AndGeocacheFilter ocBranch = new AndGeocacheFilter();
+        ocBranch.addChild(ocOrigin);
+        ocBranch.addChild(offlineLogFilter);
+
+        final OrGeocacheFilter orFilter = new OrGeocacheFilter();
+        orFilter.addChild(gcBranch);
+        orFilter.addChild(ocBranch);
+
+        final GeocacheFilter filter = GeocacheFilter.create("Test", false, false, orFilter);
+
+        // For GC: OC branch (with offline-only filter) is removed, only OwnerFilter remains
+        final List<BaseGeocacheFilter> gcResult = filter.getAndChainIfPossible(gcConnector);
+        assertThat(gcResult).isNotNull();
+        assertThat(gcResult).hasSize(1);
+        assertThat(gcResult.get(0)).isInstanceOf(OwnerGeocacheFilter.class);
+
+        // For OC: GC branch is removed, only OfflineLogFilter remains
+        final List<BaseGeocacheFilter> ocResult = filter.getAndChainIfPossible(ocConnector);
+        assertThat(ocResult).isNotNull();
+        assertThat(ocResult).hasSize(1);
+        assertThat(ocResult.get(0)).isInstanceOf(OfflineLogGeocacheFilter.class);
+    }
+
 }
+
+


### PR DESCRIPTION
## Summary

Improve the "My caches" search button, so that different names for different connectors are handled correct.

Therefor introduce connector-aware filter tree.

## Motivation

1. Searching for own caches previously considered only the username of GC for all platforms. Search for users with accounts on multiple geocaching platforms  (geocaching.com, opencaching, geocaching.su) didn't worked correctly.
2. When a filter tree contains `OriginGeocacheFilter` nodes (restricting to specific 
   connectors), search providers had to skip irrelevant branches which was not done effectivly.

## Changes

### Feature: "My caches" button
- **Search card** "My caches" in `SearchActivity` now collects all active `ILogin` 
  connectors and triggers a combined owner search across all of them with the associated user name
- **Extended `OwnerGeocacheListLoader`** with a second constructor accepting 
  `List<IConnector>`, building an OR-combined filter of `AND(Owner, Origin)` per connector
- **New `startActivityOwner()` overload** in `CacheListActivity` accepting a connector 
  list, passing connector names via the new `EXTRA_CONNECTOR_LIST` intent extra
- **New intent extra** `EXTRA_CONNECTOR_LIST` in `Intents`


### Infrastructure: Connector-aware filter simplification
- **`getConnectorRelevantFilter(IConnector)`** in `GeocacheFilter`: recursively simplifies 
  a filter tree for a given connector by:
- **`getAndChainIfPossible(IConnector)`**: convenience method combining 
  `getConnectorRelevantFilter` + `getAndChainIfPossible()`, returning `null` if connector 
  is excluded
- **Updated callers** in `GCMap`, `OkapiClient`, `SuApi`, and `ALApi` now call 
  `getAndChainIfPossible(connector)` instead of `getAndChainIfPossible()`, enabling them 
  to skip search when the connector is excluded by origin filters and to receive a 
  cleaned-up filter chain without redundant origin nodes

