### PR TITLE
Save log after image is selected

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -503,6 +503,7 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);  // call super to make lint happy
         imageListFragment.onParentActivityResult(requestCode, resultCode, data);
+        saveLog();
     }
 
     @Override


### PR DESCRIPTION
## Description
When adding an image to a cache log, the imageListFragment processes the selection but the log wasn't being saved. Added saveLog() in onActivityResult to persist the changes.

## Related issues
Fixes #18017

## Additional context
N/A