### PR TITLE
Calculate missing elevation data on importing track

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -390,7 +390,7 @@ dependencies {
 
     // Mapsforge official version
     String mapsforgeSource = 'com.github.mapsforge.mapsforge'
-    String mapsforgeVersion = '0.27.0'
+    String mapsforgeVersion = '0.28.0'
 
     // Mapsforge Snapshot from official master branch (via https://jitpack.io/#mapsforge/mapsforge)
     // String mapsforgeSource = 'com.github.mapsforge.mapsforge'

--- a/main/src/main/java/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
+++ b/main/src/main/java/cgeo/geocaching/files/GPXTrackOrRouteImporter.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.files;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.location.GeoItemHolder;
+import cgeo.geocaching.maps.RouteTrackUtils;
 import cgeo.geocaching.models.Route;
 import cgeo.geocaching.models.geoitem.IGeoItemSupplier;
 import cgeo.geocaching.storage.ContentStorage;
@@ -93,6 +94,9 @@ public class GPXTrackOrRouteImporter {
             if (null == route) {
                 return parseAsGeoJson(context, uri);
             }
+
+            RouteTrackUtils.addMissingElevationData(route);
+
             return route;
         } catch (IOException e) {
             Log.e("Problem accessing GPX Track file '" + uri + "'. Maybe file was removed or renamed by user?", e);

--- a/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
+++ b/main/src/main/java/cgeo/geocaching/maps/RouteTrackUtils.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.maps;
 
+import cgeo.geocaching.CgeoApplication;
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.export.IndividualRouteExport;
@@ -37,6 +38,7 @@ import cgeo.geocaching.utils.functions.Func0;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Point;
 import android.graphics.drawable.Drawable;
@@ -64,6 +66,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import org.apache.commons.lang3.StringUtils;
+import org.mapsforge.map.android.hills.DemFolderAndroidContent;
+import org.mapsforge.map.elevation.ElevationAPI;
+import org.mapsforge.map.layer.hills.DemFolder;
 
 public class RouteTrackUtils {
 
@@ -452,4 +457,51 @@ public class RouteTrackUtils {
     public static boolean isNavigationTargetRoute(final IGeoItemSupplier route) {
         return route instanceof NavigationTargetRoute;
     }
+
+    /**
+     * Adds missing elevation data (tracks only)
+     */
+    public static void addMissingElevationData(final Route route) {
+        if (!route.isRouteable()) {
+            final RouteSegment[] segments = route.getSegments();
+            for (RouteSegment segment : segments) {
+                if (null == segment.getElevation() || segment.getElevation().size() != segment.getSize()) {
+                    final ArrayList<Float> newElevation = getElevation(segment.getPoints());
+                    if (newElevation != null && !newElevation.isEmpty()) {
+                        segment.setElevation(newElevation);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves elevation data for given list of points
+     * <br />
+     * Uses fast elevation data retrieval from Mapsforge's hillshading routines - requires
+     * hillshading data to be downloaded first, but is independent of current map type
+     */
+    @Nullable
+    public static ArrayList<Float> getElevation(@NonNull final ArrayList<Geopoint> points) {
+        if (points.isEmpty()) {
+            return null;
+        }
+
+        final List<double[]> tempIn = new ArrayList<>();
+        for (Geopoint geo : points) {
+            tempIn.add(new double[]{ geo.getLatitude(), geo.getLongitude()});
+        }
+
+        final Context context = CgeoApplication.getInstance();
+        final DemFolder shadingFolder = new DemFolderAndroidContent(PersistableFolder.OFFLINE_MAP_SHADING.getUri(), context, context.getContentResolver());
+        final double[] tempOut = new double[points.size()];
+        new ElevationAPI(shadingFolder).getElevation(tempIn, tempOut);
+
+        final ArrayList<Float> result = new ArrayList<>(tempOut.length);
+        for (double d : tempOut) {
+            result.add((float) d);
+        }
+        return result;
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/models/Route.java
+++ b/main/src/main/java/cgeo/geocaching/models/Route.java
@@ -50,6 +50,10 @@ public class Route implements IGeoItemSupplier, Parcelable {
         this.routeable = routeable;
     }
 
+    public boolean isRouteable() {
+        return routeable;
+    }
+
     public String getName() {
         return name;
     }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/TileProviderFactory.java
@@ -76,7 +76,6 @@ public class TileProviderFactory {
         parentMenu.setGroupCheckable(R.id.menu_group_map_sources_online, true, true);
         parentMenu.findItem(R.id.menu_hillshading).setCheckable(true).setChecked(Settings.getMapShadingShowLayer()).setVisible(MapUtils.hasHillshadingTiles() && ctp.supportsHillshading());
         parentMenu.findItem(R.id.menu_backgroundmap).setCheckable(true).setChecked(Settings.getMapBackgroundMapLayer()).setVisible(ctp.supportsBackgroundMaps());
-        parentMenu.findItem(R.id.menu_check_hillshadingdata).setVisible(Settings.getTileProvider().supportsHillshading());
         parentMenu.findItem(R.id.menu_download_backgroundmap).setVisible(ctp.supportsBackgroundMaps);
         parentMenu.findItem(R.id.menu_check_routingdata).setVisible(Settings.useInternalRouting() || ProcessUtils.isInstalled(LocalizationUtils.getPlainString(R.string.package_brouter)));
     }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -2960,7 +2960,7 @@
     <string name="check_hillshading_found">Hillshading data already present</string>
     <string name="check_hillshading_missing">Found missing hillshading data:</string>
     <string name="check_hillshading_unsupported">Warning: Hillshading data is at least partly not available for the selected region</string>
-    <string name="check_hillshading_tiles_menu">Check for missing hillshading data</string>
+    <string name="check_hillshading_tiles_menu">Check for missing elevation data</string>
     <string name="mapupdate_info">Tap here to check for updates of map and theme files. Long-tap to postpone.</string>
     <string name="no_updates_found">No updates found</string>
     <string name="updates_check">Updates check</string>


### PR DESCRIPTION
## Description
- Calculates missing elevation data on importing a track file
- Requires hillshading data for track area to be downloaded already
- Works with both Google Maps and Mapsforge maps
- Renames "Check for missing hillshading data" to "Check for missing elevation data" and enables menu entry for all map types
