### PR TITLE
Add ML Kit cleanup routine (rel. to #18150)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
+++ b/main/src/main/java/cgeo/geocaching/activity/AbstractNavigationBarActivity.java
@@ -584,6 +584,8 @@ public abstract class AbstractNavigationBarActivity extends AbstractActionBarAct
                 Dialogs.basicOneTimeMessage(this, OneTimeDialogs.DialogType.NOTIFICATION_PERMISSION, () -> startActivity(new Intent(this, InstallWizardActivity.class)));
             }
 
+            // Cleanup for removed ML Kit offline translation
+            LocalStorage.cleanupMLKitfiles();
         }
     }
 

--- a/main/src/main/java/cgeo/geocaching/storage/LocalStorage.java
+++ b/main/src/main/java/cgeo/geocaching/storage/LocalStorage.java
@@ -517,4 +517,25 @@ public final class LocalStorage {
 
     }
 
+    /**
+     cleans remainders of ML Kit offline translation:
+     /data/data/cgeo.geocaching/no_backup/com.google.mlkit.translate.models/ had subfolders with the actual models
+     /data/data/cgeo.geocaching/no_backup/com.google.mlkit.InstallationId
+     /data/data/cgeo.geocaching/no_backup/com.google.mlkit.RemoteConfig
+     /data/data/cgeo.geocaching/shared_prefs/com.google.mlkit.internal.xml
+     */
+    public static void cleanupMLKitfiles() {
+        final File baseFolder = CgeoApplication.getInstance().getNoBackupFilesDir();
+        if (baseFolder != null) {
+            final File folder = new File(baseFolder, "com.google.mlkit.translate.models");
+            if (folder.exists()) {
+                FileUtils.deleteDirectory(folder);
+                FileUtils.deleteIgnoringFailure(new File(baseFolder, "com.google.mlkit.InstallationId"));
+                FileUtils.deleteIgnoringFailure(new File(baseFolder, "com.google.mlkit.RemoteConfig"));
+                FileUtils.deleteIgnoringFailure(new File(new File(CgeoApplication.getInstance().getDataDir(), "shared_prefs"), "com.google.mlkit.internal.xml"));
+                Log.e("ML Kit cleanup finished");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Description
Removes remaining files for ML Kit.

Gets triggered in `runInitAndMaintenance()` and only runs when base folder `<Context.getNoBackupFilesDir()>/com.google.mlkit.translate.models` still exists.

Notice: Should run in background actually, but that's true for most of `runInitAndMaintenance()` and should be handled in a separate issue. (related to #18108)