### PR TITLE
Rel to #17842: Refine edge-to-edge inset handling

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -241,7 +241,7 @@
         <activity
             android:name=".EditWaypointActivity"
             android:label="@string/waypoint_edit_title"
-            android:windowSoftInputMode="stateHidden" >
+            android:windowSoftInputMode="stateHidden|adjustResize" >
         </activity>
         <activity
             android:name=".NavigateAnyPointActivity"
@@ -454,7 +454,8 @@
             />
         <activity
             android:name=".log.LogCacheActivity"
-            android:label="@string/log_new_log" >
+            android:label="@string/log_new_log"
+            android:windowSoftInputMode="adjustResize" >
         </activity>
         <activity
             android:name=".log.LogTrackableActivity"

--- a/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
+++ b/main/src/main/java/cgeo/geocaching/EditWaypointActivity.java
@@ -285,8 +285,6 @@ public class EditWaypointActivity extends AbstractActionBarActivity implements C
             binding.noteLayout.setVisibility(View.GONE);
             updateCoordinates(preprojectedCoords);
         }
-
-        ViewUtils.preventKeyboardOverlap(binding.userNote);
     }
 
     private void setCoordsModificationVisibility(final IConnector con) {

--- a/main/src/main/java/cgeo/geocaching/activity/AbstractActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractActivity.java
@@ -166,15 +166,10 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
         windowInsetsController.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
         //apply edge2edge to activity content view
         ViewCompat.setOnApplyWindowInsetsListener(currentWindow.getDecorView(), (v, windowInsets) -> {
-            final View activityContent = v.findViewById(R.id.activity_content);
-            if (activityContent == null) {
-                Log.w("edge2edge: activityContent not found in " + this);
-            } else {
-                //calculate and set the activity_content's insets
-                this.currentWindowInsets = windowInsets.getInsets(DEFAULT_INSETS);
-                //trigger insets recalculation
-                refreshActivityContentInsets();
-            }
+            //calculate and set the activity_content's insets
+            this.currentWindowInsets = windowInsets.getInsets(DEFAULT_INSETS);
+            //trigger insets recalculation
+            refreshActivityContentInsets();
             return windowInsets;
         });
 
@@ -188,16 +183,22 @@ public abstract class AbstractActivity extends AppCompatActivity implements IAbs
             //method was called before insets were set
             return;
         }
-        final View activityContent = getWindow() == null || getWindow().getDecorView() == null ? null :
-            getWindow().getDecorView().findViewById(R.id.activity_content);
-        if (activityContent == null) {
+        final View decorView = getWindow() == null ? null : getWindow().getDecorView();
+        if (decorView == null) {
+            return;
+        }
+        final View activityContent = decorView.findViewById(R.id.activity_content);
+        final View activityWrapper = decorView.findViewById(R.id.activity_content_wrapper);
+        final View root = activityWrapper != null ? activityWrapper : activityContent;
+
+        if (root == null) {
             return;
         }
 
         //let subclasses modify insets according to their needs
         final Insets insets = calculateInsetsForActivityContent(this.currentWindowInsets);
         //apply final insets to activity content
-        activityContent.setPadding(
+        root.setPadding(
                 insets.left < 0 ? this.currentWindowInsets.left : insets.left,
                 insets.top < 0 ? this.currentWindowInsets.top : insets.top,
                 insets.right < 0 ? this.currentWindowInsets.right : insets.right,

--- a/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogCacheActivity.java
@@ -256,7 +256,6 @@ public class LogCacheActivity extends AbstractLoggingActivity implements LoaderM
             }
         }
         inventoryAdapter.putActions(lastSavedState.inventoryActions);
-        ViewUtils.preventKeyboardOverlap(binding.log);
         refreshGui();
 
         requestKeyboardForLogging();

--- a/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ViewUtils.java
@@ -67,11 +67,8 @@ import androidx.annotation.StyleRes;
 import androidx.annotation.StyleableRes;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.res.ResourcesCompat;
-import androidx.core.graphics.Insets;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.util.LinkifyCompat;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -898,14 +895,6 @@ public class ViewUtils {
         final Drawable circularIcon = IndeterminateDrawable.createCircularDrawable(button.getContext(), spec);
 
         return enable -> mButton.setIcon(enable ? circularIcon : originalIcon);
-    }
-
-    public static void preventKeyboardOverlap(final View view) {
-        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
-            final Insets newInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime() | WindowInsetsCompat.Type.systemBars());
-            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), newInsets.bottom);
-            return windowInsets;
-        });
     }
 
 }

