### PR TITLE
Make CacheCache size dynamic (rel. to #18108)

### DIFF
--- a/main/src/main/java/cgeo/geocaching/settings/Settings.java
+++ b/main/src/main/java/cgeo/geocaching/settings/Settings.java
@@ -32,6 +32,7 @@ import cgeo.geocaching.sensors.DirectionData;
 import cgeo.geocaching.sensors.MagnetometerAndAccelerometerProvider;
 import cgeo.geocaching.sensors.OrientationProvider;
 import cgeo.geocaching.sensors.RotationProvider;
+import cgeo.geocaching.storage.CacheCache;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.LocalStorage;
 import cgeo.geocaching.storage.PersistableFolder;
@@ -2673,7 +2674,6 @@ public class Settings {
         return rawLanguage;
     }
 
-
     public static @NonNull Set<String> getLanguagesToNotTranslate() {
         final Set<String> lngs = new HashSet<>();
         if (sharedPrefs == null) {
@@ -2686,5 +2686,9 @@ public class Settings {
             lngs.add(targetLng.getCode());
         }
         return lngs;
+    }
+
+    public static int getCacheCacheSize() {
+        return getInt(R.string.pref_cachecache_size, CacheCache.DEFAULT_CACHED_CACHES);
     }
 }

--- a/main/src/main/java/cgeo/geocaching/storage/CacheCache.java
+++ b/main/src/main/java/cgeo/geocaching/storage/CacheCache.java
@@ -2,6 +2,7 @@ package cgeo.geocaching.storage;
 
 import cgeo.geocaching.location.Viewport;
 import cgeo.geocaching.models.Geocache;
+import cgeo.geocaching.settings.Settings;
 import cgeo.geocaching.storage.DataStore.StorageLocation;
 import cgeo.geocaching.utils.LeastRecentlyUsedMap;
 import cgeo.geocaching.utils.Log;
@@ -19,11 +20,37 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class CacheCache {
 
-    private static final int MAX_CACHED_CACHES = 2000;
+    /** Absolute lower bound for the cache size, kept for memory constrained devices. */
+    private static final int MIN_CACHED_CACHES = 2000;
+    /** Absolute upper bound to avoid unbounded growth even on devices with very large heaps. */
+    private static final int MAX_CACHED_CACHES_LIMIT = 50000;
+    /** Default value */
+    public static final int DEFAULT_CACHED_CACHES = 2000;
+    /** Actual value in this session */
+    public static final int MAX_CACHED_CACHES = calculateMaxCachedCaches();
+
     private final LeastRecentlyUsedMap<String, Geocache> cachesCache;
 
     public CacheCache() {
         cachesCache = new LeastRecentlyUsedMap.LruCache<>(MAX_CACHED_CACHES);
+    }
+
+    /**
+     * Derive the maximum number of caches to keep in memory from the available heap.
+     * <br>
+     * Take up a quarter of heap at max, assuming 8kB per geocache on average
+     */
+    private static int calculateMaxCachedCaches() {
+        final int cacheSize = Settings.getCacheCacheSize();
+        if (cacheSize == 0) {
+            // dynamic setting
+            final long fromHeap = (Runtime.getRuntime().maxMemory() / 4) / (8L * 1024);
+            final int result = (int) Math.max(MIN_CACHED_CACHES, Math.min(MAX_CACHED_CACHES_LIMIT, fromHeap));
+            Log.d("CacheCache: max cached caches = " + result + " (maxMemory=" + Runtime.getRuntime().maxMemory() + ")");
+            return result;
+        } else {
+            return Math.max(MIN_CACHED_CACHES, Math.min(MAX_CACHED_CACHES_LIMIT, cacheSize));
+        }
     }
 
     public synchronized void removeAllFromCache() {
@@ -93,6 +120,10 @@ public class CacheCache {
     @NonNull
     public synchronized String toString() {
         return StringUtils.join(cachesCache.keySet(), ' ');
+    }
+
+    public synchronized int getSize() {
+        return cachesCache.size();
     }
 
 }

--- a/main/src/main/java/cgeo/geocaching/storage/DataStore.java
+++ b/main/src/main/java/cgeo/geocaching/storage/DataStore.java
@@ -6279,4 +6279,10 @@ public class DataStore {
         }
         Log.d("unlock db");
     }
+
+    /** returns number of used entries in cacheCache */
+    public static int getActualCacheCacheSize() {
+        return cacheCache.getSize();
+    }
+
 }

--- a/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
+++ b/main/src/main/java/cgeo/geocaching/utils/SystemInformation.java
@@ -17,6 +17,7 @@ import cgeo.geocaching.sensors.MagnetometerAndAccelerometerProvider;
 import cgeo.geocaching.sensors.OrientationProvider;
 import cgeo.geocaching.sensors.RotationProvider;
 import cgeo.geocaching.settings.Settings;
+import cgeo.geocaching.storage.CacheCache;
 import cgeo.geocaching.storage.ContentStorage;
 import cgeo.geocaching.storage.DataStore;
 import cgeo.geocaching.storage.FolderUtils;
@@ -46,6 +47,7 @@ import androidx.core.content.ContextCompat;
 import androidx.core.util.Pair;
 
 import java.io.File;
+import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -175,6 +177,8 @@ public final class SystemInformation {
                 .append(", Threshold: ").append(Formatter.formatBytes(memoryInfo.threshold))
                 .append(", low:").append(memoryInfo.lowMemory);
         }
+        final NumberFormat intFormat = NumberFormat.getIntegerInstance(Locale.getDefault());
+        body.append(", CacheCache: ").append(intFormat.format(DataStore.getActualCacheCacheSize())).append("/").append(intFormat.format(CacheCache.MAX_CACHED_CACHES));
     }
 
     private static void appendDatabase(@NonNull final StringBuilder body) {

--- a/main/src/main/res/values/preference_keys.xml
+++ b/main/src/main/res/values/preference_keys.xml
@@ -656,6 +656,7 @@
     <string translatable="false" name="pref_home_location">home_location</string>
     <string translatable="false" name="pref_followMyLocation">followMyLocation</string>
     <string translatable="false" name="pref_autozoom_consider_lastcenter">list_viewport_calculation_consider_lastviewport</string>
+    <string translatable="false" name="pref_cachecache_size">cachecache_size</string>
 
 
     <!-- ============================================================================================================================================================================== -->


### PR DESCRIPTION
Allow user-configured size of CacheCache for a more responsive system (CacheListActivity etc.) with large cache lists.

Opt-in feature for now. Default size of CacheCache is 2000.

Define a new preference key named `cachecache_size` of type `int` and assign either "0" for dynamic cache size allocation, or a value in between the given boundaries (2k - 50k) for a fixed size.