### PR TITLE
Initialize imperial units setting on clean install

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -307,6 +307,7 @@ public class Settings {
         final SharedPreferences prefsV0 = CgeoApplication.getInstance().getSharedPreferences(preferencesNameV0, Context.MODE_PRIVATE);
         if (currentVersion == 0 && prefsV0.getAll().isEmpty()) {
             final Editor e = sharedPrefs.edit();
+            e.putBoolean(getKey(R.string.pref_units_imperial), useImperialUnitsByDefault());
             e.putInt(getKey(R.string.pref_settingsversion), latestPreferencesVersion);
             e.apply();
             return;


### PR DESCRIPTION
## Description
On clean installs the imperial units preference wasn't getting initialized during the migration. This left it unset, causing the default to fall back to imperial. Added the initialization so it respects the locale default on first boot.

## Related issues
Fixes #18014

## Additional context
N/A