### PR TITLE
Update jsoup to 1.22.2

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -370,7 +370,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
     // Jsoup HTML parsing
-    implementation 'org.jsoup:jsoup:1.22.1'
+    implementation 'org.jsoup:jsoup:1.22.2'
 
      // GeoJson parsing: https://github.com/cocoahero/android-geojson
     implementation 'com.cocoahero.android:geojson:1.0.1@jar'

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -155,11 +155,6 @@
 # keep classes of metadata libaray (this lib heavily uses reflection)
 -keep class com.drew.** { *; }
 
-# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
-# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
-# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
--dontwarn com.google.re2j.**
-
 # Whitelist MPAndroidChart
 # Preserve all public classes and methods
 -keep class com.github.mikephil.charting.** { *; }


### PR DESCRIPTION
replaces #18031 / #18059

For release notes see https://github.com/jhy/jsoup/releases/tag/jsoup-1.22.2.

There is a fix for the re2j proguard rules, so we don't need the own configuration anymore.
