### PR TITLE
 fix (some) wrong favorite log indicator 

### DIFF
--- a/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
+++ b/main/src/main/java/cgeo/geocaching/connector/gc/GCParser.java
@@ -1856,7 +1856,8 @@ public final class GCParser {
             } else {
                 final int logIndex = mergedLogs.indexOf(modifiedLog);
                 if (logIndex >= 0) {
-                    mergedLogs.set(logIndex, logToMerge);
+                    // manually merge the favorite flag as that's only in the listing logs
+                    mergedLogs.set(logIndex, logToMerge.buildUpon().setFavorite(modifiedLog.favorite).build());
                 }
             }
         }


### PR DESCRIPTION
Favorite indicator is only available for logs in listing, not on the separate log views which are used as source for own/friends logs. For those logs that are in both sources carry over the favorite flag

fixes parts of #18208 but I'll keep that open as it's impossible to fully fix it