### PR TITLE
Fix filtering for own caches

### DIFF
--- a/main/src/androidTest/java/cgeo/geocaching/filters/StatusGeocacheFilterTest.java
+++ b/main/src/androidTest/java/cgeo/geocaching/filters/StatusGeocacheFilterTest.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.filters;
 
+import cgeo.geocaching.connector.gc.GCLogin;
 import cgeo.geocaching.filters.core.GeocacheFilterType;
 import cgeo.geocaching.filters.core.StatusGeocacheFilter;
 import cgeo.geocaching.models.Geocache;
@@ -58,6 +59,7 @@ public class StatusGeocacheFilterTest {
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // is done in called test method
     public void owned() {
+        GCLogin.getInstance().login();
         singleStandardStatus((c, b) -> {
             c.setOwnerUserId(b ? Settings.getUserName() : "");
             c.setGeocode("GCFAKE");

--- a/main/src/main/java/cgeo/geocaching/CacheListActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheListActivity.java
@@ -1589,9 +1589,12 @@ public class CacheListActivity extends AbstractListActivity implements FilteredA
         context.startActivity(cachesIntent);
     }
 
-    public static void startActivityFilter(final Context context) {
+    public static void startActivityFilter(final Context context, @Nullable final GeocacheFilterContext filterContext) {
         final Intent cachesIntent = new Intent(context, CacheListActivity.class);
         Intents.putListType(cachesIntent, CacheListType.SEARCH_FILTER);
+        if (filterContext != null) {
+            cachesIntent.putExtra(Intents.EXTRA_FILTER_CONTEXT, filterContext);
+        }
         context.startActivity(cachesIntent);
     }
 

--- a/main/src/main/java/cgeo/geocaching/SearchActivity.java
+++ b/main/src/main/java/cgeo/geocaching/SearchActivity.java
@@ -13,7 +13,10 @@ import cgeo.geocaching.connector.internal.InternalConnector;
 import cgeo.geocaching.connector.trackable.TrackableBrand;
 import cgeo.geocaching.connector.trackable.TrackableTrackingCode;
 import cgeo.geocaching.databinding.SearchActivityBinding;
+import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.GeocacheFilterContext;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.StatusGeocacheFilter;
 import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.search.GeocacheAutoCompleteAdapter;
@@ -548,7 +551,11 @@ public class SearchActivity extends AbstractNavigationBarActivity {
     }
 
     private void findOwnFn() {
-        CacheListActivity.startActivityOwner(this, Settings.getUserName(), new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT));
+        final StatusGeocacheFilter statusFilter = GeocacheFilterType.STATUS.create();
+        statusFilter.setStatusOwned(true);
+        final GeocacheFilterContext filterContext = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
+        filterContext.set(GeocacheFilter.create(null, false, false, statusFilter));
+        CacheListActivity.startActivityFilter(this, filterContext);
         ActivityMixin.overrideTransitionToFade(this);
     }
 
@@ -595,7 +602,7 @@ public class SearchActivity extends AbstractNavigationBarActivity {
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, @Nullable final Intent data) {
         if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER && resultCode == Activity.RESULT_OK) {
-            CacheListActivity.startActivityFilter(this);
+            CacheListActivity.startActivityFilter(this, null);
             ActivityMixin.overrideTransitionToFade(this);
         } else {
             super.onActivityResult(requestCode, resultCode, data);

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OCApiLiveConnector.java
@@ -160,7 +160,7 @@ public class OCApiLiveConnector extends OCApiConnector implements ISearchByViewP
     @Override
     public boolean isOwner(@NonNull final Geocache cache) {
         final String userName = getUserName();
-        return StringUtils.isNotEmpty(userName) && Strings.CS.equals(cache.getOwnerDisplayName(), userName);
+        return StringUtils.isNotEmpty(userName) && Strings.CI.equals(cache.getOwnerDisplayName(), userName);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -364,25 +364,21 @@ final class OkapiClient {
 
         final List<BaseGeocacheFilter> filters = filter.getAndChainIfPossible();
 
-        final Geopoint searchCoords;
-        final String radius;
-
-        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
-        if (df != null) {
-            searchCoords = df.getEffectiveCoordinate();
-            radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
-        } else {
-            // search around current position by default
-            searchCoords = null;
-            radius = DEFAULT_RADIUS;
-        }
-
-        //fill in the defaults
+        // fill in the defaults
         final Parameters params = new Parameters("search_method", METHOD_SEARCH_ALL);
         final Map<String, String> valueMap = new LinkedHashMap<>();
         valueMap.put("limit", "" + take);
         valueMap.put("offset", "" + skip);
-        fillSearchParameterCenter(valueMap, params, searchCoords, radius);
+
+        final DistanceGeocacheFilter df = GeocacheFilter.findInChain(filters, DistanceGeocacheFilter.class);
+        if (df != null) {
+            final String radius = df.getMaxRangeValue() == null ? DEFAULT_RADIUS : "" + (df.getMaxRangeValue().intValue() * 1000);
+            fillSearchParameterCenter(valueMap, params, df.getEffectiveCoordinate(), radius);
+        } else {
+            // search around current position by default
+            // (but limit only the number of retrieved caches, not the search radius)
+            fillSearchParameterCenter(valueMap, params, null, null);
+        }
 
         String finder = null;
 
@@ -528,11 +524,13 @@ final class OkapiClient {
 
     }
 
-    public static void fillSearchParameterCenter(@NonNull final Map<String, String> valueMap, @NonNull final Parameters params, @Nullable final Geopoint center, final String radius) {
+    public static void fillSearchParameterCenter(@NonNull final Map<String, String> valueMap, @NonNull final Parameters params, @Nullable final Geopoint center, @Nullable final String radius) {
         final Geopoint usedCenter = center != null ? center : LocationDataProvider.getInstance().currentGeo().getCoords();
         final String centerString = GeopointFormatter.format(GeopointFormatter.Format.LAT_DECDEGREE_RAW, usedCenter) + SEPARATOR + GeopointFormatter.format(GeopointFormatter.Format.LON_DECDEGREE_RAW, usedCenter);
         valueMap.put("center", centerString);
-        valueMap.put("radius", radius);
+        if (radius != null) {
+            valueMap.put("radius", radius);
+        }
         params.removeKey("search_method");
         params.put("search_method", METHOD_SEARCH_NEAREST);
     }

--- a/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
+++ b/main/src/main/java/cgeo/geocaching/connector/oc/OkapiClient.java
@@ -8,6 +8,7 @@ import cgeo.geocaching.connector.ImageResult;
 import cgeo.geocaching.connector.LogResult;
 import cgeo.geocaching.connector.UserInfo;
 import cgeo.geocaching.connector.UserInfo.UserInfoStatus;
+import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.connector.gc.GCConnector;
 import cgeo.geocaching.connector.oc.OCApiConnector.ApiSupport;
 import cgeo.geocaching.connector.oc.OCApiConnector.OAuthLevel;
@@ -85,7 +86,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
-import static java.lang.Boolean.FALSE;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -485,11 +485,16 @@ final class OkapiClient {
                     valueMap.put("status", value.substring(1));
                 }
 
-                if (statusFilter.getStatusFound() != null) {
-                    valueMap.put("found_status", statusFilter.getStatusFound() ? "found_only" : "notfound_only");
+                final Boolean statusFound = statusFilter.getStatusFound();
+                if (statusFound != null) {
+                    valueMap.put("found_status", statusFound ? "found_only" : "notfound_only");
                 }
-                if (FALSE.equals(statusFilter.getStatusOwned())) {
+
+                final Boolean statusOwned = statusFilter.getStatusOwned();
+                if (Boolean.FALSE.equals(statusOwned)) {
                     valueMap.put("exclude_my_own", "true");
+                } else if (Boolean.TRUE.equals(statusOwned) && (connector instanceof ILogin)) {
+                    valueMap.put("owner_uuid", getUserUUID(connector, ((ILogin) connector).getUserName()));
                 }
                 break;
             case LOGS_COUNT:

--- a/main/src/main/java/cgeo/geocaching/connector/su/SuApi.java
+++ b/main/src/main/java/cgeo/geocaching/connector/su/SuApi.java
@@ -13,6 +13,7 @@ import cgeo.geocaching.filters.core.GeocacheFilter;
 import cgeo.geocaching.filters.core.NameGeocacheFilter;
 import cgeo.geocaching.filters.core.OriginGeocacheFilter;
 import cgeo.geocaching.filters.core.OwnerGeocacheFilter;
+import cgeo.geocaching.filters.core.StatusGeocacheFilter;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.log.LogType;
@@ -180,6 +181,10 @@ public class SuApi {
         final OwnerGeocacheFilter ownf = GeocacheFilter.findInChain(filters, OwnerGeocacheFilter.class);
         if (ownf != null && !StringUtils.isEmpty(ownf.getStringFilter().getTextValue())) {
             return searchByOwner(ownf.getStringFilter().getTextValue(), connector);
+        }
+        final StatusGeocacheFilter statusFilter = GeocacheFilter.findInChain(filters, StatusGeocacheFilter.class);
+        if (statusFilter != null && Boolean.TRUE.equals(statusFilter.getStatusOwned())) {
+            return searchByOwner(connector.getUserName(), connector);
         }
 
         //by default, search around current position

--- a/main/src/main/java/cgeo/geocaching/connector/su/SuConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/su/SuConnector.java
@@ -252,7 +252,7 @@ public class SuConnector extends AbstractConnector implements ISearchByGeocode, 
     @NonNull
     @Override
     public EnumSet<GeocacheFilterType> getFilterCapabilities() {
-        return EnumSet.of(GeocacheFilterType.DISTANCE, GeocacheFilterType.ORIGIN, GeocacheFilterType.NAME, GeocacheFilterType.OWNER);
+        return EnumSet.of(GeocacheFilterType.DISTANCE, GeocacheFilterType.ORIGIN, GeocacheFilterType.NAME, GeocacheFilterType.OWNER, GeocacheFilterType.STATUS);
     }
 
     @Override

--- a/main/src/main/java/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
+++ b/main/src/main/java/cgeo/geocaching/filters/core/StatusGeocacheFilter.java
@@ -1,12 +1,14 @@
 package cgeo.geocaching.filters.core;
 
 import cgeo.geocaching.R;
+import cgeo.geocaching.connector.ConnectorFactory;
+import cgeo.geocaching.connector.IConnector;
+import cgeo.geocaching.connector.capability.ILogin;
 import cgeo.geocaching.enumerations.CacheType;
 import cgeo.geocaching.enumerations.WaypointType;
 import cgeo.geocaching.log.LogType;
 import cgeo.geocaching.models.Geocache;
 import cgeo.geocaching.models.Waypoint;
-import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.SqlBuilder;
 import cgeo.geocaching.ui.ImageParam;
@@ -383,7 +385,34 @@ public class StatusGeocacheFilter extends BaseGeocacheFilter {
         } else {
             sqlBuilder.openWhere(SqlBuilder.WhereType.AND);
             if (statusOwned != null) {
-                sqlBuilder.addWhere("LOWER(" + sqlBuilder.getMainTableId() + "." + DataStore.dbFieldCaches_owner_real + ") " + (statusOwned ? "=" : "<>") + " LOWER(?)", Settings.getUserName());
+                // A cache is considered "owned" if the logged-in user's name matches the cache owner
+                // for at least one active connector that supports login (ILogin).
+                // The geocode prefix (sqlLikeExp) is used to restrict the owner check to caches
+                // belonging to that specific connector (e.g. GC* for geocaching.com) (AND clause).
+                // If statusOwned is false, the entire OR block is wrapped in a NOT clause.
+                if (!statusOwned) {
+                    sqlBuilder.openWhere(SqlBuilder.WhereType.NOT);
+                }
+                sqlBuilder.openWhere(SqlBuilder.WhereType.OR);
+                final List<IConnector> connectors = ConnectorFactory.getActiveConnectors();
+                for (final IConnector connector : connectors) {
+                    if (connector instanceof ILogin) {
+                        sqlBuilder.openWhere(SqlBuilder.WhereType.AND);
+                        final String username = ((ILogin) connector).getUserName();
+                        sqlBuilder.addWhere("LOWER(" + sqlBuilder.getMainTableId() + "."
+                                + DataStore.dbFieldCaches_owner_real + ") = LOWER(?)", username);
+                        sqlBuilder.openWhere(SqlBuilder.WhereType.OR);
+                        for (String sqlLikeExp : connector.getGeocodeSqlLikeExpressions()) {
+                            sqlBuilder.addWhere(sqlBuilder.getMainTableId() + ".geocode LIKE ?", sqlLikeExp);
+                        }
+                        sqlBuilder.closeWhere();
+                        sqlBuilder.closeWhere();
+                    }
+                }
+                sqlBuilder.closeWhere();
+                if (!statusOwned) {
+                    sqlBuilder.closeWhere();
+                }
             }
             if (statusFound != null) {
                 sqlBuilder.addWhere(sqlBuilder.getMainTableId() + "." + DataStore.dbFieldCaches_found + (statusFound ? "= 1" : "<> 1"));


### PR DESCRIPTION
<!-- Fill in the following form by adding your text below the explanation comments. -->
<!-- You can use the preview tab above to review your PR before submitting it. -->

<!-- Consider assigning reviewers and setting matching labels after submitting the PR -->

## Description
<!-- Provide a summary of the content of this PR -->
<!-- Examples: - Fixes a NULL check in xyz.java -->
* Use StatusGeocacheFilter "Own" for searching for own caches from SearchActivity.
* Improve StatusGeocacheFilter "Own" to handle multiple connectors correctly.
* For Okapi-Search without geo-/distance-information, don't limit the radius for the search, only the limit of returned caches

## Related issues
<!-- List the related issues fixed or improved by this PR -->
rel #6628 
rel #4752

## Additional context
<!-- (optional, remove if not applicable) References, links, other information -->
Implementation correct behaviour for multi-connector-filter is then not so urgent any more, but nevertheless probably useful (PR #18002 , PR #17812