### PR TITLE
Update jsoup to 1.22.2

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -370,7 +370,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
     // Jsoup HTML parsing
-    implementation 'org.jsoup:jsoup:1.22.1'
+    implementation 'org.jsoup:jsoup:1.22.2'
 
      // GeoJson parsing: https://github.com/cocoahero/android-geojson
     implementation 'com.cocoahero.android:geojson:1.0.1@jar'

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -155,11 +155,6 @@
 # keep classes of metadata libaray (this lib heavily uses reflection)
 -keep class com.drew.** { *; }
 
-# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
-# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
-# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
--dontwarn com.google.re2j.**
-
 # Whitelist MPAndroidChart
 # Preserve all public classes and methods
 -keep class com.github.mikephil.charting.** { *; }

--- a/main/src/androidTest/java/cgeo/geocaching/address/GeocoderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/address/GeocoderTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class GeocoderTest {
 
-    private static final String TEST_ADDRESS = "46 rue Barrault, Paris, France";
+    private static final String TEST_ADDRESS = "46 Rue Vergniaud, Paris, France";
     private static final double TEST_LATITUDE = 48.82622;
-    private static final double TEST_LONGITUDE = 2.34644;
+    private static final double TEST_LONGITUDE = 2.34534;
     private static final Geopoint TEST_COORDS = new Geopoint(TEST_LATITUDE, TEST_LONGITUDE);
     private static final Offset<Double> TEST_OFFSET = Offset.offset(0.00050);
 
@@ -62,7 +62,7 @@ public class GeocoderTest {
             assertThat(address.getLatitude()).as(describe("latitude", geocoder)).isCloseTo(TEST_LATITUDE, TEST_OFFSET);
             assertThat(address.getLongitude()).as(describe("longitude", geocoder)).isCloseTo(TEST_LONGITUDE, TEST_OFFSET);
             if (withAddress) {
-                assertThat(StringUtils.lowerCase(address.getAddressLine(0))).as(describe("street address", geocoder)).contains("barrault");
+                assertThat(StringUtils.lowerCase(address.getAddressLine(0))).as(describe("street address", geocoder)).contains("vergniaud");
                 assertThat(address.getLocality()).as(describe("locality", geocoder)).isEqualTo("Paris");
                 assertThat(address.getCountryCode()).as(describe("country code", geocoder)).isEqualTo("FR");
                 // don't assert on country name, as this can be localized, e.g. with the mapquest geocoder
@@ -84,5 +84,4 @@ public class GeocoderTest {
     private static String describe(final String field, final String geocoder) {
         return field + " for " + geocoder + " .geocoder";
     }
-
 }

--- a/main/src/androidTest/java/cgeo/geocaching/address/GeocoderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/address/GeocoderTest.java
@@ -7,13 +7,12 @@ import cgeo.geocaching.utils.Log;
 import android.location.Address;
 import android.location.Geocoder;
 
-import androidx.test.filters.Suppress;
-
 import java.util.Locale;
 
 import io.reactivex.rxjava3.core.Single;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.data.Offset;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -43,7 +42,7 @@ public class GeocoderTest {
         }
     }
 
-    @Suppress // Suppress test for now as our CI cannot connect to our api server currently
+    @Ignore // Ignore test for now as our CI cannot connect to our api server currently
     @Test
     public void testOsmNominatumGeocoder() {
         final Locale locale = Locale.getDefault();

--- a/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTestHelpers.java
+++ b/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTestHelpers.java
@@ -9,8 +9,6 @@ import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.models.Geocache;
 
-import androidx.test.filters.Suppress;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
@@ -18,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -35,7 +34,7 @@ public class DataStoreTestHelpers {
     /**
      * Method creates dummy caches in the database
      */
-    @Suppress
+    @Ignore
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     public void testCreateDummyCaches() {
@@ -57,7 +56,7 @@ public class DataStoreTestHelpers {
         }
     }
 
-    @Suppress
+    @Ignore
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     public void testRemoveDummyCaches() {
@@ -71,9 +70,7 @@ public class DataStoreTestHelpers {
             dummyCacheCodes.add(getArtificialGeocode(i));
         }
         DataStore.removeCaches(dummyCacheCodes, EnumSet.of(LoadFlags.RemoveFlag.DB));
-
     }
-
 
     private static List<LogEntry> createDummyLogsForCache(final String geocode, final int count) {
         final List<LogEntry> result = new ArrayList<>();

--- a/main/src/main/java/cgeo/geocaching/ImageEditActivity.java
+++ b/main/src/main/java/cgeo/geocaching/ImageEditActivity.java
@@ -54,6 +54,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
     private static final String SAVED_STATE_IMAGE_INDEX = "cgeo.geocaching.saved_state_image_index";
     private static final String SAVED_STATE_IMAGE_SCALE = "cgeo.geocaching.saved_state_image_scale";
     private static final String SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE = "cgeo.geocaching.saved_state_max_image_upload_size";
+    private static final String SAVED_STATE_MAX_CAPTION_LENGTH = "cgeo.geocaching.saved_state_max_caption_length";
+    private static final String SAVED_STATE_MAX_DESCRIPTION_LENGTH = "cgeo.geocaching.saved_state_max_description_length";
     private static final String SAVED_STATE_GEOCODE = "cgeo.geocaching.saved_state_geocode";
     private static final String SAVED_STATE_IMAGE_ORIENTATION = "cgeo.geocaching.saved_state_image_orientation";
     private static final String SAVED_STATE_SAVED_IMAGE_ORIENTATION = "cgeo.geocaching.saved_state_saved_image_orientation";
@@ -66,6 +68,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
     private ViewOrientation savedImageOrientation;
     private int imageIndex = -1;
     private long maxImageUploadSize;
+    private int maxCaptionLength;
+    private int maxDescriptionLength;
 
     @Nullable private String geocode;
 
@@ -97,6 +101,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
             originalLocalUri = UriUtils.isLocalUri(originalImageUri) ? originalImageUri : null;
             imageIndex = extras.getInt(Intents.EXTRA_INDEX, -1);
             maxImageUploadSize = extras.getLong(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE);
+            maxCaptionLength = extras.getInt(Intents.EXTRA_MAX_IMAGE_CAPTION_LENGTH, 50);
+            maxDescriptionLength = extras.getInt(Intents.EXTRA_MAX_IMAGE_DESCRIPTION_LENGTH, 250);
             geocode = extras.getString(Intents.EXTRA_GEOCODE);
             imageOrientation = ImageUtils.getImageOrientation(image.getUri());
             savedImageOrientation = imageOrientation.clone();
@@ -111,6 +117,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
             imageIndex = savedInstanceState.getInt(SAVED_STATE_IMAGE_INDEX, -1);
             imageScale.set(savedInstanceState.getInt(SAVED_STATE_IMAGE_SCALE));
             maxImageUploadSize = savedInstanceState.getLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE);
+            maxCaptionLength = savedInstanceState.getInt(SAVED_STATE_MAX_CAPTION_LENGTH, 50);
+            maxDescriptionLength = savedInstanceState.getInt(SAVED_STATE_MAX_DESCRIPTION_LENGTH, 250);
             geocode = savedInstanceState.getString(SAVED_STATE_GEOCODE);
             imageOrientation = savedInstanceState.getParcelable(SAVED_STATE_IMAGE_ORIENTATION);
             savedImageOrientation = savedInstanceState.getParcelable(SAVED_STATE_SAVED_IMAGE_ORIENTATION);
@@ -124,11 +132,15 @@ public class ImageEditActivity extends AbstractActionBarActivity {
         } else {
             imageScale.set(image.targetScale);
         }
+
         imageCache.setCode(geocode);
 
         binding.imageRotate.setOnClickListener(view -> rotate90Clockwise());
         binding.imageFlip.setOnClickListener(view -> flipHorizontal());
         binding.imageEditExternal.setOnClickListener(view -> editExternal());
+
+        // Apply restrictions for length
+        applyLengthRestrictions();
 
         if (image.hasTitle()) {
             binding.caption.setText(image.getTitle());
@@ -180,6 +192,8 @@ public class ImageEditActivity extends AbstractActionBarActivity {
         outState.putInt(SAVED_STATE_IMAGE_INDEX, imageIndex);
         outState.putInt(SAVED_STATE_IMAGE_SCALE, imageScale.get());
         outState.putLong(SAVED_STATE_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
+        outState.putInt(SAVED_STATE_MAX_CAPTION_LENGTH, maxCaptionLength);
+        outState.putInt(SAVED_STATE_MAX_DESCRIPTION_LENGTH, maxDescriptionLength);
         outState.putString(SAVED_STATE_GEOCODE, geocode);
         outState.putParcelable(SAVED_STATE_IMAGE_ORIENTATION, imageOrientation);
         outState.putParcelable(SAVED_STATE_SAVED_IMAGE_ORIENTATION, savedImageOrientation);
@@ -360,6 +374,15 @@ public class ImageEditActivity extends AbstractActionBarActivity {
                 })
                 .start();
 
+    }
+
+    private void applyLengthRestrictions() {
+        // Set default values if not loaded from intent or savedInstanceState
+        final int validMaxCaptionLength = maxCaptionLength != 0 ? maxCaptionLength : 50;
+        ViewUtils.setMaxTextLength(binding.caption, binding.captionLayout, validMaxCaptionLength);
+
+        final int validMaxDescriptionLength = maxDescriptionLength != 0 ? maxDescriptionLength : 250;
+        ViewUtils.setMaxTextLength(binding.description, binding.descriptionLayout, validMaxDescriptionLength);
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/Intents.java
+++ b/main/src/main/java/cgeo/geocaching/Intents.java
@@ -31,6 +31,8 @@ public class Intents {
     public static final String EXTRA_FIELD = PREFIX + "field";
     public static final String EXTRA_IMAGES = PREFIX + "images";
     public static final String EXTRA_MAX_IMAGE_UPLOAD_SIZE = PREFIX + "max-image-upload-size";
+    public static final String EXTRA_MAX_IMAGE_CAPTION_LENGTH = PREFIX + "max-image-caption-length";
+    public static final String EXTRA_MAX_IMAGE_DESCRIPTION_LENGTH = PREFIX + "max-image-description-length";
     public static final String EXTRA_ID = PREFIX + "id";
     public static final String EXTRA_KEYWORD = PREFIX + "keyword";
     public static final String EXTRA_KEYWORD_SEARCH = PREFIX + "keyword_search";

--- a/main/src/main/java/cgeo/geocaching/connector/AbstractLoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/AbstractLoggingManager.java
@@ -125,6 +125,16 @@ public abstract class AbstractLoggingManager implements ILoggingManager {
     }
 
     @Override
+    public int getMaxImageCaptionLength() {
+        return 50;
+    }
+
+    @Override
+    public int getMaxImageDescriptionLength() {
+        return 250;
+    }
+
+    @Override
     public boolean canLogReportType(@NonNull final ReportProblemType reportType) {
         return false;
     }

--- a/main/src/main/java/cgeo/geocaching/connector/ILoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/ILoggingManager.java
@@ -94,6 +94,10 @@ public interface ILoggingManager {
 
     boolean isImageCaptionMandatory();
 
+    int getMaxImageCaptionLength();
+
+    int getMaxImageDescriptionLength();
+
     @NonNull
     List<ReportProblemType> getReportProblemTypes(@NonNull Geocache geocache);
 

--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCLoggingManager.java
@@ -233,6 +233,12 @@ class GCLoggingManager extends AbstractLoggingManager {
     public boolean supportsLogWithTrackables() {
         return true;
     }
+
+    @Override
+    public int getMaxImageDescriptionLength() {
+        return 125;
+    }
+
     @NonNull
     @Override
     public List<ReportProblemType> getReportProblemTypes(@NonNull final Geocache geocache) {

--- a/main/src/main/java/cgeo/geocaching/list/AbstractList.java
+++ b/main/src/main/java/cgeo/geocaching/list/AbstractList.java
@@ -4,18 +4,26 @@ import android.util.SparseArray;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 
 public abstract class AbstractList {
 
     public final int id;
     @NonNull
     public final String title;
+    @StringRes
+    protected final int titleResourceId;
     public final int markerId;
     private static final SparseArray<AbstractList> LISTS = new SparseArray<>();
 
-    public AbstractList(final int id, @NonNull final String title, @NonNull final int markerId) {
+    public AbstractList(final int id, @NonNull final String title, final int markerId) {
+        this(id, title, 0, markerId);
+    }
+
+    public AbstractList(final int id, @NonNull final String title, @StringRes final int titleResourceId, final int markerId) {
         this.id = id;
         this.title = title;
+        this.titleResourceId = titleResourceId;
         this.markerId = markerId;
         LISTS.put(id, this);
     }

--- a/main/src/main/java/cgeo/geocaching/list/PseudoList.java
+++ b/main/src/main/java/cgeo/geocaching/list/PseudoList.java
@@ -46,17 +46,21 @@ public abstract class PseudoList extends AbstractList {
      * private constructor to have all instances as constants in the class
      */
     private PseudoList(final int id, @StringRes final int titleResourceId, @DrawableRes final int iconResId) {
-        super(id, LocalizationUtils.getString(titleResourceId), iconResId);
+        super(id, "", titleResourceId, iconResId);
     }
 
     @Override
     public String getTitleAndCount() {
-        return "<" + title + ">";
+        return "<" + getTitle() + ">";
     }
 
     @Override
     @NonNull
     public String getTitle() {
+        // Dynamically retrieve the localized string to support language changes
+        if (titleResourceId != 0) {
+            return LocalizationUtils.getString(titleResourceId);
+        }
         return title;
     }
 

--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -60,7 +60,7 @@ public final class StoredList extends AbstractList {
     private int count; // this value is only valid as long as the list is not changed by other database operations
 
     public StoredList(final int id, final String title, final int markerId, final boolean preventAskForDeletion, final int count) {
-        super(id, title, markerId);
+        super(id, title, 0, markerId);
         this.preventAskForDeletion = preventAskForDeletion;
         this.count = count;
     }

--- a/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/MapSettingsUtils.java
@@ -127,15 +127,14 @@ public class MapSettingsUtils {
         boolean useUser1 = false;
         boolean useUser2 = false;
         if (useInternalRouting) {
-            final String profileNoneString = LocalizationUtils.getString(R.string.routingmode_none);
             final StringBuilder sb = new StringBuilder();
             final String temp1 = Strings.CI.removeEnd(Settings.getRoutingProfile(RoutingMode.USER1), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
-            if (StringUtils.isNotBlank(temp1) && !temp1.equals(profileNoneString)) {
+            if (StringUtils.isNotBlank(temp1)) {
                 sb.append("1: ").append(temp1);
                 useUser1 = true;
             }
             final String temp2 = Strings.CI.removeEnd(Settings.getRoutingProfile(RoutingMode.USER2), BRouterConstants.BROUTER_PROFILE_FILEEXTENSION);
-            if (StringUtils.isNotBlank(temp2) && !temp2.equals(profileNoneString)) {
+            if (StringUtils.isNotBlank(temp2)) {
                 sb.append(StringUtils.isNotBlank(sb) ? " - " : "").append("2: ").append(temp2);
                 useUser2 = true;
             }

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceNavigationFragment.java
@@ -116,32 +116,48 @@ public class PreferenceNavigationFragment extends BasePreferenceFragment {
     }
 
     private void updateRoutingProfilePref(@StringRes final int prefId, final RoutingMode mode, final ArrayList<String> profiles, final int number) {
-        final String current = StringUtils.defaultIfBlank(Settings.getRoutingProfile(mode), LocalizationUtils.getString(R.string.routingmode_none));
+        String current = Settings.getRoutingProfile(mode);
         final ListPreference pref = findPreference(getString(prefId));
         assert pref != null;
 
         final ArrayList<String> prefProfiles = new ArrayList<>(profiles);
+        final ArrayList<String> prefValues = new ArrayList<>(profiles);
         if (number > 0) {
+            // Add localized "none" as display entry, but use empty string as value
             prefProfiles.add(LocalizationUtils.getString(R.string.routingmode_none));
+            prefValues.add("");
 
             final String title = LocalizationUtils.getString(R.string.init_brouterProfileUserNumber, number);
             pref.setDialogTitle(title);
             pref.setTitle(title);
+
+            // Migrate: if current value is not in available profiles list (and not blank), reset to empty
+            if (StringUtils.isNotBlank(current) && !profiles.contains(current)) {
+                current = "";
+            }
         }
 
         final CharSequence[] entries = prefProfiles.toArray(new CharSequence[0]);
-        final CharSequence[] values = prefProfiles.toArray(new CharSequence[0]);
+        final CharSequence[] values = prefValues.toArray(new CharSequence[0]);
 
         pref.setEntries(entries);
         pref.setEntryValues(values);
-        pref.setSummary(current);
+
+        // Set summary: if current is blank/empty, show localized "none"
+        final String displayValue = StringUtils.isBlank(current) ? LocalizationUtils.getString(R.string.routingmode_none) : current;
+        pref.setSummary(displayValue);
+
         pref.setOnPreferenceChangeListener((preference, newValue) -> {
-            preference.setSummary(newValue.toString());
+            final String value = newValue.toString();
+            final String summary = StringUtils.isBlank(value) ? LocalizationUtils.getString(R.string.routingmode_none) : value;
+            preference.setSummary(summary);
             return true;
         });
 
-        for (int i = 0; i < entries.length; i++) {
-            if (current.contentEquals(entries[i])) {
+        // Set current selection
+        final String normalizedCurrent = StringUtils.defaultString(current);
+        for (int i = 0; i < values.length; i++) {
+            if (normalizedCurrent.equals(values[i].toString())) {
                 pref.setValueIndex(i);
                 break;
             }

--- a/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ImageListFragment.java
@@ -4,9 +4,13 @@ import cgeo.geocaching.ImageEditActivity;
 import cgeo.geocaching.Intents;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.ILoggingManager;
 import cgeo.geocaching.databinding.ImagelistFragmentBinding;
 import cgeo.geocaching.databinding.ImagelistItemBinding;
 import cgeo.geocaching.log.LogUtils;
+import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Image;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.ContentStorage;
@@ -318,6 +322,16 @@ public class ImageListFragment extends Fragment {
         selectImageIntent.putExtra(Intents.EXTRA_INDEX, imageIndex);
         selectImageIntent.putExtra(Intents.EXTRA_GEOCODE, geocode);
         selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_UPLOAD_SIZE, maxImageUploadSize);
+
+        // Get max lengths from logging manager based on connector
+        if (geocode != null) {
+            final IConnector connector = ConnectorFactory.getConnector(geocode);
+            final Geocache cache = new Geocache();
+            cache.setGeocode(geocode);
+            final ILoggingManager loggingManager = connector.getLoggingManager(cache);
+            selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_CAPTION_LENGTH, loggingManager.getMaxImageCaptionLength());
+            selectImageIntent.putExtra(Intents.EXTRA_MAX_IMAGE_DESCRIPTION_LENGTH, loggingManager.getMaxImageDescriptionLength());
+        }
 
         requireActivity().startActivityForResult(selectImageIntent, SELECT_IMAGE);
     }

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -29,6 +29,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Looper;
 import android.text.Editable;
+import android.text.InputFilter;
 import android.text.Selection;
 import android.text.Spannable;
 import android.text.TextWatcher;
@@ -83,6 +84,7 @@ import java.util.function.Predicate;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec;
 import com.google.android.material.progressindicator.IndeterminateDrawable;
+import com.google.android.material.textfield.TextInputLayout;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -152,6 +154,18 @@ public class ViewUtils {
     public static void setText(final TextView view, final String text) {
         if (view != null) {
             view.setText(text);
+        }
+    }
+
+    public static void setMaxTextLength(@NonNull final EditText textField, @Nullable final TextInputLayout textLayout, final int maxLength) {
+        if (textLayout != null) {
+            textLayout.setCounterEnabled(maxLength > 0);
+            textLayout.setCounterMaxLength(maxLength);
+        }
+
+        if (maxLength > 0) {
+            final InputFilter.LengthFilter lengthFilter = new InputFilter.LengthFilter(maxLength);
+            textField.setFilters(new InputFilter[]{lengthFilter});
         }
     }
 

--- a/main/src/main/res/layout/imageedit_activity.xml
+++ b/main/src/main/res/layout/imageedit_activity.xml
@@ -66,6 +66,7 @@
             tools:listitem="@android:layout/simple_spinner_item" />
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/captionLayout"
             style="@style/textinput_edittext_singleline"
             app:counterEnabled="true"
             app:counterMaxLength="50">
@@ -76,11 +77,11 @@
                 android:hint="@string/log_image_caption"
                 android:autofillHints="@string/log_image_caption"
                 android:inputType="textCapSentences"
-                android:maxLength="50"
                 android:minLines="1" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/descriptionLayout"
             style="@style/textinput_edittext"
             app:counterEnabled="true"
             app:counterMaxLength="250">
@@ -91,7 +92,6 @@
                 android:hint="@string/log_image_description"
                 android:autofillHints="@string/log_image_description"
                 android:inputType="textMultiLine|textCapSentences"
-                android:maxLength="250"
                 android:minLines="5" />
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/main/src/main/res/raw/changelog_full.md
+++ b/main/src/main/res/raw/changelog_full.md
@@ -3,6 +3,22 @@ This changelog contains all changes which are not intermediate developing steps.
 
 <!-- --------------------------------------------------------------------------------- --->
 
+## 2026.04.30 Bugfix Release
+
+Time to update! If you are still using Android 7 or older, this might be the last c:geo update for you! With our next feature release of c:geo we will drop support for Android 5-7 to reduce our maintenance load and to be able to update some external components used by c:geo which we are currently still holding back. We will still be supporting Android 8 up to Android 16 then (and newer versions when they will be published), a span of more than eight years of Android history.
+
+- Change: Wherigo files cannot be downloaded currently, display mitigation instructions
+- Fix: Log delete reason does not enforce lengh limit
+- New: Extended logging for crashes in download manager
+- Fix: Waypoint infosheet can become too long, buttons unreachable
+- Fix: Some location info gets truncated
+- Fix: Internal routing no longer working, only straight line shown
+- Fix: Some folder creation issues
+
+Note: If you are using internal routing, you will need to execute the following step once after installing this release: Go to c:geo home screen, open "Manage offline data" - "Update routing data", and let c:geo install the updated files. (Reason: BRouter routing data file structure has changed and all routing data files must comply to the same version.)
+
+<!-- --------------------------------------------------------------------------------- --->
+
 ## 2026.03.16 Bugfix Release
 
 Time to update! If you are still using Android 7 or older, this might be the last c:geo update for you! With our next feature release of c:geo we will drop support for Android 5-7 to reduce our maintenance load and to be able to update some external components used by c:geo which we are currently still holding back. We will still be supporting Android 8 up to Android 16 then (and newer versions when they will be published), a span of more than eight years of Android history.


### PR DESCRIPTION
replaces #18031

For release notes see https://github.com/jhy/jsoup/releases/tag/jsoup-1.22.2.

There is a fix for the re2j proguard rules, so we don't need the own configuration anymore.
