### PR TITLE
fix #18083: AdvLab Waypoints: keep visited data for labs only stored …

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/storage/DataStoreTest.java
@@ -331,6 +331,45 @@ public class DataStoreTest {
     }
 
     @Test
+    public void testStoreOfflineCacheWithMemoryData() {
+        try {
+            final Geocache cacheInMemory = new Geocache();
+            cacheInMemory.setGeocode(ARTIFICIAL_GEOCODE);
+            cacheInMemory.setCoords(new Geopoint(1, 2));
+            cacheInMemory.setDescription("Cache description in memory");
+            cacheInMemory.setShortDescription("Cache short-description in memory");
+            cacheInMemory.setPersonalNote("Personal note in memory");
+            cacheInMemory.setDetailed(true);
+
+            DataStore.saveCache(cacheInMemory, EnumSet.of(LoadFlags.SaveFlag.CACHE));
+
+            // store cache-data
+            final Geocache cacheNew = new Geocache();
+            cacheNew.setGeocode(ARTIFICIAL_GEOCODE);
+            cacheNew.setDescription("Cache description new");
+            cacheNew.setHint("Cache hint new");
+            //no coord, no personal note, no short description
+
+            DataStore.saveCache(cacheNew, EnumSet.of(LoadFlags.SaveFlag.DB));
+
+            final Geocache cacheDb = DataStore.loadCache(ARTIFICIAL_GEOCODE, LoadFlags.LOAD_CACHE_OR_DB);
+
+            assertThat(cacheDb).isNotNull();
+            assertThat(cacheDb.getGeocode()).isEqualTo(ARTIFICIAL_GEOCODE);
+
+            // all data from new cache except what was preserved from memory
+            assertThat(cacheDb.getCoords()).isEqualTo(new Geopoint(1, 2));
+            assertThat(cacheDb.getDescription()).isEqualTo("Cache description new");
+            assertThat(cacheDb.getShortDescription()).isEqualTo("Cache short-description in memory");
+            assertThat(cacheDb.getPersonalNote()).isEqualTo("Personal note in memory");
+            assertThat(cacheDb.getHint()).isEqualTo("Cache hint new");
+        } finally {
+            DataStore.removeCache(ARTIFICIAL_GEOCODE, REMOVE_ALL);
+        }
+    }
+
+
+    @Test
     public void testUpdateOfflineCache() {
         try {
             final Geopoint gp = new Geopoint(1, 2);

--- a/main/src/main/java/cgeo/geocaching/WaypointPopupFragment.java
+++ b/main/src/main/java/cgeo/geocaching/WaypointPopupFragment.java
@@ -3,6 +3,8 @@ package cgeo.geocaching;
 import cgeo.geocaching.activity.AbstractNavigationBarMapActivity;
 import cgeo.geocaching.apps.navi.NavigationAppFactory;
 import cgeo.geocaching.databinding.WaypointPopupBinding;
+import cgeo.geocaching.enumerations.LoadFlags;
+import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Units;
 import cgeo.geocaching.models.Geocache;
@@ -14,6 +16,7 @@ import cgeo.geocaching.speech.SpeechService;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.ui.CacheDetailsCreator;
 import cgeo.geocaching.ui.ViewUtils;
+import cgeo.geocaching.utils.AndroidRxUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.TextUtils;
@@ -114,6 +117,12 @@ public class WaypointPopupFragment extends AbstractDialogFragmentWithProximityNo
                 waypoint.setVisited(!waypoint.isVisited());
                 DataStore.saveWaypoint(waypoint.getId(), waypoint.getGeocode(), waypoint);
                 ViewUtils.showShortToast(getActivity(), waypoint.isVisited() ? R.string.waypoint_set_visited : R.string.waypoint_unset_visited);
+                if (waypoint.isVisited() && !cache.isOffline()) {
+                    cache.getLists().add(StoredList.STANDARD_LIST_ID);
+                    AndroidRxUtils.computationScheduler.scheduleDirect(() -> DataStore.saveCache(cache, LoadFlags.SAVE_ALL));
+                    GeocacheChangedBroadcastReceiver.sendBroadcast(getActivity(), cache.getGeocode());
+                    ViewUtils.showShortToast(getActivity(), R.string.info_cache_saved);
+                }
             });
 
             binding.edit.setOnClickListener(arg0 -> EditWaypointActivity.startActivityEditWaypoint(getActivity(), cache, waypoint.getId()));

--- a/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/al/ALApi.java
@@ -4,7 +4,6 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.connector.IConnector;
 import cgeo.geocaching.connector.gc.GCLogin;
 import cgeo.geocaching.enumerations.CacheSize;
-import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.enumerations.LoadFlags.SaveFlag;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.filters.core.BaseGeocacheFilter;
@@ -345,9 +344,6 @@ final class ALApi {
             if (!Settings.isALCfoundStateManual()) {
                 cache.setFound(response.get("IsComplete").asBoolean());
             }
-            final Geocache oldCache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-            final String personalNote = (oldCache != null && oldCache.getPersonalNote() != null) ? oldCache.getPersonalNote() : "";
-            cache.setPersonalNote(personalNote, false);
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.CACHE));
             return cache;
         } catch (final NullPointerException e) {
@@ -391,9 +387,6 @@ final class ALApi {
                 cache.setAlcMode(0);
             }
             Log.d("_AL mode from JSON: IsLinear: " + cache.isLinearAlc());
-            final Geocache oldCache = DataStore.loadCache(geocode, LoadFlags.LOAD_CACHE_OR_DB);
-            final String personalNote = (oldCache != null && oldCache.getPersonalNote() != null) ? oldCache.getPersonalNote() : "";
-            cache.setPersonalNote(personalNote, false);
             cache.setDetailedUpdatedNow();
             DataStore.saveCache(cache, EnumSet.of(SaveFlag.DB));
             return cache;

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -2356,6 +2356,12 @@ public class DataStore {
                     boolean dbUpdateRequired = !isOffline || (cacheCache.getCacheFromCache(geocode) != null);
                     if (isOffline) {
                         dbUpdateRequired |= !cache.gatherMissingFrom(existingCache);
+                    } else if (existingCache != null && existingCache.isDetailed()) {
+                        // For non-offline caches (not saved to any list), still merge user-modified
+                        // data from the existing version: visited waypoints, personal note,
+                        // user-modified coordinates, etc. The return value is irrelevant here
+                        // since dbUpdateRequired is already true for non-offline caches.
+                        cache.gatherMissingFrom(existingCache);
                     }
                     // parse the note AFTER merging the local information in
                     dbUpdateRequired |= cache.addCacheArtefactsFromNotes();


### PR DESCRIPTION
fix #18083: AdvLab Waypoints: keep visited data for labs only stored in memory on refresh