### PR TITLE
Add text length check to SimpleDialog, use it for log delete

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogActivityHelper.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogActivityHelper.java
@@ -134,7 +134,7 @@ public class LogActivityHelper {
         if (LogUtils.isOwnLog(entry, cache)) {
             dialog.confirm(() -> logDeleteTask.start(new ImmutableTriple<>(cache, entry, null)));
         } else {
-            dialog.input(new SimpleDialog.InputOptions().setInputChecker(s -> s.length() <= MAX_ALLOWED_CHARS_DELETE_REASON).setLabel(String.format(activity.getString(R.string.cache_log_delete_reason), MAX_ALLOWED_CHARS_DELETE_REASON)), reasonText -> logDeleteTask.start(new ImmutableTriple<>(cache, entry, reasonText)));
+            dialog.input(new SimpleDialog.InputOptions().setMaxAllowedLength(MAX_ALLOWED_CHARS_DELETE_REASON), reasonText -> logDeleteTask.start(new ImmutableTriple<>(cache, entry, reasonText)));
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/SimpleDialog.java
@@ -140,6 +140,7 @@ public class SimpleDialog {
         private Predicate<String> inputChecker = null;
         private String allowedChars = null;
         private String hint = null;
+        private int maxAllowedLength = 0;
 
         /** input type flag mask, use constants defined in class {@link InputType}. If a value below 0 is given then standard input type settings (text) are assumed */
         public InputOptions setInputType(final int inputType) {
@@ -179,6 +180,12 @@ public class SimpleDialog {
         /** if non-null, then only chars passing this regex pattern will be allowed to enter */
         public InputOptions setAllowedChars(final String allowedChars) {
             this.allowedChars = allowedChars;
+            return this;
+        }
+
+        /** set maximum allowed length, 0=no limit */
+        public InputOptions setMaxAllowedLength(final int maxAllowedLength) {
+            this.maxAllowedLength = maxAllowedLength;
             return this;
         }
 
@@ -650,6 +657,9 @@ public class SimpleDialog {
          }
          if (io.suffix != null) {
              textLayout.setSuffixText(io.suffix);
+         }
+         if (io.maxAllowedLength > 0) {
+             ViewUtils.setMaxTextLength(textField, textLayout, io.maxAllowedLength);
          }
 
         if (io.inputChecker != null) {

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -1778,7 +1778,6 @@
     <string name="menu_collapse_log">Collapse log</string>
     <string name="cache_log_menu_delete">Delete Log</string>
     <string name="cache_log_menu_popup_title">Log of %s</string>
-    <string name="cache_log_delete_reason">Reason (max. %d characters)</string>
     <string name="cache_log_delete_reason_default">Log was deleted using c:geo</string>
     <string name="ignore_confirm_title">Be careful</string>
     <string name="ignore_confirm_message">Ignoring a cache means that this cache will never occur again when loading data from geocaching.com. You will only be able to see the cache again by unignoring it on the website.</string>


### PR DESCRIPTION
## Description
- Extend SimpleDialog.input to support max text length
- Use method for length restriction for "log delete reason" that got introduced with #18021 (instead of individual method) for consistency.