--- a/main/src/main/res/layout/editwaypoint_activity.xml
+++ b/main/src/main/res/layout/editwaypoint_activity.xml
@@ -9,18 +9,6 @@
     android:orientation="vertical"
     tools:context=".EditWaypointActivity">
 
-    <!-- Coordinates -->
-
-    <Button
-        android:id="@+id/buttonLatLongitude"
-        style="@style/button_full_double"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="4dip"
-        app:icon="@drawable/ic_menu_variable"
-        android:freezesText="true"
-        android:hint="@string/latlongitude" />
-
     <ScrollView
         android:layout_width="fill_parent"
         android:layout_height="0dp"
@@ -33,6 +21,16 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical" >
+
+            <Button
+                android:id="@+id/buttonLatLongitude"
+                style="@style/button_full_double"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="4dip"
+                app:icon="@drawable/ic_menu_variable"
+                android:freezesText="true"
+                android:hint="@string/latlongitude" />
 
             <!-- Projection Settings -->
 

--- a/main/src/main/res/layout/editwaypoint_activity.xml
+++ b/main/src/main/res/layout/editwaypoint_activity.xml
@@ -1,191 +1,202 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:custom="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/activity_content"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:id="@+id/activity_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:padding="4dip"
     tools:context=".EditWaypointActivity">
 
-    <LinearLayout
+    <!-- Coordinates -->
+
+    <Button
+        android:id="@+id/buttonLatLongitude"
+        style="@style/button_full_double"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical" >
+        android:layout_margin="4dip"
+        app:icon="@drawable/ic_menu_variable"
+        android:freezesText="true"
+        android:hint="@string/latlongitude" />
 
-        <!-- Coordinates -->
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:padding="4dip"
+        android:clipToPadding="false"
+        android:fillViewport="true">
 
-        <Button
-            android:id="@+id/buttonLatLongitude"
-            style="@style/button_full_double"
-            app:icon="@drawable/ic_menu_variable"
-            android:freezesText="true"
-            android:hint="@string/latlongitude" />
-
-        <!-- Projection Settings -->
-
-        <Spinner
-            android:id="@+id/projection_type"
+        <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            tools:listitem="@android:layout/simple_spinner_item" />
+            android:orientation="vertical" >
 
-        <RelativeLayout
-            android:id="@+id/projection_bearing_box"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:importantForAutofill="noExcludeDescendants">
-
-            <cgeo.geocaching.ui.FormulaEditText
-                android:id="@+id/projection_bearing_distance"
-                custom:hint="@string/projection_type_bearing_hint_distance"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_toLeftOf="@+id/projection_bearing_unit"/>
+            <!-- Projection Settings -->
 
             <Spinner
-                android:id="@+id/projection_bearing_unit"
-                android:layout_width="wrap_content"
+                android:id="@+id/projection_type"
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_marginTop="25dp"
-                android:enabled="false"
-                android:entries="@array/distance_units"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
                 tools:listitem="@android:layout/simple_spinner_item" />
 
-            <cgeo.geocaching.ui.FormulaEditText
-                android:id="@+id/projection_bearing_angle"
-                custom:hint="@string/projection_type_bearing_hint_angle"
+            <RelativeLayout
+                android:id="@+id/projection_bearing_box"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/projection_bearing_distance"/>
+                android:visibility="gone"
+                android:importantForAutofill="noExcludeDescendants">
 
-        </RelativeLayout>
+                <cgeo.geocaching.ui.FormulaEditText
+                    android:id="@+id/projection_bearing_distance"
+                    custom:hint="@string/projection_type_bearing_hint_distance"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_toLeftOf="@+id/projection_bearing_unit"/>
 
-        <RelativeLayout
-            android:id="@+id/projection_offset_box"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:importantForAutofill="noExcludeDescendants">
+                <Spinner
+                    android:id="@+id/projection_bearing_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:layout_marginTop="25dp"
+                    android:enabled="false"
+                    android:entries="@array/distance_units"
+                    tools:listitem="@android:layout/simple_spinner_item" />
 
