### PR TITLE
rel to #12363 and #16034: introduce conditional cache markers

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -859,6 +859,11 @@
         </activity>
 
         <activity
+            android:name=".settings.ConditionalCacheMarkersActivity"
+            android:label="@string/conditional_marker_activity_title" >
+        </activity>
+
+        <activity
             android:name=".connector.trackable.GeokretyAuthorizationActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask"

--- a/main/src/main/java/cgeo/geocaching/models/ConditionalCacheMarker.java
+++ b/main/src/main/java/cgeo/geocaching/models/ConditionalCacheMarker.java
@@ -1,0 +1,97 @@
+package cgeo.geocaching.models;
+
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.utils.EmojiUtils;
+import cgeo.geocaching.utils.JsonUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Represents a single conditional cache marker rule: a filter paired with an emoji marker.
+ * When the filter matches a cache, the marker is shown on that cache's icon.
+ * This class is immutable — create a new instance to change values.
+ */
+public class ConditionalCacheMarker {
+
+    private static final String JSON_KEY_MARKER = "marker";
+    private static final String JSON_KEY_FILTER = "filter";
+
+    private final int markerId;
+    @Nullable private final GeocacheFilter filter;
+
+    public ConditionalCacheMarker(final int markerId, @Nullable final GeocacheFilter filter) {
+        this.markerId = markerId;
+        this.filter = filter;
+    }
+
+    public int getMarkerId() {
+        return markerId;
+    }
+
+    @Nullable
+    public GeocacheFilter getFilter() {
+        return filter;
+    }
+
+    /** Serialises this rule to a JSON object node. A null filter is stored as an absent field */
+    @NonNull
+    public ObjectNode toJson() {
+        final ObjectNode node = JsonUtils.createObjectNode();
+        JsonUtils.setInt(node, JSON_KEY_MARKER, markerId);
+        // null filter stored as absent field via JsonUtils.setText null-handling
+        JsonUtils.setText(node, JSON_KEY_FILTER, filter != null ? filter.toConfig() : null);
+        return node;
+    }
+
+    /** Deserialises a rule from a JSON node */
+    @NonNull
+    public static ConditionalCacheMarker fromJson(@NonNull final JsonNode node) {
+        final int markerId = JsonUtils.getInt(node, JSON_KEY_MARKER, EmojiUtils.NO_EMOJI);
+        final String filterConfigStr = JsonUtils.getText(node, JSON_KEY_FILTER, null);
+        final GeocacheFilter filter = filterConfigStr != null
+                ? GeocacheFilter.createFromConfig(filterConfigStr)
+                : null;
+        return new ConditionalCacheMarker(markerId, filter);
+    }
+
+    /**
+     * Returns the list of conditional marker IDs (emoji code-points) that apply to the given cache.
+     * Returns an empty list if cache is null.
+     */
+    @NonNull
+    public static List<Integer> getMarkersForCache(@Nullable final Geocache cache) {
+        return getMarkersForRules(cache, Settings.getConditionalCacheMarkers());
+    }
+
+    /**
+     * Package-private helper for testing: evaluates rules against a cache without reading from Settings.
+     * Rules are evaluated top-to-bottom. Rules with markerId == EmojiUtils.NO_EMOJI are skipped.
+     * A null or empty (non-filtering) filter matches all caches. Returns an empty list if cache is null.
+     */
+    @NonNull
+    static List<Integer> getMarkersForRules(@Nullable final Geocache cache, @NonNull final List<ConditionalCacheMarker> rules) {
+        if (cache == null) {
+            return Collections.emptyList();
+        }
+        final List<Integer> result = new ArrayList<>();
+        for (final ConditionalCacheMarker rule : rules) {
+            // null or empty (non-filtering) filter means "match all caches"
+            final boolean matches = rule.markerId != EmojiUtils.NO_EMOJI &&
+                (rule.filter == null || !rule.filter.isFiltering() || rule.filter.filter(cache));
+            if (matches) {
+                result.add(rule.markerId);
+            }
+        }
+        return result;
+    }
+}
+

