### PR TITLE
Show favpoints-text-box only for found caches

### DIFF
--- a/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
+++ b/main/src/main/java/cgeo/geocaching/CacheDetailActivity.java
@@ -1787,9 +1787,15 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
             } else {
                 favoriteLine.layout.setVisibility(View.GONE);
             }
+
             final boolean supportsFavoritePoints = cache.supportsFavoritePoints();
             binding.favpointBox.setVisibility(supportsFavoritePoints ? View.VISIBLE : View.GONE);
             if (!supportsFavoritePoints) {
+                return;
+            }
+            
+            // Add/remove to Favorites is only possible if the cache has been found
+            if (!cache.isFound()) {
                 return;
             }
 
@@ -1801,12 +1807,6 @@ public class CacheDetailActivity extends TabbedViewPagerActivity
                 binding.addToFavpoint.setVisibility(View.VISIBLE);
                 binding.removeFromFavpoint.setVisibility(View.GONE);
                 binding.favpointText.setText(R.string.cache_favpoint_not_on);
-            }
-
-            // Add/remove to Favorites is only possible if the cache has been found
-            if (!cache.isFound()) {
-                binding.addToFavpoint.setVisibility(View.GONE);
-                binding.removeFromFavpoint.setVisibility(View.GONE);
             }
         }
 


### PR DESCRIPTION
Favorite points can only be awarded for caches that have been found. So don't show for caches, which you haven't found

<img width="300" alt="grafik" src="https://github.com/user-attachments/assets/17125a3c-3d9a-4e52-bdd8-42700f7c59ec" />

