### PR TITLE
fix #17947: edge2edge in filterview: prevent laying over system components by surround scrollview with linerlayout

### DIFF
--- a/main/src/main/res/layout/cache_filter_activity.xml
+++ b/main/src/main/res/layout/cache_filter_activity.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:id="@+id/activity_content"
+    tools:context=".filters.gui.GeocacheFilterActivity">
+
+<ScrollView
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
@@ -138,3 +144,5 @@
     </LinearLayout>
 
 </ScrollView>
+
+</LinearLayout>


### PR DESCRIPTION
fix #17947: edge2edge in filterview: prevent laying over system components by surround scrollview with linerlayout