### PR TITLE
fix #18020: instruct users how to download cartridges manually

### DIFF
--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoActivity.java
@@ -2,16 +2,12 @@ package cgeo.geocaching.wherigo;
 
 import cgeo.geocaching.CacheDetailActivity;
 import cgeo.geocaching.R;
-import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.activity.CustomMenuEntryActivity;
-import cgeo.geocaching.connector.StatusResult;
 import cgeo.geocaching.databinding.WherigoActivityBinding;
 import cgeo.geocaching.databinding.WherigolistItemBinding;
 import cgeo.geocaching.enumerations.QuickLaunchItem;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.maps.DefaultMap;
-import cgeo.geocaching.storage.ContentStorage;
-import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.storage.extension.OneTimeDialogs;
 import cgeo.geocaching.ui.BadgeManager;
 import cgeo.geocaching.ui.SimpleItemListModel;
@@ -43,8 +39,6 @@ public class WherigoActivity extends CustomMenuEntryActivity {
 
     private static final String PARAM_WHERIGO_GUID = "wherigo_guid";
     private static final String PARAM_WHERIGO_GEOCODE = "wherigo_geocode";
-
-    private final WherigoDownloader wherigoDownloader = new WherigoDownloader(this, this::handleDownloadResult);
 
     private WherigoActivityBinding binding;
     private int wherigoListenerId;
@@ -99,7 +93,6 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         binding.loadGame.setOnClickListener(v -> loadGame());
         binding.saveGame.setOnClickListener(v -> saveGame());
         binding.stopGame.setOnClickListener(v -> stopGame());
-        binding.download.setOnClickListener(v -> manualCartridgeDownload());
         binding.reportProblem.setOnClickListener(v -> WherigoViewUtils.showErrorDialog(this));
         binding.map.setOnClickListener(v -> showOnMap());
         binding.cacheContextGotocache.setOnClickListener(v -> goToCache(WherigoGame.get().getContextGeocode()));
@@ -207,46 +200,32 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         CacheDetailActivity.startActivity(this, geocode);
     }
 
