### PR TITLE
Fix some list naming issues (rel. to #18092)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/list/StoredList.java
+++ b/main/src/main/java/cgeo/geocaching/list/StoredList.java
@@ -37,6 +37,7 @@ import androidx.appcompat.app.AlertDialog;
 import java.lang.ref.WeakReference;
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -398,16 +399,10 @@ public final class StoredList extends AbstractList {
                             final String temp = ((AutoCompleteTextView) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.listprefixView))).getText().toString();
                             if (Strings.CS.equals(temp, LocalizationUtils.getString(R.string.list_create_parent))) {
                                 prefix = Objects.requireNonNull(((TextInputEditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.newParent))).getText()).toString();
-                                if (!Strings.CS.endsWith(prefix.trim(), GROUP_SEPARATOR)) {
-                                    prefix = prefix.trim() + GROUP_SEPARATOR;
-                                }
                             } else if (!Strings.CS.equals(temp, LocalizationUtils.getString(R.string.init_custombnitem_none))) {
                                 prefix = temp + (!Strings.CS.endsWith(prefix.trim(), GROUP_SEPARATOR) ? GROUP_SEPARATOR : "");
                             }
-                            if (Strings.CS.equals(prefix, GROUP_SEPARATOR)) {
-                                prefix = "";
-                            }
-                            runnable.call(prefix + ((EditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.title))).getText().toString());
+                            runnable.call(handleListNameInputHelper(prefix, ((EditText) Objects.requireNonNull(((AlertDialog) d).findViewById(R.id.title))).getText().toString()));
                         }))
                     .setNegativeButton(android.R.string.cancel, (d, which) -> d.dismiss())
                     .setView(menu);
