### PR TITLE
AndroidChart update follow up

### DIFF
--- a/main/proguard-project.txt
+++ b/main/proguard-project.txt
@@ -167,10 +167,3 @@
 
 # keep classes of metadata libaray (this lib heavily uses reflection)
 -keep class com.drew.** { *; }
-
-# Whitelist AndroidChart (fork of MPAndroidChart)
-# Preserve all public classes and methods
--keep class info.appdev.charting.** { *; }
--keep public class info.appdev.charting.animation.* {
-    public protected *;
-}

--- a/main/src/main/java/cgeo/geocaching/utils/Log.java
+++ b/main/src/main/java/cgeo/geocaching/utils/Log.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.PersistableFolder;
 import cgeo.geocaching.utils.functions.Func1;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
 
 import java.io.InputStream;
@@ -22,6 +23,7 @@ import static java.lang.Boolean.TRUE;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
+@SuppressLint("LogNotTimber")
 public final class Log {
 
     private static final String TAG = "cgeo";


### PR DESCRIPTION
The proguard configuration is already done within the AndroidChart library and therefore not necessary.

The updated AndroidChart library is using the Timber library (https://github.com/JakeWharton/timber). This creates Lint warning "LogNotTimber" - see https://github.com/JakeWharton/timber#lint, when it detects usages of Android's Log. Lets skip this warning in the own Log class.
