### PR TITLE
Fix #15519: configure length of image caption and description

### DIFF
--- a/main/src/main/java/cgeo/geocaching/ImageEditActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ImageEditActivity.java
@@ -54,6 +54,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
     private static final String SAVED_STATE_IMAGE_INDEX = "cgeo.geocaching.saved_state_image_index";
     private static final String SAVED_STATE_IMAGE_SCALE = "cgeo.geocaching.saved_state_image_scale";
     private static final String SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE = "cgeo.geocaching.saved_state_max_image_upload_size";
+    private static final String SAVED_STATE_MAX_CAPTION_LENGTH = "cgeo.geocaching.saved_state_max_caption_length";
+    private static final String SAVED_STATE_MAX_DESCRIPTION_LENGTH = "cgeo.geocaching.saved_state_max_description_length";
     private static final String SAVED_STATE_GEOCODE = "cgeo.geocaching.saved_state_geocode";
     private static final String SAVED_STATE_IMAGE_ORIENTATION = "cgeo.geocaching.saved_state_image_orientation";
     private static final String SAVED_STATE_SAVED_IMAGE_ORIENTATION = "cgeo.geocaching.saved_state_saved_image_orientation";
@@ -66,6 +68,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
     private ViewOrientation savedImageOrientation;
     private int imageIndex = -1;
     private long maxImageUploadSize;
+    private int maxCaptionLength;
+    private int maxDescriptionLength;
 
     @Nullable private String geocode;
 
@@ -97,6 +101,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
             originalLocalUri = UriUtils.isLocalUri(originalImageUri) ? originalImageUri : null;
             imageIndex = extras.getInt(Intents.EXTRA_INDEX, -1);
             maxImageUploadSize = extras.getLong(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE);
+            maxCaptionLength = extras.getInt(Intents.EXTRA_MAX_IMAGE_CAPTION_LENGTH, 50);
+            maxDescriptionLength = extras.getInt(Intents.EXTRA_MAX_IMAGE_DESCRIPTION_LENGTH, 250);
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
             imageOrientation = ImageUtils.getImageOrientation(image.getUri());
             savedImageOrientation = imageOrientation.clone();
@@ -111,6 +117,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
             imageIndex = savedInstanceState.getInt(SAVED_STATE_IMAGE_INDEX, -1);
             imageScale.set(savedInstanceState.getInt(SAVED_STATE_IMAGE_SCALE));
             maxImageUploadSize = savedInstanceState.getLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE);
+            maxCaptionLength = savedInstanceState.getInt(SAVED_STATE_MAX_CAPTION_LENGTH, 50);
+            maxDescriptionLength = savedInstanceState.getInt(SAVED_STATE_MAX_DESCRIPTION_LENGTH, 250);
             geocode = savedInstanceState.getString(SAVED_STATE_GEOCODE);
             imageOrientation = savedInstanceState.getParcelable(SAVED_STATE_IMAGE_ORIENTATION);
             savedImageOrientation = savedInstanceState.getParcelable(SAVED_STATE_SAVED_IMAGE_ORIENTATION);
@@ -124,11 +132,15 @@ public class ImageEditActivity extends AbstractActionBarActivity {
         } else {
             imageScale.set(image.targetScale);
         }
+
         imageCache.setCode(geocode);
 
         binding.imageRotate.setOnClickListener(view -> rotate90Clockwise());
         binding.imageFlip.setOnClickListener(view -> flipHorizontal());
         binding.imageEditExternal.setOnClickListener(view -> editExternal());
+
+        // Apply restrictions for length
+        applyLengthRestrictions();
 
         if (image.hasTitle()) {
             binding.caption.setText(image.getTitle());
@@ -180,6 +192,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
         outState.putInt(SAVED_STATE_IMAGE_INDEX, imageIndex);
         outState.putInt(SAVED_STATE_IMAGE_SCALE, imageScale.get());
         outState.putLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
+        outState.putInt(SAVED_STATE_MAX_CAPTION_LENGTH, maxCaptionLength);
+        outState.putInt(SAVED_STATE_MAX_DESCRIPTION_LENGTH, maxDescriptionLength);
         outState.putString(SAVED_STATE_GEOCODE, geocode);
         outState.putParcelable(SAVED_STATE_IMAGE_ORIENTATION, imageOrientation);
         outState.putParcelable(SAVED_STATE_SAVED_IMAGE_ORIENTATION, savedImageOrientation);
@@ -360,6 +374,15 @@ public class ImageEditActivity extends AbstractActionBarActivity {
                 })
                 .start();
 
