### PR TITLE
Using the plugins Block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,6 @@ buildscript {
 
         // un-mocking of portable Android classes
         classpath 'com.github.bjoernq:unmockplugin:0.9.0'
-
-        // monitor our application method limit
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:4.0.0'
     }
 }
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -10,10 +10,22 @@ import static org.gradle.api.provider.ValueSourceParameters.None
  */
 
 
-/*
- * Android plugin, http://developer.android.com/tools/building/plugin-for-gradle.html
- */
-apply plugin: 'com.android.application'
+plugins {
+    // Android plugin, http://developer.android.com/tools/building/plugin-for-gradle.html
+    id 'com.android.application'
+
+    // monitor our application method limit, https://github.com/KeepSafe/dexcount-gradle-plugin
+    id 'com.getkeepsafe.dexcount' version '4.0.0'
+
+    // un-mocking of Android classes that don't depend on the Android device, but are portable Java only, like SparseArray
+    id 'de.mobilej.unmock'
+
+    // checkstyle tasks
+    id 'checkstyle'
+
+    // PMD Static Source Code Analyzer
+    id 'pmd'
+}
 
 Provider<String> gitCommitIdProvider = providers.of(GitCommitIdValueSource.class) {}
 String commitIdShort = gitCommitIdProvider.get()
@@ -774,27 +786,15 @@ tasks.configureEach { theTask ->
     }
 }
 
-/*
- * dex counting - start it manually, when necessary
- * https://github.com/KeepSafe/dexcount-gradle-plugin
- */
-apply plugin: 'com.getkeepsafe.dexcount'
-
+// dex counting - start it manually, when necessary
 dexcount {
     format = OutputFormat.LIST
     includeClassCount = true
     includeTotalMethodCount = true
 }
 
-// un-mocking of Android classes that don't depend on the Android device, but are portable Java only, like SparseArray
-apply plugin: 'de.mobilej.unmock'
-
-/*
- * own checkstyle configuration
- * Android plugin doesn't interoperate with the Checkstyle plugin
- */
-apply plugin: 'checkstyle'
-
+// own checkstyle configuration
+// Android plugin doesn't interoperate with the Checkstyle plugin
 checkstyle {
     // align checkstyle with codacy (https://github.com/codacy/codacy-checkstyle)
     // - assign the checkstyle version explicitly here
@@ -823,8 +823,6 @@ tasks.register('checkstyle', Checkstyle) {
 tasks.named('check') {
     mustRunAfter tasks.named('checkstyle')
 }
-
-apply plugin: 'pmd'
 
 // align the toolVersion with codacy (https://github.com/codacy/codacy-pmd/blob/master/build.sbt#L9C23-L9C23)
 pmd {

--- a/mapswithme-api/build.gradle
+++ b/mapswithme-api/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+}
 
 android {
     namespace = 'com.mapwithme.maps.api'


### PR DESCRIPTION
From https://docs.gradle.org/current/userguide/best_practices_general.html#use_the_plugins_block: The plugins block is the preferred way to apply plugins in Gradle.

So, move all `apply plugin:` into the `plugins` block. Additionally remove the `dexcount` declaration from the global gradle file and define the version in the `main` project. It is not more used on other places.