-            <cgeo.geocaching.ui.FormulaEditText
-                android:id="@+id/projection_offset_latitude"
-                custom:hint="@string/projection_type_offset_hint_latitude"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                <cgeo.geocaching.ui.FormulaEditText
+                    android:id="@+id/projection_bearing_angle"
+                    custom:hint="@string/projection_type_bearing_hint_angle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/projection_bearing_distance"/>
 
-            <cgeo.geocaching.ui.FormulaEditText
-                android:id="@+id/projection_offset_longitude"
-                custom:hint="@string/projection_type_offset_hint_longitude"
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/projection_offset_box"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/projection_offset_latitude"/>
+                android:visibility="gone"
+                android:importantForAutofill="noExcludeDescendants">
 
-        </RelativeLayout>
+                <cgeo.geocaching.ui.FormulaEditText
+                    android:id="@+id/projection_offset_latitude"
+                    custom:hint="@string/projection_type_offset_hint_latitude"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
 
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            >
+                <cgeo.geocaching.ui.FormulaEditText
+                    android:id="@+id/projection_offset_longitude"
+                    custom:hint="@string/projection_type_offset_hint_longitude"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/projection_offset_latitude"/>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                >
+
+                <Button
+                    android:id="@+id/variables_tidyup"
+                    style="@style/button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:layout_margin="6dp"
+                    app:icon="@drawable/ic_menu_auto_fix_high"
+                    android:text="@string/variables_tidyup"/>
+
+            </RelativeLayout>
+
+            <cgeo.geocaching.ui.VariableListView
+                android:id="@+id/variable_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
             <Button
-                android:id="@+id/variables_tidyup"
-                style="@style/button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:layout_margin="6dp"
-                app:icon="@drawable/ic_menu_auto_fix_high"
-                android:text="@string/variables_tidyup"/>
-
-        </RelativeLayout>
-
-        <cgeo.geocaching.ui.VariableListView
-            android:id="@+id/variable_list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <Button
-            android:id="@+id/projectedLatLongitude"
-            style="@style/button_full_double"
-            app:icon="@drawable/ic_menu_mylocation"
-            android:clickable="false"
-            android:focusable="false"
-            android:freezesText="true"
-            android:visibility="gone"
-            android:text="@string/latlongitude" />
-
-        <Spinner
-            android:id="@+id/type"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            tools:listitem="@android:layout/simple_spinner_item" />
-
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
-            android:hint="@string/waypoint_name" android:labelFor="@id/name" android:id="@+id/name_layout">
-            <AutoCompleteTextView
-                android:id="@+id/name"
-                style="@style/textinput_embedded_singleline" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/note_layout"
-            style="@style/textinput_edittext"
-            android:hint="@string/waypoint_note" android:labelFor="@id/note">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/note"
-                style="@style/textinput_embedded"
-                android:inputType="textMultiLine|textCapSentences"
-                android:minLines="5" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext"
-            android:hint="@string/waypoint_user_note" android:labelFor="@id/user_note">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/user_note"
-                style="@style/textinput_embedded"
-                android:inputType="textMultiLine|textCapSentences"
-                android:minLines="5" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <CheckBox
-            android:id="@+id/wpt_visited_checkbox"
-            style="@style/checkbox_full"
-            android:text="@string/waypoint_visited" />
-
-        <RadioGroup
-            android:id="@+id/modify_cache_coordinates_group"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
-
-            <RadioButton
-                android:id="@+id/modify_cache_coordinates_nothing"
-                style="@style/radiobutton_wrap"
-                android:checked="true"
-                android:text="@string/waypoint_do_not_touch_cache_coordinates" />
-
-            <RadioButton
-                android:id="@+id/modify_cache_coordinates_local"
-                style="@style/radiobutton_wrap"
-                android:text="@string/waypoint_set_as_cache_coords" />
-
-            <RadioButton
-                android:id="@+id/modify_cache_coordinates_local_and_remote"
-                style="@style/radiobutton_wrap"
-                android:text="@string/waypoint_save_and_modify_on_website"
+                android:id="@+id/projectedLatLongitude"
+                style="@style/button_full_double"
+                app:icon="@drawable/ic_menu_mylocation"
+                android:clickable="false"
+                android:focusable="false"
+                android:freezesText="true"
                 android:visibility="gone"
