### PR TITLE
Update testAndroidGeocoder

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/address/GeocoderTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/address/GeocoderTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class GeocoderTest {
 
-    private static final String TEST_ADDRESS = "46 rue Barrault, Paris, France";
+    private static final String TEST_ADDRESS = "46 Rue Vergniaud, Paris, France";
     private static final double TEST_LATITUDE = 48.82622;
-    private static final double TEST_LONGITUDE = 2.34644;
+    private static final double TEST_LONGITUDE = 2.34534;
     private static final Geopoint TEST_COORDS = new Geopoint(TEST_LATITUDE, TEST_LONGITUDE);
     private static final Offset<Double> TEST_OFFSET = Offset.offset(0.00050);
 
@@ -62,7 +62,7 @@ public class GeocoderTest {
             assertThat(address.getLatitude()).as(describe("latitude", geocoder)).isCloseTo(TEST_LATITUDE, TEST_OFFSET);
             assertThat(address.getLongitude()).as(describe("longitude", geocoder)).isCloseTo(TEST_LONGITUDE, TEST_OFFSET);
             if (withAddress) {
-                assertThat(StringUtils.lowerCase(address.getAddressLine(0))).as(describe("street address", geocoder)).contains("barrault");
+                assertThat(StringUtils.lowerCase(address.getAddressLine(0))).as(describe("street address", geocoder)).contains("vergniaud");
                 assertThat(address.getLocality()).as(describe("locality", geocoder)).isEqualTo("Paris");
                 assertThat(address.getCountryCode()).as(describe("country code", geocoder)).isEqualTo("FR");
                 // don't assert on country name, as this can be localized, e.g. with the mapquest geocoder
@@ -84,5 +84,4 @@ public class GeocoderTest {
     private static String describe(final String field, final String geocoder) {
         return field + " for " + geocoder + " .geocoder";
     }
-
 }


### PR DESCRIPTION
The test lookup result is now incorrect.
So, let's use another address (it is a nearby street).
