### PR TITLE
Only enqueue online caches in CacheDownloaderService (fix #18093)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/IConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/IConnector.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.connector;
 
 import cgeo.geocaching.connector.capability.ICredentials;
 import cgeo.geocaching.connector.capability.ILogin;
+import cgeo.geocaching.connector.capability.ISearchByGeocode;
 import cgeo.geocaching.location.Geopoint;
 import cgeo.geocaching.log.LogEntry;
 import cgeo.geocaching.log.LogType;
@@ -193,6 +194,13 @@ public interface IConnector {
      * @return success
      */
     boolean uploadModifiedCoordinates(@NonNull Geocache cache, @NonNull Geopoint wpt);
+
+    /**
+     * Does connector support updating cache data from online source?
+     */
+    default boolean hasOnlineSource() {
+        return this instanceof ISearchByGeocode;
+    }
 
     /**
      * Return {@code true} if this connector is active for online interaction (download details, do searches, ...). If

--- a/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
+++ b/main/src/main/java/cgeo/geocaching/connector/internal/InternalConnector.java
@@ -93,6 +93,11 @@ public class InternalConnector extends AbstractConnector implements ISearchByGeo
     }
 
     @Override
+    public boolean hasOnlineSource() {
+        return false;
+    }
+
+    @Override
     public boolean isActive() {
         return true;
     }

--- a/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
+++ b/main/src/main/java/cgeo/geocaching/service/CacheDownloaderService.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.service;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.ActivityMixin;
+import cgeo.geocaching.connector.ConnectorFactory;
 import cgeo.geocaching.enumerations.LoadFlags;
 import cgeo.geocaching.list.StoredList;
 import cgeo.geocaching.models.Geocache;
@@ -31,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -126,20 +128,29 @@ public class CacheDownloaderService extends AbstractForegroundIntentService {
     private static void downloadCachesInternal(final Activity context, final Collection<String> geocodes, @Nullable final Set<Integer> listIds, final boolean keepExistingLists, final boolean forceRedownload, @Nullable final Runnable onStartCallback) {
 
         final ArrayList<String> newGeocodes = new ArrayList<>();
+        int cachesSkipped = 0;
 
         for (String geocode : geocodes) {
-            final DownloadTaskProperties properties = new DownloadTaskProperties(listIds, keepExistingLists, forceRedownload);
-            final boolean isNewGeocode;
-            synchronized (downloadQuery) {
-                isNewGeocode = downloadQuery.get(geocode) == null;
-                properties.merge(downloadQuery.get(geocode));
-                downloadQuery.put(geocode, properties);
-            }
-            if (isNewGeocode) {
-                newGeocodes.add(geocode);
+            // only enqueue online connectors
+            if (ConnectorFactory.getConnector(geocode).hasOnlineSource()) {
+                final DownloadTaskProperties properties = new DownloadTaskProperties(listIds, keepExistingLists, forceRedownload);
+                final boolean isNewGeocode;
+                synchronized (downloadQuery) {
+                    isNewGeocode = downloadQuery.get(geocode) == null;
+                    properties.merge(downloadQuery.get(geocode));
+                    downloadQuery.put(geocode, properties);
+                }
+                if (isNewGeocode) {
+                    newGeocodes.add(geocode);
+                }
+            } else {
+                cachesSkipped++;
             }
         }
 
+        if (cachesSkipped > 0) {
+            ViewUtils.showShortToast(context, String.format(Locale.getDefault(), context.getString(R.string.caches_store_background_skipped), cachesSkipped));
+        }
         if (newGeocodes.isEmpty()) {
             return;
         }

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -485,6 +485,7 @@
         <item quantity="many">%d caches downloaded</item>
         <item quantity="other">%d caches downloaded</item>
     </plurals>
+    <string name="caches_store_background_skipped">Skipped offline caches: %d</string>
     <string name="caches_history">History</string>
     <string name="caches_on_map">Show on map</string>
     <string name="caches_sort">Sort</string>


### PR DESCRIPTION
## Description
- Only enqueues caches from online connector to `CacheDownloaderService`
- Shows a short notification if offline-only caches were requested

## Test case
- Create a list which has at least one user-defined cache
- Select "caches -> refresh all" for this list
- Before: Downloader notification shows one failing update
- Now: Short toast notification + correct system notification
