### PR TITLE
don't collapse logs on translation

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
@@ -133,6 +133,8 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
             holder.binding.logImages.setVisibility(View.GONE);
         }
 
+        holder.binding.logTranslateHint.setVisibility(View.GONE);
+
         // colored marker
         final int marker = log.logType.markerId;
         if (marker != 0) {

--- a/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
+++ b/main/src/main/java/cgeo/geocaching/ui/ExpandableTextView.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 
 public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextView {
     private boolean isCollapsible = false;
+    private boolean wasExpanded = false;
     private View.OnClickListener stackedOnClickListener = null;
 
     public ExpandableTextView(final Context context) {
@@ -39,7 +40,7 @@ public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextV
             final int lineLimit = Settings.getLogLineLimit();
             final int lineCount = getLineCount();
             isCollapsible = lineLimit > 0 && lineCount > lineLimit;
-            setCollapse(isCollapsible);
+            setCollapse(isCollapsible && !wasExpanded);
         });
     }
 
@@ -55,6 +56,9 @@ public class ExpandableTextView extends androidx.appcompat.widget.AppCompatTextV
         final int lineLimit = Settings.getLogLineLimit();
         setMaxLines(collapse && lineLimit > 0 ? lineLimit : Integer.MAX_VALUE);
         setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, collapse ? R.drawable.ic_menu_more : 0);
+        if (!collapse) {
+            wasExpanded = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
remember that a log text was expanded and don't auto-collapse it again on text change (= translation)
