### PR TITLE
For local instrumented tests: make sure they don't uninstall the main app

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,6 @@ systemProp.org.gradle.internal.launcher.welcomeMessageEnabled=false
 
 # AndroidX configuration
 android.useAndroidX=true
+
+# For local instrumented tests: leave original c:geo installation intact on device
+android.injected.androidTest.leaveApksInstalledAfterRun=true


### PR DESCRIPTION
For local instrumented tests: make sure they don't uninstall the main app

I have the problem when I run locally instrumented tests (via Android Studio Runners) then those tests uninstall my main app on my emulator. This usually means I have to set it up again completely (going through config wizard, importing a backup etc). This is very tedious.

With the setting in this PR instrumented test runs leave the original app (and the test app) on the device after run.