--- a/main/src/main/java/cgeo/geocaching/settings/ConditionalCacheMarkersActivity.java
+++ b/main/src/main/java/cgeo/geocaching/settings/ConditionalCacheMarkersActivity.java
@@ -1,0 +1,264 @@
+package cgeo.geocaching.settings;
+
+import cgeo.geocaching.R;
+import cgeo.geocaching.activity.AbstractActionBarActivity;
+import cgeo.geocaching.databinding.ActivityConditionalMarkersBinding;
+import cgeo.geocaching.databinding.ConditionalMarkerListItemBinding;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterContext;
+import cgeo.geocaching.filters.gui.GeocacheFilterActivity;
+import cgeo.geocaching.models.ConditionalCacheMarker;
+import cgeo.geocaching.ui.recyclerview.AbstractRecyclerViewHolder;
+import cgeo.geocaching.ui.recyclerview.ManagedListAdapter;
+import cgeo.geocaching.utils.EmojiUtils;
+import cgeo.geocaching.utils.JsonUtils;
+import cgeo.geocaching.utils.LocalizationUtils;
+import cgeo.geocaching.utils.MapMarkerUtils;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.android.material.button.MaterialButton;
+
+public class ConditionalCacheMarkersActivity extends AbstractActionBarActivity {
+
+    private ActivityConditionalMarkersBinding binding;
+    private ConditionalMarkerListAdapter markerAdapter;
+    private String originalJson;
+
+    // -------------------------------------------------------------------------
+    // View holder
+    // -------------------------------------------------------------------------
+
+    protected static final class MarkerViewHolder extends AbstractRecyclerViewHolder {
+        final ConditionalMarkerListItemBinding itemBinding;
+
+        MarkerViewHolder(final View rowView) {
+            super(rowView);
+            itemBinding = ConditionalMarkerListItemBinding.bind(rowView);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Adapter
+    // -------------------------------------------------------------------------
+
+    private final class ConditionalMarkerListAdapter extends ManagedListAdapter<ConditionalCacheMarker, MarkerViewHolder> {
+
+        ConditionalMarkerListAdapter(final androidx.recyclerview.widget.RecyclerView recyclerView) {
+            super(new ManagedListAdapter.Config(recyclerView)
+                    .setSupportDragDrop(true)
+                    .setNotifyOnPositionChange(true));
+        }
+
+        private void fillViewHolder(final MarkerViewHolder holder, final ConditionalCacheMarker item) {
+            if (item == null) {
+                return;
+            }
+            // Marker button: show emoji glyph if set, else icon
+            final int markerId = item.getMarkerId();
+            final MaterialButton markerBtn = holder.itemBinding.markerButton;
+            if (markerId != EmojiUtils.NO_EMOJI) {
+                markerBtn.setText(EmojiUtils.getEmojiAsString(markerId));
+                markerBtn.setIcon(null);
+            } else {
+                markerBtn.setText(null);
+                markerBtn.setIconResource(R.drawable.ic_menu_emoticons);
+            }
+
+            // Filter label: null or non-filtering (empty) filter = marks all caches
+            final GeocacheFilter filter = item.getFilter();
+            if (filter == null || !filter.isFiltering()) {
+                holder.itemBinding.filterLabel.setText(LocalizationUtils.getString(R.string.conditional_marker_nofilter_label));
+            } else {
+                holder.itemBinding.filterLabel.setText(filter.toUserDisplayableString());
+            }
+        }
+
+        @NonNull
+        @Override
+        public MarkerViewHolder onCreateViewHolder(@NonNull final ViewGroup parent, final int viewType) {
+            final View view = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.conditional_marker_list_item, parent, false);
+            final MarkerViewHolder holder = new MarkerViewHolder(view);
+
+            // Marker edit button
+            holder.itemBinding.markerButton.setOnClickListener(v -> {
+                final int pos = holder.getBindingAdapterPosition();
+                if (pos == androidx.recyclerview.widget.RecyclerView.NO_ID) {
+                    return;
+                }
+                final ConditionalCacheMarker rule = getItem(pos);
+                EmojiUtils.selectEmojiPopup(
+                        ConditionalCacheMarkersActivity.this,
+                        rule.getMarkerId(),
+                        null,
+                        newMarkerId -> {
+                            removeItem(pos);
+                            addItem(pos, new ConditionalCacheMarker(newMarkerId, rule.getFilter()));
+                            updateEmptyHint();
+                        });
+            });
+
+            // Filter edit button
+            holder.itemBinding.filterButton.setOnClickListener(v -> {
+                final int pos = holder.getBindingAdapterPosition();
+                if (pos == androidx.recyclerview.widget.RecyclerView.NO_ID) {
+                    return;
+                }
+                final ConditionalCacheMarker rule = getItem(pos);
+                final GeocacheFilterContext ctx = new GeocacheFilterContext(GeocacheFilterContext.FilterType.TRANSIENT);
+                final GeocacheFilter existingFilter = rule.getFilter();
+                if (existingFilter != null) {
+                    ctx.set(existingFilter);
+                }
+                // Store position in tag so onActivityResult can find it
+                holder.itemBinding.filterButton.setTag(pos);
+                GeocacheFilterActivity.selectFilter(
+                        ConditionalCacheMarkersActivity.this,
+                        ctx,
+                        null,
+                        false);
+                // We store the position separately for use in onActivityResult
+                pendingFilterEditPosition = pos;
+            });
+
+            // Delete button
+            holder.itemBinding.deleteButton.setOnClickListener(v -> {
+                final int pos = holder.getBindingAdapterPosition();
+                if (pos != androidx.recyclerview.widget.RecyclerView.NO_ID) {
+                    removeItem(pos);
+                    updateEmptyHint();
+                }
+            });
+
+            // Drag handle
+            registerStartDrag(holder, holder.itemBinding.dragHandle);
+
+            return holder;
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull final MarkerViewHolder holder, final int position) {
+            fillViewHolder(holder, getItem(position));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Activity lifecycle
+    // -------------------------------------------------------------------------
+
+    private int pendingFilterEditPosition = -1;
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTheme();
+        setTitle(LocalizationUtils.getString(R.string.conditional_marker_activity_title));
+
+        binding = ActivityConditionalMarkersBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        markerAdapter = new ConditionalMarkerListAdapter(binding.markerList);
+
+        final List<ConditionalCacheMarker> rules = new ArrayList<>(Settings.getConditionalCacheMarkers());
+        markerAdapter.setItems(rules);
+        originalJson = rulesToJson(rules);
+
+        updateEmptyHint();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(final Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_conditional_markers, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        final int itemId = item.getItemId();
+        if (itemId == R.id.menu_item_save) {
+            saveAndFinish();
+            return true;
+        } else if (itemId == R.id.menu_item_cancel) {
+            finish();
+            return true;
+        } else if (itemId == android.R.id.home) {
+            finish();
+            return true;
+        } else if (itemId == R.id.menu_item_add) {
+            addNewRule();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onActivityResult(final int requestCode, final int resultCode, @Nullable final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == GeocacheFilterActivity.REQUEST_SELECT_FILTER
+                && resultCode == Activity.RESULT_OK
+                && data != null
+                && pendingFilterEditPosition >= 0) {
+            final GeocacheFilterContext resultCtx = data.getParcelableExtra(GeocacheFilterActivity.EXTRA_FILTER_CONTEXT);
+            if (resultCtx != null && pendingFilterEditPosition < markerAdapter.getItemCount()) {
+                final ConditionalCacheMarker rule = markerAdapter.getItem(pendingFilterEditPosition);
+                // Store the returned filter as-is: non-null, evaluated on match (empty filter matches all caches)
+                final ConditionalCacheMarker updated = new ConditionalCacheMarker(rule.getMarkerId(), resultCtx.get());
+                markerAdapter.removeItem(pendingFilterEditPosition);
+                markerAdapter.addItem(pendingFilterEditPosition, updated);
+            }
+            pendingFilterEditPosition = -1;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void addNewRule() {
+        final ConditionalCacheMarker newRule = new ConditionalCacheMarker(EmojiUtils.NO_EMOJI, null);
+        final List<ConditionalCacheMarker> items = new ArrayList<>(markerAdapter.getItems());
+        items.add(newRule);
+        markerAdapter.setItems(items);
+        updateEmptyHint();
+    }
+
+    private void saveAndFinish() {
+        Settings.setConditionalCacheMarkers(markerAdapter.getItems());
+        MapMarkerUtils.clearCachedItems();
+        finish();
+    }
+
+    private void updateEmptyHint() {
+        final boolean isEmpty = markerAdapter.getItemCount() == 0;
+        binding.emptyHint.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
+        binding.markerList.setVisibility(isEmpty ? View.GONE : View.VISIBLE);
+    }
+
+    @NonNull
+    private static String rulesToJson(final List<ConditionalCacheMarker> rules) {
+        final ArrayNode array = JsonUtils.createArrayNode();
+        for (final ConditionalCacheMarker rule : rules) {
+            array.add(rule.toJson());
+        }
+        return JsonUtils.nodeToString(array);
+    }
+}
+
+
+
+

--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -24,6 +24,7 @@ import cgeo.geocaching.log.LogTypeTrackable;
 import cgeo.geocaching.log.TrackableComparator;
 import cgeo.geocaching.maps.routing.Routing;
 import cgeo.geocaching.maps.routing.RoutingMode;
+import cgeo.geocaching.models.ConditionalCacheMarker;
 import cgeo.geocaching.models.Download;
 import cgeo.geocaching.models.InfoItem;
 import cgeo.geocaching.network.HtmlImage;
@@ -42,6 +43,7 @@ import cgeo.geocaching.unifiedmap.UnifiedMapType;
 import cgeo.geocaching.unifiedmap.tileproviders.AbstractTileProvider;
 import cgeo.geocaching.unifiedmap.tileproviders.TileProviderFactory;
 import cgeo.geocaching.utils.FileUtils;
+import cgeo.geocaching.utils.JsonUtils;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.Log;
 import cgeo.geocaching.utils.OfflineTranslateUtils;
@@ -79,7 +81,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -2529,6 +2533,50 @@ public class Settings {
 
     public static boolean isDTMarkerEnabled() {
         return getBoolean(R.string.pref_dtMarkerOnCacheIcon, false);
+    }
+
+    // In-memory cache for conditional cache markers — volatile for thread visibility
+    private static final List<ConditionalCacheMarker> conditionalCacheMarkersCache = new ArrayList<>();
+    private static boolean conditionalCacheMarkersCacheInitialized = false;
+
+    /**
+     * Returns the current list of ConditionalCacheMarker rules.
+     * Uses an in-memory cache to avoid repeated JSON parsing.
+     * Returns an empty mutable list if nothing is configured.
+     */
+    @NonNull
+    public static List<ConditionalCacheMarker> getConditionalCacheMarkers() {
+        synchronized (conditionalCacheMarkersCache) {
+            if (conditionalCacheMarkersCacheInitialized) {
+                return conditionalCacheMarkersCache;
+            }
+            final String json = getString(R.string.pref_conditionalCacheMarkers, "[]");
+            final JsonNode root = JsonUtils.stringToNode(json);
+            conditionalCacheMarkersCache.clear();
+            if (root != null && root.isArray()) {
+                for (final JsonNode child : root) {
+                    conditionalCacheMarkersCache.add(cgeo.geocaching.models.ConditionalCacheMarker.fromJson(child));
+                }
+            }
+            conditionalCacheMarkersCacheInitialized = true;
+            return conditionalCacheMarkersCache;
+        }
+    }
+
+    /**
+     * Persists the list of ConditionalCacheMarker rules and updates the in-memory cache.
+     */
+    public static void setConditionalCacheMarkers(@NonNull final List<ConditionalCacheMarker> markers) {
+        synchronized (conditionalCacheMarkersCache) {
+            conditionalCacheMarkersCache.clear();
+            conditionalCacheMarkersCache.addAll(markers);
+            conditionalCacheMarkersCacheInitialized = true;
+            final ArrayNode array = JsonUtils.createArrayNode();
+            for (final ConditionalCacheMarker marker : markers) {
+                array.add(marker.toJson());
+            }
+            putString(R.string.pref_conditionalCacheMarkers, JsonUtils.nodeToString(array));
+        }
     }
 
     public static int getAttributeFilterSources() {

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/BasePreferenceFragment.java
@@ -56,7 +56,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
             R.string.pref_tileprovider, R.string.pref_tileprovider_hidden,
             // map content & behavior
             R.string.pref_maptrail,
-            R.string.pref_bigSmileysOnMap, R.string.pref_dtMarkerOnCacheIcon,
+            R.string.pref_bigSmileysOnMap, R.string.pref_dtMarkerOnCacheIcon, R.string.pref_fakekey_conditional_markers,
             R.string.pref_excludeWpOriginal, R.string.pref_excludeWpParking, R.string.pref_excludeWpVisited,
             R.string.pref_longTapOnMap,
             R.string.pref_mapRotation,

--- a/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
+++ b/main/src/main/java/cgeo/geocaching/settings/fragments/PreferenceMapContentBehaviorFragment.java
@@ -2,12 +2,15 @@ package cgeo.geocaching.settings.fragments;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.settings.ButtonPreference;
+import cgeo.geocaching.settings.ConditionalCacheMarkersActivity;
 import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.settings.SettingsActivity;
 import cgeo.geocaching.utils.LocalizationUtils;
 import cgeo.geocaching.utils.MapMarkerUtils;
 import cgeo.geocaching.utils.PreferenceUtils;
+import static cgeo.geocaching.utils.SettingsUtils.setPrefClick;
 
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -29,6 +32,9 @@ public class PreferenceMapContentBehaviorFragment extends BasePreferenceFragment
         final SettingsActivity activity = (SettingsActivity) getActivity();
         assert activity != null;
         activity.setTitle(R.string.settings_title_map_content_behavior);
+
+        setPrefClick(this, R.string.pref_fakekey_conditional_markers,
+                () -> activity.startActivity(new Intent(activity, ConditionalCacheMarkersActivity.class)));
 
         updateNotificationAudioInfo();
 

--- a/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
+++ b/main/src/main/java/cgeo/geocaching/utils/MapMarkerUtils.java
@@ -681,6 +681,10 @@ public final class MapMarkerUtils {
         readLists();
 
         final ArrayList<Integer> result = new ArrayList<>();
+
+        // Conditional cache markers are prepended so they appear first
+        result.addAll(cgeo.geocaching.models.ConditionalCacheMarker.getMarkersForCache(cache));
+
         final Set<Integer> lists = cache.getLists();
         for (final Integer list : lists) {
             final Integer markerId = list2marker.get(list);

--- a/main/src/main/res/layout/activity_conditional_markers.xml
+++ b/main/src/main/res/layout/activity_conditional_markers.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/empty_hint"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:visibility="gone"
+        android:text="@string/conditional_marker_empty_hint"
+        android:textSize="@dimen/textSize_listsPrimary"
+        android:textColor="@color/colorText_listsPrimary" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/marker_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>
+

--- a/main/src/main/res/layout/conditional_marker_list_item.xml
+++ b/main/src/main/res/layout/conditional_marker_list_item.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="48dp"
+    android:gravity="center_vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/marker_button"
+        style="@style/button_icon"
+        app:icon="@drawable/ic_menu_emoticons"
+        tools:ignore="ContentDescription" />
+
+    <Button
+        android:id="@+id/filter_button"
+        style="@style/button_icon"
+        app:icon="@drawable/ic_menu_filter"
+        tools:ignore="ContentDescription" />
+
+    <TextView
+        android:id="@+id/filter_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:textSize="@dimen/textSize_detailsSecondary"
+        android:textColor="@color/colorText_listsSecondary"
+        android:ellipsize="end"
+        android:maxLines="2"
+        tools:text="Type: Traditional" />
+
+
+    <Button
+        android:id="@+id/delete_button"
+        style="@style/button_icon"
+        app:icon="@drawable/ic_menu_delete"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
+        android:id="@+id/drag_handle"
+        android:layout_width="@dimen/buttonSize_iconButton"
+        android:layout_height="@dimen/buttonSize_iconButton"
+        android:scaleType="centerInside"
+        app:srcCompat="@drawable/ic_menu_reorder"
+        tools:src="@drawable/ic_menu_reorder"
+        tools:ignore="ContentDescription" />
+
+</LinearLayout>
+
+

--- a/main/src/main/res/menu/menu_conditional_markers.xml
+++ b/main/src/main/res/menu/menu_conditional_markers.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <item
+        android:id="@+id/menu_item_add"
+        android:icon="@drawable/ic_menu_add"
+        android:title="@string/conditional_marker_add_rule"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+    <item
+        android:id="@+id/menu_item_cancel"
+        android:icon="@drawable/ic_menu_cancel"
+        android:title="@string/cancel"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+    <item
+        android:id="@+id/menu_item_save"
+        android:icon="@drawable/ic_menu_done"
+        android:title="@string/waypoint_save"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
+</menu>
+

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -250,6 +250,8 @@
     <string translatable="false" name="pref_maptrail_maxdistance">maptrail_maxdistance</string>
     <string translatable="false" name="pref_bigSmileysOnMap">pref_bigSmileysOnMap</string>
     <string translatable="false" name="pref_dtMarkerOnCacheIcon">pref_dtMarkerOnCacheIcon</string>
+    <string translatable="false" name="pref_fakekey_conditional_markers">fakekey_conditional_markers</string>
+    <string translatable="false" name="pref_conditionalCacheMarkers">conditionalCacheMarkers</string>
     <string translatable="false" name="pref_showElevation">showElevation</string>
 
     <!-- category waypoints -->

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -879,6 +879,13 @@
         <item>&gt;1m</item>
     </string-array>
 
+    <!-- conditional cache markers -->
+    <string name="conditional_marker_activity_title">Conditional markers</string>
+    <string name="conditional_marker_add_rule">Add rule</string>
+    <string name="conditional_marker_empty_hint">No rules configured. Tap + to add one.</string>
+    <string name="conditional_marker_nofilter_label">(no filter — marks all caches)</string>
+
+
     <!-- about -->
     <string name="about_version">Version</string>
     <string name="about_changelog">Changelog</string>
@@ -1136,6 +1143,8 @@
     <string name="init_summary_bigSmileysOnMap">If enabled, symbols like the \'found smiley\' or the \'corrected coordinates\' marker will be shown enlarged on the map instead of the cache type icon.</string>
     <string name="init_dtMarkerOnCacheIcon">D/T rating on cache icons</string>
     <string name="init_summary_dtMarkerOnCacheIcon">Show an marker for the Difficulty (left) and Terrain (right) ratings on cache markers in upper-right corner ("stored" marker is moved to middle).</string>
+    <string name="init_conditionalCacheMarkers">Conditional cache markers</string>
+    <string name="init_summary_conditionalCacheMarkers">Define marker symbols to be drawn on cache icons based on filter conditions</string>
     <string name="init_showElevation">Show Elevation</string>
     <string name="init_summary_showElevation">Show elevation info for current position, taken from routing data or GNSS (if available)</string>
     <string name="init_elevation_notAvailable">"No elevation data available"</string>

--- a/main/src/main/res/xml/preferences_map_content_behavior.xml
+++ b/main/src/main/res/xml/preferences_map_content_behavior.xml
@@ -21,6 +21,11 @@
             android:summary="@string/init_summary_dtMarkerOnCacheIcon"
             android:title="@string/init_dtMarkerOnCacheIcon"
             app:iconSpaceReserved="false" />
+        <Preference
+            android:key="@string/pref_fakekey_conditional_markers"
+            android:title="@string/init_conditionalCacheMarkers"
+            android:summary="@string/init_summary_conditionalCacheMarkers"
+            app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="@string/pref_showElevation"

--- a/main/src/test/java/cgeo/geocaching/models/ConditionalCacheMarkerTest.java
+++ b/main/src/test/java/cgeo/geocaching/models/ConditionalCacheMarkerTest.java
@@ -1,0 +1,129 @@
+package cgeo.geocaching.models;
+
+import cgeo.geocaching.enumerations.CacheType;
+import cgeo.geocaching.filters.core.GeocacheFilter;
+import cgeo.geocaching.filters.core.GeocacheFilterType;
+import cgeo.geocaching.filters.core.TypeGeocacheFilter;
+import cgeo.geocaching.utils.EmojiUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ConditionalCacheMarkerTest {
+
+    private static final int MARKER_A = 0x1f600; // smiley emoji
+    private static final int MARKER_B = 0x2764;  // heart emoji
+
+    // ---- getMarkersForRules tests ----
+
+    @Test
+    public void getMarkersForRulesEmptyRules() {
+        final Geocache cache = new Geocache();
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(cache, Collections.emptyList());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getMarkersForRulesNullCache() {
+        final ConditionalCacheMarker rule = new ConditionalCacheMarker(MARKER_A, null);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(null, Collections.singletonList(rule));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getMarkersForRulesNullFilterMatchesAll() {
+        final Geocache cache = new Geocache();
+        final ConditionalCacheMarker rule = new ConditionalCacheMarker(MARKER_A, null);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(cache, Collections.singletonList(rule));
+        assertThat(result).containsExactly(MARKER_A);
+    }
+
+    @Test
+    public void getMarkersForRulesEmptyFilterMatchesAll() {
+        // A non-null empty (non-filtering) filter also matches every cache
+        final Geocache cache = new Geocache();
+        final GeocacheFilter emptyFilter = GeocacheFilter.createEmpty();
+        final ConditionalCacheMarker rule = new ConditionalCacheMarker(MARKER_A, emptyFilter);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(cache, Collections.singletonList(rule));
+        assertThat(result).containsExactly(MARKER_A);
+    }
+
+    @Test
+    public void getMarkersForRulesNoMatchingFilterNotIncluded() {
+        // TypeGeocacheFilter restricted to TRADITIONAL; cache is EARTH → should not match
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.EARTH);
+
+        final TypeGeocacheFilter typeFilter = GeocacheFilterType.TYPE.create();
+        typeFilter.setValues(Collections.singleton(CacheType.TRADITIONAL));
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, typeFilter);
+
+        final ConditionalCacheMarker rule = new ConditionalCacheMarker(MARKER_A, filter);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(cache, Collections.singletonList(rule));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getMarkersForRulesMatchingFilterIncluded() {
+        final Geocache cache = new Geocache();
+        cache.setType(CacheType.TRADITIONAL);
+
+        final TypeGeocacheFilter typeFilter = GeocacheFilterType.TYPE.create();
+        typeFilter.setValues(Collections.singleton(CacheType.TRADITIONAL));
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, typeFilter);
+
+        final ConditionalCacheMarker rule = new ConditionalCacheMarker(MARKER_A, filter);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(cache, Collections.singletonList(rule));
+        assertThat(result).containsExactly(MARKER_A);
+    }
+
+    @Test
+    public void getMarkersForRulesNoEmojiSkipped() {
+        final Geocache cache = new Geocache();
+        final ConditionalCacheMarker rule = new ConditionalCacheMarker(EmojiUtils.NO_EMOJI, null);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(cache, Collections.singletonList(rule));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void getMarkersForRulesOrderPreserved() {
+        final Geocache cache = new Geocache();
+        final ConditionalCacheMarker ruleA = new ConditionalCacheMarker(MARKER_A, null);
+        final ConditionalCacheMarker ruleB = new ConditionalCacheMarker(MARKER_B, null);
+        final List<Integer> result = ConditionalCacheMarker.getMarkersForRules(
+                cache, Arrays.asList(ruleA, ruleB));
+        assertThat(result).containsExactly(MARKER_A, MARKER_B);
+    }
+
+    // ---- JSON round-trip tests ----
+
+    @Test
+    public void jsonRoundTripWithFilter() {
+        final TypeGeocacheFilter typeFilter = GeocacheFilterType.TYPE.create();
+        typeFilter.setValues(Collections.singleton(CacheType.TRADITIONAL));
+        final GeocacheFilter filter = GeocacheFilter.create(null, false, false, typeFilter);
+        final ConditionalCacheMarker original = new ConditionalCacheMarker(MARKER_A, filter);
+
+        final ConditionalCacheMarker restored = ConditionalCacheMarker.fromJson(original.toJson());
+
+        assertThat(restored.getMarkerId()).isEqualTo(MARKER_A);
+        assertThat(restored.getFilter()).isNotNull();
+        assertThat(restored.getFilter().toConfig()).isEqualTo(filter.toConfig());
+    }
+
+    @Test
+    public void jsonRoundTripNullFilter() {
+        final ConditionalCacheMarker original = new ConditionalCacheMarker(MARKER_B, null);
+
+        final ConditionalCacheMarker restored = ConditionalCacheMarker.fromJson(original.toJson());
+
+        assertThat(restored.getMarkerId()).isEqualTo(MARKER_B);
+        assertThat(restored.getFilter()).isNull();
+    }
+}
+
+


### PR DESCRIPTION
rel to #12363 and #16034: introduce conditional cache markers

This PR introduces the concept of conditional cache markers. With this:
* it implements a part of #12363 (not the part to configure what to display where though)
* it is a possible solution for #16034: users can configure "fav points" as conditional cache marker now
* it introduced a potentially powerful new concept to create more dynamic cache markers

Feature introduces a new settings "Conditional cache markers":
<img width="483" height="592" alt="image" src="https://github.com/user-attachments/assets/cdca52fc-9b3b-458d-a79e-06cbae3cc2c5" />

Upon tap the user may add/delete/edit rules containing a cache marker and a filter condition on which to apply it:
<img width="481" height="303" alt="image" src="https://github.com/user-attachments/assets/df7c266f-3f96-485d-a9c6-fffa6f895078" />

This filter shows in map as follows (note that the heart symbol is only on two of the three tradis since only two of them have >= 200 fav points):
<img width="467" height="877" alt="image" src="https://github.com/user-attachments/assets/566b0136-53cc-433f-a695-72b309df364a" />

Implementation note: for now, if any conditional marker applies to a cache, it is displayed in place of the "list markers" (left and right side of cache). Logic is now that conditional markers have precedence over list markers. Eg if a cache has 1 conditional marker and 2 list markers, then the conditional marker is displayed left and the first list marker right. If a cache has 2 conditional markers then those are displayed (no list markers). In screenshot above, note that there are two caches which are also part of a list with blue ribbon symbol (a tradi and a lab). Both also have one condition marker which is why the list symbol is displayed on the right.
--> this placement ruling can be discussed of course