+    }
+
+    private void applyLengthRestrictions() {
+        // Set default values if not loaded from intent or savedInstanceState
+        final int validMaxCaptionLength = maxCaptionLength != 0 ? maxCaptionLength : 50;
+        ViewUtils.setMaxTextLength(binding.caption, binding.captionLayout, validMaxCaptionLength);
+
+        final int validMaxDescriptionLength = maxDescriptionLength != 0 ? maxDescriptionLength : 250;
+        ViewUtils.setMaxTextLength(binding.description, binding.descriptionLayout, validMaxDescriptionLength);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -31,6 +31,8 @@ public class Intents {
     public static final String EXTRA_FIELD = PREFIX + "field";
     public static final String EXTRA_IMAGES = PREFIX + "images";
     public static final String EXTRA_MAX_IMAGE_UPLOAD_SIZE = PREFIX + "max-image-upload-size";
+    public static final String EXTRA_MAX_IMAGE_CAPTION_LENGTH = PREFIX + "max-image-caption-length";
+    public static final String EXTRA_MAX_IMAGE_DESCRIPTION_LENGTH = PREFIX + "max-image-description-length";
     public static final String EXTRA_ID = PREFIX + "id";
     public static final String EXTRA_KEYWORD = PREFIX + "keyword";
     public static final String EXTRA_KEYWORD_SEARCH = PREFIX + "keyword_search";

--- a/main/src/main/java/cgeo/geocaching/connector/AbstractLoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/AbstractLoggingManager.java
@@ -125,6 +125,16 @@ public abstract class AbstractLoggingManager implements ILoggingManager {
     }
 
     @Override
+    public int getMaxImageCaptionLength() {
+        return 50;
+    }
+
+    @Override
+    public int getMaxImageDescriptionLength() {
+        return 250;
+    }
+
+    @Override
     public boolean canLogReportType(@NonNull final ReportProblemType reportType) {
         return false;
     }

--- a/main/src/main/java/cgeo/geocaching/connector/ILoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/ILoggingManager.java
@@ -94,6 +94,10 @@ public interface ILoggingManager {
 
     boolean isImageCaptionMandatory();
 
+    int getMaxImageCaptionLength();
+
+    int getMaxImageDescriptionLength();
+
     @NonNull
     List<ReportProblemType> getReportProblemTypes(@NonNull Geocache geocache);
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
@@ -233,6 +233,12 @@ class GCLoggingManager extends AbstractLoggingManager {
     public boolean supportsLogWithTrackables() {
         return true;
     }
+
+    @Override
+    public int getMaxImageDescriptionLength() {
+        return 125;
+    }
+
     @NonNull
     @Override
     public List<ReportProblemType> getReportProblemTypes(@NonNull final Geocache geocache) {

--- a/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
@@ -4,9 +4,13 @@ import cgeo.geocaching.ImageEditActivity;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.ILoggingManager;
 import cgeo.geocaching.databinding.ImagelistFragmentBinding;
 import cgeo.geocaching.databinding.ImagelistItemBinding;
 import cgeo.geocaching.log.LogUtils;
+import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
@@ -318,6 +322,16 @@ public class ImageListFragment extends Fragment {
         selectImageIntent.putExtra(Intents.EXTRA_INDEX, imageIndex);
         selectImageIntent.putExtra(Intents.EXTRA_GEOCODE, geocode);
         selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
+
+        // Get max lengths from logging manager based on connector
+        if (geocode != null) {
+            final IConnector connector = ConnectorFactory.getConnector(geocode);
+            final Geocache cache = new Geocache();
+            cache.setGeocode(geocode);
+            final ILoggingManager loggingManager = connector.getLoggingManager(cache);
+            selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_CAPTION_LENGTH, loggingManager.getMaxImageCaptionLength());
+            selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_DESCRIPTION_LENGTH, loggingManager.getMaxImageDescriptionLength());
+        }
 
         requireActivity().startActivityForResult(selectImageIntent, SELECT_IMAGE);
     }

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -29,6 +29,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Looper;
 import android.text.Editable;
+import android.text.InputFilter;
 import android.text.Selection;
 import android.text.Spannable;
 import android.text.TextWatcher;
@@ -83,6 +84,7 @@ import java.util.function.Predicate;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
 import com.google.android.material.progressindicator.IndeterminateDrawable;
+import com.google.android.material.textfield.TextInputLayout;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -152,6 +154,18 @@ public class ViewUtils {
     public static void setText(final TextView view, final String text) {
         if (view != null) {
             view.setText(text);
+        }
+    }
+
+    public static void setMaxTextLength(@NonNull final EditText textField, @Nullable final TextInputLayout textLayout, final int maxLength) {
+        if (textLayout != null) {
+            textLayout.setCounterEnabled(maxLength > 0);
+            textLayout.setCounterMaxLength(maxLength);
+        }
+
+        if (maxLength > 0) {
+            final InputFilter.LengthFilter lengthFilter = new InputFilter.LengthFilter(maxLength);
+            textField.setFilters(new InputFilter[]{lengthFilter});
         }
     }
 

--- a/main/src/main/res/layout/imageedit_activity.xml
+++ b/main/src/main/res/layout/imageedit_activity.xml
@@ -66,6 +66,7 @@
             tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/captionLayout"
             style="@style/textinput_edittext_singleline"
             app:counterEnabled="true"
             app:counterMaxLength="50">
@@ -76,11 +77,11 @@
                 android:hint="@string/log_image_caption"
                 android:autofillHints="@string/log_image_caption"
                 android:inputType="textCapSentences"
-                android:maxLength="50"
                 android:minLines="1" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/descriptionLayout"
             style="@style/textinput_edittext"
             app:counterEnabled="true"
             app:counterMaxLength="250">
@@ -91,7 +92,6 @@
                 android:hint="@string/log_image_description"
                 android:autofillHints="@string/log_image_description"
                 android:inputType="textMultiLine|textCapSentences"
-                android:maxLength="250"
                 android:minLines="5" />
         </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
Adapt max length of image caption and description depending on connector:
|Connector|caption|description|
| --- | --- | --- |
| GC | 50 | 125 |
|Other| 50 | 250|

## Related issues
<!-- List the related issues fixed or improved by this PR -->
Fix #15519

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->