-                tools:visibility="visible"/>
-        </RadioGroup>
+                android:text="@string/latlongitude" />
 
-    </LinearLayout>
+            <Spinner
+                android:id="@+id/type"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                tools:listitem="@android:layout/simple_spinner_item" />
 
-</ScrollView>
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_autocompletetextview"
+                android:hint="@string/waypoint_name" android:labelFor="@id/name" android:id="@+id/name_layout">
+                <AutoCompleteTextView
+                    android:id="@+id/name"
+                    style="@style/textinput_embedded_singleline" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/note_layout"
+                style="@style/textinput_edittext"
+                android:hint="@string/waypoint_note" android:labelFor="@id/note">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/note"
+                    style="@style/textinput_embedded"
+                    android:inputType="textMultiLine|textCapSentences"
+                    android:minLines="5" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout style="@style/textinput_edittext"
+                android:hint="@string/waypoint_user_note" android:labelFor="@id/user_note">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/user_note"
+                    style="@style/textinput_embedded"
+                    android:inputType="textMultiLine|textCapSentences"
+                    android:minLines="5" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <CheckBox
+                android:id="@+id/wpt_visited_checkbox"
+                style="@style/checkbox_full"
+                android:text="@string/waypoint_visited" />
+
+            <RadioGroup
+                android:id="@+id/modify_cache_coordinates_group"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+
+                <RadioButton
+                    android:id="@+id/modify_cache_coordinates_nothing"
+                    style="@style/radiobutton_wrap"
+                    android:checked="true"
+                    android:text="@string/waypoint_do_not_touch_cache_coordinates" />
+
+                <RadioButton
+                    android:id="@+id/modify_cache_coordinates_local"
+                    style="@style/radiobutton_wrap"
+                    android:text="@string/waypoint_set_as_cache_coords" />
+
+                <RadioButton
+                    android:id="@+id/modify_cache_coordinates_local_and_remote"
+                    style="@style/radiobutton_wrap"
+                    android:text="@string/waypoint_save_and_modify_on_website"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+            </RadioGroup>
+
+        </LinearLayout>
+
+    </ScrollView>
+</LinearLayout>

--- a/main/src/main/res/layout/logcache_activity.xml
+++ b/main/src/main/res/layout/logcache_activity.xml
@@ -9,28 +9,6 @@
     android:orientation="vertical"
     tools:context=".log.LogCacheActivity">
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:baselineAligned="false"
-        android:padding="4dip"
-        android:orientation="horizontal" >
-
-        <Button
-            android:id="@+id/type"
-            style="@style/button_full"
-            android:layout_width="0dip"
-            android:layout_weight="1"
-            tools:text="log type"/>
-
-        <Button
-            android:id="@+id/date"
-            style="@style/button_full"
-            android:layout_width="0dip"
-            android:layout_weight="1"
-            tools:text="log date"/>
-    </LinearLayout>
-
     <ScrollView
         android:layout_width="fill_parent"
         android:layout_height="0dp"
@@ -47,6 +25,29 @@
                 android:layout_height="wrap_content"
                 android:padding="4dip"
                 android:orientation="vertical" >
+
+                <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:baselineAligned="false"
+                    android:padding="4dip"
+                    android:orientation="horizontal" >
+
+                    <Button
+                        android:id="@+id/type"
+                        style="@style/button_full"
+                        android:layout_width="0dip"
+                        android:layout_weight="1"
+                        tools:text="log type"/>
+
+                    <Button
+                        android:id="@+id/date"
+                        style="@style/button_full"
+                        android:layout_width="0dip"
+                        android:layout_weight="1"
+                        tools:text="log date"/>
+                </LinearLayout>
+
 
                 <com.google.android.material.textfield.TextInputLayout
                     style="@style/textinput_edittext"

--- a/main/src/main/res/layout/logcache_activity.xml
+++ b/main/src/main/res/layout/logcache_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ScrollView
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -9,42 +9,44 @@
     android:orientation="vertical"
     tools:context=".log.LogCacheActivity">
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:baselineAligned="false"
+        android:padding="4dip"
+        android:orientation="horizontal" >
 