@@ -420,6 +415,19 @@ public final class StoredList extends AbstractList {
 
             ViewUtils.closeKeyboardOnLosingFocus(activity, listname);
             ViewUtils.closeKeyboardOnLosingFocus(activity, menu.findViewById(R.id.newParent));
+        }
+
+        public static String handleListNameInputHelper(final String selectedPrefix, final String selectedTitle) {
+            final String prefix = removeSeparatorsAndTrim(selectedPrefix);
+            final String title = removeSeparatorsAndTrim(selectedTitle);
+            return title.isEmpty() ? prefix : prefix.isEmpty() ? title : prefix + GROUP_SEPARATOR + title;
+        }
+
+        private static String removeSeparatorsAndTrim(final String input) {
+            return Arrays.stream(input.split(GROUP_SEPARATOR, -1))
+                    .map(String::trim)
+                    .filter(segment -> !segment.isEmpty())
+                    .collect(Collectors.joining(GROUP_SEPARATOR));
         }
 
         public void promptForListRename(final int listId, @NonNull final Runnable runAfterRename) {
@@ -462,12 +470,12 @@ public final class StoredList extends AbstractList {
                     .setTitle(R.string.list_menu_rename_list_prefix)
                     .setPositiveButton(android.R.string.ok, ((d, which) -> {
                         final String from = listprefixView.getText().toString();
-                        final String to = title.getText().toString();
+                        final String to = removeSeparatorsAndTrim(Objects.requireNonNull(title.getText()).toString());
                         if (!Strings.CS.equals(from, to)) {
                             SimpleDialog.of(activity).setTitle(R.string.list_menu_rename_list_prefix).setMessage(TextParam.text(
-                                    LocalizationUtils.getString(R.string.list_confirm_rename, from, to, to.lastIndexOf(GROUP_SEPARATOR) < 0 ? LocalizationUtils.getString(R.string.list_confirm_no_hierarchy) : ""))
+                                    LocalizationUtils.getString(R.string.list_confirm_rename, from, to, to.isEmpty() ? LocalizationUtils.getString(R.string.list_confirm_no_hierarchy) : ""))
                                 ).confirm(() -> {
-                                    DataStore.renameListPrefix(from, to);
+                                    DataStore.renameListPrefix(from + GROUP_SEPARATOR, to + (to.isEmpty() ? "" : GROUP_SEPARATOR));
                                     runAfterRename.run();
                                 });
                             }
@@ -481,6 +489,7 @@ public final class StoredList extends AbstractList {
                 ((EditText) menu.findViewById(R.id.title)).setText(s);
                 dialog.getButton(DialogInterface.BUTTON_POSITIVE).setEnabled(s.length() > 0);
             }));
+            ViewUtils.closeKeyboardOnLosingFocus(activity, title);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2962,7 +2962,17 @@ public class DataStore {
     public static List<String> getListHierarchy() {
         return withAccessLock(() -> {
             final Cursor c = database.rawQuery("SELECT DISTINCT RTRIM(title, REPLACE(title, ':', '')) FROM " + dbTableLists + " ORDER BY title COLLATE NOCASE ASC", new String[]{});
-            return cursorToColl(c, new ArrayList<>(), GET_STRING_0);
+            final Set<String> result = new HashSet<>();
+            while (c.moveToNext()) {
+                final String temp = c.getString(0).trim().replaceAll(":+$", "").trim();
+                if (!temp.isEmpty()) {
+                    result.add(temp);
+                }
+            }
+            c.close();
+            final ArrayList<String> result2 = new ArrayList<>(result);
+            Collections.sort(result2);
+            return result2;
         });
     }
 

--- a/main/src/test/java/cgeo/geocaching/list/StoredListTest.java
+++ b/main/src/test/java/cgeo/geocaching/list/StoredListTest.java
@@ -1,0 +1,37 @@
+package cgeo.geocaching.list;
+
+import static cgeo.geocaching.list.StoredList.UserInterface.handleListNameInputHelper;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class StoredListTest {
+
+    @Test
+    public void handleListNaming() {
+        // some basic list creation tests
+        assertThat(handleListNameInputHelper("",  "A")).isEqualTo("A");
+        assertThat(handleListNameInputHelper("A", "B")).isEqualTo("A:B");
+        assertThat(handleListNameInputHelper("A:B", "C")).isEqualTo("A:B:C");
+        assertThat(handleListNameInputHelper("A:B:C", "D")).isEqualTo("A:B:C:D");
+        // fix some formatting errors
+        assertThat(handleListNameInputHelper("A::B", "C")).isEqualTo("A:B:C");
+        assertThat(handleListNameInputHelper("A:", "C")).isEqualTo("A:C");
+        assertThat(handleListNameInputHelper("A::", "C")).isEqualTo("A:C");
+        assertThat(handleListNameInputHelper("A::::", "C")).isEqualTo("A:C");
+        assertThat(handleListNameInputHelper("A: ", "C")).isEqualTo("A:C");
+        assertThat(handleListNameInputHelper("A: B", "C")).isEqualTo("A:B:C");
+        assertThat(handleListNameInputHelper("A: B: ", "C")).isEqualTo("A:B:C");
+        // fix some user input errors
+        assertThat(handleListNameInputHelper("A", "::C")).isEqualTo("A:C");
+        assertThat(handleListNameInputHelper("A", "::B:C")).isEqualTo("A:B:C");
+        assertThat(handleListNameInputHelper("A", "B::C")).isEqualTo("A:B:C");
+        assertThat(handleListNameInputHelper("A", "B: :C")).isEqualTo("A:B:C");
+        assertThat(handleListNameInputHelper("", "::C")).isEqualTo("C");
+        assertThat(handleListNameInputHelper("A", "")).isEqualTo("A");
+        assertThat(handleListNameInputHelper("A", " ")).isEqualTo("A");
+        assertThat(handleListNameInputHelper("A", ":")).isEqualTo("A");
+        assertThat(handleListNameInputHelper("A", "::")).isEqualTo("A");
+    }
+
+}


### PR DESCRIPTION
## Description
Fixes many (but not all) things mentioned in #18092:
- removes leading/trailing spaces and colons on saving list name
- removes multiple consecutive colons on saving list name
- (same for setting new list prefix)
- adds unit tests for list naming handling
- closes keyboard on leaving "list prefix to" field
- returns list of list prefixes without trailing colons

## Additional context
Untouched by this PR is to enable "OK" button on just changing selected parent list.