### PR TITLE
Fix navigation interception in GeocacheFilterActivity with deferred ActivityMixin helpers

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -228,7 +228,8 @@ public final class ActivityMixin {
      *                    (e.g. from a dialog confirmation).
      *                    Return {@code true} to STOP navigation, {@code false} to CONTINUE.
      * @return A BooleanSupplier to be called from {@code onSupportNavigateUp()}. Returns {@code true}
-     *         when navigation was handled or intercepted, {@code false} if the activity is gone.
+     *         when navigation was handled or intercepted, {@code false} if the activity is gone or
+     *         navigate up could not be concluded.
      */
     public static BooleanSupplier registerBackNavigationInterceptor(
             @NonNull final AppCompatActivity activity,
@@ -267,16 +268,18 @@ public final class ActivityMixin {
             if (!isActivityValid(weakActivity)) {
                 return false;
             }
+            final boolean[] navigationHandled = new boolean[] {false};
             final Runnable continueNavigateUp = () -> {
                 final AppCompatActivity currentActivity = weakActivity.get();
                 if (isActivityValid(currentActivity)) {
-                    navigateUp(currentActivity);
+                    navigationHandled[0] = navigateUp(currentActivity);
                 }
             };
-            if (!interceptor.test(continueNavigateUp)) {
+            final boolean stop = interceptor.test(continueNavigateUp);
+            if (!stop) {
                 continueNavigateUp.run();
             }
-            return true;
+            return stop || navigationHandled[0];
         };
     }
 }

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -220,75 +220,63 @@ public final class ActivityMixin {
     }
 
     /**
-     * Registers an interceptor for back press and/or navigate up on the given activity.
+     * Registers an interceptor for back press and navigate up on the given activity.
      *
-     * @param activity       The activity to register on. Held via WeakReference to avoid memory leaks.
-     * @param interceptBack  Whether to intercept the system back press.
-     * @param interceptNavUp Whether to intercept navigate up (Toolbar ← arrow). Use the returned
-     *                       BooleanSupplier in {@code onSupportNavigateUp()}.
-     * @param interceptor    Called when back/navUp is triggered.
-     *                       Parameter: a Runnable to conclude the intercepted navigation later
-     *                       (e.g. from a dialog confirmation).
-     *                       Return {@code true} to STOP navigation, {@code false} to CONTINUE.
+     * @param activity    The activity to register on. Held via WeakReference to avoid memory leaks.
+     * @param interceptor Called when back/navUp is triggered.
+     *                    Parameter: a Runnable to conclude the intercepted navigation later
+     *                    (e.g. from a dialog confirmation).
+     *                    Return {@code true} to STOP navigation, {@code false} to CONTINUE.
      * @return A BooleanSupplier to be called from {@code onSupportNavigateUp()}. Returns {@code true}
-     *         when navigation was handled or intercepted, {@code false} if interceptNavUp is false
-     *         or the activity is gone.
+     *         when navigation was handled or intercepted, {@code false} if the activity is gone.
      */
-    public static BooleanSupplier registerNavigationInterceptor(
+    public static BooleanSupplier registerBackNavigationInterceptor(
             @NonNull final AppCompatActivity activity,
-            final boolean interceptBack,
-            final boolean interceptNavUp,
             @NonNull final Predicate<Runnable> interceptor) {
 
         final WeakReference<AppCompatActivity> weakActivity = new WeakReference<>(activity);
 
-        if (interceptBack) {
-            final OnBackPressedCallback callback = new OnBackPressedCallback(true) {
-                @Override
-                public void handleOnBackPressed() {
-                    if (!isActivityValid(weakActivity)) {
-                        setEnabled(false);
+        final OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (!isActivityValid(weakActivity)) {
+                    setEnabled(false);
+                    return;
+                }
+                final Runnable continueBackNavigation = () -> {
+                    final AppCompatActivity currentActivity = weakActivity.get();
+                    if (!isActivityValid(currentActivity)) {
                         return;
                     }
-                    final Runnable continueBackNavigation = () -> {
-                        final AppCompatActivity currentActivity = weakActivity.get();
-                        if (!isActivityValid(currentActivity)) {
-                            return;
-                        }
-                        setEnabled(false);
-                        currentActivity.getOnBackPressedDispatcher().onBackPressed();
-                        if (isActivityValid(weakActivity)) {
-                            setEnabled(true);
-                        }
-                    };
-                    final boolean stop = interceptor.test(continueBackNavigation);
-                    if (!stop) {
-                        continueBackNavigation.run();
-                    }
-                }
-            };
-            // Passing activity as LifecycleOwner: callback is automatically removed on destroy
-            activity.getOnBackPressedDispatcher().addCallback(activity, callback);
-        }
-
-        if (interceptNavUp) {
-            return () -> {
-                if (!isActivityValid(weakActivity)) {
-                    return false;
-                }
-                final Runnable continueNavigateUp = () -> {
-                    final AppCompatActivity currentActivity = weakActivity.get();
-                    if (isActivityValid(currentActivity)) {
-                        navigateUp(currentActivity);
+                    setEnabled(false);
+                    currentActivity.getOnBackPressedDispatcher().onBackPressed();
+                    if (isActivityValid(weakActivity)) {
+                        setEnabled(true);
                     }
                 };
-                if (!interceptor.test(continueNavigateUp)) {
-                    continueNavigateUp.run();
+                final boolean stop = interceptor.test(continueBackNavigation);
+                if (!stop) {
+                    continueBackNavigation.run();
                 }
-                return true;
-            };
-        }
+            }
+        };
+        // Passing activity as LifecycleOwner: callback is automatically removed on destroy
+        activity.getOnBackPressedDispatcher().addCallback(activity, callback);
 
-        return () -> false;
+        return () -> {
+            if (!isActivityValid(weakActivity)) {
+                return false;
+            }
+            final Runnable continueNavigateUp = () -> {
+                final AppCompatActivity currentActivity = weakActivity.get();
+                if (isActivityValid(currentActivity)) {
+                    navigateUp(currentActivity);
+                }
+            };
+            if (!interceptor.test(continueNavigateUp)) {
+                continueNavigateUp.run();
+            }
+            return true;
+        };
     }
 }

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -25,11 +25,11 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.NavUtils;
 import androidx.core.app.TaskStackBuilder;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.lang.ref.WeakReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
+
+import org.apache.commons.lang3.StringUtils;
 
 public final class ActivityMixin {
 
@@ -215,6 +215,10 @@ public final class ActivityMixin {
         return activity != null && !activity.isFinishing() && !activity.isDestroyed();
     }
 
+    public static boolean isActivityValid(final @Nullable WeakReference<? extends Activity> activityRef) {
+        return activityRef != null && isActivityValid(activityRef.get());
+    }
+
     /**
      * Registers an interceptor for back press and/or navigate up on the given activity.
      *
@@ -231,30 +235,29 @@ public final class ActivityMixin {
      *         or the activity is gone.
      */
     public static BooleanSupplier registerNavigationInterceptor(
-            @NonNull final Activity activity,
+            @NonNull final AppCompatActivity activity,
             final boolean interceptBack,
             final boolean interceptNavUp,
             @NonNull final Predicate<Runnable> interceptor) {
 
-        final WeakReference<Activity> weakActivity = new WeakReference<>(activity);
+        final WeakReference<AppCompatActivity> weakActivity = new WeakReference<>(activity);
 
-        if (interceptBack && activity instanceof AppCompatActivity) {
-            final AppCompatActivity appCompatActivity = (AppCompatActivity) activity;
+        if (interceptBack) {
             final OnBackPressedCallback callback = new OnBackPressedCallback(true) {
                 @Override
                 public void handleOnBackPressed() {
-                    final Activity a = weakActivity.get();
-                    if (!isActivityValid(a)) {
+                    if (!isActivityValid(weakActivity)) {
                         setEnabled(false);
                         return;
                     }
                     final Runnable continueBackNavigation = () -> {
-                        if (!isActivityValid(a)) {
+                        final AppCompatActivity currentActivity = weakActivity.get();
+                        if (!isActivityValid(currentActivity)) {
                             return;
                         }
                         setEnabled(false);
-                        triggerBack(a);
-                        if (isActivityValid(a)) {
+                        currentActivity.getOnBackPressedDispatcher().onBackPressed();
+                        if (isActivityValid(weakActivity)) {
                             setEnabled(true);
                         }
                     };
@@ -265,18 +268,18 @@ public final class ActivityMixin {
                 }
             };
             // Passing activity as LifecycleOwner: callback is automatically removed on destroy
-            appCompatActivity.getOnBackPressedDispatcher().addCallback(appCompatActivity, callback);
+            activity.getOnBackPressedDispatcher().addCallback(activity, callback);
         }
 
         if (interceptNavUp) {
             return () -> {
-                final Activity a = weakActivity.get();
-                if (!isActivityValid(a)) {
+                if (!isActivityValid(weakActivity)) {
                     return false;
                 }
                 final Runnable continueNavigateUp = () -> {
-                    if (isActivityValid(a)) {
-                        navigateUp(a);
+                    final AppCompatActivity currentActivity = weakActivity.get();
+                    if (isActivityValid(currentActivity)) {
+                        navigateUp(currentActivity);
                     }
                 };
                 if (!interceptor.test(continueNavigateUp)) {
@@ -287,36 +290,5 @@ public final class ActivityMixin {
         }
 
         return () -> false;
-    }
-
-    /**
-     * Immediately triggers back or navigate up programmatically.
-     * Use the Runnable passed to {@link #registerNavigationInterceptor(Activity, boolean, boolean, Predicate)}
-     * when navigation should resume later, for example after a confirmation dialog.
-     *
-     * @param activity     The activity to trigger navigation on.
-     * @param isNavigateUp {@code true} to simulate navigate up, {@code false} to simulate back press.
-     */
-    public static void triggerNavigation(
-            @NonNull final Activity activity,
-            final boolean isNavigateUp) {
-
-        if (!isActivityValid(activity)) {
-            return;
-        }
-        if (isNavigateUp) {
-            navigateUp(activity);
-        } else {
-            triggerBack(activity);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private static void triggerBack(@NonNull final Activity activity) {
-        if (activity instanceof AppCompatActivity) {
-            ((AppCompatActivity) activity).getOnBackPressedDispatcher().onBackPressed();
-        } else {
-            activity.onBackPressed();
-        }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -28,10 +28,16 @@ import androidx.core.app.TaskStackBuilder;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 public final class ActivityMixin {
+
+    private static final Map<Activity, AtomicBoolean> NAVIGATION_BYPASS = Collections.synchronizedMap(new WeakHashMap<>());
 
     private ActivityMixin() {
         // utility class
@@ -211,6 +217,10 @@ public final class ActivityMixin {
         }
     }
 
+    public static boolean isActivityValid(final @Nullable Activity activity) {
+        return activity != null && !activity.isFinishing() && !activity.isDestroyed();
+    }
+
     /**
      * Registers an interceptor for back press and/or navigate up on the given activity.
      *
@@ -229,41 +239,53 @@ public final class ActivityMixin {
      *         the supplier returns {@code false}, as super calls cannot be made from outside the class.
      */
     public static BooleanSupplier registerNavigationInterceptor(
-            @NonNull final AppCompatActivity activity,
+            @NonNull final Activity activity,
             final boolean interceptBack,
             final boolean interceptNavUp,
             @NonNull final Predicate<Boolean> interceptor) {
 
-        final WeakReference<AppCompatActivity> weakActivity = new WeakReference<>(activity);
+        final WeakReference<Activity> weakActivity = new WeakReference<>(activity);
 
-        if (interceptBack) {
+        if (interceptBack && activity instanceof AppCompatActivity) {
+            final AppCompatActivity appCompatActivity = (AppCompatActivity) activity;
             final OnBackPressedCallback callback = new OnBackPressedCallback(true) {
                 @Override
                 public void handleOnBackPressed() {
-                    final AppCompatActivity a = weakActivity.get();
-                    if (a == null || a.isFinishing() || a.isDestroyed()) {
+                    final Activity a = weakActivity.get();
+                    if (!isActivityValid(a)) {
                         setEnabled(false);
+                        return;
+                    }
+                    if (consumeNavigationBypass(a)) {
+                        setEnabled(false);
+                        triggerBack(a);
+                        if (isActivityValid(a)) {
+                            setEnabled(true);
+                        }
                         return;
                     }
                     final boolean stop = interceptor.test(false);
                     if (!stop) {
                         // Disable before re-triggering to avoid infinite interception loop
                         setEnabled(false);
-                        a.getOnBackPressedDispatcher().onBackPressed();
-                        if (!a.isFinishing() && !a.isDestroyed()) {
+                        triggerBack(a);
+                        if (isActivityValid(a)) {
                             setEnabled(true);
                         }
                     }
                 }
             };
             // Passing activity as LifecycleOwner: callback is automatically removed on destroy
-            activity.getOnBackPressedDispatcher().addCallback(activity, callback);
+            appCompatActivity.getOnBackPressedDispatcher().addCallback(appCompatActivity, callback);
         }
 
         if (interceptNavUp) {
             return () -> {
-                final AppCompatActivity a = weakActivity.get();
-                if (a == null || a.isFinishing() || a.isDestroyed()) {
+                final Activity a = weakActivity.get();
+                if (!isActivityValid(a)) {
+                    return false;
+                }
+                if (consumeNavigationBypass(a)) {
                     return false;
                 }
                 return interceptor.test(true);
@@ -281,16 +303,51 @@ public final class ActivityMixin {
      * @param isNavigateUp {@code true} to simulate navigate up, {@code false} to simulate back press.
      */
     public static void triggerNavigation(
-            @NonNull final AppCompatActivity activity,
+            @NonNull final Activity activity,
             final boolean isNavigateUp) {
+        triggerNavigation(activity, isNavigateUp, false);
+    }
 
-        if (activity.isFinishing() || activity.isDestroyed()) {
+    /**
+     * Programmatically simulates the user pressing back or navigate up.
+     *
+     * @param activity           The activity to trigger navigation on.
+     * @param isNavigateUp       {@code true} to simulate navigate up, {@code false} to simulate back press.
+     * @param bypassInterceptor  {@code true} to continue navigation without invoking the registered interceptor again.
+     */
+    public static void triggerNavigation(
+            @NonNull final Activity activity,
+            final boolean isNavigateUp,
+            final boolean bypassInterceptor) {
+
+        if (!isActivityValid(activity)) {
             return;
         }
+        if (bypassInterceptor) {
+            NAVIGATION_BYPASS.computeIfAbsent(activity, key -> new AtomicBoolean()).set(true);
+        }
         if (isNavigateUp) {
-            activity.onSupportNavigateUp();
+            if (bypassInterceptor || !(activity instanceof AppCompatActivity)) {
+                navigateUp(activity);
+            } else {
+                ((AppCompatActivity) activity).onSupportNavigateUp();
+            }
         } else {
-            activity.getOnBackPressedDispatcher().onBackPressed();
+            triggerBack(activity);
+        }
+    }
+
+    private static boolean consumeNavigationBypass(@NonNull final Activity activity) {
+        final AtomicBoolean bypass = NAVIGATION_BYPASS.get(activity);
+        return bypass != null && bypass.getAndSet(false);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void triggerBack(@NonNull final Activity activity) {
+        if (activity instanceof AppCompatActivity) {
+            ((AppCompatActivity) activity).getOnBackPressedDispatcher().onBackPressed();
+        } else {
+            activity.onBackPressed();
         }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -31,13 +31,12 @@ import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 public final class ActivityMixin {
 
-    private static final Map<Activity, AtomicBoolean> NAVIGATION_BYPASS = Collections.synchronizedMap(new WeakHashMap<>());
+    private static final Map<Activity, Boolean> NAVIGATION_BYPASS = Collections.synchronizedMap(new WeakHashMap<>());
 
     private ActivityMixin() {
         // utility class
@@ -324,7 +323,7 @@ public final class ActivityMixin {
             return;
         }
         if (bypassInterceptor) {
-            NAVIGATION_BYPASS.computeIfAbsent(activity, key -> new AtomicBoolean()).set(true);
+            setNavigationBypass(activity);
         }
         if (isNavigateUp) {
             if (bypassInterceptor || !(activity instanceof AppCompatActivity)) {
@@ -338,8 +337,15 @@ public final class ActivityMixin {
     }
 
     private static boolean consumeNavigationBypass(@NonNull final Activity activity) {
-        final AtomicBoolean bypass = NAVIGATION_BYPASS.get(activity);
-        return bypass != null && bypass.getAndSet(false);
+        synchronized (NAVIGATION_BYPASS) {
+            return Boolean.TRUE.equals(NAVIGATION_BYPASS.remove(activity));
+        }
+    }
+
+    private static void setNavigationBypass(@NonNull final Activity activity) {
+        synchronized (NAVIGATION_BYPASS) {
+            NAVIGATION_BYPASS.put(activity, true);
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -290,7 +290,9 @@ public final class ActivityMixin {
     }
 
     /**
-     * Programmatically simulates the user pressing back or navigate up.
+     * Immediately triggers back or navigate up programmatically.
+     * Use the Runnable passed to {@link #registerNavigationInterceptor(Activity, boolean, boolean, Predicate)}
+     * when navigation should resume later, for example after a confirmation dialog.
      *
      * @param activity     The activity to trigger navigation on.
      * @param isNavigateUp {@code true} to simulate navigate up, {@code false} to simulate back press.

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -28,15 +28,10 @@ import androidx.core.app.TaskStackBuilder;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 public final class ActivityMixin {
-
-    private static final Map<Activity, Boolean> NAVIGATION_BYPASS = Collections.synchronizedMap(new WeakHashMap<>());
 
     private ActivityMixin() {
         // utility class
@@ -228,20 +223,18 @@ public final class ActivityMixin {
      * @param interceptNavUp Whether to intercept navigate up (Toolbar ← arrow). Use the returned
      *                       BooleanSupplier in {@code onSupportNavigateUp()}.
      * @param interceptor    Called when back/navUp is triggered.
-     *                       Parameter: {@code true} = navigate up, {@code false} = back press.
+     *                       Parameter: a Runnable to conclude the intercepted navigation later
+     *                       (e.g. from a dialog confirmation).
      *                       Return {@code true} to STOP navigation, {@code false} to CONTINUE.
      * @return A BooleanSupplier to be called from {@code onSupportNavigateUp()}. Returns {@code true}
-     *         when navigation was intercepted (stopped), {@code false} to continue (call
-     *         {@code super.onSupportNavigateUp()}). Returns {@code false} immediately if
-     *         interceptNavUp is false or the activity is gone.
-     *         Note: the caller is responsible for invoking {@code super.onSupportNavigateUp()} when
-     *         the supplier returns {@code false}, as super calls cannot be made from outside the class.
+     *         when navigation was handled or intercepted, {@code false} if interceptNavUp is false
+     *         or the activity is gone.
      */
     public static BooleanSupplier registerNavigationInterceptor(
             @NonNull final Activity activity,
             final boolean interceptBack,
             final boolean interceptNavUp,
-            @NonNull final Predicate<Boolean> interceptor) {
+            @NonNull final Predicate<Runnable> interceptor) {
 
         final WeakReference<Activity> weakActivity = new WeakReference<>(activity);
 
@@ -255,22 +248,19 @@ public final class ActivityMixin {
                         setEnabled(false);
                         return;
                     }
-                    if (consumeNavigationBypass(a)) {
+                    final Runnable continueBackNavigation = () -> {
+                        if (!isActivityValid(a)) {
+                            return;
+                        }
                         setEnabled(false);
                         triggerBack(a);
                         if (isActivityValid(a)) {
                             setEnabled(true);
                         }
-                        return;
-                    }
-                    final boolean stop = interceptor.test(false);
+                    };
+                    final boolean stop = interceptor.test(continueBackNavigation);
                     if (!stop) {
-                        // Disable before re-triggering to avoid infinite interception loop
-                        setEnabled(false);
-                        triggerBack(a);
-                        if (isActivityValid(a)) {
-                            setEnabled(true);
-                        }
+                        continueBackNavigation.run();
                     }
                 }
             };
@@ -284,10 +274,15 @@ public final class ActivityMixin {
                 if (!isActivityValid(a)) {
                     return false;
                 }
-                if (consumeNavigationBypass(a)) {
-                    return false;
+                final Runnable continueNavigateUp = () -> {
+                    if (isActivityValid(a)) {
+                        navigateUp(a);
+                    }
+                };
+                if (!interceptor.test(continueNavigateUp)) {
+                    continueNavigateUp.run();
                 }
-                return interceptor.test(true);
+                return true;
             };
         }
 
@@ -296,7 +291,6 @@ public final class ActivityMixin {
 
     /**
      * Programmatically simulates the user pressing back or navigate up.
-     * Useful inside confirmation dialogs registered via {@link #registerNavigationInterceptor}.
      *
      * @param activity     The activity to trigger navigation on.
      * @param isNavigateUp {@code true} to simulate navigate up, {@code false} to simulate back press.
@@ -304,47 +298,14 @@ public final class ActivityMixin {
     public static void triggerNavigation(
             @NonNull final Activity activity,
             final boolean isNavigateUp) {
-        triggerNavigation(activity, isNavigateUp, false);
-    }
-
-    /**
-     * Programmatically simulates the user pressing back or navigate up.
-     *
-     * @param activity           The activity to trigger navigation on.
-     * @param isNavigateUp       {@code true} to simulate navigate up, {@code false} to simulate back press.
-     * @param bypassInterceptor  {@code true} to continue navigation without invoking the registered interceptor again.
-     */
-    public static void triggerNavigation(
-            @NonNull final Activity activity,
-            final boolean isNavigateUp,
-            final boolean bypassInterceptor) {
 
         if (!isActivityValid(activity)) {
             return;
         }
-        if (bypassInterceptor) {
-            setNavigationBypass(activity);
-        }
         if (isNavigateUp) {
-            if (bypassInterceptor || !(activity instanceof AppCompatActivity)) {
-                navigateUp(activity);
-            } else {
-                ((AppCompatActivity) activity).onSupportNavigateUp();
-            }
+            navigateUp(activity);
         } else {
             triggerBack(activity);
-        }
-    }
-
-    private static boolean consumeNavigationBypass(@NonNull final Activity activity) {
-        synchronized (NAVIGATION_BYPASS) {
-            return Boolean.TRUE.equals(NAVIGATION_BYPASS.remove(activity));
-        }
-    }
-
-    private static void setNavigationBypass(@NonNull final Activity activity) {
-        synchronized (NAVIGATION_BYPASS) {
-            NAVIGATION_BYPASS.put(activity, true);
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -26,6 +26,7 @@ import androidx.core.app.NavUtils;
 import androidx.core.app.TaskStackBuilder;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
@@ -268,18 +269,18 @@ public final class ActivityMixin {
             if (!isActivityValid(weakActivity)) {
                 return false;
             }
-            final boolean[] navigationHandled = new boolean[] {false};
+            final AtomicBoolean navigationHandled = new AtomicBoolean(false);
             final Runnable continueNavigateUp = () -> {
                 final AppCompatActivity currentActivity = weakActivity.get();
                 if (isActivityValid(currentActivity)) {
-                    navigationHandled[0] = navigateUp(currentActivity);
+                    navigationHandled.set(navigateUp(currentActivity));
                 }
             };
-            final boolean stop = interceptor.test(continueNavigateUp);
-            if (!stop) {
+            final boolean interceptorStoppedNavigation = interceptor.test(continueNavigateUp);
+            if (!interceptorStoppedNavigation) {
                 continueNavigateUp.run();
             }
-            return stop || navigationHandled[0];
+            return interceptorStoppedNavigation || navigationHandled.get();
         };
     }
 }

--- a/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
+++ b/main/src/main/java/cgeo/geocaching/activity/ActivityMixin.java
@@ -16,6 +16,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.EditText;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -25,6 +26,10 @@ import androidx.core.app.NavUtils;
 import androidx.core.app.TaskStackBuilder;
 
 import org.apache.commons.lang3.StringUtils;
+
+import java.lang.ref.WeakReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 public final class ActivityMixin {
 
@@ -203,6 +208,89 @@ public final class ActivityMixin {
     public static void requireActivity(final @Nullable Activity activity, final Action1<Activity> action) {
         if (activity != null) {
             action.call(activity);
+        }
+    }
+
+    /**
+     * Registers an interceptor for back press and/or navigate up on the given activity.
+     *
+     * @param activity       The activity to register on. Held via WeakReference to avoid memory leaks.
+     * @param interceptBack  Whether to intercept the system back press.
+     * @param interceptNavUp Whether to intercept navigate up (Toolbar ← arrow). Use the returned
+     *                       BooleanSupplier in {@code onSupportNavigateUp()}.
+     * @param interceptor    Called when back/navUp is triggered.
+     *                       Parameter: {@code true} = navigate up, {@code false} = back press.
+     *                       Return {@code true} to STOP navigation, {@code false} to CONTINUE.
+     * @return A BooleanSupplier to be called from {@code onSupportNavigateUp()}. Returns {@code true}
+     *         when navigation was intercepted (stopped), {@code false} to continue (call
+     *         {@code super.onSupportNavigateUp()}). Returns {@code false} immediately if
+     *         interceptNavUp is false or the activity is gone.
+     *         Note: the caller is responsible for invoking {@code super.onSupportNavigateUp()} when
+     *         the supplier returns {@code false}, as super calls cannot be made from outside the class.
+     */
+    public static BooleanSupplier registerNavigationInterceptor(
+            @NonNull final AppCompatActivity activity,
+            final boolean interceptBack,
+            final boolean interceptNavUp,
+            @NonNull final Predicate<Boolean> interceptor) {
+
+        final WeakReference<AppCompatActivity> weakActivity = new WeakReference<>(activity);
+
+        if (interceptBack) {
+            final OnBackPressedCallback callback = new OnBackPressedCallback(true) {
+                @Override
+                public void handleOnBackPressed() {
+                    final AppCompatActivity a = weakActivity.get();
+                    if (a == null || a.isFinishing() || a.isDestroyed()) {
+                        setEnabled(false);
+                        return;
+                    }
+                    final boolean stop = interceptor.test(false);
+                    if (!stop) {
+                        // Disable before re-triggering to avoid infinite interception loop
+                        setEnabled(false);
+                        a.getOnBackPressedDispatcher().onBackPressed();
+                        if (!a.isFinishing() && !a.isDestroyed()) {
+                            setEnabled(true);
+                        }
+                    }
+                }
+            };
+            // Passing activity as LifecycleOwner: callback is automatically removed on destroy
+            activity.getOnBackPressedDispatcher().addCallback(activity, callback);
+        }
+
+        if (interceptNavUp) {
+            return () -> {
+                final AppCompatActivity a = weakActivity.get();
+                if (a == null || a.isFinishing() || a.isDestroyed()) {
+                    return false;
+                }
+                return interceptor.test(true);
+            };
+        }
+
+        return () -> false;
+    }
+
+    /**
+     * Programmatically simulates the user pressing back or navigate up.
+     * Useful inside confirmation dialogs registered via {@link #registerNavigationInterceptor}.
+     *
+     * @param activity     The activity to trigger navigation on.
+     * @param isNavigateUp {@code true} to simulate navigate up, {@code false} to simulate back press.
+     */
+    public static void triggerNavigation(
+            @NonNull final AppCompatActivity activity,
+            final boolean isNavigateUp) {
+
+        if (activity.isFinishing() || activity.isDestroyed()) {
+            return;
+        }
+        if (isNavigateUp) {
+            activity.onSupportNavigateUp();
+        } else {
+            activity.getOnBackPressedDispatcher().onBackPressed();
         }
     }
 }

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -128,7 +128,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         fillViewFromFilter(filterContext.get().toConfig(), false);
         originalFilterConfig = getFilterFromView().toConfig();
 
-        navUpHandler = ActivityMixin.registerNavigationInterceptor(this, true, true, this::onNavigationIntercepted);
+        navUpHandler = ActivityMixin.registerBackNavigationInterceptor(this, this::onNavigationIntercepted);
 
         // Some features do not work / make no sense for nested filters
         if (isNested) {
@@ -260,8 +260,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
             finishWithResult();
             return true;
         } else if (itemId == R.id.menu_item_cancel) {
-            getOnBackPressedDispatcher().onBackPressed();
-            return true;
+            return onSupportNavigateUp();
         }
         return false;
     }

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -379,7 +379,8 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         final GeocacheFilter newFilter = getFilterFromView();
         final boolean filterWasChanged = originalFilterConfig != null && !originalFilterConfig.equals(newFilter.toConfig());
         if (filterWasChanged) {
-            SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes).confirm(this::finish);
+            SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes)
+                    .confirm(() -> ActivityMixin.triggerNavigation(this, isNavigateUp, true));
             return true;
         }
         return false;

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -261,8 +261,10 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
             return true;
         } else if (itemId == R.id.menu_item_cancel) {
             return onSupportNavigateUp();
+        } else if (itemId == android.R.id.home) {
+            return onSupportNavigateUp();
         }
-        return false;
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
@@ -387,7 +389,10 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     @Override
     public boolean onSupportNavigateUp() {
-        return navUpHandler.getAsBoolean();
+        if (navUpHandler.getAsBoolean()) {
+            return true;
+        }
+        return ActivityMixin.navigateUp(this) || super.onSupportNavigateUp();
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.filters.gui;
 
 import cgeo.geocaching.R;
 import cgeo.geocaching.activity.AbstractActionBarActivity;
+import cgeo.geocaching.activity.ActivityMixin;
 import cgeo.geocaching.databinding.CacheFilterActivityBinding;
 import cgeo.geocaching.databinding.CacheFilterListItemBinding;
 import cgeo.geocaching.filters.core.AndGeocacheFilter;
@@ -48,6 +49,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jetbrains.annotations.NotNull;
@@ -91,6 +93,8 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
     private boolean processBasicAdvancedListener = true;
     private boolean isNested = false;
 
+    private BooleanSupplier navUpHandler;
+
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -123,6 +127,8 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         setTitle(getString(filterContext.getType().titleId));
         fillViewFromFilter(filterContext.get().toConfig(), false);
         originalFilterConfig = getFilterFromView().toConfig();
+
+        navUpHandler = ActivityMixin.registerNavigationInterceptor(this, true, true, this::onNavigationIntercepted);
 
         // Some features do not work / make no sense for nested filters
         if (isNested) {
@@ -254,10 +260,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
             finishWithResult();
             return true;
         } else if (itemId == R.id.menu_item_cancel) {
-            finish();
-            return true;
-        } else if (itemId == android.R.id.home) {
-            onBackPressed();
+            ActivityMixin.triggerNavigation(this, false);
             return true;
         }
         return false;
@@ -366,17 +369,25 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
         finish();
     }
 
-    @Override
-    public void onBackPressed() {
-        // @todo should be replaced by setting a OnBackPressedDispatcher
+    /**
+     * Called when the user attempts to leave via back press or navigate up.
+     *
+     * @param isNavigateUp true if triggered by the Up arrow, false if by back press or Cancel menu item
+     * @return true to STOP navigation (a confirmation dialog was shown), false to CONTINUE
+     */
+    private boolean onNavigationIntercepted(final boolean isNavigateUp) {
         final GeocacheFilter newFilter = getFilterFromView();
-        final boolean filterWasChanged = !originalFilterConfig.equals(newFilter.toConfig());
+        final boolean filterWasChanged = originalFilterConfig != null && !originalFilterConfig.equals(newFilter.toConfig());
         if (filterWasChanged) {
             SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes).confirm(this::finish);
-        } else {
-            finish();
+            return true;
         }
-        super.onBackPressed();
+        return false;
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        return navUpHandler.getAsBoolean() || super.onSupportNavigateUp();
     }
 
 

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -260,7 +260,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
             finishWithResult();
             return true;
         } else if (itemId == R.id.menu_item_cancel) {
-            ActivityMixin.triggerNavigation(this, false);
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         }
         return false;

--- a/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
+++ b/main/src/main/java/cgeo/geocaching/filters/gui/GeocacheFilterActivity.java
@@ -372,15 +372,15 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
     /**
      * Called when the user attempts to leave via back press or navigate up.
      *
-     * @param isNavigateUp true if triggered by the Up arrow, false if by back press or Cancel menu item
+     * @param navigationAction concludes the intercepted back/up navigation when executed
      * @return true to STOP navigation (a confirmation dialog was shown), false to CONTINUE
      */
-    private boolean onNavigationIntercepted(final boolean isNavigateUp) {
+    private boolean onNavigationIntercepted(final Runnable navigationAction) {
         final GeocacheFilter newFilter = getFilterFromView();
         final boolean filterWasChanged = originalFilterConfig != null && !originalFilterConfig.equals(newFilter.toConfig());
         if (filterWasChanged) {
             SimpleDialog.of(this).setTitle(R.string.confirm_unsaved_changes_title).setMessage(R.string.confirm_discard_changes)
-                    .confirm(() -> ActivityMixin.triggerNavigation(this, isNavigateUp, true));
+                    .confirm(navigationAction);
             return true;
         }
         return false;
@@ -388,7 +388,7 @@ public class GeocacheFilterActivity extends AbstractActionBarActivity {
 
     @Override
     public boolean onSupportNavigateUp() {
-        return navUpHandler.getAsBoolean() || super.onSupportNavigateUp();
+        return navUpHandler.getAsBoolean();
     }
 
 


### PR DESCRIPTION
## Description

`GeocacheFilterActivity`'s confirmation dialog was non-functional: `onBackPressed()` called `super` unconditionally (closing immediately), the Toolbar ← arrow bypassed `onSupportNavigateUp()`, and `menu_item_cancel` skipped the dialog entirely.

- **`ActivityMixin`**: adds `registerBackNavigationInterceptor()` for `AppCompatActivity`, wires both `OnBackPressedDispatcher` and nav-up interception, passes deferred navigation `Runnable`s to resume intercepted back/up actions after confirmation, and provides `isActivityValid()` overloads for both `Activity` and `WeakReference`
- **Simplified interceptor API**: the navigation interceptor always handles both back press and nav-up, removing any boolean configuration and aligning the helper with its actual usage
- **WeakReference-safe continuation**: the returned navigation `Runnable`s resolve the activity through `WeakReference` before continuing navigation, avoiding leaks while keeping delayed confirmation handling simple
- **`GeocacheFilterActivity`**: replaces deprecated `onBackPressed()` handling with the new interceptor flow so back press, Toolbar ←, cancel menu item, and confirmed discard all route through the same unsaved-changes navigation path; the cancel menu item and home menu item both route through `onSupportNavigateUp()`
- **Confirmed navigation handling**: resumes the original back/up action by executing the deferred navigation callback from the confirmation dialog
- **Nav-up fallback behavior**: `registerBackNavigationInterceptor()` reports whether navigate-up was actually concluded, allowing `GeocacheFilterActivity.onSupportNavigateUp()` to fall back to `ActivityMixin.navigateUp(this)` and then `super.onSupportNavigateUp()` when the interceptor does not handle the action
- **No interference between `navigateUp` and interceptor**: `ActivityMixin.navigateUp()` is the conclude-navigation step invoked only after the interceptor has approved navigation; it does not call `onSupportNavigateUp()`, so there is no feedback loop or double-navigation risk

## Related issues

## Additional context