-        <LinearLayout
+        <Button
+            android:id="@+id/type"
+            style="@style/button_full"
+            android:layout_width="0dip"
+            android:layout_weight="1"
+            tools:text="log type"/>
+
+        <Button
+            android:id="@+id/date"
+            style="@style/button_full"
+            android:layout_width="0dip"
+            android:layout_weight="1"
+            tools:text="log date"/>
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:fillViewport="true">
+
+        <RelativeLayout
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:padding="4dip"
-            android:orientation="vertical" >
+            android:layout_height="wrap_content">
 
             <LinearLayout
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="10dip"
+                android:padding="4dip"
                 android:orientation="vertical" >
-
-                <LinearLayout
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:baselineAligned="false"
-                    android:orientation="horizontal" >
-
-                    <Button
-                        android:id="@+id/type"
-                        style="@style/button_full"
-                        android:layout_width="0dip"
-                        android:layout_weight="1"
-                        tools:text="log type"/>
-
-                    <Button
-                        android:id="@+id/date"
-                        style="@style/button_full"
-                        android:layout_width="0dip"
-                        android:layout_weight="1"
-                        tools:text="log date"/>
-                </LinearLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
                     style="@style/textinput_edittext"
@@ -135,74 +137,72 @@
                     tools:visibility="visible"
                     />
 
-            </LinearLayout>
-
-            <fragment
-                android:id="@+id/imagelist_fragment"
-                class="cgeo.geocaching.ui.ImageListFragment"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-
-            <LinearLayout
-                android:id="@+id/inventory_box"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dip"
-                android:layout_marginTop="10dip"
-                android:orientation="vertical"
-                android:visibility="gone"
-                tools:visibility="visible">
-
-                <cgeo.geocaching.ui.SectionHeader
+                <fragment
+                    android:id="@+id/imagelist_fragment"
+                    class="cgeo.geocaching.ui.ImageListFragment"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:dividerAbove="true"
-                    android:text="@string/log_inventory" />
-
-                <ListView
-                    android:id="@+id/inventory"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:clipToPadding="false"
-                    android:footerDividersEnabled="false"
-                    android:headerDividersEnabled="false"
-                    android:padding="4dip"
-                    android:scrollbars="none"
-                    tools:ignore="NestedScrolling"
-                    tools:listitem="@layout/logcache_trackable_item" >
-
-                </ListView>
+                    android:layout_height="match_parent" />
 
                 <LinearLayout
-                    android:id="@+id/inventory_changeall"
+                    android:id="@+id/inventory_box"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="right"
+                    android:layout_marginBottom="10dip"
+                    android:layout_marginTop="10dip"
                     android:orientation="vertical"
                     android:visibility="gone"
                     tools:visibility="visible">
 
-                    <Button
-                        android:id="@+id/changebutton"
-                        style="@style/button_full"
-                        android:layout_width="wrap_content"
-                        android:layout_height="0dp"
-                        android:layout_marginBottom="5dip"
-                        android:layout_marginLeft="10dip"
-                        android:layout_marginRight="10dip"
-                        android:layout_weight="1"
+                    <cgeo.geocaching.ui.SectionHeader
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:dividerAbove="true"
+                        android:text="@string/log_inventory" />
+
+                    <ListView
+                        android:id="@+id/inventory"
+                        android:layout_width="fill_parent"
+                        android:layout_height="fill_parent"
+                        android:clipToPadding="false"
+                        android:footerDividersEnabled="false"
+                        android:headerDividersEnabled="false"
+                        android:padding="4dip"
+                        android:scrollbars="none"
+                        tools:ignore="NestedScrolling"
+                        tools:listitem="@layout/logcache_trackable_item" >
+
+                    </ListView>
+
+                    <LinearLayout
+                        android:id="@+id/inventory_changeall"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
                         android:gravity="right"
