### PR TITLE
Recreate tilelayer for MF online data src in onResume (fix #17743)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -122,6 +122,10 @@ public class UnifiedMapType implements Parcelable {
 
     /** launch fresh map with current settings */
     public void launchMap(final Context fromActivity) {
+        // dismiss the originating map's cache popup so it isn't restored when the user navigates back
+        if (fromActivity instanceof UnifiedMapActivity) {
+            ((UnifiedMapActivity) fromActivity).sheetRemoveFragment();
+        }
         fromActivity.startActivity(getLaunchMapIntent(fromActivity));
     }
 

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/mapsforge/MapsforgeFragment.java
@@ -12,6 +12,7 @@ import cgeo.geocaching.unifiedmap.UnifiedMapActivity;
 import cgeo.geocaching.unifiedmap.geoitemlayer.IProviderGeoItemLayer;
 import cgeo.geocaching.unifiedmap.geoitemlayer.MapsforgeV6GeoItemLayer;
 import cgeo.geocaching.unifiedmap.layers.MBTilesLayerHelper;
+import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeOnlineTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractMapsforgeTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.utils.AngleUtils;
@@ -184,11 +185,17 @@ public class MapsforgeFragment extends AbstractMapFragment implements Observer {
         super.onResume();
         // mMapView.onResume();
         mMapView.getModel().mapViewPosition.addObserver(this);
+        if (currentTileProvider instanceof AbstractMapsforgeOnlineTileProvider) {
+            ((AbstractMapsforgeOnlineTileProvider) currentTileProvider).addTileLayer(this, mMapView);
+        }
     }
 
     @Override
     public void onPause() {
         // mMapView.onPause();
+        if (currentTileProvider instanceof AbstractMapsforgeOnlineTileProvider) {
+            ((AbstractMapsforgeOnlineTileProvider) currentTileProvider).removeTileLayer(mMapView);
+        }
         super.onPause();
 
         mMapView.getModel().mapViewPosition.removeObserver(this);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeOnlineTileProvider.java
@@ -64,34 +64,8 @@ public class AbstractMapsforgeOnlineTileProvider extends AbstractMapsforgeTilePr
     public void addTileLayer(final MapsforgeFragment fragment, final MapView map) {
         mfTileSource.setUserAgent("cgeo");
         tileLayer = new TileDownloadLayer(fragment.getTileCache(), map.getModel().mapViewPosition, mfTileSource, AndroidGraphicFactory.INSTANCE);
-        map.getLayerManager().getLayers().add(tileLayer);
-        onResume(); // start tile downloader
+        map.getLayerManager().getLayers().add(0, tileLayer); // insert at the bottom of the stack so overlays stay on top
+        ((TileDownloadLayer) tileLayer).onResume();
     }
 
-    // ========================================================================
-    // Lifecycle methods
-
-    @Override
-    public void onPause() {
-        if (tileLayer != null) {
-            ((TileDownloadLayer) tileLayer).onPause();
-        }
-        super.onPause();
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        if (tileLayer != null) {
-            ((TileDownloadLayer) tileLayer).onResume();
-        }
-    }
-
-    @Override
-    public void onDestroy() {
-        if (tileLayer != null) {
-            tileLayer.onDestroy();
-        }
-        super.onDestroy();
-    }
 }

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/tileproviders/AbstractMapsforgeTileProvider.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 
 import org.mapsforge.map.layer.TileLayer;
+import org.mapsforge.map.layer.cache.TileCache;
 import org.mapsforge.map.view.MapView;
 
 public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider {
@@ -45,10 +46,20 @@ public abstract class AbstractMapsforgeTileProvider extends AbstractTileProvider
 
     public void prepareForTileSourceChange(final MapView mapView) {
         if (tileLayer != null) {
-            onPause(); // notify tileProvider
+            onPause(); // notify tileProvider (graceful pause before destroy for providers that override it)
+            final TileCache cache = tileLayer.getTileCache();
+            removeTileLayer(mapView);
+            if (cache != null) {
+                cache.purge();
+            }
+        }
+    }
+
+    /** Tear down the tile layer but keep the cached tiles. Used for resume-rebuild (see #17743). */
+    public void removeTileLayer(final MapView mapView) {
+        if (tileLayer != null) {
             mapView.getLayerManager().getLayers().remove(tileLayer);
             tileLayer.onDestroy();
-            tileLayer.getTileCache().purge();
             tileLayer = null;
         }
     }


### PR DESCRIPTION
## Description
- Removes and recreates tilelayer for Mapsforge online datasources to recreate the stalled tile downloader threads
- Don't show cache popup on returning from navigation map
