### PR TITLE
Track invalid coordinates on Mapsforge.setCenter

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -32,6 +32,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.core.text.HtmlCompat;
 import androidx.core.util.Pair;
 
+import java.util.Arrays;
+
 import org.apache.commons.lang3.StringUtils;
 import org.mapsforge.core.graphics.Canvas;
 import org.mapsforge.core.model.Dimension;
@@ -244,7 +246,13 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
 
     @Override
     public void setCenter(final Geopoint geopoint) {
-        mMapView.setCenter(new LatLong(geopoint.getLatitude(), geopoint.getLongitude()));
+        try {
+            mMapView.setCenter(new LatLong(geopoint.getLatitude(), geopoint.getLongitude()));
+        } catch (IllegalArgumentException e) {
+            Log.e("MapsforgeFragment.setCenter: Invalid geopoint (lat=" + geopoint.getLatitude() + ", lon=" + geopoint.getLongitude() + ")\n" + Arrays.toString(e.getStackTrace()));
+            ViewUtils.showShortToast(getActivity(), R.string.err_center_coordinates_invalid);
+            mMapView.setCenter(new LatLong(41.89018, 12.49237)); // Use Rome, Colosseo as visual indicator for error case
+        }
     }
 
     @Override

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -308,6 +308,7 @@
     <string name="err_rendertheme_file_unreadable">Could not load the selected render theme. Reverting to the built-in one.</string>
     <string name="err_rendertheme_invalid">The selected render theme is not valid for this mapsforge version. Reverting to the built-in one.</string>
     <string name="err_invalid_filename_char">Character \'%c\' not allowed</string>
+    <string name="err_center_coordinates_invalid">Cannot set map center, coordinates invalid</string>
     <string name="warn_save_nothing">There is nothing to be saved.</string>
     <string name="warn_no_cache_coord">There are no caches with coordinates.</string>
     <string name="warn_no_coordinates">No Coordinates given.</string>


### PR DESCRIPTION
## Description
- Prevents a crash when calling `MapsforgeFragment.setCenter()` with invalid coordinates
- Errors are logged with a stack trace to find the cause
- Sets coordinates to "Colosseo, Rome" + shows a short notification toast to make the user aware of the error (so that they can send us the error log with the stack trace)

## Related bug trace from Play Store
```
Exception java.lang.IllegalArgumentException:
  at org.mapsforge.core.util.LatLongUtils.validateLatitude (SourceFile:307)
  at org.mapsforge.core.model.LatLong.<init> (SourceFile:55)
  at cgeo.geocaching.unifiedmap.mapsforge.MapsforgeFragment.setCenter (SourceFile:247)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity.reloadCachesAndWaypoints (SourceFile:394)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity.onMapReadyTasks (SourceFile:368)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity.$r8$lambda$3wYE5A4Tjn2rlvRtW5qGq-b1Zic (SourceFile:347)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity$$ExternalSyntheticLambda32.run (SourceFile)
  at cgeo.geocaching.unifiedmap.mapsforge.MapsforgeFragment.onViewCreated (SourceFile:108)
  at androidx.fragment.app.Fragment.performViewCreated (SourceFile:2987)
  at androidx.fragment.app.FragmentStateManager.createView (SourceFile:546)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (SourceFile:282)
  at androidx.fragment.app.FragmentManager.executeOpsTogether (SourceFile:2189)
  at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute (SourceFile:2100)
  at androidx.fragment.app.FragmentManager.execPendingActions (SourceFile:2002)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (SourceFile:3138)
  at androidx.fragment.app.FragmentManager.dispatchActivityCreated (SourceFile:3072)
  at androidx.fragment.app.FragmentController.dispatchActivityCreated (SourceFile:251)
  at androidx.fragment.app.FragmentActivity.onStart (SourceFile:502)
  at androidx.appcompat.app.AppCompatActivity.onStart (SourceFile:251)
  at cgeo.geocaching.activity.AbstractActivity.onStart (SourceFile:306)
  at cgeo.geocaching.activity.AbstractNavigationBarActivity.onStart (SourceFile:210)
  at cgeo.geocaching.unifiedmap.UnifiedMapActivity.onStart (SourceFile:1373)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1699)
  at android.app.Activity.performStart (Activity.java:9562)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:4744)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:214)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:194)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:166)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:101)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:80)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:3150)
  at android.os.Handler.dispatchMessage (Handler.java:110)
  at android.os.Looper.loopOnce (Looper.java:273)
  at android.os.Looper.loop (Looper.java:363)
  at android.app.ActivityThread.main (ActivityThread.java:10060)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:632)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:975)
```