-                        android:text="@string/log_tb_changeall" />
+                        android:orientation="vertical"
+                        android:visibility="gone"
+                        tools:visibility="visible">
+
+                        <Button
+                            android:id="@+id/changebutton"
+                            style="@style/button_full"
+                            android:layout_width="wrap_content"
+                            android:layout_height="0dp"
+                            android:layout_marginBottom="5dip"
+                            android:layout_marginLeft="10dip"
+                            android:layout_marginRight="10dip"
+                            android:layout_weight="1"
+                            android:gravity="right"
+                            android:text="@string/log_tb_changeall" />
+                    </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
-        </LinearLayout>
 
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:id="@+id/progress_bar"
-            tools:visibility="gone" />
-    </RelativeLayout>
-
-</ScrollView>
+            <com.google.android.material.progressindicator.LinearProgressIndicator
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:id="@+id/progress_bar"
+                tools:visibility="gone" />
+        </RelativeLayout>
+    </ScrollView>
+</LinearLayout>


### PR DESCRIPTION

# Analysis: Edge-to-Edge UI Overlap Bug

## Problem Description
In `CacheDetailActivity` (personal note), `LogCacheActivity`, and `EditWaypointActivity`, the editable text area is vertically enlarged downwards into the keyboard area when more text is entered than fits. This makes the text unreachable.

## Root Cause
The issue is caused by a conflict in how Window Insets (specifically the IME/Keyboard insets) are handled across the application.

1. **Global Handling in `AbstractActivity`**:
   The base class `AbstractActivity` applies padding to the view with ID `activity_content`. It uses `WindowInsetsCompat.Type.ime()`, meaning it automatically adds bottom padding to the root container when the keyboard appears.

2. **Surgical Handling via `ViewUtils.preventKeyboardOverlap`**:
   Commit `ae60e494b` (PR #17915) introduced `ViewUtils.preventKeyboardOverlap`, which adds *another* `OnApplyWindowInsetsListener` to the specific `EditText` views. This listener also adds padding based on the IME insets.

3. **Double Padding**:
   When both are active, the layout receives double the necessary padding. In a `ScrollView` (used in `LogCacheActivity` and `EditWaypointActivity`), the root is already padded by the activity, and then the internal view is padded again. This "pushes" the view incorrectly or prevents the `ScrollView` from correctly calculating its scrollable area, leading to the "disappearing text" behavior.

4. **Fullscreen Dialogs**:
   `EditNoteDialog` (used for personal notes in `CacheDetailActivity`) inherits from `AbstractFullscreenDialog`, which has its own `applyEdge2Edge` logic that manually sets padding on the root view. If this view contains an `EditText` that also tries to handle insets, similar conflicts occur.

## Current Status (as of May 11, 2026 - Iteration 3)
- **Branch**: `fix/edge-to-edge-overlap`
- **What Works**:
    - **Personal Note**: Works perfectly. It uses `AbstractFullscreenDialog` which applies padding to its root view in `applyEdge2Edge`.
- **What Partially Works**:
    - **Logging & Waypoint Notes**: The "double-padding" conflict is gone. With `clipToPadding="false"`, the text can now be scrolled up into view using cursor keys, but it still initially extends underneath the keyboard. This indicates the `ScrollView` is not automatically resizing its viewport to match the keyboard's top edge.
- **Implemented Changes**:
    - Removed redundant `ViewUtils.preventKeyboardOverlap` calls.
    - Added `adjustResize` to Manifest for Logging/Waypoints.
    - Added `clipToPadding="false"` to `ScrollView`s in Logging/Waypoints.
    - Reverted `WindowInsetsCompat.CONSUMED` to avoid "floating keyboard" issue.

## Refined Strategy
The success of the **Personal Note** is the key. It uses a `DialogFragment` that manually applies system bar + IME insets as padding to its entire view.
`AbstractActivity` tries to do something similar by padding `activity_content`, but `activity_content` is often nested inside a `activity_content_wrapper` (FrameLayout) which is inside a `LinearLayout` with a `Toolbar`.

**Next Steps**:
1.  **Compare View Hierarchies**: Analyze why `AbstractFullscreenDialog`'s padding results in a resize/scroll effect that works, while `AbstractActivity`'s padding on `activity_content` only results in a padded scroll area that requires manual scrolling.
2.  **Align AbstractActivity**: Potentially move the inset listener in `AbstractActivity` to a higher-level view or adjust how the `ScrollView` reacts to the padding to ensure the focused `EditText` is always kept above the keyboard automatically.