### PR TITLE
rel #17995: serialize SAF subdir creation and use case-insensitive lookup

### DIFF
--- a/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DocumentContentAccessor.java
@@ -63,6 +63,11 @@ class DocumentContentAccessor extends AbstractContentAccessor {
             DocumentsContract.Document.COLUMN_SIZE
     };
 
+    /**
+     * Lock object used to serialize directory creation operations and avoid duplicate directories
+     * when multiple threads attempt to create the same subdirectory concurrently (e.g. parallel Wherigo downloads).
+     */
+    private final Object subdirCreationLock = new Object();
 
     /**
      * cache for Uri permissions
@@ -369,23 +374,58 @@ class DocumentContentAccessor extends AbstractContentAccessor {
     }
 
     private Uri findCreateSubdirectory(final Uri dirUri, final String dirName, final boolean createIfNotExisting) throws IOException {
-        final List<Uri> result = queryDir(dirUri, new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME, DocumentsContract.Document.COLUMN_MIME_TYPE}, c -> {
-            if (dirName.equals(c.getString(1)) && DocumentsContract.Document.MIME_TYPE_DIR.equals(c.getString(2))) {
-                return DocumentsContract.buildDocumentUriUsingTree(dirUri, c.getString(0));
+        synchronized (subdirCreationLock) {
+            final Uri existing = findDocumentByName(dirUri, dirName);
+            if (existing != null) {
+                // Check whether the existing document is actually a directory
+                final ContentStorage.FileInformation info = getFileInfo(existing, null);
+                if (info != null && info.isDirectory) {
+                    return existing;
+                }
+
+                // A non-directory document with the same name exists – creating a directory would
+                // cause the provider to auto-rename it (e.g. "wherigo (1)"). Bail out instead.
+                Log.w("Cannot create dir '" + dirName + "' in '" + dirUri + "': a non-directory document with that name already exists");
+                return null;
+            }
+
+            if (!createIfNotExisting) {
+                return null;
+            }
+
+            try {
+                final Uri created = DocumentsContract.createDocument(getContext().getContentResolver(), dirUri, DocumentsContract.Document.MIME_TYPE_DIR, dirName);
+                if (created != null) {
+                    Log.d("Create dir '" + dirName + "' in '" + dirUri + "': " + created);
+                } else {
+                    Log.w("Cannot create dir '" + dirName + "' in '" + dirUri + "': DocumentsContract.createDocument returned null");
+                }
+                return created;
+            } catch (RuntimeException re) {
+                Log.e("Cannot create dir '" + dirName + "' in '" + dirUri + "'", re);
             }
             return null;
+        }
+    }
 
-        });
-        for (Uri uri : result) {
+    /**
+     * Returns the URI of the first child document (file or directory) of {@code dirUri} whose
+     * display name matches {@code name} case-insensitively, or {@code null} if no such child exists.
+     */
+    private Uri findDocumentByName(final Uri dirUri, final String name) throws IOException {
+        final List<Uri> result = queryDir(dirUri,
+                new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME},
+                c -> {
+                    // lookup – case-insensitive to cope with SAF provider quirks
+                    if (name.equalsIgnoreCase(c.getString(1))) {
+                        return DocumentsContract.buildDocumentUriUsingTree(dirUri, c.getString(0));
+                    }
+                    return null;
+                });
+
+        for (final Uri uri : result) {
             if (uri != null) {
                 return uri;
-            }
-        }
-        if (createIfNotExisting) {
-            try {
-                return DocumentsContract.createDocument(getContext().getContentResolver(), dirUri, DocumentsContract.Document.MIME_TYPE_DIR, dirName);
-            } catch (RuntimeException re) {
-                Log.e("Could not create dir '" + dirName + "' in '" + dirUri + "'", re);
             }
         }
         return null;


### PR DESCRIPTION
cherry-picked version of pr #18001 for `release`

* rel #17995: case-insensitive-comparison and lock on findCreateSubdirectory
* Use full URI for logging
* On finding directory, check also for files with equal name
