### PR TITLE
Update lookups.dat + add downloader for it (fix #18045)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/MainActivity.java
+++ b/main/src/main/java/cgeo/geocaching/MainActivity.java
@@ -523,6 +523,7 @@ public class MainActivity extends AbstractNavigationBarActivity {
             }
         } else if (id == R.id.menu_update_routingdata) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, DownloaderUtils::returnFromTileUpdateCheck);
+            DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_BROUTER_LOOKUPS, R.string.updates_check, updateCheckAllowed -> { });
         } else if (id == R.id.menu_update_mapdata) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(this, Download.DownloadType.DOWNLOADTYPE_ALL_MAPRELATED, R.string.updates_check, DownloaderUtils::returnFromMapUpdateCheck);
         } else if (id == R.id.menu_download_language) {

--- a/main/src/main/java/cgeo/geocaching/brouter/BRouterConstants.java
+++ b/main/src/main/java/cgeo/geocaching/brouter/BRouterConstants.java
@@ -10,6 +10,7 @@ public class BRouterConstants {
     public static final String BROUTER_PROFILE_ELEVATION_ONLY = "dummy.brf";
 
     public static final String BROUTER_TILE_FILEEXTENSION = ".rd5";
+    public static final String BROUTER_LOOKUPS_FILEEXTENSION = ".dat";
 
     public static final String PROFILE_PARAMTERKEY = "internal_routing_profile";
 

--- a/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/AbstractDownloader.java
@@ -4,6 +4,7 @@ import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.MatcherWrapper;
 
 import android.app.Activity;
@@ -36,8 +37,20 @@ public abstract class AbstractDownloader {
     public static final int ICONRES_FOLDER = R.drawable.downloader_folder;
 
     AbstractDownloader(final Download.DownloadType offlineMapType, final @StringRes int mapBase, final @StringRes int mapSourceName, final @StringRes int mapSourceInfo, final @StringRes int projectUrl, final @StringRes int likeItUrl, final PersistableFolder targetFolder) {
+        this(
+                offlineMapType,
+                mapBase == 0 ? Uri.parse("") : Uri.parse(/* LocalizationUtils.getPlainString(mapBase) */ LocalizationUtils.getString(mapBase)),
+                mapSourceName,
+                mapSourceInfo,
+                projectUrl,
+                likeItUrl,
+                targetFolder
+        );
+    }
+
+    AbstractDownloader(final Download.DownloadType offlineMapType, final Uri mapBase, final @StringRes int mapSourceName, final @StringRes int mapSourceInfo, final @StringRes int projectUrl, final @StringRes int likeItUrl, final PersistableFolder targetFolder) {
         this.offlineMapType = offlineMapType;
-        this.mapBase = mapBase == 0 ? Uri.parse("") : Uri.parse(CgeoApplication.getInstance().getString(mapBase));
+        this.mapBase = mapBase;
         this.mapSourceName = mapSourceName == 0 ? "" : CgeoApplication.getInstance().getString(mapSourceName);
         this.mapSourceInfo = mapSourceInfo == 0 ? "" : CgeoApplication.getInstance().getString(mapSourceInfo);
         this.projectUrl = projectUrl == 0 ? "" : CgeoApplication.getInstance().getString(projectUrl);

--- a/main/src/main/java/cgeo/geocaching/downloader/BRouterLookupsDownloader.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/BRouterLookupsDownloader.java
@@ -1,0 +1,121 @@
+package cgeo.geocaching.downloader;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.brouter.BRouterConstants;
+import cgeo.geocaching.models.Download;
+import cgeo.geocaching.network.Network;
+import cgeo.geocaching.network.Parameters;
+import cgeo.geocaching.storage.ContentStorage;
+import cgeo.geocaching.storage.PersistableFolder;
+import cgeo.geocaching.utils.CalendarUtils;
+import cgeo.geocaching.utils.Log;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Response;
+
+public class BRouterLookupsDownloader extends AbstractDownloader {
+
+    private static final BRouterLookupsDownloader INSTANCE = new BRouterLookupsDownloader();
+
+
+    private static final String GITHUB_API_BASE = "https://api.github.com/repos/";
+    private static final String GITHUB_RAW_BASE = "https://raw.githubusercontent.com/";
+    private static final String BROUTER_REPO = "abrensch/brouter/";
+
+    private static final String GITHUB_VERB_GET_LATEST_TAG = "releases/latest";
+    private static final String GITHUB_RESPONSE_TAGNAME = "tag_name";
+    private static final String GITHUB_VERB_GET_LATEST_COMMIT = "commits";
+    private static final String GITHUB_PARAM_PATH = "path";
+    private static final String GITHUB_VALUE_PATH = "/misc/profiles2/" + BRouterConstants.BROUTER_LOOKUPS_FILENAME;
+    private static final String GITHUB_PARAM_RESULTSIZE = "per_page";
+    private static final String GITHUB_PARAM_FILTER_FOR_TAG = "sha";
+    private static final String GITHUB_RESPONSE_COMMIT_DATE = "/0/commit/author/date";
+
+    private BRouterLookupsDownloader() {
+        super(Download.DownloadType.DOWNLOADTYPE_BROUTER_LOOKUPS, Uri.parse(GITHUB_API_BASE + BROUTER_REPO + GITHUB_VERB_GET_LATEST_TAG), R.string.brouter_name, R.string.brouter_info, R.string.brouter_projecturl, 0, PersistableFolder.ROUTING_BASE);
+        useCompanionFiles = false; // use single uri, and no companion files
+        forceExtension = BRouterConstants.BROUTER_LOOKUPS_FILEEXTENSION;
+    }
+
+    @Override
+    protected void analyzePage(final Uri uri, final List<Download> list, final @NonNull String page) {
+        Log.e("BRouterLookupsDownloader.analyzePage should never get called");
+    }
+
+    @Nullable
+    @Override
+    protected Download checkUpdateFor(final @NonNull String page, final String remoteUrl, final String remoteFilename) {
+        // retrieve timestamp of local file
+        final ContentStorage.FileInformation fi = ContentStorage.get().getFileInfo(PersistableFolder.ROUTING_BASE.getFolder(), BRouterConstants.BROUTER_LOOKUPS_FILENAME);
+        if (fi == null) {
+            // should never happen (if routing got started at least once), as routing init ensure this file's existance
+            return null;
+        }
+
+        final ObjectMapper mapper = new ObjectMapper();
+
+        // analyze GitHub tag for latest release
+        final String tag;
+        try {
+            final JsonNode node = mapper.readTree(page);
+            tag = node.get(GITHUB_RESPONSE_TAGNAME).asText();
+            Log.d("found tag: " + tag);
+        } catch (JsonProcessingException e) {
+            Log.e("BRouterLookupsDownloader.checkUpdateFor: parsing error (1): " + e.getMessage());
+            return null;
+        }
+
+        // retrieve date of last commit for lookups.dat in that release
+        final Parameters params = new Parameters();
+        params.add(GITHUB_PARAM_PATH, GITHUB_VALUE_PATH);
+        params.add(GITHUB_PARAM_RESULTSIZE, "1");
+        params.add(GITHUB_PARAM_FILTER_FOR_TAG, tag);
+        final Response response = Network.getRequest(GITHUB_API_BASE + BROUTER_REPO + GITHUB_VERB_GET_LATEST_COMMIT, params).blockingGet();
+        final String page2 = Network.getResponseData(response, true);
+
+        final String date;
+        try {
+            final JsonNode node = mapper.readTree(page2);
+            date = node.at(GITHUB_RESPONSE_COMMIT_DATE).asText();
+            Log.d("found date: " + date);
+        } catch (JsonProcessingException e) {
+            Log.e("BRouterLookupsDownloader.checkUpdateFor: parsing error (2): " + e.getMessage());
+            return null;
+        }
+
+        // compare time stamps
+        long onlineDateTime = 0;
+        try {
+            onlineDateTime = Instant.parse(date).getEpochSecond() * 1000;
+        } catch (DateTimeParseException e) {
+            Log.e("BRouterLookupsDownloader.checkUpdateFor: parsing error (3): " + e.getMessage());
+        }
+        if (onlineDateTime <= fi.lastModified) {
+            return null;
+        }
+        return new Download(BRouterConstants.BROUTER_LOOKUPS_FILENAME, Uri.parse(GITHUB_RAW_BASE + BROUTER_REPO + "master" + GITHUB_VALUE_PATH), false, CalendarUtils.yearMonthDay(onlineDateTime), "", Download.DownloadType.DOWNLOADTYPE_BROUTER_LOOKUPS, R.drawable.ic_menu_route);
+    }
+
+    // BRouter uses a single download page, need to map here to its fixed address
+    @Override
+    protected String getUpdatePageUrl(final String downloadPageUrl) {
+        return mapBase.toString();
+    }
+
+    @NonNull
+    public static BRouterLookupsDownloader getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -30,6 +30,7 @@ import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.functions.Action1;
 import cgeo.geocaching.utils.offlinetranslate.TranslationModelManager;
+import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_BROUTER_LOOKUPS;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_BROUTER_TILES;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_HILLSHADING_TILES;
 import static cgeo.geocaching.models.Download.DownloadType.DOWNLOADTYPE_LANGUAGE_MODEL;
@@ -98,6 +99,7 @@ public class DownloaderUtils {
     public static void checkForRoutingTileUpdates(final MainActivity activity) {
         if (Settings.useInternalRouting() && !PersistableFolder.ROUTING_TILES.isLegacy() && Settings.brouterAutoTileDownloadsNeedUpdate()) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.tilesupdate, DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, DownloaderUtils::returnFromTileUpdateCheck);
+            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.tilesupdate, DOWNLOADTYPE_BROUTER_LOOKUPS, R.string.updates_check, R.string. tileupdate_info, null);
         }
     }
 
@@ -291,12 +293,14 @@ public class DownloaderUtils {
      * if yes: ask user to download them all
      * if yes: trigger download(s)
      */
-    public static void checkForUpdatesAndDownloadAll(final MainActivity activity, final int layout, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, final Action1<Boolean> callback) {
+    public static void checkForUpdatesAndDownloadAll(final MainActivity activity, final int layout, final Download.DownloadType type, @StringRes final int title, @StringRes final int info, @Nullable final Action1<Boolean> callback) {
         activity.displayActionItem(layout, info, true, (actionRequested) -> {
             if (actionRequested) {
                 new CheckForDownloadsTask(activity, title, type).execute();
             }
-            callback.call(actionRequested);
+            if (callback != null) {
+                callback.call(actionRequested);
+            }
         });
     }
 

--- a/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
+++ b/main/src/main/java/cgeo/geocaching/maps/routing/Routing.java
@@ -314,7 +314,7 @@ public final class Routing {
 
         // other error
         if (!gpx.startsWith("<?xml")) {
-            Log.w("brouter returned an error message: " + gpx);
+            Log.e("brouter returned an error message: " + gpx);
             return null;
         }
 

--- a/main/src/main/java/cgeo/geocaching/models/Download.java
+++ b/main/src/main/java/cgeo/geocaching/models/Download.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.models;
 import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.downloader.AbstractDownloader;
+import cgeo.geocaching.downloader.BRouterLookupsDownloader;
 import cgeo.geocaching.downloader.BRouterTileDownloader;
 import cgeo.geocaching.downloader.CompanionFileUtils;
 import cgeo.geocaching.downloader.HillshadingTileDownloader;
@@ -44,7 +45,7 @@ public class Download {
     public boolean customMarker = false; // handled solely by caller
 
     public Download(final String name, final Uri uri, final boolean isDir, final String dateISO, final String sizeInfo, final DownloadType type, @DrawableRes final int iconRes) {
-        this.name = CompanionFileUtils.getDisplayName(name);
+        this.name = type.useDisplayName ? CompanionFileUtils.getDisplayName(name) : name;
         this.uri = uri;
         this.isDir = isDir;
         this.isBackDir = false;
@@ -58,7 +59,7 @@ public class Download {
     public Download(final PendingDownload pendingDownload) {
         final DownloadTypeDescriptor desc = DownloadType.fromTypeId(pendingDownload.getOfflineMapTypeId());
 
-        this.name = CompanionFileUtils.getDisplayName(pendingDownload.getFilename());
+        this.name = desc == null || desc.type.useDisplayName ? CompanionFileUtils.getDisplayName(pendingDownload.getFilename()) : pendingDownload.getFilename();
         this.uri = Uri.parse(pendingDownload.getRemoteUrl());
         this.isDir = false;
         this.isBackDir = false;
@@ -139,39 +140,43 @@ public class Download {
 
     public enum DownloadType {
         // id values must not be changed as they are referenced in the database & download companion files
-        DOWNLOAD_TYPE_ALL_MAPS(-2, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),       // virtual entry
-        DOWNLOAD_TYPE_ALL_THEMES(-1, R.string.downloadmap_themefile, R.drawable.downloader_theme),  // virtual entry
-        DOWNLOADTYPE_ALL_MAPRELATED(0, 0, R.drawable.ic_menu_mapmode),                 // virtual entry
-        DOWNLOADTYPE_MAP_MAPSFORGE(1, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
-        DOWNLOADTYPE_MAP_OPENANDROMAPS(2, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
-        DOWNLOADTYPE_THEME_OPENANDROMAPS(3, R.string.downloadmap_themefile, R.drawable.downloader_theme),
-        DOWNLOADTYPE_MAP_FREIZEITKARTE(4, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
-        DOWNLOADTYPE_THEME_FREIZEITKARTE(5, R.string.downloadmap_themefile, R.drawable.downloader_theme),
-        DOWNLOADTYPE_MAP_HYLLY(6, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
-        DOWNLOADTYPE_THEME_HYLLY(7, R.string.downloadmap_themefile, R.drawable.downloader_theme),
-        DOWNLOADTYPE_MAP_PAWS(8, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode),
-        DOWNLOADTYPE_THEME_PAWS(9, R.string.downloadmap_themefile, R.drawable.downloader_theme),
+        DOWNLOAD_TYPE_ALL_MAPS(-2, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true),       // virtual entry
+        DOWNLOAD_TYPE_ALL_THEMES(-1, R.string.downloadmap_themefile, R.drawable.downloader_theme, true),  // virtual entry
+        DOWNLOADTYPE_ALL_MAPRELATED(0, 0, R.drawable.ic_menu_mapmode, true),                 // virtual entry
+        DOWNLOADTYPE_MAP_MAPSFORGE(1, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true),
+        DOWNLOADTYPE_MAP_OPENANDROMAPS(2, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true),
+        DOWNLOADTYPE_THEME_OPENANDROMAPS(3, R.string.downloadmap_themefile, R.drawable.downloader_theme, true),
+        DOWNLOADTYPE_MAP_FREIZEITKARTE(4, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true),
+        DOWNLOADTYPE_THEME_FREIZEITKARTE(5, R.string.downloadmap_themefile, R.drawable.downloader_theme, true),
+        DOWNLOADTYPE_MAP_HYLLY(6, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true),
+        DOWNLOADTYPE_THEME_HYLLY(7, R.string.downloadmap_themefile, R.drawable.downloader_theme, true),
+        DOWNLOADTYPE_MAP_PAWS(8, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true),
+        DOWNLOADTYPE_THEME_PAWS(9, R.string.downloadmap_themefile, R.drawable.downloader_theme, true),
 
-        DOWNLOADTYPE_MAP_JUSTDOWNLOAD(50, R.string.downloadmap_othermapdownload, R.drawable.ic_menu_mapmode),
-        DOWNLOADTYPE_THEME_JUSTDOWNLOAD(51, R.string.downloadmap_otherthemedownload, R.drawable.downloader_theme),
+        DOWNLOADTYPE_MAP_JUSTDOWNLOAD(50, R.string.downloadmap_othermapdownload, R.drawable.ic_menu_mapmode, true),
+        DOWNLOADTYPE_THEME_JUSTDOWNLOAD(51, R.string.downloadmap_otherthemedownload, R.drawable.downloader_theme, true),
 
-        DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile, R.drawable.ic_menu_route),
-        DOWNLOADTYPE_HILLSHADING_TILES(91, R.string.downloadmap_hillshadingfile, R.drawable.ic_menu_hills),
-        DOWNLOADTYPE_LANGUAGE_MODEL(92, R.string.translator_model, R.drawable.ic_menu_translate),
-        DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS(93, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode);
+        DOWNLOADTYPE_BROUTER_TILES(90, R.string.downloadmap_tilefile, R.drawable.ic_menu_route, false),
+        DOWNLOADTYPE_BROUTER_LOOKUPS(94, R.string.downloadmap_tilefile, R.drawable.ic_menu_route, false),
+        DOWNLOADTYPE_HILLSHADING_TILES(91, R.string.downloadmap_hillshadingfile, R.drawable.ic_menu_hills, false),
+        DOWNLOADTYPE_LANGUAGE_MODEL(92, R.string.translator_model, R.drawable.ic_menu_translate, false),
+        DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS(93, R.string.downloadmap_mapfile, R.drawable.ic_menu_mapmode, true);
 
         public final int id;
         @StringRes final int typeNameResId;
         @DrawableRes final int iconResId;
+        public final boolean useDisplayName;
+
         public static final int DEFAULT = DOWNLOADTYPE_MAP_MAPSFORGE.id;
         private static final ArrayList<DownloadTypeDescriptor> offlineMapTypes = new ArrayList<>();
         private static final ArrayList<DownloadTypeDescriptor> offlineMapThemeTypes = new ArrayList<>();
         private static final ArrayList<DownloadTypeDescriptor> downloadTypes = new ArrayList<>();
 
-        DownloadType(final int id, @StringRes final int typeNameResId, @DrawableRes final int iconResId) {
+        DownloadType(final int id, @StringRes final int typeNameResId, @DrawableRes final int iconResId, final boolean useDisplayName) {
             this.id = id;
             this.typeNameResId = typeNameResId;
             this.iconResId = iconResId;
+            this.useDisplayName = useDisplayName;
         }
 
         public static ArrayList<DownloadTypeDescriptor> getOfflineMapTypes() {
@@ -253,6 +258,7 @@ public class Download {
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_THEME_JUSTDOWNLOAD, MapDownloaderJustDownloadThemes.getInstance(), R.string.downloadmap_themefile));
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_HILLSHADING_TILES, HillshadingTileDownloader.getInstance(), R.string.hillshading_name));
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_BROUTER_TILES, BRouterTileDownloader.getInstance(), R.string.brouter_name));
+                downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_BROUTER_LOOKUPS, BRouterLookupsDownloader.getInstance(), R.string.brouter_name));
                 downloadTypes.add(new DownloadTypeDescriptor(DOWNLOADTYPE_MAP_OPENANDROMAPS_BACKGROUNDS, MapDownloaderOpenAndroMapsBackgroundMaps.getInstance(), R.string.persistablefolder_backgroundmaps));
 
                 // adding maps and map themes to download types for completeness

--- a/main/src/main/res/raw/routing_lookups.dat
+++ b/main/src/main/res/raw/routing_lookups.dat
@@ -1,5 +1,5 @@
----lookupversion:10
----minorversion:14
+---lookupversion:11
+---minorversion:1
 
 ---context:way
 
@@ -18,7 +18,7 @@ highway;0000568118 living_street
 highway;0000515044 motorway
 highway;0000451760 motorway_link
 highway;0000442502 steps
-highway;0000360177 road
+highway;0000360177 road yes
 highway;0000318426 pedestrian
 highway;0000210535 trunk_link
 highway;0000192461 primary_link
@@ -30,34 +30,24 @@ highway;0000039003 platform
 highway;0000037192 proposed planned virtual
 highway;0000010307 raceway
 highway;0000003152 rest_area
-highway;0000002942 abandoned disused razed demolished dismantled
+highway;0000002942 abandoned disused razed demolished dismantled no
 highway;0000002631 services
 highway;0000002133 corridor
-highway;0000002093 crossing
 highway;0000001440 bus_stop
-highway;0000001274 yes
-highway;0000000679 unsurfaced
-highway;0000000108 byway
-highway;0000000037 driveway
-highway;0000000021 mini_roundabout
-highway;0000000020 turning_loop
-
-tracktype;0000887965 grade2
-tracktype;0000868414 grade3
-tracktype;0000595882 grade1
-tracktype;0000568372 grade4
-tracktype;0000405959 grade5
+highway;0000000001 busway
+highway;0000000001 elevator
+highway;0000000001 via_ferrata
 
 surface;0002497676 asphalt
-surface;0001568957 paved
-surface;0001562253 unpaved
+surface;0001568957 paved bricks brick chipseal
+surface;0001562253 unpaved unpaved_minor
 surface;0000727427 gravel
-surface;0000560191 ground
-surface;0000350378 dirt
-surface;0000237226 grass
-surface;0000212587 concrete concrete:plates concrete:lanes
+surface;0000560191 ground soil
+surface;0000350378 dirt dirt/sand
+surface;0000237226 grass artificial_turf
+surface;0000212587 concrete concrete:plates concrete:lanes cement
 surface;0000188743 paving_stones paving_stones:30 paving_stones:20
-surface;0000113800 cobblestone cobblestone:flattened
+surface;0000113800 cobblestone cobblestone:flattened unhewn_cobblestone
 surface;0000093164 compacted
 surface;0000091171 sand dirt/sand
 surface;0000023293 wood
@@ -69,63 +59,119 @@ surface;0000005778 mud
 surface;0000004549 grass_paver
 surface;0000004398 clay
 surface;0000003760 metal
+surface;0000000001 rock rocks rocky
+surface;0000000001 stone
 
-maxspeed;0001058313 50 30_mph 30mph
-maxspeed;0000860780 30 20_mph 20mph
-maxspeed;0000025232 10 5 7 15
-maxspeed;0000083989 20 10_mph 10mph 15_mph 15mph
+lit;0000809223 yes
+lit;0000000001 no
+lit;0000800001 sunset-sunrise dusk-dawn
+lit;0000800001 24/7
+lit;0000800001 automatic
+
+estimated_forest_class;0000000001 1
+estimated_forest_class;0000000001 2
+estimated_forest_class;0000000001 3
+estimated_forest_class;0000000001 4
+estimated_forest_class;0000000001 5
+estimated_forest_class;0000000001 6
+
+estimated_noise_class;0000000001 1
+estimated_noise_class;0000000001 2
+estimated_noise_class;0000000001 3
+estimated_noise_class;0000000001 4
+estimated_noise_class;0000000001 5
+estimated_noise_class;0000000001 6
+
+estimated_river_class;0000000001 1
+estimated_river_class;0000000001 2
+estimated_river_class;0000000001 3
+estimated_river_class;0000000001 4
+estimated_river_class;0000000001 5
+estimated_river_class;0000000001 6
+
+estimated_town_class;0000000001 1
+estimated_town_class;0000000001 2
+estimated_town_class;0000000001 3
+estimated_town_class;0000000001 4
+estimated_town_class;0000000001 5
+estimated_town_class;0000000001 6
+
+maxspeed;0001058313 50 55 56 30_mph 30mph
+maxspeed;0000860780 30 35 20_mph 20mph
+maxspeed;0000025232 10 15 5 6 8 5_mph 6_mph
+maxspeed;0000083989 20 25 10_mph 10mph 15_mph 15mph
 maxspeed;0000195097 40 45 25_mph 25mph
-maxspeed;0000204646 60 35_mph 35mph 40_mph 40mph
-maxspeed;0000130108 70 45_mph 45mph
-maxspeed;0000225071 80 50_mph 50mph
-maxspeed;0000106719 90 55_mph 55mph
+maxspeed;0000204646 60 65 35_mph 35mph 40_mph 40mph
+maxspeed;0000130108 70 75 45_mph 45mph
+maxspeed;0000225071 80 85 50_mph 50mph
+maxspeed;0000106719 90 95 55_mph 55mph
 maxspeed;0000134522 100 60_mph 60mph 65_mph 65mph
 maxspeed;0000025242 110 70_mph 70mph
 maxspeed;0000038763 120 75_mph 75mph
-maxspeed;0000026953 130
+maxspeed;0000026953 130 80_mph 79_mph
 maxspeed;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
 maxspeed;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
 
 service;0001433919 parking_aisle
-service;0001305879 driveway
+service;0001305879 driveway driveway2
 service;0000382788 alley
 service;0000018777 drive-through drive_through
 service;0000008290 emergency_access
 service;0000003138 bus
 service;0000001250 parking
 service;0000001159 logging
+service;0000000001 yard
+service;0000000001 spur
+service;0000000001 siding
+service;0000000001 crossover
 
-lit;0000809223 yes
+tracktype;0000887965 grade2
+tracktype;0000868414 grade3
+tracktype;0000595882 grade1
+tracktype;0000568372 grade4 grade3-5
+tracktype;0000405959 grade5
 
-lanes;0002838405 2
-lanes;0000718138 1
-lanes;0000259502 3
-lanes;0000141651 4
-lanes;0000018473 -1
-lanes;0000017934 5
-lanes;0000008241 6
-lanes;0000003643 1.5
-lanes;0000001087 7
-
-access;0002688349 private
-access;0000319927 yes
+access;0002688349 private restricted residents employees
+access;0000319927 yes public
 access;0000144799 no
 access;0000140215 permissive
-access;0000108802 destination
-access;0000099899 agricultural forestry
+access;0000108802 destination visitors
+access;0000099899 agricultural forestry agricultural;forestry
 access;0000039934 designated official
 access;0000011813 customers
 access;0000004007 delivery
 access;0000000100 psv
 access;0000000100 hov
+access;0000000001 permit
+access;0000000001 military
 
-foot;0001659694 yes allowed Yes
+estimated_traffic_class;0000000001 1
+estimated_traffic_class;0000000001 2
+estimated_traffic_class;0000000001 3
+estimated_traffic_class;0000000001 4
+estimated_traffic_class;0000000001 5
+estimated_traffic_class;0000000001 6
+estimated_traffic_class;0000000001 7
+
+
+lanes;0002838405 2
+lanes;0000718138 1
+lanes;0000259502 3
+lanes;0000141651 4
+lanes;0000017934 5
+lanes;0000008241 6
+lanes;0000003643 1.5
+lanes;0000001087 7
+lanes;0000000001 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+
+foot;0001659694 yes allowed
 foot;0000424847 designated official
 foot;0000202364 no
 foot;0000053031 permissive
-foot;0000011661 destination
+foot;0000011661 destination customers
 foot;0000007289 private
 foot;0000000167 use_sidepath sidewalk
+foot;0000000001 permit
 
 bicycle;0001245560 yes allowed
 bicycle;0000452059 no
@@ -133,59 +179,130 @@ bicycle;0000324902 designated official
 bicycle;0000025707 dismount
 bicycle;0000020440 permissive
 bicycle;0000008286 private
-bicycle;0000001553 destination
+bicycle;0000001553 destination customers delivery
 bicycle;0000000719 use_sidepath use_cycleway
 bicycle;0000000385 mtb
-bicycle;0000000117 opposite
+bicycle;0000000001 permit
 
-motorcar;0000135124 no
-motorcar;0000045407 yes
-motorcar;0000021494 agricultural forestry
-motorcar;0000012090 destination
-motorcar;0000008733 private
-motorcar;0000005757 designated official
-motorcar;0000004116 permissive
-motorcar;0000000979 restricted
-motorcar;0000000100 psv
-motorcar;0000000100 hov
+smoothness;0000068136 good
+smoothness;0000042124 bad Bad
+smoothness;0000040763 intermediate
+smoothness;0000033941 excellent
+smoothness;0000012683 very_bad
+smoothness;0000009837 horrible terrible
+smoothness;0000003515 very_horrible
+smoothness;0000000919 impassable
+smoothness;0000000251 robust_wheels
+smoothness;0000000221 high_clearance
+smoothness;0000000132 very_good
+smoothness;0000000083 off_road_wheels
+smoothness;0000000057 medium Medium average
+smoothness;0000000048 poor
+smoothness;0000000039 rough
+
+tunnel;0000247305 yes
+tunnel;0000016890 building_passage
+tunnel;0000004237 no
+tunnel;0000000265 passage
+tunnel;0000000241 culvert
+tunnel;0000000122 avalanche_protector
+tunnel;0000000114 covered
+
+sidewalk;0000194579 none
+sidewalk;0000111468 both
+sidewalk;0000052950 right
+sidewalk;0000024489 left
+sidewalk;0000012916 no
+sidewalk;0000005725 separate
+sidewalk;0000001950 yes
+
+bridge;0001842517 yes viaduct true suspension
+bridge;0000000001 boardwalk
+bridge;0000000001 aqueduct
+bridge;0000000001 movable
+
+footway;0000104998 sidewalk
+footway;0000065943 crossing
+footway;0000012342 both
+footway;0000008363 none
+footway;0000005903 right
+footway;0000004159 left
+footway;0000003966 no
+footway;0000001093 yes
+footway;0000000558 separate
+
+railway;0000157547 rail
+railway;0000019316 abandoned disused razed
+railway;0000016982 tram
+railway;0000014387 platform
+railway;0000004623 light_rail
+railway;0000002982 subway
+railway;0000002422 narrow_gauge
+railway;0000001859 preserved
+railway;0000000001 funicular
+railway;0000000001 monorail
 
 motor_vehicle;0000212692 no
 motor_vehicle;0000184982 yes
 motor_vehicle;0000045128 private
-motor_vehicle;0000032622 agricultural forestry agricultural;forestry agricultural,forestry
+motor_vehicle;0000032622 agricultural forestry agricultural;forestry forestry;agricultural agricultural;destination
 motor_vehicle;0000025396 designated official
-motor_vehicle;0000025092 destination
+motor_vehicle;0000025092 destination customers delivery
 motor_vehicle;0000010895 permissive
 motor_vehicle;0000000175 emergency Emergency
-motor_vehicle;0000000100 psv
-motor_vehicle;0000000100 hov
+motor_vehicle;0000000001 permit
+
+motorcar;0000135124 no
+motorcar;0000045407 yes
+motorcar;0000021494 agricultural forestry agricultural;forestry
+motorcar;0000012090 destination delivery
+motorcar;0000008733 private
+motorcar;0000005757 designated official
+motorcar;0000004116 permissive
+motorcar;0000000979 restricted
+motorcar;0000000001 permit
 
 motorcycle;0000092079 no
 motorcycle;0000027978 yes
-motorcycle;0000014652 agricultural forestry
-motorcycle;0000008862 destination
+motorcycle;0000014652 agricultural forestry agricultural;forestry
+motorcycle;0000008862 destination delivery
 motorcycle;0000004877 designated official
 motorcycle;0000003936 private
 motorcycle;0000002209 permissive
-motorcycle;0000000100 psv
-motorcycle;0000000100 hov
+motorcycle;0000000001 permit
+
+moped;0000000001 no
+moped;0000000001 yes
+moped;0000000001 designated
+moped;0000000001 use_sidepath
+
+mofa;0000000001 no
+mofa;0000000001 yes
+mofa;0000000001 designated
+mofa;0000000001 use_sidepath
+
+atv;0000000001 no
+atv;0000000001 yes
+atv;0000000001 designated official
+atv;0000000001 private
+atv;0000000001 permissive
 
 vehicle;0000030218 no
-vehicle;0000013333 destination
+vehicle;0000013333 destination delivery customers
 vehicle;0000011692 yes
 vehicle;0000007147 agricultural forestry agricultural;forestry
 vehicle;0000006305 private
 vehicle;0000001294 permissive
 vehicle;0000000105 designated
 vehicle;0000000100 psv
-vehicle;0000000100 hov
+vehicle;0000000001 permit
+vehicle;0000000001 military
+vehicle;0000000001 emergency
 
 horse;0000227398 no
-horse;0000144432 yes
-horse;0000014566 designated
-horse;0000007223 permissive
+horse;0000144432 yes permissive
+horse;0000014566 designated official
 horse;0000004755 private
-horse;0000000983 official
 horse;0000000968 unknown
 horse;0000000205 destination
 
@@ -202,14 +319,32 @@ hgv;0000043783 no
 hgv;0000019115 destination
 hgv;0000005273 delivery
 hgv;0000003055 local
-hgv;0000001088 agricultural forestry
+hgv;0000001088 agricultural forestry agricultural;forestry
 hgv;0000000461 private
 hgv;0000000320 unsuitable
 hgv;0000000306 permissive
 
+agricultural;0000000001 no
+agricultural;0000000001 yes
+agricultural;0000000001 designated official
+agricultural;0000000001 permissive
+agricultural;0000000001 private
+agricultural;0000000001 destination delivery
+
+cycleway:both;0000000001 lane
+cycleway:both;0000000001 shared_lane
+cycleway:both;0000000001 no none
+cycleway:both;0000000001 track
+cycleway:both;0000000001 separate
+cycleway:both;0000000001 share_busway
+cycleway:both;0000000001 shared
+cycleway:both;0000000001 yes
+cycleway:both;0000000001 shoulder
+
 cycleway;0000137526 no
+cycleway;0000001883 none
 cycleway;0000124777 lane
-cycleway;0000106948 track
+cycleway;0000106948 track path
 cycleway;0000044652 opposite
 cycleway;0000011237 shared
 cycleway;0000007312 opposite_lane
@@ -217,41 +352,25 @@ cycleway;0000005737 shared_lane
 cycleway;0000002533 yes
 cycleway;0000002356 opposite_track
 cycleway;0000001945 share_busway
-cycleway;0000001883 none
 cycleway;0000001705 crossing
 cycleway;0000001560 unmarked_lane
 cycleway;0000001542 right
 cycleway;0000001291 segregated
 cycleway;0000001065 both
 cycleway;0000000892 left
-cycleway;0000000399 street
 cycleway;0000000344 shoulder
 cycleway;0000000326 designated
 cycleway;0000000247 proposed planned virtual
-cycleway;0000000224 cyclestreet
-cycleway;0000000172 path
 cycleway;0000000154 sidewalk
 
-footway;0000104998 sidewalk
-footway;0000065943 crossing
-footway;0000012342 both
-footway;0000008363 none
-footway;0000005903 right
-footway;0000004159 left
-footway;0000003966 no
-footway;0000001093 yes
-footway;0000000558 separate
+conveying;0000000001 yes reversible
+conveying;0000000001 backward
+conveying;0000000001 forward
+
+path;0000000001 crossing
 
 segregated;0000224960 no
 segregated;0000051124 yes
-
-sidewalk;0000194579 none
-sidewalk;0000111468 both
-sidewalk;0000052950 right
-sidewalk;0000024489 left
-sidewalk;0000012916 no
-sidewalk;0000005725 separate
-sidewalk;0000001950 yes
 
 mtb:scale;0000114272 0
 mtb:scale;0000068284 1
@@ -274,7 +393,7 @@ sac_scale;0000004549 alpine_hiking
 sac_scale;0000001620 demanding_alpine_hiking
 sac_scale;0000000831 yes
 sac_scale;0000000712 difficult_alpine_hiking
-sac_scale;0000000265 T1-hiking
+sac_scale;0000000001 T1-hiking
 
 noexit;0000118665 yes
 
@@ -293,22 +412,15 @@ junction;0000002134 jughandle
 junction;0000001493 approach
 junction;0000000100 circular
 
-bridge;0001842517 yes viaduct true suspension
+man_made;0000000001 pier
 
-tunnel;0000247305 yes
-tunnel;0000016890 building_passage
-tunnel;0000004237 no
-tunnel;0000000265 passage
-tunnel;0000000241 culvert
-tunnel;0000000122 avalanche_protector
-tunnel;0000000114 covered
+public_transport;0000000001 platform
 
 lcn;0000073956 yes
 lcn;0000002631 proposed
 
 oneway:bicycle;0000012034 no
 oneway:bicycle;0000005217 yes
-oneway:bicycle;0000000161 opposite
 
 cycleway:right;0000012522 lane Lane
 cycleway:right;0000006644 track
@@ -332,6 +444,30 @@ cycleway:left;0000000130 opposite_track
 cycleway:left;0000000053 opposite
 cycleway:left;0000000014 yes
 
+shoulder;0000000001 yes
+shoulder;0000000001 no
+shoulder;0000000001 right
+shoulder;0000000001 left
+shoulder;0000000001 both
+
+shoulder:right;0000000001 yes
+
+cycleway:lane;0000000001 advisory
+cycleway:lane;0000000001 exclusive
+cycleway:lane;0000000001 pictogram
+
+cycleway:both:lane;0000000001 advisory
+cycleway:both:lane;0000000001 exclusive
+cycleway:both:lane;0000000001 pictogram
+
+cycleway:right:lane;0000000001 advisory
+cycleway:right:lane;0000000001 exclusive
+cycleway:right:lane;0000000001 pictogram
+
+cycleway:left:lane;0000000001 advisory
+cycleway:left:lane;0000000001 exclusive
+cycleway:left:lane;0000000001 pictogram
+
 incline;0000052784 up
 incline;0000035413 down
 incline;0000001628 yes
@@ -341,9 +477,9 @@ incline;0000000724 5% 4 5 4%
 incline;0000000530 8% 6 7 8 6% 7%
 incline;0000003109 10% 9 10 9% 10°
 incline;0000001297 15% 11 12 13 14 15 11% 12% 13% 14%
-incline;0000000997 20% 16 17 18 19 20 16% 17% 18% 19%
+incline;0000000997 20% 16 17 18 19 20 16% 17% 18% 19% 10°
 incline;0000000409 25% 21 22 23 24 25 21% 22% 23% 24%
-incline;0000000263 30% 30 40 50 40% 50%
+incline;0000000263 30% 30 40 50 40% 50% 35%
 incline;0000000861 -3% -1 -2 -3 -1% -2% -3%
 incline;0000000724 -5% -4 -5 -4%
 incline;0000000530 -8% -6 -7 -8 -6% -7%
@@ -354,17 +490,7 @@ incline;0000000409 -25% -21 -22 -23 -24 -25 -21% -22% -23% -24%
 incline;0000000172 -30% -30 -40 -50 -40% -50%
 
 toll;0000090536 yes true
-
-railway;0000157547 rail
-railway;0000019316 abandoned
-railway;0000016982 tram
-railway;0000014387 platform
-railway;0000011143 disused
-railway;0000004623 light_rail
-railway;0000002982 subway
-railway;0000002422 narrow_gauge
-railway;0000001960 razed
-railway;0000001859 preserved
+toll:motorcycle;0000000001 no
 
 seamark:type;0001564 recommended_track
 seamark:type;0000522 fairway
@@ -375,7 +501,6 @@ waterway;0000007876 riverbank
 waterway;0000002202 weir
 waterway;0000001364 dam
 waterway;0000000386 lock
-waterway;0000000321 tidal_flat_slough
 waterway;0000000179 wadi
 waterway;0000000126 dock
 waterway;0000000113 fish_pass
@@ -394,29 +519,17 @@ motorboat;0000000808 no
 motorboat;0000000025 private privat
 
 route;0000000850 ferry
-route;0000000539 hiking
+route;0000000539 hiking foot
 route;0000000505 bicycle
-route;0000000454 ski
+route;0000000454 ski piste
 route;0000000413 mtb
 route;0000000194 canoe
 route;0000000151 road
 route;0000000104 bus
 
-smoothness;0000068136 good
-smoothness;0000042124 bad Bad
-smoothness;0000040763 intermediate
-smoothness;0000033941 excellent
-smoothness;0000012683 very_bad
-smoothness;0000009837 horrible terrible
-smoothness;0000003515 very_horrible
-smoothness;0000000919 impassable
-smoothness;0000000251 robust_wheels
-smoothness;0000000221 high_clearance
-smoothness;0000000132 very_good
-smoothness;0000000083 off_road_wheels
-smoothness;0000000057 medium Medium average
-smoothness;0000000048 poor
-smoothness;0000000039 rough
+obstacle;0000000001 vegetation
+obstacle;0000000001 fallen_tree
+obstacle;0000000001 bridge
 
 rcn;0000014518 yes
 rcn;0000002862 proposed
@@ -430,8 +543,8 @@ ford;0000000289 stepping_stones
 trail_visibility;0000067438 good
 trail_visibility;0000041280 intermediate
 trail_visibility;0000039801 excellent
-trail_visibility;0000023482 bad
-trail_visibility;0000005853 horrible
+trail_visibility;0000023482 bad poor
+trail_visibility;0000005853 horrible very_bad
 trail_visibility;0000002222 no
 
 class:bicycle:mtb;0000002079 1 +1
@@ -449,6 +562,22 @@ class:bicycle;0000000516 -2
 class:bicycle;0000000245 -3
 class:bicycle;0000000170 0
 class:bicycle;0000000108 3 +3
+
+bicycle:forward;0000000001 yes
+bicycle:forward;0000000001 designated
+bicycle:forward;0000000001 use_sidepath
+bicycle:forward;0000000001 no
+
+bicycle:backward;0000000001 yes
+bicycle:backward;0000000001 designated
+bicycle:backward;0000000001 use_sidepath
+bicycle:backward;0000000001 no
+
+speed_pedelec;0000000001 yes
+speed_pedelec;0000000001 designated
+speed_pedelec;0000000001 use_sidepath
+speed_pedelec;0000000001 no
+
 
 route_bicycle_icn;0000088753 yes
 route_bicycle_icn;0000000001 proposed
@@ -480,28 +609,6 @@ route_mtb_rcn;0000013321 yes
 route_mtb_mtb;0000006853 yes
 route_bicycle_mtb;0000002240 yes
 
-brouter_route_placeholder_dummy_01;0000000001 dummy
-brouter_route_placeholder_dummy_02;0000000001 dummy
-brouter_route_placeholder_dummy_03;0000000001 dummy
-brouter_route_placeholder_dummy_04;0000000001 dummy
-brouter_route_placeholder_dummy_05;0000000001 dummy
-brouter_route_placeholder_dummy_06;0000000001 dummy
-brouter_route_placeholder_dummy_07;0000000001 dummy
-brouter_route_placeholder_dummy_08;0000000001 dummy
-brouter_route_placeholder_dummy_09;0000000001 dummy
-brouter_route_placeholder_dummy_10;0000000001 dummy
-brouter_route_placeholder_dummy_11;0000000001 dummy
-brouter_route_placeholder_dummy_12;0000000001 dummy
-brouter_route_placeholder_dummy_13;0000000001 dummy
-brouter_route_placeholder_dummy_14;0000000001 dummy
-brouter_route_placeholder_dummy_15;0000000001 dummy
-brouter_route_placeholder_dummy_16;0000000001 dummy
-brouter_route_placeholder_dummy_17;0000000001 dummy
-brouter_route_placeholder_dummy_18;0000000001 dummy
-brouter_route_placeholder_dummy_19;0000000001 dummy
-brouter_route_placeholder_dummy_20;0000000001 dummy
-brouter_route_placeholder_dummy_21;0000000001 dummy
-
 ramp:bicycle;0000001305 yes both permissive right left
 ramp:bicycle;0000000385 no
 
@@ -514,13 +621,6 @@ ramp:wheelchair;0000000439 no
 ramp:luggage;0000000162 no
 ramp:luggage;0000000054 yes automatic manual
 
-estimated_traffic_class;0000000001 1
-estimated_traffic_class;0000000001 2
-estimated_traffic_class;0000000001 3
-estimated_traffic_class;0000000001 4
-estimated_traffic_class;0000000001 5
-estimated_traffic_class;0000000001 6
-estimated_traffic_class;0000000001 7
 
 mtb:scale:uphill;0000018869 0 0+ 0-
 mtb:scale:uphill;0000015578 1 1+ 1-
@@ -539,17 +639,7 @@ crossing;0000000457 marked
 crossing;0000000131 pedestrian_signals
 crossing;0000000122 no
 
-informal;0000002424 yes
-
-indoor;0000058418 yes
-indoor;0000025038 room
-indoor;0000005295 wall
-indoor;0000004322 corridor
-indoor;0000002410 area
-indoor;0000000816 column
-indoor;0000000568 no
-indoor;0000000129 shop
-indoor;0000000099 steps
+informal;0000002424 yes true
 
 4wd_only;0000008129 yes Yes
 4wd_only;0000000487 recommended
@@ -561,11 +651,30 @@ concrete;0000000013 lanes
 bus;0001178365 yes
 bus;0000006419 designated
 bus;0000005602 no
-bus;0000001424 urban
 
 psv;0000072077 yes
 psv;0000007456 no
 psv;0000007428 designated official
+
+piste:type;0000000001 downhill
+piste:type;0000000001 nordic
+piste:type;0000000001 skitour
+piste:type;0000000001 sled
+piste:type;0000000001 hiking
+piste:type;0000000001 sleigh
+piste:type;0000000001 connection
+
+piste:grooming;0000000001 classic skating classic;skating classic+skating
+piste:grooming;0000000001 backcountry
+piste:grooming;0000000001 scooter
+piste:grooming;0000000001 mogul
+
+piste:difficulty;0000000001 novice
+piste:difficulty;0000000001 easy
+piste:difficulty;0000000001 intermediate
+piste:difficulty;0000000001 advanced
+piste:difficulty;0000000001 expert
+piste:difficulty;0000000001 freeride
 
 hov;0000006684 lane
 hov;0000003258 designated
@@ -573,19 +682,24 @@ hov;0000002162 no
 hov;0000001512 yes
 
 busway;0000000000 opposite opposite_lane opposite_track
+busway;0000000001 lane
+busway;0000000001 yes track
 busway:left;0000000000 opposite opposite_lane opposite_track
+busway:left;0000000001 lane
 busway:right;0000000000 opposite opposite_lane opposite_track
+busway:right;0000000001 lane
 
 cycleway:left:oneway;0000000769 yes
 cycleway:left:oneway;0000001595 no
 cycleway:left:oneway;0000000927 -1
+cycleway:right:oneway;0000000001 -1
 
 cycleway:right:oneway;0000003084 yes
 cycleway:right:oneway;0000002499 no
 cycleway:right:oneway;0000000017 -1
 
 zone:maxspeed;0000001616 20 DE:20 FR:20
-zone:maxspeed;0000063721 30 DE:30 FR:30 BE:30 HU:30 NO:30 AT:30 ES:30 NL:30
+zone:maxspeed;0000063721 30 DE:30 FR:30 BE:30 HU:30 NO:30 AT:30 ES:30 NL:30 IT:30 CZ:30
 
 cycleway:surface;0000002609 asphalt
 cycleway:surface;0000000150 paved
@@ -593,40 +707,52 @@ cycleway:surface;0000000012 unpaved
 cycleway:surface;0000000010 gravel
 cycleway:surface;0000000157 concrete concrete:plates concrete:lanes
 cycleway:surface;0000002239 paving_stones paving_stones:30 paving_stones:20
-cycleway:surface;0000000011 cobblestone cobblestone:flattened
+cycleway:surface;0000000011 cobblestone cobblestone:flattened unhewn_cobblestone
 cycleway:surface;0000000013 compacted
 cycleway:surface;0000000006 fine_gravel
 cycleway:surface;0000000011 sett
 
-maxspeed:backward;0001058313 50 30_mph 30mph
-maxspeed:backward;0000860780 30 20_mph 20mph
-maxspeed:backward;0000025232 10 5 7 15
-maxspeed:backward;0000083989 20 10_mph 10mph 15_mph 15mph
+footway:surface;0000000001 asphalt
+footway:surface;0000000001 paved
+footway:surface;0000000001 unpaved
+footway:surface;0000000001 gravel
+footway:surface;0000000001 concrete concrete:plates concrete:lanes
+footway:surface;0000000001 paving_stones paving_stones:30
+footway:surface;0000000001 cobblestone unhewn_cobblestone
+footway:surface;0000000001 compacted
+footway:surface;0000000001 fine_gravel
+footway:surface;0000000001 sett
+footway:surface;0000000001 wood
+
+maxspeed:backward;0001058313 50 55 56 30_mph 30mph
+maxspeed:backward;0000860780 30 35 20_mph 20mph
+maxspeed:backward;0000025232 10 15 5 6 8 5_mph 6_mph
+maxspeed:backward;0000083989 20 25 10_mph 10mph 15_mph 15mph
 maxspeed:backward;0000195097 40 45 25_mph 25mph
-maxspeed:backward;0000204646 60 35_mph 35mph 40_mph 40mph
-maxspeed:backward;0000130108 70 45_mph 45mph
-maxspeed:backward;0000225071 80 50_mph 50mph
-maxspeed:backward;0000106719 90 55_mph 55mph
+maxspeed:backward;0000204646 60 65 35_mph 35mph 40_mph 40mph
+maxspeed:backward;0000130108 70 75 45_mph 45mph
+maxspeed:backward;0000225071 80 85 50_mph 50mph
+maxspeed:backward;0000106719 90 95 55_mph 55mph
 maxspeed:backward;0000134522 100 60_mph 60mph 65_mph 65mph
 maxspeed:backward;0000025242 110 70_mph 70mph
 maxspeed:backward;0000038763 120 75_mph 75mph
-maxspeed:backward;0000026953 130
+maxspeed:backward;0000026953 130 80_mph 79_mph
 maxspeed:backward;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
 maxspeed:backward;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
 
-maxspeed:forward;0001058313 50 30_mph 30mph
-maxspeed:forward;0000860780 30 20_mph 20mph
-maxspeed:forward;0000025232 10 5 7 15
-maxspeed:forward;0000083989 20 10_mph 10mph 15_mph 15mph
+maxspeed:forward;0001058313 50 55 56 30_mph 30mph
+maxspeed:forward;0000860780 30 35 20_mph 20mph
+maxspeed:forward;0000025232 10 15 5 6 8 5_mph 6_mph
+maxspeed:forward;0000083989 20 25 10_mph 10mph 15_mph 15mph
 maxspeed:forward;0000195097 40 45 25_mph 25mph
-maxspeed:forward;0000204646 60 35_mph 35mph 40_mph 40mph
-maxspeed:forward;0000130108 70 45_mph 45mph
-maxspeed:forward;0000225071 80 50_mph 50mph
-maxspeed:forward;0000106719 90 55_mph 55mph
+maxspeed:forward;0000204646 60 65 35_mph 35mph 40_mph 40mph
+maxspeed:forward;0000130108 70 75 45_mph 45mph
+maxspeed:forward;0000225071 80 85 50_mph 50mph
+maxspeed:forward;0000106719 90 95 55_mph 55mph
 maxspeed:forward;0000134522 100 60_mph 60mph 65_mph 65mph
 maxspeed:forward;0000025242 110 70_mph 70mph
 maxspeed:forward;0000038763 120 75_mph 75mph
-maxspeed:forward;0000026953 130
+maxspeed:forward;0000026953 130 80_mph 79_mph
 maxspeed:forward;0000138654 urban RO:urban RU:urban FR:urban IT:urban AT:urban DE:urban UA:urban
 maxspeed:forward;0000138654 rural RO:rural RU:rural FR:rural IT:rural AT:rural DE:rural UA:rural
 
@@ -636,11 +762,41 @@ embedded_rails;0000000003 rail
 
 living_street;0000000404 yes
 
-sidewalk:bicycle;0000000439 yes designated
-sidewalk:left:bicycle;0000001722 yes designated
-sidewalk:right:bicycle;0000002667 yes designated
+sidewalk:bicycle;0000000439 yes
+sidewalk:bicycle;0000000439 designated
 
-bicycle_road;0000006521 yes designated
+sidewalk:left:bicycle;0000001722 yes
+sidewalk:left:bicycle;0000001722 designated
+sidewalk:right:bicycle;0000002667 yes
+sidewalk:right:bicycle;0000002667 designated
+
+sidewalk:left;0000000001 no
+sidewalk:left;0000000001 separate
+sidewalk:left;0000000001 yes
+sidewalk:left;0000000001 designated
+sidewalk:right;0000000001 no
+sidewalk:right;0000000001 separate
+sidewalk:right;0000000001 yes
+sidewalk:right;0000000001 designated
+sidewalk:both;0000000001 no
+sidewalk:both;0000000001 yes
+sidewalk:both;0000000001 separate
+
+bicycle_road;0000006521 yes
+bicycle_road;0000006521 designated
+
+cyclestreet;0000000001 yes
+cyclestreet;0000000001 designated
+
+traffic_calming;0000000001 bump
+traffic_calming;0000000001 hump
+traffic_calming;0000000001 table
+traffic_calming;0000000001 yes
+traffic_calming;0000000001 cushion
+traffic_calming;0000000001 rumble_strip
+traffic_calming;0000000001 choker
+traffic_calming;0000000001 chicane
+traffic_calming;0000000001 choked_table
 
 construction;0000144871 yes
 construction;0000008214 minor
@@ -648,76 +804,25 @@ construction;0029035962 residential
 construction;0010319731 service
 construction;0007688809 track
 construction;0007656124 unclassified
-construction;0004141444 footway
-construction;0003493551 tertiary
+construction;0004141444 footway pedestrian
+construction;0003493551 tertiary tertiary_link
 construction;0002852601 path
-construction;0002185240 secondary
-construction;0001447719 primary
+construction;0002185240 secondary secondary_link
+construction;0001447719 primary primary_link
 construction;0000699577 cycleway
-construction;0000608469 trunk
+construction;0000608469 trunk trunk_link
 construction;0000568118 living_street
-construction;0000515044 motorway
-construction;0000451760 motorway_link
+construction;0000515044 motorway motorway_link
 construction;0000442502 steps
-construction;0000360177 road
-construction;0000318426 pedestrian
-construction;0000210535 trunk_link
-construction;0000192461 primary_link
-construction;0000120758 secondary_link
-construction;0000079637 tertiary_link
-construction;0000070238 construction
-construction;0000058257 bridleway
-construction;0000039003 platform
-construction;0000037192 proposed
-construction;0000010307 raceway
-construction;0000003152 rest_area
-construction;0000002942 abandoned
-construction;0000002631 services
-construction;0000002133 corridor
-construction;0000002093 crossing
-construction;0000001440 bus_stop
-construction;0000001274 yes
-construction;0000000679 unsurfaced
-construction;0000000108 byway
-construction;0000000037 driveway
-construction;0000000021 mini_roundabout
-construction;0000000020 turning_loop
-
-estimated_forest_class;0000000001 1
-estimated_forest_class;0000000001 2
-estimated_forest_class;0000000001 3
-estimated_forest_class;0000000001 4
-estimated_forest_class;0000000001 5
-estimated_forest_class;0000000001 6
-
-estimated_noise_class;0000000001 1
-estimated_noise_class;0000000001 2
-estimated_noise_class;0000000001 3
-estimated_noise_class;0000000001 4
-estimated_noise_class;0000000001 5
-estimated_noise_class;0000000001 6
-
-estimated_river_class;0000000001 1
-estimated_river_class;0000000001 2
-estimated_river_class;0000000001 3
-estimated_river_class;0000000001 4
-estimated_river_class;0000000001 5
-estimated_river_class;0000000001 6
-
-estimated_town_class;0000000001 1
-estimated_town_class;0000000001 2
-estimated_town_class;0000000001 3
-estimated_town_class;0000000001 4
-estimated_town_class;0000000001 5
-estimated_town_class;0000000001 6
+construction;0000360177 road highway
 
 
- ---context:node
+---context:node
 
 highway;0001314954 bus_stop
 highway;0001130090 crossing
 highway;0001031274 turning_circle
-highway;0000609262 traffic_signals
+highway;0000609262 traffic_signals traffic_signals;crossing
 highway;0000306900 street_lamp
 highway;0000136339 stop
 highway;0000105097 motorway_junction
@@ -735,46 +840,33 @@ highway;0000002572 turning_loop
 highway;0000002540 steps
 highway;0000002493 services
 highway;0000002133 emergency_bay
-highway;0000001372 residential
-highway;0000001324 street_light
-highway;0000001147 incline_steep
-highway;0000001101 stile
-highway;0000000904 incline
-highway;0000000819 service
-highway;0000000817 traffic_calming
-highway;0000000662 path
-highway;0000000603 footway
-highway;0000000438 track
-highway;0000000436 no
-highway;0000000353 door
-highway;0000000283 level_crossing
-highway;0000000267 yes
-highway;0000000262 road
 highway;0000000244 construction
-highway;0000000214 unclassified
 highway;0000000213 proposed
-highway;0000000197 junction
-highway;0000000176 distance_marker
-highway;0000000158 noexit
 highway;0000000155 unknown
 highway;0000000134 traffic_sign
-highway;0000000123 tertiary
 highway;0000000115 trailhead
-highway;0000000113 priority_to_right
-highway;0000000113 culvert
-highway;0000000100 <residential>
+
 highway;0000000046 toll_bridge
 highway;0000000037 city_entry
 highway;0000002967 traffic_mirror
 highway;0000001724 priority
+highway;0000000001 toll_gantry
 
-barrier;0000606512 gate
+estimated_crossing_class;0000000001 0
+estimated_crossing_class;0000000001 1
+estimated_crossing_class;0000000001 2
+estimated_crossing_class;0000000001 3
+estimated_crossing_class;0000000001 4
+estimated_crossing_class;0000000001 5
+estimated_crossing_class;0000000001 6
+
+barrier;0000606512 gate wicket_gate
 barrier;0000164120 bollard
 barrier;0000112184 lift_gate
 barrier;0000046779 stile
 barrier;0000046255 cycle_barrier
 barrier;0000038597 entrance
-barrier;0000027579 block
+barrier;0000027579 block stone rock
 barrier;0000023074 toll_booth
 barrier;0000016782 cattle_grid
 barrier;0000016154 kissing_gate
@@ -789,13 +881,12 @@ barrier;0000001912 bump_gate
 barrier;0000001856 yes
 barrier;0000001683 hampshire_gate
 barrier;0000000445 wall
-barrier;0000000440 bus_trap
+barrier;0000000440 bus_trap sump_buster
 barrier;0000000435 ditch
 barrier;0000000420 debris
 barrier;0000000381 log
 barrier;0000000336 chicane
 barrier;0000000316 kerb
-barrier;0000000270 sump_buster
 barrier;0000000268 obstacle
 barrier;0000000223 no
 barrier;0000000213 horse_stile
@@ -813,24 +904,38 @@ barrier;0000000118 jersey_barrier
 barrier;0000000114 motorcycle_barrier
 barrier;0000000114 barrier
 barrier;0000000108 rope
-barrier;0000000095 stone
-barrier;0000000069 traffic_crossing_pole
+barrier;0000000001 height_restrictor
+barrier;0000000001 sliding_gate slide_gate
+
+entrance;0000301732 yes entrance
+entrance;0000159853 main main_entrance
+entrance;0000025621 staircase
+entrance;0000006666 home residence
+entrance;0000005428 service
+entrance;0000001853 emergency
+entrance;0000001144 exit
+entrance;0000000620 garage
+entrance;0000000285 shop
+entrance;0000000001 secondary
+
+crossing;0000251032 uncontrolled
+crossing;0000200387 traffic_signals traffic_signals;marked
+crossing;0000029717 unmarked
+crossing;0000022119 island
+crossing;0000006981 zebra
+crossing;0000003897 no
+crossing;0000002166 yes
+crossing;0000000001 marked
 
 
 access;0000078544 private
 access;0000014933 yes public
 access;0000014456 no
 access;0000008670 permissive
-access;0000006316 destination customers
+access;0000006316 destination customers delivery
 access;0000000973 agricultural forestry
 access;0000000942 designated official
-
-foot;0000272169 yes
-foot;0000036271 no
-foot;0000001118 designated official
-foot;0000000960 private
-foot;0000000833 permissive
-foot;0000000127 destination
+access;0000000001 permit
 
 bicycle;0000267569 yes
 bicycle;0000067796 no
@@ -839,6 +944,36 @@ bicycle;0000002596 dismount
 bicycle;0000000498 permissive
 bicycle;0000000359 private
 bicycle;0000000075 destination
+
+foot;0000272169 yes
+foot;0000036271 no
+foot;0000001118 designated official
+foot;0000000960 private
+foot;0000000833 permissive
+foot;0000000127 destination customers
+
+noexit;0000195286 yes
+
+traffic_signals:direction;0000062645 forward
+traffic_signals:direction;0000033961 backward
+traffic_signals:direction;0000007309 both forward;backward backward;forward
+
+traffic_calming;0000045987 bump bump;choker mini_bumps
+traffic_calming;0000040022 hump hump;choker
+traffic_calming;0000012499 table table;choker
+traffic_calming;0000006808 yes
+traffic_calming;0000005754 cushion cushion;choker
+traffic_calming;0000005466 choker choker;cushion choker;hump choker;table choker;bump
+traffic_calming;0000005305 island
+traffic_calming;0000004686 chicane
+traffic_calming;0000004032 rumble_strip
+traffic_calming;0000000186 dip double_dip
+traffic_calming;0000000001 choked_table
+
+traffic_signals;0000000001 signal traffic_lights pedestrian_crossing yes crossing junction level_crossing crossing_only pedestrian normal signals on_demand crossing_on_demand
+traffic_signals;0000000001 blinker emergency no blink_mode continuous_green blink emergency_priority
+traffic_signals;0000000001 tram_priority bus_priority stop tram_priority;blinker
+traffic_signals;0000000001 ramp_meter
 
 motorcar;0000038901 yes
 motorcar;0000009323 no
@@ -851,18 +986,19 @@ motorcar;0000000084 designated official
 motor_vehicle;0000000066 yes
 motor_vehicle;0000000001 permissive
 motor_vehicle;0000000000 designated official
-motor_vehicle;0000000030 destination
+motor_vehicle;0000000030 destination customers delivery
 motor_vehicle;0000000073 agricultural forestry
 motor_vehicle;0000000136 private
 motor_vehicle;0000000469 no
+motor_vehicle;0000000001 permit
 
 motorcycle;0000028697 yes
 motorcycle;0000007061 no
 motorcycle;0000000243 private
 motorcycle;0000000237 designated
 motorcycle;0000000117 destination
-motorcycle;0000000080 permissive
 motorcycle;0000000029 agricultural forestry
+motorcycle;0000000001 permissive
 
 vehicle;0000002176 no
 vehicle;0000000576 yes
@@ -872,12 +1008,10 @@ vehicle;0000000138 agricultural forestry
 vehicle;0000000105 permissive
 vehicle;0000000003 designated official
 
-horse;0000021837 yes
+horse;0000021837 yes permissive
 horse;0000010811 no
 horse;0000000105 private
-horse;0000000065 permissive
 horse;0000000053 designated official
-horse;0000000009 critical
 horse;0000000007 destination
 
 wheelchair;0000203478 yes true
@@ -885,27 +1019,21 @@ wheelchair;0000100082 no false
 wheelchair;0000080430 limited
 wheelchair;0000002769 designated official
 wheelchair;0000000005 private
-wheelchair;0000000005 permissive
 wheelchair;0000000139 bad
 wheelchair;0000000031 half
 wheelchair;0000000005 partial
 
+kerb;0000000001 lowered
+kerb;0000000001 flush no
+kerb;0000000001 raised
+kerb;0000000001 rolled
+
 hgv;0000001141 no
-hgv;0000000359 yes true
-hgv;0000000111 destination
+hgv;0000000359 yes true permissive
+hgv;0000000111 destination delivery
 hgv;0000000108 designated official
 hgv;0000000065 private
-hgv;0000000053 delivery
 hgv;0000000016 agricultural forestry
-hgv;0000000010 permissive
-
-crossing;0000251032 uncontrolled
-crossing;0000200387 traffic_signals
-crossing;0000029717 unmarked
-crossing;0000022119 island
-crossing;0000006981 zebra
-crossing;0000003897 no
-crossing;0000002166 yes
 
 railway;0000312710 level_crossing
 railway;0000078746 station
@@ -913,55 +1041,35 @@ railway;0000067876 buffer_stop
 railway;0000056184 switch
 railway;0000049600 crossing
 railway;0000037871 tram_stop
-railway;0000024038 halt
+railway;0000024038 halt stop
 railway;0000014285 subway_entrance
 railway;0000010890 signal
+railway;0000000001 funicular
 
 waterway;0000004698 weir
 waterway;0000001647 lock_gate
 waterway;0000000425 waterfall
-waterway;0000000337 take_right_side
-waterway;0000000332 take_left_side
-waterway;0000000219 milestone
-waterway;0000000187 depth
 waterway;0000000170 lock
 
-noexit;0000195286 yes
-
-entrance;0000301732 yes
-entrance;0000159853 main
-entrance;0000025621 staircase
-entrance;0000006666 home
-entrance;0000005428 service
-entrance;0000001853 emergency
-entrance;0000001144 exit
-entrance;0000000953 residence
-entrance;0000000620 garage
-entrance;0000000558 entrance
-entrance;0000000504 main_entrance
-entrance;0000000439 secondary_entrance
-entrance;0000000285 shop
-entrance;0000000258 private
-
-traffic_calming;0000045987 bump bump;choker
-traffic_calming;0000040022 hump hump;choker
-traffic_calming;0000012499 table table;choker
-traffic_calming;0000006808 yes *
-traffic_calming;0000005754 cushion cushion;choker
-traffic_calming;0000005466 choker choker;cushion choker;hump choker;table choker;bump
-traffic_calming;0000005305 island
-traffic_calming;0000004686 chicane
-traffic_calming;0000004032 rumble_strip
-traffic_calming;0000000847 speed_bump
-traffic_calming;0000000186 dip
+surface;0000000001 asphalt
+surface;0000000001 paved paving_stones sett cobblestone
+surface;0000000001 unpaved compacted gravel grass ground
 
 ford;0000037927 yes
 ford;0000000310 stepping_stones
 
 direction;0000274642 forward
 direction;0000249637 backward
-direction;0000021634 both
+direction;0000021634 both forward;backward backward;forward
 
-traffic_signals:direction;0000062645 forward
-traffic_signals:direction;0000033961 backward
-traffic_signals:direction;0000007309 both
+traffic_sign:direction;0000000001 forward
+traffic_sign:direction;0000000001 backward
+traffic_sign:direction;0000000001 both forward;backward backward;forward
+
+give_way:direction;0000000001 forward
+give_way:direction;0000000001 backward
+
+stop:direction;0000000001 forward
+stop:direction;0000000001 backward
+
+monitoring:bicycle;0000000001 yes induction_loop


### PR DESCRIPTION
## Description
- Adds `lookups.dat` for routing file version 11
- Adds `BRouterLookupsDownloader` to update `lookups.dat` alongside tile updates in the future
