### PR TITLE
Shorten log translation hint

### DIFF
--- a/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
+++ b/main/src/main/java/cgeo/geocaching/log/LogsViewCreator.java
@@ -27,7 +27,6 @@ import cgeo.geocaching.utils.html.UnknownTagsHandler;
 import cgeo.geocaching.utils.offlinetranslate.TranslateAccessor;
 
 import android.os.Bundle;
-import android.text.SpannableStringBuilder;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -206,7 +205,7 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
                     final OfflineTranslateUtils.Status translationStatus = getTranslationStatus(log);
                     if (translationStatus.isTranslated()) {
                         translationStatus.setNotTranslated();
-                        holder.binding.logTranslateHint.setVisibility(View.GONE);
+                        holder.binding.logTranslateNote.setVisibility(View.GONE);
                         fillViewHolder(null, holder, log);
                     } else {
                         final String logText = HtmlUtils.extractText(log.log);
@@ -216,13 +215,15 @@ public abstract class LogsViewCreator extends TabbedViewPagerFragment<LogsPageBi
                                 downloadingModel -> Toast.makeText(getContext(), R.string.translator_model_download_notification, Toast.LENGTH_SHORT).show(),
                                 translator -> OfflineTranslateUtils.translateParagraph(translator, translationStatus, logText, translated -> {
                                     holder.binding.log.setText(translated);
-                                    holder.binding.logTranslateNote.setText(new SpannableStringBuilder(LocalizationUtils.getString(R.string.translator_translation_success, new OfflineTranslateUtils.Language(translator.getSourceLanguage()))).append("\n").append(LocalizationUtils.getString(R.string.translator_attributed_to, TranslateAccessor.get().getTranslatorName())));
-                                    holder.binding.logTranslateButton.setOnClickListener(v1 -> {
+                                    holder.binding.logTranslateNote.setText(
+                                            LocalizationUtils.getLocaleDisplayFlag(translator.getSourceLanguage()) + " " +
+                                            LocalizationUtils.getString(R.string.translator_restore_original));
+                                    holder.binding.logTranslateNote.setOnClickListener(v1 -> {
                                         translationStatus.setNotTranslated();
-                                        holder.binding.logTranslateHint.setVisibility(View.GONE);
+                                        holder.binding.logTranslateNote.setVisibility(View.GONE);
                                         fillViewHolder(null, holder, log);
                                     });
-                                    holder.binding.logTranslateHint.setVisibility(View.VISIBLE);
+                                    holder.binding.logTranslateNote.setVisibility(View.VISIBLE);
                                 }, e -> Toast.makeText(getContext(), LocalizationUtils.getString(R.string.translator_translation_error, e.getMessage()), Toast.LENGTH_LONG).show()));
                         }
                 });

--- a/main/src/main/res/layout/logs_item.xml
+++ b/main/src/main/res/layout/logs_item.xml
@@ -85,33 +85,18 @@
                 android:textSize="@dimen/textSize_detailsPrimary"
                 app:drawableLeftCompat="@drawable/log_img_icon" />
 
-            <RelativeLayout
+            <TextView
+                android:id="@+id/log_translate_note"
+                android:tooltipText="@string/translator_tooltip"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
-                android:id="@+id/log_translate_hint">
+                android:layout_marginLeft="0dip"
+                android:layout_marginRight="0dip"
+                android:paddingRight="3dip"
+                android:textSize="@dimen/textSize_detailsSecondary"
+                android:textColor="@color/colorTextHint"
+                android:textIsSelectable="false" />
 
-                <TextView
-                    android:id="@+id/log_translate_note"
-                    android:tooltipText="@string/translator_tooltip"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_centerVertical="true"
-                    android:layout_gravity="left"
-                    android:layout_marginLeft="6dip"
-                    android:layout_marginRight="60dip"
-                    android:paddingRight="3dip"
-                    android:textSize="@dimen/textSize_detailsSecondary"
-                    android:textColor="@color/colorTextHint"
-                    android:textIsSelectable="false" />
-
-                <Button
-                    android:id="@+id/log_translate_button"
-                    style="@style/button_icon"
-                    android:layout_alignParentRight="true"
-                    app:icon="@drawable/ic_menu_translate" />
-            </RelativeLayout>
         </LinearLayout>
 
     </RelativeLayout>

--- a/main/src/main/res/values/strings.xml
+++ b/main/src/main/res/values/strings.xml
@@ -407,6 +407,7 @@
     <string name="translator_translation_error">Failed to translate text: %s</string>
     <string name="translator_translation_initerror">Failed to initialize translator</string>
     <string name="translator_translation_success">Translated from "%s", tap button to restore original</string>
+    <string name="translator_restore_original">Tap to restore original</string>
     <string name="translator_attributed_to">Translated by %s</string>
     <string name="crash_activity_title">Oops! c:geo crashed!</string>
     <string name="crash_activity_report">report problem</string>


### PR DESCRIPTION
## Description
Makes log translation notice less prominent. Tap on hint still triggers restoring original text.

<img width="270" height="555" alt="image" src="https://github.com/user-attachments/assets/cb6489c7-8f0f-4c78-953f-b3b091a97fa1" />