-    private void manualCartridgeDownload() {
-        SimpleDialog.of(this).setTitle(TextParam.id(R.string.wherigo_manual_download_title))
-            .input(new SimpleDialog.InputOptions().setLabel(LocalizationUtils.getString(R.string.wherigo_manual_download_cguid_label)).setInitialValue(""), input -> wherigoDownloader.downloadWherigo(input, name -> ContentStorage.get().create(PersistableFolder.WHERIGO, name)));
-    }
-
     private void handleCGuidInput(@NonNull final String cguid) {
-        final WherigoCartridgeInfo cguidCartridge = WherigoCartridgeInfo.getCartridgeForCGuid(cguid);
-        if (cguidCartridge == null) {
+        final boolean exists = checkAndDisplayExistingCartridge(cguid);
+        if (!exists) {
             SimpleDialog.of(this).setTitle(TextParam.id(R.string.wherigo_download_title))
                 .setMessage(TextParam.id(R.string.wherigo_download_message, cguid))
                 .setButtons(SimpleDialog.ButtonTextSet.YES_NO)
-                .confirm(() -> wherigoDownloader.downloadWherigo(cguid, name -> ContentStorage.get().create(PersistableFolder.WHERIGO, name)));
-        } else {
-            final String geocode = getStartingGeocode();
-            if (geocode != null) {
-                WherigoGame.get().setContextGeocode(geocode);
-            }
-            WherigoDialogManager.get().display(new WherigoCartridgeDialogProvider(cguidCartridge, false));
+                .confirm(() -> WherigoDownloader.guideManualDownload(this, cguid));
         }
+    }
+
+    private boolean checkAndDisplayExistingCartridge(final String cguid) {
+        final WherigoCartridgeInfo cguidCartridge = WherigoCartridgeInfo.getCartridgeForCGuid(cguid);
+        if (cguidCartridge == null) {
+            return false;
+        }
+        final String geocode = getStartingGeocode();
+        if (geocode != null) {
+            WherigoGame.get().setContextGeocode(geocode);
+        }
+        WherigoDialogManager.get().display(new WherigoCartridgeDialogProvider(cguidCartridge, false));
+        return true;
     }
 
     private String getStartingGeocode() {
         final Intent intent = getIntent();
         return intent == null || intent.getExtras() == null ? null : intent.getExtras().getString(PARAM_WHERIGO_GEOCODE);
-    }
-
-    private void handleDownloadResult(final String cguid, final StatusResult result) {
-        final WherigoCartridgeInfo cartridgeInfo = WherigoCartridgeInfo.getCartridgeForCGuid(cguid);
-        if (result.isOk() && cartridgeInfo != null) {
-            ActivityMixin.showToast(this, R.string.wherigo_download_successful_title);
-            final String geocode = getStartingGeocode();
-            if (geocode != null) {
-                WherigoGame.get().setContextGeocode(geocode);
-            }
-            WherigoDialogManager.displayDirect(this, new WherigoCartridgeDialogProvider(cartridgeInfo, false));
-        } else {
-            SimpleDialog.of(this).setTitle(TextParam.id(R.string.wherigo_download_failed_title))
-                .setMessage(TextParam.id(R.string.wherigo_download_failed_message, cguid, String.valueOf(result)))
-                .show();
-        }
     }
 
     @SuppressLint("SetTextI18n")
@@ -262,7 +241,6 @@ public class WherigoActivity extends CustomMenuEntryActivity {
         binding.revokeFixedLocation.setVisibility(game.isDebugModeForCartridge() && WherigoLocationProvider.get().hasFixedLocation() ? View.VISIBLE : View.GONE);
 
         binding.viewCartridges.setEnabled(true);
-        binding.download.setEnabled(true);
         binding.reportProblem.setEnabled(true);
 
         binding.resumeDialog.setVisibility(game.dialogIsPaused() ? View.VISIBLE : View.GONE);

--- a/main/src/main/java/cgeo/geocaching/wherigo/WherigoDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/wherigo/WherigoDownloader.java
@@ -11,13 +11,18 @@ import cgeo.geocaching.network.Parameters;
 import cgeo.geocaching.settings.Credentials;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.ui.TextParam;
+import cgeo.geocaching.ui.dialog.SimpleDialog;
 import cgeo.geocaching.utils.AndroidRxUtils;
+import cgeo.geocaching.utils.ClipboardUtils;
 import cgeo.geocaching.utils.Formatter;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.workertask.ProgressDialogFeature;
 import cgeo.geocaching.utils.workertask.WorkerTask;
 
+import android.content.Context;
+import android.content.DialogInterface;
 import android.net.Uri;
 import android.util.Pair;
 
@@ -95,7 +100,7 @@ public class WherigoDownloader {
         }
     }
 
-    public static StatusResult performDownload(final String username, final String password, final String cguid, final Function<String, OutputStream> outputSupplier, final Consumer<String> progress, final Supplier<Boolean> cancelFlag) {
+    private static StatusResult performDownload(final String username, final String password, final String cguid, final Function<String, OutputStream> outputSupplier, final Consumer<String> progress, final Supplier<Boolean> cancelFlag) {
 
         progress.accept(LocalizationUtils.getString(R.string.wherigo_download_progress_login));
 
@@ -220,6 +225,22 @@ public class WherigoDownloader {
             errorMsg += " (c=" + completed + ", t=" + total + ")";
             success = success & (completed == total);
             return success ? StatusResult.OK : new StatusResult(StatusCode.COMMUNICATION_ERROR, errorMsg);
+    }
+
+    public static void guideManualDownload(final Context ctx, final String cguid) {
+        final String downloadUrl = DOWNLOAD + "?CGUID=" + cguid;
+        SimpleDialog.ofContext(ctx)
+            .setTitle(TextParam.id(R.string.wherigo_download_manualguide_title))
+            .setMessage(TextParam.id(R.string.wherigo_download_manualguide_text, downloadUrl, cguid).setMarkdown(true))
+            .setNeutralButton(TextParam.id(R.string.wherigo_download_manualguide_copy_cguid_to_clipboard))
+            .setButtonClickAction(which -> {
+               if (which == DialogInterface.BUTTON_NEUTRAL) {
+                   ClipboardUtils.copyToClipboard(cguid);
+                   return true;
+               }
+               return false;
+            })
+            .show();
     }
 
 

--- a/main/src/main/res/layout/wherigo_activity.xml
+++ b/main/src/main/res/layout/wherigo_activity.xml
@@ -47,12 +47,6 @@
                 android:tooltipText="@string/wherigo_controls_cartridgelist_hint"
                 app:icon="@drawable/ic_menu_select_play" />
 
-            <Button
-                android:id="@+id/download"
-                style="@style/button_icon"
-                android:tooltipText="@string/wherigo_controls_downloadcartridge_hint"
-                app:icon="@drawable/wherigo_download" />
-
             <View
                 style="@style/separator_vertical" />
 

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -3027,6 +3027,10 @@
     <string name="wherigo_download_progress_download_status">Downloaded %1$s / %2$s (%3$s %%)</string>
     <string name="wherigo_download_accept_eula">Please log in to www.wherigo.com and accept their terms and conditions first</string>
 
+    <string name="wherigo_download_manualguide_title">Cartridge download</string>
+    <string name="wherigo_download_manualguide_text">Follow these steps to download cartridge and make it available for c:geo.\n\n**1. Download cartridge in browser:**\n* Open this [link](%1$s)\n* Follow instructions to log in\n* For option \"Download cartridge file for\", choose \"Pocket PC Device\"\n* Tap \"Download Now\"\n\n**2. Make cartridge available for c:geo**\n* Open your device\'s \"Download\" folder with Files app of your choosing and locate the just downloaded file (ends with .gwc)\n* Rename file so it starts with CGUID \"%2$s\" (use \"Copy CGUID to clipboard\" below) but still ends with \".gwc\"\n* Move file to cgeo/wherigo folder\n\n**3. Reopen c:geo Wherigo Player for cache**</string>
+    <string name="wherigo_download_manualguide_copy_cguid_to_clipboard">Copy CGUID to clipboard</string>
+
     <string name="wherigo_error_title">Wherigo Problem report</string>
     <string name="wherigo_error_game_noerror">No error reported by Wherigo Engine.</string>
     <string name="wherigo_error_game_error">Error reported by Wherigo Engine:\n\n```\n%1$s\n```\nYou may contact the author of the cartridge [here](%2$s)</string>


### PR DESCRIPTION
fix #18020: instruct users how to download cartridges manually

Instructs end users how to manually download cartridges:
<img width="379" height="655" alt="image" src="https://github.com/user-attachments/assets/8c12febb-d024-48a8-a303-d18479a1c8d2" />
