### PR TITLE
Update lifecycle to 2.10.0

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -484,11 +484,10 @@ dependencies {
     }
 
     // Support Library Lifecycle Helpers
-    String lifecycleVersion = '2.6.2'
+    String lifecycleVersion = '2.10.0'
     implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-common:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-reactivestreams:$lifecycleVersion"
 
     // workmanager (to replace foreground services for downloader)

--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -31,6 +31,11 @@
 
 -keep class androidx.appcompat.widget.ShareActionProvider { <init>(...); }
 
+# androidx.lifecycle 2.10.0+ ProGuard/R8 rules to prevent AbstractMethodError with DefaultLifecycleObserver
+-keep class * implements androidx.lifecycle.DefaultLifecycleObserver {
+    public void * (androidx.lifecycle.LifecycleOwner);
+}
+
 # Apache commons ----------------------------------------------------------------------------------
 
 # apache.commons.collections has some bean related collections, which are undefined in Android


### PR DESCRIPTION
- Upgraded `androidx.lifecycle` from 2.6.2 to 2.10.0.
- change to minSDK 23 is fine now for c:geo
- Replaced the obsolete `lifecycle-common-java8` artifact.
- Removed redundant `-ktx` dependencies from the Java codebase.
- Added a ProGuard keep rule for `DefaultLifecycleObserver` to prevent runtime crashes in minified builds.

Release notes are at https://developer.android.com/jetpack/androidx/releases/lifecycle#groovy.

Replaces #17596.
