### PR TITLE
Fix/17895 search not working

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
 		<!-- Register for global search in Android. https://developer.android.com/guide/topics/search/search-dialog.html -->
         <meta-data
             android:name="android.app.default_searchable"
-            android:value=".SearchActivity" />
+            android:value="cgeo.geocaching.SearchActivity" />
 
         <!-- Android Backup Service, to restore settings on new devices. https://developer.android.com/google/backup/index.html -->
         <meta-data

--- a/main/src/main/java/cgeo/geocaching/search/SearchUtils.java
+++ b/main/src/main/java/cgeo/geocaching/search/SearchUtils.java
@@ -83,7 +83,8 @@ public class SearchUtils {
     public static void handleDropDownVisibility(final Activity activity, final SearchView searchView, final MenuItem menuSearch) {
         final AutoCompleteTextView searchAutoComplete = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
         searchAutoComplete.setOnDismissListener(() -> {
-            if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
+            if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0
+                    && !searchAutoComplete.isPressed()) {
                 searchAutoComplete.showDropDown();
             }
         });
@@ -92,6 +93,15 @@ public class SearchUtils {
         if (activityViewroot != null) {
             activityViewroot.setOnInterceptTouchEventListener(ev -> {
                 if (!searchView.isIconified() && searchView.getSuggestionsAdapter().getCount() > 0) {
+                    // Don't intercept touches inside the SearchView (allows long-press paste)
+                    final int[] loc = new int[2];
+                    searchView.getLocationOnScreen(loc);
+                    final float x = ev.getRawX();
+                    final float y = ev.getRawY();
+                    if (x >= loc[0] && x <= loc[0] + searchView.getWidth()
+                            && y >= loc[1] && y <= loc[1] + searchView.getHeight()) {
+                        return false;
+                    }
                     menuSearch.collapseActionView();
                     searchView.setIconified(true);
                     return true; // intercept touch event to do not trigger an unwanted action


### PR DESCRIPTION
**Title:** Fix toolbar search not working on debug builds + long-press paste fix

## Summary

Fixes two related issues with the toolbar search on MainActivity (rel. to #17895):

1. **Search from toolbar does nothing on debug builds:** `SearchManager.getSearchableInfo()` returned null because `android.app.default_searchable` used the relative class name `.SearchActivity`, which at runtime was resolved against the application ID (`cgeo.geocaching.developer`) instead of the manifest package — producing a non-existent class. Fixed by using the fully qualified class name.

2. **Long-press paste dismissed when suggestions exist:** Two problems combined to prevent the paste dialog from appearing when the suggestion list was populated:
   - The touch intercept listener on the activity root collapsed the search on *any* touch when suggestions were showing, including long-presses on the search text field itself. Added a bounds check so touches inside the SearchView are not intercepted.
   - The `onDismissListener` immediately re-showed the suggestion dropdown when the system dismissed it to display the paste popup. Added an `isPressed()` guard so the dropdown is not forced back while the user is long-pressing the search field.

## Changes

- `main/AndroidManifest.xml` — use fully qualified `cgeo.geocaching.SearchActivity` in `android.app.default_searchable`
- `main/src/main/java/cgeo/geocaching/search/SearchUtils.java` — skip touch interception when the event falls within the SearchView bounds; suppress dropdown re-show during long-press