### PR TITLE
Prevent crash for translating en->en

### DIFF
--- a/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/BergamotTranslateAccessor.java
+++ b/main/src/main/java/cgeo/geocaching/utils/offlinetranslate/BergamotTranslateAccessor.java
@@ -278,7 +278,10 @@ public class BergamotTranslateAccessor implements ITranslateAccessor {
                 Schedulers.computation().createWorker().schedule(() -> {
                     try {
                         final String[] result;
-                        if (PIVOT_LANGUAGE.equals(sourceLang)) {
+                        // skip translation if src == target
+                        if (sourceLang.equals(targetLang)) {
+                            result = null;
+                        } else if (PIVOT_LANGUAGE.equals(sourceLang)) {
                             // en → target: direct
                             result = nativeLib.translateMultiple(new String[]{source}, pairKey(PIVOT_LANGUAGE, targetLang));
                         } else if (PIVOT_LANGUAGE.equals(targetLang)) {


### PR DESCRIPTION
## Description
Prevent offline translation crashing for translating en -> en

## How to reproduce
- Phone is set to "en"
- Cache is in language "en"
- Open logs view of a cache
- Select one log and tap on "Offline translate with Google"
- System will ask you to download translation models for "English[en], English[en]" => confirm
- c:geo crashes and you will return to cache list (or whatever activity you have been before)
