### PR TITLE
Fine-tuning for "select coords from map" (rel. to #18011)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -1216,14 +1216,14 @@ public class Settings {
      * live map) and the map of a single cache (which is often zoomed in more deep).
      */
     public static int getMapZoom(final UnifiedMapType.UnifiedMapTypeType mapType) {
-        if (mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetGeocode || mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetCoords) {
+        if (mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetGeocode || mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetCoords || mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_SelectCoords) {
             return getCacheZoom();
         }
         return getMapZoom();
     }
 
     public static void setMapZoom(final UnifiedMapType.UnifiedMapTypeType mapType, final int zoomLevel) {
-        if (mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetGeocode || mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetCoords) {
+        if (mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetGeocode || mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_TargetCoords || mapType == UnifiedMapType.UnifiedMapTypeType.UMTT_SelectCoords) {
             setCacheZoom(zoomLevel);
         } else {
             setMapZoom(zoomLevel);

--- a/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinateInputDialog.java
+++ b/main/src/main/java/cgeo/geocaching/ui/dialog/CoordinateInputDialog.java
@@ -269,9 +269,10 @@ public class CoordinateInputDialog {
             if (waypointOptions == CoordinateDialogDisplayModeEnum.Waypoint) {
                 setFromMap.setVisibility(View.VISIBLE);
                 setFromMap.setOnClickListener(v -> {
-                            DefaultMap.startActivitySelectCoords((Activity) context, currentCoords());
-                            dialog.cancel();
-                        }
+                        final Geopoint gp = inputData.getGeopoint();
+                        DefaultMap.startActivitySelectCoords((Activity) context, gp != null ? gp : currentCoords());
+                        dialog.cancel();
+                    }
                 );
             } else {
                 setFromMap.setVisibility(View.GONE);

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapActivity.java
@@ -89,6 +89,7 @@ import static cgeo.geocaching.settings.Settings.MAPROTATION_OFF;
 import static cgeo.geocaching.unifiedmap.UnifiedMapType.BUNDLE_MAPTYPE;
 import static cgeo.geocaching.unifiedmap.UnifiedMapType.UnifiedMapTypeType.UMTT_List;
 import static cgeo.geocaching.unifiedmap.UnifiedMapType.UnifiedMapTypeType.UMTT_PlainMap;
+import static cgeo.geocaching.unifiedmap.UnifiedMapType.UnifiedMapTypeType.UMTT_SelectCoords;
 import static cgeo.geocaching.unifiedmap.UnifiedMapType.UnifiedMapTypeType.UMTT_TargetCoords;
 import static cgeo.geocaching.unifiedmap.UnifiedMapType.UnifiedMapTypeType.UMTT_TargetGeocode;
 import static cgeo.geocaching.unifiedmap.UnifiedMapType.UnifiedMapTypeType.UMTT_Viewport;
@@ -171,9 +172,6 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
 
     private int wherigoListenerId;
     private Menu toolbarMenu;
-
-    // return to Coordinate input dialog after selected point from map
-    private boolean selectPointOnMap = false;
 
     private final CacheListActionBarChooser listChooser = new CacheListActionBarChooser(this, this::getSupportActionBar, newListId -> {
         final Optional<AbstractList> lNew = StoredList.UserInterface.getMenuLists(false, PseudoList.NEW_LIST.id).stream().filter(l2 -> l2.id == newListId).findFirst();
@@ -462,6 +460,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
                 }
                 break;
             case UMTT_TargetCoords:
+            case UMTT_SelectCoords:
                 // set given coords as map center
                 if (setDefaultCenterAndZoom) {
                     mapFragment.setCenter(mapType.coords);
@@ -873,7 +872,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
     @Override
     public int getSelectedBottomItemId() {
         return viewModel == null || viewModel.mapType == null || viewModel.mapType.type == UMTT_PlainMap ||
-                viewModel.mapType.type == UMTT_Viewport || viewModel.mapType.type == UMTT_List || viewModel.mapType.type == UMTT_TargetCoords ? MENU_MAP : MENU_HIDE_NAVIGATIONBAR;
+                viewModel.mapType.type == UMTT_Viewport || viewModel.mapType.type == UMTT_List || viewModel.mapType.type == UMTT_TargetCoords || viewModel.mapType.type == UMTT_SelectCoords ? MENU_MAP : MENU_HIDE_NAVIGATIONBAR;
     }
 
     // ========================================================================
@@ -1218,10 +1217,7 @@ public class UnifiedMapActivity extends AbstractNavigationBarMapActivity impleme
         if (result.isEmpty()) {
             if (isLongTap) {
                 viewModel.longTapCoords.setValue(touchedPoint);
-                if (getIntent().hasExtra("SelectCoordinates")) {
-                    selectPointOnMap = getIntent().getBooleanExtra("SelectCoordinates", false);
-                }
-                if (selectPointOnMap) {
+                if (viewModel.mapType.type == UMTT_SelectCoords) {
                     MapUtils.showSelectFromMapDialog(this, touchedPoint);
                 } else {
                     MapUtils.createMapLongClickPopupMenu(this, touchedPoint, new Point(x, y), viewModel.individualRoute.getValue(), route -> viewModel.individualRoute.notifyDataChanged(), this::updateRouteTrackButtonVisibility, getCurrentTargetCache(), viewModel.mapType.fromList, viewModel::setTarget)

--- a/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
+++ b/main/src/main/java/cgeo/geocaching/unifiedmap/UnifiedMapType.java
@@ -26,6 +26,7 @@ public class UnifiedMapType implements Parcelable {
         UMTT_Viewport,          // open map, shows and scales to a given Viewport
         UMTT_TargetGeocode,     // set cache or waypoint as target
         UMTT_TargetCoords,      // set coords as target
+        UMTT_SelectCoords,      // select coordinates from map, starting at given position
         UMTT_List,              // display list contents
         UMTT_SearchResult       // show and scale to searchresult
         // to be extended
@@ -134,8 +135,8 @@ public class UnifiedMapType implements Parcelable {
 
     /** launch fresh map to select coordinates from map */
     public void launchMapWithSelectCoordinates(final Context fromActivity) {
+        type = UnifiedMapTypeType.UMTT_SelectCoords;
         final Intent intent = getLaunchMapIntent(fromActivity);
-        intent.putExtra("SelectCoordinates", true);
         ((Activity) fromActivity).startActivityForResult(intent, REQUEST_CODE_GET_COORDS);
     }
 


### PR DESCRIPTION
## Description
- Add UMTT_SelectCoords as new UnifiedMapType
- On selecting coords from map, use current GPS position for new waypoints, and waypoint's position otherwise