### PR TITLE
add favorite marker to logs view

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1555,7 +1555,8 @@ public final class GCParser {
                             .setLogType(LogType.getByType(logType))
                             .setLog(logText)
                             .setFound(entry.path("GeocacheFindCount").asInt())
-                            .setFriend(markAsFriendsLog);
+                            .setFriend(markAsFriendsLog)
+                            .setFavorite(entry.path("FavoritePointUsed").asBoolean());
 
                     final ArrayNode images = (ArrayNode) entry.get("Images");
                     for (final JsonNode image : images) {

--- a/main/src/main/java/cgeo/geocaching/log/LogEntry.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogEntry.java
@@ -74,6 +74,8 @@ public class LogEntry implements Parcelable {
     @NonNull public final String cacheGuid; // used for trackables
     /** Spotted cache geocode */
     @NonNull public final String cacheGeocode; // used for trackables
+    /** Is markes as favorite */
+    public final boolean favorite;
 
     @NonNull
     public Date getDate() {
@@ -111,6 +113,7 @@ public class LogEntry implements Parcelable {
         cacheName = StringUtils.defaultString(in.readString());
         cacheGuid = StringUtils.defaultString(in.readString());
         cacheGeocode = StringUtils.defaultString(in.readString());
+        favorite = in.readInt() == 1;
     }
 
     @Override
@@ -129,6 +132,7 @@ public class LogEntry implements Parcelable {
         dest.writeString(cacheName);
         dest.writeString(cacheGuid);
         dest.writeString(cacheGeocode);
+        dest.writeInt(favorite ? 1 : 0);
     }
 
     public static final Parcelable.Creator<LogEntry> CREATOR = new Parcelable.Creator<LogEntry>() {
@@ -186,6 +190,7 @@ public class LogEntry implements Parcelable {
         String cacheName = ""; // used for trackables
         String cacheGuid = ""; // used for trackables
         String cacheGeocode = ""; // used for trackables
+        boolean favorite = false;
 
 
         /** Build an immutable {@link LogEntry} Object. */
@@ -363,6 +368,15 @@ public class LogEntry implements Parcelable {
             this.reportProblem = reportProblem;
             return self();
         }
+
+        public boolean isFavorite() {
+            return favorite;
+        }
+
+        public T setFavorite(final boolean favorite) {
+            this.favorite = favorite;
+            return self();
+        }
     }
 
     /**
@@ -385,6 +399,7 @@ public class LogEntry implements Parcelable {
         this.cacheGuid = builder.cacheGuid;
         this.cacheGeocode = builder.cacheGeocode;
         this.reportProblem = builder.reportProblem == null ? ReportProblemType.NO_PROBLEM : builder.reportProblem;
+        this.favorite = builder.favorite;
     }
 
     /**
@@ -412,7 +427,8 @@ public class LogEntry implements Parcelable {
             .setLogImages(logImages)
             .setCacheName(cacheName)
             .setCacheGuid(cacheGuid)
-            .setCacheGeocode(cacheGeocode);
+            .setCacheGeocode(cacheGeocode)
+            .setFavorite(favorite);
     }
 
 
@@ -427,7 +443,7 @@ public class LogEntry implements Parcelable {
     public int hashCode() {
         return new HashCodeBuilder()
                 .append(id).append(logType).append(author).append(log).append(date).append(found)
-                .append(friend).append(logImages).append(cacheName).append(cacheGuid).append(cacheGeocode)
+                .append(friend).append(logImages).append(cacheName).append(cacheGuid).append(cacheGeocode).append(favorite)
                 .build();
     }
 

--- a/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
@@ -93,7 +93,15 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
         }
 
         holder.binding.type.setText(log.logType.getL10n());
-        holder.binding.type.setCompoundDrawablesWithIntrinsicBounds(log.logType.getLogOverlay(), 0, 0, 0);
+        final int logTypeMarker;
+        if (log.favorite && null == log.serviceLogId && LogType.FOUND_IT == log.logType) {
+            logTypeMarker = R.drawable.marker_found_fp_offline;
+        } else if (log.favorite && null != log.serviceLogId) {
+            logTypeMarker = R.drawable.marker_found_fp;
+        } else {
+            logTypeMarker = log.logType.getLogOverlay();
+        }
+        holder.binding.type.setCompoundDrawablesWithIntrinsicBounds(logTypeMarker, 0, 0, 0);
         holder.binding.type.setCompoundDrawablePadding(4);
 
         holder.binding.author.setText(StringEscapeUtils.unescapeHtml4(log.author));

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -263,7 +263,7 @@ public class DataStore {
     private static final CacheCache cacheCache = new CacheCache();
     private static volatile SQLiteDatabase database = null;
     private static final ReentrantReadWriteLock databaseLock = new ReentrantReadWriteLock();
-    private static final int dbVersion = 108;
+    private static final int dbVersion = 109;
     public static final int customListIdOffset = 10;
 
     /**
@@ -303,11 +303,12 @@ public class DataStore {
             101, // add service_image_id to saved log images
             102, // add projection attributes to waypoints
             103, // add more projection attributes to waypoints
-            104,  // add geofence radius for lab stages
-            105,  // Migrate UDC geocodes from ZZ1000-based numbers to random ones
-            106,  // Update lab caches DT rating to zero from minus one
-            107,   // Unify named filters and conditional markers; new cg_filters schema
-            108   // add health_score column to cg_caches
+            104, // add geofence radius for lab stages
+            105, // Migrate UDC geocodes from ZZ1000-based numbers to random ones
+            106, // Update lab caches DT rating to zero from minus one
+            107, // Unify named filters and conditional markers; new cg_filters schema
+            108, // add health_score column to cg_caches
+            109  // add favorite column to cg_logs
             ));
 
     @NonNull private static final String dbTableCaches = "cg_caches";
@@ -501,7 +502,8 @@ public class DataStore {
             + dbFieldLogs_log + " TEXT, "
             + "date LONG, "
             + "found INTEGER NOT NULL DEFAULT 0, "
-            + "friend INTEGER "
+            + "friend INTEGER, "
+            + "favorite INTEGER NOT NULL DEFAULT 0 "
             + "); ";
 
     private static final String dbCreateLogCount = "CREATE TABLE IF NOT EXISTS " + dbTableLogCount + " ("
@@ -2035,6 +2037,15 @@ public class DataStore {
                             onUpgradeError(e, 108);
                         }
                     }
+                    // add favorite flag to cg_logs
+                    if (oldVersion < 109) {
+                        try {
+                            createColumnIfNotExists(db, dbTableLogs, "favorite INTEGER NOT NULL DEFAULT 0");
+                        } catch (final SQLException e) {
+                            onUpgradeError(e, 109);
+                        }
+                    }
+
                 }
 
                 //at the very end of onUpgrade: rewrite downgradeable versions in database
@@ -2964,6 +2975,7 @@ public class DataStore {
                 insertLog.bindLong(8, log.date);
                 insertLog.bindLong(9, log.found);
                 insertLog.bindLong(10, log.friend ? 1 : 0);
+                insertLog.bindLong(11, log.favorite ? 1 : 0);
                 final long logId = insertLog.executeInsert();
                 if (log.hasLogImages()) {
                     final SQLiteStatement insertImage = PreparedStatement.INSERT_LOG_IMAGE.getStatement();
@@ -3989,8 +4001,8 @@ public class DataStore {
 
                 final String dateOrderSql = " ORDER BY " + getGeocacheLogOrderByClause() + ", service_log_id DESC, cg_logs._id ASC";
                 final Cursor cursor = database.rawQuery(
-                        //                     0           1               2     3       4            5    6     7      8                                       9                10      11     12   13           14
-                        "SELECT cg_logs._id AS cg_logs_id, service_log_id, type, author, author_guid, log, date, found, friend, " + dbTableLogImages + "._id as cg_logImages_id, log_id, title, url, description, service_image_id"
+                        //                     0           1               2     3       4            5    6     7      8       9                                                  10               11      12     13   14           15
+                        "SELECT cg_logs._id AS cg_logs_id, service_log_id, type, author, author_guid, log, date, found, friend, favorite, " + dbTableLogImages + "._id as cg_logImages_id, log_id, title, url, description, service_image_id"
                                 + " FROM " + dbTableLogs + " LEFT OUTER JOIN " + dbTableLogImages
                                 + " ON ( cg_logs._id = log_id ) WHERE geocode = ?  " + " AND author LIKE ? " + whereFriendSql + dateOrderSql, new String[]{geocode, StringUtils.isEmpty(authorName) ? "%" : authorName});
 
@@ -4012,13 +4024,14 @@ public class DataStore {
                                 .setLog(cursor.getString(5))
                                 .setDate(cursor.getLong(6))
                                 .setFound(cursor.getInt(7))
-                                .setFriend(cursor.getInt(8) == 1);
-                        if (!cursor.isNull(9)) {
-                            log.addLogImage(new Image.Builder().setUrl(cursor.getString(12)).setTitle(cursor.getString(11)).setDescription(cursor.getString(13)).setServiceImageId(cursor.getString(14)).build());
+                                .setFriend(cursor.getInt(8) == 1)
+                                .setFavorite(cursor.getInt(9) == 1);
+                        if (!cursor.isNull(10)) {
+                            log.addLogImage(new Image.Builder().setUrl(cursor.getString(13)).setTitle(cursor.getString(12)).setDescription(cursor.getString(14)).setServiceImageId(cursor.getString(15)).build());
                         }
                     } else {
                         // We cannot get several lines for the same log entry if it does not contain an image.
-                        log.addLogImage(new Image.Builder().setUrl(cursor.getString(12)).setTitle(cursor.getString(11)).setDescription(cursor.getString(13)).setServiceImageId(cursor.getString(14)).build());
+                        log.addLogImage(new Image.Builder().setUrl(cursor.getString(13)).setTitle(cursor.getString(12)).setDescription(cursor.getString(14)).setServiceImageId(cursor.getString(15)).build());
                     }
                 }
                 if (log != null) {
@@ -5372,7 +5385,7 @@ public class DataStore {
         OFFLINE_LOG_ID_OF_GEOCODE("SELECT _id FROM " + dbTableLogsOffline + " WHERE geocode = ?"),
         COUNT_CACHES_ON_STANDARD_LIST("SELECT COUNT(geocode) FROM " + dbTableCachesLists + " WHERE list_id = " + StoredList.STANDARD_LIST_ID),
         COUNT_ALL_CACHES("SELECT COUNT(DISTINCT(geocode)) FROM " + dbTableCachesLists + " WHERE list_id >= " + StoredList.STANDARD_LIST_ID),
-        INSERT_LOG("INSERT INTO " + dbTableLogs + " (geocode, updated, service_log_id, type, author, author_guid, log, date, found, friend) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
+        INSERT_LOG("INSERT INTO " + dbTableLogs + " (geocode, updated, service_log_id, type, author, author_guid, log, date, found, friend, favorite) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"),
         CLEAN_LOG("DELETE FROM " + dbTableLogs + " WHERE geocode = ? AND date >= ? AND date <= ? AND type = ? AND author = ?"),
         INSERT_ATTRIBUTE("INSERT INTO " + dbTableAttributes + " (geocode, updated, attribute) VALUES (?, ?, ?)"),
         INSERT_CATEGORY("INSERT INTO " + dbTableCategories + " (geocode, category) VALUES (?, ?)"),

--- a/main/src/main/res/drawable/marker_found_fp.xml
+++ b/main/src/main/res/drawable/marker_found_fp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="13dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:fillColor="#5D4037"/>
+    <path
+        android:pathData="m12,2a10,10 0,0 0,-10 10,10 10,0 0,0 10,10 10,10 0,0 0,10 -10,10 10,0 0,0 -10,-10zM8.85,6.5c1.218,0 2.387,0.566 3.15,1.455 0.763,-0.889 1.932,-1.455 3.15,-1.455 2.156,-0 3.85,1.687 3.85,3.85 0,2.639 -2.379,4.803 -5.984,8.072l-1.016,0.924 -1.016,-0.924c-3.605,-3.269 -5.984,-5.433 -5.984,-8.072 0,-2.163 1.694,-3.85 3.85,-3.85z"
+        android:fillColor="#fdd835"/>
+</vector>

--- a/main/src/main/res/drawable/marker_found_fp_offline.xml
+++ b/main/src/main/res/drawable/marker_found_fp_offline.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="13dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+      android:fillColor="#5D4037"/>
+  <path
+      android:pathData="m12,2a10,10 0,0 0,-10 10,10 10,0 0,0 10,10 10,10 0,0 0,10 -10,10 10,0 0,0 -10,-10zM8.85,6.5c1.218,0 2.387,0.566 3.15,1.455 0.763,-0.889 1.932,-1.455 3.15,-1.455 2.156,-0 3.85,1.687 3.85,3.85 0,2.639 -2.379,4.803 -5.984,8.072l-1.016,0.924 -1.016,-0.924c-3.605,-3.269 -5.984,-5.433 -5.984,-8.072 0,-2.163 1.694,-3.85 3.85,-3.85z"
+      android:fillColor="#F57C00"/>
+</vector>


### PR DESCRIPTION
If the log has a favorite assigned (for GC.com only + offline logs for now, OC doesn't return that info via API) show FP marker instead of found marker in logs view:
<img width="464" height="604" alt="image" src="https://github.com/user-attachments/assets/2b91291d-ed55-466e-b75a-65ad1af202bb" />
