### PR TITLE
Infosheet fragment cleanup/restore (rel. to #17215)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarMapActivity.java
@@ -219,9 +219,14 @@ public abstract class AbstractNavigationBarMapActivity extends AbstractNavigatio
     // - restore current value
     // - open new sheet (if non-empty)
     public void sheetManageLifecycleOnStart(@Nullable final UnifiedMapViewModel.SheetInfo sheetInfo, @NonNull final Action1<UnifiedMapViewModel.SheetInfo> setSheetInfo) {
-        sheetRemoveFragment();
         setSheetInfo.call(sheetInfo);
         sheetShowDetails(sheetInfo);
+    }
+
+    public void sheetManageLifecycleOnStop(@Nullable final UnifiedMapViewModel viewModel) {
+        final UnifiedMapViewModel.SheetInfo si = viewModel.sheetInfo.getValue();
+        sheetRemoveFragment();
+        viewModel.sheetInfo.setValue(si);
     }
 
     // handling of http429 warning message

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -1406,6 +1406,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     @Override
     protected void onStop() {
         this.resumeDisposables.clear();
+        sheetManageLifecycleOnStop(viewModel);
         super.onStop();
     }
 


### PR DESCRIPTION
## Description
The first part of issue #17215 (`IllegalArgumentException` in map's `onStart`) is the most prominent crash in Play Store stats currently, listing app. 600 instances for 2026.03.16 / 2026.04.30 releases.

This PR attempts to to fix this issue by removing/restoring infosheet fragment in `onStop` / `onStart`. Infosheet got removed in `onStart` anyway, I moved that to `onStop` instead.

Let's check whether there are any unwanted side-effects, therefore preparing it for `master` first.
