### PR TITLE
Fix recurring prompt for tile update (fix #18084)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
+++ b/main/src/main/java/cgeo/geocaching/downloader/DownloaderUtils.java
@@ -99,7 +99,7 @@ public class DownloaderUtils {
     public static void checkForRoutingTileUpdates(final MainActivity activity) {
         if (Settings.useInternalRouting() && !PersistableFolder.ROUTING_TILES.isLegacy() && Settings.brouterAutoTileDownloadsNeedUpdate()) {
             DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.tilesupdate, DOWNLOADTYPE_BROUTER_TILES, R.string.updates_check, R.string.tileupdate_info, DownloaderUtils::returnFromTileUpdateCheck);
-            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.tilesupdate, DOWNLOADTYPE_BROUTER_LOOKUPS, R.string.updates_check, R.string. tileupdate_info, null);
+            DownloaderUtils.checkForUpdatesAndDownloadAll(activity, R.id.tilesupdate, DOWNLOADTYPE_BROUTER_LOOKUPS, R.string.updates_check, R.string. tileupdate_info, DownloaderUtils::returnFromTileUpdateCheck);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1566,7 +1566,7 @@ public class Settings {
         return (System.currentTimeMillis() / 1000) - (delay && (intervalInHours > 72) ? (long) (intervalInHours - 72) * HOURS_TO_SECONDS : 0);
     }
 
-    // checks given timestamp against interval; initializes timestampt, if needed
+    // checks given timestamp against interval; initializes timestamp, if needed
     private static boolean needsIntervalAction(final @StringRes int prefTimestamp, final int intervalInHours, final Runnable initAction) {
         // check disabled?
         if (intervalInHours < 1) {


### PR DESCRIPTION
## Description
Did not set timestamp correctly after postponed update check, leading to recurring requests to update downloaded data.